### PR TITLE
[#98771] Remove modal height override to restore overflow scrolling

### DIFF
--- a/app/assets/stylesheets/app/order_management.scss
+++ b/app/assets/stylesheets/app/order_management.scss
@@ -1,7 +1,3 @@
-.modal-body {
-  max-height: 800px;
-}
-
 .order-action .btn {
   margin-top: 1em;
 }


### PR DESCRIPTION
This change is @mgreich -approved.

Before:
<img width="679" alt="with 800px height override" src="https://cloud.githubusercontent.com/assets/46662/9553656/15a63eb4-4d86-11e5-805a-9950901468e3.png">

After (you'll have to take my word that a scrollbar appears along the right side):
<img width="681" alt="without height override" src="https://cloud.githubusercontent.com/assets/46662/9553653/141a2132-4d86-11e5-9165-9093bc401ecb.png">