### PR TITLE
Convert accessory scaling decorators to use SimpleDelegator

### DIFF
--- a/app/support/accessories/scaling/auto.rb
+++ b/app/support/accessories/scaling/auto.rb
@@ -2,7 +2,7 @@
 # and auto-updates if the duration changes
 class Accessories::Scaling::Auto < Accessories::Scaling::Manual
   def update_quantity
-    @order_detail.quantity = @order_detail.parent_order_detail.reservation.actual_duration_mins.to_i
+    order_detail.quantity = order_detail.parent_order_detail.reservation.actual_duration_mins.to_i
   end
 
   def quantity_editable?

--- a/app/support/accessories/scaling/default.rb
+++ b/app/support/accessories/scaling/default.rb
@@ -1,15 +1,12 @@
-class Accessories::Scaling::Default
-  attr_accessor :enabled, :order_detail
+class Accessories::Scaling::Default < SimpleDelegator
+  attr_accessor :enabled
 
-  # We need to respond_to? these as opposed to sending them to method_missing
-  delegate :to_s, :to_param, :errors, :to => :order_detail
-
-  def initialize(order_detail)
-    @order_detail = order_detail
+  def order_detail
+    __getobj__
   end
 
   def update_quantity
-    @order_detail.quantity ||= 1
+    order_detail.quantity ||= 1
   end
 
   def quantity_editable?
@@ -26,21 +23,15 @@ class Accessories::Scaling::Default
 
   def assign_attributes(attrs)
     self.enabled = attrs.delete :enabled if attrs[:enabled]
-    @order_detail.assign_attributes(attrs)
+    order_detail.assign_attributes(attrs)
   end
 
   # Since this is a decorator, allow comparison with the base OrderDetail
   def ==(other)
     if other.is_a? OrderDetail
-      @order_detail == other
+      order_detail == other
     else
       self.equal? other
     end
-  end
-
-  private
-
-  def method_missing(method, *args)
-    @order_detail.send(method, *args)
   end
 end

--- a/app/support/accessories/scaling/manual.rb
+++ b/app/support/accessories/scaling/manual.rb
@@ -2,7 +2,7 @@
 # but does not get auto-updated
 class Accessories::Scaling::Manual < Accessories::Scaling::Default
   def update_quantity
-    @order_detail.quantity ||= @order_detail.parent_order_detail.reservation.actual_duration_mins.to_i
+    order_detail.quantity ||= order_detail.parent_order_detail.reservation.actual_duration_mins.to_i
   end
 
   def quantity_as_time?


### PR DESCRIPTION
I was getting warnings from rspec 2.99 when doing assertions like
`expect(order_detail).to be_complete`, but felt like this was a
significant enough change to warrant its own PR.

> Matching with be_persisted on an object that doesn't respond to
`persisted?` is deprecated. Use `respond_to_missing?` or `respond_to?`
on your object instead.

Using SimpleDelegator seems to be the simplest solution because it will
handle `respond_to?`.