### PR TITLE
[#60973] Update Facility staff-related permissions

### DIFF
--- a/app/models/message_summarizer/order_details_in_dispute_summary.rb
+++ b/app/models/message_summarizer/order_details_in_dispute_summary.rb
@@ -2,7 +2,7 @@ class MessageSummarizer::OrderDetailsInDisputeSummary < MessageSummarizer::Facil
   private
 
   def allowed?
-    ability.can?(:manage, Facility)
+    ability.can?(:disputed, Order)
   end
 
   def get_count

--- a/app/models/message_summarizer/order_details_in_dispute_summary.rb
+++ b/app/models/message_summarizer/order_details_in_dispute_summary.rb
@@ -2,7 +2,7 @@ class MessageSummarizer::OrderDetailsInDisputeSummary < MessageSummarizer::Facil
   private
 
   def allowed?
-    ability.can?(:disputed_orders, Facility)
+    ability.can?(:manage, Facility)
   end
 
   def get_count

--- a/app/views/admin/shared/_tabnav_order.html.haml
+++ b/app/views/admin/shared/_tabnav_order.html.haml
@@ -2,7 +2,7 @@
   = display_tab "New / In Process", facility_orders_path, action: :index
   - if current_ability.can?(:show_problems, Order)
     = display_tab "Problem Orders", show_problems_facility_orders_path, action: :show_problems
-  - if SettingsHelper.has_review_period? && current_ability.can?(:manage, Facility)
+  - if SettingsHelper.has_review_period? && current_ability.can?(:disputed, Order)
     = display_tab "Disputed", disputed_facility_orders_path, action: :disputed
   - if current_user.manager_of?(current_facility)
     = tab "Add New", new_facility_order_import_path(current_facility), (controller.controller_name == 'facility_orders_import')

--- a/app/views/admin/shared/_tabnav_order.html.haml
+++ b/app/views/admin/shared/_tabnav_order.html.haml
@@ -1,6 +1,8 @@
 %ul.nav.nav-tabs.js-tab-counts
   = display_tab "New / In Process", facility_orders_path, action: :index
-  - if current_user.manager_of?(current_facility)
+  - if current_ability.can?(:show_problems, Order)
     = display_tab "Problem Orders", show_problems_facility_orders_path, action: :show_problems
-    = display_tab "Disputed", disputed_facility_orders_path, action: :disputed if SettingsHelper.has_review_period?
+  - if SettingsHelper.has_review_period? && current_ability.can?(:manage, Facility)
+    = display_tab "Disputed", disputed_facility_orders_path, action: :disputed
+  - if current_user.manager_of?(current_facility)
     = tab "Add New", new_facility_order_import_path(current_facility), (controller.controller_name == 'facility_orders_import')

--- a/app/views/admin/shared/_tabnav_reservation.html.haml
+++ b/app/views/admin/shared/_tabnav_reservation.html.haml
@@ -3,5 +3,5 @@
   = display_tab "New / In Process", facility_reservations_path, action: :index
   - if current_ability.can?(:show_problems, Reservation)
     = display_tab "Problem Reservations", show_problems_facility_reservations_path, action: :show_problems
-  - if SettingsHelper.has_review_period? && current_ability.can?(:manage, Facility)
+  - if SettingsHelper.has_review_period? && current_ability.can?(:disputed, Reservation)
     = display_tab "Disputed", disputed_facility_reservations_path, action: :disputed

--- a/app/views/admin/shared/_tabnav_reservation.html.haml
+++ b/app/views/admin/shared/_tabnav_reservation.html.haml
@@ -1,6 +1,7 @@
 %ul.nav.nav-tabs
   = tab "Daily View", timeline_facility_reservations_path(current_facility), tab_active?(:timeline)
   = display_tab "New / In Process", facility_reservations_path, action: :index
-  - if current_user.manager_of?(current_facility)
+  - if current_ability.can?(:show_problems, Reservation)
     = display_tab "Problem Reservations", show_problems_facility_reservations_path, action: :show_problems
-    = display_tab "Disputed", disputed_facility_reservations_path, action: :disputed if SettingsHelper.has_review_period?
+  - if SettingsHelper.has_review_period? && current_ability.can?(:manage, Facility)
+    = display_tab "Disputed", disputed_facility_reservations_path, action: :disputed

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -91,7 +91,7 @@ class Ability
 
       if user.manager_of?(resource)
         can :manage, [
-          AccountUser, FacilityAccount, Journal,
+          AccountUser, Facility, FacilityAccount, Journal,
           Statement, StoredFile, PricePolicy, InstrumentPricePolicy,
           ItemPricePolicy, OrderStatus, PriceGroup, ReportsController,
           ScheduleRule, ServicePricePolicy, PriceGroupProduct, ProductAccessGroup,
@@ -106,8 +106,7 @@ class Ability
           account.facility.nil? || account.facility == resource
         end
 
-        can :show_problems, Order
-        can [:update, :manage], Facility
+        can :show_problems, [Order, Reservation]
       end
 
       # Facility senior staff is based off of staff, but has a few more abilities

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -77,6 +77,7 @@ class Ability
           :edit_admin,
           :index,
           :show,
+          :tab_counts,
           :timeline,
           :update,
           :update_admin,

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -63,9 +63,36 @@ class Ability
 
       if user.operator_of?(resource)
         can :manage, [
-          AccountPriceGroupMember, OrderDetail, Order, Reservation,
-          UserPriceGroupMember, ProductUser, TrainingRequest
+          AccountPriceGroupMember,
+          OrderDetail,
+          ProductUser,
+          TrainingRequest,
+          UserPriceGroupMember,
         ]
+
+        can [
+          :assign_price_policies_to_problem_orders,
+          :create,
+          :edit,
+          :edit_admin,
+          :index,
+          :show,
+          :timeline,
+          :update,
+          :update_admin,
+        ], Reservation
+
+        can [
+          :assign_price_policies_to_problem_orders,
+          :batch_update,
+          :create,
+          :index,
+          :order_in_past,
+          :send_receipt,
+          :show,
+          :tab_counts,
+          :update,
+        ], Order
 
         can [:index, :view_details, :schedule, :show], [Product]
 
@@ -86,6 +113,7 @@ class Ability
 
       if user.facility_director_of?(resource)
         can [ :activate, :deactivate ], ExternalService
+        can :disputed, [Order, Reservation]
         can :manage, TrainingRequest
       end
 

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe FacilityOrdersController do
       @action=:disputed
     end
 
-    it_should_allow_operators_only
+    it_should_allow_managers_only
   end
 
   context '#index' do

--- a/spec/controllers/facility_reservations_controller_spec.rb
+++ b/spec/controllers/facility_reservations_controller_spec.rb
@@ -150,7 +150,12 @@ RSpec.describe FacilityReservationsController do
   end
 
   context '#disputed' do
-    skip "TODO test exists for the FacilityOrdersController version"
+    before(:each) do
+      @method = :get
+      @action = :disputed
+    end
+
+    it_should_allow_managers_only # TODO: identical to FacilityOrdersController#disputed spec
   end
 
   context '#edit' do

--- a/spec/controllers/facility_reservations_controller_spec.rb
+++ b/spec/controllers/facility_reservations_controller_spec.rb
@@ -423,8 +423,15 @@ RSpec.describe FacilityReservationsController do
     end
   end
 
-  context '#tab_counts' do
-    skip "TODO test exists for the FacilityOrdersController version"
+  describe "#tab_counts" do
+    before(:each) do
+      @method = :get
+      @action = :tab_counts
+      @params.merge!(tabs: %w(new_or_in_process_orders disputed_orders problem_order_details))
+    end
+
+    it_should_allow_operators_only
+    # TODO: more complete tests exist for the FacilityOrdersController version
   end
 
   context 'admin' do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Ability do
   let(:facility) { create(:setup_facility) }
   let(:instrument) { create(:instrument_requiring_approval, facility: facility) }
   let(:stub_controller) { OpenStruct.new }
-  let(:subject_resource) { :stub }
+  let(:subject_resource) { facility }
 
   shared_examples_for "it can manage price group members" do
     it "can manage its members" do
@@ -119,7 +119,7 @@ RSpec.describe Ability do
 
     it_behaves_like "it can manage training requests"
     it_behaves_like "it can read notifications"
-    it_behaves_like "it cannot access problem reservations"
+    it_behaves_like "it can access problem reservations"
   end
 
   describe "senior staff" do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe Ability do
     it { expect(ability.can?(:read, Notification)).to be false }
   end
 
+  shared_examples_for "it can access problem reservations" do
+    it { expect(ability.can?(:show_problems, Reservation)).to be true }
+  end
+
+  shared_examples_for "it cannot access problem reservations" do
+    it { expect(ability.can?(:show_problems, Reservation)).to be false }
+  end
+
   describe "administrator" do
     let(:user) { create(:user, :administrator) }
 
@@ -83,6 +91,7 @@ RSpec.describe Ability do
     end
 
     it_behaves_like "it can manage training requests"
+    it_behaves_like "it can access problem reservations"
   end
 
   describe "facility director" do
@@ -110,6 +119,7 @@ RSpec.describe Ability do
 
     it_behaves_like "it can manage training requests"
     it_behaves_like "it can read notifications"
+    it_behaves_like "it cannot access problem reservations"
   end
 
   describe "senior staff" do
@@ -117,6 +127,7 @@ RSpec.describe Ability do
 
     it_behaves_like "it can manage training requests"
     it_behaves_like "it cannot read notifications"
+    it_behaves_like "it cannot access problem reservations"
   end
 
   describe "staff" do
@@ -124,6 +135,7 @@ RSpec.describe Ability do
 
     it_behaves_like "it can create but not manage training requests"
     it_behaves_like "it can read notifications"
+    it_behaves_like "it cannot access problem reservations"
   end
 
   describe "unprivileged user" do
@@ -166,5 +178,6 @@ RSpec.describe Ability do
     end
 
     it_behaves_like "it cannot read notifications"
+    it_behaves_like "it cannot access problem reservations"
   end
 end

--- a/spec/models/message_summarizer_spec.rb
+++ b/spec/models/message_summarizer_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe MessageSummarizer do
     before { order_detail.update_attribute(:dispute_at, 1.day.ago) }
 
     context "and the user can access disputed order details" do
-      before { ability.can(:disputed_orders, Facility) }
+      before { ability.can(:manage, Facility) }
 
       context "when in a manager context" do
         let(:admin_tab?) { true }

--- a/spec/models/message_summarizer_spec.rb
+++ b/spec/models/message_summarizer_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe MessageSummarizer do
     before { order_detail.update_attribute(:dispute_at, 1.day.ago) }
 
     context "and the user can access disputed order details" do
-      before { ability.can(:manage, Facility) }
+      before { ability.can(:disputed, Order) }
 
       context "when in a manager context" do
         let(:admin_tab?) { true }


### PR DESCRIPTION
This should bring the Notices drop-down permissions in line with what users may access through other parts of the UI.

The notices drop-down uses `Ability` permissions to determine what to show the user, while the corresponding links in the UI are *not* using `Ability` checks. So we ended up with inconsistencies, like hiding the problem reservations tab from Staff and Senior Staff, while showing problem reservations in the notices drop-down.

This came down to replacing the `:manage` (anything goes) permissions to `Reservation` and `Order` objects for Staff (that is, `#operator_of?(current_facility)`) with specific grants.