### PR TITLE
Use alphabetic sequnce for PriceGroup name

### DIFF
--- a/spec/factories/price_groups.rb
+++ b/spec/factories/price_groups.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :price_group do
     facility
-    sequence(:name) { |n| "Price Group #{n}" }
+    sequence(:name, "AAAAAAAA") { |n| "Price Group #{n}" }
     display_order 999
     is_internal true
     admin_editable true

--- a/spec/price_policies_controller_shared_examples.rb
+++ b/spec/price_policies_controller_shared_examples.rb
@@ -94,6 +94,7 @@ shared_examples_for PricePoliciesController do |product_type, params_modifier = 
         before :each do
           @price_group2_policy = make_price_policy(@price_group2, :can_purchase => false, :unit_cost => 13)
         end
+
         it 'should set can_purchase based off old policy' do
           do_request
           assigns[:price_policies].map(&:price_group).should == [@price_policy.price_group, @price_group2_policy.price_group]
@@ -102,7 +103,7 @@ shared_examples_for PricePoliciesController do |product_type, params_modifier = 
         end
         it 'should set fields based off the old policy' do
           do_request
-          expect(assigns[:price_policies].map(&:price_group)).to match_array([@price_policy.price_group, @price_group2_policy.price_group])
+          expect(assigns[:price_policies].map(&:price_group)).to eq([@price_policy.price_group, @price_group2_policy.price_group])
           expect(assigns[:price_policies][0].unit_cost).to eq(@price_policy.unit_cost)
           expect(assigns[:price_policies][1].unit_cost).to eq(@price_group2_policy.unit_cost)
         end


### PR DESCRIPTION
We were getting an odd test failure where we’re looking for price
groups in a specific order. It was failing when that order spanned
“Price Group 999” to “Price Group 1000” because “1000” comes before
“999” alphabetically.