### PR TITLE
[#79913] "Begin Now" appears alongside "End Reservation"

### DIFF
--- a/app/support/reservations/moving_up.rb
+++ b/app/support/reservations/moving_up.rb
@@ -36,6 +36,6 @@ module Reservations::MovingUp
   # returns true if this reservation can be moved to
   # an earlier time slot, false otherwise
   def can_move?
-    !(cancelled? || order_detail.complete? || earliest_possible.nil?)
+    !(cancelled? || order_detail.complete? || in_grace_period? || earliest_possible.nil?)
   end
 end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -216,6 +216,14 @@ describe Reservation do
         (earliest.reserve_end_at-earliest.reserve_start_at).should == (@reservation1.reserve_end_at-@reservation1.reserve_start_at)
       end
 
+      it 'should not be moveable if the reservation is in the grace period' do
+        @instrument.update_attributes(reserve_interval: 1)
+        @reservation1.duration_mins = 1
+        Timecop.freeze(@reservation1.reserve_start_at - 4.minutes) do
+          expect(@reservation1).to_not be_can_move
+        end
+      end
+
       it 'should not be moveable if the reservation is cancelled' do
         @reservation1.should be_can_move
         @reservation1.canceled_at=Time.zone.now


### PR DESCRIPTION
You should not be able to move forward if you are in the grace period. 

Only happening on 1-minute interval instruments.
