### PR TITLE
Don't format populating prices; prevent errors on default values

### DIFF
--- a/app/views/price_policies/_price_policy_fields.html.haml
+++ b/app/views/price_policies/_price_policy_fields.html.haml
@@ -19,13 +19,13 @@
         %td= pg.type_string
         %td= check_box_tag "price_policy_#{pg.id}[can_purchase]", '1', pp.can_purchase?, :class => 'can_purchase'
         - if !pg.is_internal?
-          %td.centered= text_field_tag "price_policy_#{pg.id}[unit_cost]", number_to_currency(pp.unit_cost, :unit => ''), :size => 8
+          %td.centered= text_field_tag "price_policy_#{pg.id}[unit_cost]", number_to_currency(pp.unit_cost, :unit => '', :delimiter => ''), :size => 8
           %td.centered
         - elsif pg.is_master_internal?
-          %td.centered= text_field_tag "price_policy_#{pg.id}[unit_cost]", number_to_currency(pp.unit_cost, :unit => ''), :size => 8, :class => 'master_unit_cost'
+          %td.centered= text_field_tag "price_policy_#{pg.id}[unit_cost]", number_to_currency(pp.unit_cost, :unit => '', :delimiter => ''), :size => 8, :class => 'master_unit_cost'
           %td
         - else
           %td.centered
             %span.unit_cost
-            = hidden_field_tag "price_policy_#{pg.id}[unit_cost]", number_to_currency(pp.unit_cost, :unit => ''), :class => "unit_cost"
-          %td.centered= text_field_tag "price_policy_#{pg.id}[unit_subsidy]", number_to_currency(pp.unit_subsidy, :unit => ''), :size => 8
+            = hidden_field_tag "price_policy_#{pg.id}[unit_cost]", number_to_currency(pp.unit_cost, :unit => '', :delimiter => ''), :class => "unit_cost"
+          %td.centered= text_field_tag "price_policy_#{pg.id}[unit_subsidy]", number_to_currency(pp.unit_subsidy, :unit => '', :delimiter => ''), :size => 8

--- a/app/views/price_policies/instrument/_external_row.html.haml
+++ b/app/views/price_policies/instrument/_external_row.html.haml
@@ -1,22 +1,22 @@
 %td
   Rate
   %br
-  = text_field_tag "price_policy_#{pg.id}[usage_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:usage_rate] : number_to_currency(pp.usage_rate, :unit => ''), :size => 8
+  = text_field_tag "price_policy_#{pg.id}[usage_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:usage_rate] : number_to_currency(pp.usage_rate, :unit => '', :delimiter => ''), :size => 8
   %br
 %td
   Rate
   %br
-  = text_field_tag "price_policy_#{pg.id}[reservation_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:reservation_rate] : number_to_currency(pp.reservation_rate, :unit => ''), :size => 8
+  = text_field_tag "price_policy_#{pg.id}[reservation_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:reservation_rate] : number_to_currency(pp.reservation_rate, :unit => '', :delimiter => ''), :size => 8
 %td
   Rate
   %br
-  = text_field_tag "price_policy_#{pg.id}[overage_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:overage_rate] : number_to_currency(pp.overage_rate, :unit => ''), :size => 8
+  = text_field_tag "price_policy_#{pg.id}[overage_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:overage_rate] : number_to_currency(pp.overage_rate, :unit => '', :delimiter => ''), :size => 8
 %td
   Amount
   %br
-  = text_field_tag "price_policy_#{pg.id}[minimum_cost]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:minimum_cost] : number_to_currency(pp.minimum_cost, :unit => ''), :size => 8
+  = text_field_tag "price_policy_#{pg.id}[minimum_cost]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:minimum_cost] : number_to_currency(pp.minimum_cost, :unit => '', :delimiter => ''), :size => 8
 
 %td
   Amount
   %br
-  = text_field_tag "price_policy_#{pg.id}[cancellation_cost]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:cancellation_cost] : number_to_currency(pp.cancellation_cost, :unit => ''), :size => 8
+  = text_field_tag "price_policy_#{pg.id}[cancellation_cost]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:cancellation_cost] : number_to_currency(pp.cancellation_cost, :unit => '', :delimiter => ''), :size => 8

--- a/app/views/price_policies/instrument/_internal_row.html.haml
+++ b/app/views/price_policies/instrument/_internal_row.html.haml
@@ -1,25 +1,25 @@
 %td
-  = hidden_field_tag "price_policy_#{pg.id}[usage_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:usage_rate] : number_to_currency(pp.usage_rate, :unit => ''), :class => "usage_cost"
+  = hidden_field_tag "price_policy_#{pg.id}[usage_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:usage_rate] : number_to_currency(pp.usage_rate, :unit => '', :delimiter => ''), :class => "usage_cost"
   Adjustment
   %br
-  = text_field_tag "price_policy_#{pg.id}[usage_subsidy]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:usage_subsidy] : number_to_currency(pp.usage_subsidy, :unit => ''), :size => 8
+  = text_field_tag "price_policy_#{pg.id}[usage_subsidy]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:usage_subsidy] : number_to_currency(pp.usage_subsidy, :unit => '', :delimiter => ''), :size => 8
 %td
