### PR TITLE
[#94618] Show most recently used facilities near the top of the index

### DIFF
--- a/app/assets/stylesheets/app/typography.scss
+++ b/app/assets/stylesheets/app/typography.scss
@@ -40,3 +40,7 @@ label {
   margin-bottom: 0;
 }
 
+// Custom headers
+.header-tight {
+  line-height: 1.1;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,17 +84,17 @@ class ApplicationController < ActionController::Base
   #
   # interprets the sentinel all_facility as all facilities
   def manageable_facilities
-    @manageable_facilities = case current_facility
-
-    when all_facility
-      # if client ever wants cross-facility billing for a subset of facilities,
-      # make this return session_user.manageable_facilities in the case of all_facility
-      Facility.scoped
-    when nil
-      session_user.manageable_facilities
-    else # only facility that can be managed is the current facility
-      Facility.where(:id => current_facility.id)
-    end
+    @manageable_facilities =
+      case current_facility
+      when all_facility
+        # if client ever wants cross-facility billing for a subset of facilities,
+        # make this return session_user.manageable_facilities in the case of all_facility
+        Facility.sorted
+      when nil
+        session_user.manageable_facilities
+      else # only facility that can be managed is the current facility
+        Facility.where(id: current_facility.id)
+      end
   end
 
   # return an ActiveRecord:Relation of facilities where this user has a role (ie is staff or higher)

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -41,7 +41,7 @@ class FacilitiesController < ApplicationController
     # show list of operable facilities for current user, and admins manage all facilities
     @active_tab = 'manage_facilites'
     if session_user.administrator?
-      @facilities = Facility.all
+      @facilities = Facility.sorted
       flash.now[:notice] = "No facilities have been added" if @facilities.empty?
     else
       @facilities = operable_facilities

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -7,6 +7,7 @@ class FacilitiesController < ApplicationController
   before_filter :check_acting_as, :except => [:index, :show]
   before_filter :load_order_details, only: [:confirm_transactions, :move_transactions, :reassign_chart_strings]
   before_filter :set_admin_billing_tab, only: [:confirm_transactions, :disputed_orders, :movable_transactions, :transactions]
+  before_filter :set_recently_used_facilities, only: [:index]
   before_filter :set_two_column_head_layout, only: [:disputed_orders, :movable_transactions, :transactions]
   before_filter :store_fullpath_in_session, only: [:index, :show]
 
@@ -19,6 +20,11 @@ class FacilitiesController < ApplicationController
   include FacilitiesHelper
 
   layout 'two_column'
+
+  def set_recently_used_facilities
+    @recently_used_facilities =
+      current_user.present? && current_user.recently_used_facilities.sorted
+  end
 
   # GET /facilities
   def index

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -43,6 +43,7 @@ class Facility < ActiveRecord::Base
   delegate :requiring_approval, :requiring_approval_by_type, to: :products, prefix: true
 
   scope :active, :conditions => { :is_active => true }
+  scope :sorted, order: :name
 
   def self.ids_from_urls(urls)
     where("url_name in (?)", urls).select(:id).map(&:id)
@@ -54,10 +55,6 @@ class Facility < ActiveRecord::Base
   def destroy
     # TODO: can you ever delete a facility? Currently no.
     # super
-  end
-
-  def <=> (obj)
-    name.casecmp obj.name
   end
 
   def description

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -39,6 +39,10 @@ class Facility < ActiveRecord::Base
   validates_format_of    :abbreviation, :with => /^[a-zA-Z\d\-\.\s]+$/, :message => "may include letters, numbers, hyphens, spaces, or periods only"
   validates_format_of    :journal_mask, :with => /^C\d{2}$/, :message => "must be in the format C##"
 
+  validates :short_description,
+    length: { maximum: 300 },
+    if: -> { SettingsHelper.feature_on?(:limit_short_description) }
+
   delegate :in_dispute, to: :order_details, prefix: true
   delegate :requiring_approval, :requiring_approval_by_type, to: :products, prefix: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -157,4 +157,11 @@ class User < ActiveRecord::Base
   def to_s
     full_name
   end
+
+  def recently_used_facilities(limit = 5)
+    @recently_used_facilities ||= Hash.new do |hash, key|
+      hash[key] = Facility.where(id: orders.pluck(:facility_id).uniq).limit(limit)
+    end
+    @recently_used_facilities[limit]
+  end
 end

--- a/app/views/facilities/index.html.haml
+++ b/app/views/facilities/index.html.haml
@@ -1,11 +1,13 @@
+- plural_model_name = Facility.model_name.human.pluralize
+
 = content_for :h1 do
-  = Facility.model_name.human.pluralize
+  = plural_model_name
 
 .alert.alert-info= t(".welcome")
 
-- if @facilities.empty?
-  .alert.alert-info= "No #{Facility.model_name.human.pluralize.downcase} are available at this time."
-
-- @facilities.sort.each do |facility|
-  %h3= link_to h(facility), facility_path(facility)
-  %p= facility.short_description
+- if @facilities.any?
+  - @facilities.each do |facility|
+    %h3= link_to facility, facility_path(facility)
+    %p= facility.short_description
+- else
+  .alert.alert-info= t(".empty", items: plural_model_name.downcase)

--- a/app/views/facilities/index.html.haml
+++ b/app/views/facilities/index.html.haml
@@ -10,12 +10,12 @@
   - if @recently_used_facilities.present?
     %h4= t(".recently_used")
     - @recently_used_facilities.each do |facility|
-      %h3.header-tight= link_to facility, facility_path(facility)
+      %h4.header-tight= link_to facility, facility_path(facility)
     %hr
     %h4= t(".all")
 
   - @facilities.each do |facility|
-    %h3= link_to facility, facility_path(facility)
+    %h4.header-tight= link_to facility, facility_path(facility)
     %p= facility.short_description
 
 - else

--- a/app/views/facilities/index.html.haml
+++ b/app/views/facilities/index.html.haml
@@ -6,8 +6,17 @@
 .alert.alert-info= t(".welcome")
 
 - if @facilities.any?
+
+  - if @recently_used_facilities.present?
+    %h4= t(".recently_used")
+    - @recently_used_facilities.each do |facility|
+      %h3.header-tight= link_to facility, facility_path(facility)
+    %hr
+    %h4= t(".all")
+
   - @facilities.each do |facility|
     %h3= link_to facility, facility_path(facility)
     %p= facility.short_description
+
 - else
   .alert.alert-info= t(".empty", items: plural_model_name.downcase)

--- a/app/views/facilities/list.html.haml
+++ b/app/views/facilities/list.html.haml
@@ -1,17 +1,17 @@
 = content_for :h1 do
-  Manage Facilities
+  = t(".head")
 
 - if current_user.administrator?
-  %p= link_to 'Add Facility', new_facility_path, :class => 'btn-add'
+  %p= link_to t(".add"), new_facility_path, class: "btn-add"
 
 - if @facilities.any?
   %table.table.table-striped.table-hover
     %thead
       %tr
-        %th== Name
-        %th== Status
+        %th= Facility.human_attribute_name(:name).titlecase
+        %th= Facility.human_attribute_name(:status).titlecase
     %tbody
-      - @facilities.sort.each do |facility|
+      - @facilities.each do |facility|
         %tr
-          %td= link_to h(facility), facility_default_admin_path(facility)
+          %td= link_to facility, facility_default_admin_path(facility)
           %td= facility.status_string

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -676,9 +676,15 @@ en:
       no_orders: There are no disputed orders for this facility
 
     index:
+      empty: "No %{items} are available at this time."
       welcome: |
         Welcome to NU Core, the centralized ordering system for all shared facilities at Northwestern University.
         Please select the shared facility below to view and purchase services and products offered by the facility.
+
+    list:
+      add: Add Facility
+      head: Manage Facilities
+
     show:
       daily_view: 'daily view'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -676,7 +676,9 @@ en:
       no_orders: There are no disputed orders for this facility
 
     index:
+      all: All Facilities
       empty: "No %{items} are available at this time."
+      recently_used: Recently Used Facilities
       welcome: |
         Welcome to NU Core, the centralized ordering system for all shared facilities at Northwestern University.
         Please select the shared facility below to view and purchase services and products offered by the facility.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -85,6 +85,7 @@ api:
 # For these settings use SettingsHelper#feature_on?
 feature:
   create_users_on: true
+  limit_short_description_on: true
   password_update_on: true
   recharge_accounts_on: true
   expense_accounts_on: true

--- a/lib/role.rb
+++ b/lib/role.rb
@@ -31,9 +31,9 @@ module Role
     # returns relation of facilities for which this user is staff, a director, or an admin
     define_method(:operable_facilities) do
       if self.try(:administrator?)
-        Facility.scoped
+        Facility.sorted
       else
-        self.facilities.where("user_roles.role IN(?)", UserRole.facility_roles)
+        facilities.sorted.where("user_roles.role IN(?)", UserRole.facility_roles)
       end
     end
 
@@ -43,9 +43,9 @@ module Role
     # returns relation of facilities for which this user is a director or admin
     define_method(:manageable_facilities) do
       if self.try(:administrator?) or self.try(:billing_administrator?)
-        Facility.scoped
+        Facility.sorted
       else
-        facilities.where("user_roles.role IN (?)", UserRole.facility_management_roles)
+        facilities.sorted.where("user_roles.role IN (?)", UserRole.facility_management_roles)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -164,4 +164,42 @@ describe User do
     end
   end
 
+  describe "#recently_used_facilities" do
+    subject { user.recently_used_facilities(limit) }
+    let(:account) { create(:setup_account, owner: user) }
+    let(:facilities) { products.map(&:facility) }
+    let(:limit) { 5 }
+    let(:products) { create_list(:setup_item, 6) }
+    let(:user) { create(:user) }
+
+    context "when the user has no orders" do
+      it { expect(subject).to be_empty }
+    end
+
+    context "when the user has orders" do
+      before(:each) do
+        products.first(order_count).each do |product|
+          create(:setup_order, account: account, product: product, user: user)
+        end
+      end
+
+      context "made in fewer than 5 facilities" do
+        let(:order_count) { 4 }
+
+        it { expect(subject).to eq(facilities.first(order_count)) }
+      end
+
+      context "made in 5 facilities" do
+        let(:order_count) { 5 }
+
+        it { expect(subject).to eq(facilities.first(order_count)) }
+      end
+
+      context "made in more than 5 facilities" do
+        let(:order_count) { 6 }
+
+        it { expect(subject).to eq(facilities.first(limit)) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
If a user is logged in and has made at least one order, the facilities index page will list the user's five most recently ordered-from facilities at the top, followed by a complete facility listing:

<img width="1217" alt="screen shot 2015-09-10 at 1 51 43 pm" src="https://cloud.githubusercontent.com/assets/46662/9797996/f2960ac4-57c3-11e5-9d5a-917a443bdcd0.png">

If there user is not logged in or the user has made no orders, the page will look as before, with all facilities listed.

This includes template cleanup/i18n and conversion of `@facilities` from an `Array` into a relation.