### PR TITLE
Destroy statements when their rows are gone [#86773]

### DIFF
--- a/app/models/statement_row.rb
+++ b/app/models/statement_row.rb
@@ -4,6 +4,9 @@ class StatementRow < ActiveRecord::Base
 
   validates_presence_of :order_detail_id, :statement_id
 
+  before_destroy { @parent_statement = self.statement }
+  after_destroy { @parent_statement.destroy if @parent_statement.statement_rows.empty? }
+
   def amount
     order_detail.total
   end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -1,82 +1,79 @@
 require 'spec_helper'
 
 describe Statement do
-  before :each do
-    @facility=FactoryGirl.create(:facility)
-    @user=FactoryGirl.create(:user)
-    @account=FactoryGirl.create(:nufs_account, :account_users_attributes => account_users_attributes_hash(:user => @user))
-  end
+  subject(:statement) { create(:statement, account: account, created_by: user.id, facility: facility) }
 
-  it "can be created with valid attributes" do
-    @statement = Statement.create({:facility => @facility, :created_by => 1, :account => @account})
-    @statement.should be_valid
-  end
+  let(:account) { create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: user)) }
+  let(:facility) { create(:facility) }
+  let(:user) { create(:user) }
 
-  context "finalized_at" do
-    before :each do
-      @facility  = FactoryGirl.create(:facility)
-      @statement = Statement.create({:facility => @facility, :created_by => 1})
+  context 'when missing required attributes' do
+    context 'without created_by' do
+      let(:invalid_statement) { Statement.new(created_by: nil, facility: facility) }
+
+      it 'should be invalid' do
+        expect(invalid_statement).to_not be_valid
+        expect(invalid_statement.errors[:created_by]).to be_present
+      end
+    end
+
+    context 'without facility' do
+      let(:invalid_statement) { Statement.new(created_by: user.id, facility_id: nil) }
+
+      it 'should be invalid' do
+        expect(invalid_statement).to_not be_valid
+        expect(invalid_statement.errors[:facility_id]).to be_present
+      end
     end
   end
 
-  it "requires created_by" do
-    @statement = Statement.new({:created_by => nil})
-    @statement.should_not be_valid
-    @statement.errors[:created_by].should_not be_nil
-
-    @statement = Statement.new({:created_by => 1})
-    @statement.valid?
-    @statement.errors[:created_by].should be_empty
-  end
-
-  it "requires a facility" do
-    @statement = Statement.new({:facility_id => nil})
-    @statement.should_not be_valid
-    @statement.errors[:facility_id].should_not be_nil
-
-    @statement = Statement.new({:facility_id => 1})
-    @statement.valid?
-    @statement.errors[:facility_id].should be_empty
+  context 'with valid attributes' do
+    it 'should be valid' do
+      expect(statement).to be_valid
+      expect(statement.errors).to be_blank
+    end
   end
 
   context 'with order details' do
     before :each do
-      @statement = Statement.create({:facility => @facility, :created_by => 1, :account => @account})
       @order_details = []
       3.times do
-        @order_details << place_and_complete_item_order(@user, @facility, @account, true)
+        @order_details << place_and_complete_item_order(user, facility, account, true)
         # @item is set by place_and_complete_item_order, so we need to define it as open
         # for each one
-        define_open_account(@item.account, @account.account_number)
+        define_open_account(@item.account, account.account_number)
       end
-      @order_details.each { |od| @statement.add_order_detail(od) }
+      @order_details.each { |od| statement.add_order_detail(od) }
     end
 
     context 'with the ordered_at switched up' do
       before :each do
-        @order_details[0].order.update_attributes(:ordered_at => 2.days.ago)
-        @order_details[1].order.update_attributes(:ordered_at => 3.days.ago)
-        @order_details[2].order.update_attributes(:ordered_at => 1.day.ago)
+        @order_details[0].order.update_attributes(ordered_at: 2.days.ago)
+        @order_details[1].order.update_attributes(ordered_at: 3.days.ago)
+        @order_details[2].order.update_attributes(ordered_at: 1.day.ago)
       end
+
       it 'should return the first date' do
-        @statement.first_order_detail_date.should == @order_details[1].ordered_at
+        expect(statement.first_order_detail_date).to eq @order_details[1].ordered_at
       end
     end
 
     it 'should set the statement_id of each order detail' do
-      @order_details.each { |od| od.statement_id.should_not be_nil }
+      @order_details.each do |order_detail|
+        expect(order_detail.statement_id).to be_present
+      end
     end
 
     it 'should have 3 order_details' do
-      @statement.order_details.size.should == 3
+      expect(statement.order_details.size).to eq 3
     end
 
     it 'should have 3 rows' do
-      @statement.statement_rows.size.should == 3
+      expect(statement.statement_rows.size).to eq 3
     end
 
     it 'should not be reconciled' do
-      @statement.should_not be_reconciled
+      expect(statement).to_not be_reconciled
     end
 
     context 'with one order detail reconciled' do
@@ -85,17 +82,27 @@ describe Statement do
       end
 
       it 'should not be reconciled' do
-        @statement.should_not be_reconciled
+        expect(statement).to_not be_reconciled
       end
     end
 
     context 'with all order_details reconciled' do
       before :each do
-        @order_details.each { |od| od.to_reconciled! }
+        @order_details.each(&:to_reconciled!)
       end
 
       it 'should be reconciled' do
-        @statement.should be_reconciled
+        expect(statement).to be_reconciled
+      end
+    end
+
+    context '#remove_order_detail' do
+      it 'is destroyed when it no longer has any statement_rows' do
+        @order_details.each do |order_detail|
+          statement.remove_order_detail(order_detail)
+        end
+
+        expect { statement.reload }.to raise_error ActiveRecord::RecordNotFound
       end
     end
   end


### PR DESCRIPTION
The change in 6e8d3d0 should address the issue raised in the ticket (statements existing with no rows), but testing it is another thing.

I marked the first version of the `#remove_order_detail` spec "pending" because I don't know why `destroyed?` returns false in that case. I've verified that the `after_destroy` in `StatementRow` is executing, and the statement seems to be getting destroyed when examining it with `pry`. I ended up adding the `statement.reload` version of the test, but any insight on that appreciated.
