### PR TITLE
Change instrument reservations to chronological

### DIFF
--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -83,7 +83,7 @@ class InstrumentsController < ProductsCommonController
 
   # GET /instruments/1/schedule
   def schedule
-    @admin_reservations = @instrument.schedule.reservations.find(:all, :conditions => ['reserve_end_at > ? AND order_detail_id IS NULL', Time.zone.now])
+    @admin_reservations = @instrument.schedule.reservations.where('reserve_end_at > ? AND order_detail_id IS NULL', Time.zone.now).order("reserve_start_at ASC")
   end
 
   def public_schedule


### PR DESCRIPTION
Admin Reservations should appear chronologically on the "Reservations" page for an Instrument.
