### PR TITLE
Remove --silent from rake tasks created via whenever/cron

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,6 +1,10 @@
 # IMPORTANT!!! You should never edit this file in your custom fork.
 # If you want to add custom jobs to your instance, add them to schedule_custom.rb
 
+# Override the default :rake option excluding the `--silent` option so output is
+# still sent via email to sysadmins
+job_type :rake, "cd :path && :environment_variable=:environment bundle exec rake :task :output"
+
 every 5.minutes do
   rake "order_details:expire_reservations"
 end


### PR DESCRIPTION
This will prevent the —silent option from being included in cron tasks created by whenever. That makes sure that any output is sent via email as configured within the crontab.