### PR TITLE
[#95795] Avoid numeric overflow on price policy create/edit

### DIFF
--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -101,13 +101,11 @@ class PricePoliciesController < ApplicationController
     @price_policies = @product.price_policies.for_date(@start_date)
     raise ActiveRecord::RecordNotFound if @price_policies.none?
 
-    if ActiveRecord::Base.transaction do
-        raise ActiveRecord::Rollback unless @price_policies.all?(&:destroy)
-        flash[:notice] = "Price Rules were successfully removed"
-        redirect_to facility_product_price_policies_path
-      end
+    if PricePolicyUpdater.destroy_all!(@price_policies, @start_date)
+      flash[:notice] = I18n.t("controllers.price_policies.destroy.success")
+      redirect_to facility_product_price_policies_path
     else
-      flash[:error] = "An error was encountered while trying to remove the Price Rules"
+      flash[:error] = I18n.t("controllers.price_policies.destroy.failure")
       redirect_to facility_product_price_policies_path
     end
   end

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -71,15 +71,13 @@ class PricePoliciesController < ApplicationController
   # DELETE /facilities/:facility_id/{product_type}/:product_id/price_policies/:id
   def destroy
     return remove_active_policy_warning if @start_date <= Date.today
-    load_price_policies_for_start_date!
 
-    if PricePolicyUpdater.destroy_all!(@price_policies, @start_date)
+    if PricePolicyUpdater.destroy_all_for_product!(@product, @start_date)
       flash[:notice] = I18n.t("controllers.price_policies.destroy.success")
-      redirect_to facility_product_price_policies_path
     else
       flash[:error] = I18n.t("controllers.price_policies.destroy.failure")
-      redirect_to facility_product_price_policies_path
     end
+    redirect_to facility_product_price_policies_path
   end
 
   private
@@ -122,11 +120,6 @@ class PricePoliciesController < ApplicationController
       .call
       .find_by_url_name!(params["#{product_var}_id".to_sym])
     instance_variable_set("@#{product_var}", @product)
-  end
-
-  def load_price_policies_for_start_date!
-    @price_policies = @product.price_policies.for_date(@start_date)
-    raise ActiveRecord::RecordNotFound if @price_policies.none?
   end
 
   def model_name

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -49,23 +49,20 @@ class PricePoliciesController < ApplicationController
     render 'price_policies/new'
   end
 
-  # POST /price_policies
+  # POST /facilities/:facility_id/{product_type}/:product_id/price_policies
   def create
     @start_date = start_date_from_params
-    @expire_date   = params[:expire_date]
+    @expire_date = params[:expire_date]
+
     build_price_policies
     update_policies_from_params
 
-    respond_to do |format|
-      if ActiveRecord::Base.transaction do
-          raise ActiveRecord::Rollback unless @price_policies.all?(&:save)
-          flash[:notice] = 'Price Rules were successfully created.'
-          format.html { redirect_to facility_product_price_policies_path }
-        end
-      else
-        flash[:error] = "There was an error saving the policy"
-        format.html { render "price_policies/new" }
-      end
+    if save_all_price_policies!
+      flash[:notice] = I18n.t("controllers.price_policies.create.success")
+      redirect_to facility_product_price_policies_path
+    else
+      flash[:error] = I18n.t("controllers.price_policies.errors.save")
+      render "price_policies/new"
     end
   end
 
@@ -95,7 +92,7 @@ class PricePoliciesController < ApplicationController
       flash[:notice] = I18n.t("controllers.price_policies.update.success")
       redirect_to facility_product_price_policies_path
     else
-      flash[:error] = I18n.t("controllers.price_policies.update.failure")
+      flash[:error] = I18n.t("controllers.price_policies.errors.save")
       render "price_policies/edit"
     end
   end

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -51,7 +51,6 @@ class PricePoliciesController < ApplicationController
 
   # POST /facilities/:facility_id/{product_type}/:product_id/price_policies
   def create
-    @start_date = start_date_from_params
     @expire_date = params[:expire_date]
 
     build_price_policies!
@@ -65,10 +64,8 @@ class PricePoliciesController < ApplicationController
     end
   end
 
-  # GET /price_policies/1/edit
+  # GET /facilities/:facility_id/{product_type}/:product_id/price_policies/:id/edit
   def edit
-    @start_date = start_date_from_params
-
     build_price_policies!
 
     @expire_date=@price_policies.map(&:expire_date).compact.first
@@ -79,8 +76,6 @@ class PricePoliciesController < ApplicationController
 
   # PUT /facilities/:facility_id/{product_type}/:product_id/price_policies/:id
   def update
-    @start_date = start_date_from_params
-
     build_price_policies!
 
     @expire_date = params[:expire_date]
@@ -155,11 +150,12 @@ class PricePoliciesController < ApplicationController
   #
   # Override CanCan's find -- it won't properly search by zoned date
   def init_price_policy
+    @start_date = start_date_from_params
     product_var="@#{model_name.gsub('PricePolicy', '').downcase}"
 
     instance_variable_set(
       "@#{model_name.underscore}",
-      instance_variable_get(product_var).price_policies.for_date(start_date_from_params).first
+      instance_variable_get(product_var).price_policies.for_date(@start_date).first
     )
   end
 

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -57,7 +57,7 @@ class PricePoliciesController < ApplicationController
 
   # DELETE /facilities/:facility_id/{product_type}/:product_id/price_policies/:id
   def destroy
-    return remove_active_policy_warning_and_redirect if @start_date <= Date.today
+    return flash_remove_active_policy_warning_and_redirect if @start_date <= Date.today
 
     if PricePolicyUpdater.destroy_all_for_product!(@product, @start_date)
       flash[:notice] = I18n.t("controllers.price_policies.destroy.success")
@@ -126,7 +126,7 @@ class PricePoliciesController < ApplicationController
     @product_var ||= model_name.gsub(/PricePolicy\z/, "").downcase
   end
 
-  def remove_active_policy_warning_and_redirect
+  def flash_remove_active_policy_warning_and_redirect
     flash[:error] =
       I18n.t("controllers.price_policies.errors.remove_active_policy")
     redirect_to facility_product_price_policies_path

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -80,27 +80,23 @@ class PricePoliciesController < ApplicationController
     render 'price_policies/edit'
   end
 
-  # PUT /price_policies/1
+  # PUT /facilities/:facility_id/{product_type}/:product_id/price_policies/:id
   def update
     @start_date = start_date_from_params
 
     build_price_policies
 
-    @expire_date    = params[:expire_date]
+    @expire_date = params[:expire_date]
     @max_expire_date = PricePolicy.generate_expire_date(@start_date)
 
     update_policies_from_params
 
-    respond_to do |format|
-      if ActiveRecord::Base.transaction do
-          raise ActiveRecord::Rollback unless @price_policies.all?(&:save)
-          flash[:notice] = 'Price Rules were successfully updated.'
-          format.html { redirect_to facility_product_price_policies_path }
-        end
-      else
-        flash[:error] = "There was an error saving the policy"
-        format.html { render 'price_policies/edit' }
-      end
+    if save_all_price_policies!
+      flash[:notice] = I18n.t("controllers.price_policies.update.success")
+      redirect_to facility_product_price_policies_path
+    else
+      flash[:error] = I18n.t("controllers.price_policies.update.failure")
+      render "price_policies/edit"
     end
   end
 
@@ -152,6 +148,12 @@ class PricePoliciesController < ApplicationController
     groups_with_policy = Hash[original_price_policies.map {|pp| [pp.price_group, pp] }]
     current_facility.price_groups.each do |pg|
       @price_policies << (groups_with_policy[pg] || model_class.new({:price_group_id => pg.id, :product_id => @product.id, :can_purchase => false }))
+    end
+  end
+
+  def save_all_price_policies!
+    ActiveRecord::Base.transaction do
+      @price_policies.all?(&:save) || raise(ActiveRecord::Rollback)
     end
   end
 

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -57,7 +57,7 @@ class PricePoliciesController < ApplicationController
 
   # DELETE /facilities/:facility_id/{product_type}/:product_id/price_policies/:id
   def destroy
-    return remove_active_policy_warning if @start_date <= Date.today
+    return remove_active_policy_warning_and_redirect if @start_date <= Date.today
 
     if PricePolicyUpdater.destroy_all_for_product!(@product, @start_date)
       flash[:notice] = I18n.t("controllers.price_policies.destroy.success")
@@ -150,7 +150,7 @@ class PricePoliciesController < ApplicationController
     @product_var ||= model_name.gsub(/PricePolicy\z/, "").downcase
   end
 
-  def remove_active_policy_warning
+  def remove_active_policy_warning_and_redirect
     flash[:error] =
       I18n.t("controllers.price_policies.errors.remove_active_policy")
     redirect_to facility_product_price_policies_path

--- a/app/helpers/price_policies_helper.rb
+++ b/app/helpers/price_policies_helper.rb
@@ -1,6 +1,5 @@
 module PricePoliciesHelper
 
-
   def format_date(date)
     return date.is_a?(String) ? date : date.strftime("%m/%d/%Y")
   end
@@ -32,22 +31,19 @@ module PricePoliciesHelper
   end
 
   def display_usage_rate(price_group, price_policy)
-     if params["price_policy_#{price_group.id}"].present?
-       rate = params["price_policy_#{price_group.id}"][:usage_rate] * 60
-     else
-       rate = price_policy.hourly_usage_rate
-     end
-
-     number_to_currency rate, :unit => '', :delimiter => ''
+    param_for_price_group(price_group, :usage_rate) ||
+      number_to_currency(price_policy.hourly_usage_rate, unit: "", delimiter: "")
   end
 
   def display_usage_subsidy(price_group, price_policy)
-    if params["price_policy_#{price_group.id}"].present?
-      sub = params["price_policy_#{price_group.id}"][:usage_subsidy] * 60
-    else
-      sub = price_policy.hourly_usage_subsidy
-    end
+    param_for_price_group(price_group, :usage_subsidy) ||
+    number_to_currency(price_policy.hourly_usage_subsidy, unit: "", delimiter: "")
+  end
 
-    number_to_currency sub, :unit => '', :delimiter => ''
+  private
+
+  def param_for_price_group(price_group, key)
+    price_group_key = "price_policy_#{price_group.id}"
+    params[price_group_key].present? && params[price_group_key][key]
   end
 end

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -40,7 +40,7 @@ class PriceGroup < ActiveRecord::Base
   end
 
   def name
-    is_master_internal? ? "#{I18n.t('institution_name')} #{self[:name]}" : self[:name]
+    master_internal? ? "#{I18n.t('institution_name')} #{self[:name]}" : self[:name]
   end
 
   def to_s
@@ -51,8 +51,8 @@ class PriceGroup < ActiveRecord::Base
     is_internal? ? 'Internal' : 'External'
   end
 
-  def is_master_internal?
-    self.is_internal? && self.display_order == 1
+  def master_internal?
+    is_internal? && display_order == 1
   end
 
   def <=> (obj)
@@ -62,5 +62,9 @@ class PriceGroup < ActiveRecord::Base
   def can_delete?
     # use !.any? because it uses SQL count(), unlike none?
     !global? && !order_details.any?
+  end
+
+  def external?
+    !is_internal?
   end
 end

--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -29,18 +29,6 @@ class PricePolicyBuilder
     price_policies
   end
 
-  def last_price_policy_for_price_group(price_group)
-    product
-      .price_policies
-      .where(price_group_id: price_group.id)
-      .order(:expire_date)
-      .last
-  end
-
-  def make_all_price_policies_purchaseable
-    price_policies.each { |price_policy| price_policy.can_purchase = true }
-  end
-
   private
 
   def editable?
@@ -54,8 +42,24 @@ class PricePolicyBuilder
     end
   end
 
-  def policy_for_price_group(price_group)
-    groups_with_policy[price_group] || new_price_policy(price_group)
+  def groups_with_policy
+    @groups_with_policy ||= original_price_policies_hash
+  end
+
+  def last_price_policy_for_price_group(price_group)
+    product
+      .price_policies
+      .where(price_group_id: price_group.id)
+      .order(:expire_date)
+      .last
+  end
+
+  def make_all_price_policies_purchaseable
+    price_policies.each { |price_policy| price_policy.can_purchase = true }
+  end
+
+  def model_class
+    @model_class ||= "#{product.class}PricePolicy".constantize
   end
 
   def new_price_policy(price_group)
@@ -66,29 +70,25 @@ class PricePolicyBuilder
     )
   end
 
