### PR TITLE
Auto-canceller cancels past reservations sitting in cart #71349

### DIFF
--- a/app/support/auto_canceller.rb
+++ b/app/support/auto_canceller.rb
@@ -14,8 +14,9 @@ class AutoCanceller
 
   def cancelable_reservations
     @cancelable_reservations ||= Reservation.
-      joins(:product, :order_detail).
+      joins(:product, :order_detail => :order).
       where(build_sql, :now => Time.zone.now).
+      merge(Order.purchased).
       readonly(false)
   end
 
@@ -51,7 +52,7 @@ private
       AND
         auto_cancel_mins > 0
       AND
-        (state = 'new' OR state = 'inprocess')
+        (order_details.state = 'new' OR order_details.state = 'inprocess')
       AND
         #{time_condition}
     SQL

--- a/spec/services/auto_canceller_spec.rb
+++ b/spec/services/auto_canceller_spec.rb
@@ -61,6 +61,17 @@ describe AutoCanceller do
       completed_reservation.order_detail.reload.order_status.should_not == cancelled_status
     end
 
+    it 'should not cancel a past reservation in the cart' do
+      cart_reservation = FactoryGirl.create(:setup_reservation,
+        :product => instrument,
+        :reserve_start_at => base_date - 1.day,
+        :reserve_end_at => base_date - 1.day + 1.hour,
+        :reserved_by_admin => true)
+
+      canceller.cancel_reservations
+      cart_reservation.order_detail.reload.order_status.should_not == cancelled_status
+    end
+
     context 'with cancellation fee' do
       before :each do
         instrument.price_policies.first.update_attributes(:cancellation_cost => 10)


### PR DESCRIPTION
When ordering using the multi-item form while acting as, the auto-canceler cancels past reservations while they're still sitting in the cart.
