### PR TITLE
[#121286] Only run cron jobs on a single server

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -5,15 +5,15 @@
 # still sent via email to sysadmins
 job_type :rake, "cd :path && :environment_variable=:environment bundle exec rake :task :output"
 
-every 5.minutes do
+every 5.minutes, roles: [:db] do
   rake "order_details:expire_reservations"
 end
 
-every 5.minutes do
+every 5.minutes, roles: [:db] do
   rake "order_details:auto_logout"
 end
 
-every :day, at: '4:17am' do
+every :day, at: '4:17am', roles: [:db] do
   rake "order_details:remove_merge_orders"
 end
 


### PR DESCRIPTION
It feels a little weird to put capistrano-based functionality in the
open branch, but it will still work fine without capistrano, and `:db`
is the standard role for a single server (usually the one used for
running db:migrate).

PR for NU coming soon.