### PR TITLE
Whether or not a relay is enabled should be configurable and not environment dependent

### DIFF
--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -141,7 +141,7 @@ class InstrumentsController < ProductsCommonController
       relay = @instrument.relay
       status=true
 
-      if SettingsHelper.relays_enabled?
+      if SettingsHelper.relays_enabled_for_admin?
         status = (params[:switch] == 'on' ? relay.activate : relay.deactivate)
       end
 

--- a/app/support/reservation_instrument_switcher.rb
+++ b/app/support/reservation_instrument_switcher.rb
@@ -47,7 +47,7 @@ class ReservationInstrumentSwitcher
   end
 
   def relays_enabled?
-    SettingsHelper.relays_enabled?
+    SettingsHelper.relays_enabled_for_reservation?
   end
 
   def instrument

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -57,13 +57,17 @@ relays:
   # can also be NetBooter::Telnet
   connect_module: NetBooter::Http
   test:
-    enabled: false
+    admin_enabled: false
+    reservation_enabled: false
   development:
-    enabled: false
+    admin_enabled: false
+    reservation_enabled: false
   staging:
-    enabled: true
+    admin_enabled: true
+    reservation_enabled: false
   production:
-    enabled: true
+    admin_enabled: true
+    reservation_enabled: true
 #
 # For these settings use SettingsHelper#feature_on?
 feature:

--- a/lib/settings_helper.rb
+++ b/lib/settings_helper.rb
@@ -19,8 +19,12 @@ module SettingsHelper
     Settings.billing.review_period > 0
   end
 
-  def self.relays_enabled?
-    setting "relays.#{Rails.env}.enabled"
+  def self.relays_enabled_for_admin?
+    setting "relays.#{Rails.env}.admin_enabled"
+  end
+
+  def self.relays_enabled_for_reservation?
+    setting "relays.#{Rails.env}.reservation_enabled"
   end
 
   #


### PR DESCRIPTION
UIC's relays aren't working on stage because `ReservationInstrumentSwitcher#relays_enabled?` is only ever true in environment "production". Admin reservations worked, however, because `InstrumentsController#switch` enabled for all environments except test. This PR determines whether or not a relay is enabled by looking at a setting, not environment.
