### PR TITLE
[#121571] Fix link in "needs approval" email

### DIFF
--- a/app/controllers/facility_order_details_controller.rb
+++ b/app/controllers/facility_order_details_controller.rb
@@ -15,6 +15,12 @@ class FacilityOrderDetailsController < ApplicationController
     super
   end
 
+  def show
+    # This is deprecated in favor of OrderManagement::OrderDetailsController, but
+    # we want to avoid 404s
+    redirect_to facility_order_path(current_facility, @order)
+  end
+
   def destroy
     if @order.to_be_merged?
       begin

--- a/app/views/notifier/order_status_changed_to_pending_approval.html.haml
+++ b/app/views/notifier/order_status_changed_to_pending_approval.html.haml
@@ -3,4 +3,4 @@
 %p #{@order_detail.user} has placed a reservation for #{@order_detail.product}. It is currently pending approval.
 
 %p
-  %a= link_to "Please approve order ##{@order_detail}.", facility_order_order_detail_url(@order_detail.facility, @order_detail.order, @order_detail)
+  %a= link_to "Please approve Order ##{@order_detail}.", facility_order_url(@order_detail.facility, @order_detail.order)

--- a/app/views/notifier/order_status_changed_to_pending_approval.text.erb
+++ b/app/views/notifier/order_status_changed_to_pending_approval.text.erb
@@ -2,4 +2,4 @@
 
 <%= @order_detail.user %> has placed a reservation for <%= @order_detail.product %>. It is currently pending approval.
 
-Please approve it at <%= facility_order_order_detail_url(@order_detail.facility, @order_detail.order, @order_detail) %>.
+Please approve Order #<%= @order_detail %> at <%= facility_order_url(@order_detail.facility, @order_detail.order) %>.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,7 +178,7 @@ Nucore::Application.routes.draw do
         get 'tab_counts'
       end
 
-      resources :order_details, :controller => 'facility_order_details', :only => [:destroy] do
+      resources :order_details, :controller => 'facility_order_details', :only => [:show, :destroy] do
         resources :reservations, :controller => 'facility_reservations', :only => [:edit, :update, :show]
         resources :accessories, only: [:new, :create]
         member do


### PR DESCRIPTION
As part of the new order detail management popup we removed the old
actions for editing an order detail. This points to the proper place,
also adding a redirect for the now-non-existent path.