### PR TITLE
allow searching on lowercase prefixes

### DIFF
--- a/app/support/order_searcher.rb
+++ b/app/support/order_searcher.rb
@@ -8,7 +8,7 @@ class OrderSearcher
 
     if query =~ /\d+-\d+/
       relation = search_full(query)
-    elsif query =~ /[A-Z]+-\d+/
+    elsif query =~ /[A-Za-z]+-\d+/
       relation = search_external query
     elsif query =~ /\d+/
       relation = OrderDetail.where("order_details.id = :id OR order_details.order_id = :id", :id => query)

--- a/spec/app_support/order_searcher_spec.rb
+++ b/spec/app_support/order_searcher_spec.rb
@@ -12,4 +12,10 @@ describe OrderSearcher do
     expect(searcher.search(nil)).to eq []
   end
 
+  it 'searches externally when lowercase prefix is given' do
+    query = 'cx-36'
+    expect(searcher).to receive(:search_external).with query
+    searcher.search query
+  end
+
 end


### PR DESCRIPTION
This fixes all of the  "order_search#index (ActiveRecord::StatementInvalid)" errors that recently came in from stage.
