### PR TITLE
Remove unused actions

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -1,7 +1,7 @@
 class FacilitiesController < ApplicationController
 
   customer_tab :index, :list, :show
-  admin_tab :edit, :manage, :schedule, :update, :agenda, :transactions,
+  admin_tab :edit, :manage, :update, :transactions,
             :reassign_chart_strings, :movable_transactions,
             :confirm_transactions, :move_transactions, :disputed_orders
   before_filter :authenticate_user!, except: [:index, :show] # public pages do not require authentication
@@ -102,16 +102,6 @@ class FacilitiesController < ApplicationController
     else
       render action: "edit"
     end
-  end
-
-  def schedule
-    @active_tab = "admin_products"
-    render layout: "product"
-  end
-
-  def agenda
-    @active_tab = "admin_products"
-    render layout: "product"
   end
 
   # GET /facilities/transactions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,7 +79,6 @@ Nucore::Application.routes.draw do
 
       match 'public_schedule', :to => 'instruments#public_schedule'
       match 'schedule',        :to => 'instruments#schedule'
-      match 'agenda',          :to => 'instruments#agenda'
       match 'status',          :to => 'instruments#instrument_status'
       match 'switch',          :to => 'instruments#switch'
 
@@ -126,8 +125,6 @@ Nucore::Application.routes.draw do
 
     resources :price_group_products, :only => [:edit, :update]
 
-    match 'schedule', :to => 'facilities#schedule'
-    match 'agenda',   :to => 'facilities#agenda'
     resources :order_statuses, :except => [:show]
 
     resources :facility_users, :controller => 'facility_users', :only => [:index, :destroy] do

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -103,7 +103,7 @@ class Ability
         can :administer, User
         can :manage, User if controller.is_a?(UsersController)
 
-        can [ :schedule, :agenda, :list, :show ], Facility
+        can [ :list, :show ], Facility
         can :act_as, Facility
 
         can :index, [ BundleProduct, PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ScheduleRule, ServicePricePolicy, ProductAccessory, ProductAccessGroup ]


### PR DESCRIPTION
I noticed these while I was cleaning up something else, and realized
these aren’t used anywhere (plus they’re broken—there’s no `product`
layout, and hasn’t been since the initial fork in github).