### PR TITLE
Make paperclip configurable to support S3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'prawn_rails',      '0.0.11'
 
 ## other
 gem 'delayed_job_active_record', '~> 4.0.1'
+gem 'fog'
 gem 'rake'
 gem 'spreadsheet',      '~> 0.6.5.5'
 gem 'fast-aes',         '0.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.0.2)
+    CFPropertyList (2.3.1)
     aasm (2.2.0)
     actionmailer (3.2.21)
       actionpack (= 3.2.21)
@@ -130,6 +131,7 @@ GEM
     exception_notification (4.0.1)
       actionmailer (>= 3.0.4)
       activesupport (>= 3.0.4)
+    excon (0.45.3)
     execjs (1.4.0)
       multi_json (~> 1.0)
     factory_girl (4.5.0)
@@ -139,6 +141,102 @@ GEM
       railties (>= 3.0.0)
     fast-aes (0.1.1)
     ffi (1.9.6)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.32.0)
+      fog-atmos
+      fog-aws (>= 0.6.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.32)
+      fog-ecloud (= 0.1.1)
+      fog-google (>= 0.0.2)
+      fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (0.6.0)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.7.2)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-core (1.32.0)
+      builder
+      excon (~> 0.45)
+      formatador (~> 0.2)
+      mime-types
+      net-scp (~> 1.1)
+      net-ssh (>= 2.1.3)
+    fog-ecloud (0.1.1)
+      fog-core
+      fog-xml
+    fog-google (0.0.7)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-local (0.2.1)
+      fog-core (~> 1.27)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (0.0.3)
+      fog-core
+      fog-xml
+      nokogiri
+    fog-radosgw (0.0.4)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.0.1)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (0.4.7)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
     font-awesome-rails (3.2.1.2)
       railties (>= 3.2, < 5.0)
     foreigner (1.1.1)
@@ -160,6 +258,8 @@ GEM
     hike (1.2.3)
     hitimes (1.2.2)
     i18n (0.7.0)
+    inflecto (0.0.2)
+    ipaddress (0.8.0)
     journey (1.0.4)
     jquery-rails (2.1.4)
       railties (>= 3.0, < 5.0)
@@ -359,6 +459,7 @@ DEPENDENCIES
   exception_notification (~> 4.0.1)
   factory_girl_rails (~> 4.5.0)
   fast-aes (= 0.1.1)
+  fog
   font-awesome-rails (~> 3.2.0)
   foreigner (= 1.1.1)
   guard-rspec

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Welcome to NU Core! This guide will help you get a development environment up an
         aws_access_key_id: YOUR_S3_KEY_GOES_HERE
         aws_secret_access_key: YOUR_S3_SECRET_KEY_GOES_HERE
       fog_directory: YOUR_S3_BUCKET_NAME_GOES_HERE
+      path: ":class/:attachment/:id_partition/:style/:safe_filename"
     ```
 
 7. Start your server

--- a/README.md
+++ b/README.md
@@ -51,13 +51,30 @@ Welcome to NU Core! This guide will help you get a development environment up an
     rake demo:seed
     ```
 
-6. Start your server
+6. Configure your file storage
+
+    By default, files are stored on the local filesystem. If you wish to use
+    Amazon's S3 instead, create a local settings override file such as
+    `config/settings/development.local.yml` or `config/settings/production.local.yml`
+    and include the following, substituting your AWS settings:
+
+    ```
+    paperclip:
+      storage: fog
+      fog_credentials:
+        provider: AWS
+        aws_access_key_id: YOUR_S3_KEY_GOES_HERE
+        aws_secret_access_key: YOUR_S3_SECRET_KEY_GOES_HERE
+      fog_directory: YOUR_S3_BUCKET_NAME_GOES_HERE
+    ```
+
+7. Start your server
 
     ```
     bin/rails s
     ```
 
-7. Log in
+8. Log in
 
     Visit http://localhost:3000
 
@@ -71,7 +88,7 @@ Welcome to NU Core! This guide will help you get a development environment up an
     | ast123@example.com | Facility Staff |
     | ddi123@example.com | Facility Director |
 
-8. Play around! You're running NU Core!
+9. Play around! You're running NU Core!
 
 
 ### Test it

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -111,10 +111,7 @@ class Journal < ActiveRecord::Base
   before_validation :set_facility_id, :on => :create, :if => :has_order_details_for_creation?
   after_create :create_new_journal_rows, :if => :has_order_details_for_creation?
 
