### PR TITLE
Ensure NotificationHelper tests get run with review period disabled

### DIFF
--- a/app/support/notification_sender.rb
+++ b/app/support/notification_sender.rb
@@ -16,7 +16,7 @@ class NotificationSender
 
       raise ActiveRecord::Rollback if @errors.any?
 
-      find_accounts_to_notify if Settings.billing.review_period > 0
+      find_accounts_to_notify if SettingsHelper.has_review_period?
       mark_order_details_as_reviewed
       notify_accounts
     end

--- a/spec/app_support/notification_sender_spec.rb
+++ b/spec/app_support/notification_sender_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe NotificationSender, :aggregate_failures do
   let(:ids) { order_details.map(&:id) }
   let(:action) { described_class.new(facility, ids) }
 
+  # This feature only gets used when there is a review period, so go ahead and enable it.
+  before { allow(SettingsHelper).to receive(:has_review_period?).and_return true }
+
   describe "with a reasonable sized group" do
     let!(:order_details) { 5.times.map { place_product_order(user, facility, item, account) } }
 


### PR DESCRIPTION
If the review period feature is off, then the test fails.