### PR TITLE
[#103993] Set default Payment#processing_fee to $0

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -9,6 +9,7 @@ class Payment < ActiveRecord::Base
   end
 
   validates :source, presence: true, inclusion: { in: valid_sources }
-  validates :account, :amount, presence: true
+  validates :account, :amount, numericality: true, presence: true
+  validates :processing_fee, numericality: true, allow_nil: false
 
 end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -9,7 +9,8 @@ class Payment < ActiveRecord::Base
   end
 
   validates :source, presence: true, inclusion: { in: valid_sources }
-  validates :account, :amount, numericality: true, presence: true
+  validates :account, presence: true
+  validates :amount, presence: true, numericality: true
   validates :processing_fee, numericality: true, allow_nil: false
 
 end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -10,7 +10,8 @@ class Payment < ActiveRecord::Base
 
   validates :source, presence: true, inclusion: { in: valid_sources }
   validates :account, presence: true
-  validates :amount, presence: true, numericality: true
-  validates :processing_fee, numericality: true, allow_nil: false
+  # TODO use `numericality: { other_than: 0 }` in newer rails
+  validates :amount, presence: true, numericality: true, exclusion: { in: [0], message: "may not be 0" }
+  validates :processing_fee, presence: true, numericality: true, allow_nil: false
 
 end

--- a/db/migrate/20151221210653_make_processing_fee_non_null.rb
+++ b/db/migrate/20151221210653_make_processing_fee_non_null.rb
@@ -1,0 +1,9 @@
+class MakeProcessingFeeNonNull < ActiveRecord::Migration
+  def up
+    change_column :payments, :processing_fee, :decimal, precision: 10, scale: 2, null: false, default: 0
+  end
+
+  def down
+    change_column :payments, :processing_fee, :decimal, precision: 10, scale: 2, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20151201221103) do
+ActiveRecord::Schema.define(:version => 20151221210653) do
 
   create_table "account_users", :force => true do |t|
     t.integer  "account_id",               :null => false
@@ -306,15 +306,15 @@ ActiveRecord::Schema.define(:version => 20151201221103) do
   add_index "orders", ["user_id"], :name => "index_orders_on_user_id"
 
   create_table "payments", :force => true do |t|
-    t.integer  "account_id",                                    :null => false
+    t.integer  "account_id",                                                     :null => false
     t.integer  "statement_id"
-    t.string   "source",                                        :null => false
+    t.string   "source",                                                         :null => false
     t.string   "source_id"
-    t.decimal  "amount",         :precision => 10, :scale => 2, :null => false
+    t.decimal  "amount",         :precision => 10, :scale => 2,                  :null => false
     t.integer  "paid_by_id"
-    t.datetime "created_at",                                    :null => false
-    t.datetime "updated_at",                                    :null => false
-    t.decimal  "processing_fee", :precision => 10, :scale => 2
+    t.datetime "created_at",                                                     :null => false
+    t.datetime "updated_at",                                                     :null => false
+    t.decimal  "processing_fee", :precision => 10, :scale => 2, :default => 0.0, :null => false
   end
 
   add_index "payments", ["account_id"], :name => "index_payments_on_account_id"

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -19,4 +19,20 @@ RSpec.describe Payment do
       expect(payment.paid_by_id).to eq(user.id)
     end
   end
+
+  describe "processing_fee" do
+    let(:payment) { described_class.new }
+
+    it "has a default processing fee of zero" do
+      expect(payment.processing_fee).to eq(0)
+      payment.valid?
+      expect(payment.errors).not_to include(:processing_fee)
+    end
+
+    it "is invalid if you try to set the processing fee to nil" do
+      payment.processing_fee = nil
+      expect(payment).to be_invalid
+      expect(payment.errors).to include(:processing_fee)
+    end
+  end
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -20,6 +20,43 @@ RSpec.describe Payment do
     end
   end
 
+  describe "amount" do
+    subject(:payment) { described_class.new(amount: amount) }
+    before { payment.valid? }
+
+    context "positive amount" do
+      let(:amount) { 23.45 }
+
+      it "does not have an error on amount" do
+        expect(payment.errors).not_to include(:amount)
+      end
+    end
+
+    context "negative amount" do
+      let(:amount) { -23.45 }
+
+      it "does not have an error on amount" do
+        expect(payment.errors).not_to include(:amount)
+      end
+    end
+
+    context "a zero amount" do
+      let(:amount) { 0 }
+
+      it "has an error on amount" do
+        expect(payment.errors).to include(:amount)
+      end
+    end
+
+    context "a nil amount" do
+      let(:amount) { nil }
+
+      it "has an error on amount" do
+        expect(payment.errors).to include(:amount)
+      end
+    end
+  end
+
   describe "processing_fee" do
     let(:payment) { described_class.new }
 


### PR DESCRIPTION
And make it not-null.

I didn’t want to give :amount a default because it’s something that
should always be supplied by the user, whereas processing_fee could
likely not be a feature that’s used.