### PR TITLE
[#119594] Order users and accounts in Price Groups views

### DIFF
--- a/app/controllers/price_groups_controller.rb
+++ b/app/controllers/price_groups_controller.rb
@@ -32,7 +32,11 @@ class PriceGroupsController < ApplicationController
       raise ActiveRecord::RecordNotFound
     end
 
-    @user_members = get_paginated_group_members(:user_price_group_members)
+    @user_members = @price_group.user_price_group_members
+      .includes(:user)
+      .joins(:user)
+      .order(:last_name, :first_name)
+    @user_members = paginate(@user_members)
     @tab = :users
 
     render action: "show"
@@ -40,7 +44,11 @@ class PriceGroupsController < ApplicationController
 
   # GET /facilities/:facility_id/price_groups/:id/accounts
   def accounts
-    @account_members = get_paginated_group_members(:account_price_group_members)
+    @account_members = @price_group.account_price_group_members
+      .includes(:account)
+      .joins(:account)
+      .order(:account_number)
+    @account_members = paginate(@account_members)
     @tab = :accounts
 
     render action: "show"
@@ -95,8 +103,8 @@ class PriceGroupsController < ApplicationController
 
   private
 
-  def get_paginated_group_members(method)
-    @price_group.public_send(method).paginate(page: params[:page], per_page: 10)
+  def paginate(relation)
+    relation.paginate(page: params[:page], per_page: 10)
   end
 
   def load_price_group_and_ability!

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -2,6 +2,9 @@ class PriceGroup < ActiveRecord::Base
   belongs_to :facility
   has_many   :order_details, :through => :price_policies, :dependent => :restrict
   has_many   :price_group_members, :dependent => :destroy
+  has_many   :user_price_group_members, class_name: 'UserPriceGroupMember'
+  has_many   :account_price_group_members, class_name: 'AccountPriceGroupMember'
+
   has_many   :price_policies, :dependent => :destroy
 
   validates_presence_of   :facility_id # enforce facility constraint here, though it's not always required
@@ -9,7 +12,7 @@ class PriceGroup < ActiveRecord::Base
   validates_uniqueness_of :name, :scope => :facility_id
 
   default_scope :order => 'is_internal DESC, display_order ASC, name ASC'
-  
+
   before_destroy :is_not_global
   before_create  lambda {|o| o.display_order = 999 if !o.facility_id.nil?}
 
@@ -18,14 +21,6 @@ class PriceGroup < ActiveRecord::Base
   scope :cancer_center, :conditions => { :name => Settings.price_group.name.cancer_center, :facility_id => nil }
 
   scope :globals, :conditions => { :facility_id => nil }
-
-  def user_price_group_members
-    UserPriceGroupMember.where(:price_group_id => id, :type => 'UserPriceGroupMember').all
-  end
-
-  def account_price_group_members
-    AccountPriceGroupMember.where(:price_group_id => id, :type => 'AccountPriceGroupMember').all
-  end
 
   def is_not_global
     !global?
@@ -44,7 +39,7 @@ class PriceGroup < ActiveRecord::Base
   end
 
   def to_s
-    self.name  
+    self.name
   end
 
   def type_string

--- a/spec/controllers/price_groups_controller_spec.rb
+++ b/spec/controllers/price_groups_controller_spec.rb
@@ -13,8 +13,8 @@ describe PriceGroupsController do
 
   context 'index' do
     before :each do
-      @method=:get
-      @action=:index
+      @method = :get
+      @action = :index
     end
 
     it_should_allow_managers_only do
@@ -37,8 +37,8 @@ describe PriceGroupsController do
 
   context 'create' do
     before :each do
-      @method=:post
-      @action=:create
+      @method = :post
+      @action = :create
       @params.merge!(:price_group => FactoryGirl.attributes_for(:price_group, :facility_id => @authable.id))
     end
 
@@ -55,8 +55,8 @@ describe PriceGroupsController do
     context 'show' do
 
       before :each do
-        @method=:get
-        @action=:show
+        @method = :get
+        @action = :show
       end
 
       it_should_allow_managers_only :redirect do
@@ -71,13 +71,13 @@ describe PriceGroupsController do
     context 'users' do
 
       before :each do
-        @method=:get
-        @action=:users
+        @method = :get
+        @action = :users
       end
 
       it_should_allow_managers_only do
-        expect(assigns(:user_members)).to be_kind_of Array
-        expect(assigns(:tab)).to_not be_nil
+        expect(assigns(:user_members)).to be_kind_of ActiveRecord::Relation
+        expect(assigns(:tab)).to eq(:users)
         should render_template 'show'
       end
 
@@ -87,13 +87,13 @@ describe PriceGroupsController do
     context 'accounts' do
 
       before :each do
-        @method=:get
+        @method = :get
         @action=:accounts
       end
 
       it_should_allow_managers_only do
-        expect(assigns(:account_members)).to be_kind_of Array
-        expect(assigns(:tab)).to_not be_nil
+        expect(assigns(:account_members)).to be_kind_of ActiveRecord::Relation
+        expect(assigns(:tab)).to eq(:accounts)
         should render_template 'show'
       end
 
@@ -103,8 +103,8 @@ describe PriceGroupsController do
     context 'edit' do
 
       before :each do
-        @method=:get
-        @action=:edit
+        @method = :get
+        @action = :edit
       end
 
       it_should_allow_managers_only do
@@ -119,8 +119,8 @@ describe PriceGroupsController do
     context 'update' do
 
       before :each do
-        @method=:put
-        @action=:update
+        @method = :put
+        @action = :update
         @params.merge!(:price_group => FactoryGirl.attributes_for(:price_group, :facility_id => @authable.id))
       end
 
@@ -137,8 +137,8 @@ describe PriceGroupsController do
     context 'destroy' do
 
       before :each do
-        @method=:delete
-        @action=:destroy
+        @method = :delete
+        @action = :destroy
       end
 
       it_should_allow_managers_only :redirect do


### PR DESCRIPTION
There was no ordering applied previously. This also fixes the query so
it doesn’t load all of the members into an array.