### PR TITLE
Fix CI failure on invalid files

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -116,8 +116,8 @@ class Journal < ActiveRecord::Base
                           :url => "#{ENV['RAILS_RELATIVE_URL_ROOT']}/:attachment/:id_partition/:style/:basename.:extension",
                           :path => ":rails_root/public/:attachment/:id_partition/:style/:basename.:extension"
   # The CDF type is set on files created by the spreadsheet gem
-  # FIXME CDFV2-corrupt is what's being created on CI
-  validates_attachment_content_type :file, content_type: ['application/vnd.ms-excel', 'CDF', 'application/CDFV2-corrupt']
+  # FIXME CDFV2-corrupt, and sometimes CDFV2-encrypted is what's being created on CI
+  validates_attachment_content_type :file, content_type: ['application/vnd.ms-excel', 'CDF', /application\/CDFV2-\w+/]
 
   # Digs up journals pertaining to the passed in facilities
   #


### PR DESCRIPTION
CI suddenly started generating the XLS files with the content type
`application/CDFV2-encrypted`. Cause of this change is unknown, but
this was the easiest way to work around it.