### PR TITLE
Display notes on journal index and detail #59775

### DIFF
--- a/app/views/facility_journals/index.html.haml
+++ b/app/views/facility_journals/index.html.haml
@@ -7,14 +7,14 @@
 - if has_pending_journals?
   %h2= t(".head.pending")
 
-  
+
   - if @pending_journals.present?
     %div= t(".instructions_html")
-    
+
     - @pending_journals.each do |pending_journal|
       - facility_abbreviations = pending_journal.facility_abbreviations
       = form_for([current_facility, pending_journal]) do |f|
-        = f.error_messages 
+        = f.error_messages
         %table
           %tr
             %th= t(".th.download")
@@ -40,7 +40,7 @@
 
             - if all_facility?
               %td= facility_abbreviations.join("<br>").html_safe
-            
+
             %td=h number_to_currency(pending_journal.amount)
             %td= f.text_field :reference
             %td= f.text_field :description
@@ -61,6 +61,7 @@
       %th= Journal.human_attribute_name(:created_at).titlecase
       %th= Journal.human_attribute_name(:journal_date).titlecase
       %th= Journal.human_attribute_name(:reference)
+      %th= Journal.human_attribute_name(:description)
       %th= Journal.human_attribute_name(:journal_status)
     - @journals.each do |j|
       %tr
@@ -68,4 +69,5 @@
         %td=h human_datetime(j.created_at)
         %td=h human_date(j.journal_date)
         %td=h j.reference
+        %td=h j.description
         %td=h j.status_string

--- a/app/views/facility_journals/show.html.haml
+++ b/app/views/facility_journals/show.html.haml
@@ -16,6 +16,12 @@
     %label= t('.label.journal_date')
     =h human_date @journal.journal_date
   %li
+    %label= t('.label.reference')
+    =h @journal.reference
+  %li
+    %label= t('.label.description')
+    =h @journal.description
+  %li
     %label= t('.label.journal_status')
     =h @journal.status_string
   - if Settings.financial.journal_format.xls

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -198,6 +198,8 @@ en:
         created_by: "Created By"
         journal_date: "Journal Date"
         journal_status: "Journal Status"
+        reference: "Reference"
+        description: "Notes"
       instruct:
         orders: |
           Orders on this page reflect updates made to orders since journaling.  To view the journal as originally
@@ -474,7 +476,7 @@ en:
     pick_accessories:
       link: Add Accessories to order...
       instruct: "Please enter a quantity for each accessory used during the reservation. If an accessory was not used please leave the quantity blank."
-    
+
     index:
       description: "Here you may define one or more accessories that can be used during a reservation of this product"
 


### PR DESCRIPTION
The ticket said either index or detail page but it was easy to add both.  However, I'm unclear why we're using both t() and Journal.human_attribute_name() as they seem to pull from different sources.
