### PR TITLE
Clean up rspec deprecations

### DIFF
--- a/spec/lib/status_change_notifications_spec.rb
+++ b/spec/lib/status_change_notifications_spec.rb
@@ -29,8 +29,8 @@ describe StatusChangeNotifications do
   private
 
   def notifier_should_receive_email(email)
-    Notifier.should_receive(:order_detail_status_change).with(@order_detail, @initial_order_status, @order_status, email).once.and_return(stub(:deliver => true))
+    expect(Notifier).to receive(:order_detail_status_change).with(@order_detail, @initial_order_status, @order_status, email).once.and_return(double deliver: true)
     @order_detail.change_status!(@order_status)
   end
-  
+
 end

--- a/spec/models/order_import_spec.rb
+++ b/spec/models/order_import_spec.rb
@@ -319,7 +319,7 @@ end
         @order_import.save!
 
         # expectations
-        Notifier.should_receive(:order_receipt).once.and_return( stub({:deliver => nil }) )
+        expect(Notifier).to receive(:order_receipt).once.and_return(double(deliver: nil))
 
         # run the import
         @order_import.process!
@@ -362,7 +362,7 @@ end
           @order_import.save!
 
           # expectations
-          Notifier.should_receive(:order_receipt).once.and_return( stub({:deliver => nil }) )
+          expect(Notifier).to receive(:order_receipt).once.and_return(double(deliver: nil))
 
           # run the import
           @order_import.process!
@@ -448,7 +448,7 @@ end
       end
 
       it "should send out notification for second order" do
-        Notifier.should_receive(:order_receipt).once.and_return( stub({:deliver => nil }) )
+        expect(Notifier).to receive(:order_receipt).once.and_return(double(deliver: nil))
         @order_import.process!
       end
 


### PR DESCRIPTION
Remove deprecations for “stub is deprecated. Use double instead.”
