### PR TITLE
[#94276] Pass fulfilled_at into account_is_open when journaling

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -29,7 +29,7 @@ class Journal < ActiveRecord::Base
         end
 
         begin
-          ValidatorFactory.instance(account.account_number, od.product.account).account_is_open!
+          ValidatorFactory.instance(account.account_number, od.product.account).account_is_open!(od.fulfilled_at)
         rescue ValidatorError => e
           row_errors << I18n.t("activerecord.errors.models.journal.invalid_account",
             account_number: account.account_number_to_s,

--- a/lib/validator/validator_default.rb
+++ b/lib/validator/validator_default.rb
@@ -34,7 +34,7 @@ class ValidatorDefault
   # Validates a payment source. Returns nil and raises
   # no +Exception+ if a payment source is open to new
   # payments. Otherwise a +ValidatorError+ will be raised.
-  def account_is_open!
+  def account_is_open!(fulfilled_at = nil)
   end
 
 

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -298,6 +298,19 @@ describe FacilityJournalsController do
           expect(assigns(:journal)).to be_persisted
         end
       end
+
+      context 'when the account is not open' do
+        let(:validator) { ValidatorDefault.new }
+        let(:fulfilled_at) { @order_detail.fulfilled_at.change(usec: 0) }
+        before do
+          @params[:order_detail_ids] = [@order_detail.id]
+
+          allow(ValidatorFactory).to receive(:instance).and_return(validator)
+          expect(validator).to receive(:account_is_open!).with(fulfilled_at).and_raise(ValidatorError, "Not open")
+        end
+
+        it_behaves_like 'journal error', "Account 904-7777777 is invalid. Not open"
+      end
     end
 
     context "searching" do


### PR DESCRIPTION
Order details that were fulfilled before a chart string expired was not being accepted because we weren't looking at the fulfilled_at. This is a regression in the [NU code](https://github.com/tablexi/nucore-nu/commit/b7b5773fcb1a321e9861ea1c32e4aed3ed52d54f).