### PR TITLE
Fix for next_available_reservation stack overflow

### DIFF
--- a/app/support/products/scheduling_support.rb
+++ b/app/support/products/scheduling_support.rb
@@ -75,6 +75,9 @@ module Products::SchedulingSupport
   # find the next available reservation based on schedule rules and existing reservations
   def next_available_reservation(after = Time.zone.now, duration = 1.minute, options = {})
     rules = rules_for_day after.wday, options[:user]
+    # if the user has no schedule rules, there will be no time that they can
+    # move the reservation to
+    return nil unless rules.any?
     reservation_in_week after, duration, rules, options
   end
 
@@ -90,6 +93,7 @@ module Products::SchedulingSupport
   private
 
   def reservation_in_week(after, duration, rules, options)
+
     day_of_week = after.wday
 
     0.upto(6) do |i|
@@ -103,6 +107,7 @@ module Products::SchedulingSupport
 
       # advance to start of next day
       after = after.end_of_day + 1.second
+      return nil if options[:until] && after >= options[:until]
     end
 
     # no availability found in this week; check next week

--- a/app/support/reservations/moving_up.rb
+++ b/app/support/reservations/moving_up.rb
@@ -7,9 +7,12 @@ module Reservations::MovingUp
   # if there is no such time slot. For read-only purposes.
   def earliest_possible
     after = 1.minute.from_now
-
-    next_res = product.next_available_reservation(after, duration_mins.minutes, :exclude => self, :user => user)
-    return nil if next_res.nil? || next_res.reserve_start_at > reserve_start_at
+    next_res = product.next_available_reservation(after,
+                                                  duration_mins.minutes,
+                                                  exclude: self,
+                                                  user: user,
+                                                  until: reserve_start_at)
+    return nil if next_res.nil? || next_res.reserve_start_at >= reserve_start_at
     next_res
   end
 


### PR DESCRIPTION
- Fail immediately if user has no scheduling rules.
- Support :until parameter so it doesn’t go too far out