-  = hidden_field_tag "price_policy_#{pg.id}[reservation_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:reservation_rate] : number_to_currency(pp.reservation_rate, :unit => ''), :class => "reservation_cost"
+  = hidden_field_tag "price_policy_#{pg.id}[reservation_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:reservation_rate] : number_to_currency(pp.reservation_rate, :unit => '', :delimiter => ''), :class => "reservation_cost"
   Adjustment
   %br
-  = text_field_tag "price_policy_#{pg.id}[reservation_subsidy]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:reservation_subsidy] : number_to_currency(pp.reservation_subsidy, :unit => ''), :size => 8
+  = text_field_tag "price_policy_#{pg.id}[reservation_subsidy]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:reservation_subsidy] : number_to_currency(pp.reservation_subsidy, :unit => '', :delimiter => ''), :size => 8
 %td
-  = hidden_field_tag "price_policy_#{pg.id}[overage_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:overage_rate] : number_to_currency(pp.overage_rate, :unit => ''), :class => "overage_cost"
+  = hidden_field_tag "price_policy_#{pg.id}[overage_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:overage_rate] : number_to_currency(pp.overage_rate, :unit => '', :delimiter => ''), :class => "overage_cost"
   Adjustment
   %br
-  = text_field_tag "price_policy_#{pg.id}[overage_subsidy]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:overage_subsidy] : number_to_currency(pp.overage_subsidy, :unit => ''), :size => 8
+  = text_field_tag "price_policy_#{pg.id}[overage_subsidy]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:overage_subsidy] : number_to_currency(pp.overage_subsidy, :unit => '', :delimiter => ''), :size => 8
 %td
   Amount
   %br
   %span.minimum_cost
-  = hidden_field_tag "price_policy_#{pg.id}[minimum_cost]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:minimum_cost] : number_to_currency(pp.minimum_cost, :unit => ''), :size => 8, :class => 'minimum_cost'
+  = hidden_field_tag "price_policy_#{pg.id}[minimum_cost]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:minimum_cost] : number_to_currency(pp.minimum_cost, :unit => '', :delimiter => ''), :size => 8, :class => 'minimum_cost'
 %td
   Amount
   %br
   %span.cancellation_cost
-  = hidden_field_tag "price_policy_#{pg.id}[cancellation_cost]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:cancellation_cost] : number_to_currency(pp.cancellation_cost, :unit => ''), :size => 8, :class => 'cancellation_cost'
+  = hidden_field_tag "price_policy_#{pg.id}[cancellation_cost]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:cancellation_cost] : number_to_currency(pp.cancellation_cost, :unit => '', :delimiter => ''), :size => 8, :class => 'cancellation_cost'

--- a/app/views/price_policies/instrument/_master_internal_row.html.haml
+++ b/app/views/price_policies/instrument/_master_internal_row.html.haml
@@ -1,20 +1,20 @@
 %td
   Rate
   %br
-  = text_field_tag "price_policy_#{pg.id}[usage_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:usage_rate] : number_to_currency(pp.usage_rate, :unit => ''), :size => 8, :class => 'master_usage_cost'
+  = text_field_tag "price_policy_#{pg.id}[usage_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:usage_rate] : number_to_currency(pp.usage_rate, :unit => '', :delimiter => ''), :size => 8, :class => 'master_usage_cost'
 %td
   Rate
   %br
-  = text_field_tag "price_policy_#{pg.id}[reservation_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:reservation_rate] : number_to_currency(pp.reservation_rate, :unit => ''), :size => 8, :class => 'master_reservation_cost'
+  = text_field_tag "price_policy_#{pg.id}[reservation_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:reservation_rate] : number_to_currency(pp.reservation_rate, :unit => '', :delimiter => ''), :size => 8, :class => 'master_reservation_cost'
 %td
   Rate
   %br
-  = text_field_tag "price_policy_#{pg.id}[overage_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:overage_rate] : number_to_currency(pp.overage_rate, :unit => ''), :size => 8, :class => 'master_overage_cost'
+  = text_field_tag "price_policy_#{pg.id}[overage_rate]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:overage_rate] : number_to_currency(pp.overage_rate, :unit => '', :delimiter => ''), :size => 8, :class => 'master_overage_cost'
 %td
   Amount
   %br
-  = text_field_tag "price_policy_#{pg.id}[minimum_cost]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:minimum_cost] : number_to_currency(pp.minimum_cost, :unit => ''), :size => 8, :class => 'master_minimum_cost'
+  = text_field_tag "price_policy_#{pg.id}[minimum_cost]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:minimum_cost] : number_to_currency(pp.minimum_cost, :unit => '', :delimiter => ''), :size => 8, :class => 'master_minimum_cost'
 %td
   Amount
   %br
-  = text_field_tag "price_policy_#{pg.id}[cancellation_cost]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:cancellation_cost] : number_to_currency(pp.cancellation_cost, :unit => ''), :size => 8, :class => 'master_cancellation_cost'
+  = text_field_tag "price_policy_#{pg.id}[cancellation_cost]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:cancellation_cost] : number_to_currency(pp.cancellation_cost, :unit => '', :delimiter => ''), :size => 8, :class => 'master_cancellation_cost'


### PR DESCRIPTION
Submitting price rules with default values >= 1,000 fails because of the comma. Don't add the comma.

Task #74657 :: Text change to Reservation Cost error
