### PR TITLE
[#94617] Add ability to enter end time during reservation creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ group :development, :test do
   gem 'single_test',       '0.4.0'
   gem 'spring'
   gem 'spring-commands-rspec'
+  gem 'teaspoon-jasmine'
   gem 'thin'
   gem 'timecop',           '~> 0.6.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,6 +297,10 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
+    teaspoon (1.0.2)
+      railties (>= 3.2.5, < 5)
+    teaspoon-jasmine (2.2.0)
+      teaspoon (>= 1.0.0)
     therubyracer (0.12.0)
       libv8 (~> 3.16.14.0)
       ref
@@ -380,6 +384,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   synaccess_connect (= 0.2.2)!
+  teaspoon-jasmine
   therubyracer
   thin
   timecop (~> 0.6.3)

--- a/app/assets/javascripts/app/manage_orders.coffee
+++ b/app/assets/javascripts/app/manage_orders.coffee
@@ -19,7 +19,7 @@ $.fn.animateHighlight = (options = {}) ->
 class OrderDetailManagement
   constructor: (@$element) ->
     @$element.find('.datepicker').datepicker()
-    @$element.find('.timeinput').timeinput();
+    @$element.find('.timeinput').timeinput()
     @$element.find('.copy_actual_from_reservation a').click(@copyReservationTimeIntoActual)
     @initTotalCalculating()
     @initPriceUpdating()
@@ -151,5 +151,5 @@ $ ->
 
   $('.updated-order-detail').animateHighlight({ highlightClass: 'alert-info', solidDuration: 5000 })
 
-  $('.timeinput').timeinput();
-  $('#product_add').chosen();
+  $('.timeinput').timeinput()
+  $('#product_add').chosen()

--- a/app/assets/javascripts/app/reservation_time_field_adjustor.js.coffee
+++ b/app/assets/javascripts/app/reservation_time_field_adjustor.js.coffee
@@ -40,36 +40,40 @@ class window.ReservationTimeFieldAdjustor
       @$form.find('[name="reservation[duration_mins]_display"]')
 
   _durationChangeCallback: =>
-    durationMinutes = @timeParser.to_minutes(@$durationDisplayField.val())
+    durationMinutes = @_durationMinutes()
     if durationMinutes % @reserveInterval == 0
       @reserveEnd
         .setDateTime(@reserveStart.getDateTime().addMinutes(durationMinutes))
 
   _getDuration: -> @reserveEnd.getDateTime() - @reserveStart.getDateTime()
 
-  _minimumDuration: -> @reserveInterval * 60 * 1000
+  _durationMinutes: -> @timeParser.to_minutes(@$durationDisplayField.val())
 
   _reserveEndChangeCallback: =>
     duration = @_getDuration()
 
     if duration < 0
-      duration = @_minimumDuration()
-      @reserveStart
-        .setDateTime(@reserveEnd.getDateTime()
-        .addMilliseconds(-1 * duration))
-    @_setDurationFields(duration)
+      # If the duration ends up negative, i.e. end is before start,
+      # set the end to the start time plus the duration specified in the box
+      duration = @_durationMinutes()
+      @reserveEnd
+        .setDateTime(@reserveStart.getDateTime()
+        .addMinutes(duration))
+    @_setDurationFields()
 
   _reserveStartChangeCallback: =>
     duration = @_getDuration()
+
     if duration < 0
-      duration = @_minimumDuration()
+      duration = @_durationMinutes()
       @reserveEnd
         .setDateTime(@reserveStart.getDateTime()
-        .addMilliseconds(duration))
-    @_setDurationFields(duration)
+        .addMinutes(duration))
+    @_setDurationFields
 
-  _setDurationFields: (duration) ->
-    durationMinutes = duration / 60000
+  _setDurationFields:  ->
+    durationMinutes = @_getDuration() / 60 / 1000
+
     @$durationDisplayField
       .val(@timeParser.from_minutes(durationMinutes))
       .trigger("keyup")

--- a/app/assets/javascripts/app/reservation_time_field_adjustor.js.coffee
+++ b/app/assets/javascripts/app/reservation_time_field_adjustor.js.coffee
@@ -1,28 +1,16 @@
 class window.DateTimeSelectionWidgetGroup
   constructor: (@$dateField, @$hourField, @$minuteField, @$meridianField, @reserveInterval) ->
 
-  getDateTime: -> new Date(@year(), @month(), @day(), @hour(), @minute())
-
-  year: -> parseInt(@_splitDate()[2], 10)
-  month: -> parseInt(@_splitDate()[0], 10) - 1
-  day: -> parseInt(@_splitDate()[1], 10)
-
-  hour: ->
-    hour = parseInt(@$hourField.val(), 10) % 12
-    hour += 12 if @$meridianField.val() == "PM"
-    hour
-
-  minute: -> parseInt(@$minuteField.val(), 10)
+  getDateTime: ->
+    formatter = TimeFormatter.fromString(@$dateField.val(), @$hourField.val(), @$minuteField.val(), @$meridianField.val())
+    formatter.toDateTime()
 
   setDateTime: (dateTime) ->
-    @$dateField.val(dateTime.toString("M/d/yyyy"))
+    formatter = new TimeFormatter(dateTime)
 
-    hour = dateTime.getHours() % 12
-    meridian = if dateTime.getHours() < 12 then 'AM' else 'PM'
-    hour = 12 if hour == 0
-
-    @$hourField.val(hour)
-    @$meridianField.val(meridian)
+    @$dateField.val(formatter.dateString())
+    @$hourField.val(formatter.hour12())
+    @$meridianField.val(formatter.meridian())
 
     @$minuteField
       .val(dateTime.getMinutes() - (dateTime.getMinutes() % @reserveInterval))
@@ -32,8 +20,6 @@ class window.DateTimeSelectionWidgetGroup
   change: (callback) ->
     fields = [@$dateField, @$hourField, @$minuteField, @$meridianField]
     $field.change(callback) for $field in fields
-
-  _splitDate: -> @$dateField.val().split("/")
 
 class window.ReservationTimeFieldAdjustor
   constructor: (@$form, @reserveInterval) ->
@@ -68,7 +54,6 @@ class window.ReservationTimeFieldAdjustor
 
     if duration < 0
       duration = @_minimumDuration()
