### PR TITLE
[#60973] Ensure notices tab style matches the nav

### DIFF
--- a/app/assets/stylesheets/app/header.scss
+++ b/app/assets/stylesheets/app/header.scss
@@ -14,7 +14,7 @@ header {
     }
   }
 
-  .navbar-inner {
+  .navbar-inner, .dropdown-toggle {
     padding: 10px 0;
     @include gradient-vertical($headerBackgroundColorHighLight, $headerBackgroundColor);
   }
@@ -25,12 +25,12 @@ header {
       border-left: 1px solid $usernavDividerColor;
     }
     > li > a {
-      color: $usernavColor;
+      color: $usernavColor !important;
       text-shadow: none;
       padding: 10px 0;
 
       &:hover {
-        color: $usernavColorHover;
+        color: $usernavColorHover !important;
       }
     }
 


### PR DESCRIPTION
When clicked, the "Notices" tab's style would revert to the bootstrap default, ignoring what might be defined in nucore-overrides.scss.

It should have no real effect on this fork, but it's noticeable with NU's and UIC's styles.