### PR TITLE
[#88724] Ignore rails hidden form fields when deciding when to disable the submit button

### DIFF
--- a/app/assets/javascripts/app/manage_orders.coffee
+++ b/app/assets/javascripts/app/manage_orders.coffee
@@ -112,8 +112,11 @@ class OrderDetailManagement
       leaveEnabled = $(this).hasClass('js-always-enabled') || $(this).is('[type=submit]') || obj.isRailsFormInput(this)
       !leaveEnabled
 
-    # remove the submit button if all form elements are disabled
-    any_enabled = form_elements.filter(':not([type=submit])').is(':not(:disabled)')
+    # remove the submit button if all form elements are disabled (and ignore
+    # Rails hidden inputs)
+    any_enabled = form_elements.filter(':not([type=submit])')
+      .filter(":not(#{@railsFormInputSelector})")
+      .is(':not(:disabled)')
     form_elements.filter('[type=submit]').remove() unless any_enabled
 
   initReconcileNote: ->
@@ -140,7 +143,9 @@ class OrderDetailManagement
       $(this).closest('.control-group').find('.account-owner').text(owner_name)
 
   isRailsFormInput: (input) ->
-    $(input).is("[name=_method],[name=utf8],[name=authenticity_token]")
+    $(input).is(@railsFormInputSelector)
+
+  railsFormInputSelector: "[name=_method],[name=utf8],[name=authenticity_token]"
 
 $ ->
   prepareForm = ->


### PR DESCRIPTION
Proper behavior: if any visible/non rails input (utf8, _method) is active, then
the submit button should be enabled. If they are all disabled, then the submit
button should be disabled as well.

After the recent change where we don't disable the hidden utf8, etc fields, the
submit button was always visible.