### PR TITLE
[#119006] Optimize journal closing

### DIFF
--- a/app/support/journals/closer.rb
+++ b/app/support/journals/closer.rb
@@ -30,7 +30,8 @@ class Journals::Closer
     false_value = NUCore::Database.boolean(false)
     if journal.update_attributes(params.merge(is_successful: false_value))
       # remove all the orders from the journal
-      journal.order_details.update_all(journal_id: nil)
+      # Do not use the Journal#order_details relation because it goes through journal_rows
+      OrderDetail.where(journal_id: journal.id).update_all(journal_id: nil)
       true
     else
       false

--- a/app/support/journals/closer.rb
+++ b/app/support/journals/closer.rb
@@ -1,0 +1,73 @@
+class Journals::Closer
+  attr_reader :journal, :params
+
+  def initialize(journal, params)
+    @journal = journal
+    # It's like strong_params...
+    @params = params.slice(:reference, :description, :updated_by)
+  end
+
+  def perform(status)
+    rollback_on_fail do
+      case status
+      when 'failed'
+        mark_as_failed
+      when 'succeeded_errors'
+        mark_as_succeeded_with_errors
+      when 'succeeded'
+        mark_as_succeeded
+      else
+        journal.errors.add(:base, I18n.t('controllers.facility_journals.update.error.status'))
+        false
+      end
+    end
+  end
+
+  private
+
+  def mark_as_failed
+    # Oracle is sometimes not converting false to null
+    false_value = NUCore::Database.boolean(false)
+    if journal.update_attributes(params.merge(is_successful: false_value))
+      # remove all the orders from the journal
+      journal.order_details.update_all(journal_id: nil)
+      true
+    else
+      false
+    end
+  end
+
+  def update_all?
+    false
+  end
+
+  def mark_as_succeeded_with_errors
+    journal.update_attributes(params.merge(is_successful: true))
+  end
+
+  def mark_as_succeeded
+    if journal.update_attributes(params.merge(is_successful: true))
+      reconciled_status = OrderStatus.reconciled.first
+      if update_all?
+        journal.order_details.update_all(state: 'reconciled', order_status_id: reconciled_status.id)
+      else
+        journal.order_details.each do |od|
+          od.change_status!(reconciled_status)
+        end
+      end
+      true
+    else
+      false
+    end
+  end
+
+  def rollback_on_fail
+    Journal.transaction requires_new: true do
+      if yield
+        true
+      else
+        raise ActiveRecord::Rollback
+      end
+    end
+  end
+end

--- a/app/support/journals/closer.rb
+++ b/app/support/journals/closer.rb
@@ -37,10 +37,6 @@ class Journals::Closer
     end
   end
 
-  def update_all?
-    false
-  end
-
   def mark_as_succeeded_with_errors
     journal.update_attributes(params.merge(is_successful: true))
   end
@@ -48,14 +44,7 @@ class Journals::Closer
   def mark_as_succeeded
     if journal.update_attributes(params.merge(is_successful: true))
       reconciled_status = OrderStatus.reconciled.first
-      if update_all?
-        journal.order_details.update_all(state: 'reconciled', order_status_id: reconciled_status.id)
-      else
-        journal.order_details.each do |od|
-          od.change_status!(reconciled_status)
-        end
-      end
-      true
+      journal.order_details.update_all(state: 'reconciled', order_status_id: reconciled_status.id)
     else
       false
     end

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -22,9 +22,7 @@ describe FacilityJournalsController do
     @authable_account2 = @authable.facility_accounts.create(FactoryGirl.attributes_for(:facility_account))
     @order_detail3 = place_and_complete_item_order(@user, @authable, @account2, true)
 
-    @more_details = 100.times.map { place_and_complete_item_order(@user, @authable, @account, true) }
-
-    ([@order_detail1, @order_detail3] + @more_details).each do |od|
+    [@order_detail1, @order_detail3].each do |od|
       od.update_attribute(:reviewed_at, 1.day.ago)
     end
 
@@ -104,49 +102,25 @@ describe FacilityJournalsController do
       context 'successful journal' do
         before :each do
           @params.merge!({:journal_status => 'succeeded'})
-        end
-
-        describe 'benchmark' do
-          specify 'update each' do
-            10.times do
-              Journal.transaction do
-                puts(Benchmark.measure { do_request })
-                raise ActiveRecord::Rollback
-              end
-            end
-          end
-
-          specify 'update_all' do
-            allow_any_instance_of(Journals::Closer).to receive(:update_all?).and_return true
-            10.times do
-              Journal.transaction do
-                puts(Benchmark.measure { do_request })
-                raise ActiveRecord::Rollback
-              end
-            end
-          end
+          do_request
         end
 
         it 'should not have any errors' do
-          do_request
           assigns[:journal].errors.should be_empty
           flash[:error].should be_nil
         end
 
         it 'should set the updated by to the logged in user and leave created by alone' do
-          do_request
           assigns[:journal].updated_by.should == @director.id
           assigns[:journal].created_by.should == @admin.id
         end
 
         it "has an is_successful value of true" do
-          do_request
           expect(assigns[:journal].is_successful?).to be true
           expect(assigns[:journal]).to be_successful
         end
 
         it 'should set all the order details to reconciled' do
-          do_request
           reconciled_status = OrderStatus.reconciled.first
           @order_detail1.reload.order_status.should == reconciled_status
           @order_detail3.reload.order_status.should == reconciled_status


### PR DESCRIPTION
This is the open version of https://github.com/tablexi/nucore-nu/pull/86

NU has had timeout issues with closing journals with many order details.

This changes to use update_all on order details on successful journal
closing instead of an update on each individual order detail. We lose
the versions audit details, but the performance is about an order of
magnitude faster. After this, we should be able to drop the timeouts we
increased back to a normal level.

The first commit includes the benchmarking shown below (running against a local docker db c.f. #85), and the second commit removes the benchmarking to what would be the final state.

```
original
  0.110000   0.030000   0.140000 (  0.173225)
  0.070000   0.000000   0.070000 (  0.101981)
  0.070000   0.010000   0.080000 (  0.102546)
  0.060000   0.010000   0.070000 (  0.102396)
  0.070000   0.000000   0.070000 (  0.115820)
  0.060000   0.010000   0.070000 (  0.099806)
  0.060000   0.010000   0.070000 (  0.100836)
  0.070000   0.000000   0.070000 (  0.102700)
  0.090000   0.020000   0.110000 (  0.130646)
  0.070000   0.000000   0.070000 (  0.097616)

update_all
  0.030000   0.000000   0.030000 (  0.041834)
  0.010000   0.000000   0.010000 (  0.018699)
  0.010000   0.010000   0.020000 (  0.019488)
  0.020000   0.000000   0.020000 (  0.023885)
  0.020000   0.000000   0.020000 (  0.029898)
  0.020000   0.000000   0.020000 (  0.026476)
  0.020000   0.010000   0.030000 (  0.026347)
  0.020000   0.000000   0.020000 (  0.027293)
  0.010000   0.000000   0.010000 (  0.024198)
  0.020000   0.000000   0.020000 (  0.027155)
```