### PR TITLE
[#60973] Refine facility administrator abilities

### DIFF
--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -112,12 +112,6 @@ class Ability
         can :edit, [PriceGroupProduct]
       end
 
-      if user.facility_director_of?(resource)
-        can [ :activate, :deactivate ], ExternalService
-        can :disputed, [Order, Reservation]
-        can :manage, TrainingRequest
-      end
-
       if user.manager_of?(resource)
         can :manage, [
           AccountUser, Facility, FacilityAccount, Journal,
@@ -135,7 +129,8 @@ class Ability
           account.facility.nil? || account.facility == resource
         end
 
-        can :show_problems, [Order, Reservation]
+        can [:disputed, :show_problems], [Order, Reservation]
+        can [:activate, :deactivate], ExternalService
       end
 
       # Facility senior staff is based off of staff, but has a few more abilities

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe Ability do
   end
 
   shared_examples_for "it can manage training requests" do
-    let(:subject_resource) { create(:training_request, product: instrument) }
-
     it "can manage training requests" do
       expect(ability.can?(:manage, TrainingRequest)).to be true
     end
@@ -55,6 +53,14 @@ RSpec.describe Ability do
 
   shared_examples_for "it cannot access problem reservations" do
     it { expect(ability.can?(:show_problems, Reservation)).to be false }
+  end
+
+  shared_examples_for "it can access disputed orders" do
+    it { expect(ability.can?(:disputed, Order)).to be true }
+  end
+
+  shared_examples_for "it cannot access disputed orders" do
+    it { expect(ability.can?(:disputed, Order)).to be false }
   end
 
   describe "administrator" do
@@ -94,6 +100,15 @@ RSpec.describe Ability do
     it_behaves_like "it can access problem reservations"
   end
 
+  describe "facility administrator" do
+    let(:user) { create(:user, :facility_administrator, facility: facility) }
+
+    it_behaves_like "it can read notifications"
+    it_behaves_like "it can manage training requests"
+    it_behaves_like "it can access problem reservations"
+    it_behaves_like "it can access disputed orders"
+  end
+
   describe "facility director" do
     let(:user) { create(:user, :facility_director, facility: facility) }
 
@@ -120,6 +135,7 @@ RSpec.describe Ability do
     it_behaves_like "it can manage training requests"
     it_behaves_like "it can read notifications"
     it_behaves_like "it can access problem reservations"
+    it_behaves_like "it can access disputed orders"
   end
 
   describe "senior staff" do
@@ -128,6 +144,7 @@ RSpec.describe Ability do
     it_behaves_like "it can manage training requests"
     it_behaves_like "it cannot read notifications"
     it_behaves_like "it cannot access problem reservations"
+    it_behaves_like "it cannot access disputed orders"
   end
 
   describe "staff" do
@@ -136,6 +153,7 @@ RSpec.describe Ability do
     it_behaves_like "it can create but not manage training requests"
     it_behaves_like "it can read notifications"
     it_behaves_like "it cannot access problem reservations"
+    it_behaves_like "it cannot access disputed orders"
   end
 
   describe "unprivileged user" do
@@ -179,5 +197,6 @@ RSpec.describe Ability do
 
     it_behaves_like "it cannot read notifications"
     it_behaves_like "it cannot access problem reservations"
+    it_behaves_like "it cannot access disputed orders"
   end
 end


### PR DESCRIPTION
This merges the abilities of Facility Administrators and Directors, which should correct the issue where Facility Administrators could not access disputed orders but Directors could.