### PR TITLE
[#122474] Restore ability for facility staff to batch update reservations

### DIFF
--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -85,6 +85,7 @@ class Ability
         can [
           :administer,
           :assign_price_policies_to_problem_orders,
+          :batch_update,
           :create,
           :edit,
           :edit_admin,

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe FacilityOrdersController do
 
   context '#batch_update' do
     before :each do
-      @method=:post
-      @action=:batch_update
+      @method = :post
+      @action = :batch_update
     end
 
     it_should_allow_operators_only :redirect

--- a/spec/controllers/facility_reservations_controller_spec.rb
+++ b/spec/controllers/facility_reservations_controller_spec.rb
@@ -93,7 +93,12 @@ RSpec.describe FacilityReservationsController do
   end
 
   context '#batch_update' do
-    skip "TODO test exists for the FacilityOrdersController version"
+    before :each do
+      @method = :post
+      @action = :batch_update
+    end
+
+    it_should_allow_operators_only :redirect
   end
 
   context '#create' do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe Ability do
     it { is_expected.not_to be_allowed_to(:administer, User) }
     it { is_expected.not_to be_allowed_to(:suspend, Account) }
     it { is_expected.not_to be_allowed_to(:unsuspend, Account) }
+    it { is_expected.not_to be_allowed_to(:batch_update, Order) }
+    it { is_expected.not_to be_allowed_to(:batch_update, Reservation) }
 
     context "in a single facility" do
       it { is_expected.not_to be_allowed_to(:manage_accounts, facility) }
@@ -107,6 +109,8 @@ RSpec.describe Ability do
       it { is_expected.to be_allowed_to(:manage, User) }
       it { is_expected.to be_allowed_to(:manage_accounts, facility) }
       it { is_expected.to be_allowed_to(:manage_billing, facility) }
+      it { is_expected.to be_allowed_to(:batch_update, Order) }
+      it { is_expected.to be_allowed_to(:batch_update, Reservation) }
     end
 
     context "in cross-facility" do
@@ -169,7 +173,10 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:manage, TrainingRequest) }
     it { is_expected.to be_allowed_to(:show_problems, Reservation) }
     it { is_expected.to be_allowed_to(:disputed, Order) }
+    it { is_expected.to be_allowed_to(:batch_update, Order) }
+    it { is_expected.to be_allowed_to(:batch_update, Reservation) }
     it { is_expected.to be_allowed_to(:administer, User) }
+
     it_behaves_like "it can destroy admistrative reservations"
   end
 
@@ -201,6 +208,8 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:read, Notification) }
     it { is_expected.to be_allowed_to(:show_problems, Reservation) }
     it { is_expected.to be_allowed_to(:disputed, Order) }
+    it { is_expected.to be_allowed_to(:batch_update, Order) }
+    it { is_expected.to be_allowed_to(:batch_update, Reservation) }
     it { is_expected.to be_allowed_to(:administer, User) }
     it { is_expected.not_to be_allowed_to(:manage_accounts, Facility.cross_facility) }
     it { is_expected.not_to be_allowed_to(:manage_billing, Facility.cross_facility) }
@@ -212,6 +221,8 @@ RSpec.describe Ability do
     it { is_expected.not_to be_allowed_to(:disputed, Order) }
     it { is_expected.not_to be_allowed_to(:manage, Account) }
     it { is_expected.not_to be_allowed_to(:show_problems, Reservation) }
+    it { is_expected.to be_allowed_to(:batch_update, Order) }
+    it { is_expected.to be_allowed_to(:batch_update, Reservation) }
     it { is_expected.to be_allowed_to(:read, Notification) }
     it { is_expected.to be_allowed_to(:administer, User) }
     it_behaves_like "it can destroy admistrative reservations"


### PR DESCRIPTION
I didn’t want to get into the black hole that could be writing the missing specs for this method; I just wanted to get the bug fixed.