### PR TITLE
[#94617] Do not run some reservation JS on admin reservations

### DIFF
--- a/app/assets/javascripts/app/reservation_time_checker.coffee
+++ b/app/assets/javascripts/app/reservation_time_checker.coffee
@@ -1,8 +1,12 @@
 class window.ReservationTimeChecker
   constructor: (@selector, @alertId = 'duration-alert')->
-    @initAlert()
-    @respondToChange()
+    if @validPage()
+      @initAlert()
+      @respondToChange()
 
+  validPage: ->
+    # These variable are not set on the admin reservation pages
+    reserveInterval? && reserveMinimum? && reserveMaximum?
 
   duration: ->
     parser = new TimeParser()

--- a/app/assets/javascripts/app/reservation_time_field_adjustor.js.coffee
+++ b/app/assets/javascripts/app/reservation_time_field_adjustor.js.coffee
@@ -86,5 +86,7 @@ class window.ReservationTimeFieldAdjustor
     )
 
 $ ->
-  $("form.new_reservation, form.edit_reservation").each ->
-    new ReservationTimeFieldAdjustor($(this), reserveInterval)
+  # reserveInterval is not set on admin reservation pages, and we don't need these handlers there
+  if reserveInterval?
+    $("form.new_reservation, form.edit_reservation").each ->
+      new ReservationTimeFieldAdjustor($(this), reserveInterval)


### PR DESCRIPTION
The admin reservation new/edit pages were not showing the calendar
because of JS errors caused by referencing variables that don’t exist
on those pages.

The ReservationTimeChecker error has been happening for a while, but
has no visible effect, just an error to the console.