### PR TITLE
make sure ExternalServiceReceiver type is stored

### DIFF
--- a/app/models/external_service/survey_response.rb
+++ b/app/models/external_service/survey_response.rb
@@ -14,6 +14,7 @@ class SurveyResponse
 
     ExternalServiceReceiver.transaction do
       receiver = ExternalServiceReceiver.find_or_initialize_by_receiver_id_and_external_service_id od.id, external_service.id
+      receiver.receiver = od # must assign so receiver type is stored
       receiver.response_data = response_data
       receiver.save!
       od.merge!


### PR DESCRIPTION
This will fix CI, and this is one reason why my original version of PR #114 didn't use `find_or_initialize_by`. You have to explicitly assign the receiver; you can't just assign the id. That's because we need Rails to store the receiver type in external_service_receivers table. I forgot about that until I debugged CI.