-  has_attached_file       :file,
-                          :storage => :filesystem,
-                          :url => "#{ENV['RAILS_RELATIVE_URL_ROOT']}/:attachment/:id_partition/:style/:basename.:extension",
-                          :path => ":rails_root/public/:attachment/:id_partition/:style/:basename.:extension"
+  has_attached_file :file, Settings.paperclip.to_hash
 
   do_not_validate_attachment_file_type :file
 

--- a/app/models/order_import.rb
+++ b/app/models/order_import.rb
@@ -111,7 +111,7 @@ class OrderImport < ActiveRecord::Base
   def handle_save_nothing_on_error # TODO refactor and rename
     Order.transaction do
       begin
-        CSV.open(upload_file_path, headers: true, skip_lines: /^,*$/).each do |row|
+        CSV.parse(upload_file.read, headers: true, skip_lines: /^,*$/).each do |row|
           row_importer = import_row(row)
           self.error_report += row_importer.row_with_errors.to_csv
 
@@ -176,7 +176,7 @@ class OrderImport < ActiveRecord::Base
 
   def rows_by_order_key # TODO refactor
     rows = Hash.new { |hash, key| hash[key] = [] }
-    CSV.open(upload_file_path, headers: true, skip_lines: /^,*$/).each do |row|
+    CSV.parse(upload_file.read, headers: true, skip_lines: /^,*$/).each do |row|
       order_key = OrderRowImporter.order_key_for_row(row)
       rows[order_key] << row
     end

--- a/app/models/stored_file.rb
+++ b/app/models/stored_file.rb
@@ -6,10 +6,7 @@ class StoredFile < ActiveRecord::Base
   validates_presence_of   :product_id,      :if => lambda {|o| o.file_type == 'info' || o.file_type == 'template'}
   validates_presence_of   :order_detail_id, :if => lambda {|o| o.file_type == 'template_result' || o.file_type == 'sample_result'}
   validates_inclusion_of  :file_type, :in => %w(info template template_result sample_result import_error import_upload)
