### PR TITLE
[#119372] Do not error on instrument validations when reservation interval is 0

### DIFF
--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -22,8 +22,8 @@ class Instrument < Product
             :auto_cancel_mins,
             numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_nil: true }
 
-  validate :minimum_reservation_is_interval,
-           :maximum_reservation_is_interval,
+  validate :minimum_reservation_is_multiple_of_interval,
+           :maximum_reservation_is_multiple_of_interval,
            :max_reservation_not_less_than_min
 
   # Callbacks
@@ -67,16 +67,20 @@ class Instrument < Product
 
   private
 
-  def minimum_reservation_is_interval
-    interval? :min_reserve_mins
+  def minimum_reservation_is_multiple_of_interval
+    validate_multiple_of_reserve_interval :min_reserve_mins
   end
 
-  def maximum_reservation_is_interval
-    interval? :max_reserve_mins
+  def maximum_reservation_is_multiple_of_interval
+    validate_multiple_of_reserve_interval :max_reserve_mins
   end
 
-  def interval?(attribute)
-    if send(attribute).to_i > 0 && send(attribute) % reserve_interval != 0
+  def validate_multiple_of_reserve_interval(attribute)
+    field_value = send(attribute).to_i
+    # other validations will handle the errors if these are false
+    return unless reserve_interval.to_i > 0 && field_value > 0
+
+    if field_value % reserve_interval != 0
       self.errors.add attribute, :not_interval, reserve_interval: reserve_interval
     end
   end

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -25,56 +25,79 @@ describe Instrument do
   end
 
   describe 'min/max reservation is a multiple of reservation interval' do
+    subject { instrument }
+    let(:reserve_interval) { 5 }
+    let(:min_reserve_mins) { 1 }
+    let(:max_reserve_mins) { 1000 }
 
-    it 'ensures that the minimum reservation time is a multiple of the reservation interval' do
-      instrument.reserve_interval = 5
-      instrument.min_reserve_mins = 10
-      expect(instrument).to be_valid
+    before do
+      instrument.assign_attributes(reserve_interval: reserve_interval,
+        min_reserve_mins: min_reserve_mins,
+        max_reserve_mins: max_reserve_mins)
     end
 
-    it 'is not valid if the minimum reservation time is not a multiple of the reservation interval' do
-      expect(instrument).to be_valid
-      instrument.reserve_interval = 3
-      instrument.min_reserve_mins = 10
-      expect(instrument).to_not be_valid
-      expect(instrument.errors[:min_reserve_mins]).to be_present
+    describe 'min reservation' do
+      context 'is a multiple' do
+        let(:min_reserve_mins) { reserve_interval * 4 }
+        it 'does not have an error' do
+          instrument.valid?
+          expect(instrument.errors[:min_reserve_mins]).to be_blank
+        end
+      end
+
+      context 'is not a multiple' do
+        let(:min_reserve_mins) { reserve_interval * 4 + 1 }
+
+        it 'is is not valid' do
+          expect(instrument).not_to be_valid
+          expect(instrument.errors[:min_reserve_mins]).to be_present
+        end
+      end
+
+      context 'when the reservation interval is not set' do
+        let(:reserve_interval) { nil }
+        it 'does not error' do
+          expect { instrument.valid? }.not_to raise_error
+          expect(instrument.errors[:reserve_interval]).to be_present
+        end
+      end
     end
 
-    it 'ensures that the maximum reservation time is a multiple of the reservation interval' do
-      instrument.reserve_interval = 5
-      instrument.min_reserve_mins = 10
-      instrument.max_reserve_mins = 10
-      expect(instrument).to be_valid
-    end
+    describe 'max reservation' do
+      context 'is a multiple' do
+        let(:max_reserve_mins) { reserve_interval * 4 }
+        it 'does not have an error' do
+          instrument.valid?
+          expect(instrument.errors[:max_reserve_mins]).to be_blank
+        end
+      end
 
-    it 'is not valid if the maximum reservation time is not a multiple of the reservation interval' do
-      expect(instrument).to be_valid
-      instrument.reserve_interval = 3
-      instrument.min_reserve_mins = 10
-      instrument.max_reserve_mins = 10
-      expect(instrument).to_not be_valid
-      expect(instrument.errors[:max_reserve_mins]).to be_present
-    end
+      context 'is not a multiple' do
+        let(:max_reserve_mins) { reserve_interval * 4 + 1 }
 
-    it 'ensures that the maximum reservation time is not less than the minimum reservation time' do
-      instrument.min_reserve_mins = 10
-      instrument.max_reserve_mins = 5
-      expect(instrument).to_not be_valid
-      expect(instrument.errors[:max_reserve_mins]).to be_present
-    end
+        it 'is not valid' do
+          expect(instrument).not_to be_valid
+          expect(instrument.errors[:max_reserve_mins]).to be_present
+        end
+      end
 
