### PR TITLE
[#102969] Allow skipping monitoring of daemons

### DIFF
--- a/doc/HOWTO_daemons.txt
+++ b/doc/HOWTO_daemons.txt
@@ -39,3 +39,12 @@ The default configuration for daemons includes a monitoring process that will re
 output is sent to log/<daemon_name>.output and log/<daemon_name>.log. Since a daemon is a stand-alone process you can
 see it in your system's `ps` output by grepping for <daemon_name>.
 
+Skip Monitoring
+-------------------
+If you wish to forego monitoring, for example if you are using a separate monitoring
+system such as Eye, you can start up the daemon directly with the --no-monitor option:
+
+ruby lib/daemons/auto_cancel.rb start -- --no-monitor
+(the additional -- is required)
+
+ruby lib/daemons/auto_cancel.rb stop

--- a/lib/daemons/base.rb
+++ b/lib/daemons/base.rb
@@ -14,14 +14,15 @@ class Daemons::Base
   #   What you want to call the daemon. Log and PID
   #   files will be named after +name+, as will the
   #   the actual process in `ps` output
+
   def initialize(name)
-    @rails_root=File.expand_path(File.join('..', '..'), File.dirname(__FILE__))
-    self.name=name
-    self.daemon_opts={
+    @rails_root = File.expand_path(File.join('..', '..'), File.dirname(__FILE__))
+    self.name = name
+    self.daemon_opts = {
       :dir_mode => :normal,
-      :dir => @rails_root,
+      :dir => File.join(@rails_root, 'tmp/pids'),
       :backtrace => true,
-      :monitor => true,
+      :monitor => monitor?,
       :log_output => true,
       :log_dir => File.join(@rails_root, 'log')
     }
@@ -55,4 +56,10 @@ class Daemons::Base
     end
   end
 
+  private
+
+  # See usage notes in doc/HOWTO_daemons.txt
+  def monitor?
+    !ARGV.include?('--no-monitor')
+  end
 end


### PR DESCRIPTION
Allow passing a command line argument that disables the daemon monitoring.
This is useful if you are using something external like eye to do your
monitoring.

This also moves the daemon pids into tmp/pids