### PR TITLE
[#120379] Improve performance of all transaction view

### DIFF
--- a/app/helpers/transaction_history_helper.rb
+++ b/app/helpers/transaction_history_helper.rb
@@ -7,7 +7,7 @@ module TransactionHistoryHelper
     search_fields.map! { |i| i.to_s } if search_fields
     options = []
     products.each do |product|
-      options << [product.name, product.id, { :"data-facility" => product.facility.id,
+      options << [product.name, product.id, { :"data-facility" => product.facility_id,
                                               :"data-restricted" => product.requires_approval?,
                                               :"data-product-type" => product.type.downcase}]
     end

--- a/app/inputs/transaction_chosen_input.rb
+++ b/app/inputs/transaction_chosen_input.rb
@@ -5,10 +5,10 @@ class TransactionChosenInput < SimpleForm::Inputs::Base #CollectionSelectInput
     options[:label_method] ||= :name
     options[:value_method] ||= :id
 
-    search_fields[attribute_name] = [collection_items.first.send(options[:value_method].to_sym)] if collection_items.size == 1
+    search_fields[attribute_name] = [collection_items.first.send(options[:value_method].to_sym)] if collection_items.to_a.size == 1
 
     select_options = {:multiple => true, :"data-placeholder" => placeholder_label }
-    select_options.merge!({:disabled => :disabled}) unless collection_items && collection_items.size > 1
+    select_options.merge!({:disabled => :disabled}) unless collection_items.to_a.size > 1
 
     template.select_tag(attribute_name, option_data, select_options).html_safe
   end

--- a/app/inputs/transaction_chosen_input.rb
+++ b/app/inputs/transaction_chosen_input.rb
@@ -26,7 +26,7 @@ class TransactionChosenInput < SimpleForm::Inputs::Base #CollectionSelectInput
   private
 
   def collection_items
-    template.instance_variable_get("@#{attribute_name}").to_a
+    template.instance_variable_get("@#{attribute_name}")
   end
 
   def model_label

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -11,7 +11,7 @@ class Account < ActiveRecord::Base
   include DateHelper
 
   has_many   :account_users, :inverse_of => :account
-  has_one    :owner, :class_name => 'AccountUser', :conditions => {:user_role => AccountUser::ACCOUNT_OWNER, :deleted_at => nil}
+  has_one    :owner, :class_name => 'AccountUser', :conditions => { user_role: AccountUser::ACCOUNT_OWNER, deleted_at: nil }
   has_one    :owner_user, :through => :owner, :source => :user
   has_many   :business_admins, :class_name => 'AccountUser', :conditions => {:user_role => AccountUser::ACCOUNT_ADMINISTRATOR, :deleted_at => nil}
   has_many   :price_group_members

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -12,6 +12,7 @@ class Account < ActiveRecord::Base
 
   has_many   :account_users, :inverse_of => :account
   has_one    :owner, :class_name => 'AccountUser', :conditions => {:user_role => AccountUser::ACCOUNT_OWNER, :deleted_at => nil}
+  has_one    :owner_user, :through => :owner, :source => :user
   has_many   :business_admins, :class_name => 'AccountUser', :conditions => {:user_role => AccountUser::ACCOUNT_ADMINISTRATOR, :deleted_at => nil}
   has_many   :price_group_members
   has_many   :order_details
@@ -120,9 +121,9 @@ class Account < ActiveRecord::Base
     account_number <=> obj.account_number
   end
 
-  def owner_user
-    self.owner.user if owner
-  end
+  # def owner_user
+  #   self.owner.user if owner
+  # end
 
   def owner_user_name
     owner_user.try(:name) || ""

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -121,10 +121,6 @@ class Account < ActiveRecord::Base
     account_number <=> obj.account_number
   end
 
-  # def owner_user
-  #   self.owner.user if owner
-  # end
-
   def owner_user_name
     owner_user.try(:name) || ""
   end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -112,8 +112,7 @@ class OrderDetail < ActiveRecord::Base
     details = scoped
 
     if facility_id.present?
-      details = joins(:order)
-      details = details.where(orders: { :facility_id => facility_id })
+      details = details.joins(:order).where(orders: { :facility_id => facility_id })
     end
 
     details

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -108,11 +108,12 @@ class OrderDetail < ActiveRecord::Base
     for_facility_id(facility.id)
   end
 
-  def self.for_facility_id(facility_id=nil)
-    details = joins(:order)
+  def self.for_facility_id(facility_id = nil)
+    details = scoped
 
-    unless facility_id.nil?
-      details = details.where(:orders => { :facility_id => facility_id})
+    if facility_id.present?
+      details = joins(:order)
+      details = details.where(orders: { :facility_id => facility_id })
     end
 
     details

--- a/lib/nucore.rb
+++ b/lib/nucore.rb
@@ -24,6 +24,10 @@ module NUCore
       @@is_oracle ||= ActiveRecord::Base.connection.adapter_name == 'OracleEnhanced'
     end
 
+    def self.mysql?
+      @@is_mysql ||= ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+    end
+
 
     def self.boolean(value)
       # Oracle doesn't always properly handle boolean values correctly

--- a/lib/transaction_search.rb
+++ b/lib/transaction_search.rb
@@ -81,7 +81,7 @@ module TransactionSearch
     @products = Product.find_by_sql(@order_details.joins(:product).
                                                    select("distinct(products.id), products.name, products.facility_id, products.type, products.requires_approval").
                                                    reorder("products.name").to_sql)
-    @account_owners = User.find_by_sql(@order_details.joins(:account => {:owner => :user}).
+    @account_owners = User.find_by_sql(@order_details.joins(:account => :owner_user).
                                                       select("distinct(users.id), users.first_name, users.last_name").
                                                       reorder("users.last_name, users.first_name").to_sql)
 
@@ -131,7 +131,9 @@ module TransactionSearch
         includes(:reservation).
         includes(:order => :user).
         includes(:price_policy).
-        preload(:bundle)
+        preload(:bundle).
+        preload(:account => :owner_user)
+
   end
 
   def sort_and_paginate

--- a/spec/factories/nufs_accounts.rb
+++ b/spec/factories/nufs_accounts.rb
@@ -3,7 +3,7 @@ overridable_factory :nufs_account do
     "9#{'%02d' % n}-7777777" # fund3-dept7
   end
 
-  sequence(:description, 'a') { |n| "nufs account #{n}" }
+  sequence(:description, 'aaaaaaaa') { |n| "nufs account #{n}" }
   expires_at { Time.zone.now + 1.month }
   created_by 0
 end


### PR DESCRIPTION
The loading of the search options, especially when running cross-facility
has gotten fairly slow. This makes some changes to how some of those
options are loaded to speed things up.

While testing against UIC, we discovered they're running MySQL 5.1, so some
of the optimizations aren't as good as they are on 5.6+.

##### Cross Facility view:

MySQL version | Original | Optimized
----|----|----
5.1 | ~2.75s | 1.4s
5.6 | ~1.5s  | 1s

##### Single facility:

MySQL version | Original | Optimized
----|----|----
5.1 | ~1.5s | 1.4s
5.6 | .9s | .7s

And from testing on staging (which is 5.1), I saw similar scale improvements:

Facility view | Original | Optimized
----|----|----
Cross | 2s | .75ms
Single | .8s | .75ms

I also tested against Oracle for single facilities, and saw slight, but
similar improvements.