-  def groups_with_policy
-    @groups_with_policy ||= original_price_policies_hash
-  end
-
   def original_price_policies_hash
     original_price_policies.map do |price_policy|
       [price_policy.price_group, price_policy]
     end.to_h
   end
 
-  def model_class
-    @model_class ||= "#{product.class}PricePolicy".constantize
-  end
-
   def original_price_policies_editable?
     original_price_policies.all?(&:editable?)
   end
 
-  def price_policies_for_start_date
-    product.price_policies.for_date(start_date)
-  end
-
   def original_price_policies
     @original_price_policies ||= price_policies_for_start_date || []
+  end
+
+  def policy_for_price_group(price_group)
+    groups_with_policy[price_group] || new_price_policy(price_group)
+  end
+
+  def price_policies_for_start_date
+    product.price_policies.for_date(start_date)
   end
 end

--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -1,0 +1,65 @@
+class PricePolicyBuilder
+  attr_reader :product, :start_date
+
+  delegate :facility, to: :product
+
+  def self.get(product, start_date)
+    self.new(product, start_date).get_price_policies
+  end
+
+  def initialize(product, start_date)
+    @product = product
+    @start_date = start_date
+  end
+
+  def get_price_policies
+    return [] unless editable?
+    facility.price_groups.map do |price_group|
+      policy_for_price_group(price_group)
+    end
+  end
+
+  private
+
+  def editable?
+    original_price_policies.empty? || original_price_policies_editable?
+  end
+
+  def policy_for_price_group(price_group)
+    groups_with_policy[price_group] || new_price_policy(price_group)
+  end
+
+  def new_price_policy(price_group)
+    model_class.new(
+      price_group_id: price_group.id,
+      product_id: product.id,
+      can_purchase: false,
+    )
+  end
+
+  def groups_with_policy
+    @groups_with_policy ||= original_price_policies_hash
+  end
+
+  def original_price_policies_hash
+    original_price_policies.map do |price_policy|
+      [price_policy.price_group, price_policy]
+    end.to_h
+  end
+
+  def model_class
+    @model_class ||= "#{product.class}PricePolicy".constantize
+  end
+
+  def original_price_policies_editable?
+    original_price_policies.all?(&:editable?)
+  end
+
+  def price_policies_for_start_date
+    product.price_policies.for_date(start_date)
+  end
+
+  def original_price_policies
+    @original_price_policies ||= price_policies_for_start_date || []
+  end
+end

