### PR TITLE
Make account owner trait share-able among subclasses

### DIFF
--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -1,0 +1,14 @@
+FactoryGirl.define do
+  trait :with_account_owner do
+    transient do
+      owner { FactoryGirl.create(:user) }
+    end
+
+    # Every account must have an account_user "owner" in order for the account
+    # to be valid in rails. And foreign key constraints require that each
+    # account_user has an account inserted before the account_user is inserted.
+    callback(:after_build, :before_create) do |account, evaluator|
+      account.account_users << build(:account_user, user: evaluator.owner)
+    end
+  end
+end

--- a/spec/factories/nufs_accounts.rb
+++ b/spec/factories/nufs_accounts.rb
@@ -11,9 +11,10 @@ end
 FactoryGirl.modify do
   factory :nufs_account do
     trait :with_order do
+      with_account_owner
+
       transient do
         product nil
-        owner { FactoryGirl.create(:user) }
       end
 
       account_users_attributes { [FactoryGirl.attributes_for(:account_user, user: owner)] }

--- a/vendor/engines/split_accounts/spec/factories/split_accounts.rb
+++ b/vendor/engines/split_accounts/spec/factories/split_accounts.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :split_account, class: SplitAccounts::SplitAccount do
+    with_account_owner
 
     transient do
-      owner { create(:user) }
       without_splits { false } # set to true to skip generating a valid split
     end
 
@@ -10,13 +10,6 @@ FactoryGirl.define do
     sequence(:description) { |n| "split account #{n}" }
     expires_at { Time.zone.now + 1.month }
     created_by 0
-
-    # Every account must have an account_user "owner" in order for the account
-    # to be valid in rails. And foreign key constraints require that each
-    # account_user has an account inserted before the account_user is inserted.
-    callback(:after_build, :before_create) do |split_account, evaluator|
-      split_account.account_users << build(:account_user, user: evaluator.owner, account: split_account)
-    end
 
     trait :with_two_splits do
       callback(:after_build, :before_create) do |split_account, evalutor|


### PR DESCRIPTION
I’m doing this so I can use the `with_owner` trait on purchase orders and credit cards easily within  my credit card branch.