### PR TITLE
Clean up owner_user association

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -11,8 +11,11 @@ class Account < ActiveRecord::Base
   include DateHelper
 
   has_many   :account_users, :inverse_of => :account
-  has_one    :owner, :class_name => 'AccountUser', :conditions => { user_role: AccountUser::ACCOUNT_OWNER, deleted_at: nil }
-  has_one    :owner_user, :through => :owner, :source => :user
+  # Using a basic hash doesn't work with the `owner_user` :through association. It would
+  # only include the last item in the hash as part of the scoping.
+  # TODO Consider changing when we get to Rails 4.
+  has_one    :owner, class_name: 'AccountUser', conditions: "account_users.user_role = '#{AccountUser::ACCOUNT_OWNER}' AND account_users.deleted_at IS NULL"
+  has_one    :owner_user, through: :owner, source: :user
   has_many   :business_admins, :class_name => 'AccountUser', :conditions => {:user_role => AccountUser::ACCOUNT_ADMINISTRATOR, :deleted_at => nil}
   has_many   :price_group_members
   has_many   :order_details


### PR DESCRIPTION
We had a test that would fail about 20% of the time because the
`owner_user` association was losing the `user_role` conditional.

Calling `Account.first.owner_user` would result in the SQL:
`SELECT `users`.* FROM `users` INNER JOIN `account_users` ON
`users`.`id` = `account_users`.`user_id` WHERE
`account_users`.`account_id` = 204 AND `account_users`.`deleted_at` IS
NULL LIMIT 1`. If I flipped the order of the keys in the hash, I would
get the “Owner” condition, but not the deleted_at.

This seems like it could be a bug in ActiveRecord, but since we’re
still on 3.2, so I didn’t want to delve too far down.