### PR TITLE
[#121941] Fix display of schedule rules when server is not in local time

### DIFF
--- a/app/controllers/timelineable.rb
+++ b/app/controllers/timelineable.rb
@@ -6,13 +6,13 @@ module Timelineable
   end
 
   def timeline
-    @display_date = display_date_as_time.to_date
+    @display_date = display_date_as_time
     @schedules = current_facility.schedules.active.order(:name)
   end
 
   private
 
   def display_date_as_time
-    (parse_usa_date(params[:date]) if params[:date]) || Time.zone.now
+    parse_usa_date(params[:date]) || Time.current.beginning_of_day
   end
 end

--- a/app/controllers/timelineable.rb
+++ b/app/controllers/timelineable.rb
@@ -6,7 +6,7 @@ module Timelineable
   end
 
   def timeline
-    @display_date = display_date_as_time
+    @display_datetime = display_date_as_time
     @schedules = current_facility.schedules.active.order(:name)
   end
 

--- a/app/helpers/timeline_helper.rb
+++ b/app/helpers/timeline_helper.rb
@@ -44,8 +44,8 @@ module TimelineHelper
 
   def spans_midnight_class(datetime_start, datetime_end)
     classes = []
-    classes << 'runs_into_tomorrow' if datetime_end > @display_date.end_of_day
-    classes << 'runs_into_yesterday' if datetime_start < @display_date.beginning_of_day
+    classes << 'runs_into_tomorrow' if datetime_end > @display_datetime.end_of_day
+    classes << 'runs_into_yesterday' if datetime_start < @display_datetime.beginning_of_day
     return classes
   end
 

--- a/app/views/facility_reservations/timeline.html.haml
+++ b/app/views/facility_reservations/timeline.html.haml
@@ -14,12 +14,12 @@
   = modelless_form_for url: timeline_facility_reservations_path(current_facility), method: :get, id: "timeline_date_search" do |f|
     #reservation_date_container
       = link_to "&laquo;".html_safe,
-        timeline_facility_reservations_path(current_facility, date: format_usa_date(@display_date - 1.day)), id: "reservation_left"
+        timeline_facility_reservations_path(current_facility, date: format_usa_date(@display_datetime - 1.day)), id: "reservation_left"
       #reservation_date
-        = l(@display_date.to_date, format: :timeline_navigation)
-        = hidden_field_tag "date", format_usa_date(@display_date), class: "datepicker"
+        = l(@display_datetime.to_date, format: :timeline_navigation)
+        = hidden_field_tag "date", format_usa_date(@display_datetime), class: "datepicker"
       = link_to "&raquo;".html_safe,
-        timeline_facility_reservations_path(current_facility, date: format_usa_date(@display_date + 1.day)), id: "reservation_right"
+        timeline_facility_reservations_path(current_facility, date: format_usa_date(@display_datetime + 1.day)), id: "reservation_right"
     .timeline_options
       = f.input :show_canceled,
         as: :boolean,

--- a/app/views/facility_reservations/timeline.html.haml
+++ b/app/views/facility_reservations/timeline.html.haml
@@ -16,7 +16,7 @@
       = link_to "&laquo;".html_safe,
         timeline_facility_reservations_path(current_facility, date: format_usa_date(@display_date - 1.day)), id: "reservation_left"
       #reservation_date
-        = l(@display_date, format: :timeline_navigation)
+        = l(@display_date.to_date, format: :timeline_navigation)
         = hidden_field_tag "date", format_usa_date(@display_date), class: "datepicker"
       = link_to "&raquo;".html_safe,
         timeline_facility_reservations_path(current_facility, date: format_usa_date(@display_date + 1.day)), id: "reservation_right"

--- a/app/views/reservations/public_timeline.html.haml
+++ b/app/views/reservations/public_timeline.html.haml
@@ -14,7 +14,7 @@
       = link_to "&laquo;".html_safe,
         facility_public_timeline_path(current_facility, date: format_usa_date(@display_date - 1.day)), id: "reservation_left"
       #reservation_date
-        = l(@display_date, format: :timeline_navigation)
+        = l(@display_date.to_date, format: :timeline_navigation)
         = hidden_field_tag "date", format_usa_date(@display_date), class: "datepicker"
       = link_to "&raquo;".html_safe,
         facility_public_timeline_path(current_facility, date: format_usa_date(@display_date + 1.day)), id: "reservation_right"

--- a/app/views/reservations/public_timeline.html.haml
+++ b/app/views/reservations/public_timeline.html.haml
@@ -12,12 +12,12 @@
   = modelless_form_for url: facility_public_timeline_path(current_facility), method: :get, id: "timeline_date_search" do |f|
     #reservation_date_container
       = link_to "&laquo;".html_safe,
-        facility_public_timeline_path(current_facility, date: format_usa_date(@display_date - 1.day)), id: "reservation_left"
+        facility_public_timeline_path(current_facility, date: format_usa_date(@display_datetime - 1.day)), id: "reservation_left"
       #reservation_date
-        = l(@display_date.to_date, format: :timeline_navigation)
-        = hidden_field_tag "date", format_usa_date(@display_date), class: "datepicker"
+        = l(@display_datetime.to_date, format: :timeline_navigation)
+        = hidden_field_tag "date", format_usa_date(@display_datetime), class: "datepicker"
       = link_to "&raquo;".html_safe,
-        facility_public_timeline_path(current_facility, date: format_usa_date(@display_date + 1.day)), id: "reservation_right"
+        facility_public_timeline_path(current_facility, date: format_usa_date(@display_datetime + 1.day)), id: "reservation_right"
 
 .clear
 .span10.offset1

--- a/app/views/shared/timeline/_facility_tooltip.html.haml
+++ b/app/views/shared/timeline/_facility_tooltip.html.haml
@@ -1,7 +1,7 @@
 %strong= reservation.admin? ? 'Administrative Reservation' : reservation.user
 
 %br
-%span= reservation_date_range_display(@display_date, reservation)
+%span= reservation_date_range_display(@display_datetime, reservation)
 - if reservation.order_detail
   %span{:class => reservation.order_detail.order_status.to_s.downcase}= "- #{reservation.order_detail.order_status}"
 

--- a/app/views/shared/timeline/_instrument.html.haml
+++ b/app/views/shared/timeline/_instrument.html.haml
@@ -8,9 +8,9 @@
     -# Add .reschedulable to enable drag/drop
     .timeline
       .unit_container
-        = render :partial => "shared/timeline/reservation", :collection => ( instrument.visible_reservations(@display_date) + ScheduleRule.unavailable_for_date(instrument, @display_date)), :as => :reservation, :locals => { :product => instrument }
-        - if @display_date.beginning_of_day == Time.zone.now.beginning_of_day
-          .current_time{:style => "left: #{datetime_left_position(@display_date, Time.zone.now)}"}
+        = render :partial => "shared/timeline/reservation", :collection => ( instrument.visible_reservations(@display_datetime) + ScheduleRule.unavailable_for_date(instrument, @display_datetime)), :as => :reservation, :locals => { :product => instrument }
+        - if @display_datetime.beginning_of_day == Time.zone.now.beginning_of_day
+          .current_time{:style => "left: #{datetime_left_position(@display_datetime, Time.zone.now)}"}
 
       - if !public_timeline? && instrument.has_real_relay?
         = render partial: 'shared/timeline/relay_switch', locals: { instrument: instrument }

--- a/app/views/shared/timeline/_reservation.html.haml
+++ b/app/views/shared/timeline/_reservation.html.haml
@@ -1,2 +1,2 @@
-%div{ :style => "width: #{reservation_width(@display_date, reservation)}; left: #{reservation_left_position(@display_date, reservation)}; z-index: #{reservation_counter};", :class => reservation_classes(reservation, product) }[reservation, :block]
+%div{ :style => "width: #{reservation_width(@display_datetime, reservation)}; left: #{reservation_left_position(@display_datetime, reservation)}; z-index: #{reservation_counter};", :class => reservation_classes(reservation, product) }[reservation, :block]
 = render :partial => "shared/timeline/tooltip", :locals => { :reservation => reservation } unless reservation.blackout?

--- a/app/views/shared/timeline/_tooltip.html.haml
+++ b/app/views/shared/timeline/_tooltip.html.haml
@@ -1,5 +1,5 @@
 %div[reservation, :tooltip]
   - if public_timeline?
-    %span= reservation_date_range_display(@display_date, reservation)
+    %span= reservation_date_range_display(@display_datetime, reservation)
   - else
     = render partial: 'shared/timeline/facility_tooltip', locals: { reservation: reservation }

--- a/spec/controllers/facility_reservations_controller_spec.rb
+++ b/spec/controllers/facility_reservations_controller_spec.rb
@@ -240,21 +240,32 @@ RSpec.describe FacilityReservationsController do
     context 'instrument listing' do
       before :each do
         @instrument2 = FactoryGirl.create(:instrument,
-                      :facility_account => @facility_account,
-                      :facility => @authable,
-                      :is_hidden => true)
+                      facility_account: @facility_account,
+                      facility: @authable,
+                      is_hidden: true)
         maybe_grant_always_sign_in :director
         @method = :get
         @action = :timeline
