### PR TITLE
[#121326] Send emails for training requests

### DIFF
--- a/app/controllers/training_requests_controller.rb
+++ b/app/controllers/training_requests_controller.rb
@@ -14,7 +14,9 @@ class TrainingRequestsController < ApplicationController
   # POST /facilities/:facility_id/products/:product_id/training_requests
   def create
     load_product
-    if TrainingRequest.create(user: current_user, product: @product)
+    @training_request = TrainingRequest.new(user: current_user, product: @product)
+    if @training_request.save
+      trigger_email_to_facility_staff
       flash[:notice] = t("training_requests.create.success", product: @product)
     else
       flash[:error] = t("training_requests.create.failure", product: @product)
@@ -40,6 +42,10 @@ class TrainingRequestsController < ApplicationController
   end
 
   private
+
+  def trigger_email_to_facility_staff
+    TrainingRequestMailer.delay.notify_facility_staff(current_user.id, @product.id)
+  end
 
   def flash_arguments
     @flash_arguments ||= {

--- a/app/mailers/training_request_mailer.rb
+++ b/app/mailers/training_request_mailer.rb
@@ -1,0 +1,10 @@
+class TrainingRequestMailer < BaseMailer
+  def notify_facility_staff(user_id, product_id)
+    @user = User.find(user_id)
+    @product = Product.find(product_id)
+
+    if @product.training_request_contacts.any?
+      mail(to: @product.training_request_contacts, subject: t("training_request_mailer.notify_facility_staff.subject", facility: @product.facility))
+    end
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -210,6 +210,14 @@ class Product < ActiveRecord::Base
     product_users.find_by_user_id(user.id)
   end
 
+  def training_request_contacts
+    CsvArrayString.new(self[:training_request_contacts])
+  end
+
+  def training_request_contacts=(str)
+    self[:training_request_contacts] = CsvArrayString.new(str).to_s
+  end
+
   private
 
   def account_required

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -28,6 +28,14 @@ class Product < ActiveRecord::Base
     errors.add(:contact_email, :required) unless email.present?
   end
 
+  validate do |record|
+    # Simple validation that all emails contain an @ followed by a word character,
+    # and is not at the start of the string.
+    unless training_request_contacts.all? { |email| email =~ /.@\w/ }
+      record.errors.add(:training_request_contacts)
+    end
+  end
+
   scope :active,             :conditions => { :is_archived => false, :is_hidden => false }
   scope :active_plus_hidden, :conditions => { :is_archived => false}
   scope :archived,           :conditions => { :is_archived => true }

--- a/app/views/admin/shared/_product_details_fields.haml
+++ b/app/views/admin/shared/_product_details_fields.haml
@@ -17,6 +17,8 @@
     = f.input :account, :hint => t('shared.product_details_fields.account')
   = f.input :initial_order_status_id, :collection => OrderStatus.initial_statuses(current_facility).collect {|cf| [cf.name_with_level, cf.id] }, :hint => t('shared.product_details_fields.initial_order_status'), :include_blank => false
   = f.input :requires_approval, :as => :boolean, :label => false, :inline_label => t('shared.product_details_fields.requires_approval')
+  - if SettingsHelper.feature_on?(:training_requests)
+    = f.input :training_request_contacts, as: :string, hint: t('shared.product_details_fields.training_request_contacts')
 
 = f.input :is_archived, :as => :boolean, :label => false, :inline_label => t('shared.product_details_fields.is_archived')
 = f.input :is_hidden,   :as => :boolean, :label => false, :inline_label => t('shared.product_details_fields.is_hidden', :field => f.object.class.name.downcase)

--- a/app/views/admin/shared/_product_manage.haml
+++ b/app/views/admin/shared/_product_manage.haml
@@ -12,5 +12,7 @@
 
   = f.input :initial_order_status
   = f.input :requires_approval
+  - if SettingsHelper.feature_on?(:training_requests) && f.object.training_request_contacts?
+    = f.input :training_request_contacts
 = f.input :is_archived
 = f.input :is_hidden

--- a/app/views/training_request_mailer/notify_facility_staff.html.haml
+++ b/app/views/training_request_mailer/notify_facility_staff.html.haml
@@ -1,0 +1,2 @@
+%p= t(".body_html", user: @user, product: @product)
+%p= t(".link_html", link: facility_user_access_list_url(@product.facility.url_name, @user.id))

--- a/app/views/training_request_mailer/notify_facility_staff.text.erb
+++ b/app/views/training_request_mailer/notify_facility_staff.text.erb
@@ -1,0 +1,3 @@
+<%= t(".body", user: @user, product: @product) %>
+
+<%= t(".link_html", link: facility_user_access_list_url(@product.facility.url_name, @user.id)) %>

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -187,6 +187,7 @@ en:
         initial_order_status: Initial Order Status
         is_archived: Is Inactive?
         is_hidden: Is Hidden?
+        training_request_contacts: Training Request Contacts
       instrument:
         min_reserve_mins: Minimum Reservation Minutes
         max_reserve_mins: Maximum Reservation Minutes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,7 @@ en:
       is_archived: "Inactivate the product, disallowing purchase and viewing"
       is_hidden: "Hide %{field} from end users; visible to staff when \"ordering on behalf\" of another user"
       contact_email: "If left blank, email will default to the facility's email address (%{facility_email})."
+      training_request_contacts: Comma separated list of email addresses to be notified when a training request is placed.
       deposit_account:
         label: "Recharge Chart String and Account"
         instruct: "Revenue account to which fees will be deposited"
@@ -1122,6 +1123,16 @@ en:
       success: "The request from %{user} for %{product} has been removed."
       failure: "The request from %{user} for %{product} was not able to be removed."
     no_requests: There are no outstanding training requests.
+
+  training_request_mailer:
+    notify_facility_staff:
+      body: "%{user} has requested training for %{product}."
+      body_html: >
+        <strong>%{user}</strong> has requested training for <strong>%{product}</strong>.
+      link_html: >
+        Visit <a href="%{link}">here</a> to give them access.
+      link: "Visit here to give them access: %{link}"
+      subject: "%{facility} - User Requested Training"
 
   activerecord:
     errors:

--- a/db/migrate/20160120162354_add_contact_email_for_training_requests.rb
+++ b/db/migrate/20160120162354_add_contact_email_for_training_requests.rb
@@ -1,0 +1,5 @@
+class AddContactEmailForTrainingRequests < ActiveRecord::Migration
+  def change
+    add_column :products, :training_request_contacts, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20151221210653) do
+ActiveRecord::Schema.define(:version => 20160120162354) do
 
   create_table "account_users", :force => true do |t|
     t.integer  "account_id",               :null => false
@@ -419,28 +419,29 @@ ActiveRecord::Schema.define(:version => 20151221210653) do
   add_index "product_users", ["user_id"], :name => "index_product_users_on_user_id"
 
   create_table "products", :force => true do |t|
-    t.string   "type",                    :limit => 50,                     :null => false
-    t.integer  "facility_id",                                               :null => false
-    t.string   "name",                    :limit => 200,                    :null => false
-    t.string   "url_name",                :limit => 50,                     :null => false
+    t.string   "type",                      :limit => 50,                     :null => false
+    t.integer  "facility_id",                                                 :null => false
+    t.string   "name",                      :limit => 200,                    :null => false
+    t.string   "url_name",                  :limit => 50,                     :null => false
     t.text     "description"
     t.integer  "schedule_id"
-    t.boolean  "requires_approval",                                         :null => false
+    t.boolean  "requires_approval",                                           :null => false
     t.integer  "initial_order_status_id"
-    t.boolean  "is_archived",                                               :null => false
-    t.boolean  "is_hidden",                                                 :null => false
-    t.datetime "created_at",                                                :null => false
-    t.datetime "updated_at",                                                :null => false
+    t.boolean  "is_archived",                                                 :null => false
+    t.boolean  "is_hidden",                                                   :null => false
+    t.datetime "created_at",                                                  :null => false
+    t.datetime "updated_at",                                                  :null => false
     t.integer  "min_reserve_mins"
     t.integer  "max_reserve_mins"
     t.integer  "min_cancel_hours"
     t.integer  "facility_account_id"
-    t.string   "account",                 :limit => 5
-    t.boolean  "show_details",                           :default => false, :null => false
+    t.string   "account",                   :limit => 5
+    t.boolean  "show_details",                             :default => false, :null => false
     t.integer  "auto_cancel_mins"
     t.string   "contact_email"
     t.integer  "reserve_interval"
-    t.integer  "lock_window",                            :default => 0,     :null => false
+    t.integer  "lock_window",                              :default => 0,     :null => false
+    t.text     "training_request_contacts"
   end
 
   add_index "products", ["facility_account_id"], :name => "fk_facility_accounts"

--- a/lib/csv_array_string.rb
+++ b/lib/csv_array_string.rb
@@ -1,0 +1,18 @@
+# Takes a string that is a comma-separated list
+# the #to_a and any Enumerable methods will run only
+# over values that exist.
+# CsvArrayString.new("test, test2, ,, test3").to_a
+#   => ["test", "test2", "test3"]
+class CsvArrayString < SimpleDelegator
+  include Enumerable
+  delegate :each, to: :to_a
+
+  def to_a
+    __getobj__.to_s.split(",").select(&:present?).map(&:strip)
+  end
+
+  def to_s
+    to_a.join(", ")
+  end
+
+end

--- a/spec/controllers/training_requests_controller_spec.rb
+++ b/spec/controllers/training_requests_controller_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+# require 'controller_spec_helper'
+
+RSpec.describe TrainingRequestsController do
+  let(:facility) { FactoryGirl.create(:setup_facility) }
+  let(:product) { FactoryGirl.create(:setup_item, facility: facility,
+    requires_approval: true, training_request_contacts: training_request_contacts) }
+  let(:training_request_contacts) { "test@example.com, test2@example.com" }
+  let(:user) { FactoryGirl.create(:user) }
+
+  describe "#new" do
+    def do_request
+      get :new, facility_id: facility.url_name, product_id: product.url_name
+    end
+
+    describe "while not logged in" do
+      it "sends the user to sign in" do
+        do_request
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    describe "while logged in" do
+      before { sign_in user }
+
+      it "gives access" do
+        do_request
+        expect(response).to be_success
+      end
+
+      it "has the product" do
+        do_request
+        expect(assigns[:product]).to eq(product)
+      end
+    end
+  end
+
+  describe "#create" do
+    def do_request
+      put :create, facility_id: facility.url_name, product_id: product.url_name
+    end
+
+    describe "not logged in" do
+      it "sends the user to sign in" do
+        do_request
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    describe "while logged in" do
+      before { sign_in user }
+
+      describe "and the user does not already have a request pending" do
+        it "creates a new training request" do
+          expect { do_request }.to change(TrainingRequest, :count).by(1)
+        end
+
+        it "sends an email" do
+          expect { do_request }.to change(ActionMailer::Base.deliveries, :count).by(1)
+        end
+
+        describe "no contacts are assigned" do
+          let(:training_request_contacts) { "" }
+          it "does not send an email" do
+            expect { do_request }.not_to change(ActionMailer::Base.deliveries, :count)
+          end
+        end
+      end
+
+      describe "but the user has a request pending already" do
+        before { TrainingRequest.create!(user: user, product: product) }
+
+        it "does not create the training request" do
+          expect { do_request }.not_to change(TrainingRequest, :count)
+        end
+
+        it "does not send an email" do
+          expect { do_request }.not_to change(ActionMailer::Base.deliveries, :count)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/training_requests_controller_spec.rb
+++ b/spec/controllers/training_requests_controller_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-# require 'controller_spec_helper'
 
 RSpec.describe TrainingRequestsController do
   let(:facility) { FactoryGirl.create(:setup_facility) }

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -526,16 +526,37 @@ RSpec.describe Product do
     describe "a single address" do
       let(:contacts) { "testing@example.com" }
       it { is_expected.to eq ["testing@example.com"] }
+      it "is valid" do
+        product.valid?
+        expect(product.errors).not_to include(:training_request_contacts)
+      end
     end
 
     describe "multiple addresses" do
       let(:contacts) { "testing@example.com, test2@nucore.com" }
       it { is_expected.to eq ["testing@example.com", "test2@nucore.com"] }
+      it "is valid" do
+        product.valid?
+        expect(product.errors).not_to include(:training_request_contacts)
+      end
     end
 
     describe "some extra commas in there" do
-      let(:contacts) { "testing@example.com,, ,test2@nucore.com," }
-      it { is_expected.to eq ["testing@example.com", "test2@nucore.com"] }
+      let(:contacts) { "testing@example.com,, ,test2@nucore.com,test-something+other@test.com" }
+      it { is_expected.to eq ["testing@example.com", "test2@nucore.com", "test-something+other@test.com"] }
+      it "is valid" do
+        product.valid?
+        expect(product.errors).not_to include(:training_request_contacts)
+      end
+    end
+
+    describe "invalid emails" do
+      let(:contacts) { "valid@tablexi.com, invalid@ " }
+      it { is_expected.to eq ["valid@tablexi.com", "invalid@"] }
+      it "is invalid" do
+        expect(product).to be_invalid
+        expect(product.errors).to include(:training_request_contacts)
+      end
     end
   end
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,509 +1,557 @@
 require "rails_helper"
 
 RSpec.describe Product do
-  subject(:product) { create(:instrument_requiring_approval) }
+  describe "with everything configured" do
+    subject(:product) { create(:instrument_requiring_approval) }
 
-  let(:access_group) { create(:product_access_group, product: product) }
-  let(:facility) { @facility }
-  let!(:product_user) { product.product_users.create(product: product, user: user, approved_by: user.id) }
-  let(:schedule_rule) { product.schedule_rules.create(attributes_for :schedule_rule) }
-  let(:user) { create(:user) }
+    let(:access_group) { create(:product_access_group, product: product) }
+    let(:facility) { @facility }
+    let!(:product_user) { product.product_users.create(product: product, user: user, approved_by: user.id) }
+    let(:schedule_rule) { product.schedule_rules.create(attributes_for :schedule_rule) }
+    let(:user) { create(:user) }
 
-  class TestProduct < Product
-    def account_required
-      false
+    class TestProduct < Product
+      def account_required
+        false
+      end
     end
-  end
 
-  before :each do
-    @facility         = FactoryGirl.create(:facility)
-    @facility_account = @facility.facility_accounts.create(FactoryGirl.attributes_for(:facility_account))
-  end
-
-  it "should not create using factory" do
-    @product = Product.create(FactoryGirl.attributes_for(:item, :facility_account_id => @facility_account.id))
-    expect(@product.errors[:type]).not_to be_nil
-  end
-
-  context 'with item' do
     before :each do
-      @item = @facility.items.create(FactoryGirl.attributes_for(:item, :facility_account_id => @facility_account.id))
+      @facility         = FactoryGirl.create(:facility)
+      @facility_account = @facility.facility_accounts.create(FactoryGirl.attributes_for(:facility_account))
     end
 
-    it "should create map to default price groups" do
-      expect(PriceGroupProduct.where(product_id: @item.id).count)
-        .to eq PriceGroup.globals.count
-      expect(PriceGroupProduct.find_by_product_id_and_price_group_id(@item.id, PriceGroup.base.first.id)).not_to be_nil
-      expect(PriceGroupProduct.find_by_product_id_and_price_group_id(@item.id, PriceGroup.external.first.id)).not_to be_nil
+    it "should not create using factory" do
+      @product = Product.create(FactoryGirl.attributes_for(:item, :facility_account_id => @facility_account.id))
+      expect(@product.errors[:type]).not_to be_nil
     end
 
-    it 'should give correct initial order status' do
-      os=OrderStatus.inprocess.first
-      @item.update_attribute(:initial_order_status_id, os.id)
-      expect(@item.initial_order_status).to eq(os)
-    end
-
-    it 'should give default order status if status not set' do
-      expect(Item.new.initial_order_status).to eq(OrderStatus.default_order_status)
-    end
-  end
-
-  context "with price policies" do
-    subject(:instrument) { create(:instrument_requiring_approval) }
-
-    before { instrument.price_policies.each(&:delete) }
-
-    let!(:current_price_policies) do
-      3.times.map do
-        create(:instrument_price_policy,
-          product: instrument,
-          start_date: 3.days.ago,
-          expire_date: 3.days.from_now,
-        )
-      end
-    end
-
-    let!(:past_price_policies) do
-      [4,1,5,3,2].map do |n|
-        create(:instrument_price_policy,
-          product: instrument,
-          start_date: n.months.ago,
-          expire_date: n.months.ago + 2.weeks,
-        )
-      end
-    end
-
-    let!(:upcoming_price_policies) do
-      [4,1,5,3,2].map do |n|
-        create(:instrument_price_policy,
-          product: instrument,
-          start_date: n.months.from_now,
-          expire_date: n.months.from_now + 2.weeks,
-        )
-      end
-    end
-
-    context "#current_price_policies" do
-      it "returns current price policies" do
-        expect(instrument.current_price_policies).to eq current_price_policies
-      end
-    end
-
-    context "#past_price_policies" do
-      it "returns past_price_policies" do
-        expect(instrument.past_price_policies).to eq past_price_policies
-      end
-    end
-
-    context "#past_price_policies_grouped_by_start_date" do
-      let(:policies) { instrument.past_price_policies_grouped_by_start_date }
-
-      it "groups and sorts policies in descending chronological order" do
-        expect(policies.keys).to eq policies.keys.sort.reverse
-      end
-    end
-
-    context "#upcoming_price_policies" do
-      it "returns upcoming_price_policies" do
-        expect(instrument.upcoming_price_policies).to eq upcoming_price_policies
-      end
-    end
-
-    context "#upcoming_price_policies_grouped_by_start_date" do
-      let(:policies) { instrument.upcoming_price_policies_grouped_by_start_date }
-
-      it "groups and sorts policies in ascending chronological order" do
-        expect(policies.keys).to eq policies.keys.sort
-      end
-    end
-  end
-
-  context 'email' do
-    before :each do
-      @facility = FactoryGirl.create(:facility, :email => 'facility@example.com')
-      @product = TestProduct.create!(:contact_email => 'product@example.com', :facility => @facility, :name => 'Test Product', :url_name => 'test')
-    end
-
-    before :all do
-      SettingsHelper::enable_feature(:expense_accounts, false)
-    end
-
-    after :all do
-      reset_settings
-    end
-
-    context 'product specific enabled' do
-      before :all do
-        @original_setting = SettingsHelper::feature_on? :product_specific_contacts
-        SettingsHelper::enable_feature(:product_specific_contacts)
-      end
-      after :all do
-        SettingsHelper::enable_feature(:product_specific_contacts, @original_setting)
-      end
-
-      it "should return the product's email if it has it" do
-        expect(@product.email).to eq('product@example.com')
-      end
-      it "should return the facility's email if no product email" do
-        @product.contact_email = ''
-        expect(@product.email).to eq('facility@example.com')
-      end
-      it 'should validate with the product email set' do
-        expect(@product).to be_valid
-      end
-      it "should validate with the facility's email set" do
-        @product.contact_email = ''
-        expect(@product).to be_valid
-      end
-      it 'should not validate without an email on either product or facility' do
-        @facility.update_attributes!(:email => '')
-        @product.contact_email = ''
-        expect(@product).not_to be_valid
-        expect(@product.errors.full_messages).to include "Contact email must be set on either the product or the facility"
-      end
-    end
-    context 'product specific disabled' do
-      before :all do
-        @original_setting = SettingsHelper::feature_on? :product_specific_contacts
-        SettingsHelper::enable_feature(:product_specific_contacts, false)
-      end
-      after :all do
-        SettingsHelper::enable_feature(:product_specific_contacts, @original_setting)
-      end
-      it "should return the facility's email address even if the product has an email" do
-        expect(@product.email).to eq('facility@example.com')
-      end
-      it "should validate if the product email is set" do
-        expect(@product).to be_valid
-      end
-      it "should validate if the product email is not set, but the the facility is" do
-        @product.contact_email = ''
-        expect(@product).to be_valid
-      end
-      it "should validate even if the facility's email is blank" do
-        @facility.update_attributes!(:email => '')
-        @product.contact_email = ''
-        expect(@product).to be_valid
-      end
-    end
-  end
-
-  context 'can_purchase?' do
-    class TestPricePolicy < PricePolicy
-    end
-    before :each do
-      @product = TestProduct.create!(:facility => @facility, :name => 'Test Product', :url_name => 'test')
-      @price_group = FactoryGirl.create(:price_group, :facility => @facility)
-      @price_group2 = FactoryGirl.create(:price_group, :facility => @facility)
-      @user = FactoryGirl.create(:user)
-      FactoryGirl.create(:user_price_group_member, :user => @user, :price_group => @price_group)
-      @user.reload
-
-      @user_price_group_ids = @user.price_groups.map(&:id)
-    end
-    it 'should not be purchasable if it is archived' do
-      @product.update_attributes :is_archived => true
-      expect(@product).not_to be_available_for_purchase
-    end
-
-    it 'should not be purchasable if the facility is inactive' do
-      @product.facility.update_attributes :is_active => false
-      expect(@product).not_to be_available_for_purchase
-    end
-
-    it 'should not be purchasable if you pass it empty groups' do
-      expect(@product).not_to be_can_purchase([])
-    end
-
-    it "should not be purchasable if there are no pricing rules ever" do
-      expect(@product).not_to be_can_purchase(@user_price_group_ids)
-    end
-
-    it "should not be purchasable if there is no price rule for a user, but there are current price rules" do
-      @price_policy = TestPricePolicy.create!(:price_group => @price_group2,
-                                              :product => @product,
-                                              :start_date => Time.zone.now - 1.day,
-                                              :expire_date => Time.zone.now + 7.days,
-                                              :can_purchase => true)
-      expect(@product).not_to be_can_purchase(@user_price_group_ids)
-    end
-
-    it "should be purchasable if there is a current price rule for the user's group" do
-      @price_policy = TestPricePolicy.create!(:price_group => @price_group,
-                                              :product => @product,
-                                              :start_date => Time.zone.now - 1.day,
-                                              :expire_date => Time.zone.now + 7.days,
-                                              :can_purchase => true)
-      expect(@product).to be_can_purchase(@user_price_group_ids)
-    end
-
-    it "should be purchasable if the user has an expired price rule where they were allowed to purchase" do
-      @price_policy = TestPricePolicy.create!(:price_group => @price_group,
-                                              :product => @product,
-                                              :start_date => Time.zone.now - 7.days,
-                                              :expire_date => Time.zone.now - 1.day,
-                                              :can_purchase => true)
-      expect(@product).to be_can_purchase(@user_price_group_ids)
-    end
-
-    it "should not be purchasable if there is a current rule, but marked as can_purchase = false" do
-      @price_policy = TestPricePolicy.create!(:price_group => @price_group,
-                                              :product => @product,
-                                              :start_date => Time.zone.now - 1.day,
-                                              :expire_date => Time.zone.now + 7.days,
-                                              :can_purchase => false)
-      expect(@product).not_to be_can_purchase(@user_price_group_ids)
-    end
-
-    it 'should not be purchasable if the most recent expired policy is marked can_purchase = false' do
-      @price_policy = TestPricePolicy.create!(:price_group => @price_group,
-                                              :product => @product,
-                                              :start_date => Time.zone.now - 7.day,
-                                              :expire_date => Time.zone.now - 6.days,
-                                              :can_purchase => true)
-      @price_policy2 = TestPricePolicy.create!(:price_group => @price_group,
-                                              :product => @product,
-                                              :start_date => Time.zone.now - 5.day,
-                                              :expire_date => Time.zone.now + 4.days,
-                                              :can_purchase => false)
-      expect(@product).not_to be_can_purchase(@user_price_group_ids)
-    end
-
-    it 'should be purchasable if the most recent expired policy is can_purchase, but old ones arent' do
-      @price_policy = TestPricePolicy.create!(:price_group => @price_group,
-                                              :product => @product,
-                                              :start_date => Time.zone.now - 7.day,
-                                              :expire_date => Time.zone.now - 6.days,
-                                              :can_purchase => false)
-      @price_policy2 = TestPricePolicy.create!(:price_group => @price_group,
-                                              :product => @product,
-                                              :start_date => Time.zone.now - 5.day,
-                                              :expire_date => Time.zone.now + 4.days,
-                                              :can_purchase => true)
-      expect(@product).to be_can_purchase(@user_price_group_ids)
-    end
-
-    it 'should be purchasable if there is a current policy with can_purchase, but a future one that cant' do
-      @current_price_policy = TestPricePolicy.create!(:price_group => @price_group,
-                                              :product => @product,
-                                              :start_date => Time.zone.now - 7.day,
-                                              :expire_date => Time.zone.now + 1.day,
-                                              :can_purchase => true)
-      @future_price_policy2 = TestPricePolicy.create!(:price_group => @price_group,
-                                              :product => @product,
-                                              :start_date => Time.zone.now + 2.day,
-                                              :expire_date => Time.zone.now + 4.days,
-                                              :can_purchase => false)
-      expect(@product.current_price_policies).to eq([@current_price_policy])
-      expect(@product).to be_can_purchase(@user_price_group_ids)
-    end
-
-    it 'should not be purchasable if there is a current policy without can_purchase, but a future one that can' do
-      @current_price_policy = TestPricePolicy.create!(:price_group => @price_group,
-                                                       :product => @product,
-                                                       :start_date => Time.zone.now - 7.day,
-                                                       :expire_date => Time.zone.now + 1.day,
-                                                       :can_purchase => false)
-      @future_price_policy2 = TestPricePolicy.create!(:price_group => @price_group,
-                                                      :product => @product,
-                                                      :start_date => Time.zone.now + 2.day,
-                                                      :expire_date => Time.zone.now + 4.days,
-                                                      :can_purchase => true)
-      expect(@product).not_to be_can_purchase(@user_price_group_ids)
-    end
-    it 'should be purchasable if there are no current policies, but two future policies, one of which is purchasable and one is not' do
-      expect(@product.current_price_policies).to be_empty
-      @price_policy_pg1 = TestPricePolicy.create!(:price_group => @price_group,
-                                                  :product => @product,
-                                                  :start_date => Time.zone.now + 2.day,
-                                                  :expire_date => Time.zone.now + 4.days,
-                                                  :can_purchase => true)
-      @price_policy_pg2 = TestPricePolicy.create!(:price_group => @price_group2,
-                                                      :product => @product,
-                                                      :start_date => Time.zone.now + 2.day,
-                                                      :expire_date => Time.zone.now + 4.days + 1.second,
-                                                      :can_purchase => false)
-      FactoryGirl.create(:user_price_group_member, :user => @user, :price_group => @price_group2)
-      @user_price_group_ids = @user.reload.price_groups.map(&:id)
-      expect(@product).to be_can_purchase(@user_price_group_ids)
-    end
-
-    it 'should not be purchasable if there are no current policies, and most recent for each group cannot can_purchase' do
-      @price_policy_pg1_1 = TestPricePolicy.create!(:price_group => @price_group,
-                                                  :product => @product,
-                                                  :start_date => Time.zone.now - 7.days,
-                                                  :expire_date => Time.zone.now - 5.days,
-                                                  :can_purchase => false)
-      @price_policy_pg1_2 = TestPricePolicy.create!(:price_group => @price_group,
-                                                  :product => @product,
-                                                  :start_date => Time.zone.now - 4.days,
-                                                  :expire_date => Time.zone.now - 4.days,
-                                                  :can_purchase => false)
-
-      @price_policy_pg2_1 = TestPricePolicy.create!(:price_group => @price_group2,
-                                                  :product => @product,
-                                                  :start_date => Time.zone.now - 7.days,
-                                                  :expire_date => Time.zone.now - 5.days,
-                                                  :can_purchase => false)
-      @price_policy_pg2_2 = TestPricePolicy.create!(:price_group => @price_group2,
-                                                  :product => @product,
-                                                  :start_date => Time.zone.now - 5.days,
-                                                  :expire_date => Time.zone.now - 4.days,
-                                                  :can_purchase => false)
-      FactoryGirl.create(:user_price_group_member, :user => @user, :price_group => @price_group2)
-      @user_price_group_ids = @user.reload.price_groups.map(&:id)
-      expect(@product).not_to be_can_purchase(@user_price_group_ids)
-
-    end
-  end
-
-  describe 'accessories' do
-    before :each do
-      create :accessory
-      dup = ProductAccessory.first.dup
-      dup.deleted_at = Time.zone.now
-      dup.save!
-    end
-
-    let(:product_accessory) { ProductAccessory.first.product }
-
-    it 'has 1 active accessory' do
-      expect(product_accessory.accessories.size).to eq 1
-    end
-
-    it 'has 1 active product accessory' do
-      expect(product_accessory.product_accessories.size).to eq 1
-    end
-  end
-
-  context '#access_group_for_user' do
-    context 'with an access group' do
+    context 'with item' do
       before :each do
-        schedule_rule.product_access_groups = [ access_group ]
+        @item = @facility.items.create(FactoryGirl.attributes_for(:item, :facility_account_id => @facility_account.id))
       end
 
-      context 'with a user in the access group' do
-        before :each do
-          product_user.product_access_group = access_group
-          product_user.save
-        end
+      it "should create map to default price groups" do
+        expect(PriceGroupProduct.where(product_id: @item.id).count)
+          .to eq PriceGroup.globals.count
+        expect(PriceGroupProduct.find_by_product_id_and_price_group_id(@item.id, PriceGroup.base.first.id)).not_to be_nil
+        expect(PriceGroupProduct.find_by_product_id_and_price_group_id(@item.id, PriceGroup.external.first.id)).not_to be_nil
+      end
 
-        it 'returns the access group' do
-          expect(product.access_group_for_user(user)).to eq access_group
+      it 'should give correct initial order status' do
+        os=OrderStatus.inprocess.first
+        @item.update_attribute(:initial_order_status_id, os.id)
+        expect(@item.initial_order_status).to eq(os)
+      end
+
+      it 'should give default order status if status not set' do
+        expect(Item.new.initial_order_status).to eq(OrderStatus.default_order_status)
+      end
+    end
+
+    context "with price policies" do
+      subject(:instrument) { create(:instrument_requiring_approval) }
+
+      before { instrument.price_policies.each(&:delete) }
+
+      let!(:current_price_policies) do
+        3.times.map do
+          create(:instrument_price_policy,
+            product: instrument,
+            start_date: 3.days.ago,
+            expire_date: 3.days.from_now,
+          )
         end
       end
 
-      context 'with a user not in the access group' do
-        it 'returns no access group' do
-          expect(product.access_group_for_user(user)).to be_nil
+      let!(:past_price_policies) do
+        [4,1,5,3,2].map do |n|
+          create(:instrument_price_policy,
+            product: instrument,
+            start_date: n.months.ago,
+            expire_date: n.months.ago + 2.weeks,
+          )
+        end
+      end
+
+      let!(:upcoming_price_policies) do
+        [4,1,5,3,2].map do |n|
+          create(:instrument_price_policy,
+            product: instrument,
+            start_date: n.months.from_now,
+            expire_date: n.months.from_now + 2.weeks,
+          )
+        end
+      end
+
+      context "#current_price_policies" do
+        it "returns current price policies" do
+          expect(instrument.current_price_policies).to eq current_price_policies
+        end
+      end
+
+      context "#past_price_policies" do
+        it "returns past_price_policies" do
+          expect(instrument.past_price_policies).to eq past_price_policies
+        end
+      end
+
+      context "#past_price_policies_grouped_by_start_date" do
+        let(:policies) { instrument.past_price_policies_grouped_by_start_date }
+
+        it "groups and sorts policies in descending chronological order" do
+          expect(policies.keys).to eq policies.keys.sort.reverse
+        end
+      end
+
+      context "#upcoming_price_policies" do
+        it "returns upcoming_price_policies" do
+          expect(instrument.upcoming_price_policies).to eq upcoming_price_policies
+        end
+      end
+
+      context "#upcoming_price_policies_grouped_by_start_date" do
+        let(:policies) { instrument.upcoming_price_policies_grouped_by_start_date }
+
+        it "groups and sorts policies in ascending chronological order" do
+          expect(policies.keys).to eq policies.keys.sort
         end
       end
     end
 
-    it 'without an access group' do
-      expect(product.access_group_for_user(user)).to be_nil
-    end
-  end
+    context 'email' do
+      before :each do
+        @facility = FactoryGirl.create(:facility, :email => 'facility@example.com')
+        @product = TestProduct.create!(:contact_email => 'product@example.com', :facility => @facility, :name => 'Test Product', :url_name => 'test')
+      end
 
-  describe "#can_be_used_by?" do
-    context "when the product requires approval" do
-      before { schedule_rule.product_access_groups = [access_group] }
+      before :all do
+        SettingsHelper::enable_feature(:expense_accounts, false)
+      end
 
-      context "an access list exists for the user" do
-        before :each do
-          product_user = product_access_group = access_group
-          product_user.save
+      after :all do
+        reset_settings
+      end
+
+      context 'product specific enabled' do
+        before :all do
+          @original_setting = SettingsHelper::feature_on? :product_specific_contacts
+          SettingsHelper::enable_feature(:product_specific_contacts)
         end
+        after :all do
+          SettingsHelper::enable_feature(:product_specific_contacts, @original_setting)
+        end
+
+        it "should return the product's email if it has it" do
+          expect(@product.email).to eq('product@example.com')
+        end
+        it "should return the facility's email if no product email" do
+          @product.contact_email = ''
+          expect(@product.email).to eq('facility@example.com')
+        end
+        it 'should validate with the product email set' do
+          expect(@product).to be_valid
+        end
+        it "should validate with the facility's email set" do
+          @product.contact_email = ''
+          expect(@product).to be_valid
+        end
+        it 'should not validate without an email on either product or facility' do
+          @facility.update_attributes!(:email => '')
+          @product.contact_email = ''
+          expect(@product).not_to be_valid
+          expect(@product.errors.full_messages).to include "Contact email must be set on either the product or the facility"
+        end
+      end
+      context 'product specific disabled' do
+        before :all do
+          @original_setting = SettingsHelper::feature_on? :product_specific_contacts
+          SettingsHelper::enable_feature(:product_specific_contacts, false)
+        end
+        after :all do
+          SettingsHelper::enable_feature(:product_specific_contacts, @original_setting)
+        end
+        it "should return the facility's email address even if the product has an email" do
+          expect(@product.email).to eq('facility@example.com')
+        end
+        it "should validate if the product email is set" do
+          expect(@product).to be_valid
+        end
+        it "should validate if the product email is not set, but the the facility is" do
+          @product.contact_email = ''
+          expect(@product).to be_valid
+        end
+        it "should validate even if the facility's email is blank" do
+          @facility.update_attributes!(:email => '')
+          @product.contact_email = ''
+          expect(@product).to be_valid
+        end
+      end
+    end
+
+    context 'can_purchase?' do
+      class TestPricePolicy < PricePolicy
+      end
+      before :each do
+        @product = TestProduct.create!(:facility => @facility, :name => 'Test Product', :url_name => 'test')
+        @price_group = FactoryGirl.create(:price_group, :facility => @facility)
+        @price_group2 = FactoryGirl.create(:price_group, :facility => @facility)
+        @user = FactoryGirl.create(:user)
+        FactoryGirl.create(:user_price_group_member, :user => @user, :price_group => @price_group)
+        @user.reload
+
+        @user_price_group_ids = @user.price_groups.map(&:id)
+      end
+      it 'should not be purchasable if it is archived' do
+        @product.update_attributes :is_archived => true
+        expect(@product).not_to be_available_for_purchase
+      end
+
+      it 'should not be purchasable if the facility is inactive' do
+        @product.facility.update_attributes :is_active => false
+        expect(@product).not_to be_available_for_purchase
+      end
+
+      it 'should not be purchasable if you pass it empty groups' do
+        expect(@product).not_to be_can_purchase([])
+      end
+
+      it "should not be purchasable if there are no pricing rules ever" do
+        expect(@product).not_to be_can_purchase(@user_price_group_ids)
+      end
+
+      it "should not be purchasable if there is no price rule for a user, but there are current price rules" do
+        @price_policy = TestPricePolicy.create!(:price_group => @price_group2,
+                                                :product => @product,
+                                                :start_date => Time.zone.now - 1.day,
+                                                :expire_date => Time.zone.now + 7.days,
+                                                :can_purchase => true)
+        expect(@product).not_to be_can_purchase(@user_price_group_ids)
+      end
+
+      it "should be purchasable if there is a current price rule for the user's group" do
+        @price_policy = TestPricePolicy.create!(:price_group => @price_group,
+                                                :product => @product,
+                                                :start_date => Time.zone.now - 1.day,
+                                                :expire_date => Time.zone.now + 7.days,
+                                                :can_purchase => true)
+        expect(@product).to be_can_purchase(@user_price_group_ids)
+      end
+
+      it "should be purchasable if the user has an expired price rule where they were allowed to purchase" do
+        @price_policy = TestPricePolicy.create!(:price_group => @price_group,
+                                                :product => @product,
+                                                :start_date => Time.zone.now - 7.days,
+                                                :expire_date => Time.zone.now - 1.day,
+                                                :can_purchase => true)
+        expect(@product).to be_can_purchase(@user_price_group_ids)
+      end
+
+      it "should not be purchasable if there is a current rule, but marked as can_purchase = false" do
+        @price_policy = TestPricePolicy.create!(:price_group => @price_group,
+                                                :product => @product,
+                                                :start_date => Time.zone.now - 1.day,
+                                                :expire_date => Time.zone.now + 7.days,
+                                                :can_purchase => false)
+        expect(@product).not_to be_can_purchase(@user_price_group_ids)
+      end
+
+      it 'should not be purchasable if the most recent expired policy is marked can_purchase = false' do
+        @price_policy = TestPricePolicy.create!(:price_group => @price_group,
+                                                :product => @product,
+                                                :start_date => Time.zone.now - 7.day,
+                                                :expire_date => Time.zone.now - 6.days,
+                                                :can_purchase => true)
+        @price_policy2 = TestPricePolicy.create!(:price_group => @price_group,
+                                                :product => @product,
+                                                :start_date => Time.zone.now - 5.day,
+                                                :expire_date => Time.zone.now + 4.days,
+                                                :can_purchase => false)
+        expect(@product).not_to be_can_purchase(@user_price_group_ids)
+      end
+
+      it 'should be purchasable if the most recent expired policy is can_purchase, but old ones arent' do
+        @price_policy = TestPricePolicy.create!(:price_group => @price_group,
+                                                :product => @product,
+                                                :start_date => Time.zone.now - 7.day,
+                                                :expire_date => Time.zone.now - 6.days,
+                                                :can_purchase => false)
+        @price_policy2 = TestPricePolicy.create!(:price_group => @price_group,
+                                                :product => @product,
+                                                :start_date => Time.zone.now - 5.day,
+                                                :expire_date => Time.zone.now + 4.days,
+                                                :can_purchase => true)
+        expect(@product).to be_can_purchase(@user_price_group_ids)
+      end
+
+      it 'should be purchasable if there is a current policy with can_purchase, but a future one that cant' do
+        @current_price_policy = TestPricePolicy.create!(:price_group => @price_group,
+                                                :product => @product,
+                                                :start_date => Time.zone.now - 7.day,
+                                                :expire_date => Time.zone.now + 1.day,
+                                                :can_purchase => true)
+        @future_price_policy2 = TestPricePolicy.create!(:price_group => @price_group,
+                                                :product => @product,
+                                                :start_date => Time.zone.now + 2.day,
+                                                :expire_date => Time.zone.now + 4.days,
+                                                :can_purchase => false)
+        expect(@product.current_price_policies).to eq([@current_price_policy])
+        expect(@product).to be_can_purchase(@user_price_group_ids)
+      end
+
+      it 'should not be purchasable if there is a current policy without can_purchase, but a future one that can' do
+        @current_price_policy = TestPricePolicy.create!(:price_group => @price_group,
+                                                         :product => @product,
+                                                         :start_date => Time.zone.now - 7.day,
+                                                         :expire_date => Time.zone.now + 1.day,
+                                                         :can_purchase => false)
+        @future_price_policy2 = TestPricePolicy.create!(:price_group => @price_group,
+                                                        :product => @product,
+                                                        :start_date => Time.zone.now + 2.day,
+                                                        :expire_date => Time.zone.now + 4.days,
+                                                        :can_purchase => true)
+        expect(@product).not_to be_can_purchase(@user_price_group_ids)
+      end
+      it 'should be purchasable if there are no current policies, but two future policies, one of which is purchasable and one is not' do
+        expect(@product.current_price_policies).to be_empty
+        @price_policy_pg1 = TestPricePolicy.create!(:price_group => @price_group,
+                                                    :product => @product,
+                                                    :start_date => Time.zone.now + 2.day,
+                                                    :expire_date => Time.zone.now + 4.days,
+                                                    :can_purchase => true)
+        @price_policy_pg2 = TestPricePolicy.create!(:price_group => @price_group2,
+                                                        :product => @product,
+                                                        :start_date => Time.zone.now + 2.day,
+                                                        :expire_date => Time.zone.now + 4.days + 1.second,
+                                                        :can_purchase => false)
+        FactoryGirl.create(:user_price_group_member, :user => @user, :price_group => @price_group2)
+        @user_price_group_ids = @user.reload.price_groups.map(&:id)
+        expect(@product).to be_can_purchase(@user_price_group_ids)
+      end
+
+      it 'should not be purchasable if there are no current policies, and most recent for each group cannot can_purchase' do
+        @price_policy_pg1_1 = TestPricePolicy.create!(:price_group => @price_group,
+                                                    :product => @product,
+                                                    :start_date => Time.zone.now - 7.days,
+                                                    :expire_date => Time.zone.now - 5.days,
+                                                    :can_purchase => false)
+        @price_policy_pg1_2 = TestPricePolicy.create!(:price_group => @price_group,
+                                                    :product => @product,
+                                                    :start_date => Time.zone.now - 4.days,
+                                                    :expire_date => Time.zone.now - 4.days,
+                                                    :can_purchase => false)
+
+        @price_policy_pg2_1 = TestPricePolicy.create!(:price_group => @price_group2,
+                                                    :product => @product,
+                                                    :start_date => Time.zone.now - 7.days,
+                                                    :expire_date => Time.zone.now - 5.days,
+                                                    :can_purchase => false)
+        @price_policy_pg2_2 = TestPricePolicy.create!(:price_group => @price_group2,
+                                                    :product => @product,
+                                                    :start_date => Time.zone.now - 5.days,
+                                                    :expire_date => Time.zone.now - 4.days,
+                                                    :can_purchase => false)
+        FactoryGirl.create(:user_price_group_member, :user => @user, :price_group => @price_group2)
+        @user_price_group_ids = @user.reload.price_groups.map(&:id)
+        expect(@product).not_to be_can_purchase(@user_price_group_ids)
+
+      end
+    end
+
+    describe 'accessories' do
+      before :each do
+        create :accessory
+        dup = ProductAccessory.first.dup
+        dup.deleted_at = Time.zone.now
+        dup.save!
+      end
+
+      let(:product_accessory) { ProductAccessory.first.product }
+
+      it 'has 1 active accessory' do
+        expect(product_accessory.accessories.size).to eq 1
+      end
+
+      it 'has 1 active product accessory' do
+        expect(product_accessory.product_accessories.size).to eq 1
+      end
+    end
+
+    context '#access_group_for_user' do
+      context 'with an access group' do
+        before :each do
+          schedule_rule.product_access_groups = [ access_group ]
+        end
+
+        context 'with a user in the access group' do
+          before :each do
+            product_user.product_access_group = access_group
+            product_user.save
+          end
+
+          it 'returns the access group' do
+            expect(product.access_group_for_user(user)).to eq access_group
+          end
+        end
+
+        context 'with a user not in the access group' do
+          it 'returns no access group' do
+            expect(product.access_group_for_user(user)).to be_nil
+          end
+        end
+      end
+
+      it 'without an access group' do
+        expect(product.access_group_for_user(user)).to be_nil
+      end
+    end
+
+    describe "#can_be_used_by?" do
+      context "when the product requires approval" do
+        before { schedule_rule.product_access_groups = [access_group] }
+
+        context "an access list exists for the user" do
+          before :each do
+            product_user = product_access_group = access_group
+            product_user.save
+          end
+
+          it "allows access" do
+            expect(product.can_be_used_by?(user)).to be true
+          end
+        end
+
+        context "an access list does not exist for the user" do
+          let(:denied_user) { build_stubbed(:user) }
+
+          it "denies access" do
+            expect(product.can_be_used_by?(denied_user)).to be false
+          end
+        end
+      end
+
+      context "when the product does not require approval" do
+        before { product.update_attribute(:requires_approval, false) }
 
         it "allows access" do
           expect(product.can_be_used_by?(user)).to be true
         end
       end
+    end
 
-      context "an access list does not exist for the user" do
-        let(:denied_user) { build_stubbed(:user) }
+    context '#find_product_user' do
+      context 'when a user is a product user' do
+        it 'finds the product_user' do
+          expect(product.find_product_user(user)).to eq product_user
+        end
+      end
 
-        it "denies access" do
-          expect(product.can_be_used_by?(denied_user)).to be false
+      context 'when a user is not a product user' do
+        let(:other_user) { create(:user) }
+
+        it 'does not find a product_user' do
+          expect(product.find_product_user(other_user)).to be_nil
         end
       end
     end
 
-    context "when the product does not require approval" do
-      before { product.update_attribute(:requires_approval, false) }
+    context '#has_access_list?' do
+      context 'when its type supports access groups' do
+        context 'when it has an access group' do
+          before :each do
+            product.product_access_groups = [ access_group ]
+          end
 
-      it "allows access" do
-        expect(product.can_be_used_by?(user)).to be true
-      end
-    end
-  end
-
-  context '#find_product_user' do
-    context 'when a user is a product user' do
-      it 'finds the product_user' do
-        expect(product.find_product_user(user)).to eq product_user
-      end
-    end
-
-    context 'when a user is not a product user' do
-      let(:other_user) { create(:user) }
-
-      it 'does not find a product_user' do
-        expect(product.find_product_user(other_user)).to be_nil
-      end
-    end
-  end
-
-  context '#has_access_list?' do
-    context 'when its type supports access groups' do
-      context 'when it has an access group' do
-        before :each do
-          product.product_access_groups = [ access_group ]
+          it 'has an access list' do
+            expect(product.has_access_list?).to be true
+          end
         end
 
-        it 'has an access list' do
-          expect(product.has_access_list?).to be true
+        context 'when it has no access groups' do
+          it 'does not have an access list' do
+            expect(product.has_access_list?).to be false
+          end
         end
       end
 
-      context 'when it has no access groups' do
+      context 'when its type does not support access groups' do
+        let(:generic_item) { build(:setup_item) }
+
         it 'does not have an access list' do
-          expect(product.has_access_list?).to be false
+          expect(generic_item.has_access_list?).to be false
         end
       end
     end
 
-    context 'when its type does not support access groups' do
-      let(:generic_item) { build(:setup_item) }
+    context "url_name collisions" do
+      context "when a product's url_name exists in its facility" do
+        let(:new_product) { build(:instrument_requiring_approval, url_name: product.url_name, facility: product.facility) }
 
-      it 'does not have an access list' do
-        expect(generic_item.has_access_list?).to be false
+        it "is invalid" do
+          expect(new_product).to_not be_valid
+          expect(new_product.errors.messages).to include :url_name
+        end
+      end
+
+      context "when a product's url_name exists in another facility" do
+        let(:other_facility) { create(:facility) }
+        let(:new_product) { build(:instrument_requiring_approval, url_name: "product_name", facility: facility) }
+
+        before :each do
+          other_facility.facility_accounts.create(attributes_for(:facility_account))
+          create(:instrument_requiring_approval, url_name: "product_name", facility: other_facility)
+        end
+
+        it "is valid" do
+          expect(new_product).to be_valid
+        end
       end
     end
   end
 
-  context "url_name collisions" do
-    context "when a product's url_name exists in its facility" do
-      let(:new_product) { build(:instrument_requiring_approval, url_name: product.url_name, facility: product.facility) }
+  describe "#training_request_contacts" do
+    let(:product) { build(:item, training_request_contacts: contacts) }
+    subject(:emails) { product.training_request_contacts.to_a }
 
-      it "is invalid" do
-        expect(new_product).to_not be_valid
-        expect(new_product.errors.messages).to include :url_name
-      end
+    describe "blank" do
+      let(:contacts) { "" }
+      it { is_expected.to eq [] }
     end
 
-    context "when a product's url_name exists in another facility" do
-      let(:other_facility) { create(:facility) }
-      let(:new_product) { build(:instrument_requiring_approval, url_name: "product_name", facility: facility) }
+    describe "nil" do
+      let(:contacts) { nil }
+      it { is_expected.to eq [] }
+    end
 
-      before :each do
-        other_facility.facility_accounts.create(attributes_for(:facility_account))
-        create(:instrument_requiring_approval, url_name: "product_name", facility: other_facility)
-      end
+    describe "a single address" do
+      let(:contacts) { "testing@example.com" }
+      it { is_expected.to eq ["testing@example.com"] }
+    end
 
-      it "is valid" do
-        expect(new_product).to be_valid
-      end
+    describe "multiple addresses" do
+      let(:contacts) { "testing@example.com, test2@nucore.com" }
+      it { is_expected.to eq ["testing@example.com", "test2@nucore.com"] }
+    end
+
+    describe "some extra commas in there" do
+      let(:contacts) { "testing@example.com,, ,test2@nucore.com," }
+      it { is_expected.to eq ["testing@example.com", "test2@nucore.com"] }
+    end
+  end
+
+  describe "#training_request_contacts=" do
+    let(:product) { build(:item) }
+    let(:contacts) { "testing@example.com,, ,test2@nucore.com," }
+    let(:cleaned_contacts) { "testing@example.com, test2@nucore.com" }
+
+    it "cleans the attribute when doing =" do
+      product.training_request_contacts = contacts
+      expect(product.read_attribute(:training_request_contacts)).to eq(cleaned_contacts)
+    end
+
+    it "cleans the attribute when doing assigns_attributes" do
+      product.assign_attributes(training_request_contacts: contacts)
+      expect(product.read_attribute(:training_request_contacts)).to eq(cleaned_contacts)
     end
   end
 end


### PR DESCRIPTION
Admins can set a comma-separated list of email addresses who will receive
notification anytime a user submits a training request. If the field is left
blank, no emails will be sent.

This is on a per-instrument basis. We decided against any facility-level or
mass configuration.