-      console.debug @reserveEnd.getDateTime()
       @reserveStart
         .setDateTime(@reserveEnd.getDateTime()
         .addMilliseconds(-1 * duration))

--- a/app/assets/javascripts/app/reservation_time_field_adjustor.js.coffee
+++ b/app/assets/javascripts/app/reservation_time_field_adjustor.js.coffee
@@ -1,0 +1,105 @@
+class window.DateTimeSelectionWidgetGroup
+  constructor: (@$dateField, @$hourField, @$minuteField, @$meridianField, @reserveInterval) ->
+
+  getDateTime: -> new Date(@year(), @month(), @day(), @hour(), @minute())
+
+  year: -> parseInt(@_splitDate()[2], 10)
+  month: -> parseInt(@_splitDate()[0], 10) - 1
+  day: -> parseInt(@_splitDate()[1], 10)
+
+  hour: ->
+    hour = parseInt(@$hourField.val(), 10)
+    hour += 12 if @$meridianField.val() == "PM"
+    hour
+
+  minute: -> parseInt(@$minuteField.val(), 10)
+
+  setDateTime: (dateTime) ->
+    @$dateField.val(dateTime.toString("M/d/yyyy"))
+    if dateTime.getHours() > 12
+      @$hourField.val(dateTime.getHours() - 12)
+      @$meridianField.val("PM")
+    else
+      @$hourField.val(dateTime.getHours())
+      @$meridianField.val("AM")
+    @$minuteField
+      .val(dateTime.getMinutes() - (dateTime.getMinutes() % @reserveInterval))
+    @change()
+
+  change: (callback) ->
+    fields = [@$dateField, @$hourField, @$minuteField, @$meridianField]
+    if callback
+      $field.change(callback) for $field in fields
+    else
+      $field.change() for $field in fields
+
+  _splitDate: -> @$dateField.val().split("/")
+
+class window.ReservationTimeFieldAdjustor
+  constructor: (@$form, @reserveInterval) ->
+    @timeParser = new TimeParser()
+    @addListeners()
+
+  addListeners: ->
+    @reserveStart = new DateTimeSelectionWidgetGroup(
+      @$form.find('[name="reservation[reserve_start_date]"]')
+      @$form.find('[name="reservation[reserve_start_hour]"]')
+      @$form.find('[name="reservation[reserve_start_min]"]')
+      @$form.find('[name="reservation[reserve_start_meridian]"]')
+      @reserveInterval
+    )
+
+    @reserveEnd = new DateTimeSelectionWidgetGroup(
+      @$form.find('[name="reservation[reserve_end_date]"]')
+      @$form.find('[name="reservation[reserve_end_hour]"]')
+      @$form.find('[name="reservation[reserve_end_min]"]')
+      @$form.find('[name="reservation[reserve_end_meridian]"]')
+      @reserveInterval
+    )
+
+    @$durationField = @$form.find('[name="reservation[duration_mins]"]')
+    @$durationDisplayField =
+      @$form.find('[name="reservation[duration_mins]_display"]')
+
+    @$durationField.change(@_durationChangeCallback)
+    @reserveStart.change(@_reserveStartChangeCallback)
+    @reserveEnd.change(@_reserveEndChangeCallback)
+
+  _durationChangeCallback: =>
+    durationMinutes = @timeParser.to_minutes(@$durationDisplayField.val())
+    if durationMinutes % @reserveInterval == 0
+      @reserveEnd
+        .setDateTime(@reserveStart.getDateTime().addMinutes(durationMinutes))
+
+  _getDuration: -> @reserveEnd.getDateTime() - @reserveStart.getDateTime()
+
+  minimumDuration: -> @reserveInterval * 60 * 1000
+
+  _reserveEndChangeCallback: =>
+    duration = @_getDuration()
+    if duration < 0
+      duration = @minimumDuration()
+      @reserveStart
+        .setDateTime(@reserveEnd.getDateTime()
+        .addMilliseconds(-1 * duration))
+    @_setDurationFields(duration)
+
+  _reserveStartChangeCallback: =>
+    duration = @_getDuration()
+    if duration < 0
+      duration = @minimumDuration()
+      @reserveEnd
+        .setDateTime(@reserveStart.getDateTime()
+        .addMilliseconds(duration))
+    @_setDurationFields(duration)
+
+  _setDurationFields: (duration) ->
+    durationMinutes = duration / 60000
+    @$durationDisplayField
+      .val(@timeParser.from_minutes(durationMinutes))
+      .trigger("keyup")
+    @$durationField.val(durationMinutes)
+
+$ ->
+  $("form.new_reservation, form.edit_reservation").each ->
+    new ReservationTimeFieldAdjustor($(this), reserveInterval)

--- a/app/assets/javascripts/app/reservations.coffee
+++ b/app/assets/javascripts/app/reservations.coffee
@@ -1,5 +1,5 @@
 $ ->
-  target = '#new_reservation #reservation_duration_mins'
+  target = '#new_reservation #reservation_duration_mins, .edit_reservation #reservation_duration_mins'
 
   if $(target).length
     new ReservationTimeChecker(target)

--- a/app/assets/javascripts/app/time_formatter.coffee
+++ b/app/assets/javascripts/app/time_formatter.coffee
@@ -1,0 +1,52 @@
+class window.TimeFormatter
+  constructor: (@dateTime) ->
+
+  hour12: ->
+    hour = @hour24() % 12
+    hour = 12 if hour == 0
+    hour
+
+  hour24: ->
+    @dateTime.getHours()
+
+  minute: ->
+    @dateTime.getMinutes()
+
+  meridian: ->
+    if @hour24() < 12 then 'AM' else 'PM'
+
+  year: ->
+    @dateTime.getFullYear()
+
+  # getMonth() returns 0-11, we want to return the more natural 1-12
+  month: ->
+    @dateTime.getMonth() + 1
+
+  day: ->
+    @dateTime.getDate()
+
+  dateString: ->
+    @dateTime.toString("M/d/yyyy")
+
+  toString: ->
+    @dateTime.toString()
+
+  toDateTime: ->
+    @dateTime
+
+  @fromString: (date, hour, minute, meridian) ->
+    parsedHour = parseInt(hour, 10) % 12
+    parsedHour += 12 if meridian == "PM"
+
+    parsedMinute = parseInt(minute, 10)
+
+    split = date.split("/")
+
+    # Date uses 0-11 for months
+    parsedMonth = parseInt(split[0], 10) - 1
+    parsedDay = parseInt(split[1], 10)
+    parsedYear = parseInt(split[2], 10)
+
+    date = new Date(parsedYear, parsedMonth, parsedDay, parsedHour, parsedMinute)
+    new TimeFormatter(date)
+

