### PR TITLE
Add rubocop configuration

### DIFF
--- a/.rubocop-txi.yml
+++ b/.rubocop-txi.yml
@@ -3,7 +3,6 @@ AllCops:
     - "db/schema.rb" # You can't touch this
     - ".bundle/**/*" # Auto-generated
     - "bin/**/*"     # Auto-generated
-    - "vendor/**/*"  # We cannot solve the world's problems
   RunRailsCops: true
 
 Lint/HandleExceptions:

--- a/.rubocop-txi.yml
+++ b/.rubocop-txi.yml
@@ -1,0 +1,53 @@
+AllCops:
+  Exclude:
+    - "db/schema.rb" # You can't touch this
+    - ".bundle/**/*" # Auto-generated
+    - "bin/**/*"     # Auto-generated
+    - "vendor/**/*"  # We cannot solve the world's problems
+  RunRailsCops: true
+
+Lint/HandleExceptions:
+  Exclude:
+    - "config/unicorn/*"
+
+Metrics/AbcSize:
+  Max: 25
+
+Metrics/LineLength:
+  Max: 120
+
+Metrics/MethodLength:
+  Max: 20
+
+Style/ClassAndModuleChildren:
+  Exclude:
+    - "app/controllers/**/*" # We generally use compact style here
+
+Style/EmptyLinesAroundBlockBody:
+  Exclude:
+    # These are naturally DSL-y, and so let's be lenient.
+    - "spec/**/*"
+    - "lib/tasks/*.rake"
+
+Style/EmptyLinesAroundClassBody:
+  EnforcedStyle: empty_lines
+
+Style/EmptyLinesAroundModuleBody:
+  EnforcedStyle: empty_lines
+
+Style/SignalException:
+  EnforcedStyle: only_raise
+
+Style/SingleSpaceBeforeFirstArg:
+  Exclude:
+    # We often add extra spaces for alignment in factories.
+    - "spec/factories/**/*"
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/TrailingComma:
+  EnforcedStyleForMultiline: comma
+
+Style/TrivialAccessors:
+  ExactNameMatch: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,10 @@
+inherit_from:
+  - .rubocop-txi.yml
+
+# Overrides can go here, but try to conform to TXI standards as specified in
+# .rubocop-txi.yml when possible.
+#
+# Example...
+# Metrics/CyclomaticComplexity:
+#   Enabled: false # We've got nasty methods!
+#

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ gem 'synaccess_connect', '0.2.2', github: 'tablexi/synaccess'
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'rubocop', require: false
 end
 
 group :development, :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,9 @@ GEM
       multi_json (~> 1.0)
     afm (0.2.2)
     arel (3.0.3)
+    ast (2.1.0)
+    astrolabe (1.3.1)
+      parser (~> 2.2)
     awesome_nested_set (2.1.6)
       activerecord (>= 3.0.0)
     awesome_print (1.1.0)
@@ -324,6 +327,8 @@ GEM
       activesupport (>= 3.2.0)
       cocaine (~> 0.5.5)
       mime-types
+    parser (2.2.3.0)
+      ast (>= 1.1, < 3.0)
     pdf-reader (1.3.3)
       Ascii85 (~> 1.0.0)
       afm (~> 0.2.0)
@@ -331,6 +336,7 @@ GEM
       ruby-rc4
       ttfunk
     polyglot (0.3.5)
+    powerpack (0.1.1)
     prawn (0.12.0)
       pdf-reader (>= 0.9.0)
       ttfunk (~> 1.0.2)
@@ -372,6 +378,7 @@ GEM
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
+    rainbow (2.0.0)
     rake (10.4.2)
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
@@ -407,8 +414,15 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
+    rubocop (0.35.0)
+      astrolabe (~> 1.3)
+      parser (>= 2.2.3.0, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
     ruby-oci8 (2.2.0.2)
     ruby-ole (1.2.11.8)
+    ruby-progressbar (1.7.5)
     ruby-rc4 (0.1.5)
     sass (3.4.18)
     sass-rails (3.2.6)
@@ -525,6 +539,7 @@ DEPENDENCIES
   rspec-collection_matchers
   rspec-rails (~> 3.3.0)
   rspec_junit_formatter (= 0.2.3)
+  rubocop
   ruby-oci8 (~> 2.2.0)
   sass-rails (~> 3.2.6)
   shoulda-matchers (~> 2.8.0)


### PR DESCRIPTION
I’m thinking we should just run rubocop as we’re working on new files; I don’t think it’s worth a big push on its own.

If we’re going to be doing rubocop cleanup, I’d like to see it always be its own commit when possible to make it easier to see what’s actually changes (especially in small PRs).