### PR TITLE
Treat the full_title as an empty string when blank

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
   end
 
   def html_title(title=nil)
-    full_title = title.nil? ? "" : "#{title} - "
+    full_title = title.blank? ? "" : "#{title} - "
     (full_title + app_name).html_safe
   end
 


### PR DESCRIPTION
This should prevent titles like " - NU Core" slipping through. It's something I noticed on `/facilities/:facility:id/accounts/user/:user_id` but could be elsewhere.