### PR TITLE
Update database.yml templates default database names

### DIFF
--- a/config/database.yml.mysql.template
+++ b/config/database.yml.mysql.template
@@ -8,8 +8,8 @@ defaults: &defaults
 
 development:
   <<: *defaults
-  database: nucore-open_development
+  database: nucore_open_development
 
 test:
   <<: *defaults
-  database: nucore-open_test
+  database: nucore_open_test

--- a/config/database.yml.oracle.template
+++ b/config/database.yml.oracle.template
@@ -5,11 +5,11 @@ defaults: &defaults
 
 development:
   <<: *defaults
-  username: nucore_development
+  username: nucore_open_development
   password:
 
 test:
   <<: *defaults
-  username: nucore_test
+  username: nucore_open_test
   password:
 


### PR DESCRIPTION
Minor change.  Database names with dashes technically work in mysql, but they can get hairy with certain mysql commands.  It's easier/cleaner to use underscores rather than dashes so you don't ever have to quote/tick the database name within the mysql console.  Also, the oracle and mysql database yml's should probably use the same database names.