### PR TITLE
[#89151] Update Journal total when OrderDetail actual_cost changes

### DIFF
--- a/app/models/journal_row.rb
+++ b/app/models/journal_row.rb
@@ -6,4 +6,8 @@ class JournalRow < ActiveRecord::Base
   validates_presence_of :account if SettingsHelper.feature_on? :expense_accounts
 
   delegate :fulfilled_at, to: :order_detail, allow_nil: true
+
+  def update_amount
+    update_attributes(amount: order_detail.actual_cost)
+  end
 end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -21,6 +21,7 @@ class OrderDetail < ActiveRecord::Base
 
   before_save :clear_statement, if: :account_id_changed?
   before_save :reassign_price, if: lambda { |o| o.account_id_changed? || o.quantity_changed? }
+  before_save :update_journal_row_amounts, if: :actual_cost_changed?
 
   before_save :set_problem_order
   def set_problem_order
@@ -607,6 +608,10 @@ class OrderDetail < ActiveRecord::Base
     elsif actual_cost
       assign_actual_price
     end
+  end
+
+  def update_journal_row_amounts
+    journal_rows.each(&:update_amount)
   end
 
   def assign_estimated_price(second_account=nil, date = Time.zone.now)


### PR DESCRIPTION
Currently, journal totals (through summing `journal_row` `amount` values) are set when created. This should update the journal totals whenever the actual costs of its `order_details` change.
