### PR TITLE
Handle nil param for AccountBuilder.for

### DIFF
--- a/app/services/account_builder.rb
+++ b/app/services/account_builder.rb
@@ -34,6 +34,7 @@ class AccountBuilder
   #   AccountBuilder.for("BuilderDoesNotExist") => AccountBuilder
   #
   def self.for(account_type)
+    return self unless account_type.present?
     begin
       klass = "#{account_type}_builder".classify
       klass.constantize

--- a/spec/services/account_builder_spec.rb
+++ b/spec/services/account_builder_spec.rb
@@ -46,7 +46,13 @@ RSpec.describe AccountBuilder, type: :service do
     end
   end
 
-  describe ".for() factory" do
+  describe ".for" do
+    context "when passed nil" do
+      it "returns default builder" do
+        expect(described_class.for(nil)).to eq(AccountBuilder)
+      end
+    end
+
     context "when subclassed account builder exists" do
       before do
         ExistingBuilder = Class.new(AccountBuilder)


### PR DESCRIPTION
`AccountBuilder.for(nil)` should return `AccountBuilder` but was instead returning `Builder`.  Added a guard to squash this bug and provided a spec to verify.