### PR TITLE
[#89493 ] Remove order forms from transaction tables

### DIFF
--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -37,7 +37,15 @@
         - if !current_facility || all_facility?
 
           %td= order_detail.order.facility
-        = render :partial => 'shared/order_detail_cell', :locals => { :od => order_detail }
+        %td.user-order-detail
+          .order-detail-description
+            = order_detail_description(order_detail)
+            - if order_detail.reservation
+              %br
+              %em= order_detail.reservation
+          - if order_detail.note.present?
+            .order-detail-extra.order-detail-note= "Note: #{order_detail.note}"
+
 
         %td= order_detail.order.user.full_name
         -# %td= order_detail.order.created_by_user.full_name

--- a/lib/transaction_search.rb
+++ b/lib/transaction_search.rb
@@ -118,11 +118,12 @@ module TransactionSearch
     @order_details = @order_details.
         includes(:order => :facility).
         includes(:account).
-        includes(:product).
-        includes(:order_status).
+        preload(:product).
+        preload(:order_status).
         includes(:reservation).
         includes(:order => :user).
-        includes(:price_policy)
+        includes(:price_policy).
+        preload(:bundle)
   end
 
   def sort_and_paginate


### PR DESCRIPTION
Removing the order forms has a significant impact on performance of the page.

I also changed preloading strategies for associations. I used `preload` for the associations where there is a lot of data in the row, but only a couple distinct usages. This seems to improve the speed in my testing, although when testing against oracle it's hard to figure out what's just network latency.
