### PR TITLE
Test on Circle with Ruby 2.1.7

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: 2.1.6
+    version: 2.1.7
   timezone: "America/Chicago"
 
 


### PR DESCRIPTION
I played with 2.2.3, but that's a little more troublesome, partly due to needing to upgrade to rails 3.2.22 to support Ruby 2.2.