### PR TITLE
Update minimums on keyup, for consistency

### DIFF
--- a/app/assets/javascripts/price_policy.js.coffee
+++ b/app/assets/javascripts/price_policy.js.coffee
@@ -71,7 +71,7 @@ $(document).ready ->
     toggleGroupFields $(this)
   ).trigger("change")
 
-  $("input[type=text]").change(->
+  $("input[type=text]").keyup(->
     setInternalCost this
     $(".usage_adjustment").each -> updateUsageSubsidy(this)
-  ).trigger("change").keyup(-> setInternalCost(this))
+  ).trigger("keyup")


### PR DESCRIPTION
This changes the `change` handler into a `keyup` to match the other related handlers. It tightened up the code a bit as a nice side-effect.

I think this means it's possible to (say) paste a value into a field and not have the event fire. We could work around it by triggering it on change as well, or maybe on form submit, if it's an issue we might run into.
