### PR TITLE
Reload routes when using the feature flag metadata helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,11 +29,14 @@ RSpec.configure do |config|
   config.around(:each) do |example|
     if example.metadata[:feature_setting]
       example.metadata[:feature_setting].each do |feature, value|
-        saved_setting = SettingsHelper.feature_on?(feature)
         SettingsHelper.enable_feature(feature, value)
-        example.run
-        SettingsHelper.enable_feature(feature, saved_setting)
       end
+      Nucore::Application.reload_routes!
+
+      example.run
+
+      Settings.reload!
+      Nucore::Application.reload_routes!
     else
       example.run
     end


### PR DESCRIPTION
Without the route reloading, if the flag was originally false, routes would not be available even after enabling the feature.

This should address the test failures on UIC.