### PR TITLE
[#60973] Show admin notifications when in admin context

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,5 +1,5 @@
 class NotificationsController < ApplicationController
-  admin_tab     :all
+  customer_tab  :all
   before_filter :authenticate_user!
   before_filter :check_acting_as
   before_filter :check_notifications

--- a/app/models/message_summarizer.rb
+++ b/app/models/message_summarizer.rb
@@ -7,6 +7,10 @@ class MessageSummarizer
     @controller = controller
   end
 
+  def has_visible_tab?
+    manager_context? || notifications.any?
+  end
+
   def message_count
     @message_count ||= message_summaries.sum(&:count)
   end
@@ -16,6 +20,10 @@ class MessageSummarizer
   end
 
   private
+
+  def manager_context?
+    @controller.current_facility && @controller.admin_tab?
+  end
 
   def notifications
     @notifications ||= NotificationsSummary.new(@controller)

--- a/app/models/message_summarizer.rb
+++ b/app/models/message_summarizer.rb
@@ -1,7 +1,7 @@
 class MessageSummarizer
   include Enumerable
 
-  delegate :each, to: :message_summaries
+  delegate :each, to: :visible_summaries
 
   def initialize(controller)
     @controller = controller
@@ -16,17 +16,27 @@ class MessageSummarizer
   end
 
   def visible_tab?
-    manager_context? || notifications.any?
+    visible_summaries.any?
+  end
+
+  def visible_summaries
+    summaries.select(&:visible?)
+  end
+
+  def summaries
+    [
+      notifications,
+      order_details_in_dispute,
+      problem_order_details,
+      problem_reservation_order_details,
+      training_requests,
+    ]
   end
 
   private
 
-  def manager_context?
-    @controller.admin_tab?
-  end
-
   def message_count
-    @message_count ||= message_summaries.sum(&:count)
+    @message_count ||= visible_summaries.sum(&:count)
   end
 
   def notifications
@@ -50,13 +60,4 @@ class MessageSummarizer
     @training_requests ||= TrainingRequestsSummary.new(@controller)
   end
 
-  def message_summaries
-    [
-      notifications,
-      order_details_in_dispute,
-      problem_order_details,
-      problem_reservation_order_details,
-      training_requests,
-    ].select(&:any?)
-  end
 end

--- a/app/models/message_summarizer.rb
+++ b/app/models/message_summarizer.rb
@@ -11,18 +11,22 @@ class MessageSummarizer
     manager_context? || notifications.any?
   end
 
-  def message_count
-    @message_count ||= message_summaries.sum(&:count)
-  end
-
   def messages?
     message_count > 0
+  end
+
+  def tab_label
+    I18n.t("message_summarizer.heading", count: message_count)
   end
 
   private
 
   def manager_context?
     @controller.admin_tab?
+  end
+
+  def message_count
+    @message_count ||= message_summaries.sum(&:count)
   end
 
   def notifications

--- a/app/models/message_summarizer.rb
+++ b/app/models/message_summarizer.rb
@@ -8,7 +8,11 @@ class MessageSummarizer
   end
 
   def message_count
-    message_summaries.sum(&:count)
+    @message_count ||= message_summaries.sum(&:count)
+  end
+
+  def messages?
+    message_count > 0
   end
 
   private

--- a/app/models/message_summarizer.rb
+++ b/app/models/message_summarizer.rb
@@ -7,16 +7,16 @@ class MessageSummarizer
     @controller = controller
   end
 
-  def has_visible_tab?
-    manager_context? || notifications.any?
-  end
-
   def messages?
     message_count > 0
   end
 
   def tab_label
     I18n.t("message_summarizer.heading", count: message_count)
+  end
+
+  def visible_tab?
+    manager_context? || notifications.any?
   end
 
   private

--- a/app/models/message_summarizer.rb
+++ b/app/models/message_summarizer.rb
@@ -22,7 +22,7 @@ class MessageSummarizer
   private
 
   def manager_context?
-    @controller.current_facility && @controller.admin_tab?
+    @controller.admin_tab?
   end
 
   def notifications

--- a/app/models/message_summarizer.rb
+++ b/app/models/message_summarizer.rb
@@ -11,10 +11,6 @@ class MessageSummarizer
     message_summaries.sum(&:count)
   end
 
-  def messages?
-    message_summaries.any?
-  end
-
   private
 
   def notifications

--- a/app/models/message_summarizer/facility_message_summary.rb
+++ b/app/models/message_summarizer/facility_message_summary.rb
@@ -1,0 +1,11 @@
+class MessageSummarizer::FacilityMessageSummary < MessageSummarizer::MessageSummary
+  private
+
+  def in_context?
+    facility && controller.admin_tab?
+  end
+
+  def facility
+    controller.current_facility
+  end
+end

--- a/app/models/message_summarizer/message_summary.rb
+++ b/app/models/message_summarizer/message_summary.rb
@@ -43,10 +43,6 @@ class MessageSummarizer::MessageSummary
     "#{I18n.t(i18n_key)} (#{count})"
   end
 
-  def manager_context?
-    facility && controller.admin_tab?
-  end
-
   def path
     raise NotImplementedError.new("Subclass must implement")
   end

--- a/app/models/message_summarizer/message_summary.rb
+++ b/app/models/message_summarizer/message_summary.rb
@@ -10,7 +10,7 @@ class MessageSummarizer::MessageSummary
   end
 
   def count
-    @count ||= allowed? ? get_count : 0
+    @count ||= (visible? && allowed?) ? get_count : 0
   end
 
   def link
@@ -45,5 +45,9 @@ class MessageSummarizer::MessageSummary
 
   def path
     raise NotImplementedError.new("Subclass must implement")
+  end
+
+  def visible?
+    controller.admin_tab?
   end
 end

--- a/app/models/message_summarizer/message_summary.rb
+++ b/app/models/message_summarizer/message_summary.rb
@@ -10,25 +10,25 @@ class MessageSummarizer::MessageSummary
   end
 
   def count
-    @count ||= (visible? && allowed?) ? get_count : 0
+    @count ||= get_count
   end
 
   def link
     controller.view_context.link_to(label, path)
   end
 
+  def visible?
+    allowed? && in_context?
+  end
+
   private
 
-  def ability
-    controller.current_ability
+  def in_context?
+    raise NotImplementedError.new("Subclass must implement")
   end
 
   def allowed?
     raise NotImplementedError.new("Subclass must implement")
-  end
-
-  def facility
-    controller.current_facility
   end
 
   def get_count
@@ -39,15 +39,15 @@ class MessageSummarizer::MessageSummary
     raise NotImplementedError.new("Subclass must implement")
   end
 
-  def label
-    "#{I18n.t(i18n_key)} (#{count})"
-  end
-
   def path
     raise NotImplementedError.new("Subclass must implement")
   end
 
-  def visible?
-    controller.admin_tab?
+  def ability
+    controller.current_ability
+  end
+
+  def label
+    "#{I18n.t(i18n_key)} (#{count})"
   end
 end

--- a/app/models/message_summarizer/message_summary.rb
+++ b/app/models/message_summarizer/message_summary.rb
@@ -43,6 +43,10 @@ class MessageSummarizer::MessageSummary
     "#{I18n.t(i18n_key)} (#{count})"
   end
 
+  def manager_context?
+    facility && controller.admin_tab?
+  end
+
   def path
     raise NotImplementedError.new("Subclass must implement")
   end

--- a/app/models/message_summarizer/notifications_summary.rb
+++ b/app/models/message_summarizer/notifications_summary.rb
@@ -1,4 +1,8 @@
 class MessageSummarizer::NotificationsSummary < MessageSummarizer::MessageSummary
+  def in_context?
+    any?
+  end
+
   private
 
   def allowed?
@@ -19,9 +23,5 @@ class MessageSummarizer::NotificationsSummary < MessageSummarizer::MessageSummar
 
   def user
     controller.current_user
-  end
-
-  def visible?
-    true
   end
 end

--- a/app/models/message_summarizer/notifications_summary.rb
+++ b/app/models/message_summarizer/notifications_summary.rb
@@ -20,4 +20,8 @@ class MessageSummarizer::NotificationsSummary < MessageSummarizer::MessageSummar
   def user
     controller.current_user
   end
+
+  def visible?
+    true
+  end
 end

--- a/app/models/message_summarizer/order_details_in_dispute_summary.rb
+++ b/app/models/message_summarizer/order_details_in_dispute_summary.rb
@@ -2,7 +2,7 @@ class MessageSummarizer::OrderDetailsInDisputeSummary < MessageSummarizer::Messa
   private
 
   def allowed?
-    facility && ability.can?(:disputed_orders, Facility)
+    manager_context? && ability.can?(:disputed_orders, Facility)
   end
 
   def get_count

--- a/app/models/message_summarizer/order_details_in_dispute_summary.rb
+++ b/app/models/message_summarizer/order_details_in_dispute_summary.rb
@@ -2,7 +2,7 @@ class MessageSummarizer::OrderDetailsInDisputeSummary < MessageSummarizer::Messa
   private
 
   def allowed?
-    manager_context? && ability.can?(:disputed_orders, Facility)
+    ability.can?(:disputed_orders, Facility)
   end
 
   def get_count

--- a/app/models/message_summarizer/order_details_in_dispute_summary.rb
+++ b/app/models/message_summarizer/order_details_in_dispute_summary.rb
@@ -1,4 +1,4 @@
-class MessageSummarizer::OrderDetailsInDisputeSummary < MessageSummarizer::MessageSummary
+class MessageSummarizer::OrderDetailsInDisputeSummary < MessageSummarizer::FacilityMessageSummary
   private
 
   def allowed?

--- a/app/models/message_summarizer/problem_order_details_summary.rb
+++ b/app/models/message_summarizer/problem_order_details_summary.rb
@@ -2,7 +2,7 @@ class MessageSummarizer::ProblemOrderDetailsSummary < MessageSummarizer::Message
   private
 
   def allowed?
-    facility && ability.can?(:show_problems, Order)
+    manager_context? && ability.can?(:show_problems, Order)
   end
 
   def get_count

--- a/app/models/message_summarizer/problem_order_details_summary.rb
+++ b/app/models/message_summarizer/problem_order_details_summary.rb
@@ -1,4 +1,4 @@
-class MessageSummarizer::ProblemOrderDetailsSummary < MessageSummarizer::MessageSummary
+class MessageSummarizer::ProblemOrderDetailsSummary < MessageSummarizer::FacilityMessageSummary
   private
 
   def allowed?

--- a/app/models/message_summarizer/problem_order_details_summary.rb
+++ b/app/models/message_summarizer/problem_order_details_summary.rb
@@ -2,7 +2,7 @@ class MessageSummarizer::ProblemOrderDetailsSummary < MessageSummarizer::Message
   private
 
   def allowed?
-    manager_context? && ability.can?(:show_problems, Order)
+    ability.can?(:show_problems, Order)
   end
 
   def get_count

--- a/app/models/message_summarizer/problem_reservation_order_details_summary.rb
+++ b/app/models/message_summarizer/problem_reservation_order_details_summary.rb
@@ -1,4 +1,4 @@
-class MessageSummarizer::ProblemReservationOrderDetailsSummary < MessageSummarizer::MessageSummary
+class MessageSummarizer::ProblemReservationOrderDetailsSummary < MessageSummarizer::FacilityMessageSummary
   private
 
   def allowed?

--- a/app/models/message_summarizer/problem_reservation_order_details_summary.rb
+++ b/app/models/message_summarizer/problem_reservation_order_details_summary.rb
@@ -2,7 +2,7 @@ class MessageSummarizer::ProblemReservationOrderDetailsSummary < MessageSummariz
   private
 
   def allowed?
-    facility && ability.can?(:show_problems, Reservation)
+    manager_context? && ability.can?(:show_problems, Reservation)
   end
 
   def get_count

--- a/app/models/message_summarizer/problem_reservation_order_details_summary.rb
+++ b/app/models/message_summarizer/problem_reservation_order_details_summary.rb
@@ -2,7 +2,7 @@ class MessageSummarizer::ProblemReservationOrderDetailsSummary < MessageSummariz
   private
 
   def allowed?
-    manager_context? && ability.can?(:show_problems, Reservation)
+    ability.can?(:show_problems, Reservation)
   end
 
   def get_count

--- a/app/models/message_summarizer/training_requests_summary.rb
+++ b/app/models/message_summarizer/training_requests_summary.rb
@@ -1,4 +1,4 @@
-class MessageSummarizer::TrainingRequestsSummary < MessageSummarizer::MessageSummary
+class MessageSummarizer::TrainingRequestsSummary < MessageSummarizer::FacilityMessageSummary
   private
 
   def allowed?

--- a/app/models/message_summarizer/training_requests_summary.rb
+++ b/app/models/message_summarizer/training_requests_summary.rb
@@ -2,7 +2,7 @@ class MessageSummarizer::TrainingRequestsSummary < MessageSummarizer::MessageSum
   private
 
   def allowed?
-    facility && ability.can?(:manage, TrainingRequest)
+    manager_context? && ability.can?(:manage, TrainingRequest)
   end
 
   def get_count

--- a/app/models/message_summarizer/training_requests_summary.rb
+++ b/app/models/message_summarizer/training_requests_summary.rb
@@ -2,7 +2,7 @@ class MessageSummarizer::TrainingRequestsSummary < MessageSummarizer::MessageSum
   private
 
   def allowed?
-    manager_context? && ability.can?(:manage, TrainingRequest)
+    ability.can?(:manage, TrainingRequest)
   end
 
   def get_count

--- a/app/views/shared/_message_summary.html.haml
+++ b/app/views/shared/_message_summary.html.haml
@@ -1,9 +1,9 @@
 - summarizer = MessageSummarizer.new(controller)
-%li
-  - if summarizer.messages?
-    %ul.nav.pull-right
-      %li.dropdown.pull-right
-        - if summarizer.messages?
+- if summarizer.has_visible_tab?
+  %li
+    - if summarizer.messages?
+      %ul.nav.pull-right
+        %li.dropdown.pull-right
           = link_to t("message_summarizer.heading", count: summarizer.message_count),
             :notifications,
             class: "dropdown-toggle",
@@ -12,7 +12,7 @@
           %ul.dropdown-menu
             - summarizer.each do |message_summary|
               %li= message_summary.link
-  - else
-    .navbar-text= t("message_summarizer.heading", count: 0)
+    - else
+      .navbar-text= t("message_summarizer.heading", count: 0)
 
-%li.divider-vertical
+  %li.divider-vertical

--- a/app/views/shared/_message_summary.html.haml
+++ b/app/views/shared/_message_summary.html.haml
@@ -4,7 +4,7 @@
     - if summarizer.messages?
       %ul.nav.pull-right
         %li.dropdown.pull-right
-          = link_to t("message_summarizer.heading", count: summarizer.message_count),
+          = link_to summarizer.tab_label,
             :notifications,
             class: "dropdown-toggle",
             data: { toggle: "dropdown" }
@@ -13,6 +13,6 @@
             - summarizer.each do |message_summary|
               %li= message_summary.link
     - else
-      .navbar-text= t("message_summarizer.heading", count: 0)
+      .navbar-text= summarizer.tab_label
 
   %li.divider-vertical

--- a/app/views/shared/_message_summary.html.haml
+++ b/app/views/shared/_message_summary.html.haml
@@ -1,13 +1,18 @@
 - summarizer = MessageSummarizer.new(controller)
 %li
-  %ul.nav.pull-right
-    %li.dropdown.pull-right
-      = link_to t("message_summarizer.heading", count: summarizer.message_count),
-        :notifications,
-        class: "dropdown-toggle",
-        data: { toggle: "dropdown" }
+  - if summarizer.messages?
+    %ul.nav.pull-right
+      %li.dropdown.pull-right
+        - if summarizer.messages?
+          = link_to t("message_summarizer.heading", count: summarizer.message_count),
+            :notifications,
+            class: "dropdown-toggle",
+            data: { toggle: "dropdown" }
 
-      %ul.dropdown-menu
-        - summarizer.each do |message_summary|
-          %li= message_summary.link
+          %ul.dropdown-menu
+            - summarizer.each do |message_summary|
+              %li= message_summary.link
+  - else
+    .navbar-text= t("message_summarizer.heading", count: 0)
+
 %li.divider-vertical

--- a/app/views/shared/_message_summary.html.haml
+++ b/app/views/shared/_message_summary.html.haml
@@ -10,7 +10,7 @@
             data: { toggle: "dropdown" }
 
           %ul.dropdown-menu
-            - summarizer.each do |message_summary|
+            - summarizer.select(&:any?).each do |message_summary|
               %li= message_summary.link
     - else
       .navbar-text= summarizer.tab_label

--- a/app/views/shared/_message_summary.html.haml
+++ b/app/views/shared/_message_summary.html.haml
@@ -1,14 +1,13 @@
 - summarizer = MessageSummarizer.new(controller)
-- if summarizer.messages?
-  %li
-    %ul.nav.pull-right
-      %li.dropdown.pull-right
-        = link_to t("message_summarizer.heading", count: summarizer.message_count),
-          :notifications,
-          class: "dropdown-toggle",
-          data: { toggle: "dropdown" }
+%li
+  %ul.nav.pull-right
+    %li.dropdown.pull-right
+      = link_to t("message_summarizer.heading", count: summarizer.message_count),
+        :notifications,
+        class: "dropdown-toggle",
+        data: { toggle: "dropdown" }
 
-        %ul.dropdown-menu
-          - summarizer.each do |message_summary|
-            %li= message_summary.link
-  %li.divider-vertical
+      %ul.dropdown-menu
+        - summarizer.each do |message_summary|
+          %li= message_summary.link
+%li.divider-vertical

--- a/app/views/shared/_message_summary.html.haml
+++ b/app/views/shared/_message_summary.html.haml
@@ -1,5 +1,5 @@
 - summarizer = MessageSummarizer.new(controller)
-- if summarizer.has_visible_tab?
+- if summarizer.visible_tab?
   %li
     - if summarizer.messages?
       %ul.nav.pull-right

--- a/lib/nav_tab.rb
+++ b/lib/nav_tab.rb
@@ -22,16 +22,16 @@ module NavTab
     end
   end
 
+  # Returns true if the current action is an admin tab action
+  def admin_tab?
+    ((self.class.admin_actions || []) & [action_name.to_sym, :all]).any?
+  end
+
   protected
 
   # Returns true if the current action is a customer tab action
   def customer_tab?
     ((self.class.customer_actions || []) & [action_name.to_sym, :all]).any?
-  end
-
-  # Returns true if the current action is an admin tab action
-  def admin_tab?
-    ((self.class.admin_actions || []) & [action_name.to_sym, :all]).any?
   end
 
 end

--- a/spec/models/message_summarizer_spec.rb
+++ b/spec/models/message_summarizer_spec.rb
@@ -67,30 +67,44 @@ describe MessageSummarizer do
 
   context "when no active notifications, training requests, disputed or problem orders exist" do
     it_behaves_like "there are no messages"
+
+    context "when not in a manager context" do
+      it { expect(subject).not_to have_visible_tab }
+    end
+
+    context "when in a manager context" do
+      let(:admin_tab?) { true }
+
+      it { expect(subject).to have_visible_tab }
+    end
   end
 
   context "when an active notification exists" do
     before { create_merge_notification }
 
-    shared_examples_for "the user may view notifications" do
+    context "and the user may view notifications" do
+      before { ability.can(:read, Notification) }
+
       it_behaves_like "there is one overall message"
 
-      context "when not scoped to a facility" do
-        let(:current_facility) { nil }
+      context "when not in a manager context" do
+        it_behaves_like "there is one overall message"
+        it { expect(subject).to have_visible_tab }
+        it { expect(subject.first.link).to match(/\bNotices \(1\)/) }
+      end
+
+      context "when in a manager context "do
+        let(:admin_tab?) { true }
 
         it_behaves_like "there is one overall message"
+        it { expect(subject).to have_visible_tab }
         it { expect(subject.first.link).to match(/\bNotices \(1\)/) }
       end
     end
 
-    context "and the user may view notifications" do
-      before { ability.can(:read, Notification) }
-
-      it_behaves_like "the user may view notifications"
-    end
-
     context "and the user may not view notifications" do
       it_behaves_like "there are no messages"
+      it { expect(subject).not_to have_visible_tab }
     end
   end
 
@@ -104,16 +118,19 @@ describe MessageSummarizer do
         let(:admin_tab?) { true }
 
         it_behaves_like "there is one overall message"
+        it { expect(subject).to have_visible_tab }
         it { expect(subject.first.link).to match(/\bDisputed Orders \(1\)/) }
       end
 
       context "when not in a manager context" do
         it_behaves_like "there are no messages"
+        it { expect(subject).not_to have_visible_tab }
       end
     end
 
     context "and the user cannot access disputed order details" do
       it_behaves_like "there are no messages"
+      it { expect(subject).not_to have_visible_tab }
     end
   end
 
@@ -129,16 +146,19 @@ describe MessageSummarizer do
         let(:admin_tab?) { true }
 
         it_behaves_like "there is one overall message"
+        it { expect(subject).to have_visible_tab }
         it { expect(subject.first.link).to match(/\bProblem Orders \(1\)/) }
       end
 
       context "when not in a manager context" do
         it_behaves_like "there are no messages"
+        it { expect(subject).not_to have_visible_tab }
       end
     end
 
     context "and the user cannot access problem orders" do
       it_behaves_like "there are no messages"
+      it { expect(subject).not_to have_visible_tab }
     end
   end
 
@@ -152,16 +172,19 @@ describe MessageSummarizer do
         let(:admin_tab?) { true }
 
         it_behaves_like "there is one overall message"
+        it { expect(subject).to have_visible_tab }
         it { expect(subject.first.link).to match(/\bProblem Reservations \(1\)/) }
       end
 
       context "when not in a manager context" do
         it_behaves_like "there are no messages"
+        it { expect(subject).not_to have_visible_tab }
       end
     end
 
     context "and the user cannot access problem reservations" do
       it_behaves_like "there are no messages"
+      it { expect(subject).not_to have_visible_tab }
     end
   end
 
@@ -175,16 +198,19 @@ describe MessageSummarizer do
         let(:admin_tab?) { true }
 
         it_behaves_like "there is one overall message"
+        it { expect(subject).to have_visible_tab }
         it { expect(subject.first.link).to match(/\bTraining Requests \(1\)/) }
       end
 
       context "when not in a manager context" do
         it_behaves_like "there are no messages"
+        it { expect(subject).not_to have_visible_tab }
       end
     end
 
     context "and the user cannot manage training requests" do
       it_behaves_like "there are no messages"
+      it { expect(subject).not_to have_visible_tab }
     end
   end
 end

--- a/spec/models/message_summarizer_spec.rb
+++ b/spec/models/message_summarizer_spec.rb
@@ -37,6 +37,7 @@ describe MessageSummarizer do
 
   shared_examples_for "there are no messages" do
     it "has no messages of any kind" do
+      expect(subject).not_to be_messages
       expect(subject.count).to eq(0)
       expect(subject.message_count).to eq(0)
 
@@ -48,6 +49,7 @@ describe MessageSummarizer do
 
   shared_examples_for "there is one overall message" do
     it "has one message" do
+      expect(subject).to be_messages
       expect(subject.count).to eq(1)
       expect(subject.message_count).to eq(1)
 

--- a/spec/models/message_summarizer_spec.rb
+++ b/spec/models/message_summarizer_spec.rb
@@ -68,11 +68,15 @@ describe MessageSummarizer do
     it { expect(subject.tab_label).to eq("Notices (#{count})") }
   end
 
+  shared_examples_for "the notices tab is not visible" do
+    it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
+  end
+
   context "when no active notifications, training requests, disputed or problem orders exist" do
     it_behaves_like "there are no messages"
 
     context "when not in a manager context" do
-      it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
+      it_behaves_like "the notices tab is not visible"
     end
 
     context "when in a manager context" do
@@ -107,7 +111,7 @@ describe MessageSummarizer do
 
     context "and the user may not view notifications" do
       it_behaves_like "there are no messages"
-      it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
+      it_behaves_like "the notices tab is not visible"
     end
   end
 
@@ -126,12 +130,12 @@ describe MessageSummarizer do
       end
 
       context "when not in a manager context" do
-        it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
+        it_behaves_like "the notices tab is not visible"
       end
     end
 
     context "and the user cannot access disputed order details" do
-      it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
+      it_behaves_like "the notices tab is not visible"
     end
   end
 
@@ -152,12 +156,12 @@ describe MessageSummarizer do
       end
 
       context "when not in a manager context" do
-        it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
+        it_behaves_like "the notices tab is not visible"
       end
     end
 
     context "and the user cannot access problem orders" do
-      it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
+      it_behaves_like "the notices tab is not visible"
     end
   end
 
@@ -176,12 +180,12 @@ describe MessageSummarizer do
       end
 
       context "when not in a manager context" do
-        it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
+        it_behaves_like "the notices tab is not visible"
       end
     end
 
     context "and the user cannot access problem reservations" do
-      it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
+      it_behaves_like "the notices tab is not visible"
     end
   end
 
@@ -200,12 +204,12 @@ describe MessageSummarizer do
       end
 
       context "when not in a manager context" do
-        it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
+        it_behaves_like "the notices tab is not visible"
       end
     end
 
     context "and the user cannot manage training requests" do
-      it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
+      it_behaves_like "the notices tab is not visible"
     end
   end
 end

--- a/spec/models/message_summarizer_spec.rb
+++ b/spec/models/message_summarizer_spec.rb
@@ -64,7 +64,7 @@ describe MessageSummarizer do
   end
 
   shared_examples_for "it has a visible notices tab" do |count|
-    it { expect(subject).to have_visible_tab }
+    it { expect(subject).to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
     it { expect(subject.tab_label).to eq("Notices (#{count})") }
   end
 
@@ -72,7 +72,7 @@ describe MessageSummarizer do
     it_behaves_like "there are no messages"
 
     context "when not in a manager context" do
-      it { expect(subject).not_to have_visible_tab }
+      it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
     end
 
     context "when in a manager context" do
@@ -107,7 +107,7 @@ describe MessageSummarizer do
 
     context "and the user may not view notifications" do
       it_behaves_like "there are no messages"
-      it { expect(subject).not_to have_visible_tab }
+      it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
     end
   end
 
@@ -126,12 +126,12 @@ describe MessageSummarizer do
       end
 
       context "when not in a manager context" do
-        it { expect(subject).not_to have_visible_tab }
+        it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
       end
     end
 
     context "and the user cannot access disputed order details" do
-      it { expect(subject).not_to have_visible_tab }
+      it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
     end
   end
 
@@ -152,12 +152,12 @@ describe MessageSummarizer do
       end
 
       context "when not in a manager context" do
-        it { expect(subject).not_to have_visible_tab }
+        it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
       end
     end
 
     context "and the user cannot access problem orders" do
-      it { expect(subject).not_to have_visible_tab }
+      it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
     end
   end
 
@@ -176,12 +176,12 @@ describe MessageSummarizer do
       end
 
       context "when not in a manager context" do
-        it { expect(subject).not_to have_visible_tab }
+        it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
       end
     end
 
     context "and the user cannot access problem reservations" do
-      it { expect(subject).not_to have_visible_tab }
+      it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
     end
   end
 
@@ -200,12 +200,12 @@ describe MessageSummarizer do
       end
 
       context "when not in a manager context" do
-        it { expect(subject).not_to have_visible_tab }
+        it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
       end
     end
 
     context "and the user cannot manage training requests" do
-      it { expect(subject).not_to have_visible_tab }
+      it { expect(subject).not_to be_visible_tab } # TODO: change to have_visible_tab after RSpec upgrade
     end
   end
 end

--- a/spec/models/message_summarizer_spec.rb
+++ b/spec/models/message_summarizer_spec.rb
@@ -18,8 +18,8 @@ describe MessageSummarizer do
     allow(controller).to receive(:current_facility).and_return(current_facility)
     allow(controller).to receive(:current_user).and_return(user)
 
-    MessageSummarizer::MessageSummary.subclasses.each do |klass|
-      allow_any_instance_of(klass).to receive(:path).and_return("/stub")
+    subject.summaries.each do |summary|
+      allow(summary).to receive(:path).and_return("/stub")
     end
   end
 
@@ -81,6 +81,7 @@ describe MessageSummarizer do
 
     context "when in a manager context" do
       let(:admin_tab?) { true }
+      before { ability.can(:manage, :all) }
 
       it_behaves_like "it has a visible notices tab", 0
     end
@@ -200,6 +201,7 @@ describe MessageSummarizer do
 
         it_behaves_like "there is one overall message"
         it_behaves_like "it has a visible notices tab", 1
+
         it { expect(subject.first.link).to match(/\bTraining Requests \(1\)/) }
       end
 

--- a/spec/models/message_summarizer_spec.rb
+++ b/spec/models/message_summarizer_spec.rb
@@ -37,7 +37,6 @@ describe MessageSummarizer do
 
   shared_examples_for "there are no messages" do
     it "has no messages of any kind" do
-      expect(subject).not_to be_messages
       expect(subject.count).to eq(0)
       expect(subject.message_count).to eq(0)
 
@@ -49,7 +48,6 @@ describe MessageSummarizer do
 
   shared_examples_for "there is one overall message" do
     it "has one message" do
-      expect(subject).to be_messages
       expect(subject.count).to eq(1)
       expect(subject.message_count).to eq(1)
 

--- a/spec/models/message_summarizer_spec.rb
+++ b/spec/models/message_summarizer_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe MessageSummarizer do
   subject { MessageSummarizer.new(controller) }
   let(:ability) { Object.new.extend(CanCan::Ability) }
+  let(:admin_tab?) { false }
   let(:controller) { ApplicationController.new }
   let(:current_facility) { facility }
   let(:facility) { order.facility }
@@ -12,9 +13,11 @@ describe MessageSummarizer do
   let(:user) { create(:user) }
 
   before(:each) do
+    allow(controller).to receive(:admin_tab?).and_return(admin_tab?)
     allow(controller).to receive(:current_ability).and_return(ability)
     allow(controller).to receive(:current_facility).and_return(current_facility)
     allow(controller).to receive(:current_user).and_return(user)
+
     MessageSummarizer::MessageSummary.subclasses.each do |klass|
       allow_any_instance_of(klass).to receive(:path).and_return("/stub")
     end
@@ -97,12 +100,14 @@ describe MessageSummarizer do
     context "and the user can access disputed order details" do
       before { ability.can(:disputed_orders, Facility) }
 
-      it_behaves_like "there is one overall message"
-      it { expect(subject.first.link).to match(/\bDisputed Orders \(1\)/) }
+      context "when in a manager context" do
+        let(:admin_tab?) { true }
 
-      context "when not scoped to a facility" do
-        let(:current_facility) { nil }
+        it_behaves_like "there is one overall message"
+        it { expect(subject.first.link).to match(/\bDisputed Orders \(1\)/) }
+      end
 
+      context "when not in a manager context" do
         it_behaves_like "there are no messages"
       end
     end
@@ -120,12 +125,14 @@ describe MessageSummarizer do
     context "and the user can access problem orders" do
       before { ability.can(:show_problems, Order) }
 
-      it_behaves_like "there is one overall message"
-      it { expect(subject.first.link).to match(/\bProblem Orders \(1\)/) }
+      context "when in a manager context" do
+        let(:admin_tab?) { true }
 
-      context "when not scoped to a facility" do
-        let(:current_facility) { nil }
+        it_behaves_like "there is one overall message"
+        it { expect(subject.first.link).to match(/\bProblem Orders \(1\)/) }
+      end
 
+      context "when not in a manager context" do
         it_behaves_like "there are no messages"
       end
     end
@@ -141,12 +148,14 @@ describe MessageSummarizer do
     context "and the user can access problem reservations" do
       before { ability.can(:show_problems, Reservation) }
 
-      it_behaves_like "there is one overall message"
-      it { expect(subject.first.link).to match(/\bProblem Reservations \(1\)/) }
+      context "when in a manager context" do
+        let(:admin_tab?) { true }
 
-      context "when not scoped to a facility" do
-        let(:current_facility) { nil }
+        it_behaves_like "there is one overall message"
+        it { expect(subject.first.link).to match(/\bProblem Reservations \(1\)/) }
+      end
 
+      context "when not in a manager context" do
         it_behaves_like "there are no messages"
       end
     end
@@ -162,12 +171,14 @@ describe MessageSummarizer do
     context "and the user can manage training requests" do
       before { ability.can(:manage, TrainingRequest) }
 
-      it_behaves_like "there is one overall message"
-      it { expect(subject.first.link).to match(/\bTraining Requests \(1\)/) }
+      context "when in a manager context" do
+        let(:admin_tab?) { true }
 
-      context "when not scoped to a facility" do
-        let(:current_facility) { nil }
+        it_behaves_like "there is one overall message"
+        it { expect(subject.first.link).to match(/\bTraining Requests \(1\)/) }
+      end
 
+      context "when not in a manager context" do
         it_behaves_like "there are no messages"
       end
     end

--- a/spec/models/message_summarizer_spec.rb
+++ b/spec/models/message_summarizer_spec.rb
@@ -39,7 +39,6 @@ describe MessageSummarizer do
     it "has no messages of any kind" do
       expect(subject).not_to be_messages
       expect(subject.count).to eq(0)
-      expect(subject.message_count).to eq(0)
 
       iteration_count = 0
       subject.each { ++iteration_count }
@@ -51,7 +50,6 @@ describe MessageSummarizer do
     it "has one message" do
       expect(subject).to be_messages
       expect(subject.count).to eq(1)
-      expect(subject.message_count).to eq(1)
 
       summaries = []
 
@@ -65,6 +63,11 @@ describe MessageSummarizer do
     end
   end
 
+  shared_examples_for "it has a visible notices tab" do |count|
+    it { expect(subject).to have_visible_tab }
+    it { expect(subject.tab_label).to eq("Notices (#{count})") }
+  end
+
   context "when no active notifications, training requests, disputed or problem orders exist" do
     it_behaves_like "there are no messages"
 
@@ -75,7 +78,7 @@ describe MessageSummarizer do
     context "when in a manager context" do
       let(:admin_tab?) { true }
 
-      it { expect(subject).to have_visible_tab }
+      it_behaves_like "it has a visible notices tab", 0
     end
   end
 
@@ -89,7 +92,7 @@ describe MessageSummarizer do
 
       context "when not in a manager context" do
         it_behaves_like "there is one overall message"
-        it { expect(subject).to have_visible_tab }
+        it_behaves_like "it has a visible notices tab", 1
         it { expect(subject.first.link).to match(/\bNotices \(1\)/) }
       end
 
@@ -97,7 +100,7 @@ describe MessageSummarizer do
         let(:admin_tab?) { true }
 
         it_behaves_like "there is one overall message"
-        it { expect(subject).to have_visible_tab }
+        it_behaves_like "it has a visible notices tab", 1
         it { expect(subject.first.link).to match(/\bNotices \(1\)/) }
       end
     end
@@ -118,7 +121,7 @@ describe MessageSummarizer do
         let(:admin_tab?) { true }
 
         it_behaves_like "there is one overall message"
-        it { expect(subject).to have_visible_tab }
+        it_behaves_like "it has a visible notices tab", 1
         it { expect(subject.first.link).to match(/\bDisputed Orders \(1\)/) }
       end
 
@@ -144,7 +147,7 @@ describe MessageSummarizer do
         let(:admin_tab?) { true }
 
         it_behaves_like "there is one overall message"
-        it { expect(subject).to have_visible_tab }
+        it_behaves_like "it has a visible notices tab", 1
         it { expect(subject.first.link).to match(/\bProblem Orders \(1\)/) }
       end
 
@@ -168,7 +171,7 @@ describe MessageSummarizer do
         let(:admin_tab?) { true }
 
         it_behaves_like "there is one overall message"
-        it { expect(subject).to have_visible_tab }
+        it_behaves_like "it has a visible notices tab", 1
         it { expect(subject.first.link).to match(/\bProblem Reservations \(1\)/) }
       end
 
@@ -192,7 +195,7 @@ describe MessageSummarizer do
         let(:admin_tab?) { true }
 
         it_behaves_like "there is one overall message"
-        it { expect(subject).to have_visible_tab }
+        it_behaves_like "it has a visible notices tab", 1
         it { expect(subject.first.link).to match(/\bTraining Requests \(1\)/) }
       end
 

--- a/spec/models/message_summarizer_spec.rb
+++ b/spec/models/message_summarizer_spec.rb
@@ -123,13 +123,11 @@ describe MessageSummarizer do
       end
 
       context "when not in a manager context" do
-        it_behaves_like "there are no messages"
         it { expect(subject).not_to have_visible_tab }
       end
     end
 
     context "and the user cannot access disputed order details" do
-      it_behaves_like "there are no messages"
       it { expect(subject).not_to have_visible_tab }
     end
   end
@@ -151,13 +149,11 @@ describe MessageSummarizer do
       end
 
       context "when not in a manager context" do
-        it_behaves_like "there are no messages"
         it { expect(subject).not_to have_visible_tab }
       end
     end
 
     context "and the user cannot access problem orders" do
-      it_behaves_like "there are no messages"
       it { expect(subject).not_to have_visible_tab }
     end
   end
@@ -177,13 +173,11 @@ describe MessageSummarizer do
       end
 
       context "when not in a manager context" do
-        it_behaves_like "there are no messages"
         it { expect(subject).not_to have_visible_tab }
       end
     end
 
     context "and the user cannot access problem reservations" do
-      it_behaves_like "there are no messages"
       it { expect(subject).not_to have_visible_tab }
     end
   end
@@ -203,13 +197,11 @@ describe MessageSummarizer do
       end
 
       context "when not in a manager context" do
-        it_behaves_like "there are no messages"
         it { expect(subject).not_to have_visible_tab }
       end
     end
 
     context "and the user cannot manage training requests" do
-      it_behaves_like "there are no messages"
       it { expect(subject).not_to have_visible_tab }
     end
   end


### PR DESCRIPTION
When problem/disputed orders or training requests exist, these notifications should only appear in the nav tab when the user is in a manager context.

Merged order notifications should still appear in the nav tab in any context.