### PR TITLE
[#96992] Unable to start reservations

### DIFF
--- a/app/support/products/scheduling_support.rb
+++ b/app/support/products/scheduling_support.rb
@@ -27,6 +27,7 @@ module Products::SchedulingSupport
 
   def started_reservations
     self.purchased_reservations
+      .not_canceled
       .merge(Reservation.relay_in_progress)
   end
 

--- a/spec/app_support/reservation_instrument_switcher_spec.rb
+++ b/spec/app_support/reservation_instrument_switcher_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe ReservationInstrumentSwitcher do
+  let(:instrument) { FactoryGirl.create(:setup_instrument, relay: create(:relay_syna)) }
+  let(:reservation) { FactoryGirl.create(:purchased_reservation, product: instrument) }
+  let(:action) { described_class.new(reservation) }
+
+  describe '#switch_on!' do
+    def do_action
+      action.switch_on!
+    end
+
+    before do
+      allow(reservation).to receive(:can_switch_instrument_on?).and_return(true)
+    end
+
+    context 'no other reservations' do
+      it 'starts the reservation' do
+        expect { do_action }.to change { reservation.reload.actual_start_at }.from(nil)
+      end
+    end
+
+    context 'with a long running reservation' do
+      let!(:running_reservation) { FactoryGirl.create(:purchased_reservation, :long_running, product: instrument) }
+
+      it 'moves the running reservation to problem status' do
+        expect { do_action }.to change { running_reservation.order_detail.reload.problem }.from(false).to(true)
+      end
+    end
+
+    context 'with a problem reservation that got canceled' do
+      let!(:running_reservation) { FactoryGirl.create(:purchased_reservation, :long_running, product: instrument) }
+      before { running_reservation.order_detail.update_order_status! running_reservation.user, OrderStatus.canceled_status, admin: true }
+
+      it 'does not do anything to the canceled reservation' do
+        expect { do_action }.not_to change { running_reservation.reload }
+      end
+    end
+  end
+end

--- a/spec/factories/reservations.rb
+++ b/spec/factories/reservations.rb
@@ -20,6 +20,12 @@ FactoryGirl.define do
       reserve_end_at { 45.minutes.from_now }
       actual_start_at { 15.minutes.ago }
     end
+
+    trait :long_running do
+      yesterday
+      actual_start_at { reserve_start_at }
+      actual_end_at nil
+    end
   end
 
   factory :setup_reservation, :class => Reservation, :parent => :reservation do


### PR DESCRIPTION
when there are canceled reservations that do have actual_start_at and
no actual_end_at, we were trying to move them to complete.