### PR TITLE
Manager unable to move reservations. Bug #74751

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -365,9 +365,13 @@ class OrderDetail < ActiveRecord::Base
     change_status! product.initial_order_status
   end
 
-  def save_as_user!(user)
+  def save_as_user(user)
     @being_purchased_by_admin = user.operator_of?(product.facility)
-    save!
+    save
+  end
+
+  def save_as_user!(user)
+    raise ActiveRecord::RecordInvalid.new(self) unless save_as_user(user)
   end
 
   def cancelable?

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -126,14 +126,18 @@ class Reservation < ActiveRecord::Base
     self.actual_end_at   ||= self.reserve_end_at
   end
 
-  def save_as_user!(user)
+  def save_as_user(user)
     if (user.operator_of?(product.facility))
       @reserved_by_admin = true
-      self.save!
+      self.save
     else
       @reserved_by_admin = false
-      self.save_extended_validations!
+      self.save_extended_validations
     end
+  end
+
+  def save_as_user!(user)
+    raise ActiveRecord::RecordInvalid.new(self) unless save_as_user(user)
   end
 
   def admin?

--- a/app/support/order_details/param_updater.rb
+++ b/app/support/order_details/param_updater.rb
@@ -29,11 +29,11 @@ class OrderDetails::ParamUpdater
     assign_attributes(params)
 
     @order_detail.transaction do
-      @order_detail.reservation.save if @order_detail.reservation
+      @order_detail.reservation.save_as_user(@editing_user) if @order_detail.reservation
       if order_status_id && order_status_id.to_i != @order_detail.order_status_id
         change_order_status(order_status_id, @options[:cancel_fee]) || raise(ActiveRecord::Rollback)
       else
-        @order_detail.save || raise(ActiveRecord::Rollback)
+        @order_detail.save_as_user(@editing_user) || raise(ActiveRecord::Rollback)
       end
     end
 

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -229,6 +229,25 @@ describe OrderManagement::OrderDetailsController do
           end
         end
 
+        context 'and it is a restricted instrument' do
+          before :each do
+            instrument.update_attributes(:requires_approval => true, :min_reserve_mins => 10)
+            @params[:order_detail] = {
+              :reservation => {
+                :reserve_start_at => reservation.reserve_start_at,
+                :duration_mins => 30
+              }
+            }
+          end
+
+          it 'should allow editing' do
+            do_request
+            expect(assigns(:order_detail)).to_not be_changed
+            expect(assigns(:order_detail).reservation).to_not be_changed
+            expect(flash[:error]).to be_blank
+          end
+        end
+
       end
 
       describe 'cancelling an order' do


### PR DESCRIPTION
When updating a reservation on a restricted instrument where the user is not on the access list, it was not using the admin's overrides, e.g. reserving outside of scheduling blocks.
