### PR TITLE
Handle reports where there are no reservations [#82279]

### DIFF
--- a/app/models/reports/instrument_day_report.rb
+++ b/app/models/reports/instrument_day_report.rb
@@ -36,7 +36,7 @@ class Reports::InstrumentDayReport
     end
 
     def to_ary
-      @data.map { |value| @report_type.transform(value) }
+      @data.map { |value| @report_type.try(:transform, value) }
     end
   end
 


### PR DESCRIPTION
This should resolve the situation where the "Actual Hours" tab under `/facilities/[:id]/instrument_reports/instrument` would error out when there were no reservations.