--- a/app/services/price_policy_updater.rb
+++ b/app/services/price_policy_updater.rb
@@ -1,0 +1,42 @@
+class PricePolicyUpdater
+  def self.update_all!(price_policies, start_date, expire_date, params)
+    self.new(price_policies, start_date, expire_date, params).update_all!
+  end
+
+  def initialize(price_policies, start_date, expire_date, params)
+    @price_policies = price_policies
+    @start_date = start_date
+    @expire_date = expire_date
+    @params = params
+  end
+
+  def update_all!
+    update && save!
+  end
+
+  private
+
+  def update
+    @price_policies.each do |price_policy|
+      price_policy.attributes = price_group_attributes(price_policy.price_group)
+    end
+  end
+
+  def save!
+    ActiveRecord::Base.transaction do
+      @price_policies.all?(&:save) || raise(ActiveRecord::Rollback)
+    end
+  end
+
+  def price_group_attributes(price_group)
+    initial_price_group_attributes(price_group).tap do |attributes|
+      attributes[:charge_for] = @params[:charge_for] if @params[:charge_for].present?
+      attributes[:expire_date] = @expire_date
+      attributes[:start_date] = @start_date
+    end
+  end
+
+  def initial_price_group_attributes(price_group)
+    @params["price_policy_#{price_group.id}"] || { can_purchase: false }
+  end
+end

