### PR TITLE
[#80149] Fix reports default dates

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -29,19 +29,18 @@ class ReportsController < ApplicationController
 
 
   def init_report_params
-    @date_start = params[:date_start].presence && parse_usa_date(params[:date_start])
+    @date_start = parse_usa_date(params[:date_start])
     if @date_start.blank?
       @date_start = (Time.zone.now - 1.month).beginning_of_month
     else
-      @date_start=parse_usa_date(params[:date_start]).beginning_of_day
+      @date_start = @date_start.beginning_of_day
     end
 
-    @date_end = params[:date_end].presence && parse_usa_date(params[:date_end])
+    @date_end = parse_usa_date(params[:date_end])
     if @date_end.blank?
-      @date_end=@date_start + 42.days
-      @date_end=Date.new(@date_end.year, @date_end.month) - 1.day
+      @date_end = @date_start.end_of_month
     else
-      @date_end=@date_end.end_of_day
+      @date_end = @date_end.end_of_day
     end
   end
 

--- a/spec/controllers/general_reports_controller_spec.rb
+++ b/spec/controllers/general_reports_controller_spec.rb
@@ -14,6 +14,39 @@ describe GeneralReportsController do
     { :action => :price_group, :index => 4, :report_on_label => 'Name', :report_on => Proc.new{|od| od.price_policy ? od.price_policy.price_group.name : 'Unassigned'} }
   ])
 
+  describe 'time parameters', :timecop_freeze do
+    let(:now) { Time.zone.parse('2014-03-06 12:00') }
+
+    before do
+      allow(controller).to receive(:authenticate_user!).and_return true
+      allow(controller).to receive(:current_user).and_return build_stubbed(:user) #mock_model(User, administrator?: true, operator?: true, full_name: 'name')
+      allow(controller).to receive(:current_facility).and_return mock_model(Facility)
+    end
+
+    context 'defaults' do
+      before { get :product }
+
+      it 'assigns the proper start date' do
+        expect(assigns(:date_start)).to eq(Time.zone.local(2014, 2, 1))
+      end
+
+      it 'assigns the proper end date' do
+        expect(assigns(:date_end).to_i).to eq(Time.zone.local(2014, 2, 28, 23, 59, 59).to_i)
+      end
+    end
+
+    context 'with date parameters' do
+      before { get :product, date_start: '01/01/2014', date_end: '01/31/2014' }
+
+      it 'assigns the start date to the beginning of the day' do
+        expect(assigns(:date_start)).to eq(Time.zone.local(2014, 1, 1))
+      end
+
+      it 'assigns the end date to the end of the day' do
+        expect(assigns(:date_end).to_i).to eq(Time.zone.local(2014, 1, 31, 23, 59, 59).to_i)
+      end
+    end
+  end
 
   context 'report searching' do
     before :each do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,9 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 
   config.around(:each, :timecop_freeze) do |example|
-    Timecop.freeze do
+    # freeze time to specific time by defining let(:now)
+    time = defined?(now) ? now : Time.zone.now
+    Timecop.freeze time do
       example.call
     end
   end


### PR DESCRIPTION
Default end date was not end_of_day, and not in app timezone.