-    it 'does not error when minimum reservation is set, but reservation interval is not' do
-      instrument.reserve_interval = nil
-      instrument.min_reserve_mins = 30
-      expect { instrument.valid? }.not_to raise_error
-      expect(instrument.errors[:reserve_interval]).to be_present
-    end
+      context 'when the maximum reservation is less than the minimum reservation' do
+        let(:min_reserve_mins) { 10 }
+        let(:max_reserve_mins) { 5 }
 
-    it 'does not error when maximum reservation is set, but reserve_interval is not' do
-      instrument.reserve_interval = nil
-      instrument.max_reserve_mins = 30
-      expect { instrument.valid? }.not_to raise_error
-      expect(instrument.errors[:reserve_interval]).to be_present
+        it 'is not valid' do
+          expect(instrument).not_to be_valid
+          expect(instrument.errors[:max_reserve_mins]).to be_present
+        end
+      end
+
+      context 'when the reservation interval is not set' do
+        let(:reserve_interval) { nil }
+        it 'does not error' do
+          expect { instrument.valid? }.not_to raise_error
+          expect(instrument.errors[:reserve_interval]).to be_present
+        end
+      end
     end
   end
 

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -24,41 +24,58 @@ describe Instrument do
     end
   end
 
-  it 'ensures that the minimum reservation time is a multiple of the reservation interval' do
-    instrument.reserve_interval = 5
-    instrument.min_reserve_mins = 10
-    expect(instrument).to be_valid
-  end
+  describe 'min/max reservation is a multiple of reservation interval' do
 
-  it 'is not valid if the minimum reservation time is not a multiple of the reservation interval' do
-    expect(instrument).to be_valid
-    instrument.reserve_interval = 3
-    instrument.min_reserve_mins = 10
-    expect(instrument).to_not be_valid
-    expect(instrument.errors[:min_reserve_mins]).to be_present
-  end
+    it 'ensures that the minimum reservation time is a multiple of the reservation interval' do
+      instrument.reserve_interval = 5
+      instrument.min_reserve_mins = 10
+      expect(instrument).to be_valid
+    end
 
-  it 'ensures that the maximum reservation time is a multiple of the reservation interval' do
-    instrument.reserve_interval = 5
-    instrument.min_reserve_mins = 10
-    instrument.max_reserve_mins = 10
-    expect(instrument).to be_valid
-  end
+    it 'is not valid if the minimum reservation time is not a multiple of the reservation interval' do
+      expect(instrument).to be_valid
+      instrument.reserve_interval = 3
+      instrument.min_reserve_mins = 10
+      expect(instrument).to_not be_valid
+      expect(instrument.errors[:min_reserve_mins]).to be_present
+    end
 
-  it 'is not valid if the maximum reservation time is not a multiple of the reservation interval' do
-    expect(instrument).to be_valid
-    instrument.reserve_interval = 3
-    instrument.min_reserve_mins = 10
-    instrument.max_reserve_mins = 10
-    expect(instrument).to_not be_valid
-    expect(instrument.errors[:max_reserve_mins]).to be_present
-  end
+    it 'ensures that the maximum reservation time is a multiple of the reservation interval' do
+      instrument.reserve_interval = 5
+      instrument.min_reserve_mins = 10
+      instrument.max_reserve_mins = 10
+      expect(instrument).to be_valid
+    end
 
-  it 'ensures that the maximum reservation time is not less than the minimum reservation time' do
-    instrument.min_reserve_mins = 10
-    instrument.max_reserve_mins = 5
-    expect(instrument).to_not be_valid
-    expect(instrument.errors[:max_reserve_mins]).to be_present
+    it 'is not valid if the maximum reservation time is not a multiple of the reservation interval' do
+      expect(instrument).to be_valid
+      instrument.reserve_interval = 3
+      instrument.min_reserve_mins = 10
+      instrument.max_reserve_mins = 10
+      expect(instrument).to_not be_valid
+      expect(instrument.errors[:max_reserve_mins]).to be_present
+    end
+
+    it 'ensures that the maximum reservation time is not less than the minimum reservation time' do
+      instrument.min_reserve_mins = 10
+      instrument.max_reserve_mins = 5
+      expect(instrument).to_not be_valid
+      expect(instrument.errors[:max_reserve_mins]).to be_present
+    end
+
+    it 'does not error when minimum reservation is set, but reservation interval is not' do
+      instrument.reserve_interval = nil
+      instrument.min_reserve_mins = 30
+      expect { instrument.valid? }.not_to raise_error
+      expect(instrument.errors[:reserve_interval]).to be_present
+    end
+
+    it 'does not error when maximum reservation is set, but reserve_interval is not' do
+      instrument.reserve_interval = nil
+      instrument.max_reserve_mins = 30
+      expect { instrument.valid? }.not_to raise_error
+      expect(instrument.errors[:reserve_interval]).to be_present
+    end
   end
 
   it { should ensure_inclusion_of(:reserve_interval).in_array Instrument::RESERVE_INTERVALS }


### PR DESCRIPTION
To reproduce:
* Go to Instruments#new
* In Reservation Restrictions, Leave the Interval (minutes) blank
* Put a value into either Minimum (minutes) or Maximum (minutes)
* Submit the form

The error was happening because reserve_interval was nil.