### PR TITLE
[#92949] Consider admin reservations when checking for running reservations

### DIFF
--- a/app/models/order_status.rb
+++ b/app/models/order_status.rb
@@ -24,6 +24,10 @@ class OrderStatus < ActiveRecord::Base
     complete.first
   end
 
+  def self.canceled_status
+    canceled.first
+  end
+
   def editable?
     !!facility
   end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -44,17 +44,10 @@ class Reservation < ActiveRecord::Base
   # Scopes
   #####
 
-  def self.active_without_admin
-    not_canceled.where(orders: { state: 'purchased' } )
-  end
-
-  def self.active_with_admin
+  def self.active
     not_canceled
       .where({orders: { state: ['purchased', nil] }})
       .joins_order
-  end
-  class << self
-    alias_method :active, :active_with_admin
   end
 
   def self.joins_order

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -122,7 +122,6 @@ class Reservation < ActiveRecord::Base
 
   def self.relay_in_progress
     where("actual_start_at IS NOT NULL AND actual_end_at IS NULL")
-      .merge(OrderDetail.pending)
   end
 
   # Instance Methods

--- a/app/support/products/scheduling_support.rb
+++ b/app/support/products/scheduling_support.rb
@@ -14,7 +14,7 @@ module Products::SchedulingSupport
   end
 
   def active_reservations
-    self.reservations.active_with_admin
+    self.reservations.active
   end
 
   def purchased_reservations

--- a/app/support/reservations/relay_support.rb
+++ b/app/support/reservations/relay_support.rb
@@ -32,8 +32,9 @@ module Reservations::RelaySupport
 
   def other_reservations_using_relay
     order_detail.reservation.product.schedule.reservations
-      .active_without_admin
+      .active_with_admin
       .relay_in_progress
+      .where(order_details: { state: ['new', 'inprocess', nil]})
       .not_this_reservation(self)
   end
 

--- a/app/support/reservations/relay_support.rb
+++ b/app/support/reservations/relay_support.rb
@@ -32,7 +32,7 @@ module Reservations::RelaySupport
 
   def other_reservations_using_relay
     order_detail.reservation.product.schedule.reservations
-      .active_with_admin
+      .active
       .relay_in_progress
       .where(order_details: { state: ['new', 'inprocess', nil]})
       .not_this_reservation(self)

--- a/spec/factories/reservations.rb
+++ b/spec/factories/reservations.rb
@@ -6,6 +6,19 @@ FactoryGirl.define do
     trait :yesterday do
       reserve_start_at { Time.zone.parse("#{Date.today} 10:00:00") - 1.day }
     end
+
+    trait :later_yesterday do
+      reserve_start_at { Time.zone.parse("#{Date.today} 10:00:00") - 1.day + 1.hour }
+    end
+
+    trait :running do
+      after(:create) do |reservation|
+        reservation.reserve_start_at = 30.minutes.ago
+        reservation.reserve_end_at  = 30.minutes.from_now
+        reservation.actual_start_at = 30.minutes.ago
+        reservation.save!
+      end
+    end
   end
 
   factory :setup_reservation, :class => Reservation, :parent => :reservation do

--- a/spec/factories/reservations.rb
+++ b/spec/factories/reservations.rb
@@ -12,12 +12,9 @@ FactoryGirl.define do
     end
 
     trait :running do
-      after(:create) do |reservation|
-        reservation.reserve_start_at = 30.minutes.ago
-        reservation.reserve_end_at  = 30.minutes.from_now
-        reservation.actual_start_at = 30.minutes.ago
-        reservation.save!
-      end
+      reserve_start_at { 15.minutes.ago }
+      reserve_end_at { 45.minutes.from_now }
+      actual_start_at { 15.minutes.ago }
     end
   end
 


### PR DESCRIPTION
Previously we didn't consider admin reservations when looking for running reservations. This changes the logic to now consider admin reservations.

https://pm.tablexi.com/issues/92949