-        @params={ :facility_id => @authable.url_name }
-        do_request
+        @params = { facility_id: @authable.url_name }
       end
 
       it 'should show schedules for hidden instruments' do
+        do_request
         expect(assigns(:schedules)).to match_array([@product.schedule, @instrument2.schedule])
       end
 
+      it "defaults the display date to today" do
+        do_request
+        expect(assigns[:display_date]).to eq(Time.current.beginning_of_day)
+      end
+
+      it "parses the date" do
+        @params.merge!(date: "6/14/2015")
+        do_request
+        expect(assigns[:display_date]).to eq(Time.zone.parse("2015-06-14T00:00"))
+      end
     end
+
     context 'orders' do
       before :each do
         # create unpurchased reservation

--- a/spec/controllers/facility_reservations_controller_spec.rb
+++ b/spec/controllers/facility_reservations_controller_spec.rb
@@ -256,13 +256,13 @@ RSpec.describe FacilityReservationsController do
 
       it "defaults the display date to today" do
         do_request
-        expect(assigns[:display_date]).to eq(Time.current.beginning_of_day)
+        expect(assigns[:display_datetime]).to eq(Time.current.beginning_of_day)
       end
 
       it "parses the date" do
         @params.merge!(date: "6/14/2015")
         do_request
-        expect(assigns[:display_date]).to eq(Time.zone.parse("2015-06-14T00:00"))
+        expect(assigns[:display_datetime]).to eq(Time.zone.parse("2015-06-14T00:00"))
       end
     end
 

