### PR TITLE
[#98882 102019] Reservation time validation updates

### DIFF
--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -29,14 +29,14 @@ module ReservationsHelper
   end
 
   def start_time_disabled?(reservation)
-    return false unless reservation.persisted?
+    return false if !reservation.persisted? || reservation.in_cart?
 
     original = Reservation.find(reservation)
     !original.reserve_start_at_editable?
   end
 
   def end_time_disabled?(reservation)
-    return false unless reservation.persisted?
+    return false if !reservation.persisted? || reservation.in_cart?
 
     original = Reservation.find(reservation)
     !original.reserve_end_at_editable?

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -60,6 +60,10 @@ class Order < ActiveRecord::Base
     define_method(method_name) { total_cost method_name }
   end
 
+  def in_cart?
+    !ordered_at?
+  end
+
   def move_order_details_to_default_status
     order_details.each { |od| od.set_default_status! }
   end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -51,7 +51,7 @@ class OrderDetail < ActiveRecord::Base
   delegate :invoice_number, to: :statement, prefix: true
   delegate :requires_but_missing_actuals?, to: :reservation, allow_nil: true
 
-  delegate :user, :facility, :ordered_at, :to => :order
+  delegate :in_cart?, :facility, :ordered_at, :user, to: :order
   delegate :price_group, :to => :price_policy, :allow_nil => true
   def estimated_price_group
     estimated_price_policy.try(:price_group)

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -31,7 +31,7 @@ class Reservation < ActiveRecord::Base
   delegate :note, :ordered_on_behalf_of?, :complete?, :account, :order,
       :problem?, :complete!, :to => :order_detail, :allow_nil => true
 
-  delegate :user, :account, :to => :order, :allow_nil => true
+  delegate :account, :in_cart?, :user, to: :order, allow_nil: true
   delegate :facility, :to => :product, :allow_nil => true
   delegate :lock_window, to: :product, prefix: true
   delegate :owner, :to => :account, :allow_nil => true

--- a/app/support/reservations/duration_change_validations.rb
+++ b/app/support/reservations/duration_change_validations.rb
@@ -24,7 +24,7 @@ class Reservations::DurationChangeValidations
   end
 
   def start_time_not_changed
-    if !reservation.reserve_start_at_editable? && reservation.reserve_start_at_changed?
+    if reservation.reserve_start_at_changed? && !was_reserve_start_at_editable?(reservation)
       previous_time = reservation.reserve_start_at_was.change(sec: 0)
       updated_time = reservation.reserve_start_at.change(sec: 0)
       if previous_time != updated_time
@@ -39,5 +39,11 @@ class Reservations::DurationChangeValidations
     if reservation_started && reservation_shortened
       errors.add(:reserve_end_at, I18n.t('activerecord.errors.models.reservation.shorten_reserve_end_at'))
     end
+  end
+
+  private
+
+  def was_reserve_start_at_editable?(reservation)
+    Reservation.find(reservation).reserve_start_at_editable?
   end
 end

--- a/app/views/reservations/_reservation_fields.html.haml
+++ b/app/views/reservations/_reservation_fields.html.haml
@@ -1,5 +1,5 @@
 .datetime-block
-  - start_disabled = f.object.persisted? && !f.object.reserve_start_at_editable?
+  - start_disabled = start_time_disabled?(f.object)
   = f.input :reserve_start_date, input_html: { class: "datepicker", disabled: start_disabled }
   .control-group
     .controls

--- a/spec/app_support/reservations/duration_change_validations_spec.rb
+++ b/spec/app_support/reservations/duration_change_validations_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Reservations::DurationChangeValidations do
 
@@ -6,16 +6,25 @@ describe Reservations::DurationChangeValidations do
   let(:reservation) { create :setup_reservation }
 
   describe "#start_time_not_changed" do
-    context "with an upcoming reservation" do
-      let(:reservation) { create :setup_reservation, reserve_start_at: 5.minute.from_now, reserve_end_at: 70.minutes.from_now }
+    let(:reservation) do
+      create(
+        :setup_reservation,
+        reserve_start_at: reserve_start_at,
+        reserve_end_at: reserve_end_at,
+      )
+    end
 
-      it 'allows changing start time' do
+    context "with an upcoming reservation" do
+      let(:reserve_start_at) { 5.minutes.from_now }
+      let(:reserve_end_at) { 70.minutes.from_now }
+
+      it "allows changing start time" do
         reservation.reserve_start_at = 10.minutes.from_now
         validator.valid?
         expect(validator.errors).to be_empty
       end
 
-      it 'allows shortening end time' do
+      it "allows shortening end time" do
         reservation.reserve_end_at = 65.minutes.from_now
         validator.valid?
         expect(validator.errors).to be_empty
@@ -23,20 +32,21 @@ describe Reservations::DurationChangeValidations do
     end
 
     context "with an ongoing reseration" do
-      let(:reservation) { create :setup_reservation, reserve_start_at: 30.minutes.ago, reserve_end_at: 40.minutes.from_now }
+      let(:reserve_start_at) { 30.minutes.ago }
+      let(:reserve_end_at) { 40.minutes.from_now }
 
-      it 'denies changing start time' do
+      it "denies changing start time" do
         reservation.reserve_start_at = 40.minutes.ago
         validator.valid?
         expect(validator.errors.full_messages)
-          .to include('Reserve start at cannot change once the reservation has started')
+          .to include("Reserve start at cannot change once the reservation has started")
       end
 
-      it 'denies shortening end time' do
+      it "denies shortening end time" do
         reservation.reserve_end_at = 35.minutes.from_now
         validator.valid?
         expect(validator.errors.full_messages)
-          .to include('Reserve end at cannot be shortened once the reservation has started')
+          .to include("Reserve end at cannot be shortened once the reservation has started")
       end
 
       context "with start time containing seconds" do
@@ -45,7 +55,7 @@ describe Reservations::DurationChangeValidations do
           reservation.save!
         end
 
-        it 'does not think start time changed' do
+        it "does not think start time changed" do
           reservation.reserve_start_at = 30.minutes.ago
           validator.valid?
           expect(validator.errors).to be_empty
@@ -56,41 +66,41 @@ describe Reservations::DurationChangeValidations do
     context "with a past reservation" do
       let(:reservation) { create :setup_reservation, reserve_start_at: 15.minutes.ago, reserve_end_at: 5.minutes.ago, product: create(:setup_instrument, min_reserve_mins: 5) }
 
-      it 'denies changing start time' do
+      it "denies changing start time" do
         reservation.reserve_start_at = 10.minutes.ago
         validator.valid?
         expect(validator.errors.full_messages)
-          .to include('Reserve start at cannot change once the reservation has started')
+          .to include("Reserve start at cannot change once the reservation has started")
       end
 
-      it 'denies shortening end time' do
+      it "denies shortening end time" do
         reservation.reserve_end_at = 10.minutes.ago
         validator.valid?
         expect(validator.errors.full_messages)
-          .to include('Reserve end at cannot be shortened once the reservation has started')
+          .to include("Reserve end at cannot be shortened once the reservation has started")
       end
     end
   end
 
   describe "#copy_errors!" do
     before do
-      validator.errors.add(:base, 'I am an error')
+      validator.errors.add(:base, "I am an error")
       validator.copy_errors!
     end
 
     it "copies errors to reservation" do
-      reservation.errors.full_messages.include?('I am an error')
+      reservation.errors.full_messages.include?("I am an error")
     end
   end
 
   describe "#invalid?" do
     before do
-      validator.errors.add(:base, 'I am an error')
+      validator.errors.add(:base, "I am an error")
       validator.invalid?
     end
 
     it "copies errors to reservation" do
-      reservation.errors.full_messages.include?('I am an error')
+      reservation.errors.full_messages.include?("I am an error")
     end
   end
 

--- a/spec/app_support/reservations/duration_change_validations_spec.rb
+++ b/spec/app_support/reservations/duration_change_validations_spec.rb
@@ -31,7 +31,7 @@ describe Reservations::DurationChangeValidations do
       end
     end
 
-    context "with an ongoing reseration" do
+    context "with an ongoing reservation" do
       let(:reserve_start_at) { 30.minutes.ago }
       let(:reserve_end_at) { 40.minutes.from_now }
 
@@ -118,7 +118,7 @@ describe Reservations::DurationChangeValidations do
       it { expect(validator).to be_valid }
     end
 
-    context "with an ongoing reseration" do
+    context "with an ongoing reservation" do
       before do
         reservation.assign_attributes(
           reserve_start_at: 30.minutes.ago,

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -26,9 +26,7 @@ describe ReservationsController do
     create(:account_price_group_member, account: @account, price_group: @price_group)
   end
 
-
   context 'index' do
-
     before :each do
       @order.stub(:cart_valid?).and_return(true)
       @order.stub(:place_order?).and_return(true)
@@ -149,14 +147,12 @@ describe ReservationsController do
       @params = {}
     end
 
-
     it "should redirect to default view" do
       maybe_grant_always_sign_in(:staff)
       @params.merge!(:status => 'junk')
       do_request
       should redirect_to "/reservations/upcoming"
     end
-
 
     context "upcoming" do
       before :each do
@@ -231,7 +227,6 @@ describe ReservationsController do
       end
     end
 
-
     context 'all' do
       before :each do
         @params = {:status => 'all'}
@@ -247,9 +242,7 @@ describe ReservationsController do
         should render_template('list')
       end
     end
-
   end
-
 
   context 'creating a reservation in the past' do
     before :each do
@@ -302,11 +295,9 @@ describe ReservationsController do
     it_should_allow_all facility_operators, 'set the right estimated price' do
       assigns[:reservation].order_detail.reload.estimated_cost.should == 120
     end
-
   end
 
   context 'create' do
-
     before :each do
       @method=:post
       @action=:create
@@ -505,7 +496,6 @@ describe ReservationsController do
       end
     end
 
-
     context 'with other things in the cart (bundle or multi-add)' do
 
       before :each do
@@ -523,12 +513,9 @@ describe ReservationsController do
         assert_redirected_to cart_path
       end
     end
-
   end
 
-
   context 'new' do
-
     before :each do
       @method=:get
       @action=:new
@@ -551,6 +538,7 @@ describe ReservationsController do
       assigns[:min_date].should == (Time.zone.now+assigns[:max_days_ago].days).strftime("%Y%m%d")
       assigns[:max_date].should == (Time.zone.now + 365.days).strftime("%Y%m%d")
     end
+
     # guests should only be able to go the default reservation window into the future
     it_should_allow_all [:guest] do
       assigns[:max_window].should == PriceGroupProduct::DEFAULT_RESERVATION_WINDOW
@@ -707,9 +695,7 @@ describe ReservationsController do
     end
   end
 
-
   context 'needs future reservation' do
-
     before :each do
       # create reservation for tomorrow @ 9 am for 60 minutes, with order detail reference
       @start        = Time.zone.now.end_of_day + 1.second + 9.hours
@@ -718,9 +704,7 @@ describe ReservationsController do
       assert @reservation.valid?
     end
 
-
     context 'show' do
-
       before :each do
         @method=:get
         @action=:show
@@ -733,7 +717,6 @@ describe ReservationsController do
         assigns[:order].should == @reservation.order_detail.order
         should respond_with :success
       end
-
     end
 
     describe "#edit" do
@@ -790,7 +773,6 @@ describe ReservationsController do
     end
 
     context 'update' do
-
       before :each do
         @method=:put
         @action=:update
@@ -887,9 +869,7 @@ describe ReservationsController do
           response.should render_template(:edit)
         end
       end
-
     end
-
   end
 
   context 'earliest move possible' do
@@ -989,7 +969,6 @@ describe ReservationsController do
   end
 
   context 'needs now reservation' do
-
     before :each do
       # create reservation for tomorrow @ 9 am for 60 minutes, with order detail reference
       @start        = Time.zone.now + 1.second

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -85,6 +85,14 @@ FactoryGirl.define do
       create :instrument_price_policy, price_group: product.facility.price_groups.last, usage_rate: 1, product: product
       product.reload
     end
+
+    trait :always_available do
+      after(:create) do |product|
+        product.schedule_rules.destroy_all
+        create(:all_day_schedule_rule, instrument: product)
+        product.reload
+      end
+    end
   end
 
   factory :instrument_requiring_approval, parent: :setup_instrument do

--- a/spec/factories/reservations.rb
+++ b/spec/factories/reservations.rb
@@ -31,6 +31,10 @@ FactoryGirl.define do
       running
       actual_start_at { reserve_start_at - 5.minutes }
     end
+
+    trait :tomorrow do
+      reserve_start_at { 1.day.from_now }
+    end
   end
 
   factory :setup_reservation, :class => Reservation, :parent => :reservation do

--- a/spec/factories/reservations.rb
+++ b/spec/factories/reservations.rb
@@ -3,6 +3,10 @@ FactoryGirl.define do
     reserve_start_at { Time.zone.parse("#{Date.today} 10:00:00") + 1.day }
     reserve_end_at { reserve_start_at + 1.hour }
 
+    trait :canceled do
+      canceled_at { 1.minute.ago }
+    end
+
     trait :yesterday do
       reserve_start_at { Time.zone.parse("#{Date.today} 10:00:00") - 1.day }
     end

--- a/spec/helpers/reservations_helper_spec.rb
+++ b/spec/helpers/reservations_helper_spec.rb
@@ -12,7 +12,17 @@ describe ReservationsHelper do
       context "and reserve_end_at is in the past" do
         subject(:reservation) { create(:setup_reservation, :yesterday) }
 
-        it { expect(end_time_disabled?(reservation)).to be true }
+        context "and the reservation is in a cart" do
+          before { reservation.order.ordered_at = nil }
+
+          it { expect(end_time_disabled?(reservation)).to be false }
+        end
+
+        context "and the reservation has been ordered" do
+          before { reservation.order.ordered_at = Time.zone.now }
+
+          it { expect(end_time_disabled?(reservation)).to be true }
+        end
       end
 
       context "and reserve_end_at is in the future" do
@@ -38,7 +48,17 @@ describe ReservationsHelper do
       context "and reserve_start_at is in the past" do
         subject(:reservation) { create(:setup_reservation, :yesterday) }
 
-        it { expect(start_time_disabled?(reservation)).to be true }
+        context "and the reservation is in a cart" do
+          before { reservation.order.ordered_at = false }
+
+          it { expect(start_time_disabled?(reservation)).to be false }
+        end
+
+        context "and the reservation has been ordered" do
+          before { reservation.order.ordered_at = Time.zone.now }
+
+          it { expect(start_time_disabled?(reservation)).to be true }
+        end
       end
 
       context "and reserve_start_at is in the future" do

--- a/spec/helpers/reservations_helper_spec.rb
+++ b/spec/helpers/reservations_helper_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+describe ReservationsHelper do
+  describe "#end_time_disabled?" do
+    context "when the reservation is not persisted" do
+      subject(:reservation) { Reservation.new }
+
+      it { expect(end_time_disabled?(reservation)).to be false }
+    end
+
+    context "when the reservation is persisted" do
+      context "and reserve_end_at is in the past" do
+        subject(:reservation) { create(:setup_reservation, :yesterday) }
+
+        it { expect(end_time_disabled?(reservation)).to be true }
+      end
+
+      context "and reserve_end_at is in the future" do
+        subject(:reservation) { create(:setup_reservation, :tomorrow) }
+
+        context "and reserve_end_at is set to a time in the past but not saved" do
+          before { reservation.reserve_end_at = 1.day.ago }
+
+          it { expect(end_time_disabled?(reservation)).to be false }
+        end
+      end
+    end
+  end
+
+  describe "#start_time_disabled?" do
+    context "when the reservation is not persisted" do
+      subject(:reservation) { Reservation.new }
+
+      it { expect(start_time_disabled?(reservation)).to be false }
+    end
+
+    context "when the reservation is persisted" do
+      context "and reserve_start_at is in the past" do
+        subject(:reservation) { create(:setup_reservation, :yesterday) }
+
+        it { expect(start_time_disabled?(reservation)).to be true }
+      end
+
+      context "and reserve_start_at is in the future" do
+        subject(:reservation) { create(:setup_reservation, :tomorrow) }
+
+        context "and reserve_start_at is set to a time in the past but not saved" do
+          before { reservation.reserve_start_at = 1.day.ago }
+
+          it { expect(start_time_disabled?(reservation)).to be false }
+        end
+      end
+    end
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -479,4 +479,18 @@ describe Order do
       @order2.merge_order.should == @order
     end
   end
+
+  describe "#in_cart?" do
+    context "when ordered_at is set" do
+      subject(:order) { build(:order, ordered_at: Time.zone.now) }
+
+      it { expect(order).not_to be_in_cart }
+    end
+
+    context "when ordered_at is not set" do
+      subject(:order) { build(:order, ordered_at: nil) }
+
+      it { expect(order).to be_in_cart }
+    end
+  end
 end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -27,6 +27,28 @@ describe Reservation do
     Reservation.any_instance.stub(:admin?).and_return(false)
   end
 
+  describe "#can_edit?" do
+    context "when the reservation has been persisted" do
+      context "and has been canceled" do
+        subject(:reservation) { create(:setup_reservation, :canceled) }
+
+        it { expect(reservation).not_to be_can_edit }
+      end
+
+      context "and has not been canceled" do
+        subject(:reservation) { create(:setup_reservation) }
+
+        it { expect(reservation).to be_can_edit }
+      end
+    end
+
+    context "when the reservation has not been persisted" do
+      subject(:reservation) { build(:reservation) }
+
+      it { expect(reservation).to be_can_edit }
+    end
+  end
+
   it 'allows starting of a reservation, whose duration is equal to the max duration, within the grace period' do
     reservation.product.update_attribute :max_reserve_mins, reservation.duration_mins
 

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -61,7 +61,6 @@ describe Reservation do
     end
   end
 
-
   context 'canceled?' do
     before :each do
       @reservation = @instrument.reservations.create(:reserve_start_date => (Date.today+1.day).to_s, :reserve_start_hour => '10',
@@ -78,7 +77,6 @@ describe Reservation do
       @reservation.should be_canceled
     end
   end
-
 
   context 'with order details' do
     subject(:reservation) { @reservation1 }
@@ -582,11 +580,9 @@ describe Reservation do
         end
       end
     end
-
   end
 
   context 'maximum reservation length' do
-
     before :each do
       @instrument.update_attributes(:max_reserve_mins => 60)
     end
@@ -613,7 +609,6 @@ describe Reservation do
       @reservation.stub(:admin?).and_return(true)
       @reservation.should be_valid
     end
-
   end
 
   context 'minimum reservation length' do
@@ -895,7 +890,6 @@ describe Reservation do
   end
 
   context 'has_actuals?' do
-
     it 'should not have actuals' do
       reservation.should_not be_has_actuals
     end
@@ -905,7 +899,6 @@ describe Reservation do
       reservation.actual_end_at=Time.zone.now
       reservation.should be_has_actuals
     end
-
   end
 
   context "as_calendar_obj" do


### PR DESCRIPTION
I did some cleanup as I was investigating, but the two primary issues this should address are:

* Being able to change reservation times while its cart is open: cee3913f433671ccc455347c949b5a5e3c4c97f0
* Taking a reservation whose start time is currently outside a lock window, and changing it to a time within a lock window: 5a2c6eb4c3e513a36809e5ec5d4971a184254c7e