--- a/app/services/price_policy_updater.rb
+++ b/app/services/price_policy_updater.rb
@@ -3,11 +3,21 @@ class PricePolicyUpdater
     self.new(price_policies, start_date, expire_date, params).update_all!
   end
 
-  def initialize(price_policies, start_date, expire_date, params)
+  def self.destroy_all!(price_policies, start_date)
+    self.new(price_policies, start_date).destroy_all!
+  end
+
+  def initialize(price_policies, start_date, expire_date = nil, params = nil)
     @price_policies = price_policies
     @start_date = start_date
     @expire_date = expire_date
     @params = params
+  end
+
+  def destroy_all!
+    ActiveRecord::Base.transaction do
+      @price_policies.all?(&:destroy) || raise(ActiveRecord::Rollback)
+    end
   end
 
   def update_all!

--- a/app/services/price_policy_updater.rb
+++ b/app/services/price_policy_updater.rb
@@ -3,7 +3,9 @@ class PricePolicyUpdater
     self.new(price_policies, start_date, expire_date, params).update_all!
   end
 
-  def self.destroy_all!(price_policies, start_date)
+  def self.destroy_all_for_product!(product, start_date)
+    price_policies = product.price_policies.for_date(start_date)
+    raise ActiveRecord::RecordNotFound if price_policies.none?
     self.new(price_policies, start_date).destroy_all!
   end
 

--- a/app/services/price_policy_updater.rb
+++ b/app/services/price_policy_updater.rb
@@ -18,7 +18,7 @@ class PricePolicyUpdater
 
   def destroy_all!
     ActiveRecord::Base.transaction do
-      @price_policies.all?(&:destroy) || raise(ActiveRecord::Rollback)
+      @price_policies.destroy_all || raise(ActiveRecord::Rollback)
     end
   end
 

--- a/app/views/price_policies/_price_policy_fields.html.haml
+++ b/app/views/price_policies/_price_policy_fields.html.haml
@@ -1,31 +1,44 @@
 = content_for :head_content do
-  = javascript_include_tag 'price_policy'
+  = javascript_include_tag "price_policy"
 
-= render :partial => 'price_policies/dates', :locals => { :f => f }
+= render "price_policies/dates", f: f
 
 %table.table.table-striped.table-hover.price-policy-table
   %thead
     %tr
-      %th Price Group
-      %th Type
-      %th Can purchase?
-      %th.centered Unit Cost
-      %th.centered Unit Adjustment
+      %th= t(".price_group")
+      %th= t(".type")
+      %th= t(".can_purchase")
+      %th.centered= t(".unit_cost")
+      %th.centered= t(".unit_adjustment")
   %tbody
-    - @price_policies.each do |pp|
-      - pg = pp.price_group
+    - @price_policies.each do |price_policy|
+      - price_group = price_policy.price_group
       %tr
-        %td= pg.name
-        %td= pg.type_string
-        %td= check_box_tag "price_policy_#{pg.id}[can_purchase]", '1', pp.can_purchase?, :class => 'can_purchase'
-        - if !pg.is_internal?
-          %td.centered= text_field_tag "price_policy_#{pg.id}[unit_cost]", number_to_currency(pp.unit_cost, :unit => '', :delimiter => ''), :size => 8
+        %td= price_group.name
+        %td= price_group.type_string
+        %td= check_box_tag "price_policy_#{price_group.id}[can_purchase]",
+          "1", price_policy.can_purchase?, class: "can_purchase"
+        - if price_group.external?
           %td.centered
