### PR TITLE
Handle 2 digit years in import data

### DIFF
--- a/app/models/budgeted_chart_string.rb
+++ b/app/models/budgeted_chart_string.rb
@@ -5,14 +5,14 @@ class BudgetedChartString < ActiveRecord::Base
   validates_length_of   :project, :is => 8, :allow_blank => true
   validates_length_of   :activity, :is => 2, :allow_blank => true
   validates_length_of   :account, :is => 5, :allow_blank => true
-  
+
   def self.import(filename)
     file = File.open(filename, 'r') rescue nil
     if file.blank?
       puts "error: Invalid file #{filename}"
       return
     end
-    
+
     deleted   = self.count
     imported  = 0
     skipped   = 0
@@ -72,6 +72,7 @@ class BudgetedChartString < ActiveRecord::Base
     end
   end
 
+  # Parses strings of the format DDMMMYY (e.g. 31AUG08) to dates
   def self.parse_2_digit_year_date(date_string)
     Time.zone.parse(date_string.sub(/\A(\d{1,2})([A-Z]{3})(\d\d)\z/, '\1 \2 20\3'))
   end

--- a/spec/models/budgeted_chart_string_spec.rb
+++ b/spec/models/budgeted_chart_string_spec.rb
@@ -48,4 +48,18 @@ describe BudgetedChartString do
       assert_equal "2105600", @bcs2.dept
     end
   end
+
+  context 'Parsing dates with 2-digit years' do
+    def parse_date(date_string)
+      BudgetedChartString.parse_2_digit_year_date(date_string).strftime('%Y%m%d')
+    end
+
+    it 'should parse strings as 21st century dates' do
+      expect(parse_date('1JAN00')).to eq('20000101')
+      expect(parse_date('08JUN04')).to eq('20040608')
+      expect(parse_date('31DEC14')).to eq('20141231')
+      expect(parse_date('31MAR49')).to eq('20490331')
+      expect(parse_date('05FEB99')).to eq('20990205')
+    end
+  end
 end


### PR DESCRIPTION
This should allow budgeted_chart_string_spec to pass again.
