### PR TITLE
[#102019] Reservation backdating updates

### DIFF
--- a/app/controllers/facility_reservations_controller.rb
+++ b/app/controllers/facility_reservations_controller.rb
@@ -46,7 +46,7 @@ class FacilityReservationsController < ApplicationController
 
     raise ActiveRecord::RecordNotFound unless @reservation == Reservation.find(params[:id])
     set_windows
-    unless @reservation.admin_editable? || @reservation.can_edit_actuals?
+    if @reservation.locked?
       return redirect_to facility_order_order_detail_reservation_path(current_facility, @order, @order_detail, @reservation)
     end
   end
@@ -57,7 +57,7 @@ class FacilityReservationsController < ApplicationController
     @order_detail = @order.order_details.find(params[:order_detail_id])
     @reservation  = @order_detail.reservation
     @instrument   = @order_detail.product
-    unless @reservation == Reservation.find(params[:id]) && (@reservation.admin_editable? || @reservation.can_edit_actuals?)
+    if @reservation != Reservation.find(params[:id]) || @reservation.locked?
       raise ActiveRecord::RecordNotFound
     end
     set_windows

--- a/app/controllers/facility_reservations_controller.rb
+++ b/app/controllers/facility_reservations_controller.rb
@@ -46,7 +46,7 @@ class FacilityReservationsController < ApplicationController
 
     raise ActiveRecord::RecordNotFound unless @reservation == Reservation.find(params[:id])
     set_windows
-    unless @reservation.can_edit? || @reservation.can_edit_actuals?
+    unless @reservation.admin_editable? || @reservation.can_edit_actuals?
       return redirect_to facility_order_order_detail_reservation_path(current_facility, @order, @order_detail, @reservation)
     end
   end
@@ -57,7 +57,9 @@ class FacilityReservationsController < ApplicationController
     @order_detail = @order.order_details.find(params[:order_detail_id])
     @reservation  = @order_detail.reservation
     @instrument   = @order_detail.product
-    raise ActiveRecord::RecordNotFound unless @reservation == Reservation.find(params[:id]) && (@reservation.can_edit? || @reservation.can_edit_actuals?)
+    unless @reservation == Reservation.find(params[:id]) && (@reservation.admin_editable? || @reservation.can_edit_actuals?)
+      raise ActiveRecord::RecordNotFound
+    end
     set_windows
 
     @reservation.assign_times_from_params(params[:reservation])
@@ -197,11 +199,13 @@ class FacilityReservationsController < ApplicationController
   private
 
   def reserve_changed?
-    @reservation.can_edit? && @reservation.changes.any? { |k,v| k == 'reserve_start_at' || k == 'reserve_end_at' }
+    @reservation.admin_editable? &&
+    (@reservation.reserve_start_at_changed? || @reservation.reserve_end_at_changed?)
   end
 
   def actual_changed?
-    @reservation.can_edit_actuals? && @reservation.changes.any? { |k,v| k == 'actual_start_at' || k == 'actual_end_at' }
+    @reservation.can_edit_actuals? &&
+    (@reservation.actual_start_at_changed? || @reservation.actual_end_at_changed?)
   end
 
   def update_prices

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -318,7 +318,7 @@ class ReservationsController < ApplicationController
 
   # TODO you shouldn't be able to edit reservations that have passed or are outside of the cancellation period (check to make sure order has been placed)
   def invalid_for_update?
-    can_edit = @reservation.can_edit?
+    can_edit = @reservation.admin_editable?
     can_edit &&= @reservation.can_customer_edit? unless current_user.administrator?
     params[:id].to_i != @reservation.id ||
     @reservation.actual_end_at ||

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -273,7 +273,7 @@ class ReservationsController < ApplicationController
       :actual_start_meridian
     )
 
-    if !@reservation.reserve_start_at_editable?
+    if !@reservation.admin_editable? && !@reservation.reserve_start_at_editable?
       reservation_params.tap do |p|
         p[:reserve_start_date] = @reservation.reserve_start_date
         p[:reserve_start_hour] = @reservation.reserve_start_hour

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -234,7 +234,7 @@ class Reservation < ActiveRecord::Base
   end
 
   def reservation_changed?