--- a/app/assets/stylesheets/app/reservation_edit.scss
+++ b/app/assets/stylesheets/app/reservation_edit.scss
@@ -4,6 +4,12 @@
     float: left;
     margin-right: 1em;
   }
+
+  .started-at {
+    @extend .control-group;
+    margin-top: -16px;
+    font-style: italic;
+  }
 }
 
 .time-select {

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -7,8 +7,6 @@ class ReservationsController < ApplicationController
   before_filter :load_basic_resources, :only => [:new, :create, :edit, :update]
   before_filter :load_and_check_resources, :only => [ :move, :switch_instrument ]
 
-  helper_method :show_scheduled_reserve_times?
-
   include TranslationHelper
   include FacilityReservationsHelper
 
@@ -185,11 +183,7 @@ class ReservationsController < ApplicationController
       return
     end
 
-    if show_scheduled_reserve_times?
-      @reservation.assign_times_from_params(reservation_params)
-    else
-      @reservation.assign_reserve_end_from_actual_duration_mins(reservation_params[:actual_duration_mins])
-    end
+    @reservation.assign_times_from_params(reservation_params)
 
     render_edit and return unless duration_change_valid?
 
@@ -413,9 +407,5 @@ class ReservationsController < ApplicationController
     params[:reservation]
     .except(:reserve_end_date, :reserve_end_hour, :reserve_end_min, :reserve_end_meridian)
     .merge(product: @instrument)
-  end
-
-  def show_scheduled_reserve_times?
-    !@reservation.actual_start_at
   end
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -93,7 +93,7 @@ class ReservationsController < ApplicationController
   # POST /orders/1/order_details/1/reservations
   def create
     raise ActiveRecord::RecordNotFound unless @reservation.nil?
-    @reservation = @order_detail.build_reservation(params[:reservation].merge(:product => @instrument))
+    @reservation = @order_detail.build_reservation(reservation_create_params)
 
     if !@order_detail.bundled? && params[:order_account].blank?
       flash.now[:error]=I18n.t 'controllers.reservations.create.no_selection'
@@ -407,6 +407,12 @@ class ReservationsController < ApplicationController
   def duration_change_valid?
     validator = Reservations::DurationChangeValidations.new(@reservation)
     validator.valid?
+  end
+
+  def reservation_create_params
+    params[:reservation]
+    .except(:reserve_end_date, :reserve_end_hour, :reserve_end_min, :reserve_end_meridian)
+    .merge(product: @instrument)
   end
 
   def show_scheduled_reserve_times?

--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -41,12 +41,4 @@ module ReservationsHelper
     original = Reservation.find(reservation)
     !original.reserve_end_at_editable?
   end
-
-  def duration(reservation)
-    if show_scheduled_reserve_times?
-      reservation.duration_mins
-    else
-      reservation.actual_duration_mins(reservation.reserve_end_at)
-    end
-  end
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -136,8 +136,10 @@ class Reservation < ActiveRecord::Base
 
 
   def round_reservation_times
-    self.reserve_start_at = time_ceil(self.reserve_start_at) if self.reserve_start_at
-    self.reserve_end_at   = time_ceil(self.reserve_end_at) if self.reserve_end_at
+    interval = product.reserve_interval.minutes # Round to the nearest reservation interval
+    self.reserve_start_at = time_ceil(self.reserve_start_at, interval) if self.reserve_start_at
+    self.reserve_end_at   = time_ceil(self.reserve_end_at, interval) if self.reserve_end_at
+    self
   end
 
   def assign_actuals_off_reserve

--- a/app/support/reservations/date_support.rb
+++ b/app/support/reservations/date_support.rb
@@ -20,15 +20,6 @@ module Reservations::DateSupport
     set_all_split_times
   end
 
-  def assign_reserve_end_from_actual_duration_mins(duration_mins_param)
-    if actual_start_at
-      actual_start = actual_start_at.change(sec: 0)
-      reserve_start = reserve_start_at.change(sec: 0)
-      offset = ((actual_start - reserve_start) / 60).floor
-      self.reserve_end_at = reserve_start_at + (offset + duration_mins_param.to_i).minutes
-    end
-  end
-
   #
   # Virtual attributes
   #

--- a/app/views/facility_reservations/_reservation_fields.html.haml
+++ b/app/views/facility_reservations/_reservation_fields.html.haml
@@ -1,29 +1,31 @@
 - if @reservation.can_edit?
   .datetime-block
-    = f.input :reserve_start_date, input_html: { class: 'datepicker' }
+    = f.input :reserve_start_date, input_html: { class: "datepicker" }
     .control-group
       .controls
         .string.optional.control-label &nbsp;
         = time_select f, :reserve_start
-    = f.input :duration_mins, input_html: { class: 'timeinput' }
-    = f.input :admin_note, input_html: { class: 'span6' } unless @order_detail
+    = f.input :duration_mins, input_html: { class: "timeinput" }
+    = f.input :admin_note, input_html: { class: "span6" } unless @order_detail
+    = f.input :reserve_end_date, input_html: { class: "datepicker" }
 
 - else
-  = f.input :reserve_start_date, label: 'Reservation', as: :readonly, input_html: { value: @reservation.reserve_to_s }
+  = f.input :reserve_start_date, label: "Reservation", as: :readonly, input_html: { value: @reservation.reserve_to_s }
+  = f.input :reserve_end_date, input_html: { class: "datepicker" }
 .clearfix
 
 - if @order_detail
   - if @reservation.can_edit_actuals?
     .datetime-block
-      = f.input :actual_start_date, input_html: { class: 'datepicker' }
+      = f.input :actual_start_date, input_html: { class: "datepicker" }
       .control-group
         .controls
           .string.optional.control-label &nbsp;
           = time_select f, :actual_start
-      = f.input :actual_duration_mins, input_html: { class: 'timeinput' }
+      = f.input :actual_duration_mins, input_html: { class: "timeinput" }
     - unless @reservation.has_actuals?
       .copy_actual_from_reservation
-        = link_to 'Copy from reservation','#'
+        = link_to "Copy from reservation", "#"
         %span.start_date.hidden= @reservation.reserve_start_at
         %span.end_date.hidden= @reservation.reserve_end_at
     - if @instrument.reservation_only?

--- a/app/views/reservations/_js_variables.html.haml
+++ b/app/views/reservations/_js_variables.html.haml
@@ -1,0 +1,15 @@
+:javascript
+  var events_path     = "#{facility_instrument_reservations_path(@instrument.facility, @instrument, :format => 'js', :with_details => @instrument.show_details?)}";
+  var minDate         = "#{@min_date}";
+  var maxDate         = "#{@max_date}";
+  var maxDaysFromNow  = #{@max_window};
+  var minDaysFromNow  = #{@max_days_ago};
+  var minTime         = #{@instrument.first_available_hour};
+  var maxTime         = #{@instrument.last_available_hour+1};
+  var withDetails     = #{@instrument.show_details? || false};
+  var isBundle        = #{@order_detail.bundled? || @order.order_details.count > 1};
+  var ctrlMechanism   = "#{@instrument.control_mechanism}";
+  var ordering_on_behalf = #{acting_as?};
+  var reserveInterval = #{@instrument.reserve_interval};
+  var reserveMinimum  = #{@instrument.min_reserve_mins || 0};
+  var reserveMaximum  = #{@instrument.max_reserve_mins || 0};

--- a/app/views/reservations/_reservation_fields.html.haml
+++ b/app/views/reservations/_reservation_fields.html.haml
@@ -1,14 +1,15 @@
 .datetime-block
   - start_disabled = f.object.persisted? && !f.object.reserve_start_at_editable?
-  - date_field = show_scheduled_reserve_times? ? :reserve_start_date : :actual_start_date
-  = f.input date_field, input_html: { class: "datepicker", disabled: start_disabled }
+  = f.input :reserve_start_date, input_html: { class: "datepicker", disabled: start_disabled }
   .control-group
     .controls
       .string.optional.control-label &nbsp;
-      - time_field = show_scheduled_reserve_times? ? :reserve_start : :actual_start
-      = time_select f, time_field, { minute_step: @instrument.reserve_interval }, disabled: start_disabled
-  - duration_field = show_scheduled_reserve_times? ? :duration_mins : :actual_duration_mins
-  = f.input duration_field, input_html: { value: f.object.new_record? ? default_duration : duration(f.object), class: 'timeinput', disabled: end_time_disabled?(f.object) }
+      = time_select f, :reserve_start, { minute_step: @instrument.reserve_interval }, disabled: start_disabled
+  = f.input :duration_mins, input_html: { value: f.object.new_record? ? default_duration : f.object.duration_mins, class: 'timeinput', disabled: end_time_disabled?(f.object) }
+
+  - if f.object.actual_start_at?
+    .datetime-block
+      .started-at= "Started: #{l(f.object.actual_start_at, format: :usa)}"
 
 .datetime-block
   = f.input :reserve_end_date, input_html: { class: "datepicker" }

--- a/app/views/reservations/_reservation_fields.html.haml
+++ b/app/views/reservations/_reservation_fields.html.haml
@@ -1,7 +1,7 @@
 .datetime-block
   - start_disabled = f.object.persisted? && !f.object.reserve_start_at_editable?
   - date_field = show_scheduled_reserve_times? ? :reserve_start_date : :actual_start_date
-  = f.input date_field, :input_html => { :class => 'datepicker', disabled: start_disabled }
+  = f.input date_field, input_html: { class: "datepicker", disabled: start_disabled }
   .control-group
     .controls
       .string.optional.control-label &nbsp;
@@ -10,4 +10,9 @@
   - duration_field = show_scheduled_reserve_times? ? :duration_mins : :actual_duration_mins
   = f.input duration_field, input_html: { value: f.object.new_record? ? default_duration : duration(f.object), class: 'timeinput', disabled: end_time_disabled?(f.object) }
 
-
+.datetime-block
+  = f.input :reserve_end_date, input_html: { class: "datepicker" }
+  .control-group
+    .controls
+      .string.optional.control-label &nbsp;
+      = time_select f, :reserve_end, { minute_step: @instrument.reserve_interval }

--- a/app/views/reservations/edit.html.haml
+++ b/app/views/reservations/edit.html.haml
@@ -1,15 +1,7 @@
 = content_for :head_content do
-  = render :partial => 'shared/headers/calendar'
+  = render partial: 'shared/headers/calendar'
   = javascript_include_tag 'reservations.js'
-
-  :javascript
-    var events_path     = "#{facility_instrument_reservations_path(@instrument.facility, @instrument, :format => 'js', :with_details => @instrument.show_details?)}";
-    var minDate         = "#{@min_date}";
-    var maxDate         = "#{@max_date}";
-    var maxDaysFromNow  = #{@max_window};
-    var minTime         = #{@instrument.first_available_hour};
-    var maxTime         = #{@instrument.last_available_hour+1};
-    var withDetails     = #{@instrument.show_details? || false};
+  = render partial: 'js_variables'
 
 - unless @order.purchased?
   = content_for :breadcrumb do
@@ -33,9 +25,9 @@
 
   .row
     .well.span12
-      = render :partial => 'reservation_fields', :locals => {:f => f}
+      = render partial: 'reservation_fields', locals: { f: f }
   %ul.inline
-    %li= f.submit 'Save', :class => 'btn'
+    %li= f.submit 'Save', class: 'btn'
     - if @order.purchased?
       %li= link_to 'Cancel', reservations_path
     - else

--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -1,22 +1,7 @@
 = content_for :head_content do
-  = render :partial => 'shared/headers/calendar'
+  = render partial: 'shared/headers/calendar'
   = javascript_include_tag 'reservations.js'
-
-  :javascript
-    var events_path     = "#{facility_instrument_reservations_path(@instrument.facility, @instrument, :format => 'js', :with_details => @instrument.show_details?)}";
-    var minDate         = "#{@min_date}";
-    var maxDate         = "#{@max_date}";
-    var maxDaysFromNow  = #{@max_window};
-    var minDaysFromNow  = #{@max_days_ago};
-    var minTime         = #{@instrument.first_available_hour};
-    var maxTime         = #{@instrument.last_available_hour+1};
-    var withDetails     = #{@instrument.show_details? || false};
-    var isBundle        = #{@order_detail.bundled? || @order.order_details.count > 1};
-    var ctrlMechanism   = "#{@instrument.control_mechanism}";
-    var ordering_on_behalf = #{acting_as?};
-    var reserveInterval = #{@instrument.reserve_interval};
-    var reserveMinimum  = #{@instrument.min_reserve_mins || 0};
-    var reserveMaximum  = #{@instrument.max_reserve_mins || 0};
+  = render partial: 'js_variables'
 
 = content_for :breadcrumb do
   %ul.breadcrumb
@@ -36,31 +21,31 @@
 
 .wysiwyg= @instrument.description
 
-= render :partial => 'documentation'
+= render partial: 'documentation'
 
 = simple_form_for([@order, @order_detail, @reservation]) do |f|
   = f.error_messages
-  = render :partial => 'account_field', :locals => { :f => f } unless @order_detail.bundled?
+  = render partial: 'account_field', locals: { f: f } unless @order_detail.bundled?
 
   .row
     .well.span12
-      = render :partial => 'reservation_fields', :locals => {:f => f}
+      = render partial: 'reservation_fields', locals: { f: f }
 
   - if acting_as? && @order.order_details.size == 1
     .row
       .span12.send-notification
-        = label_tag :send_notification, :class => 'checkbox' do
+        = label_tag :send_notification, class: 'checkbox' do
           = hidden_field_tag :send_notification, 0
           = check_box_tag :send_notification, 1, params[:send_notification] == '1'
           = t('reservations.new.notify')
 
   %ul.inline
-    %li= f.submit 'Create', :class => 'btn', :id => 'reservation_submit'
+    %li= f.submit 'Create', class: 'btn', id: 'reservation_submit'
     - url_after_action = facility_path(@instrument.facility)
     - if @order_detail.bundled?
       %li= link_to 'Cancel', url_after_action
     - else
-      %li= link_to 'Cancel', remove_order_path(@order, @order_detail, :redirect_to => url_after_action), :method => :put
+      %li= link_to 'Cancel', remove_order_path(@order, @order_detail, redirect_to: url_after_action), method: :put
 
 #overlay
   #spinner

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -242,6 +242,7 @@ en:
         to_s: Reservation
         reserve_to_s: Reservation
         reserve_start_date: Reserve Start
+        reserve_end_date: Reserve End
         duration_mins: Duration
         actuals_string: Actual Usage
         actual_start_date: Actual Start

--- a/spec/javascripts/date_time_selection_widget_group_spec.js.coffee
+++ b/spec/javascripts/date_time_selection_widget_group_spec.js.coffee
@@ -32,13 +32,41 @@ describe "DateTimeSelectionWidgetGroup", ->
         expect(@subject.getDateTime()).toEqual(new Date(2016, 2, 2, 9, 15))
 
     describe "when the hour value is changed", ->
-      for hour in [1..12]
-        describe "to #{hour}", ->
-          beforeEach -> $("input[name=hour]", fixture.el).val(hour)
+      describe "3 AM", ->
+        beforeEach ->
+          $("input[name=hour]", fixture.el).val(3)
+          $("input[name=meridian]", fixture.el).val("AM")
 
-          it "converts the new field values into the expected Date object", ->
-            expect(@subject.getDateTime())
-              .toEqual(new Date(2015, 10, 13, hour, 15))
+        it "converts the new field values into the expected Date object", ->
+          expect(@subject.getDateTime())
+            .toEqual(new Date(2015, 10, 13, 3, 15))
+
+      describe "4 PM", ->
+        beforeEach ->
+          $("input[name=hour]", fixture.el).val(4)
+          $("input[name=meridian]", fixture.el).val("PM")
+
+        it "converts the new field values into the expected Date object", ->
+          expect(@subject.getDateTime())
+            .toEqual(new Date(2015, 10, 13, 16, 15))
+
+      describe "midnight", ->
+        beforeEach ->
+          $("input[name=hour]", fixture.el).val(12)
+          $("input[name=meridian]", fixture.el).val("AM")
+
+        it "converts the new field values into the expected Date object", ->
+          expect(@subject.getDateTime())
+            .toEqual(new Date(2015, 10, 13, 0, 15))
+
+      describe "noon", ->
+        beforeEach ->
+          $("input[name=hour]", fixture.el).val(12)
+          $("input[name=meridian]", fixture.el).val("PM")
+
+        it "converts the new field values into the expected Date object", ->
+          expect(@subject.getDateTime())
+            .toEqual(new Date(2015, 10, 13, 12, 15))
 
     describe "when the minute value is changed", ->
       for minute in [0..59] by 15
@@ -85,6 +113,22 @@ describe "DateTimeSelectionWidgetGroup", ->
 
       it "sets the meridian field", ->
         expect($("input[name=meridian]", fixture.el).val()).toEqual("PM")
+
+    describe "when the time is noon hour", ->
+      beforeEach -> @subject.setDateTime(new Date(2016, 2, 2, 12, 45))
+
+      it "sets itself to the right datetime", ->
+        expect($("input[name=date]", fixture.el).val()).toEqual("3/2/2016")
+        expect($("input[name=hour]", fixture.el).val()).toEqual("12")
+        expect($("input[name=meridian]", fixture.el).val()).toEqual("PM")
+
+    describe "when the time is midnight hour", ->
+      beforeEach -> @subject.setDateTime(new Date(2016, 2, 2, 0, 45))
+
+      it "sets itself to the right datetime", ->
+        expect($("input[name=date]", fixture.el).val()).toEqual("3/2/2016")
+        expect($("input[name=hour]", fixture.el).val()).toEqual("12")
+        expect($("input[name=meridian]", fixture.el).val()).toEqual("AM")
 
     describe "when the time is not aligned to the reserveInterval", ->
       beforeEach -> @subject.setDateTime(new Date(2016, 2, 2, 13, 39))

--- a/spec/javascripts/date_time_selection_widget_group_spec.js.coffee
+++ b/spec/javascripts/date_time_selection_widget_group_spec.js.coffee
@@ -1,0 +1,97 @@
+#= require jquery
+
+describe "DateTimeSelectionWidgetGroup", ->
+  fixture.set '
+    <form>
+      <input name="date" value="11/13/2015">
+      <input name="hour" value="9">
+      <input name="minute" value="15">
+      <input name="meridian" value="AM">
+    </form>
+  '
+
+  beforeEach ->
+    $date = $("input[name=date]", fixture.el)
+    $hour = $("input[name=hour]", fixture.el)
+    $minute = $("input[name=minute]", fixture.el)
+    $meridian = $("input[name=meridian]", fixture.el)
+    reserveInterval = 15
+
+    @subject = new DateTimeSelectionWidgetGroup(
+      $date, $hour, $minute, $meridian, reserveInterval
+    )
+
+  describe "#getDateTime", ->
+    it "converts existing field values into the expected Date object", ->
+      expect(@subject.getDateTime()).toEqual(new Date(2015, 10, 13, 9, 15))
+
+    describe "when the date value is changed", ->
+      beforeEach -> $("input[name=date]", fixture.el).val("3/2/2016")
+
+      it "converts the new field values into the expected Date object", ->
+        expect(@subject.getDateTime()).toEqual(new Date(2016, 2, 2, 9, 15))
+
+    describe "when the hour value is changed", ->
+      for hour in [1..12]
+        describe "to #{hour}", ->
+          beforeEach -> $("input[name=hour]", fixture.el).val(hour)
+
+          it "converts the new field values into the expected Date object", ->
+            expect(@subject.getDateTime())
+              .toEqual(new Date(2015, 10, 13, hour, 15))
+
+    describe "when the minute value is changed", ->
+      for minute in [0..59] by 15
+        describe "to #{minute}", ->
+          beforeEach -> $("input[name=minute]", fixture.el).val(minute)
+
+          it "converts the new field values into the expected Date object", ->
+            expect(@subject.getDateTime())
+              .toEqual(new Date(2015, 10, 13, 9, minute))
+
+  describe "#setDateTime", ->
+    describe "when the time is before noon", ->
+      beforeEach -> @subject.setDateTime(new Date(2016, 2, 2, 11, 45))
+
+      it "sets itself to the expected Date object", ->
+        expect(@subject.getDateTime()).toEqual(new Date(2016, 2, 2, 11, 45))
+
+      it "sets the date field", ->
+        expect($("input[name=date]", fixture.el).val()).toEqual("3/2/2016")
+
+      it "sets the hour field", ->
+        expect($("input[name=hour]", fixture.el).val()).toEqual("11")
+
+      it "sets the minute field", ->
+        expect($("input[name=minute]", fixture.el).val()).toEqual("45")
+
+      it "sets the meridian field", ->
+        expect($("input[name=meridian]", fixture.el).val()).toEqual("AM")
+
+    describe "when the time is after noon", ->
+      beforeEach -> @subject.setDateTime(new Date(2016, 2, 2, 13, 45))
+
+      it "sets itself to the expected Date object", ->
+        expect(@subject.getDateTime()).toEqual(new Date(2016, 2, 2, 13, 45))
+
+      it "sets the date field", ->
+        expect($("input[name=date]", fixture.el).val()).toEqual("3/2/2016")
+
+      it "sets the hour field", ->
+        expect($("input[name=hour]", fixture.el).val()).toEqual("1")
+
+      it "sets the minute field", ->
+        expect($("input[name=minute]", fixture.el).val()).toEqual("45")
+
+      it "sets the meridian field", ->
+        expect($("input[name=meridian]", fixture.el).val()).toEqual("PM")
+
+    describe "when the time is not aligned to the reserveInterval", ->
+      beforeEach -> @subject.setDateTime(new Date(2016, 2, 2, 13, 39))
+
+      it "rounds down to the previous valid interval", ->
+        expect(@subject.getDateTime()).toEqual(new Date(2016, 2, 2, 13, 30))
+        expect($("input[name=minute]", fixture.el).val()).toEqual("30")
+
+  xdescribe "#change", ->
+    it "TODO: needs tests"

--- a/spec/javascripts/spec_helper.coffee
+++ b/spec/javascripts/spec_helper.coffee
@@ -1,0 +1,32 @@
+# Teaspoon includes some support files, but you can use anything from your own support path too.
+# require support/jasmine-jquery-1.7.0
+# require support/jasmine-jquery-2.0.0
+# require support/jasmine-jquery-2.1.0
+# require support/sinon
+# require support/your-support-file
+#
+# PhantomJS (Teaspoons default driver) doesn't have support for Function.prototype.bind, which has caused confusion.
+# Use this polyfill to avoid the confusion.
+#= require support/bind-poly
+#
+# You can require your own javascript files here. By default this will include everything in application, however you
+# may get better load performance if you require the specific files that are being used in the spec that tests them.
+#= require application
+#
+# Deferring execution
+# If you're using CommonJS, RequireJS or some other asynchronous library you can defer execution. Call
+# Teaspoon.execute() after everything has been loaded. Simple example of a timeout:
+#
+# Teaspoon.defer = true
+# setTimeout(Teaspoon.execute, 1000)
+#
+# Matching files
+# By default Teaspoon will look for files that match _spec.{js,js.coffee,.coffee}. Add a filename_spec.js file in your
+# spec path and it'll be included in the default suite automatically. If you want to customize suites, check out the
+# configuration in teaspoon_env.rb
+#
+# Manifest
+# If you'd rather require your spec files manually (to control order for instance) you can disable the suite matcher in
+# the configuration and use this file as a manifest.
+#
+# For more information: http://github.com/modeset/teaspoon

--- a/spec/javascripts/time_formatter_spec.js.coffee
+++ b/spec/javascripts/time_formatter_spec.js.coffee
@@ -1,0 +1,75 @@
+describe "TimeFormatter", ->
+
+  describe 'fromString', ->
+    describe 'date parsing', ->
+      beforeEach ->
+        @formatter = new TimeFormatter.fromString('4/17/2015', '3', '15', 'AM')
+
+      it 'has the correct year', ->
+        expect(@formatter.year()).toEqual(2015)
+
+      it 'has the correct month', ->
+        expect(@formatter.month()).toEqual(4)
+        expect(@formatter.toString()).toContain('Apr')
+
+      it 'has the correct day', ->
+        expect(@formatter.day()).toEqual(17)
+
+      it 'has the correctly formatted date', ->
+        expect(@formatter.dateString()).toEqual('4/17/2015')
+
+    describe 'time parsing', ->
+      it 'sets the right time for an AM', ->
+        formatter = new TimeFormatter.fromString('6/13/2015', '3', '15', 'AM')
+        expect(formatter.hour24()).toEqual(3)
+        expect(formatter.minute()).toEqual(15)
+
+      it 'sets the right time for PM', ->
+        formatter = new TimeFormatter.fromString('6/13/2015', '3', '15', 'PM')
+        expect(formatter.hour24()).toEqual(15)
+        expect(formatter.minute()).toEqual(15)
+
+      it 'sets the right hour for midnight', ->
+        formatter = new TimeFormatter.fromString('6/13/2015', '12', '00', 'AM')
+        expect(formatter.hour24()).toEqual(0)
+
+      it 'sets the right hour for noon', ->
+        formatter = new TimeFormatter.fromString('6/13/2015', '12', '00', 'PM')
+        expect(formatter.hour24()).toEqual(12)
+
+  describe 'from a Date', ->
+    it 'has the right month', ->
+      date = new Date(2015, 3, 12, 3, 15)
+      formatter = new TimeFormatter(date)
+      expect(formatter.month()).toEqual(4)
+      expect(date.toString()).toContain('Apr')
+      expect(formatter.toString()).toContain('Apr')
+
+    it 'gives the right formatted date', ->
+      date = new Date(2015, 3, 12, 3, 15)
+      formatter = new TimeFormatter(date)
+      expect(formatter.dateString()).toEqual('4/12/2015')
+
+    it 'gives the right thing for an AM', ->
+      date = new Date(2015, 3, 12, 3, 15)
+      formatter = new TimeFormatter(date)
+      expect(formatter.hour12()).toEqual(3)
+      expect(formatter.meridian()).toEqual('AM')
+
+    it 'gives the right thing for a PM', ->
+      date = new Date(2015, 3, 12, 15, 15)
+      formatter = new TimeFormatter(date)
+      expect(formatter.hour12()).toEqual(3)
+      expect(formatter.meridian()).toEqual('PM')
+
+    it 'gives the right thing for midnight', ->
+      date = new Date(2015, 3, 12, 0, 15)
+      formatter = new TimeFormatter(date)
+      expect(formatter.hour12()).toEqual(12)
+      expect(formatter.meridian()).toEqual('AM')
+
+    it 'gives the right thing for noon', ->
+      date = new Date(2015, 3, 12, 12, 15)
+      formatter = new TimeFormatter(date)
+      expect(formatter.hour12()).toEqual(12)
+      expect(formatter.meridian()).toEqual('PM')

--- a/spec/models/reservation_date_support_spec.rb
+++ b/spec/models/reservation_date_support_spec.rb
@@ -43,14 +43,4 @@ describe Reservations::DateSupport do
       end
     end
   end
-
-  context '#assign_reserve_end_from_actual_duration_mins' do
-    before do
-      reservation.assign_reserve_end_from_actual_duration_mins(70)
-    end
-
-    it 'assigns reserve_end_at' do
-      expect(reservation.reserve_end_at).to eq(reservation.reserve_start_at + 65.minutes)
-    end
-  end
 end

--- a/spec/teaspoon_env.rb
+++ b/spec/teaspoon_env.rb
@@ -1,0 +1,178 @@
+Teaspoon.configure do |config|
+  # Determines where the Teaspoon routes will be mounted. Changing this to "/jasmine" would allow you to browse to
+  # `http://localhost:3000/jasmine` to run your tests.
+  config.mount_at = "/teaspoon"
+
+  # Specifies the root where Teaspoon will look for files. If you're testing an engine using a dummy application it can
+  # be useful to set this to your engines root (e.g. `Teaspoon::Engine.root`).
+  # Note: Defaults to `Rails.root` if nil.
+  config.root = nil
+
+  # Paths that will be appended to the Rails assets paths
+  # Note: Relative to `config.root`.
+  config.asset_paths = ["spec/javascripts", "spec/javascripts/stylesheets"]
+
+  # Fixtures are rendered through a controller, which allows using HAML, RABL/JBuilder, etc. Files in these paths will
+  # be rendered as fixtures.
+  config.fixture_paths = ["spec/javascripts/fixtures"]
+
+  # SUITES
+  #
+  # You can modify the default suite configuration and create new suites here. Suites are isolated from one another.
+  #
+  # When defining a suite you can provide a name and a block. If the name is left blank, :default is assumed. You can
+  # omit various directives and the ones defined in the default suite will be used.
+  #
+  # To run a specific suite
+  # - in the browser: http://localhost/teaspoon/[suite_name]
+  # - with the rake task: rake teaspoon suite=[suite_name]
+  # - with the cli: teaspoon --suite=[suite_name]
+  config.suite do |suite|
+    # Specify the framework you would like to use. This allows you to select versions, and will do some basic setup for
+    # you -- which you can override with the directives below. This should be specified first, as it can override other
+    # directives.
+    # Note: If no version is specified, the latest is assumed.
+    #
+    # Versions: 1.3.1, 2.0.3, 2.1.3, 2.2.0
+    suite.use_framework :jasmine, "2.2.0"
+
+    # Specify a file matcher as a regular expression and all matching files will be loaded when the suite is run. These
+    # files need to be within an asset path. You can add asset paths using the `config.asset_paths`.
+    suite.matcher = "{spec/javascripts,app/assets}/**/*_spec.{js,js.coffee,coffee}"
+
+    # Load additional JS files, but requiring them in your spec helper is the preferred way to do this.
+    #suite.javascripts = []
+
+    # You can include your own stylesheets if you want to change how Teaspoon looks.
+    # Note: Spec related CSS can and should be loaded using fixtures.
+    #suite.stylesheets = ["teaspoon"]
+
+    # This suites spec helper, which can require additional support files. This file is loaded before any of your test
+    # files are loaded.
+    suite.helper = "spec_helper"
+
+    # Partial to be rendered in the head tag of the runner. You can use the provided ones or define your own by creating
+    # a `_boot.html.erb` in your fixtures path, and adjust the config to `"/boot"` for instance.
+    #
+    # Available: boot, boot_require_js
+    suite.boot_partial = "boot"
+
+    # Partial to be rendered in the body tag of the runner. You can define your own to create a custom body structure.
+    suite.body_partial = "body"
+
+    # Hooks allow you to use `Teaspoon.hook("fixtures")` before, after, or during your spec run. This will make a
+    # synchronous Ajax request to the server that will call all of the blocks you've defined for that hook name.
+    #suite.hook :fixtures, &proc{}
+
+    # Determine whether specs loaded into the test harness should be embedded as individual script tags or concatenated
+    # into a single file. Similar to Rails' asset `debug: true` and `config.assets.debug = true` options. By default, 
+    # Teaspoon expands all assets to provide more valuable stack traces that reference individual source files.
+    #suite.expand_assets = true
+  end
+
+  # Example suite. Since we're just filtering to files already within the root test/javascripts, these files will also
+  # be run in the default suite -- but can be focused into a more specific suite.
+  #config.suite :targeted do |suite|
+  #  suite.matcher = "spec/javascripts/targeted/*_spec.{js,js.coffee,coffee}"
+  #end
+
+  # CONSOLE RUNNER SPECIFIC
+  #
+  # These configuration directives are applicable only when running via the rake task or command line interface. These
+  # directives can be overridden using the command line interface arguments or with ENV variables when using the rake
+  # task.
+  #
+  # Command Line Interface:
+  # teaspoon --driver=phantomjs --server-port=31337 --fail-fast=true --format=junit --suite=my_suite /spec/file_spec.js
+  #
+  # Rake:
+  # teaspoon DRIVER=phantomjs SERVER_PORT=31337 FAIL_FAST=true FORMATTERS=junit suite=my_suite
+
+  # Specify which headless driver to use. Supports PhantomJS and Selenium Webdriver.
+  #
+  # Available: :phantomjs, :selenium, :capybara_webkit
+  # PhantomJS: https://github.com/modeset/teaspoon/wiki/Using-PhantomJS
+  # Selenium Webdriver: https://github.com/modeset/teaspoon/wiki/Using-Selenium-WebDriver
+  # Capybara Webkit: https://github.com/modeset/teaspoon/wiki/Using-Capybara-Webkit
+  #config.driver = :phantomjs
+
+  # Specify additional options for the driver.
+  #
+  # PhantomJS: https://github.com/modeset/teaspoon/wiki/Using-PhantomJS
+  # Selenium Webdriver: https://github.com/modeset/teaspoon/wiki/Using-Selenium-WebDriver
+  # Capybara Webkit: https://github.com/modeset/teaspoon/wiki/Using-Capybara-Webkit
+  #config.driver_options = nil
+
+  # Specify the timeout for the driver. Specs are expected to complete within this time frame or the run will be
+  # considered a failure. This is to avoid issues that can arise where tests stall.
+  #config.driver_timeout = 180
+
+  # Specify a server to use with Rack (e.g. thin, mongrel). If nil is provided Rack::Server is used.
+  #config.server = nil
+
+  # Specify a port to run on a specific port, otherwise Teaspoon will use a random available port.
+  #config.server_port = nil
+
+  # Timeout for starting the server in seconds. If your server is slow to start you may have to bump this, or you may
+  # want to lower this if you know it shouldn't take long to start.
+  #config.server_timeout = 20
+
+  # Force Teaspoon to fail immediately after a failing suite. Can be useful to make Teaspoon fail early if you have
+  # several suites, but in environments like CI this may not be desirable.
+  #config.fail_fast = true
+
+  # Specify the formatters to use when outputting the results.
+  # Note: Output files can be specified by using `"junit>/path/to/output.xml"`.
+  #
+  # Available: :dot, :clean, :documentation, :json, :junit, :pride, :rspec_html, :snowday, :swayze_or_oprah, :tap, :tap_y, :teamcity
+  #config.formatters = [:dot]
+
+  # Specify if you want color output from the formatters.
+  #config.color = true
+
+  # Teaspoon pipes all console[log/debug/error] to $stdout. This is useful to catch places where you've forgotten to
+  # remove them, but in verbose applications this may not be desirable.
+  #config.suppress_log = false
+
+  # COVERAGE REPORTS / THRESHOLD ASSERTIONS
+  #
+  # Coverage reports requires Istanbul (https://github.com/gotwarlost/istanbul) to add instrumentation to your code and
+  # display coverage statistics.
+  #
+  # Coverage configurations are similar to suites. You can define several, and use different ones under different
+  # conditions.
+  #
+  # To run with a specific coverage configuration
+  # - with the rake task: rake teaspoon USE_COVERAGE=[coverage_name]
+  # - with the cli: teaspoon --coverage=[coverage_name]
+
+  # Specify that you always want a coverage configuration to be used. Otherwise, specify that you want coverage
+  # on the CLI.
+  # Set this to "true" or the name of your coverage config.
+  #config.use_coverage = nil
+
+  # You can have multiple coverage configs by passing a name to config.coverage.
+  # e.g. config.coverage :ci do |coverage|
+  # The default coverage config name is :default.
+  config.coverage do |coverage|
+    # Which coverage reports Istanbul should generate. Correlates directly to what Istanbul supports.
+    #
+    # Available: text-summary, text, html, lcov, lcovonly, cobertura, teamcity
+    #coverage.reports = ["text-summary", "html"]
+
+    # The path that the coverage should be written to - when there's an artifact to write to disk.
+    # Note: Relative to `config.root`.
+    #coverage.output_path = "coverage"
+
+    # Assets to be ignored when generating coverage reports. Accepts an array of filenames or regular expressions. The
+    # default excludes assets from vendor, gems and support libraries.
+    #coverage.ignore = [%r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}]
+
+    # Various thresholds requirements can be defined, and those thresholds will be checked at the end of a run. If any
+    # aren't met the run will fail with a message. Thresholds can be defined as a percentage (0-100), or nil.
+    #coverage.statements = nil
+    #coverage.functions = nil
+    #coverage.branches = nil
+    #coverage.lines = nil
+  end
+end


### PR DESCRIPTION
https://pm.tablexi.com/issues/94617
This adds reservation end time fields that update the duration and vice-versa. @jhanggi I went a bit deeper into the clockpunch guts than I'd have liked. Setting the visible duration field and firing `change()` got me into an infinite loop, so this is setting the hidden field on its own.