### PR TITLE
Price Policy coffeescript updates

### DIFF
--- a/app/assets/javascripts/price_policy.js.coffee
+++ b/app/assets/javascripts/price_policy.js.coffee
@@ -42,7 +42,7 @@ $(document).ready ->
     if isFiniteAndPositive(usageAdjustment) then usageAdjustment else 0
 
   setUsageSubsidy = (usageAdjustmentElement, usageSubsidy)->
-    $(usageAdjustmentElement).parents("tr").find("span.minimum_cost").data("usageSubsidy", usageSubsidy.toFixed(2))
+    $(usageAdjustmentElement).parents("tr").find("span.minimum_cost").data("usageSubsidy", usageSubsidy)
 
   refreshCosts = ->
     $(".master_minimum_cost").each (index, element)-> setInternalCost element


### PR DESCRIPTION
This addresses two issues from the previous change (and obsoletes PR #131):
- Subsidies should apply to a single policy row and not affect others
- Minimum cost values should be to the penny

Still outstanding: subsidized minimum costs display just as values, not as calculations (that is: "$80.00" instead of something along the lines of "$100.00 - $20.00 subsidy = $80.00")
