### PR TITLE
prevents the "begin now" link from showing at the same time as the "begin reservation" link

### DIFF
--- a/app/presenters/reservation_user_action_presenter.rb
+++ b/app/presenters/reservation_user_action_presenter.rb
@@ -17,9 +17,14 @@ class ReservationUserActionPresenter
 
   def user_actions
     actions = []
-    actions << switch_actions if can_switch_instrument?
+
+    if can_switch_instrument?
+      actions << switch_actions
+    elsif can_move?
+      actions << move_link
+    end
+
     actions << cancel_link if can_cancel?
-    actions << move_link if can_move?
     actions.compact.join('&nbsp;|&nbsp;').html_safe
   end
 


### PR DESCRIPTION
Ran into the attached problem while looking at PR #101. This fixes it. If you can switch an instrument you shouldn't see the "Begin now" link.

![screen shot 2014-03-03 at 11 53 54 am](https://f.cloud.github.com/assets/569564/2313436/9190f600-a309-11e3-81a7-381d6436ae1a.png)
