### PR TITLE
[#98770] Change statement PDF filename

### DIFF
--- a/app/support/statement_pdf.rb
+++ b/app/support/statement_pdf.rb
@@ -32,7 +32,8 @@ class StatementPdf
 
   def filename
     date = I18n.l(@statement.created_at.to_date, format: :usa_filename_safe)
-    I18n.t("statements.pdf.filename", date: date, facility: @facility.abbreviation,
+    I18n.t("statements.pdf.filename", date: date,
+      facility: @facility.abbreviation.gsub(/\s+/, "_"),
       invoice_number: @statement.invoice_number)
   end
 

--- a/app/support/statement_pdf.rb
+++ b/app/support/statement_pdf.rb
@@ -31,11 +31,9 @@ class StatementPdf
   end
 
   def filename
-    "Statement-#{date_stamp}.pdf"
-  end
-
-  def date_stamp
-    I18n.l(@statement.created_at.to_date, format: :usa_filename_safe)
+    date = I18n.l(@statement.created_at.to_date, format: :usa_filename_safe)
+    I18n.t("statements.pdf.filename", date: date, facility: @facility.abbreviation,
+      invoice_number: @statement.invoice_number)
   end
 
   def render

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -477,7 +477,7 @@ en:
         dispute: "In Dispute"
         unassigned: "Unassigned"
     pdf:
-      filename: "Statement-%{date}.pdf"
+      filename: "%{facility}-%{invoice_number}-%{date}.pdf"
 
   orders:
     add_account:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -476,6 +476,8 @@ en:
       td:
         dispute: "In Dispute"
         unassigned: "Unassigned"
+    pdf:
+      filename: "Statement-%{date}.pdf"
 
   orders:
     add_account:


### PR DESCRIPTION
This is pulled up from https://github.com/tablexi/nucore-nu/pull/88

It adds additional information like the facility into statement PDF filenames and allows overriding via locales.