-  has_attached_file       :file,
-                          :storage => :filesystem,
-                          :url => "#{ENV['RAILS_RELATIVE_URL_ROOT']}/:attachment/:id_partition/:style/:safe_filename",
-                          :path => ":rails_root/public/:attachment/:id_partition/:style/:safe_filename"
+  has_attached_file       :file, Settings.paperclip.to_hash
   validates_attachment_presence :file
 
   # TODO Limit attachment types for safe uploads

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -4,6 +4,10 @@ Paperclip.interpolates :safe_filename do |attachment, style|
   filename(attachment, style).gsub(/#/, '-')
 end
 
+Paperclip.interpolates :rails_relative_url_root do |_, _|
+  ENV['RAILS_RELATIVE_URL_ROOT'] || ""
+end
+
 # XLS files created by the spreadsheet gem have problems with their filetypes
 # https://github.com/zdavatz/spreadsheet/issues/97
 Paperclip.options[:content_type_mappings] = {

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -91,3 +91,8 @@ feature:
   edit_accounts_on: true
   suspend_accounts_on: true
   product_specific_contacts_on: true
+
+paperclip:
+  storage: filesystem
+  url: ":rails_relative_url_root/:attachment/:id_partition/:style/:safe_filename"
+  path: ":rails_root/public/:attachment/:id_partition/:style/:safe_filename"

--- a/lib/tasks/store_files_on_s3.rake
+++ b/lib/tasks/store_files_on_s3.rake
@@ -1,6 +1,22 @@
 namespace :paperclip do
+  def allow_task?
+    if Settings.paperclip.storage == "fog"
+      true
+    else
+      puts "Cannot move files to S3 unless paperclip storage is set to 'fog'."
+      puts "See the section on configuring file storage in the README."
+      false
+    end
+  rescue NoMethodError
+    puts "It doesn't look like paperclip is configured."
+    puts "See the section on configuring file storage in the README."
+    false
+  end
+
   desc "Move files from local to S3"
   task move_to_s3: :environment do
+    next unless allow_task?
+
     StoredFile.all.each do |stored_file|
       id_partition = ("%09d" % stored_file.id).scan(/\d{3}/).join("/")
       filename = stored_file.file_file_name.gsub(/#/, "-")

--- a/lib/tasks/store_files_on_s3.rake
+++ b/lib/tasks/store_files_on_s3.rake
@@ -1,0 +1,25 @@
+namespace :paperclip do
+  desc "Move files from local to S3"
+  task move_to_s3: :environment do
+    StoredFile.all.each do |stored_file|
+      id_partition = ("%09d" % stored_file.id).scan(/\d{3}/).join("/")
+      filename = stored_file.file_file_name.gsub(/#/, "-")
+      local_filepath = "#{Rails.root}/public/files/#{id_partition}/original/#{filename}"
+
+      print "Processing #{local_filepath}"
+
+      begin
+        File.open(local_filepath) do |filehandle|
+          stored_file.file.assign(filehandle)
+          if stored_file.file.save
+            puts "; stored to #{stored_file.file.url}"
+          else
+            puts "; S3 store failed!"
+          end
+        end
+      rescue Errno::ENOENT => e
+        puts ": Skipping! File does not exist."
+      end
+    end
+  end
+end

--- a/spec/models/order_import_spec.rb
+++ b/spec/models/order_import_spec.rb
@@ -355,7 +355,7 @@ end
 
     context "an excetion is raised when opening the CSV" do
       before do
-        CSV.stub(:open).and_raise(ArgumentError, "invalid byte sequence in UTF-8")
+        CSV.stub(:parse).and_raise(ArgumentError, "invalid byte sequence in UTF-8")
         import.upload_file.file = generate_import_file
         import.upload_file.save!
         import.process_upload!

--- a/spec/models/stored_file_spec.rb
+++ b/spec/models/stored_file_spec.rb
@@ -60,5 +60,9 @@ describe StoredFile do
     it "is stored with a partitioned path" do
       expect(file_upload.file.url.match(%r(\A/files/\d+/\d+/\d+/)))
     end
+
+    it "stored the file content" do
+      expect(file_upload.read).to eq(File.read(file1))
+    end
   end
 end

--- a/spec/models/stored_file_spec.rb
+++ b/spec/models/stored_file_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe StoredFile do
 
@@ -33,15 +33,32 @@ describe StoredFile do
     end
   end
 
-  it "should create file and store on disk with partitioned path" do
-    @facility         = FactoryGirl.create(:facility)
-    @facility_account = @facility.facility_accounts.create(FactoryGirl.attributes_for(:facility_account))
-    @item             = @facility.items.create(FactoryGirl.attributes_for(:item, :facility_account_id => @facility_account.id))
-    @creator          = FactoryGirl.create(:user)
-    @file1            = "#{Rails.root}/spec/files/template1.txt"
-    @file_upload      = @item.stored_files.create(:name => "File 1", :file => File.open(@file1), :file_type => "info",
-                                                  :creator => @creator)
-    assert @file_upload.valid?
-    assert @file_upload.file.url.match(/^\/files\/\d+\/\d+\/\d+\//)
+  context "when uploading" do
+    let(:facility) { create(:facility) }
+    let(:facility_account) do
+      facility.facility_accounts.create(attributes_for(:facility_account))
+    end
+    let(:item) do
+      facility.items.create(
+        attributes_for(:item, facility_account_id: facility_account.id)
+      )
+    end
+    let(:file1) { "#{Rails.root}/spec/files/template1.txt" }
+    let(:file_upload) do
+      item.stored_files.create(
+        name: "File 1",
+        file: File.open(file1),
+        file_type: "info",
+        creator: create(:user),
+      )
+    end
+
+    it "is valid" do
+      expect(file_upload).to be_valid
+    end
+
+    it "is stored with a partitioned path" do
+      expect(file_upload.file.url.match(%r(\A/files/\d+/\d+/\d+/)))
+    end
   end
 end

--- a/spec/models/stored_file_spec.rb
+++ b/spec/models/stored_file_spec.rb
@@ -58,7 +58,7 @@ describe StoredFile do
     end
 
     it "is stored with a partitioned path" do
-      expect(file_upload.file.url.match(%r(\A/files/\d+/\d+/\d+/)))
+      expect(file_upload.file.url).to match(%r(\A/files/\d+/\d+/\d+/))
     end
 
     it "stored the file content" do


### PR DESCRIPTION
This moves the hardcoded paperclip settings into `settings/`. I've included instructions in the README on configuring the app to use S3.

It also includes a rake task that should migrate all `StoredFile`s on the filesystem to S3, to be run after configuring the system to use S3: `bundle exec rake paperclip:move_to_s3`. We should save the output of this run to track down any files it was unable to migrate.

Something to watch out for: I tried upgrading the paperclip gem to 4.3, but it seems to break journaling here: https://github.com/tablexi/nucore-open/blob/master/spec/models/journal_spec.rb#L170