### PR TITLE
Fix locale key name

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -359,7 +359,7 @@ en:
   reservations:
     logout:
       body: "You will be logged out automatically in 60 seconds. Would you like to remain logged in?"
-      cancel_button: "Stay logged in"
+      cancel: "Stay logged in"
     new:
       label: "Payment source"
       documentation: "Documentation"


### PR DESCRIPTION
This makes the translation key to match how it's used in the `reservations/list` partial.
