### PR TITLE
Call clear_statement for cancellations without reservations [#86774]

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -388,6 +388,7 @@ class OrderDetail < ActiveRecord::Base
     if reservation && order_status.root == OrderStatus.cancelled.first
       cancel_reservation(updated_by, order_status, options[:admin], options[:apply_cancel_fee])
     else
+      clear_statement if order_status.root == OrderStatus.cancelled.first
       change_status! order_status, &block
     end
   end


### PR DESCRIPTION
This should resolve the problem when a statemented order_detail with no reservation being cancelled was not also clearing its statement.
