### PR TITLE
Fix missing translation error

### DIFF
--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -62,8 +62,7 @@ class UserRole < ActiveRecord::Base
   validates_presence_of :user_id
   validates_inclusion_of :role, in: ->(roles) { valid_roles }, message: "is not a valid value"
   validates_uniqueness_of :role,
-    scope: [:facility_id, :user_id],
-    message: I18n.t("activerecord.errors.models.user_role.duplicate")
+    scope: [:facility_id, :user_id]
   validates_with UserRoleFacilityValidator
 
   def facility_role?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1135,7 +1135,7 @@ en:
           change_reserve_start_at: cannot change once the reservation has started
           shorten_reserve_end_at: cannot be shortened once the reservation has started
         user_role:
-          duplicate: The user already has this role
+          taken: The user already has this role
           global_cannot_have_facility: Global role %{role} may not have a facility.
           role_must_have_facility: "%{role} must be associated with a facility."
         training_request:


### PR DESCRIPTION
While trying to pull the latest open/master into UIC, we were getting
a test failure on a missing translation. I'm not 100% why it wasn't
finding the translation, especially, why it was working in open, but not uic, but this appears to work. There's a circle branch running with the latest from open/master and this change.