### PR TITLE
[#123960] All transactions in billing tab were red

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,11 +41,6 @@ module ApplicationHelper
     link_to title, {:sort => column, :dir => direction}, {:class => (column == sort_column ? sort_direction : 'sortable')}
   end
 
-  # TODO: deprecate in favor of OrderDetailPresenter#row_class
-  def needs_reconcile_warning?(order_detail)
-    OrderDetailPresenter.new(order_detail).row_class
-  end
-
   #
   # currency display helpers
   [ :total, :cost, :subsidy ].each do |type|

--- a/app/helpers/transaction_history_helper.rb
+++ b/app/helpers/transaction_history_helper.rb
@@ -1,6 +1,6 @@
 module TransactionHistoryHelper
   def row_class(order_detail)
-    needs_reconcile_warning?(order_detail) ? 'reconcile-warning' : ''
+    OrderDetailPresenter.new(order_detail).row_class
   end
 
   def product_options(products, search_fields)

--- a/app/views/facility_accounts/show_statement.html.haml
+++ b/app/views/facility_accounts/show_statement.html.haml
@@ -22,7 +22,7 @@
         %th.currency Amount
     %tbody
       - @order_details.each do |od|
-        %tr{:class => needs_reconcile_warning?(od) ? 'reconcile-warning' : ''}
+        %tr{ class: row_class(od) }
           %td= link_to od.description, facility_order_path(current_facility, od.order)
           %td= human_datetime(od.order.ordered_at)
           %td

--- a/app/views/shared/_problem_order_details.html.haml
+++ b/app/views/shared/_problem_order_details.html.haml
@@ -17,7 +17,7 @@
       %th= t(".th.problem")
   %tbody
     - @order_details.each do |order_detail|
-      %tr{class: needs_reconcile_warning?(order_detail) ? "reconcile-warning" : ""}
+      %tr{ class: row_class(order_detail) }
         %td.centered= link_to order_detail.order_id,
           facility_order_path(current_facility, order_detail.order)
         %td.centered= link_to order_detail.id,

--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -20,7 +20,7 @@
       %th= OrderDetail.human_attribute_name("order_status")
   %tbody
     - query_in_slices(order_details).each do |order_detail|
-      %tr{:class => row_class(order_detail)}
+      %tr{ class: row_class(order_detail) }
         - if @order_detail_action
           %td= check_box_tag "order_detail_ids[]", order_detail.id, false, {:class => 'toggle'}
         - if @order_detail_link


### PR DESCRIPTION
Introduced as part of a refactoring of the OrderDetailPresenter.
`row_class` returns either “reconcile-warning” or “”. “” was evaluating
to true in `needs_reconcile_warning?`.

This removes the `needs_reconcile_warning?` helper method. There could
still be the next step of removing `row_class` helper in favor of the
`Presenter.wrap`, but that was a bigger change than I wanted to make to
get a quick fix.