--- a/spec/helpers/timeline_helper_spec.rb
+++ b/spec/helpers/timeline_helper_spec.rb
@@ -2,16 +2,16 @@ require "rails_helper"
 
 RSpec.describe TimelineHelper do
   before :each do
-    @display_date = Time.zone.now
+    @display_datetime = Time.zone.now
   end
 
   context 'datetime_left_position' do
     it 'should return 0 if the start time is yesterday' do
-      expect(datetime_left_position(@display_date, Time.zone.now.beginning_of_day - 1.hour)).to eq('0px')
+      expect(datetime_left_position(@display_datetime, Time.zone.now.beginning_of_day - 1.hour)).to eq('0px')
     end
     it 'should return 60 for 8am' do
       eight_pm = Time.zone.now.beginning_of_day.change({:hour => 8})
-      expect(datetime_left_position(@display_date, eight_pm)).to eq("#{(480 * TimelineHelper::MINUTE_TO_PIXEL_RATIO).floor}px")
+      expect(datetime_left_position(@display_datetime, eight_pm)).to eq("#{(480 * TimelineHelper::MINUTE_TO_PIXEL_RATIO).floor}px")
     end
 
   end
@@ -28,19 +28,19 @@ RSpec.describe TimelineHelper do
     it 'should return a full width if start and end are in the same day' do
       width = (120 * TimelineHelper::MINUTE_TO_PIXEL_RATIO).floor
       expect(@reservation.duration_mins).to eq(120)
-      expect(datetime_width(@display_date, @reservation.reserve_start_at, @reservation.reserve_end_at)).to eq("#{width}px")
+      expect(datetime_width(@display_datetime, @reservation.reserve_start_at, @reservation.reserve_end_at)).to eq("#{width}px")
     end
 
     it 'should be shorter if it starts before midnight' do
       expect(@reservation_spans_yesterday.duration_mins).to eq(180)
       width = (120 * TimelineHelper::MINUTE_TO_PIXEL_RATIO).floor
