### PR TITLE
[#88724] Error when editing a reconciled OD's reconcile note.

### DIFF
--- a/app/assets/javascripts/app/manage_orders.coffee
+++ b/app/assets/javascripts/app/manage_orders.coffee
@@ -106,9 +106,11 @@ class OrderDetailManagement
       $('.cancel-fee-option').toggle(parseInt($(this).val()) == cancel_id)
 
   disableForm: ->
+    obj = @
     form_elements = @$element.find('select,textarea,input')
     form_elements.prop 'disabled', ->
-      !($(this).hasClass('js-always-enabled') || $(this).is('[type=submit]'))
+      leaveEnabled = $(this).hasClass('js-always-enabled') || $(this).is('[type=submit]') || obj.isRailsFormInput(this)
+      !leaveEnabled
 
     # remove the submit button if all form elements are disabled
     any_enabled = form_elements.filter(':not([type=submit])').is(':not(:disabled)')
@@ -137,6 +139,8 @@ class OrderDetailManagement
       owner_name = $(this).find(':selected').data('account-owner')
       $(this).closest('.control-group').find('.account-owner').text(owner_name)
 
+  isRailsFormInput: (input) ->
+    $(input).is("[name=_method],[name=utf8],[name=authenticity_token]")
 
 $ ->
   prepareForm = ->


### PR DESCRIPTION
The `_method` input was being disabled, along with the `utf8` and `authentication_token`
when the other form fields were getting disabled. Because `_method=put` was not
being submitted, the router was treating it as a POST resulting in a route not
found.