### PR TITLE
Handle explicit nil argument in #update_approvals [#73573]

### DIFF
--- a/app/support/product_approver.rb
+++ b/app/support/product_approver.rb
@@ -36,7 +36,8 @@ class ProductApprover
     @approver = approver
   end
 
-  def update_approvals(products_to_approve, access_group_hash = {})
+  def update_approvals(products_to_approve, access_group_hash = nil)
+    access_group_hash ||= {}
     @all_products.each_with_object(Stats.new) do |product, stats|
       if products_to_approve.include?(product)
         approve_access(product) && stats.grant

--- a/spec/app_support/product_approver_spec.rb
+++ b/spec/app_support/product_approver_spec.rb
@@ -54,13 +54,73 @@ describe ProductApprover do
       end
     end
 
-    it 'has no changes' do
-      stats = product_approver.update_approvals([], {})
+    shared_examples 'no grants were changed' do
+      it 'does not change grants' do
+        expect(stats).not_to be_grants_changed
+      end
 
-      expect(stats).not_to be_grants_changed
-      expect(stats.granted).to eq 0
-      expect(stats.revoked).to eq 0
-      expect(stats).not_to be_access_groups_changed
+      it 'makes no grants' do
+        expect(stats.granted).to eq 0
+      end
+
+      it 'makes no revocations' do
+        expect(stats.revoked).to eq 0
+      end
+    end
+
+    shared_examples 'no access group changes were made' do
+      it 'changes no access groups' do
+        expect(stats).not_to be_access_groups_changed
+      end
+    end
+
+    context 'with no changes' do
+      context 'with an empty access_group_hash' do
+        let(:stats) { product_approver.update_approvals([]) }
+
+        it_behaves_like 'no grants were changed'
+        it_behaves_like 'no access group changes were made'
+      end
+
+      context 'with a nil access_group_hash' do
+        let(:stats) { product_approver.update_approvals([], nil) }
+
+        it_behaves_like 'no grants were changed'
+        it_behaves_like 'no access group changes were made'
+      end
+    end
+
+    shared_examples 'grants were changed' do |expected_grants, expected_revocations|
+      it 'changed grants' do
+        expect(stats).to be_grants_changed
+      end
+
+      it 'made the expected number of grants' do
+        expect(stats.granted).to eq expected_grants
+      end
+
+      it 'made the expected number of revocations' do
+        expect(stats.revoked).to eq expected_revocations
+      end
+    end
+
+    context 'without access groups' do
+      let(:products_to_approve) { all_products[0..3] }
+      let(:stats) { product_approver.update_approvals(products_to_approve, access_group_hash) }
+
+      context 'with an empty access_group_hash' do
+        let(:access_group_hash) { {} }
+
+        it_behaves_like 'grants were changed', 4, 0
+        it_behaves_like 'no access group changes were made'
+      end
+
+      context 'with a nil access_group_hash' do
+        let(:access_group_hash) { nil }
+
+        it_behaves_like 'grants were changed', 4, 0
+        it_behaves_like 'no access group changes were made'
+      end
     end
 
     context 'with access groups' do


### PR DESCRIPTION
This works around a situation I ran into when testing on the NU fork: If the none of the products on the access list form have scheduling groups, `param[:product_access_group]` is `nil`. This explicit `nil` would get passed as the `access_group_hash` argument to `#update_approvals`, and would throw an exception when trying to use it as a hash.