-        - elsif pg.is_master_internal?
-          %td.centered= text_field_tag "price_policy_#{pg.id}[unit_cost]", number_to_currency(pp.unit_cost, :unit => '', :delimiter => ''), :size => 8, :class => 'master_unit_cost'
+            = text_field_tag "price_policy_#{price_group.id}[unit_cost]",
+              number_to_currency(price_policy.unit_cost, unit: "", delimiter: ""),
+              size: 8
+          %td.centered
+        - elsif price_group.master_internal?
+          %td.centered
+            = text_field_tag "price_policy_#{price_group.id}[unit_cost]",
+              number_to_currency(price_policy.unit_cost, unit: "", delimiter: ""),
+              size: 8,
+              class: "master_unit_cost"
           %td
         - else
           %td.centered
             %span.unit_cost
-            = hidden_field_tag "price_policy_#{pg.id}[unit_cost]", number_to_currency(pp.unit_cost, :unit => '', :delimiter => ''), :class => "unit_cost"
-          %td.centered= text_field_tag "price_policy_#{pg.id}[unit_subsidy]", number_to_currency(pp.unit_subsidy, :unit => '', :delimiter => ''), :size => 8
+            = hidden_field_tag "price_policy_#{price_group.id}[unit_cost]",
+              number_to_currency(price_policy.unit_cost, unit: "", delimiter: ""),
+              class: "unit_cost"
+          %td.centered
+            = text_field_tag "price_policy_#{price_group.id}[unit_subsidy]",
+              number_to_currency(price_policy.unit_subsidy, unit: "", delimiter: ""),
+              size: 8

--- a/app/views/price_policies/edit.html.haml
+++ b/app/views/price_policies/edit.html.haml
@@ -1,21 +1,21 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :sidebar do
-  = render :partial => 'admin/shared/sidenav_product', :locals => { :sidenav_tab =>@product.product_type }
+  = render "admin/shared/sidenav_product", sidenav_tab: @product.product_type
 
 = content_for :tabnav do
-  = render :partial => 'admin/shared/tabnav_product', :locals => {:secondary_tab => 'pricing_rules'}
+  = render "admin/shared/tabnav_product", secondary_tab: "pricing_rules"
 
-%h2=h @product
-%h3 Edit Pricing Rules
-= render :partial => 'price_policies/instructional_text'
+%h2= @product
+%h3= t(".head")
+= render "price_policies/instructional_text"
 
-= modelless_form_for :url => price_policy_path(@product, params[:id]), :method => 'PUT' do |f|
-  - @price_policies.each do |pp|
-    - @price_policy = pp
+= modelless_form_for url: price_policy_path(@product, params[:id]), method: :put do |f|
+  - @price_policies.each do |price_policy|
+    - @price_policy = price_policy
     = error_messages_for :price_policy
-  = render :partial => "price_policies/#{@product.is_a?(Instrument) ? 'instrument/' : ''}price_policy_fields", :locals => { :f => f }
+  = render "price_policies/#{@product.is_a?(Instrument) ? 'instrument/' : ''}price_policy_fields", f: f
   %ul.inline
-    %li= submit_tag 'Save Rules', :class => 'btn'
-    %li= link_to 'Cancel', price_policies_path
+    %li= submit_tag t(".save"), class: "btn"
+    %li= link_to t(".cancel"), price_policies_path

--- a/app/views/price_policies/instrument/_external_row.html.haml
+++ b/app/views/price_policies/instrument/_external_row.html.haml
@@ -1,14 +1,19 @@
 %td
-  Rate
+  = t("price_policies.rate")
   %br
-  = text_field_tag "price_policy_#{pg.id}[usage_rate]", display_usage_rate(pg, pp), :size => 8, :class => "usage_rate"
+  = text_field_tag "price_policy_#{pg.id}[usage_rate]",
+    display_usage_rate(pg, pp), size: 8, class: "usage_rate"
 
 %td
-  Amount
+  = t("price_policies.amount")
   %br
-  = text_field_tag "price_policy_#{pg.id}[minimum_cost]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:minimum_cost] : number_to_currency(pp.minimum_cost, :unit => '', :delimiter => ''), :size => 8
+  = text_field_tag "price_policy_#{pg.id}[minimum_cost]",
+      params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:minimum_cost] : number_to_currency(pp.minimum_cost, unit: "", delimiter: ""),
+      size: 8
 
 %td
-  Amount
+  = t("price_policies.amount")
   %br
-  = text_field_tag "price_policy_#{pg.id}[cancellation_cost]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:cancellation_cost] : number_to_currency(pp.cancellation_cost, unit: '', delimiter: ''), size: 8
+  = text_field_tag "price_policy_#{pg.id}[cancellation_cost]",
+    params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:cancellation_cost] : number_to_currency(pp.cancellation_cost, unit: '', delimiter: ''),
+    size: 8

