### PR TITLE
Disambiguate sort columns (for Oracle)

### DIFF
--- a/vendor/engines/c2po/lib/c2po/facility_accounts_controller_extension.rb
+++ b/vendor/engines/c2po/lib/c2po/facility_accounts_controller_extension.rb
@@ -80,7 +80,11 @@ module C2po
 
     def get_unreconciled_details
       OrderDetail
-        .order([:account_id, :statement_id, :order_id, :id])
+        .order(%w(
+          orders.account_id
+          order_details.statement_id
+          order_details.order_id
+          order_details.id))
         .account_unreconciled(current_facility, @selected)
         .paginate(page: params[:page])
     end


### PR DESCRIPTION
MySQL was OK with the way it was but Oracle found the columns ambiguous. Specs that were failing under Oracle pass for me with this (and pass with MySQL as well).
