### PR TITLE
[#98883] Remove user switch (order on behalf) link from flash after user creation

### DIFF
--- a/vendor/engines/c2po/app/views/users/_new_user.html.haml
+++ b/vendor/engines/c2po/app/views/users/_new_user.html.haml
@@ -1,4 +1,8 @@
 .notice
   %p= "#{t('users.new_user.success')} #{link_to "#{@new_user} (#{@new_user.username})", facility_user_path(current_facility, @new_user)}.".html_safe
   %p= link_to t('users.new_user.add_to_payment_source'), facility_accounts_path(current_facility)
-  %p= link_to t('users.new_user.order_for'), facility_user_switch_to_path(current_facility, @new_user)
+
+  - if current_facility.single_facility?
+    %p
+      = link_to t("users.new_user.order_for"),
+        facility_user_switch_to_path(current_facility, @new_user)

--- a/vendor/engines/c2po/app/views/users/_new_user.html.haml
+++ b/vendor/engines/c2po/app/views/users/_new_user.html.haml
@@ -1,8 +1,3 @@
 .notice
   %p= "#{t('users.new_user.success')} #{link_to "#{@new_user} (#{@new_user.username})", facility_user_path(current_facility, @new_user)}.".html_safe
   %p= link_to t('users.new_user.add_to_payment_source'), facility_accounts_path(current_facility)
-
-  - if current_facility.single_facility?
-    %p
-      = link_to t("users.new_user.order_for"),
-        facility_user_switch_to_path(current_facility, @new_user)


### PR DESCRIPTION
The "order on behalf" link should not appear when in a cross-facility ("all") context.