--- a/app/views/price_policies/instrument/_internal_row.html.haml
+++ b/app/views/price_policies/instrument/_internal_row.html.haml
@@ -1,15 +1,20 @@
 %td
-  = hidden_field_tag "price_policy_#{pg.id}[usage_rate]", display_usage_rate(pg, pp), class: "usage_cost"
-  Adjustment
+  = hidden_field_tag "price_policy_#{pg.id}[usage_rate]",
+    display_usage_rate(pg, pp),
+    class: "usage_cost"
+  = t("price_policies.adjustment")
   %br
-  = text_field_tag "price_policy_#{pg.id}[usage_subsidy]", display_usage_subsidy(pg, pp), size: 8, class: "usage_adjustment"
+  = text_field_tag "price_policy_#{pg.id}[usage_subsidy]",
+    display_usage_subsidy(pg, pp), size: 8, class: "usage_adjustment"
+
 %td
-  Amount
+  = t("price_policies.amount")
   %br
   %span.minimum_cost{ data: { usage_subsidy: pp.usage_subsidy } }
   = hidden_price_policy_tag(pg.id, pp.minimum_cost, :minimum_cost, params["price_policy_#{pg.id}"])
+
 %td
-  Amount
+  = t("price_policies.amount")
   %br
   %span.cancellation_cost
   = hidden_price_policy_tag(pg.id, pp.cancellation_cost, :cancellation_cost, params["price_policy_#{pg.id}"])

--- a/app/views/price_policies/instrument/_master_internal_row.html.haml
+++ b/app/views/price_policies/instrument/_master_internal_row.html.haml
@@ -1,12 +1,21 @@
 %td
-  Rate
+  = t("price_policies.rate")
   %br
-  = text_field_tag "price_policy_#{pg.id}[usage_rate]", display_usage_rate(pg, pp), :size => 8, :class => 'master_usage_cost usage_rate'
+  = text_field_tag "price_policy_#{pg.id}[usage_rate]",
+    display_usage_rate(pg, pp), size: 8, class: "master_usage_cost usage_rate"
+
 %td
-  Amount
+  = t("price_policies.amount")
   %br
-  = text_field_tag "price_policy_#{pg.id}[minimum_cost]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:minimum_cost] : number_to_currency(pp.minimum_cost, :unit => '', :delimiter => ''), :size => 8, :class => 'master_minimum_cost'
+  = text_field_tag "price_policy_#{pg.id}[minimum_cost]",
+    params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:minimum_cost] : number_to_currency(pp.minimum_cost, unit: "", delimiter: ""),
+    size: 8,
+    class: "master_minimum_cost"
+
 %td
-  Amount
+  = t("price_policies.amount")
   %br
-  = text_field_tag "price_policy_#{pg.id}[cancellation_cost]", params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:cancellation_cost] : number_to_currency(pp.cancellation_cost, unit: '', delimiter: ''), size: 8, class: 'master_cancellation_cost'
+  = text_field_tag "price_policy_#{pg.id}[cancellation_cost]",
+    params["price_policy_#{pg.id}"] ? params["price_policy_#{pg.id}"][:cancellation_cost] : number_to_currency(pp.cancellation_cost, unit: "", delimiter: ""),
+    size: 8,
+    class: "master_cancellation_cost"

--- a/app/views/price_policies/instrument/_price_policy_fields.html.haml
+++ b/app/views/price_policies/instrument/_price_policy_fields.html.haml
@@ -25,10 +25,11 @@
         %td= price_group.type_string
         %td= check_box_tag "price_policy_#{price_group.id}[can_purchase]",
           "1", price_policy.can_purchase?, class: "can_purchase"
-        - if price_group.external?
+        - case
+        - when price_group.external?
           = render "price_policies/instrument/external_row",
             pg: price_group, pp: price_policy
-        - elsif price_group.master_internal?
+        - when price_group.master_internal?
           = render "price_policies/instrument/master_internal_row",
             pg: price_group, pp: price_policy
         - else

--- a/app/views/price_policies/instrument/_price_policy_fields.html.haml
+++ b/app/views/price_policies/instrument/_price_policy_fields.html.haml
@@ -1,31 +1,36 @@
 = content_for :head_content do
-  = javascript_include_tag 'price_policy'
+  = javascript_include_tag "price_policy"
 
-= render :partial => 'price_policies/dates', :locals => { :f => f }
+= render "price_policies/dates", f: f
 
-- policy = @price_policies.first
-= f.input :charge_for, :collection => charge_for_options(policy.product), :selected => policy.charge_for
-
+- price_policy = @price_policies.first
+= f.input :charge_for,
+  collection: charge_for_options(price_policy.product),
+  selected: price_policy.charge_for
 
 %table.table.table-striped.table-hover.price-policy-table
   %thead
     %tr
-      %th Price Group
-      %th Type
-      %th Can Purchase?
-      %th Rate Per Hour
-      %th Minimum Cost
-      %th Reservation Cost
+      %th= t(".price_group")
+      %th= t(".type")
+      %th= t(".can_purchase")
+      %th= t(".rate_per_hour")
+      %th= t(".minimum_cost")
+      %th= t(".reservation_cost")
   %tbody
