### PR TITLE
[#98857] Use blank for ownerless account owner names

### DIFF
--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -13,16 +13,12 @@ module AccountsHelper
       [
         account.to_s,
         account.id,
-        { 'data-account-owner' => account_owner_name(account) },
+        { 'data-account-owner' => account.owner_user_name },
       ]
     end
   end
 
   def available_accounts_options
     options_for_select(available_accounts_array, @order_detail.account_id)
-  end
-
-  def account_owner_name(account)
-    account.owner_user.try(:name) || ""
   end
 end

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -13,12 +13,16 @@ module AccountsHelper
       [
         account.to_s,
         account.id,
-        { 'data-account-owner' => account.owner_user.name },
+        { 'data-account-owner' => account_owner_name(account) },
       ]
     end
   end
 
   def available_accounts_options
     options_for_select(available_accounts_array, @order_detail.account_id)
+  end
+
+  def account_owner_name(account)
+    account.owner_user.try(:name) || ""
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -254,7 +254,7 @@ class Account < ActiveRecord::Base
 
   def to_s(with_owner = false, flag_suspended = true)
     desc = "#{description} / #{account_number_to_s}"
-    desc += " / #{owner_user.name}" if with_owner && owner_user
+    desc += " / #{owner_user_name}" if with_owner && owner_user.present?
     desc += " (#{display_status.upcase})" if flag_suspended && suspended?
     desc
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -124,6 +124,10 @@ class Account < ActiveRecord::Base
     self.owner.user if owner
   end
 
+  def owner_user_name
+    owner_user.try(:name) || ""
+  end
+
   def business_admin_users
     self.business_admins.collect{|au| au.user}
   end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -7,6 +7,18 @@ describe Account do
 
   it_should_behave_like "an Account"
 
+  describe "#owner_user_name" do
+    context "when the account has an owner" do
+      it { expect(account.owner_user_name).to eq(user.name) }
+    end
+
+    context "when the account has no owner" do
+      before { account.account_users.each(&:destroy) }
+
+      it { expect(account.owner_user_name).to be_blank }
+    end
+  end
+
   context '#unreconciled_total' do
     context 'without unreconciled order_details' do
       it 'should total 0' do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -171,6 +171,8 @@ describe Account do
   end
 
   context do
+    let(:nufs_account) { @nufs_account }
+
     before(:each) do
       @facility          = FactoryGirl.create(:facility)
       @user              = FactoryGirl.create(:user)
@@ -183,15 +185,15 @@ describe Account do
       @price_group_member = create(:account_price_group_member, account: @nufs_account, price_group: @price_group)
     end
 
-    context 'description' do
-      it 'override #to_s and not include owner' do
-        @nufs_account.to_s.should include(@nufs_account.account_number)
-        @nufs_account.to_s.should include(@nufs_account.description)
-        @nufs_account.to_s.should_not include(@nufs_account.owner_user.name)
+    context "description" do
+      it "overrides #to_s and does not include owner" do
+        expect(nufs_account.to_s).to include(nufs_account.account_number)
+        expect(nufs_account.to_s).to include(nufs_account.description)
+        expect(nufs_account.to_s).not_to include(nufs_account.owner_user_name)
       end
 
-      it 'override #to_s and include owner' do
-        @nufs_account.to_s(true).should include(@nufs_account.owner_user.name)
+      it "overrides #to_s and includes owner" do
+        expect(nufs_account.to_s(true)).to include(nufs_account.owner_user_name)
       end
     end
 


### PR DESCRIPTION
Though this shouldn't happen going forward, there are some ownerless accounts in UICore, causing the order detail modal to not load.