### PR TITLE
Fix spec that is broken when merging into the NU branch.

### DIFF
--- a/spec/controllers/bundles_controller_spec.rb
+++ b/spec/controllers/bundles_controller_spec.rb
@@ -82,7 +82,7 @@ describe BundlesController do
 
     context "when the bundle requires approval" do
       before(:each) do
-        add_account_for_user(:guest, bundle)
+        add_account_for_user(:guest, bundle.products.first)
         BundlesController.any_instance.stub(:price_policy_available_for_product?).and_return(true)
         bundle.update_attributes(requires_approval: true)
       end
@@ -153,7 +153,7 @@ describe BundlesController do
 
       context "when the user is an admin" do
         before(:each) do
-          add_account_for_user(:admin, bundle)
+          add_account_for_user(:admin, bundle.products.first)
           sign_in @admin
           do_request
         end


### PR DESCRIPTION
The account needed to be added to one of the products within the bundle,
not the bundle itself.

https://github.com/tablexi/nucore-open/pull/298/files#diff-a4df8e7f76722c53491b648a90dfe540L85