### PR TITLE
[#120317] Restore in-progress reservation update

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -273,16 +273,22 @@ class ReservationsController < ApplicationController
       :actual_start_meridian
     )
 
-    if !@reservation.admin_editable? && !@reservation.reserve_start_at_editable?
-      reservation_params.tap do |p|
-        p[:reserve_start_date] = @reservation.reserve_start_date
-        p[:reserve_start_hour] = @reservation.reserve_start_hour
-        p[:reserve_start_min] = @reservation.reserve_start_min
-        p[:reserve_start_meridian] = @reservation.reserve_start_meridian
-      end
-    end
+    reservation_params.merge!(reservation_start_as_params) if fixed_start_time?
 
     reservation_params
+  end
+
+  def fixed_start_time?
+    !@reservation.admin_editable? || !@reservation.reserve_start_at_editable?
+  end
+
+  def reservation_start_as_params
+    {
+      reserve_start_date: @reservation.reserve_start_date,
+      reserve_start_hour: @reservation.reserve_start_hour,
+      reserve_start_min: @reservation.reserve_start_min,
+      reserve_start_meridian: @reservation.reserve_start_meridian,
+    }
   end
 
   def switch_instrument_off!

--- a/spec/app_support/reservations/date_support_spec.rb
+++ b/spec/app_support/reservations/date_support_spec.rb
@@ -113,7 +113,7 @@ describe Reservations::DateSupport do
     end
   end
 
-  context "#assign_times_from_params" do
+  describe "#assign_times_from_params" do
     subject(:reservation) { create(:purchased_reservation, :started_early) }
 
     context "with a running reservation" do
@@ -220,16 +220,12 @@ describe Reservations::DateSupport do
         end
 
         context "and reserve_end_at is unset" do
-          it "is 0" do
-            expect(reservation.duration_mins).to eq(0)
-          end
+          it { expect(reservation.duration_mins).to eq(0) }
         end
       end
 
       context "when reserve_start_at is unset" do
-        it "is 0" do
-          expect(reservation.duration_mins).to eq(0)
-        end
+        it { expect(reservation.duration_mins).to eq(0) }
       end
     end
   end


### PR DESCRIPTION
This should correct the issue where `ReservatrionsController#update` on a started `Reservation` would fail due to the existing start date/time parameters being blank.

The key difference was restoring the start date/time params when `!@reservation.admin_editable? || !@reservation.reserve_start_at_editable?` rather than `!@reservation.admin_editable? && !@reservation.reserve_start_at_editable?`.