-    changes.any? { |k,v| k == 'reserve_start_at' || k == 'reserve_end_at' }
+    reserve_start_at_changed? || reserve_end_at_changed?
   end
 
   def valid_before_purchase?

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -209,7 +209,7 @@ class Reservation < ActiveRecord::Base
 
     return false unless next_available
 
-    current_end_at = reserve_end_at.change(:sec => 0)
+    current_end_at = reserve_end_at.change(sec: 0)
     next_start_at = next_available.reserve_start_at.change(sec: 0)
 
     current_end_at == next_start_at
@@ -223,13 +223,8 @@ class Reservation < ActiveRecord::Base
     before_lock_window? || Time.zone.now >= reserve_start_at
   end
 
-  # can the ADMIN edit the reservation?
-  def can_edit?
-    return true if id.nil? # object is new and hasn't been saved to the DB successfully
-
-    # an admin can edit the reservation times as long as the reservation has not been canceled,
-    # even if it is in the past.
-    !canceled?
+  def admin_editable?
+    new_record? || !canceled?
   end
 
   # TODO does this need to be more robust?

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -197,7 +197,7 @@ class Reservation < ActiveRecord::Base
   end
 
   def reserve_start_at_editable?
-    before_lock_window? && actual_start_at.blank?
+    before_lock_window? && !started?
   end
 
   def reserve_end_at_editable?

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -260,6 +260,10 @@ class Reservation < ActiveRecord::Base
     !!(!canceled? && product.control_mechanism != Relay::CONTROL_MECHANISMS[:manual] && !has_actuals?) # TODO refactor?
   end
 
+  def locked?
+    !(admin_editable? || can_edit_actuals?)
+  end
+
   protected
 
   def has_order_detail?

--- a/app/support/reservations/date_support.rb
+++ b/app/support/reservations/date_support.rb
@@ -14,7 +14,7 @@ module Reservations::DateSupport
   end
 
   def assign_times_from_params(params)
-    assign_reserve_from_params(params) if can_edit?
+    assign_reserve_from_params(params) if admin_editable?
     assign_actuals_from_params(params) if can_edit_actuals?
 
     set_all_split_times

--- a/app/support/reservations/duration_change_validations.rb
+++ b/app/support/reservations/duration_change_validations.rb
@@ -8,8 +8,8 @@ class Reservations::DurationChangeValidations
 
   attr_reader :reservation
 
-  validate :start_time_not_changed
-  validate :duration_not_shortened
+  validate :start_time_not_changed, unless: "reservation.in_cart?"
+  validate :duration_not_shortened, unless: "reservation.in_cart?"
 
   after_validation :copy_errors!
 

--- a/app/views/facility_accounts/show_statement.html.haml
+++ b/app/views/facility_accounts/show_statement.html.haml
@@ -29,8 +29,8 @@
             %ul
               - product_name = order_detail_description(od)
               %li= product_name
-              - unless od.reservation.nil?
-                - if od.reservation.can_edit?
+              - if od.reservation.present?
+                - if od.reservation.admin_editable?
                   %li.indented= link_to od.reservation, edit_facility_order_order_detail_reservation_path(current_facility, od.order, od, od.reservation)
                 - else
                   %li.indented= link_to od.reservation, facility_order_order_detail_reservation_path(current_facility, od.order, od, od.reservation)

--- a/app/views/facility_reservations/_reservation_fields.html.haml
+++ b/app/views/facility_reservations/_reservation_fields.html.haml
@@ -1,4 +1,4 @@
-- if @reservation.can_edit?
+- if @reservation.admin_editable?
   .datetime-block
     = f.input :reserve_start_date, input_html: { class: "datepicker" }
     .control-group

--- a/app/views/facility_reservations/index.html.haml
+++ b/app/views/facility_reservations/index.html.haml
@@ -37,7 +37,7 @@
             %td{:colspan => 2}
               = human_datetime(order.ordered_at)
             %td{:colspan => 2}
-              - if res.can_edit?
+              - if res.admin_editable?
                 = link_to res, edit_facility_order_order_detail_reservation_path(current_facility, order, od, res)
               - else
                 = link_to res, facility_order_order_detail_reservation_path(current_facility, order, od, res)

