### PR TITLE
Suppress training request notifications when the feature is off

### DIFF
--- a/app/models/message_summarizer/training_requests_summary.rb
+++ b/app/models/message_summarizer/training_requests_summary.rb
@@ -13,6 +13,10 @@ class MessageSummarizer::TrainingRequestsSummary < MessageSummarizer::FacilityMe
     "message_summarizer.training_requests"
   end
 
+  def in_context?
+    SettingsHelper.feature_on?(:training_requests) && super
+  end
+
   def path
     controller.facility_training_requests_path(facility)
   end

--- a/spec/models/message_summarizer_spec.rb
+++ b/spec/models/message_summarizer_spec.rb
@@ -199,10 +199,16 @@ RSpec.describe MessageSummarizer do
       context "when in a manager context" do
         let(:admin_tab?) { true }
 
-        it_behaves_like "there is one overall message"
-        it_behaves_like "it has a visible notices tab", 1
+        context "and the training request feature is enabled", feature_setting: { training_requests: true } do
+          it_behaves_like "there is one overall message"
+          it_behaves_like "it has a visible notices tab", 1
 
-        it { expect(subject.first.link).to match(/\bTraining Requests \(1\)/) }
+          it { expect(subject.first.link).to match(/\bTraining Requests \(1\)/) }
+        end
+
+        context "and the training request feature is disabled", feature_setting: { training_requests: false } do
+          it_behaves_like "the notices tab is not visible"
+        end
       end
 
       context "when not in a manager context" do


### PR DESCRIPTION
I ran into an exception while running with training requests off. If a training request exists, it would try to put a link in the drop-down whether the feature was enabled or not. But creating that link fails because the route to it only exists when the feature is enabled.

With this, if the feature is off, the notifications for it are off too.