### PR TITLE
[#103870] Make training requests an optional feature

### DIFF
--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -77,11 +77,16 @@ class ProductsCommonController < ApplicationController
 
     # is the user approved?
     if add_to_cart && !@product.can_be_used_by?(acting_user) && !session_user_can_override_restrictions?(@product)
-      if TrainingRequest.submitted?(session_user, @product)
-        flash[:notice] = t_model_error(Product, "already_requested_access", product: @product)
-        return redirect_to facility_path(current_facility)
+      if SettingsHelper.feature_on?(:training_requests)
+        if TrainingRequest.submitted?(session_user, @product)
+          flash[:notice] = t_model_error(Product, "already_requested_access", product: @product)
+          return redirect_to facility_path(current_facility)
+        else
+          return redirect_to new_facility_product_training_request_path(current_facility, @product)
+        end
       else
-        return redirect_to new_facility_product_training_request_path(current_facility, @product)
+        add_to_cart = false
+        @error = "requires_approval"
       end
     end
 

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -55,6 +55,11 @@ en:
           requires_approval: The %{product} requires approval to reserve. Would you like to be contacted by the core for access or training?
         instrument:
           not_available: The %{instrument} instrument is currently unavailable for reservation online.
+          requires_approval_html: |
+            The %{instrument} instrument requires approval to reserve;
+            please contact the facility for further information:<br/><br/>
+            %{facility}<br/>
+            <a href=\"mailto:%{email}\">%{email}</a>
           acting_as_not_on_approval_list: The user you are ordering for is not on the authorized list for this instrument.
           no_accounts: "Sorry, but we could not find a valid payment source that you can use to reserve this instrument"
           no_price_groups: "You are not in a price group that may reserve instrument %{instrument_name}; please contact the facility."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -91,6 +91,7 @@ feature:
   edit_accounts_on: true
   suspend_accounts_on: true
   product_specific_contacts_on: true
+  training_requests_on: true
 
 # This may be overridden in settings.local.yml if your fork is using S3, so
 # be sure to check there for configuration

--- a/spec/controllers/bundles_controller_spec.rb
+++ b/spec/controllers/bundles_controller_spec.rb
@@ -93,25 +93,14 @@ describe BundlesController do
           do_request
         end
 
-        around(:each) do |example|
-          saved_setting = SettingsHelper.feature_on?(:training_requests)
-          SettingsHelper.enable_feature(:training_requests, training_requests)
-          example.run
-          SettingsHelper.enable_feature(:training_requests, saved_setting)
-        end
-
-        context "if the training request feature is enabled" do
-          let(:training_requests) { true }
-
+        context "if the training request feature is enabled", feature_setting: { training_requests: true } do
           it "gives the user the option to submit a request for approval" do
             expect(assigns[:add_to_cart]).to be_blank
             assert_redirected_to(new_facility_product_training_request_path(facility, bundle))
           end
         end
 
-        context "if the training request feature is disabled" do
-          let(:training_requests) { false }
-
+        context "if the training request feature is disabled", feature_setting: { training_requests: false } do
           it "denies access to the user" do
             expect(assigns[:add_to_cart]).to be_blank
             expect(flash[:notice]).to include("bundle requires approval")

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -158,9 +158,29 @@ describe InstrumentsController do
           do_request
         end
 
-        it "gives the user the option to submit a request for approval" do
-          expect(assigns[:add_to_cart]).to be_blank
-          assert_redirected_to(new_facility_product_training_request_path(facility, instrument))
+        around(:each) do |example|
+          saved_setting = SettingsHelper.feature_on?(:training_requests)
+          SettingsHelper.enable_feature(:training_requests, training_requests)
+          example.run
+          SettingsHelper.enable_feature(:training_requests, saved_setting)
+        end
+
+        context "if the training request feature is enabled" do
+          let(:training_requests) { true }
+
+          it "gives the user the option to submit a request for approval" do
+            expect(assigns[:add_to_cart]).to be_blank
+            assert_redirected_to(new_facility_product_training_request_path(facility, instrument))
+          end
+        end
+
+        context "if the training request feature is disabled" do
+          let(:training_requests) { false }
+
+          it "denies access to the user" do
+            expect(assigns[:add_to_cart]).to be_blank
+            expect(flash[:notice]).to include("instrument requires approval")
+          end
         end
       end
 

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -158,25 +158,14 @@ describe InstrumentsController do
           do_request
         end
 
-        around(:each) do |example|
-          saved_setting = SettingsHelper.feature_on?(:training_requests)
-          SettingsHelper.enable_feature(:training_requests, training_requests)
-          example.run
-          SettingsHelper.enable_feature(:training_requests, saved_setting)
-        end
-
-        context "if the training request feature is enabled" do
-          let(:training_requests) { true }
-
+        context "if the training request feature is enabled", feature_setting: { training_requests: true } do
           it "gives the user the option to submit a request for approval" do
             expect(assigns[:add_to_cart]).to be_blank
             assert_redirected_to(new_facility_product_training_request_path(facility, instrument))
           end
         end
 
-        context "if the training request feature is disabled" do
-          let(:training_requests) { false }
-
+        context "if the training request feature is disabled", feature_setting: { training_requests: false } do
           it "denies access to the user" do
             expect(assigns[:add_to_cart]).to be_blank
             expect(flash[:notice]).to include("instrument requires approval")

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -89,9 +89,29 @@ describe ItemsController do
           do_request
         end
 
-        it "gives the user the option to submit a request for approval" do
-          expect(assigns[:add_to_cart]).to be_blank
-          assert_redirected_to(new_facility_product_training_request_path(facility, item))
+        around(:each) do |example|
+          saved_setting = SettingsHelper.feature_on?(:training_requests)
+          SettingsHelper.enable_feature(:training_requests, training_requests)
+          example.run
+          SettingsHelper.enable_feature(:training_requests, saved_setting)
+        end
+
+        context "if the training request feature is enabled" do
+          let(:training_requests) { true }
+
+          it "gives the user the option to submit a request for approval" do
+            expect(assigns[:add_to_cart]).to be_blank
+            assert_redirected_to(new_facility_product_training_request_path(facility, item))
+          end
+        end
+
+        context "if the training request feature is disabled" do
+          let(:training_requests) { false }
+
+          it "denies access to the user" do
+            expect(assigns[:add_to_cart]).to be_blank
+            expect(flash[:notice]).to include("item requires approval")
+          end
         end
       end
 

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -89,25 +89,14 @@ describe ItemsController do
           do_request
         end
 
-        around(:each) do |example|
-          saved_setting = SettingsHelper.feature_on?(:training_requests)
-          SettingsHelper.enable_feature(:training_requests, training_requests)
-          example.run
-          SettingsHelper.enable_feature(:training_requests, saved_setting)
-        end
-
-        context "if the training request feature is enabled" do
-          let(:training_requests) { true }
-
+        context "if the training request feature is enabled", feature_setting: { training_requests: true } do
           it "gives the user the option to submit a request for approval" do
             expect(assigns[:add_to_cart]).to be_blank
             assert_redirected_to(new_facility_product_training_request_path(facility, item))
           end
         end
 
-        context "if the training request feature is disabled" do
-          let(:training_requests) { false }
-
+        context "if the training request feature is disabled", feature_setting: { training_requests: false } do
           it "denies access to the user" do
             expect(assigns[:add_to_cart]).to be_blank
             expect(flash[:notice]).to include("item requires approval")

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -75,25 +75,14 @@ describe ServicesController do
           do_request
         end
 
-        around(:each) do |example|
-          saved_setting = SettingsHelper.feature_on?(:training_requests)
-          SettingsHelper.enable_feature(:training_requests, training_requests)
-          example.run
-          SettingsHelper.enable_feature(:training_requests, saved_setting)
-        end
-
-        context "if the training request feature is enabled" do
-          let(:training_requests) { true }
-
+        context "if the training request feature is enabled", feature_setting: { training_requests: true } do
           it "gives the user the option to submit a request for approval" do
             expect(assigns[:add_to_cart]).to be_blank
             assert_redirected_to(new_facility_product_training_request_path(facility, service))
           end
         end
 
-        context "if the training request feature is disabled" do
-          let(:training_requests) { false }
-
+        context "if the training request feature is disabled", feature_setting: { training_requests: false } do
           it "denies access to the user" do
             expect(assigns[:add_to_cart]).to be_blank
             expect(flash[:notice]).to include("service requires approval")

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -75,9 +75,29 @@ describe ServicesController do
           do_request
         end
 
-        it "gives the user the option to submit a request for approval" do
-          expect(assigns[:add_to_cart]).to be_blank
-          assert_redirected_to(new_facility_product_training_request_path(facility, service))
+        around(:each) do |example|
+          saved_setting = SettingsHelper.feature_on?(:training_requests)
+          SettingsHelper.enable_feature(:training_requests, training_requests)
+          example.run
+          SettingsHelper.enable_feature(:training_requests, saved_setting)
+        end
+
+        context "if the training request feature is enabled" do
+          let(:training_requests) { true }
+
+          it "gives the user the option to submit a request for approval" do
+            expect(assigns[:add_to_cart]).to be_blank
+            assert_redirected_to(new_facility_product_training_request_path(facility, service))
+          end
+        end
+
+        context "if the training request feature is disabled" do
+          let(:training_requests) { false }
+
+          it "denies access to the user" do
+            expect(assigns[:add_to_cart]).to be_blank
+            expect(flash[:notice]).to include("service requires approval")
+          end
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,19 @@ RSpec.configure do |config|
 
   config.include FactoryGirl::Syntax::Methods
 
+  config.around(:each) do |example|
+    if example.metadata[:feature_setting]
+      example.metadata[:feature_setting].each do |feature, value|
+        saved_setting = SettingsHelper.feature_on?(feature)
+        SettingsHelper.enable_feature(feature, value)
+        example.run
+        SettingsHelper.enable_feature(feature, saved_setting)
+      end
+    else
+      example.run
+    end
+  end
+
   config.around(:each, :timecop_freeze) do |example|
     # freeze time to specific time by defining let(:now)
     time = defined?(now) ? now : Time.zone.now


### PR DESCRIPTION
Default is on, but when off it should act as it did before https://github.com/tablexi/nucore-open/pull/298 and display a message to the user about contacting the facility for approval.