### PR TITLE
[#94617] Fix ability to create admin reservations

### DIFF
--- a/app/views/facility_reservations/_reservation_fields.html.haml
+++ b/app/views/facility_reservations/_reservation_fields.html.haml
@@ -7,11 +7,10 @@
         = time_select f, :reserve_start
     = f.input :duration_mins, input_html: { class: "timeinput" }
     = f.input :admin_note, input_html: { class: "span6" } unless @order_detail
-    = f.input :reserve_end_date, input_html: { class: "datepicker" }
 
 - else
   = f.input :reserve_start_date, label: "Reservation", as: :readonly, input_html: { value: @reservation.reserve_to_s }
-  = f.input :reserve_end_date, input_html: { class: "datepicker" }
+
 .clearfix
 
 - if @order_detail


### PR DESCRIPTION
As part of "#94617 Add ability to enter end time during reservation creation"
a change was made adding a couple extraneous fields to the facility admin
reservation form. As we had decided that the change should only affect
the user-side, and not the facility admin side, I am reverting the changes to
this view.

https://github.com/tablexi/nucore-open/pull/288