### PR TITLE
[#90838] Apply datepicker to class instead of ID

### DIFF
--- a/app/assets/javascripts/accounts.js
+++ b/app/assets/javascripts/accounts.js
@@ -16,7 +16,7 @@ $(function(){
     $('.affiliate_other').toggle($('.affiliate:visible option:selected').text() == 'Other')
   }
 
-  $("#datepicker").datepicker({minDate:+0, maxDate:'+3y', dateFormat: 'mm/dd/yy'});
+  $(".datepicker").datepicker({minDate:+0, maxDate:'+3y', dateFormat: 'mm/dd/yy'});
 
   $("#class_type").change(function() {
     toggleInputs();


### PR DESCRIPTION
I'm not aware of any elements that have an ID `datepicker` so I think the intent was to apply to the class all along.
