### PR TITLE
[#96853] Use SQL for query instead of loading all

### DIFF
--- a/app/models/nufs_account.rb
+++ b/app/models/nufs_account.rb
@@ -21,7 +21,7 @@ class NufsAccount < Account
   end
 
   def can_reconcile?(order_detail)
-    order_detail.journal.try(:is_successful) || OrderDetail.need_journal.include?(order_detail)
+    order_detail.journal.try(:is_successful) || OrderDetail.need_journal.exists?(order_detail.id)
   end
 
   private


### PR DESCRIPTION
OrderDetail.need_journal was loading ~3500 records. When there are
several order details on the Orders#show view, this got very slow.

This pushes the lookup for existence into SQL.