### PR TITLE
[#123990] Account Managers may not "Order For" a user

### DIFF
--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -47,6 +47,7 @@ class Ability
 
       if resource.blank? || resource == Facility.cross_facility
         can :manage, [Account, AccountUser, User]
+        cannot :switch_to, User
       end
 
       cannot [:suspend, :unsuspend], Account

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe Ability do
       it { is_expected.not_to be_allowed_to(:manage_accounts, facility) }
       it { is_expected.not_to be_allowed_to(:manage, AccountUser) }
       it { is_expected.not_to be_allowed_to(:manage, User) }
+      it { is_expected.not_to be_allowed_to(:switch_to, User) }
     end
 
     context "in cross-facility" do
@@ -58,6 +59,7 @@ RSpec.describe Ability do
       it { is_expected.to be_allowed_to(:manage_accounts, facility) }
       it { is_expected.to be_allowed_to(:manage, AccountUser) }
       it { is_expected.to be_allowed_to(:manage, User) }
+      it { is_expected.not_to be_allowed_to(:switch_to, User) }
     end
 
     context "in no facility" do
@@ -65,6 +67,7 @@ RSpec.describe Ability do
 
       it { is_expected.to be_allowed_to(:manage, AccountUser) }
       it { is_expected.to be_allowed_to(:manage, User) }
+      it { is_expected.not_to be_allowed_to(:switch_to, User) }
     end
   end
 


### PR DESCRIPTION
When searching for users under the "Users" tab, the search results should show an "Order For" link if the logged-in user is allowed to `switch_to` a `User`. Account Managers should only encounter this when in the "all" (cross-facility) context, where placing an order wouldn't make sense. This change removes the `switch_to` ability for Account Managers, so they should no longer see "Order For" links.