### PR TITLE
[#88161] Anticipate missing data in API responses

### DIFF
--- a/app/controllers/api/order_details_controller.rb
+++ b/app/controllers/api/order_details_controller.rb
@@ -1,5 +1,6 @@
 class Api::OrderDetailsController < ApplicationController
   respond_to :json
+  rescue_from ActiveRecord::RecordNotFound, with: :order_detail_not_found
 
   http_basic_authenticate_with name: Settings.api.basic_auth_name, password: Settings.api.basic_auth_password
 
@@ -31,8 +32,13 @@ class Api::OrderDetailsController < ApplicationController
   end
 
   def order_detail
-    @order_detail = OrderDetail.find_by_id(params[:id]) unless defined?(@order_detail)
-    @order_detail
+    @order_detail ||= OrderDetail.find(params[:id])
+  end
+
+  def order_detail_not_found
+    respond_to do |format|
+      format.json { render text: { error: "not found" }.to_json, status: 404 }
+    end
   end
 
   def user_to_hash(user)

--- a/app/controllers/api/order_details_controller.rb
+++ b/app/controllers/api/order_details_controller.rb
@@ -5,48 +5,16 @@ class Api::OrderDetailsController < ApplicationController
   http_basic_authenticate_with name: Settings.api.basic_auth_name, password: Settings.api.basic_auth_password
 
   def show
-    render json: response_to_hash
+    render json: Api::OrderDetail.new(order_detail).to_h
   end
 
   private
-
-  def account
-    @account = order_detail.try(:account) unless defined?(@account)
-    @account
-  end
-
-  def account_to_hash
-    if account.present?
-      { id: account.id, owner: user_to_hash(account.owner.user) }
-    end
-  end
-
-  def ordered_for_to_hash
-    if order_detail.present?
-      user_to_hash(order_detail.order.user)
-    end
-  end
-
-  def response_to_hash
-    { account: account_to_hash, ordered_for: ordered_for_to_hash }
-  end
 
   def order_detail
     @order_detail ||= OrderDetail.find(params[:id])
   end
 
   def order_detail_not_found
-    respond_to do |format|
-      format.json { render text: { error: "not found" }.to_json, status: 404 }
-    end
-  end
-
-  def user_to_hash(user)
-    {
-      id: user.id,
-      name: user.name,
-      username: user.username,
-      email: user.email,
-    }
+    render json: { error: "not found" }, status: 404
   end
 end

--- a/app/controllers/api/order_details_controller.rb
+++ b/app/controllers/api/order_details_controller.rb
@@ -4,21 +4,36 @@ class Api::OrderDetailsController < ApplicationController
   http_basic_authenticate_with name: Settings.api.basic_auth_name, password: Settings.api.basic_auth_password
 
   def show
-    od = OrderDetail.find(params[:id])
-    account = od.account
-    owner = account.owner.user
-    ordered_for = od.order.user
-
-    render json: {
-      account: {
-        id: account.id,
-        owner: user_to_hash(owner),
-      },
-      ordered_for: user_to_hash(ordered_for),
-    }
+    render json: response_to_hash
   end
 
   private
+
+  def account
+    @account = order_detail.try(:account) unless defined?(@account)
+    @account
+  end
+
+  def account_to_hash
+    if account.present?
+      { id: account.id, owner: user_to_hash(account.owner.user) }
+    end
+  end
+
+  def ordered_for_to_hash
+    if order_detail.present?
+      user_to_hash(order_detail.order.user)
+    end
+  end
+
+  def response_to_hash
+    { account: account_to_hash, ordered_for: ordered_for_to_hash }
+  end
+
+  def order_detail
+    @order_detail = OrderDetail.find_by_id(params[:id]) unless defined?(@order_detail)
+    @order_detail
+  end
 
   def user_to_hash(user)
     {

--- a/app/models/api/order_detail.rb
+++ b/app/models/api/order_detail.rb
@@ -1,0 +1,35 @@
+class Api::OrderDetail
+  def initialize(order_detail)
+    @order_detail = order_detail
+  end
+
+  def to_h
+    { account: account_to_hash, ordered_for: ordered_for_to_hash }
+  end
+
+  private
+
+  def account
+    @account = @order_detail.try(:account) unless defined?(@account)
+    @account
+  end
+
+  def account_to_hash
+    if account.present?
+      { id: account.id, owner: user_to_hash(account.owner.user) }
+    end
+  end
+
+  def ordered_for_to_hash
+    user_to_hash(@order_detail.order.user)
+  end
+
+  def user_to_hash(user)
+    {
+      id: user.id,
+      name: user.name,
+      username: user.username,
+      email: user.email,
+    }
+  end
+end

--- a/app/models/api/order_detail.rb
+++ b/app/models/api/order_detail.rb
@@ -10,8 +10,7 @@ class Api::OrderDetail
   private
 
   def account
-    @account = @order_detail.try(:account) unless defined?(@account)
-    @account
+    @account ||= @order_detail.account
   end
 
   def account_to_hash

--- a/spec/models/api/order_detail_spec.rb
+++ b/spec/models/api/order_detail_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+describe Api::OrderDetail do
+  subject { Api::OrderDetail.new(order_detail) }
+
+  let(:expected_hash) {{ account: account_hash, ordered_for: ordered_for_hash }}
+
+  let(:order) { double(Order, user: ordered_for) }
+  let(:order_detail) { double(OrderDetail, account: account, order: order) }
+  let(:ordered_for) { build(:user, id: 2) }
+  let(:ordered_for_hash) {{
+    id: ordered_for.id,
+    name: ordered_for.name,
+    username: ordered_for.username,
+    email: ordered_for.email,
+  }}
+
+  describe "#to_h" do
+    context "when the order_detail has an account" do
+      let(:account) { double(Account, id: 1, owner: account_user) }
+      let(:account_owner) { build(:user, id: 1) }
+      let(:account_user) { double(AccountUser, user: account_owner) }
+      let(:account_hash) {{
+        id: account.id,
+        owner: {
+          id: account_owner.id,
+          name: account_owner.name,
+          username: account_owner.username,
+          email: account_owner.email,
+        }
+      }}
+
+      it "generates the expected hash" do
+        expect(subject.to_h).to eq(expected_hash)
+      end
+    end
+
+    context "when the order_detail has no account" do
+      let(:account) { nil }
+      let(:account_hash) { nil }
+
+      it "generates the expected hash" do
+        expect(subject.to_h).to eq(expected_hash)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This should more gracefully handle cases where an `order_detail` is has no associated account, or (as unlikely as this may be) where the `order_detail` does not exist.

A related PR for IMSERC is up next.