### PR TITLE
[#119048] Restore unavailability display on timelines

### DIFF
--- a/app/models/schedule_rule.rb
+++ b/app/models/schedule_rule.rb
@@ -31,8 +31,8 @@ class ScheduleRule < ActiveRecord::Base
     rules.each do |rule|
       res = Reservation.new({
         :product => instrument,
-        :reserve_start_at => day.dup.change(:hour => rule.start_hour, :min => rule.start_min),
-        :reserve_end_at => day.dup.change(:hour => rule.end_hour, :min => rule.end_min),
+        :reserve_start_at => day.to_time.change(:hour => rule.start_hour, :min => rule.start_min),
+        :reserve_end_at => day.to_time.change(:hour => rule.end_hour, :min => rule.end_min),
         :blackout => true
         })
       reservations << res

--- a/spec/models/schedule_rule_spec.rb
+++ b/spec/models/schedule_rule_spec.rb
@@ -26,8 +26,10 @@ describe ScheduleRule do
       shared_examples_for "it generates reservations to cover unavailability" do
         it "returns two dummy reservations" do
           expect(reservations.size).to eq(2)
+
           reservations.each do |reservation|
             expect(reservation).to be_kind_of(Reservation)
+            expect(reservation).to be_blackout
             expect(reservation).not_to be_persisted
           end
         end


### PR DESCRIPTION
Since `@display_date` wasn't being used as a `Time`, #313 changed `@display_date` to a `Date`. Except it was: `ScheduleRule.unavailable_for_date` takes a `day` argument and expecting it to behave like a `Time`. The reserve start/end times were no longer being generated correctly, and we lost the greyed-out areas on timelines showing off-hours unavailability.

This patch explicitly converts `day` into a `Time` so the hour and minute manipulation work even if it's a `Date`, though it should work either way.