### PR TITLE
Fix spec broken when not using statements

### DIFF
--- a/spec/presenters/statement_presenter_spec.rb
+++ b/spec/presenters/statement_presenter_spec.rb
@@ -18,8 +18,10 @@ RSpec.describe StatementPresenter do
 
   describe "#download_path" do
     it "returns a download path to the PDF version of the statement" do
-      expect(subject.download_path)
-        .to eq("/facilities/#{facility.url_name}/accounts/#{account.id}/statements/#{statement.id}.pdf")
+      if AccountManager.using_statements?
+        expect(subject.download_path)
+          .to eq("/facilities/#{facility.url_name}/accounts/#{account.id}/statements/#{statement.id}.pdf")
+      end
     end
   end
 


### PR DESCRIPTION
UIC does not have statements enabled so the route generated here does not exist.