--- a/app/views/order_management/order_details/_reservation.html.haml
+++ b/app/views/order_management/order_details/_reservation.html.haml
@@ -1,7 +1,7 @@
 = f.simple_fields_for reservation do |r|
 
   .datetime-block
-    - if reservation.can_edit?
+    - if reservation.admin_editable?
       = r.input :reserve_start_date, :input_html => { :class => 'datepicker' }
       .control-group
         .controls

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -49,6 +49,45 @@ describe Reservation do
     end
   end
 
+  describe "#locked?" do
+    before(:each) do
+      reservation.stub(:admin_editable?).and_return(admin_editable?)
+      reservation.stub(:can_edit_actuals?).and_return(can_edit_actuals?)
+    end
+
+    context "when editable by admins" do
+      let(:admin_editable?) { true }
+
+      context "and actuals are editable" do
+        let(:can_edit_actuals?) { true }
+
+        it { expect(reservation).not_to be_locked }
+      end
+
+      context "and actuals are not editable" do
+        let(:can_edit_actuals?) { false }
+
+        it { expect(reservation).not_to be_locked }
+      end
+    end
+
+    context "when not editable by admins" do
+      let(:admin_editable?) { false }
+
+      context "and actuals are editable" do
+        let(:can_edit_actuals?) { true }
+
+        it { expect(reservation).not_to be_locked }
+      end
+
+      context "and actuals are not editable" do
+        let(:can_edit_actuals?) { false }
+
+        it { expect(reservation).to be_locked }
+      end
+    end
+  end
+
   describe "#reservation_changed?" do
     context "when altering the reservation start time" do
       it "becomes true" do

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -27,25 +27,25 @@ describe Reservation do
     Reservation.any_instance.stub(:admin?).and_return(false)
   end
 
-  describe "#can_edit?" do
+  describe "#admin_editable?" do
     context "when the reservation has been persisted" do
       context "and has been canceled" do
         subject(:reservation) { create(:setup_reservation, :canceled) }
 
-        it { expect(reservation).not_to be_can_edit }
+        it { expect(reservation).not_to be_admin_editable }
       end
 
       context "and has not been canceled" do
         subject(:reservation) { create(:setup_reservation) }
 
-        it { expect(reservation).to be_can_edit }
+        it { expect(reservation).to be_admin_editable }
       end
     end
 
     context "when the reservation has not been persisted" do
       subject(:reservation) { build(:reservation) }
 
-      it { expect(reservation).to be_can_edit }
+      it { expect(reservation).to be_admin_editable }
     end
   end
 

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -49,6 +49,31 @@ describe Reservation do
     end
   end
 
+  describe "#reservation_changed?" do
+    context "when altering the reservation start time" do
+      it "becomes true" do
+        expect { reservation.reserve_start_at += 1 }
+          .to change(reservation, :reservation_changed?).from(false).to(true)
+      end
+    end
+
+    context "when altering the reservation end time" do
+      it "becomes true" do
+        expect { reservation.reserve_end_at += 1 }
+          .to change(reservation, :reservation_changed?).from(false).to(true)
+      end
+    end
+
+    context "when the reservation times do not change" do
+      it "remains false" do
+        expect {
+          reservation.reserve_start_at += 0
+          reservation.reserve_end_at += 0
+        }.not_to change(reservation, :reservation_changed?).from(false)
+      end
+    end
+  end
+
   it 'allows starting of a reservation, whose duration is equal to the max duration, within the grace period' do
     reservation.product.update_attribute :max_reserve_mins, reservation.duration_mins
 


### PR DESCRIPTION
This includes some new specs and refactoring I did while investigating but the meat is in these two commits:

* 5e2c1402f4fabd5982eb2506b6fcab840f83b446
  We were reverting the reservation start date/time params silently even when editable by an administrator and in a cart. By allowing these params through in this case, admins can backdate and non-admins will see a validation error if they try.

* d505efba063c81ca56f885025e34498ae697902f
  Even with the backdated params allowed through, we were denying changes even if the order was not yet complete. This allows them through if the reservation is still in a cart.