### PR TITLE
[#121396] Sending Notifications for more than 1000 OD causes Oracle error

### DIFF
--- a/app/controllers/facility_notifications_controller.rb
+++ b/app/controllers/facility_notifications_controller.rb
@@ -44,9 +44,7 @@ class FacilityNotificationsController < ApplicationController
     end
     @accounts_to_notify = sender.account_ids_to_notify
     @errors = sender.errors
-    @orders_notified = sender.order_details
 
-    # render nothing: true
     redirect_to :action => :index
   end
 

--- a/spec/app_support/notification_sender_spec.rb
+++ b/spec/app_support/notification_sender_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe NotificationSender, :aggregate_failures do
+  let(:user) { create(:user) }
+
+  let(:facility) { create(:facility) }
+
+  let(:facility_account) do
+    facility.facility_accounts.create(attributes_for(:facility_account))
+  end
+
+  let(:item) do
+    facility
+    .items
+    .create(attributes_for(:item, facility_account_id: facility_account.id))
+  end
+
+  let(:account) { create(:nufs_account, :account_users_attributes => account_users_attributes_hash(:user => user), :facility_id => facility.id) }
+  let(:ids) { order_details.map(&:id) }
+  let(:action) { described_class.new(facility, ids) }
+
+  describe "with a reasonable sized group" do
+    let!(:order_details) { 5.times.map { place_product_order(user, facility, item, account) } }
+
+    before { OrderDetail.update_all(state: "complete", price_policy_id: item.price_policies.first.id) }
+
+    it "notifies the appropriate accounts and sets the order details to reviewed" do
+      expect(action.perform).to be_truthy
+      expect(action.account_ids_notified).to eq([account.id])
+      expect(order_details).to be_all { |od| od.reload.reviewed_at? }
+    end
+
+    describe "with an id that does not exist" do
+      let(:ids) { [-1, order_details.first.id] }
+
+      it "has an error for the id" do
+        expect(action.perform).to be_falsey
+        expect(action.errors.first).to include("-1")
+        expect(order_details.first.reload).not_to be_reviewed
+      end
+    end
+  end
+
+  describe "with more than 1000 items" do
+    let!(:order_details) do
+      1001.times.map do
+        place_product_order(user, facility, item, account)
+      end
+    end
+
+    it "allows notification" do
+      OrderDetail.update_all(state: "complete", price_policy_id: item.price_policies.first.id)
+      expect(action.perform).to be_truthy
+      expect(action.account_ids_notified).to eq([account.id])
+    end
+  end
+end

--- a/spec/app_support/notification_sender_spec.rb
+++ b/spec/app_support/notification_sender_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe NotificationSender, :aggregate_failures do
     .create(attributes_for(:item, facility_account_id: facility_account.id))
   end
 
-  let(:account) { create(:nufs_account, :account_users_attributes => account_users_attributes_hash(:user => user), :facility_id => facility.id) }
+  let(:account) { create(:setup_account, owner: user, facility_id: facility.id) }
   let(:ids) { order_details.map(&:id) }
   let(:action) { described_class.new(facility, ids) }
 
@@ -38,20 +38,6 @@ RSpec.describe NotificationSender, :aggregate_failures do
         expect(action.errors.first).to include("-1")
         expect(order_details.first.reload).not_to be_reviewed
       end
-    end
-  end
-
-  describe "with more than 1000 items" do
-    let!(:order_details) do
-      1001.times.map do
-        place_product_order(user, facility, item, account)
-      end
-    end
-
-    it "allows notification" do
-      OrderDetail.update_all(state: "complete", price_policy_id: item.price_policies.first.id)
-      expect(action.perform).to be_truthy
-      expect(action.account_ids_notified).to eq([account.id])
     end
   end
 end

--- a/spec/controllers/facility_notifications_controller_spec.rb
+++ b/spec/controllers/facility_notifications_controller_spec.rb
@@ -73,10 +73,7 @@ RSpec.describe FacilityNotificationsController do
     it_should_allow_managers_only :redirect do
       expect(assigns(:errors)).to be_empty
       expect(assigns(:accounts_to_notify).to_a).to eq([[@account.id, @authable.id]])
-      expect(assigns(:orders_notified)).to eq([@order_detail1, @order_detail2])
-
-      expect(@order_detail1.reload.reviewed_at).to be_present
-      expect(@order_detail1.reviewed_at).to be > 6.days.from_now
+      expect([@order_detail1, @order_detail2]).to be_all { |od| od.reload.reviewed_at > 6.days.from_now }
 
       expect(Notifier.deliveries.count).to eq(1)
     end
@@ -88,7 +85,7 @@ RSpec.describe FacilityNotificationsController do
 
       it_should_allow_managers_only :redirect do
         expect(assigns(:errors)).to be_empty
-        expect(assigns(:orders_notified)).to eq([@order_detail1, @order_detail2, @order_detail3])
+        expect([@order_detail1, @order_detail2, @order_detail3]).to be_all { |od| od.reload.reviewed_at? }
         expect(assigns(:accounts_to_notify).to_a).to eq([[@account.id, @authable.id], [@account2.id, @authable.id]])
       end
 


### PR DESCRIPTION
Oracle does not allow more than 1000 items in a `WHERE IN` clause. This
breaks it up into 1000 item AR::Relations and loops over those as
necessary.

Unfortunately, this makes the code more complicated, but it's about as simple as I can make it while dealing with this limitation. It will still use one giant AR relation for MySQL.

Once this goes through CI (I have the branch on NU as well), I'd say we can remove the 1000 item spec (which is obviously slow).