### PR TITLE
Replace html tags in title with space #62643

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,25 +10,26 @@ module ApplicationHelper
 
   def html_title(title=nil)
     full_title = title.nil? ? "" : "#{title} - "
+    full_title.gsub!(/<[^>]*>/, ' ')
     full_title += app_name
     full_title.html_safe
   end
-  
+
   def order_detail_description(order_detail)
     name = "";
     if order_detail.bundle
       name << "#{h order_detail.bundle}";
       name << " &mdash; "
-    end 
+    end
     name << h(order_detail.product)
     name.html_safe
   end
-  
+
   def human_rate_calculation(rate, subsidy)
     # handle nil input
     rate    = 0 if rate.nil?
     subsidy = 0 if subsidy.nil?
-    
+
     # render appropriate string
     if subsidy > 0
       "#{number_to_currency rate}<br />-#{number_to_currency subsidy}<br /> =<b>#{number_to_currency rate-subsidy}</b>".html_safe
@@ -38,7 +39,7 @@ module ApplicationHelper
       ""
     end
   end
-  
+
   def sortable (column, title = nil)
     title ||= column.titleize
     direction = column == sort_column && sort_direction == 'asc' ? 'desc' : 'asc'
@@ -72,7 +73,7 @@ module ApplicationHelper
 
   def menu_facilities
     return [] unless session_user
-    session_user.facilities    
+    session_user.facilities
   end
 
 

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -54,6 +54,12 @@ describe InstrumentsController do
       do_request
       assigns[:instrument].should == @instrument
     end
+
+    it 'should not have html tags in title from login button' do
+      do_request
+      response.body.should match(/<title>/)
+      response.body.should match('<title>[^<>]+</title>')
+    end
   end
 
 
@@ -287,7 +293,7 @@ describe InstrumentsController do
         it 'should create a new schedule' do
           expect { do_request }.to change{ Schedule.count }.by(1)
         end
-          
+
         it 'should be the newest schedule' do
           do_request
           assigns(:instrument).schedule.should == Schedule.last
@@ -506,7 +512,7 @@ describe InstrumentsController do
                                               :facility_account => @facility_account,
                                               :no_relay => true)
         @instrument_with_relay.update_attributes(:relay => FactoryGirl.create(:relay_syna, :instrument => @instrument_with_relay))
-        
+
         @instrument_with_dummy_relay = FactoryGirl.create(:instrument,
                                               :facility => @authable,
                                               :facility_account => @facility_account,


### PR DESCRIPTION
The <code>:h1</code> symbol is used for title and in this case, the </code>:h1</code> contains html.  I added a change to strip tags and replace them with a space.  This will leave whatever was inside the tag in place.  I'm unsure if this is the ideal solution or if the complete removal of the tag plus tag contents is preferred.

This fix is not specific to the ticket and will strip any html tags sent into the <code>html_title</code> helper.
