### PR TITLE
[#121342] Restore external users' ability to log in

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,6 @@ class User < ActiveRecord::Base
   # Gem ldap_authenticatable expects User to respond_to? :ldap_attributes. For us should return nil.
   attr_accessor :ldap_attributes
 
-
   # Scopes
   def self.with_recent_orders(facility)
     order_query = Order.recent.for_facility(facility)

--- a/config/initializers/ldap.rb
+++ b/config/initializers/ldap.rb
@@ -3,6 +3,19 @@ require 'username_only_authenticatable'
 Rails.application.config.to_prepare do
   if File.exist?("#{Rails.root}/config/ldap.yml")
     User.send(:devise, :ldap_authenticatable)
+
+    class User
+      # If a Devise Strategy calls `validate` with a resource and it returns false,
+      # then the strategy chain is halted. Previous versions of the LDAP strategy
+      # would only call `validate` with a fully authenticated resource, but 0.8+
+      # will find the resource in the database first and then call against the LDAP
+      # server. This prevents the LDAP authentication for external users.
+      def self.find_for_ldap_authentication(attributes={})
+        resource = super
+        resource unless resource.authenticated_locally?
+      end
+    end
+
     UsersController.send(:include, Ldap::UsersControllerExtension)
   end
 end

--- a/lib/ldap/search.rb
+++ b/lib/ldap/search.rb
@@ -10,7 +10,7 @@ module Ldap
     private
 
     def admin_ldap
-      Devise::LdapAdapter::LdapConnect.admin
+      Devise::LDAP::Connection.admin
     end
 
     def make_user_from_ldap(ldap_user)


### PR DESCRIPTION
The recent upgrade of the Devise LDAP adapter changed its behavior so
external users would no longer fall back to the
database_authenticatable strategy.