### PR TITLE
[#60973] Fix color of "Notices (0)"

### DIFF
--- a/app/views/shared/_message_summary.html.haml
+++ b/app/views/shared/_message_summary.html.haml
@@ -1,7 +1,7 @@
 - summarizer = MessageSummarizer.new(controller)
 - if summarizer.visible_tab?
-  %li
-    - if summarizer.messages?
+  - if summarizer.messages?
+    %li
       %ul.nav.pull-right
         %li.dropdown.pull-right
           = link_to summarizer.tab_label,
@@ -12,7 +12,7 @@
           %ul.dropdown-menu
             - summarizer.select(&:any?).each do |message_summary|
               %li= message_summary.link
-    - else
-      .navbar-text= summarizer.tab_label
+  - else
+    %li.navbar-text= summarizer.tab_label
 
   %li.divider-vertical


### PR DESCRIPTION
It's not obvious with the open color scheme, but on NU, the text for
"Notices (0)" in the header was gray as opposed to the white that it's
supposed to be.

![nucore-notice](https://cloud.githubusercontent.com/assets/1099111/9965494/32eaee1c-5dfc-11e5-950b-03d433912677.png)

