### PR TITLE
Couple fixes for the start/end reservation functionality

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -265,8 +265,10 @@ class ReservationsController < ApplicationController
   private
 
   def switch_instrument_off!
-    ReservationInstrumentSwitcher.new(@reservation).switch_off!
-    flash[:notice] = 'The instrument has been deactivated successfully'
+    unless @reservation.other_reservation_using_relay?
+      ReservationInstrumentSwitcher.new(@reservation).switch_off!
+      flash[:notice] = 'The instrument has been deactivated successfully'
+    end
     session[:reservation_ended] = true if params[:reservation_ended].present?
   end
 

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -121,7 +121,7 @@ class Reservation < ActiveRecord::Base
   #####
 
   def start_reservation!
-    product.started_reservations.each(&:complete!)
+    product.schedule.products.map(&:started_reservations).flatten.each(&:complete!)
     self.actual_start_at = Time.zone.now
     save!
   end

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -1090,6 +1090,21 @@ describe ReservationsController do
             should redirect_to new_order_order_detail_accessory_path(@order, @order_detail)
           end
         end
+
+        context 'and a reservation using the same relay as another running reservation' do
+          let!(:reservation_running) { create(:purchased_reservation, product: @instrument,
+            actual_start_at: 30.minutes.ago, reserve_start_at: 30.minutes.ago,
+            reserve_end_at: 30.minutes.from_now) }
+
+          before { @params[:reservation_id] = reservation_running.id }
+
+          it 'does not switch off the relay' do
+            expect_any_instance_of(ReservationInstrumentSwitcher).to_not receive(:switch_off!)
+
+            sign_in @guest
+            do_request
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
https://pm.tablexi.com/issues/77963

Fixed: 

1. When clicking "End Reservation" check if other reservations using relay before switching off
2. When clicking "Start Reservation" we should end reservations for other reservations on the shared calendar

I also added a spec to make sure AutoLogout checks the shared calendar before deactivating the relay.