### PR TITLE
[#123990] Allow operators to switch to users on search

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -15,6 +15,9 @@ class SearchController < ApplicationController
     render layout: false
   end
 
+  # ApplicationController#current_ability depends on current_facility being set
+  # correctly. Since ApplicationController#current_facility loads based on the
+  # facility's url_name, we need to override to load it through its id instead.
   def current_facility
     @facility ||= load_facility
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -15,6 +15,10 @@ class SearchController < ApplicationController
     render layout: false
   end
 
+  def current_facility
+    @facility ||= load_facility
+  end
+
   private
 
   def load_facility

--- a/app/views/search/_manage_user_table.html.haml
+++ b/app/views/search/_manage_user_table.html.haml
@@ -9,7 +9,7 @@
     - @users.each do |user|
       %tr
         %td.centered
-          - if current_ability.can?(:manage, @facility)
+          - if current_ability.can?(:switch_to, User)
             = link_to("Order For", facility_user_switch_to_path(@facility, user))
         %td
           = link_to "#{user.last_name}, #{user.first_name}", facility_user_path(@facility, user)

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -118,7 +118,7 @@ class Ability
           fileupload.file_type == 'sample_result'
         end
 
-        can :administer, User
+        can [:administer, :switch_to], User
         can :manage, User if controller.is_a?(UsersController)
 
         can [ :list, :show ], Facility

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -176,6 +176,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:batch_update, Order) }
     it { is_expected.to be_allowed_to(:batch_update, Reservation) }
     it { is_expected.to be_allowed_to(:administer, User) }
+    it { is_expected.to be_allowed_to(:switch_to, User) }
 
     it_behaves_like "it can destroy admistrative reservations"
   end
@@ -211,6 +212,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:batch_update, Order) }
     it { is_expected.to be_allowed_to(:batch_update, Reservation) }
     it { is_expected.to be_allowed_to(:administer, User) }
+    it { is_expected.to be_allowed_to(:switch_to, User) }
     it { is_expected.not_to be_allowed_to(:manage_accounts, Facility.cross_facility) }
     it { is_expected.not_to be_allowed_to(:manage_billing, Facility.cross_facility) }
     it { is_expected.not_to be_allowed_to(:manage_users, Facility.cross_facility) }
@@ -225,6 +227,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:batch_update, Reservation) }
     it { is_expected.to be_allowed_to(:read, Notification) }
     it { is_expected.to be_allowed_to(:administer, User) }
+    it { is_expected.to be_allowed_to(:switch_to, User) }
     it_behaves_like "it can destroy admistrative reservations"
   end
 
@@ -249,6 +252,7 @@ RSpec.describe Ability do
     it { is_expected.not_to be_allowed_to(:manage, Account) }
     it { is_expected.to be_allowed_to(:create, TrainingRequest) }
     it_behaves_like "it can not manage training requests"
+    it { is_expected.not_to be_allowed_to(:switch_to, User) }
 
     %i(sample_result template_result).each do |file_type|
       describe "downloading a #{file_type}" do


### PR DESCRIPTION
Previously the "Order For" link would appear in search results to users that could manage the current Facility, which does not necessarily include directors or staff.

This adds explicit switch_to User abilities to roles that are considered Facility operators, and uses this Ability check in the view that displays the "Order For" link in user search results.