### PR TITLE
[#98883] Add UI for managing global user roles

### DIFF
--- a/app/assets/javascripts/activate_chosen.js.coffee
+++ b/app/assets/javascripts/activate_chosen.js.coffee
@@ -1,0 +1,1 @@
+$ -> $(".js--chosen").chosen()

--- a/app/assets/javascripts/app/user_roles.js.coffee
+++ b/app/assets/javascripts/app/user_roles.js.coffee
@@ -1,0 +1,1 @@
+$ -> $("select[multiple].js--chosen").chosen()

--- a/app/assets/javascripts/app/user_roles.js.coffee
+++ b/app/assets/javascripts/app/user_roles.js.coffee
@@ -1,1 +1,0 @@
-$ -> $("select[multiple].js--chosen").chosen()

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,7 @@
 //= require jquery.ui.effect
 //= require bootstrap
 //= require chosen.jquery.min
+//= require activate_chosen
 //= require _common
 //= require date
 //= require_tree ./app

--- a/app/controllers/global_user_roles_controller.rb
+++ b/app/controllers/global_user_roles_controller.rb
@@ -1,0 +1,19 @@
+class GlobalUserRolesController < GlobalSettingsController
+
+  def index
+    @users = UserPresenter.wrap(User.with_global_roles)
+  end
+
+  def destroy
+    user = User.find(params[:id])
+    if (user == current_user)
+      flash[:error] = "nope"
+    else
+      user.user_roles.global.each(&:destroy)
+      flash[:notice] = "yep"
+    end
+
+    redirect_to global_user_roles_url
+  end
+
+end

--- a/app/controllers/global_user_roles_controller.rb
+++ b/app/controllers/global_user_roles_controller.rb
@@ -30,32 +30,28 @@ class GlobalUserRolesController < GlobalSettingsController
     if @user == current_user
       flash[:error] = translate("self_not_allowed", action: "change")
     else
-      assign_global_role!
-      flash[:notice] =
-        translate("update.success", user: @user.username, role: role_name)
+      assign_global_roles!
+      flash[:notice] = translate("update.success", user: @user.username)
     end
   rescue ActiveRecord::RecordInvalid
-    flash[:error] =
-      translate("update.failure", user: @user.username, role: role_name)
+    flash[:error] = translate("update.failure", user: @user.username)
   ensure
     redirect_to global_user_roles_url
   end
 
   private
 
-  def assign_global_role!
+  def assign_global_roles!
     @user.transaction do
       @user.user_roles.global.destroy_all
-      UserRole.create!(user: @user, role: role_name)
+      params[:roles].each do |role_name|
+        UserRole.create!(user: @user, role: role_name)
+      end
     end
   end
 
   def load_user
     @user = User.find(params[:id])
-  end
-
-  def role_name
-    @role_name ||= params[:user_role][:role]
   end
 
   def translate(key, arguments = {})

--- a/app/controllers/global_user_roles_controller.rb
+++ b/app/controllers/global_user_roles_controller.rb
@@ -65,10 +65,6 @@ class GlobalUserRolesController < GlobalSettingsController
     @user = User.find(params[:id])
   end
 
-  def roles_from_params
-    params[:roles].presence || []
-  end
-
   def translate(key, arguments = {})
     I18n.t("global_user_roles.#{key}", arguments)
   end

--- a/app/controllers/global_user_roles_controller.rb
+++ b/app/controllers/global_user_roles_controller.rb
@@ -20,7 +20,28 @@ class GlobalUserRolesController < GlobalSettingsController
     redirect_to global_user_roles_url
   end
 
+  def edit
+    @user = UserPresenter.new(User.find(params[:id]))
+  end
+
   def search
+  end
+
+  def update
+    user = User.find(params[:id])
+    if user == current_user
+      flash[:error] = t("global_user_roles.update.self_not_allowed")
+    else
+      role_name = params[:user_role][:role]
+      user.transaction do
+        user.user_roles.global.each(&:destroy)
+        UserRole.create!(user: user, role: role_name)
+      end
+      flash[:notice] =
+        t("global_user_roles.update.success", user: user.username, role: role_name)
+    end
+
+    redirect_to global_user_roles_url
   end
 
 end

--- a/app/controllers/global_user_roles_controller.rb
+++ b/app/controllers/global_user_roles_controller.rb
@@ -6,14 +6,21 @@ class GlobalUserRolesController < GlobalSettingsController
 
   def destroy
     user = User.find(params[:id])
-    if (user == current_user)
-      flash[:error] = "nope"
+    if user == current_user
+      flash[:error] = t("global_user_roles.destroy.self_not_allowed")
     else
       user.user_roles.global.each(&:destroy)
-      flash[:notice] = "yep"
+      if user.user_roles.global.empty?
+        flash[:notice] = t("global_user_roles.destroy.success", username: user.username)
+      else
+        flash[:error] = t("global_user_roles.destroy.failure", username: user.username)
+      end
     end
 
     redirect_to global_user_roles_url
+  end
+
+  def search
   end
 
 end

--- a/app/controllers/global_user_roles_controller.rb
+++ b/app/controllers/global_user_roles_controller.rb
@@ -7,15 +7,7 @@ class GlobalUserRolesController < GlobalSettingsController
   end
 
   def destroy
-    case
-    when @user == current_user
-      flash[:error] = translate("self_not_allowed", action: "remove")
-    when @user.user_roles.global.destroy_all
-      flash[:notice] = translate("destroy.success", user: @user.username)
-    else
-      flash[:error] = translate("destroy.failure", user: @user.username)
-    end
-
+    destroy_all_global_roles
     redirect_to global_user_roles_url
   end
 
@@ -32,7 +24,10 @@ class GlobalUserRolesController < GlobalSettingsController
   end
 
   def update
-    if @user == current_user
+    case
+    when params[:roles].blank?
+      destroy_all_global_roles
+    when @user == current_user
       flash[:error] = translate("self_not_allowed", action: "change")
     else
       assign_global_roles!
@@ -55,8 +50,23 @@ class GlobalUserRolesController < GlobalSettingsController
     end
   end
 
+  def destroy_all_global_roles
+    case
+    when @user == current_user
+      flash[:error] = translate("self_not_allowed", action: "remove")
+    when @user.user_roles.global.destroy_all
+      flash[:notice] = translate("destroy.success", user: @user.username)
+    else
+      flash[:error] = translate("destroy.failure", user: @user.username)
+    end
+  end
+
   def load_user
     @user = User.find(params[:id])
+  end
+
+  def roles_from_params
+    params[:roles].presence || []
   end
 
   def translate(key, arguments = {})

--- a/app/controllers/global_user_roles_controller.rb
+++ b/app/controllers/global_user_roles_controller.rb
@@ -20,7 +20,12 @@ class GlobalUserRolesController < GlobalSettingsController
   end
 
   def edit
-    @user = UserPresenter.new(@user)
+    if @user == current_user
+      flash[:error] = translate("self_not_allowed", action: "change")
+      redirect_to global_user_roles_url
+    else
+      @user = UserPresenter.new(@user)
+    end
   end
 
   def search

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -25,4 +25,5 @@ class SearchController < ApplicationController
         Facility.cross_facility
       end
   end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,6 +8,11 @@ module ApplicationHelper
     #NUCore.app_name
   end
 
+  def can_create_users?
+    SettingsHelper.feature_on?(:create_users) &&
+      current_ability.can?(:manage_users, current_facility || Facility.cross_facility)
+  end
+
   def html_title(title=nil)
     full_title = title.blank? ? "" : "#{title} - "
     (full_title + app_name).html_safe

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,7 @@ class User < ActiveRecord::Base
   # Scopes
 
   def self.with_global_roles
-    where(id: UserRole.where(facility_id: nil).select("distinct user_id"))
+    where(id: UserRole.global.select("distinct user_id"))
   end
 
   def self.with_recent_orders(facility)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,13 +41,17 @@ class User < ActiveRecord::Base
   attr_accessor :ldap_attributes
 
   # Scopes
+
+  def self.with_global_roles
+    where(id: UserRole.where(facility_id: nil).select("distinct user_id"))
+  end
+
   def self.with_recent_orders(facility)
     order_query = Order.recent.for_facility(facility)
     select("DISTINCT users.*")
       .joins(:orders)
       .merge(order_query)
   end
-
 
   # finds all user role mappings for a this user in a facility
   def facility_user_roles(facility)

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -34,6 +34,10 @@ class UserRole < ActiveRecord::Base
     account_manager + administrator + billing_administrator + facility_roles
   end
 
+  def self.global
+    where(facility_id: nil)
+  end
+
   #
   # Assigns +role+ to +user+ for +facility+
   # [_user_]

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -39,7 +39,7 @@ class UserRole < ActiveRecord::Base
   end
 
   def self.global
-    where(facility_id: nil)
+    where(role: global_roles)
   end
 
   #

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -53,4 +53,17 @@ class UserRole < ActiveRecord::Base
 
   validates_presence_of :user_id
   validates_inclusion_of :role, in: valid_roles, message: "is not a valid value"
+  validates_uniqueness_of :role,
+    scope: [:facility_id, :user_id],
+    message: I18n.t("activerecord.errors.models.user_role.duplicate")
+  validates_with UserRoleFacilityValidator
+
+  def facility_role?
+    self.class.facility_roles.include?(role)
+  end
+
+  def global_role?
+    !facility_role?
+  end
+
 end

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -30,8 +30,12 @@ class UserRole < ActiveRecord::Base
     facility_roles - [FACILITY_STAFF, FACILITY_SENIOR_STAFF]
   end
 
+  def self.global_roles
+    account_manager + administrator + billing_administrator
+  end
+
   def self.valid_roles
-    account_manager + administrator + billing_administrator + facility_roles
+    global_roles + facility_roles
   end
 
   def self.global

--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -74,7 +74,7 @@ class NavTab::LinkCollection
   end
 
   def admin_users
-    if ability.can?(:administer, User)
+    if single_facility? && ability.can?(:administer, User)
       NavTab::Link.new(tab: :admin_users, url: facility_users_path(facility))
     end
   end

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -10,6 +10,10 @@ class UserPresenter < SimpleDelegator
     global_roles.join(", ")
   end
 
+  def name_last_comma_first
+    "#{last_name}, #{first_name}"
+  end
+
   private
 
   def global_roles

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -1,0 +1,19 @@
+class UserPresenter < SimpleDelegator
+
+  delegate :global, to: :user_roles, prefix: true
+
+  def self.wrap(users)
+    users.map { |user| new(user) }
+  end
+
+  def global_role_list
+    global_roles.join(", ")
+  end
+
+  private
+
+  def global_roles
+    user_roles_global.pluck(:role)
+  end
+
+end

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -21,8 +21,11 @@ class UserPresenter < SimpleDelegator
 
   private
 
+  # TODO: Existing data may have duplicate roles, thus the "uniq" call.
+  # Duplicate UserRoles are invalid so new duplicates should not be possible.
+  # It should be safe to remove the "uniq" once the old duplicates are gone.
   def global_roles
-    user_roles_global.pluck(:role)
+    user_roles_global.pluck(:role).uniq
   end
 
 end

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -1,4 +1,5 @@
 class UserPresenter < SimpleDelegator
+  include ActionView::Helpers::FormOptionsHelper
 
   delegate :global, to: :user_roles, prefix: true
 
@@ -8,6 +9,10 @@ class UserPresenter < SimpleDelegator
 
   def global_role_list
     global_roles.join(", ")
+  end
+
+  def global_role_select_options
+    options_for_select(UserRole.global_roles, selected: user_roles.map(&:role))
   end
 
   def name_last_comma_first

--- a/app/services/user_finder.rb
+++ b/app/services/user_finder.rb
@@ -15,7 +15,7 @@ class UserFinder
   end
 
   def result
-    [relation.order(:last_name, :first_name).limit(@limit), relation.count]
+    [UserPresenter.wrap(users), relation.count]
   end
 
   private
@@ -36,5 +36,9 @@ class UserFinder
 
   def relation
     @relation ||= User.where(condition_sql, search_term: @search_term)
+  end
+
+  def users
+    relation.order(:last_name, :first_name).limit(@limit)
   end
 end

--- a/app/validators/user_role_facility_validator.rb
+++ b/app/validators/user_role_facility_validator.rb
@@ -1,0 +1,17 @@
+class UserRoleFacilityValidator < ActiveModel::Validator
+
+  def validate(record)
+    if record.facility_id.present?
+      if record.global_role?
+        record.errors[:role] <<
+          I18n.t("activerecord.errors.models.user_role.global_cannot_have_facility", role: record.role)
+      end
+    else
+      if record.facility_role?
+        record.errors[:role] <<
+          I18n.t("activerecord.errors.models.user_role.role_must_have_facility", role: record.role)
+      end
+    end
+  end
+
+end

--- a/app/views/admin/shared/_sidenav_global.html.haml
+++ b/app/views/admin/shared/_sidenav_global.html.haml
@@ -1,2 +1,3 @@
 %ul.sidebar-nav
   = tab t("pages.affiliates"), affiliates_path, sidenav_tab == "affiliates"
+  = tab t("pages.global_user_roles"), global_user_roles_path, sidenav_tab == "global_user_roles"

--- a/app/views/facility_users/map_user.html.haml
+++ b/app/views/facility_users/map_user.html.haml
@@ -1,26 +1,26 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 = content_for :sidebar do
-  = render :partial => 'admin/shared/sidenav_admin', :locals => { :sidenav_tab => 'staff' }
+  = render "admin/shared/sidenav_admin", sidenav_tab: "staff"
 
 %h2 Grant Facility Role
 
-= form_for(:user_role, :url => facility_facility_user_map_user_path) do |f|
+= form_for(:user_role, url: facility_facility_user_map_user_path) do |f|
   = f.error_messages
   %ul.form
     %li
-      = label_tag :username, nil, :class => 'require'
-      = text_field_tag :username, @user.username, :disabled => true
+      = label_tag :username, nil, class: "require"
+      = text_field_tag :username, @user.username, disabled: true
     %li
-      = label_tag :name, nil, :class => 'require'
-      = text_field_tag :name, @user.full_name, :disabled => true
+      = label_tag :name, nil, class: "require"
+      = text_field_tag :name, @user.full_name, disabled: true
     %li
-      = label_tag :email, nil, :class => 'require' 
-      = text_field_tag :email, @user.email, :disabled => true
+      = label_tag :email, nil, class: "require"
+      = text_field_tag :email, @user.email, disabled: true
     %li
-      = f.label :role, 'User Role', :class => 'require'
+      = f.label :role, "User Role", class: "require"
       %p.instruction Select the facility role for this user
-      = f.select :role, options_for_select(UserRole.facility_roles, {:selected => UserRole::FACILITY_STAFF.to_s})
+      = f.select :role, options_for_select(UserRole.facility_roles, selected: UserRole::FACILITY_STAFF.to_s)
   %ul.inline
-    %li= f.submit 'Create', :class => 'btn'
-    %li= link_to 'Cancel', facility_facility_users_path
+    %li= f.submit "Create", class: "btn"
+    %li= link_to "Cancel", facility_facility_users_path

--- a/app/views/facility_users/map_user.html.haml
+++ b/app/views/facility_users/map_user.html.haml
@@ -3,10 +3,10 @@
 = content_for :sidebar do
   = render "admin/shared/sidenav_admin", sidenav_tab: "staff"
 
-%h2 Grant Facility Role
+%h2= t(".h2")
 
-= form_for(:user_role, url: facility_facility_user_map_user_path) do |f|
-  = f.error_messages
+= form_for(:user_role, url: facility_facility_user_map_user_path) do |form|
+  = form.error_messages
   %ul.form
     %li
       = label_tag :username, nil, class: "require"
@@ -18,9 +18,9 @@
       = label_tag :email, nil, class: "require"
       = text_field_tag :email, @user.email, disabled: true
     %li
-      = f.label :role, "User Role", class: "require"
-      %p.instruction Select the facility role for this user
-      = f.select :role, options_for_select(UserRole.facility_roles, selected: UserRole::FACILITY_STAFF.to_s)
+      = form.label :role, nil, class: "require"
+      = form.select :role, options_for_select(UserRole.facility_roles, selected: UserRole::FACILITY_STAFF.to_s)
+
   %ul.inline
-    %li= f.submit "Create", class: "btn"
-    %li= link_to "Cancel", facility_facility_users_path
+    %li= form.submit t(".submit"), class: "btn"
+    %li= link_to t(".cancel"), facility_facility_users_path

--- a/app/views/facility_users/map_user.html.haml
+++ b/app/views/facility_users/map_user.html.haml
@@ -1,5 +1,6 @@
 = content_for :h1 do
   = current_facility
+
 = content_for :sidebar do
   = render "admin/shared/sidenav_admin", sidenav_tab: "staff"
 
@@ -7,19 +8,18 @@
 
 = form_for(:user_role, url: facility_facility_user_map_user_path) do |form|
   = form.error_messages
-  %ul.form
-    %li
-      = label_tag :username, nil, class: "require"
-      = text_field_tag :username, @user.username, disabled: true
-    %li
-      = label_tag :name, nil, class: "require"
-      = text_field_tag :name, @user.full_name, disabled: true
-    %li
-      = label_tag :email, nil, class: "require"
-      = text_field_tag :email, @user.email, disabled: true
-    %li
-      = form.label :role, nil, class: "require"
-      = form.select :role, options_for_select(UserRole.facility_roles, selected: UserRole::FACILITY_STAFF.to_s)
+  .form
+    = label_tag :username, nil, class: "require"
+    = text_field_tag :username, @user.username, disabled: true
+
+    = label_tag :name, nil, class: "require"
+    = text_field_tag :name, @user.full_name, disabled: true
+
+    = label_tag :email, nil, class: "require"
+    = text_field_tag :email, @user.email, disabled: true
+
+    = form.label :role, nil, class: "require"
+    = form.select :role, options_for_select(UserRole.facility_roles, selected: UserRole::FACILITY_STAFF.to_s)
 
   %ul.inline
     %li= form.submit t(".submit"), class: "btn"

--- a/app/views/global_user_roles/edit.html.haml
+++ b/app/views/global_user_roles/edit.html.haml
@@ -19,8 +19,8 @@
       = label_tag :email, nil, class: "require"
       = text_field_tag :email, @user.email, disabled: true
     %li
-      = form.label :role, nil, class: "require"
-      = form.select :role, @user.global_role_select_options, include_blank: true
+      = form.label :roles, nil, class: "require"
+      = select_tag :roles, @user.global_role_select_options, multiple: true
 
   %ul.inline
     %li= form.submit t(".submit"), class: "btn"

--- a/app/views/global_user_roles/edit.html.haml
+++ b/app/views/global_user_roles/edit.html.haml
@@ -8,19 +8,18 @@
 
 = form_for(:user_role, url: global_user_role_path(@user.id), method: :put) do |form|
   = form.error_messages
-  %ul.form
-    %li
-      = label_tag :username, nil, class: "require"
-      = text_field_tag :username, @user.username, disabled: true
-    %li
-      = label_tag :name, nil, class: "require"
-      = text_field_tag :name, @user.full_name, disabled: true
-    %li
-      = label_tag :email, nil, class: "require"
-      = text_field_tag :email, @user.email, disabled: true
-    %li
-      = form.label :roles, nil, class: "require"
-      = select_tag :roles, @user.global_role_select_options, multiple: true
+  .form
+    = label_tag :username, nil, class: "require"
+    = text_field_tag :username, @user.username, disabled: true
+
+    = label_tag :name, nil, class: "require"
+    = text_field_tag :name, @user.full_name, disabled: true
+
+    = label_tag :email, nil, class: "require"
+    = text_field_tag :email, @user.email, disabled: true
+
+    = form.label :roles, nil, class: "require"
+    = select_tag :roles, @user.global_role_select_options, multiple: true
 
   %ul.inline
     %li= form.submit t(".submit"), class: "btn"

--- a/app/views/global_user_roles/edit.html.haml
+++ b/app/views/global_user_roles/edit.html.haml
@@ -1,0 +1,27 @@
+= content_for :h1 do
+  = t("pages.global_settings")
+
+= content_for :sidebar do
+  = render "admin/shared/sidenav_global", sidenav_tab: "global_user_roles"
+
+%h2= t("pages.global_user_roles")
+
+= form_for(:user_role, url: global_user_role_path(@user.id), method: :put) do |form|
+  = form.error_messages
+  %ul.form
+    %li
+      = label_tag :username, nil, class: "require"
+      = text_field_tag :username, @user.username, disabled: true
+    %li
+      = label_tag :name, nil, class: "require"
+      = text_field_tag :name, @user.full_name, disabled: true
+    %li
+      = label_tag :email, nil, class: "require"
+      = text_field_tag :email, @user.email, disabled: true
+    %li
+      = form.label :role, nil, class: "require"
+      = form.select :role, @user.global_role_select_options, include_blank: true
+
+  %ul.inline
+    %li= form.submit t(".submit"), class: "btn"
+    %li= link_to t(".cancel"), global_user_roles_path

--- a/app/views/global_user_roles/edit.html.haml
+++ b/app/views/global_user_roles/edit.html.haml
@@ -19,7 +19,11 @@
     = text_field_tag :email, @user.email, disabled: true
 
     = form.label :roles, nil, class: "require"
-    = select_tag :roles, @user.global_role_select_options, multiple: true
+    = select_tag :roles,
+      @user.global_role_select_options,
+      class: "js--chosen",
+      data: { placeholder: t(".select_role_placeholder") },
+      multiple: true
 
   %ul.inline
     %li= form.submit t(".submit"), class: "btn"

--- a/app/views/global_user_roles/edit.html.haml
+++ b/app/views/global_user_roles/edit.html.haml
@@ -18,6 +18,10 @@
     = label_tag :email, nil, class: "require"
     = text_field_tag :email, @user.email, disabled: true
 
+    -# Chosen attempts to disable autocomplete, but Chrome still does.
+    -# This hidden field tells Chrome to really disable autocomplete:
+    %input.hidden{type: "text", id: "PreventChromeAutocomplete", name: "PreventChromeAutocomplete"}
+
     = form.label :roles, nil, class: "require"
     = select_tag :roles,
       @user.global_role_select_options,

--- a/app/views/global_user_roles/index.html.haml
+++ b/app/views/global_user_roles/index.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  = "TK PLACEHOLDER"
+  = t("pages.global_settings")
 
 = content_for :sidebar do
   = render "admin/shared/sidenav_global", sidenav_tab: "global_user_roles"
@@ -7,7 +7,7 @@
 %h2= t("pages.global_user_roles")
 
 %ul.inline
-  %li= link_to t(".grant_role"), "#TK", class: "btn-add"
+  %li= link_to t(".grant_role"), search_global_user_roles_path, class: "btn-add"
 
 - if @users.empty?
   %p.notice= t(".no_users")

--- a/app/views/global_user_roles/index.html.haml
+++ b/app/views/global_user_roles/index.html.haml
@@ -24,11 +24,16 @@
       - @users.each do |user|
         %tr
           %td.centered
-            = link_to t(".remove_roles"),
-              global_user_role_path(user),
-              confirm: t(".remove_roles_confirm"),
-              method: :delete
+            - if current_user.id != user.id
+              = link_to t(".remove_roles"),
+                global_user_role_path(user.id),
+                confirm: t(".remove_roles_confirm"),
+                method: :delete
           %td= user.full_name
-          %td= user.username
+          %td
+            - if current_user.id == user.id
+              = user.username
+            - else
+              = link_to user.username, edit_global_user_role_path(user.id)
           %td= user.email
           %td= user.global_role_list

--- a/app/views/global_user_roles/index.html.haml
+++ b/app/views/global_user_roles/index.html.haml
@@ -7,7 +7,7 @@
 %h2= t("pages.global_user_roles")
 
 %ul.inline
-  %li= link_to t(".grant_role"), search_global_user_roles_path, class: "btn-add"
+  %li= link_to t(".grant_roles"), search_global_user_roles_path, class: "btn-add"
 
 - if @users.empty?
   %p.notice= t(".no_users")

--- a/app/views/global_user_roles/index.html.haml
+++ b/app/views/global_user_roles/index.html.haml
@@ -1,0 +1,34 @@
+= content_for :h1 do
+  = "TK PLACEHOLDER"
+
+= content_for :sidebar do
+  = render "admin/shared/sidenav_global", sidenav_tab: "global_user_roles"
+
+%h2= t("pages.global_user_roles")
+
+%ul.inline
+  %li= link_to t(".grant_role"), "#TK", class: "btn-add"
+
+- if @users.empty?
+  %p.notice= t(".no_users")
+- else
+  %table.table.table-striped.table-hover
+    %thead
+      %tr
+        %th
+        %th= t(".th.name")
+        %th= t(".th.username")
+        %th= t(".th.email")
+        %th= t(".th.roles")
+    %tbody
+      - @users.each do |user|
+        %tr
+          %td.centered
+            = link_to t(".remove_roles"),
+              global_user_role_path(user),
+              confirm: t(".remove_roles_confirm"),
+              method: :delete
+          %td= user.full_name
+          %td= user.username
+          %td= user.email
+          %td= user.global_role_list

--- a/app/views/global_user_roles/search.html.haml
+++ b/app/views/global_user_roles/search.html.haml
@@ -8,11 +8,11 @@
 = form_tag user_search_results_path, id: "ajax_form" do
   %p.instructions
     = t(".instructions.search")
-    - if SettingsHelper.feature_on?(:create_users)
+    - if can_create_users?
       = t(".instructions.add_user")
 
   = text_field_tag :search_term, nil, size: 30, class: "search-query"
   = submit_tag "Search", class: "btn"
   = hidden_field_tag :search_type, "global_user_role"
-  = hidden_field_tag :create_link, SettingsHelper.feature_on?(:create_users)
+  = hidden_field_tag :create_link, can_create_users?
 #result

--- a/app/views/global_user_roles/search.html.haml
+++ b/app/views/global_user_roles/search.html.haml
@@ -14,7 +14,5 @@
   = text_field_tag :search_term, nil, size: 30, class: "search-query"
   = submit_tag "Search", class: "btn"
   = hidden_field_tag :search_type, "global_user_role"
-  = hidden_field_tag :create_link,
-    SettingsHelper.feature_on?(:create_users) ? "true" : "false"
-
+  = hidden_field_tag :create_link, SettingsHelper.feature_on?(:create_users)
 #result

--- a/app/views/global_user_roles/search.html.haml
+++ b/app/views/global_user_roles/search.html.haml
@@ -16,5 +16,5 @@
   = hidden_field_tag :search_type, "global_user_role"
   = hidden_field_tag :create_link,
     SettingsHelper.feature_on?(:create_users) ? "true" : "false"
-%br
+
 #result

--- a/app/views/global_user_roles/search.html.haml
+++ b/app/views/global_user_roles/search.html.haml
@@ -6,10 +6,15 @@
 
 %h2= t(".h2")
 = form_tag user_search_results_path, id: "ajax_form" do
-  %p.instructions= t(".instruct")
+  %p.instructions
+    = t(".instructions.search")
+    - if SettingsHelper.feature_on?(:create_users)
+      = t(".instructions.add_user")
+
   = text_field_tag :search_term, nil, size: 30, class: "search-query"
   = submit_tag "Search", class: "btn"
   = hidden_field_tag :search_type, "global_user_role"
-  = hidden_field_tag :create_link, "true"
+  = hidden_field_tag :create_link,
+    SettingsHelper.feature_on?(:create_users) ? "true" : "false"
 %br
 #result

--- a/app/views/global_user_roles/search.html.haml
+++ b/app/views/global_user_roles/search.html.haml
@@ -1,0 +1,15 @@
+= content_for :h1 do
+  = t("pages.global_settings")
+
+= content_for :sidebar do
+  = render "admin/shared/sidenav_global", sidenav_tab: "global_user_roles"
+
+%h2= t(".h2")
+= form_tag user_search_results_path, id: "ajax_form" do
+  %p.instructions= t(".instruct")
+  = text_field_tag :search_term, nil, size: 30, class: "search-query"
+  = submit_tag "Search", class: "btn"
+  = hidden_field_tag :search_type, "global_user_role"
+  = hidden_field_tag :create_link, "true"
+%br
+#result

--- a/app/views/search/_global_user_role_link.html.haml
+++ b/app/views/search/_global_user_role_link.html.haml
@@ -1,0 +1,1 @@
+= link_to user.name_last_comma_first, edit_global_user_role_path(user.id)

--- a/app/views/users/_search_form.html.haml
+++ b/app/views/users/_search_form.html.haml
@@ -6,5 +6,5 @@
   = submit_tag "Search", class: "btn"
   = hidden_field_tag :facility_id, current_facility.id
   = hidden_field_tag :search_type, "manage_user"
-  = hidden_field_tag :create_link, "true"
+  = hidden_field_tag :create_link, can_create_users?
 %br

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -387,6 +387,9 @@ en:
       failure: Global roles could not be removed for %{username}.
       self_not_allowed: You may not remove global roles from yourself.
       success: All global roles have been removed for %{username}.
+    edit:
+      cancel: Cancel
+      submit: Grant
     index:
       remove_roles: Remove Roles
       remove_roles_confirm: Are you sure?
@@ -402,6 +405,9 @@ en:
         Click on the name of the user you wish to grant global roles to.
         If the search does not return any acceptable matches,
         you may create a new user.
+    update:
+      self_not_allowed: You may not change global roles for yourself.
+      success: The %{role} role was granted to %{user}.
 
   order_imports:
     new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -224,6 +224,10 @@ en:
         name: Name
         roles: Roles
         username: Username
+    map_user:
+      cancel: Cancel
+      h2: Grant Facility Role
+      submit: Create
     search:
       instruct: "Search for an existing user by name, NetID, or username.  Click on the name of the user you wish to grant access to.  If the search does not return any acceptable matches, you may create a new user."
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -383,6 +383,10 @@ en:
       no_problem_reservations: There are no problem reservations.
 
   global_user_roles:
+    destroy:
+      failure: Global roles could not be removed for %{username}.
+      self_not_allowed: You may not remove global roles from yourself.
+      success: All global roles have been removed for %{username}.
     index:
       remove_roles: Remove Roles
       remove_roles_confirm: Are you sure?
@@ -391,6 +395,13 @@ en:
         name: Name
         roles: Roles
         username: Username
+    search:
+      h2: Grant global roles to a user
+      instruct: |
+        Search for an existing user by name, NetID, or username.
+        Click on the name of the user you wish to grant global roles to.
+        If the search does not return any acceptable matches,
+        you may create a new user.
 
   order_imports:
     new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -390,6 +390,7 @@ en:
       cancel: Cancel
       submit: Grant
     index:
+      grant_roles: Grant Roles
       remove_roles: Remove Roles
       remove_roles_confirm: Are you sure?
       th:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -407,8 +407,8 @@ en:
         you may create a new user.
     self_not_allowed: You may not %{action} global roles for yourself.
     update:
-      failure: The %{role} role was not granted to %{user}.
-      success: The %{role} role was granted to %{user}.
+      failure: Global role assignment for %{user} failed.
+      success: Global role assignment for %{user} succeeded.
 
   order_imports:
     new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1120,6 +1120,10 @@ en:
           move_failed: Sorry, but your reservation could not be moved. Please try again later.
           change_reserve_start_at: cannot change once the reservation has started
           shorten_reserve_end_at: cannot be shortened once the reservation has started
+        user_role:
+          duplicate: The user already has this role
+          global_cannot_have_facility: Global role %{role} may not have a facility.
+          role_must_have_facility: "%{role} must be associated with a facility."
         training_request:
           product:
             requires_no_approval: This product does not require approval

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -400,11 +400,13 @@ en:
         username: Username
     search:
       h2: Grant global roles to a user
-      instruct: |
-        Search for an existing user by name, NetID, or username.
-        Click on the name of the user you wish to grant global roles to.
-        If the search does not return any acceptable matches,
-        you may create a new user.
+      instructions:
+        search: |
+          Search for an existing user by name, NetID, or username.
+          Click on the name of the user you wish to grant global roles to.
+        add_user: |
+          If the search does not return any acceptable matches,
+          you may create a new user.
     self_not_allowed: You may not %{action} global roles for yourself.
     update:
       failure: Global role assignment for %{user} failed.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -392,6 +392,7 @@ en:
       success: All global roles have been removed for %{user}.
     edit:
       cancel: Cancel
+      select_role_placeholder: Select Roles…
       submit: Grant
     index:
       grant_roles: Grant Roles

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -384,9 +384,8 @@ en:
 
   global_user_roles:
     destroy:
-      failure: Global roles could not be removed for %{username}.
-      self_not_allowed: You may not remove global roles from yourself.
-      success: All global roles have been removed for %{username}.
+      failure: Global roles could not be removed for %{user}.
+      success: All global roles have been removed for %{user}.
     edit:
       cancel: Cancel
       submit: Grant
@@ -405,8 +404,9 @@ en:
         Click on the name of the user you wish to grant global roles to.
         If the search does not return any acceptable matches,
         you may create a new user.
+    self_not_allowed: You may not %{action} global roles for yourself.
     update:
-      self_not_allowed: You may not change global roles for yourself.
+      failure: The %{role} role was not granted to %{user}.
       success: The %{role} role was granted to %{user}.
 
   order_imports:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -382,6 +382,16 @@ en:
         Each will need to be corrected.
       no_problem_reservations: There are no problem reservations.
 
+  global_user_roles:
+    index:
+      remove_roles: Remove Roles
+      remove_roles_confirm: Are you sure?
+      th:
+        email: Email
+        name: Name
+        roles: Roles
+        username: Username
+
   order_imports:
     new:
       h2: "Bulk Import"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -274,7 +274,11 @@ Nucore::Application.routes.draw do
     end
   end
 
-  resources :global_user_roles # TK exceptions?
+  resources :global_user_roles do
+    collection do
+      get "search"
+    end
+  end
 
   # order process
   match '/orders/cart', :to => 'orders#cart', :as => 'cart'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -274,10 +274,11 @@ Nucore::Application.routes.draw do
     end
   end
 
+  resources :global_user_roles # TK exceptions?
+
   # order process
   match '/orders/cart', :to => 'orders#cart', :as => 'cart'
   match "/orders(\/:status)", :to => 'orders#index', :as => 'orders_status', :constraints => { :status => /pending|all/ } ## emacs quoting \/
-
 
   put '/orders/:id/remove/:order_detail_id', :to => 'orders#remove',      :as => 'remove_order'
   match '/order/:id/add_account',            :to => 'orders#add_account', :as => 'add_account'

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -19,7 +19,9 @@ class Ability
         can :manage, AccountPriceGroupMember
       else
         can :manage, :all
-        cannot [:manage_accounts, :manage_billing, :manage_users], Facility.cross_facility
+        unless user.billing_administrator?
+          cannot [:manage_accounts, :manage_billing, :manage_users], Facility.cross_facility
+        end
         cannot :manage, User unless resource.is_a?(Facility) && resource.single_facility?
       end
       return

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -22,7 +22,9 @@ class Ability
         unless user.billing_administrator?
           cannot [:manage_accounts, :manage_billing, :manage_users], Facility.cross_facility
         end
-        cannot :manage, User unless resource.is_a?(Facility) && resource.single_facility?
+        unless user.account_manager?
+          cannot :manage, User unless resource.is_a?(Facility) && resource.single_facility?
+        end
       end
       return
     end

--- a/spec/controller_spec_helper.rb
+++ b/spec/controller_spec_helper.rb
@@ -262,7 +262,7 @@ def grant_role(user, authable=nil)
       UserRole.grant(user, UserRole::FACILITY_DIRECTOR, authable)
       expect(user.reload).to be_facility_director_of(authable)
     when 'staff'
-      UserRole.grant(user, UserRole::FACILITY_STAFF, authable)
+      UserRole.create!(user: user, role: UserRole::FACILITY_STAFF, facility: authable) unless user.facility_staff_of?(authable)
       expect(user.reload).to be_facility_staff_of(authable)
     when 'owner'
       # Creating a NufsAccount requires an owner to be present, and some pre-Rails3 tests try to add the same user

--- a/spec/controllers/affiliates_controller_spec.rb
+++ b/spec/controllers/affiliates_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AffiliatesController do
   render_views
 
   before(:all) { create_users }
-
+  before(:each) { @authable = create(:facility) }
 
   context 'index' do
 

--- a/spec/controllers/global_user_roles_controller_spec.rb
+++ b/spec/controllers/global_user_roles_controller_spec.rb
@@ -1,17 +1,7 @@
 require "rails_helper"
+require "controllers/shared_examples"
 
 RSpec.describe GlobalUserRolesController do
-  shared_examples_for "the user must log in" do
-    it "redirects to the login screen" do
-      expect(response).to be_redirect
-      expect(response.location).to eq(new_user_session_url)
-    end
-  end
-
-  shared_examples_for "the user is not allowed" do
-    it { expect(response).to be_forbidden }
-  end
-
   describe "#index" do
     before(:each) do
       sign_in(user) if user.present?

--- a/spec/controllers/global_user_roles_controller_spec.rb
+++ b/spec/controllers/global_user_roles_controller_spec.rb
@@ -69,11 +69,11 @@ RSpec.describe GlobalUserRolesController do
 
   describe "#update" do
     let(:administrator) { create(:user, :administrator) }
-    let(:role) { "Administrator" }
+    let(:roles) { ["Administrator"] }
 
     before(:each) do
       sign_in(administrator)
-      put(:update, id: user.id, user_role: { role: role })
+      put(:update, id: user.id, roles: roles)
     end
 
     after { expect(response).to redirect_to(global_user_roles_url) }
@@ -91,7 +91,7 @@ RSpec.describe GlobalUserRolesController do
       let(:user) { create(:user) }
 
       it "grants the role" do
-        expect(flash[:notice]).to include("granted to")
+        expect(flash[:notice]).to include("succeeded")
         expect(user).to be_administrator
       end
     end
@@ -100,18 +100,18 @@ RSpec.describe GlobalUserRolesController do
       let(:user) { create(:user, :account_manager) }
 
       it "grants the new role" do
-        expect(flash[:notice]).to include("granted to")
+        expect(flash[:notice]).to include("succeeded")
         expect(user).not_to be_account_manager
         expect(user).to be_administrator
       end
     end
 
     context "when the role does not exist" do
-      let(:role) { "?This%role+will-never|exist]" }
+      let(:roles) { ["?This%role+will-never|exist]"] }
       let(:user) { create(:user) }
 
       it "does not grant the role" do
-        expect(flash[:error]).to include("role was not granted")
+        expect(flash[:error]).to include("failed")
         expect(user.user_roles).to be_empty
       end
     end
@@ -121,7 +121,7 @@ RSpec.describe GlobalUserRolesController do
       let(:user) { create(:user, :facility_director, facility: facility) }
 
       it "grants the global role" do
-        expect(flash[:notice]).to include("granted to")
+        expect(flash[:notice]).to include("succeeded")
         expect(user).to be_administrator
       end
 
@@ -134,7 +134,7 @@ RSpec.describe GlobalUserRolesController do
       let(:user) { create(:user, :administrator) }
 
       it "retains the user's global role" do
-        expect(flash[:notice]).to include("granted to")
+        expect(flash[:notice]).to include("succeeded")
         expect(user).to be_administrator
       end
     end

--- a/spec/controllers/global_user_roles_controller_spec.rb
+++ b/spec/controllers/global_user_roles_controller_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe GlobalUserRolesController do
+  shared_examples_for "the user must log in" do
+    it "redirects to the login screen" do
+      expect(response).to be_redirect
+      expect(response.location).to eq(new_user_session_url)
+    end
+  end
+
+  shared_examples_for "the user is not allowed" do
+    it { expect(response).to be_forbidden }
+  end
+
+  describe "#index" do
+    before(:each) do
+      sign_in(user) if user.present?
+      get(:index)
+    end
+
+    context "when not logged in" do
+      let(:user) { nil }
+
+      it_behaves_like "the user must log in"
+    end
+
+    context "when logged in" do
+      context "as an unprivileged user" do
+        let(:user) { create(:user) }
+
+        it_behaves_like "the user is not allowed"
+      end
+
+      context "as a global administrator" do
+        let(:user) { create(:user, :administrator) }
+
+        it { expect(response).to be_success }
+      end
+    end
+  end
+
+  describe "#destroy" do
+    let(:administrators) { create_list(:user, 2, :administrator) }
+    let(:user) { administrators.first }
+
+    before(:each) do
+      sign_in(user)
+      delete(:destroy, id: user_with_roles_to_destroy)
+    end
+
+    context "when removing global roles for another user" do
+      let(:user_with_roles_to_destroy) { administrators.last }
+
+      it "removes global administrator roles from the user" do
+        expect(flash[:notice]).to be_present
+        expect(user_with_roles_to_destroy).not_to be_administrator
+      end
+    end
+
+    context "when attempting to remove global roles from itself" do
+      let(:user_with_roles_to_destroy) { user }
+
+      it "removes no global administrator roles" do
+        expect(flash[:error]).to be_present
+        expect(administrators).to all be_administrator
+      end
+    end
+  end
+end

--- a/spec/controllers/global_user_roles_controller_spec.rb
+++ b/spec/controllers/global_user_roles_controller_spec.rb
@@ -121,6 +121,15 @@ RSpec.describe GlobalUserRolesController do
         expect(user).not_to be_account_manager
         expect(user).to be_administrator
       end
+
+      context "and no roles are specified in params" do
+        let(:roles) { nil }
+
+        it "revokes the user's existing global roles" do
+          expect(flash[:notice]).to include("roles have been removed")
+          expect(user).not_to be_account_manager
+        end
+      end
     end
 
     context "when the role does not exist" do

--- a/spec/controllers/global_user_roles_controller_spec.rb
+++ b/spec/controllers/global_user_roles_controller_spec.rb
@@ -57,6 +57,33 @@ RSpec.describe GlobalUserRolesController do
     end
   end
 
+  describe "#edit" do
+    let(:administrators) { create_list(:user, 2, :administrator) }
+
+    before(:each) do
+      sign_in(administrators.first)
+      get(:edit, id: user.id)
+    end
+
+    context "when attempting to edit itself" do
+      let(:user) { administrators.first }
+
+      it "redirects the user away from the edit form" do
+        expect(flash[:error]).to include("may not change global roles")
+        expect(response).to redirect_to(global_user_roles_url)
+      end
+    end
+
+    context "when attempting to edit another user" do
+      let(:user) { administrators.last }
+
+      it "displays the edit form" do
+        expect(response.code).to eq("200")
+        expect(assigns[:user]).to eq(user)
+      end
+    end
+  end
+
   describe "#update" do
     let(:administrator) { create(:user, :administrator) }
     let(:roles) { ["Administrator"] }

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe NotificationsController do
 
   context 'index' do
     before :each do
+      @authable = create(:facility)
       @method=:get
       @action=:index
     end

--- a/spec/controllers/shared_examples.rb
+++ b/spec/controllers/shared_examples.rb
@@ -1,0 +1,10 @@
+RSpec.shared_examples_for "the user must log in" do
+  it "redirects to the login screen" do
+    expect(response).to be_redirect
+    expect(response.location).to eq(new_user_session_url)
+  end
+end
+
+RSpec.shared_examples_for "the user is not allowed" do
+  it { expect(response).to be_forbidden }
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,6 +2,43 @@ require "rails_helper"
 require 'controller_spec_helper'
 
 RSpec.describe ApplicationHelper do
+  describe "#can_create_users?" do
+    let(:current_ability) { Ability.new(user, current_facility, stub_controller) }
+    let(:current_facility) { build_stubbed(:facility) }
+    let(:stub_controller) { OpenStruct.new }
+    let(:user) { build_stubbed(:user) }
+
+    before(:each) do
+      allow(current_ability)
+        .to receive(:can?)
+        .with(:manage_users, current_facility) { can_manage_users? }
+    end
+
+    context "when the user can :manage_users for the current facility" do
+      let(:can_manage_users?) { true }
+
+      context "and the :create_users feature is on", feature_setting: { create_users: true } do
+        it { expect(can_create_users?).to be true }
+      end
+
+      context "and the :create_users feature is off", feature_setting: { create_users: false } do
+        it { expect(can_create_users?).to be false }
+      end
+    end
+
+    context "when the user cannot :manage_users for the current facility" do
+      let(:can_manage_users?) { false }
+
+      context "and the :create_users feature is on", feature_setting: { create_users: true } do
+        it { expect(can_create_users?).to be false }
+      end
+
+      context "and the :create_users feature is off", feature_setting: { create_users: false } do
+        it { expect(can_create_users?).to be false }
+      end
+    end
+  end
+
   describe "#menu_facilities" do
     before(:all) do
       create_users

--- a/spec/lib/transaction_history_search_spec.rb
+++ b/spec/lib/transaction_history_search_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe TransactionSearch do
   end
 
   before :each do
+    @authable = create(:facility)
     ignore_order_detail_account_validations
     @user = FactoryGirl.create(:user)
     @staff = FactoryGirl.create(:user, :username => "staff")
     @staff2 = FactoryGirl.create(:user, :username => "staff2")
-    UserRole.grant(@staff, UserRole::FACILITY_DIRECTOR)
+    UserRole.create!(user: @staff, role: UserRole::FACILITY_DIRECTOR, facility: facility)
     @controller = TransactionSearcher.new
-    @authable         = FactoryGirl.create(:facility)
     @facility_account = @authable.facility_accounts.create(FactoryGirl.attributes_for(:facility_account))
     @price_group      = @authable.price_groups.create(FactoryGirl.attributes_for(:price_group))
     @account          = FactoryGirl.create(:nufs_account, :account_users_attributes => account_users_attributes_hash(:user => @staff))

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -95,6 +95,33 @@ RSpec.describe User do
 
   it "belongs to the Cancer Center price group if the user is in the Cancer Center view"
 
+  describe ".with_global_roles" do
+    subject(:users_with_global_roles) { described_class.with_global_roles }
+    let!(:unprivileged_users) { create_list(:user, 2) }
+
+    context "when no users have global roles" do
+      it { is_expected.to be_empty }
+    end
+
+    context "when users have the account manager role" do
+      let!(:privileged_users) { create_list(:user, 2, :account_manager) }
+
+      it { is_expected.to match_array(privileged_users) }
+    end
+
+    context "when users have the billing administrator role" do
+      let!(:privileged_users) { create_list(:user, 2, :billing_administrator) }
+
+      it { is_expected.to match_array(privileged_users) }
+    end
+
+    context "when users have the global administrator role" do
+      let!(:privileged_users) { create_list(:user, 2, :administrator) }
+
+      it { is_expected.to match_array(privileged_users) }
+    end
+  end
+
   describe "#accounts_for_product" do
     let(:account) { create(:nufs_account, account_users_attributes: [attributes_for(:account_user, user: user)]) }
 

--- a/spec/presenters/user_presenter_spec.rb
+++ b/spec/presenters/user_presenter_spec.rb
@@ -5,39 +5,27 @@ RSpec.describe UserPresenter do
   let(:global_role_list) { subject.global_role_list }
   let(:global_role_select_options) { subject.global_role_select_options }
 
-  shared_examples_for "it has no global roles" do
-    it { expect(global_role_list).to eq("") }
-    it { expect(global_role_select_options).not_to include('selected="selected"') }
-  end
-
-  shared_examples_for "it has one global role" do
-    it { expect(global_role_list).to eq("Administrator") }
-    it { expect(global_role_select_options).to include('selected="selected">Administrator') }
-    it { expect(global_role_select_options).not_to include('selected="selected">Billing Administrator') }
-  end
-
-  shared_examples_for "it has multiple global roles" do
-    it { expect(global_role_list).to eq("Administrator, Billing Administrator") }
-    it { expect(global_role_select_options).to include('selected="selected">Administrator') }
-    it { expect(global_role_select_options).to include('selected="selected">Billing Administrator') }
-  end
-
   context "when the user has no global roles" do
     let(:user) { create(:user) }
 
-    it_behaves_like "it has no global roles"
+    it { expect(global_role_list).to eq("") }
+    it { expect(global_role_select_options).not_to include('selected="selected"') }
   end
 
   context "when the user has one global role" do
     let(:user) { create(:user, :administrator) }
 
-    it_behaves_like "it has one global role"
+    it { expect(global_role_list).to eq("Administrator") }
+    it { expect(global_role_select_options).to include('selected="selected">Administrator') }
+    it { expect(global_role_select_options).not_to include('selected="selected">Billing Administrator') }
   end
 
   context "when the user has multiple global roles" do
     let(:user) { create(:user, :administrator, :billing_administrator) }
 
-    it_behaves_like "it has multiple global roles"
+    it { expect(global_role_list).to eq("Administrator, Billing Administrator") }
+    it { expect(global_role_select_options).to include('selected="selected">Administrator') }
+    it { expect(global_role_select_options).to include('selected="selected">Billing Administrator') }
   end
 
   describe "#name_last_comma_first" do

--- a/spec/presenters/user_presenter_spec.rb
+++ b/spec/presenters/user_presenter_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe UserPresenter do
+  subject { described_class.new(user) }
+  let(:global_role_list) { subject.global_role_list }
+  let(:global_role_select_options) { subject.global_role_select_options }
+
+  shared_examples_for "it has no global roles" do
+    it { expect(global_role_list).to eq("") }
+    it { expect(global_role_select_options).not_to include('selected="selected"') }
+  end
+
+  shared_examples_for "it has one global role" do
+    it { expect(global_role_list).to eq("Administrator") }
+    it { expect(global_role_select_options).to include('selected="selected">Administrator') }
+    it { expect(global_role_select_options).not_to include('selected="selected">Billing Administrator') }
+  end
+
+  shared_examples_for "it has multiple global roles" do
+    it { expect(global_role_list).to eq("Administrator, Billing Administrator") }
+    it { expect(global_role_select_options).to include('selected="selected">Administrator') }
+    it { expect(global_role_select_options).to include('selected="selected">Billing Administrator') }
+  end
+
+  context "when the user has no global roles" do
+    let(:user) { create(:user) }
+
+    it_behaves_like "it has no global roles"
+  end
+
+  context "when the user has one global role" do
+    let(:user) { create(:user, :administrator) }
+
+    it_behaves_like "it has one global role"
+  end
+
+  context "when the user has multiple global roles" do
+    let(:user) { create(:user, :administrator, :billing_administrator) }
+
+    it_behaves_like "it has multiple global roles"
+  end
+
+  describe "#name_last_comma_first" do
+    let(:user) { create(:user, first_name: "First", last_name: "Last") }
+
+    it { expect(subject.name_last_comma_first).to eq("Last, First") }
+  end
+end


### PR DESCRIPTION
This adds a UI, available only to Global Administrators, for granting and revoking global user roles.
The UI is based on the one in place for facility user roles.

Notes:

* A user may not grant or revoke roles for itself. It would be easy to lock yourself out, and would complicate the controller actions.
* A user may have multiple global roles, though it might result in some odd behavior. I've done some testing, but it can use more.
  - In UIC, there are Global Admins who are also Billing Administrators. This combination seems to work all right with UIC's feature flags but I don't know if I've missed something.
  - The new Account Manager role is still incompatible with the Global Administrator role, in that the tabs for the Global Administrator will take precedence. Still, the various functions allowed by both roles should work, even if it's difficult or impossible to reach them through navigation. Still, the UI will not stop you from granting this role combination. If we need to make this combination work, we need to discuss further.
* This adds some validations on `UserRole` that might make existing data technically invalid, in that we have some duplicate `UserRole`s and nonexistent role names in production. Since granting/removing roles always involves removing all global roles first, I don't expect this to be a problem.