### PR TITLE
[#88851] Sort past and upcoming price policies

### DIFF
--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -20,8 +20,8 @@ class PricePoliciesController < ApplicationController
   def index
     @current_price_policies = @product.price_policies.current
     @current_start_date = @current_price_policies.first ? @current_price_policies.first.start_date : nil
-    @past_price_policies_by_date = @product.price_policies.past.group_by(&:start_date)
-    @next_price_policies_by_date = @product.price_policies.upcoming.group_by(&:start_date)
+    @past_price_policies_by_date = @product.past_price_policies_grouped_by_start_date
+    @next_price_policies_by_date = @product.upcoming_price_policies_grouped_by_start_date
     render 'price_policies/index'
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -71,6 +71,22 @@ class Product < ActiveRecord::Base
     price_policies.current_for_date(date).purchaseable
   end
 
+  def past_price_policies
+    price_policies.past
+  end
+
+  def past_price_policies_grouped_by_start_date
+    past_price_policies.order("start_date DESC").group_by(&:start_date)
+  end
+
+  def upcoming_price_policies
+    price_policies.upcoming
+  end
+
+  def upcoming_price_policies_grouped_by_start_date
+    upcoming_price_policies.order("start_date ASC").group_by(&:start_date)
+  end
+
   def <=> (obj)
     name.casecmp obj.name
   end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Product do
-
   subject(:product) { create(:instrument_requiring_approval) }
 
   let(:access_group) { create(:product_access_group, product: product) }
@@ -51,8 +50,74 @@ describe Product do
 
   end
 
-  context 'current_price_policies' do
-    it "should return all current price policies"
+  context "with price policies" do
+    subject(:instrument) { create(:instrument_requiring_approval) }
+
+    before { instrument.price_policies.each(&:delete) }
+
+    let!(:current_price_policies) do
+      3.times.map do
+        create(:instrument_price_policy,
+          product: instrument,
+          start_date: 3.days.ago,
+          expire_date: 3.days.from_now,
+        )
+      end
+    end
+
+    let!(:past_price_policies) do
+      [4,1,5,3,2].map do |n|
+        create(:instrument_price_policy,
+          product: instrument,
+          start_date: n.months.ago,
+          expire_date: n.months.ago + 2.weeks,
+        )
+      end
+    end
+
+    let!(:upcoming_price_policies) do
+      [4,1,5,3,2].map do |n|
+        create(:instrument_price_policy,
+          product: instrument,
+          start_date: n.months.from_now,
+          expire_date: n.months.from_now + 2.weeks,
+        )
+      end
+    end
+
+    context "#current_price_policies" do
+      it "returns current price policies" do
+        expect(instrument.current_price_policies).to eq current_price_policies
+      end
+    end
+
+    context "#past_price_policies" do
+      it "returns past_price_policies" do
+        expect(instrument.past_price_policies).to eq past_price_policies
+      end
+    end
+
+    context "#past_price_policies_grouped_by_start_date" do
+      let(:policies) { instrument.past_price_policies_grouped_by_start_date }
+
+      it "groups and sorts policies in descending chronological order" do
+        expect(policies.keys).to eq policies.keys.sort.reverse
+      end
+    end
+
+    context "#upcoming_price_policies" do
+      it "returns upcoming_price_policies" do
+        expect(instrument.upcoming_price_policies).to eq upcoming_price_policies
+      end
+    end
+
+    context "#upcoming_price_policies_grouped_by_start_date" do
+      let(:policies) { instrument.upcoming_price_policies_grouped_by_start_date }
+
+      it "groups and sorts policies in ascending chronological order" do
+        expect(policies.keys).to eq policies.keys.sort
+      end
+    end
   end
 
   context 'email' do


### PR DESCRIPTION
For display, past price policies are listed in descending chronological order, while upcoming policies are in ascending chronological order.