-    - @price_policies.each do |pp|
-      - pg = pp.price_group
+    - @price_policies.each do |price_policy|
+      - price_group = price_policy.price_group
       %tr
-        %td= pg.name
-        %td= pg.type_string
-        %td= check_box_tag "price_policy_#{pg.id}[can_purchase]", '1', pp.can_purchase?, :class => 'can_purchase'
-        - if !pg.is_internal?
-          = render :partial => 'price_policies/instrument/external_row', :locals => { :pg => pg, :pp => pp }
-        - elsif pg.is_master_internal?
-          = render :partial => 'price_policies/instrument/master_internal_row', :locals => { :pg => pg, :pp => pp }
+        %td= price_group.name
+        %td= price_group.type_string
+        %td= check_box_tag "price_policy_#{price_group.id}[can_purchase]",
+          "1", price_policy.can_purchase?, class: "can_purchase"
+        - if price_group.external?
+          = render "price_policies/instrument/external_row",
+            pg: price_group, pp: price_policy
+        - elsif price_group.master_internal?
+          = render "price_policies/instrument/master_internal_row",
+            pg: price_group, pp: price_policy
         - else
-          = render :partial => 'price_policies/instrument/internal_row', :locals => { :pg => pg, :pp => pp }
+          = render "price_policies/instrument/internal_row",
+            pg: price_group, pp: price_policy

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -126,16 +126,16 @@ en:
       no_notices: "You have no notifications at this time"
 
     price_policies:
-      create:
-        success: Price Rules were successfully created.
       destroy:
         success: Price Rules were successfully removed.
         failure: An error was encountered while trying to remove the Price Rules
+      edit:
+        success: Price Rules were successfully updated.
       errors:
         remove_active_policy: "Sorry, but you cannot remove an active price policy. If you really want to do so move the start date to the future and try again."
         save: There was an error saving the policy
-      update:
-        success: Price Rules were successfully updated.
+      new:
+        success: Price Rules were successfully created.
 
     orders:
       purchase:

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -128,6 +128,9 @@ en:
     price_policies:
       errors:
         remove_active_policy: "Sorry, but you cannot remove an active price policy. If you really want to do so move the start date to the future and try again."
+      update:
+        success: Price Rules were successfully updated.
+        failure: There was an error saving the policy
 
     orders:
       purchase:

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -128,6 +128,9 @@ en:
     price_policies:
       create:
         success: Price Rules were successfully created.
+      destroy:
+        success: Price Rules were successfully removed.
+        failure: An error was encountered while trying to remove the Price Rules
       errors:
         remove_active_policy: "Sorry, but you cannot remove an active price policy. If you really want to do so move the start date to the future and try again."
         save: There was an error saving the policy

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -126,11 +126,13 @@ en:
       no_notices: "You have no notifications at this time"
 
     price_policies:
+      create:
+        success: Price Rules were successfully created.
       errors:
         remove_active_policy: "Sorry, but you cannot remove an active price policy. If you really want to do so move the start date to the future and try again."
+        save: There was an error saving the policy
       update:
         success: Price Rules were successfully updated.
-        failure: There was an error saving the policy
 
     orders:
       purchase:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
       timeline_navigation: "%a, %B %e, %Y"
       usa: "%m/%d/%Y"
       usa_filename_safe: "%m-%d-%Y"
+      ymd: "%Y-%m-%d"
 
   time:
     formats:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -713,11 +713,29 @@ en:
       no_orders: There are no orders in this facility
 
   price_policies:
+    edit:
+      head: Edit Pricing Rules
+      cancel: Cancel
+      save: Save Rules
+    instrument:
+      price_policy_fields:
+        price_group: Price Group
+        type: Type
+        can_purchase: Can Purchase?
+        rate_per_hour: Rate Per Hour
+        minimum_cost: Minimum Cost
+        reservation_cost: Reservation Cost
     instructional_text:
       common: "All Northwestern users must be charged the same base rate.  Rates must be reviewed by the Provost's Office.  You may define adjustments to this rate for individual internal price groups."
       item: ""
       service: ""
       instrument: "The user will be charged the sum of actual, scheduled, and overage usage fees.  Actual usage is measured by power relay or manually entered by facility staff.  Scheduled usage is calculated from the user's reservation.  Overage is any usage that exceeds the user's reservation.  If an overage rate is not specified, the actual usage rate will be applied for any overage."
+    price_policy_fields:
+      price_group: Price Group
+      type: Type
+      can_purchase: Can Purchase?
+      unit_cost: Unit Cost
+      unit_adjustment: Unit Adjustment
     problem: There is a problem with this price policy.
     errors:
       none_exist_for_date: No valid price policies exists for that date.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -714,6 +714,8 @@ en:
       no_orders: There are no orders in this facility
 
   price_policies:
+    adjustment: Adjustment
+    amount: Amount
     edit:
       head: Edit Pricing Rules
       cancel: Cancel
