### PR TITLE
Remove not implemented specs

### DIFF
--- a/spec/controller_spec_helper.rb
+++ b/spec/controller_spec_helper.rb
@@ -188,7 +188,6 @@ def it_should_allow_managers_only(response=:success, spec_desc='', &eval)
     instance_exec(user, &eval) if eval
   end
 
-  it 'should test more than auth' unless eval
 end
 
 def it_should_allow_managers_and_senior_staff_only(response=:success, spec_desc='', &eval)
@@ -203,7 +202,6 @@ def it_should_allow_managers_and_senior_staff_only(response=:success, spec_desc=
     instance_exec(user, &eval) if eval
   end
 
-  it 'should test more than auth' unless eval
 end
 
 
@@ -219,7 +217,6 @@ def it_should_allow_operators_only(response=:success, spec_desc='', &eval)
     instance_exec(user, &eval) if eval
   end
 
-  it 'should test more than auth' unless eval
 end
 
 
@@ -239,7 +236,6 @@ def it_should_allow_admin_only(response=:success, spec_desc='', &eval)
     instance_eval &eval if eval
   end
 
-  it 'should test more than auth' unless eval
 end
 
 

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -191,9 +191,5 @@ RSpec.describe AccountsController do
     end
   end
 
-  context "POST /accounts/create" do
-    it "should 403 unless class_type is legit"
-  end
-
 end
 

--- a/spec/controllers/facility_reservations_controller_spec.rb
+++ b/spec/controllers/facility_reservations_controller_spec.rb
@@ -214,7 +214,6 @@ RSpec.describe FacilityReservationsController do
         expect(assigns[:order_details]).to eq([@order_detail_reservation])
       end
 
-      it "provides sort headers that don't result in errors"
     end
   end
 

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -129,8 +129,6 @@ RSpec.describe OrdersController do
         expect(response).to redirect_to cart_path
       end
     end
-
-    it 'should test more than auth'
   end
 
 
@@ -746,7 +744,6 @@ RSpec.describe OrdersController do
           is_expected.to set_flash.to(/You are not authorized to place an order on behalf of another user for the facility/)
         end
       end
-      it "should show a warning if the user doesn't have access to the product to be added"
     end
   end
 
@@ -833,7 +830,6 @@ RSpec.describe OrdersController do
 
     end
 
-    it "should not allow updates of quantities for instruments"
   end
 
   context "update order_detail notes" do
@@ -919,10 +915,6 @@ RSpec.describe OrdersController do
         expect(assigns[:order].order_details.first.validate_for_purchase).to eq("Please make a reservation")
       end
     end
-
-    it "should show links for uploading files for services where required by service"
-    it "should show links for submitting survey for services where required by service"
-
   end
 
 
@@ -984,13 +976,6 @@ RSpec.describe OrdersController do
       expect(assigns[:order_statuses]).not_to be_include @order_status_other
     end
 
-    it "should validate and transition to validated"
-
-    it "should only allow checkout if the cart has at least one order_detail"
-  end
-
-  context "receipt /receipt/:order_id" do
-    it "should 404 unless :order_id exists and is related to the current user"
   end
 
 end

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -54,8 +54,6 @@ RSpec.describe DateHelper do
       end
 
     end
-
-    it "should do something with extra_date_info (unknown)"
   end
 
   describe "#human_datetime" do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -300,26 +300,6 @@ RSpec.describe Account do
     expect(order_detail.reload.statement).to eq(statement)
   end
 
-
-  context "billing" do
-    before(:each) do
-      @facility1        = FactoryGirl.create(:facility)
-      @facility2        = FactoryGirl.create(:facility)
-      @user             = FactoryGirl.create(:user)
-      @account          = FactoryGirl.create(:nufs_account, :account_users_attributes => account_users_attributes_hash(:user => @user))
-    end
-
-    it "should find all accounts that need statements for a facility"
-
-    it "should return the correct billable balance for a facility"
-
-    it "should return the correct pending balance for a facility"
-
-    it "should return the correct facility balance for a given date"
-
-    it "should return the most recent account statement for a given facility"
-  end
-
   unless Account.config.facility_account_types.empty?
     context "limited facilities" do
       before :each do

--- a/spec/models/old_instrument_price_policy_spec.rb
+++ b/spec/models/old_instrument_price_policy_spec.rb
@@ -373,12 +373,6 @@ RSpec.describe OldInstrumentPricePolicy do
       costs    = pp.estimate_cost_and_subsidy(start_dt, end_dt)
       expect(costs).to be_nil
     end
-
-    # TODO finish these tests
-    it "should return nil if the start or end time is outside of the schedule rules" # we should catch this before price estimatation.  should probably remove this test.
-    it "should apply schedule rule discounts to rate and not subsidy only" # what about a discount making [(rate * discount) - subsidy] negative?
-    it "should correctly estimate cost with minimum cost" # minimum cost is before subsidies are taken int account.  but what if the subsidy is greater than the minimum cost?
-
   end
 
   context "cost estimate tests with all day schedule rules" do
@@ -584,23 +578,12 @@ RSpec.describe OldInstrumentPricePolicy do
       end
     end
 
-    it "should correctly calculate cost with usage and reservation rate and subsidy"
-    it "should correctly calculate cost with usage and overage rate"
-    it "should correctly calculate cost with usage and overage rate and subsidy"
-    it "should correctly calculate cost with reservation and overage rate"
-    it "should correctly calculate cost with reservation and overage rate and subsidy"
     it "should return nil for calculate cost with reservation and overage rate without actual hours" do
       @reservation.actual_start_at = nil
       @reservation.actual_end_at = nil
       @ipp.update_attributes(:overage_rate => 120, :overage_subsidy => 119)
       expect(@ipp.calculate_cost_and_subsidy(@reservation)).to be_nil
     end
-    it "should correctly calculate cost with usage, reservation, and overage rate and subsidy"
-    it "should correctly calculate cost across time changes"
-    it "should return nil for cost if purchase is restricted"
-    it "should correctly calculate cast across multiple days"
-    it "should correctly calculate cost for a schedule rule with a discount"
-    it "should correctly calculate cost across schedule rules"
-    it "should correctly calculate cost across schedule rules with discounts"
+
   end
 end

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -330,8 +330,6 @@ RSpec.describe OrderDetail do
       expect(@order_detail.valid_for_purchase?).not_to eq(true)
     end
 
-    it "should not be valid if the chart string account does not match the product account"
-
     context 'needs open account' do
       before :each do
         create(:price_group_product, product: @item, price_group: @price_group, reservation_window: nil)
@@ -415,46 +413,6 @@ RSpec.describe OrderDetail do
       it 'allows purchase' do
         expect(order_detail).to be_valid_for_purchase
       end
-    end
-
-#    before :each do
-#      @price_group    = create(:price_group, facility: @facility)
-#      @pg_user_member = create(:user_price_group_member, user: @user, price_group: @price_group)
-#      @order          = @user.orders.create(attributes_for(:order, facility_id: @facility.id, account_id: @account.id, created_by: @user.id))
-#      @instrument     = @facility.instruments.create(attributes_for(:instrument, facility_account_id: @facility_account.id))
-#      @order_detail   = @order.order_details.create(attributes_for(:order_detail).update(product_id: @instrument.id, account_id: @account.id))
-#    end
-
-
-    context 'problem orders' do
-
-#      before :each do
-#        @rule           = @instrument.schedule_rules.create(attributes_for(:schedule_rule).merge(start_hour: 0, end_hour: 17))
-#        @instrument_pp  = @instrument.instrument_price_policies.create(attributes_for(:instrument_price_policy, price_group_id: @price_group.id))
-#        @reservation    = @instrument.reservations.create(reserve_start_date: Date.today+1.day, reserve_start_hour: 10,
-#                                                          reserve_start_min: 0, reserve_start_meridian: 'am',
-#                                                          duration_value: 60, duration_unit: 'minutes')
-#
-#        @order_detail.reservation=@reservation
-#        define_open_account(@order_detail.product.account, @order_detail.account.account_number)
-#        create(:price_group_product, product: @instrument, price_group: @price_group)
-#
-#        @order_detail.to_inprocess!
-#        @order_detail.to_complete!
-#      end
-
-
-      # The setup for instrument order tests is absolutely painful...
-      it 'should test that an order with no actual start date is a problem'
-      it 'should test that an order with no actual end date is a problem'
-      it 'should test that an order with actuals is not a problem'
-
-    end
-
-    context "instrument purchase validation" do
-      it "should validate for a valid instrument with reservation"
-      it "should not be valid if an instrument reservation is not valid"
-      it "should not be valid if there is no estimated or actual price"
     end
   end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -144,15 +144,6 @@ RSpec.describe Order do
       expect(@order.validate_order!).to be false
     end
 
-    ## TODO simplify these to prevent overlapping test coverage with order_detail_spec
-    it "should validate_extras for a valid instrument with reservation"
-    it "should validate_extras for a service with no survey"
-    it "should not validate_extras for a service with a survey and no response set"
-    it "should not validate_extras for a service with a survey and a uncompleted response set"
-    it "should validate_extras for a service with a survey and a completed response set"
-    it "should not validate_extras for a service file template upload with no template results"
-    it "should validate_extras for a service file template upload with template results"
-    it "should validate_extras for a valid item"
   end
 
   context "purchase state transition" do
@@ -253,10 +244,6 @@ RSpec.describe Order do
       expect(@order.validate_order!).to be false
     end
 
-    it "should check for reservation conflicts before purchase"
-    it "should check for price policy changes before purchase"
-    it "should check for payment source expiration before purchase"
-    it "should check for chart string account being open before purchase"
   end
 
   context do # 'add, clear, adjust' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -93,8 +93,6 @@ RSpec.describe User do
     expect(user).to be_external
   end
 
-  it "belongs to the Cancer Center price group if the user is in the Cancer Center view"
-
   describe ".with_global_roles" do
     subject(:users_with_global_roles) { described_class.with_global_roles }
     let!(:unprivileged_users) { create_list(:user, 2) }

--- a/vendor/engines/c2po/spec/controllers/facility_accounts_controller_extension_spec.rb
+++ b/vendor/engines/c2po/spec/controllers/facility_accounts_controller_extension_spec.rb
@@ -270,9 +270,6 @@ RSpec.describe FacilityAccountsController do
       expect(@order_detail.reconciled_note).not_to be_nil
     end
 
-    it 'should test multiple cards sent in one POST'
-    it 'should test transaction failure'
-
   end
 
 
@@ -295,9 +292,6 @@ RSpec.describe FacilityAccountsController do
       expect(@order_detail.state).to eq('reconciled')
       expect(@order_detail.reconciled_note).not_to be_nil
     end
-
-    it 'should test multiple purchase orders sent in one POST'
-    it 'should test transaction failure'
 
   end
 


### PR DESCRIPTION
Remove specs that are `not implemented yet` since they are noise at this point in time.  We can refer back to this pull request to implement any missing tests in the future.
```
1) FacilityJournalsController#show should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:191

2) FacilityAccountsController accounts_receivable should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:191

3) FacilitiesController disputed_orders behaves like transactions should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:191

4) FacilitiesController transactions behaves like transactions should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:191

5) FacilitiesController movable_transactions behaves like transactions should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:191

6) OrderDetail auto scaled accessory defaults to 1 if less than a minute
   # No reason given
   # ./spec/models/order_details/accessorized_order_detail_spec.rb:118

7) OrderDetail manual scaled accessory defaults to 1 if less than a minute
   # No reason given
   # ./spec/models/order_details/accessorized_order_detail_spec.rb:76

8) Order validate_order state transition should validate_extras for a valid item
   # Not yet implemented
   # ./spec/models/order_spec.rb:155

9) Order validate_order state transition should validate_extras for a valid instrument with reservation
   # Not yet implemented
   # ./spec/models/order_spec.rb:148

10) Order validate_order state transition should not validate_extras for a service with a survey and a uncompleted response set
   # Not yet implemented
   # ./spec/models/order_spec.rb:151

11) Order validate_order state transition should not validate_extras for a service file template upload with no template results
   # Not yet implemented
   # ./spec/models/order_spec.rb:153

12) Order validate_order state transition should validate_extras for a service file template upload with template results
   # Not yet implemented
   # ./spec/models/order_spec.rb:154

13) Order validate_order state transition should not validate_extras for a service with a survey and no response set
   # Not yet implemented
   # ./spec/models/order_spec.rb:150

14) Order validate_order state transition should validate_extras for a service with a survey and a completed response set
   # Not yet implemented
   # ./spec/models/order_spec.rb:152

15) Order validate_order state transition should validate_extras for a service with no survey
   # Not yet implemented
   # ./spec/models/order_spec.rb:149

16) Order  order detail updates should clear the facility and the account when destroying the last order_detail from the cart
   # No reason given
   # ./spec/models/order_spec.rb:436

17) Order purchase state transition should check for payment source expiration before purchase
   # Not yet implemented
   # ./spec/models/order_spec.rb:258

18) Order purchase state transition should check for reservation conflicts before purchase
   # Not yet implemented
   # ./spec/models/order_spec.rb:256

19) Order purchase state transition should check for price policy changes before purchase
   # Not yet implemented
   # ./spec/models/order_spec.rb:257

20) Order purchase state transition should check for chart string account being open before purchase
   # Not yet implemented
   # ./spec/models/order_spec.rb:259

21) AccountsController POST /accounts/create should 403 unless class_type is legit
   # Not yet implemented
   # ./spec/controllers/accounts_controller_spec.rb:195

22) OrderDetail item purchase validation should not be valid if the chart string account does not match the product account
   # Not yet implemented
   # ./spec/models/order_detail_spec.rb:333

23) OrderDetail instrument instrument purchase validation should not be valid if there is no estimated or actual price
   # Not yet implemented
   # ./spec/models/order_detail_spec.rb:457

24) OrderDetail instrument instrument purchase validation should not be valid if an instrument reservation is not valid
   # Not yet implemented
   # ./spec/models/order_detail_spec.rb:456

25) OrderDetail instrument instrument purchase validation should validate for a valid instrument with reservation
   # Not yet implemented
   # ./spec/models/order_detail_spec.rb:455

26) OrderDetail instrument problem orders should test that an order with no actual end date is a problem
   # Not yet implemented
   # ./spec/models/order_detail_spec.rb:449

27) OrderDetail instrument problem orders should test that an order with actuals is not a problem
   # Not yet implemented
   # ./spec/models/order_detail_spec.rb:450

28) OrderDetail instrument problem orders should test that an order with no actual start date is a problem
   # Not yet implemented
   # ./spec/models/order_detail_spec.rb:448

29) InstrumentsController instrument id switch should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:222

30) InstrumentsController instrument id status should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:222

31) DateHelper#parse_usa_date should do something with extra_date_info (unknown)
   # Not yet implemented
   # ./spec/helpers/date_helper_spec.rb:58

32) FileUploadsController destroy info should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:206

33) FileUploadsController uploader_create product info should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:206

34) Account billing should return the correct pending balance for a facility
   # Not yet implemented
   # ./spec/models/account_spec.rb:316

35) Account billing should return the correct billable balance for a facility
   # Not yet implemented
   # ./spec/models/account_spec.rb:314

36) Account billing should find all accounts that need statements for a facility
   # Not yet implemented
   # ./spec/models/account_spec.rb:312

37) Account billing should return the correct facility balance for a given date
   # Not yet implemented
   # ./spec/models/account_spec.rb:318

38) Account billing should return the most recent account statement for a given facility
   # Not yet implemented
   # ./spec/models/account_spec.rb:320

39) Reservation basic reservation rules should not let reservations be made outside the reservation window
   # No reason given
   # ./spec/models/reservation_spec.rb:842

40) OrdersController cart meta data should show links for submitting survey for services where required by service
   # Not yet implemented
   # ./spec/controllers/orders_controller_spec.rb:924

41) OrdersController cart meta data should show links for uploading files for services where required by service
   # Not yet implemented
   # ./spec/controllers/orders_controller_spec.rb:923

42) OrdersController update order_detail quantities should not allow updates of quantities for instruments
   # Not yet implemented
   # ./spec/controllers/orders_controller_spec.rb:836

43) OrdersController choose_account should test more than auth
   # Not yet implemented
   # ./spec/controllers/orders_controller_spec.rb:133

44) OrdersController checkout should validate and transition to validated
   # Not yet implemented
   # ./spec/controllers/orders_controller_spec.rb:987

45) OrdersController checkout should only allow checkout if the cart has at least one order_detail
   # Not yet implemented
   # ./spec/controllers/orders_controller_spec.rb:989

46) OrdersController add to cart acting_as should show a warning if the user doesn't have access to the product to be added
   # Not yet implemented
   # ./spec/controllers/orders_controller_spec.rb:749

47) OrdersController receipt /receipt/:order_id should 404 unless :order_id exists and is related to the current user
   # Not yet implemented
   # ./spec/controllers/orders_controller_spec.rb:993

48) OldInstrumentPricePolicy cost estimate tests should correctly estimate cost with minimum cost
   # Not yet implemented
   # ./spec/models/old_instrument_price_policy_spec.rb:380

49) OldInstrumentPricePolicy cost estimate tests should apply schedule rule discounts to rate and not subsidy only
   # Not yet implemented
   # ./spec/models/old_instrument_price_policy_spec.rb:379

50) OldInstrumentPricePolicy cost estimate tests should return nil if the start or end time is outside of the schedule rules
   # Not yet implemented
   # ./spec/models/old_instrument_price_policy_spec.rb:378

51) OldInstrumentPricePolicy actual cost calculation tests should correctly calculate cost across schedule rules
   # Not yet implemented
   # ./spec/models/old_instrument_price_policy_spec.rb:603

52) OldInstrumentPricePolicy actual cost calculation tests should correctly calculate cost with usage and overage rate
   # Not yet implemented
   # ./spec/models/old_instrument_price_policy_spec.rb:588

53) OldInstrumentPricePolicy actual cost calculation tests should correctly calculate cost across schedule rules with discounts
   # Not yet implemented
   # ./spec/models/old_instrument_price_policy_spec.rb:604

54) OldInstrumentPricePolicy actual cost calculation tests should correctly calculate cost across time changes
   # Not yet implemented
   # ./spec/models/old_instrument_price_policy_spec.rb:599

55) OldInstrumentPricePolicy actual cost calculation tests should correctly calculate cost with reservation and overage rate and subsidy
   # Not yet implemented
   # ./spec/models/old_instrument_price_policy_spec.rb:591

56) OldInstrumentPricePolicy actual cost calculation tests should correctly calculate cost with usage and reservation rate and subsidy
   # Not yet implemented
   # ./spec/models/old_instrument_price_policy_spec.rb:587

57) OldInstrumentPricePolicy actual cost calculation tests should correctly calculate cast across multiple days
   # Not yet implemented
   # ./spec/models/old_instrument_price_policy_spec.rb:601

58) OldInstrumentPricePolicy actual cost calculation tests should correctly calculate cost with usage, reservation, and overage rate and subsidy
   # Not yet implemented
   # ./spec/models/old_instrument_price_policy_spec.rb:598

59) OldInstrumentPricePolicy actual cost calculation tests should return nil for cost if purchase is restricted
   # Not yet implemented
   # ./spec/models/old_instrument_price_policy_spec.rb:600

60) OldInstrumentPricePolicy actual cost calculation tests should correctly calculate cost with reservation and overage rate
   # Not yet implemented
   # ./spec/models/old_instrument_price_policy_spec.rb:590

61) OldInstrumentPricePolicy actual cost calculation tests should correctly calculate cost for a schedule rule with a discount
   # Not yet implemented
   # ./spec/models/old_instrument_price_policy_spec.rb:602

62) OldInstrumentPricePolicy actual cost calculation tests should correctly calculate cost with usage and overage rate and subsidy
   # Not yet implemented
   # ./spec/models/old_instrument_price_policy_spec.rb:589

63) FacilityOrdersController#disputed should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:191

64) FacilityOrdersController#batch_update should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:222

65) FacilityOrdersController#show_problems should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:191

66) User belongs to the Cancer Center price group if the user is in the Cancer Center view
   # Not yet implemented
   # ./spec/models/user_spec.rb:96

67) FacilityReservationsController#tab_counts should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:222

68) FacilityReservationsController#disputed should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:191

69) FacilityReservationsController#show should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:222

70) FacilityReservationsController#batch_update should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:222

71) FacilityReservationsController#show_problems TODO test exists for the FacilityOrdersController version
   # No reason given
   # ./spec/controllers/facility_reservations_controller_spec.rb:241

72) FacilityReservationsController admin #update_admin should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:222

73) FacilityReservationsController admin #edit_admin should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:222

74) FacilityReservationsController#index once signed in provides sort headers that don't result in errors
   # Not yet implemented
   # ./spec/controllers/facility_reservations_controller_spec.rb:217

75) FacilityReservationsController#new should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:222

76) OrderStatusesController update should test more than auth
   # Not yet implemented
   # ./spec/controller_spec_helper.rb:191
```