### PR TITLE
Add empty text to the text/plain section [#87160]

### DIFF
--- a/app/mailers/export_raw_report_mailer.rb
+++ b/app/mailers/export_raw_report_mailer.rb
@@ -3,7 +3,9 @@ class ExportRawReportMailer < ActionMailer::Base
 
   def raw_report_email(to_address, report)
     attachments[report.filename] = report.to_csv
-    mail(to: to_address, subject: report.description)
+    mail(to: to_address, subject: report.description) do |format|
+      format.text { render(text: "") }
+    end
   end
 
   def mail(arguments)


### PR DESCRIPTION
Without this, the MIME formatting was invalid (at least for GMail).
