### PR TITLE
Auto logout orders are set to problem orders

### DIFF
--- a/app/support/auto_logout.rb
+++ b/app/support/auto_logout.rb
@@ -42,7 +42,7 @@ class AutoLogout
   def complete_reservation(od)
     reservation = od.reservation
     reservation.product.relay.deactivate unless reservation.other_reservation_using_relay?
-    reservation.end_reservation!
+    reservation.order_detail.complete!
   rescue => e
     STDERR.puts "Error on Order # #{od} - #{e}"
     raise ActiveRecord::Rollback


### PR DESCRIPTION
Currently we're complete the reservation which sets completes the order, sets actuals, and prices. We want to only complete the order so the order goes into the problem queue.