-      expect(datetime_width(@display_date, @reservation_spans_yesterday.reserve_start_at, @reservation_spans_yesterday.reserve_end_at)).to eq("#{width}px")
+      expect(datetime_width(@display_datetime, @reservation_spans_yesterday.reserve_start_at, @reservation_spans_yesterday.reserve_end_at)).to eq("#{width}px")
     end
 
     it 'should be shorter if it ends after midnight' do
       expect(@reservation_spans_tomorrow.duration_mins).to eq(240)
       width = (60 * TimelineHelper::MINUTE_TO_PIXEL_RATIO).floor
-      expect(datetime_width(@display_date, @reservation_spans_tomorrow.reserve_start_at, @reservation_spans_tomorrow.reserve_end_at)).to eq("#{width}px")
+      expect(datetime_width(@display_datetime, @reservation_spans_tomorrow.reserve_start_at, @reservation_spans_tomorrow.reserve_end_at)).to eq("#{width}px")
     end
   end
 

--- a/spec/models/schedule_rule_spec.rb
+++ b/spec/models/schedule_rule_spec.rb
@@ -21,44 +21,31 @@ RSpec.describe ScheduleRule do
         instrument.schedule_rules.create(attributes_for(:schedule_rule))
       end
 
-      let(:reservations) { ScheduleRule.unavailable_for_date(instrument, day) }
+      let(:now) { Time.zone.parse("2015-07-05T12:14:00") }
+      let(:reservations) { ScheduleRule.unavailable_for_date(instrument, now) }
 
-      shared_examples_for "it generates reservations to cover unavailability" do
-        it "returns two dummy reservations" do
-          expect(reservations.size).to eq(2)
+      it "returns two dummy reservations" do
+        expect(reservations.size).to eq(2)
 
-          reservations.each do |reservation|
-            expect(reservation).to be_kind_of(Reservation)
-            expect(reservation).to be_blackout
-            expect(reservation).not_to be_persisted
-          end
-        end
-
-        it "reserves midnight to 9 AM as unavailable" do
-          expect(reservations.first.reserve_start_at)
-            .to eq(day.to_time.change(hour: 0, min: 0))
-          expect(reservations.first.reserve_end_at)
-            .to eq(day.to_time.change(hour: 9, min: 0))
-        end
-
-        it "reserves 5 PM to midnight as unavailable" do
-          expect(reservations.last.reserve_start_at)
-            .to eq(day.to_time.change(hour: 17, min: 0))
-          expect(reservations.last.reserve_end_at)
-            .to eq(day.to_time.change(hour: 24, min: 0))
+        reservations.each do |reservation|
+          expect(reservation).to be_kind_of(Reservation)
+          expect(reservation).to be_blackout
+          expect(reservation).not_to be_persisted
         end
       end
 
-      context "when the 'day' argument is a date" do
-        let(:day) { Date.today }
-
-        it_behaves_like "it generates reservations to cover unavailability"
+      it "reserves midnight to 9 AM as unavailable" do
+        expect(reservations.first.reserve_start_at)
+          .to eq(now.beginning_of_day)
+        expect(reservations.first.reserve_end_at)
+          .to eq(Time.zone.parse("2015-07-05T09:00:00"))
       end
 
-      context "when the 'day' argument is a time" do
-        let(:day) { Time.zone.now }
-
-        it_behaves_like "it generates reservations to cover unavailability"
+      it "reserves 5 PM to midnight as unavailable" do
+        expect(reservations.last.reserve_start_at)
+          .to eq(Time.zone.parse("2015-07-05T17:00:00"))
+        expect(reservations.last.reserve_end_at)
+          .to eq(Time.zone.parse("2015-07-06T00:00:00"))
       end
     end
   end


### PR DESCRIPTION
If the server time does not match the application time (what’s set in
`config/application.rb` `config.time_zone`, then schedule rules would
be shifted by the offset between the app time and the server time.

There are still a couple issues that are related to when the browser time doesn't match the application time we'll need to address. I've opened tickets for those in redmine in the open project.