### PR TITLE
Support account numbers with overridden fields

### DIFF
--- a/app/services/nufs_account_builder.rb
+++ b/app/services/nufs_account_builder.rb
@@ -22,7 +22,7 @@ class NufsAccountBuilder < AccountBuilder
   def set_expires_at
     account.set_expires_at!
   rescue AccountNumberFormatError => e
-    nil # do nothing
+    account.expires_at = Time.current
   end
 
 end

--- a/app/services/nufs_account_builder.rb
+++ b/app/services/nufs_account_builder.rb
@@ -6,8 +6,8 @@ class NufsAccountBuilder < AccountBuilder
 
   # Override strong_params for `build` account.
   def account_params_for_build
-    [ 
-      { account_number_parts: [:account_number] },
+    [
+      { account_number_parts: NufsAccount.account_number_field_names },
       :account_number,
       :description,
     ]
@@ -21,7 +21,8 @@ class NufsAccountBuilder < AccountBuilder
   # Sets `expires_at` via a factory.
   def set_expires_at
     account.set_expires_at!
-    account
+  rescue AccountNumberFormatError => e
+    nil # do nothing
   end
 
 end

--- a/app/support/accounts/account_number_sectionable.rb
+++ b/app/support/accounts/account_number_sectionable.rb
@@ -1,4 +1,12 @@
 module Accounts::AccountNumberSectionable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def account_number_field_names
+      new.account_number_fields.keys
+    end
+  end
+
   def account_number_fields
     { :account_number => { :required => true } }
   end


### PR DESCRIPTION
This fix allows NU and other sites with custom Validators (NU uses fund, dept, program, etc) to support
Strong params. 

It also handles the case of invalid chart strings raising
an error when it tries to set the expiration date (it should end up
swallowing the error).

This should have minimal effect on open, but is necessary in NU.
