### PR TITLE
[#94303] Could not update quantity before using external service

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -224,6 +224,10 @@ class OrdersController < ApplicationController
 
   # PUT /orders/:id/update (submission from a cart)
   def update_or_purchase
+    # When returning from an external service, we may be called with a get; in that
+    # case, we should just redirect to the show path
+    redirect_to action: :show and return if request.get?
+
     # if update button was clicked
     if params[:commit] == "Update"
       update
@@ -238,8 +242,9 @@ class OrdersController < ApplicationController
     params[:order_datetime] = build_order_date if acting_as?
     @order.transaction do
       if update_order_details
+        # Must show instead of render to maintain "more options" state when
+        # ordering on behalf of
         render :show
-        # redirect_to order_path(@order)
       else
         logger.debug "errors #{@order.errors.full_messages}"
         flash[:error] = @order.errors.full_messages.join("<br/>").html_safe

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -282,7 +282,7 @@ Nucore::Application.routes.draw do
       match 'add',            :via => [:get, :put]
       match 'purchase',       :via => [:get, :put]
       match 'choose_account', :via => [:get, :post]
-      put   'update_or_purchase'
+      match 'update_or_purchase', via: [:get, :put]
       get   'receipt'
       put   'clear'
     end


### PR DESCRIPTION
Using update quantity takes you to update_or_purchase. When leaving to the external service, that becomes the referer, so we would get a 404 when coming back from the service.

This isn't the most elegant solution, but in order to maintain support for #61929 'More options' date reset in cart, we can't do a redirect to show after updating quantities, so this was the simplest.