### PR TITLE
#72691 default start time on reservation in past?

### DIFF
--- a/app/controllers/facility_reservations_controller.rb
+++ b/app/controllers/facility_reservations_controller.rb
@@ -129,7 +129,7 @@ class FacilityReservationsController < ApplicationController
   def new
     @instrument   = current_facility.instruments.find_by_url_name!(params[:instrument_id])
     @reservation  = @instrument.next_available_reservation || Reservation.new(:duration_value => @instrument.min_reserve_mins, :duration_unit => 'minutes')
-
+    @reservation.round_reservation_times
     set_windows
 
     render :layout => 'two_column'

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -158,6 +158,7 @@ class ReservationsController < ApplicationController
   def new
     raise ActiveRecord::RecordNotFound unless @reservation.nil?
     @reservation  = @instrument.next_available_reservation || Reservation.new(:product => @instrument, :duration_value => (@instrument.min_reserve_mins.to_i < 15 ? 15 : @instrument.min_reserve_mins), :duration_unit => 'minutes')
+    @reservation.round_reservation_times
     flash[:notice] = t_model_error(Instrument, 'acting_as_not_on_approval_list') unless @instrument.is_approved_for?(acting_user)
     set_windows
 

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -53,6 +53,11 @@ module DateHelper
     end
   end
 
+  def time_ceil(time, precision = 5.minutes)
+    time = time.dup.change(:sec => 0)
+    Time.zone.at((time.to_f / precision).ceil * precision)
+  end
+
   #TODO Replace calls to this with select_time(default_time, :ignore_date => true, :prefix => field, :ampm => true)
   # once we've migrated to Rails 3.1.
   # 3.0 doesn't support the :ampm option

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -125,6 +125,11 @@ class Reservation < ActiveRecord::Base
   # Instance Methods
   #####
 
+  def round_reservation_times
+    self.reserve_start_at = time_ceil(self.reserve_start_at)
+    self.reserve_end_at   = time_ceil(self.reserve_end_at)
+  end
+
   def assign_actuals_off_reserve
     self.actual_start_at ||= self.reserve_start_at
     self.actual_end_at   ||= self.reserve_end_at

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -37,4 +37,26 @@ describe DateHelper do
   describe "#human_date"
   describe "#human_time"
 
+  describe 'time_ceil' do
+    it 'rounds up to the nearest 5 minute' do
+      time_ceil(Time.zone.parse('2013-08-15 12:03')).should == Time.zone.parse('2013-08-15 12:05')
+    end
+
+    it 'drops the seconds before rounding' do
+      time_ceil(Time.zone.parse('2013-08-15 12:05:30')).should == Time.zone.parse('2013-08-15 12:05')
+    end
+
+    it 'does not round up if already at 5 minutes' do
+      time_ceil(Time.zone.parse('2013-08-15 12:05')).should == Time.zone.parse('2013-08-15 12:05')
+    end
+
+    it 'rounds up to 15 minute' do
+      time_ceil(Time.zone.parse('2013-08-15 12:05'), 15.minutes).should == Time.zone.parse('2013-08-15 12:15')
+    end
+
+    it 'rounds up to an hour' do
+      time_ceil(Time.zone.parse('2013-08-15 12:05'), 1.hour).should == Time.zone.parse('2013-08-15 13:00')
+    end
+  end
+
 end


### PR DESCRIPTION
Instruments with 1 minute schedule rule were sometimes falling back to :00 in the new reservation form when the next available reservation time was not an increment of 5 minutes (e.g. 1:33 would get populated in the form as 1:00)
