### PR TITLE
[#119628] Do not validate media type for DownloadableFiles

### DIFF
--- a/app/models/concerns/downloadable_file.rb
+++ b/app/models/concerns/downloadable_file.rb
@@ -2,7 +2,7 @@ module DownloadableFile
   extend ActiveSupport::Concern
 
   included do
-    has_attached_file :file, Settings.paperclip.to_hash
+    has_attached_file :file, Settings.paperclip.to_hash.merge(validate_media_type: false)
 
     # TODO Limit attachment types for safe uploads
     do_not_validate_attachment_file_type :file


### PR DESCRIPTION
Paperclip gets really fussy when you try to upload a file and the MIME
type it detects does not match the file extension. This was happening
occasionally on NU for order uploads, and started happening for UIC.

This disables paperclip’s validations.

Already done in NU on https://github.com/tablexi/nucore-nu/pull/79

I’ve done this as a hotfix on UIC to verify that this fixes their issue.