@@ -742,6 +744,7 @@ en:
       none_exist_for_date: No valid price policies exists for that date.
       none_exist: No current price policies
       fewer_than_price_groups: Some price groups are missing price policies
+    rate: Rate
 
   price_groups:
     price_group_fields:

--- a/spec/helpers/price_policies_helper_spec.rb
+++ b/spec/helpers/price_policies_helper_spec.rb
@@ -1,0 +1,81 @@
+require "spec_helper"
+
+describe PricePoliciesHelper do
+  let(:price_group) { build_stubbed(:price_group, id: 0) }
+  let(:price_policy) { build_stubbed(:instrument_usage_price_policy, product: nil) }
+
+  describe "#charge_for_options" do
+    let(:instrument) { build_stubbed(:instrument) }
+    let(:options) { charge_for_options(instrument) }
+
+    context "when the instrument is reservation-only" do
+      before { instrument.stub(:reservation_only?).and_return(true) }
+
+      it { expect(options).to eq([%w(Reservation reservation)]) }
+    end
+
+    context "when the instrument is not reservation-only" do
+      before { instrument.stub(:reservation_only?).and_return(false) }
+
+      it do
+        expect(options).to match_array([
+          %w(Overage overage), %w(Reservation reservation), %w(Usage usage),
+        ])
+      end
+    end
+  end
+
+  describe "#display_usage_rate" do
+    let(:usage_rate) { display_usage_rate(price_group, price_policy) }
+
+    before(:each) do
+      price_policy.stub(:hourly_usage_rate).and_return(BigDecimal("54.32"))
+    end
+
+    context "when params for the price group are present" do
+      let(:params) do
+        { price_policy_0: { usage_rate: "43.21" } }.with_indifferent_access
+      end
+
+      it "returns 60 times the usage rate from params, formatted" do
+        expect(usage_rate).to eq("2592.60")
+      end
+    end
+
+    context "when params for the price group are not present" do
+      it "returns the hourly_usage_rate, formatted" do
+        expect(usage_rate).to eq("54.32")
+      end
+    end
+  end
+
+  describe "#display_usage_subsidy" do
+    let(:usage_subsidy) { display_usage_subsidy(price_group, price_policy) }
+
+    before(:each) do
+      price_policy.stub(:hourly_usage_subsidy).and_return(BigDecimal("54.32"))
+    end
+
+    context "when params for the price group are present" do
+      let(:params) do
+        { price_policy_0: { usage_subsidy: "43.21" } }.with_indifferent_access
+      end
+
+      it "returns 60 times the usage subsidy from params, formatted" do
+        expect(usage_subsidy).to eq("2592.60")
+      end
+    end
+
+    context "when params for the price group are not present" do
+      it "returns the hourly_usage_subsidy, formatted" do
+        expect(usage_subsidy).to eq("54.32")
+      end
+    end
+  end
+
+  describe "#edit_price_policy_path"
+  describe "#format_date"
+  describe "#new_price_policy_path"
+  describe "#price_policies_path"
+  describe "#price_policy_path"
+end

--- a/spec/helpers/price_policies_helper_spec.rb
+++ b/spec/helpers/price_policies_helper_spec.rb
@@ -37,8 +37,8 @@ describe PricePoliciesHelper do
         { price_policy_0: { usage_rate: "43.21" } }.with_indifferent_access
       end
 
-      it "returns 60 times the usage rate from params, formatted" do
-        expect(usage_rate).to eq("2592.60")
+      it "returns the usage rate from params" do
+        expect(usage_rate).to eq("43.21")
       end
     end
 
@@ -61,8 +61,8 @@ describe PricePoliciesHelper do
         { price_policy_0: { usage_subsidy: "43.21" } }.with_indifferent_access
       end
 
-      it "returns 60 times the usage subsidy from params, formatted" do
-        expect(usage_subsidy).to eq("2592.60")
+      it "returns usage subsidy from params" do
+        expect(usage_subsidy).to eq("43.21")
       end
     end
 


### PR DESCRIPTION
I did a lot of cleanup and refactoring while working through this one, but the fix itself is in this commit: 6fcbc03895ebf25ae2c4ea77d9fb496d270f351d

What it boiled down to is this:

Let's say I'm creating or editing an `Instrument` price policy (and not any other `Product` type). I set the base rate as 10.00 per hour. I then check the "Can Purchase?" box next to the External Rate, but leave the Rate Per Hour blank, and then click "Save Rules". This fails, and I'm sent back to the price policy edit screen, where the system, using the `display_usage_rate` helper, has filled in the base rate field from `params`. It made two assumptions: that it's a number, and that it's a rate per minute. Since it's a string, multiplication turns it into "10.0010.0010.0010.0010.00…" and if I attempt to save with that rate, we get the numeric overflow exception.

But since it's already an hourly rate, and we want to display it as an hourly rate, the conversion doesn't seem necessary in the first place, so this change removes the multiplier.