### PR TITLE
[#98879] Accessory popup error in New/In Process Queue

### DIFF
--- a/app/views/facility_reservations/index.html.haml
+++ b/app/views/facility_reservations/index.html.haml
@@ -58,4 +58,3 @@
 
   = will_paginate(@order_details)
   = render :partial => '/price_display_footnote', :locals => { :admin => true }
-  #pick_accessories_dialog


### PR DESCRIPTION
When ending a reservation from the new/in process queue, the accessory
window was not popping up properly. The `#pick_accessories_dialog`
needs a couple classes (modal, fade, etc) in order to display properly.
Without explicitly declaring it on the page, the javascript will create
the element with all the necessary attributes.