### PR TITLE
[#120455] Support split accounts journaling

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -57,9 +57,19 @@ class Account < ActiveRecord::Base
     config.cross_facility?(self.name)
   end
 
-  # Returns true if this account type can assign an affiliate.
+  # Returns true if this account type supports affiliate.
   def self.using_affiliate?
     config.using_affiliate?(self.name)
+  end
+
+  # Returns true if this account type supports statements.
+  def self.using_statements?
+    config.using_statements?(self.name)
+  end
+
+  # Returns true if this account type supports journal.
+  def self.using_journal?
+    config.using_journal?(self.name)
   end
 
   def self.for_facility(facility)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -307,6 +307,13 @@ class Account < ActiveRecord::Base
     return @account_user
   end
 
+  # Optionally override this method for models that inherit from Account.
+  # Forces journal rows to be destroyed and recreated when an order detail is
+  # updated.
+  def recreate_journal_rows_on_order_detail_update?
+    false
+  end
+
   private
 
   def self.ids_with_orders(facility)

--- a/app/models/account_config.rb
+++ b/app/models/account_config.rb
@@ -33,6 +33,12 @@ class AccountConfig
     @affiliate_account_types ||= []
   end
 
+  # Returns an array of subclassed Account object names that support journal.
+  # Engines can append to this list.
+  def journal_account_types
+    @journal_account_types ||= ["NufsAccount"]
+  end
+
   # Given an subclassed `Account` name return a param-friendly string. Replaces
   # any backslashes with underscore to support namespaced class names.
   def account_type_to_param(account_type)
@@ -74,9 +80,19 @@ class AccountConfig
     global_account_types.include?(account_type.to_s.classify)
   end
 
-  # Returns true if this account type can assign an affiliate.
+  # Returns true if this account type supports affiliate.
   def using_affiliate?(account_type)
     affiliate_account_types.include?(account_type.to_s.classify)
+  end
+
+  # Returns true if this account type supports statements.
+  def using_statements?(account_type)
+    statement_account_types.include?(account_type.to_s.classify)
+  end
+
+  # Returns true if this account type supports journal.
+  def using_journal?(account_type)
+    journal_account_types.include?(account_type.to_s.classify)
   end
 
 end

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -4,57 +4,6 @@ class Journal < ActiveRecord::Base
   class CreationError < StandardError; end
 
   module Overridable
-    def create_journal_rows!(order_details)
-      recharge_by_product = {}
-      facility_ids_already_in_journal = Set.new
-      order_detail_ids = []
-      pending_facility_ids = Journal.facility_ids_with_pending_journals
-      row_errors = []
-      recharge_enabled=SettingsHelper.feature_on? :recharge_accounts
-
-      # create rows for each transaction
-      order_details.each do |od|
-        row_errors << "##{od} is already journaled in journal ##{od.journal_id}" if od.journal_id
-        account = od.account
-        od_facility_id = od.order.facility_id
-
-        # unless we've already encountered this facility_id during
-        # this call to create_journal_rows,
-        unless facility_ids_already_in_journal.member? od_facility_id
-
-          # check against facility_ids which actually have pending journals
-          # in the DB
-          if pending_facility_ids.member? od_facility_id
-            raise CreationError.new(I18n.t("activerecord.errors.models.journal.pending_overlap", label: od.to_s, facility: Facility.find(od_facility_id)))
-          end
-          facility_ids_already_in_journal.add(od_facility_id)
-        end
-
-        begin
-          ValidatorFactory.instance(account.account_number, od.product.account).account_is_open!(od.fulfilled_at)
-        rescue ValidatorError => e
-          row_errors << I18n.t("activerecord.errors.models.journal.invalid_account",
-            account_number: account.account_number_to_s,
-            validation_error: e.message
-          )
-        end
-
-        JournalRow.create!(journal_row_attributes_from_order_detail(od))
-        order_detail_ids << od.id
-        recharge_by_product[od.product_id] = recharge_by_product[od.product_id].to_f + od.total if recharge_enabled
-      end
-
-      # create rows for each recharge chart string
-      recharge_by_product.each_pair do |product_id, total|
-        product = Product.find(product_id)
-        JournalRow.create!(journal_row_attributes_from_product_and_total(product, total))
-      end
-
-      set_journal_for_order_details(order_detail_ids) if row_errors.blank?
-
-      row_errors.uniq
-    end
-
     def create_spreadsheet
       rows = journal_rows
       return false if rows.empty?
@@ -68,27 +17,6 @@ class Journal < ActiveRecord::Base
       # remove temp file
       File.unlink(temp_file.path) rescue nil
       status
-    end
-
-    private
-
-    def journal_row_attributes_from_order_detail(order_detail)
-      {
-        account: order_detail.product.account,
-        amount: order_detail.total,
-        description: order_detail.long_description,
-        journal_id: id,
-        order_detail_id: order_detail.id,
-      }
-    end
-
-    def journal_row_attributes_from_product_and_total(product, total)
-      {
-        account: product.facility_account.revenue_account,
-        amount: total * -1,
-        description: product.to_s,
-        journal_id: id,
-      }
     end
   end
 
@@ -141,6 +69,11 @@ class Journal < ActiveRecord::Base
     pending_facility_ids = Journal.connection.select_values(pending_facility_ids_sql)
 
     return pending_facility_ids
+  end
+
+  def create_journal_rows!(order_details)
+    builder = JournalRowBuilder.new(self, order_details).create
+    builder.errors.uniq
   end
 
   def facility_ids
@@ -257,9 +190,4 @@ class Journal < ActiveRecord::Base
     end
   end
 
-  def set_journal_for_order_details(order_detail_ids)
-    array_slice(order_detail_ids) do |id_slice|
-      OrderDetail.where(id: id_slice).update_all(journal_id: self.id)
-    end
-  end
 end

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -28,7 +28,7 @@ class Journal < ActiveRecord::Base
 
   has_many                :journal_rows
   belongs_to              :facility
-  has_many                :order_details, :through => :journal_rows
+  has_many                :order_details, through: :journal_rows, uniq: true
   belongs_to              :created_by_user, :class_name => 'User', :foreign_key => :created_by
 
   validates_presence_of   :reference, :updated_by, :on => :update

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -242,8 +242,8 @@ class OrderDetail < ActiveRecord::Base
   end
 
   scope :need_statement, lambda { |facility| {
-    :joins => [:product, :account],
-    :conditions => [
+    joins: [:product, :account],
+    conditions: [
       "products.facility_id = :facility_id
         AND order_details.state = :state
         AND problem = :problem
@@ -252,23 +252,29 @@ class OrderDetail < ActiveRecord::Base
         AND order_details.price_policy_id IS NOT NULL
         AND accounts.type IN (:account_types)
         AND (dispute_at IS NULL OR dispute_resolved_at IS NOT NULL)",
-      :facility_id => facility.id,
-      :state =>'complete',
-      :problem => false,
-      :reviewed_at => Time.zone.now,
-      :account_types => Account.config.statement_account_types
+      facility_id: facility.id,
+      state: 'complete',
+      problem: false,
+      reviewed_at: Time.zone.now,
+      account_types: Account.config.statement_account_types,
     ]
   }}
 
   scope :need_journal, lambda { {
-    :joins => [:product, :account],
-    :conditions => ['order_details.state = ?
-                     AND problem = ?
-                     AND reviewed_at <= ?
-                     AND accounts.type IN (?)
-                     AND journal_id IS NULL
-                     AND order_details.price_policy_id IS NOT NULL
-                     AND (dispute_at IS NULL OR dispute_resolved_at IS NOT NULL)', 'complete', false, Time.zone.now, Account.config.journal_account_types]
+    joins: [:product, :account],
+    conditions: [
+      "order_details.state = :state
+        AND problem = :problem
+        AND reviewed_at <= :reviewed_at
+        AND accounts.type IN (:account_types)
+        AND journal_id IS NULL
+        AND order_details.price_policy_id IS NOT NULL
+        AND (dispute_at IS NULL OR dispute_resolved_at IS NOT NULL)",
+      state: "complete",
+      problem: false,
+      reviewed_at: Time.zone.now,
+      account_types: Account.config.journal_account_types,
+    ]
   } }
 
   scope :statemented, lambda {|facility| {

--- a/app/services/converters/converter_factory.rb
+++ b/app/services/converters/converter_factory.rb
@@ -1,0 +1,20 @@
+module Converters
+  class ConverterFactory
+
+    attr_accessor :account_type
+
+    def initialize(options = {})
+      @account_type = options[:account].class.to_s.underscore if options[:account]
+      @account_type ||= "default"
+    end
+
+    def for(converter_type)
+      begin
+        Settings.converters[account_type][converter_type].constantize
+      rescue NameError, NoMethodError
+        Settings.converters["default"][converter_type].constantize
+      end
+    end
+
+  end
+end

--- a/app/services/converters/order_detail_to_journal_rows.rb
+++ b/app/services/converters/order_detail_to_journal_rows.rb
@@ -1,5 +1,5 @@
 module Converters
-  class OrderDetailToJournalRows
+  class OrderDetailToJournalRowAttributes
 
     attr_accessor :journal, :order_detail, :total
 

--- a/app/services/converters/order_detail_to_journal_rows.rb
+++ b/app/services/converters/order_detail_to_journal_rows.rb
@@ -1,0 +1,23 @@
+module Converters
+  class OrderDetailToJournalRows
+
+    attr_accessor :journal, :order_detail, :total
+
+    def initialize(journal, order_detail, options = {})
+      @journal = journal
+      @order_detail = order_detail
+      @total = options[:total] || order_detail.total
+    end
+
+    def to_a
+      [{
+        account: order_detail.product.account,
+        amount: total,
+        description: order_detail.long_description,
+        order_detail_id: order_detail.id,
+        journal_id: journal.try(:id),
+      }]
+    end
+
+  end
+end

--- a/app/services/converters/order_detail_to_journal_rows.rb
+++ b/app/services/converters/order_detail_to_journal_rows.rb
@@ -9,7 +9,7 @@ module Converters
       @total = options[:total] || order_detail.total
     end
 
-    def to_a
+    def convert
       [{
         account: order_detail.product.account,
         amount: total,

--- a/app/services/converters/product_to_journal_rows.rb
+++ b/app/services/converters/product_to_journal_rows.rb
@@ -1,0 +1,22 @@
+module Converters
+  class ProductToJournalRows
+
+    attr_accessor :journal, :product, :total
+
+    def initialize(journal, product, total)
+      @journal = journal
+      @product = product
+      @total = total
+    end
+
+    def to_a
+      [{
+        account: product.facility_account.revenue_account,
+        amount: total * -1,
+        description: product.to_s,
+        journal_id: journal.try(:id),
+      }]
+    end
+
+  end
+end

--- a/app/services/converters/product_to_journal_rows.rb
+++ b/app/services/converters/product_to_journal_rows.rb
@@ -9,7 +9,7 @@ module Converters
       @total = total
     end
 
-    def to_a
+    def convert
       [{
         account: product.facility_account.revenue_account,
         amount: total * -1,

--- a/app/services/converters/product_to_journal_rows.rb
+++ b/app/services/converters/product_to_journal_rows.rb
@@ -1,5 +1,5 @@
 module Converters
-  class ProductToJournalRows
+  class ProductToJournalRowAttributes
 
     attr_accessor :journal, :product, :total
 

--- a/app/services/journal_row_builder.rb
+++ b/app/services/journal_row_builder.rb
@@ -1,0 +1,161 @@
+require "set"
+
+# Ported from Journal model.
+# We should improve upon this logic.
+class JournalRowBuilder
+  include NUCore::Database::ArrayHelper
+
+  attr_reader :order_details, :journal, :journal_rows, :errors, :options,
+              :recharge_enabled, :product_recharges, :journaled_facility_ids
+
+  def initialize(journal, order_details)
+    @order_details = order_details
+    @journal = journal
+    reset
+  end
+
+  # Reset instance variables both on initialize and build.
+  # Returns self to support chaining.
+  def reset
+    @errors = []
+    @journal_rows = []
+    @journaled_facility_ids = Set.new
+    @product_recharges = {}
+    @recharge_enabled = SettingsHelper.feature_on?(:recharge_accounts)
+  end
+
+  # Idempotent method that builds an array of new journal_rows. Also adds to
+  # errors if any problems occur. Does not save anything to the database.
+  # Returns self to support chaining.
+  def build
+    reset
+    order_details.each do |order_detail|
+      validate_order_detail_unjournaled(order_detail)
+      validate_facility_can_journal(order_detail)
+      validate_account(order_detail)
+      new_journal_rows = order_detail_to_journal_rows(order_detail)
+      update_product_recharges(order_detail)
+      @journal_rows.concat(new_journal_rows)
+    end
+    add_journal_rows_from_product_recharges
+
+    self
+  end
+
+  # Creates journal rows for the given order_details.
+  # Does not gracefully handle unexpected database failures.
+  # Wrapping everything in a transaction was not an option because oracle will
+  # only support 1000 transactions per request.
+  def create
+    build
+    if valid? && journal_rows.present?
+      journal_rows.each { |journal_row| JournalRow.create!(journal_row) }
+      set_journal_for_order_details(journal, order_details.map(&:id))
+    end
+    self
+  end
+
+  # Returns true if errors are not present; otherwise false.
+  # Best to use this incase errors implementation changes.
+  def valid?
+    errors.blank?
+  end
+
+  # Set an array of facility_ids with pending journals
+  def pending_facility_ids
+    @pending_facility_ids ||= Journal.facility_ids_with_pending_journals
+  end
+
+  # Validate the order_detail hasn't already been journaled
+  def validate_order_detail_unjournaled(order_detail)
+    if order_detail.journal_id.present?
+      @errors << "#{order_detail} is already journaled in journal #{order_detail.journal_id}"
+    end
+  end
+
+  # Validate the order_details's facility doesn't currently have a pending
+  # journal.
+  #
+  # Ported from original journal model logic. Consider replacing the raised
+  # error with a push to `@errors` instead.
+  def validate_facility_can_journal(order_detail)
+    facility_id = order_detail.order.facility_id
+    unless journaled_facility_ids.member?(facility_id)
+      if pending_facility_ids.member?(facility_id)
+        raise ::Journal::CreationError.new(I18n.t(
+          "activerecord.errors.models.journal.pending_overlap",
+          label: order_detail.to_s,
+          facility: Facility.find(facility_id)
+        ))
+      else
+        journaled_facility_ids.add(facility_id)
+      end
+    end
+  end
+
+  # Validate each journal_row account. This is necessary because an order_detail
+  # may generate multiple journal_rows with different accounts, and we need to
+  # validate them all.
+  #
+  # TODO: we may need to add a validator factory for split_accounts. Otherwise
+  # we assume a product account can not be a split account.
+  def validate_account(order_detail)
+    account = order_detail.account
+    begin
+      ValidatorFactory.instance(account.account_number, order_detail.product.account).account_is_open!(order_detail.fulfilled_at)
+    rescue ValidatorError => e
+      @errors << I18n.t(
+        "activerecord.errors.models.journal.invalid_account",
+        account_number: account.account_number_to_s,
+        validation_error: e.message
+      )
+    end
+  end
+
+  # Given an order detail, return an array of one or more new JournalRow
+  # objects.
+  def order_detail_to_journal_rows(order_detail)
+    factory = Converters::ConverterFactory.new(account: order_detail.account)
+    klass = factory.for("order_detail_to_journal_rows")
+    klass.new(journal, order_detail).to_a
+  end
+
+  # Given a product and total, return an array of one or more new JournalRow
+  # objects.
+  def product_to_journal_rows(product, total)
+    factory = Converters::ConverterFactory.new
+    klass = factory.for("product_to_journal_rows")
+    klass.new(journal, product, total).to_a
+  end
+
+  # If recharge_enabled, then sum up the product_recharges by product so each
+  # product recharge can later be added as an additional journal_row.
+  def update_product_recharges(order_detail)
+    if recharge_enabled
+      product_id = order_detail.product_id
+      product_recharges[product_id] ||= 0
+      product_recharges[product_id] += order_detail.total
+    end
+  end
+
+  # When you’re creating a journal, for a single order detail you’ll have one
+  # or more journal rows for money coming out of an account and one journal row
+  # for the money going into the recharge account. One journal row is positive
+  # and one is negative. Only builds journal_rows if the recharge_enabled
+  # feature is enabled.
+  def add_journal_rows_from_product_recharges
+    product_recharges.each_pair do |product_id, total|
+      product = Product.find(product_id)
+      new_journal_rows = product_to_journal_rows(product, total)
+      @journal_rows.concat(new_journal_rows)
+    end
+  end
+
+  # Updates the journal_id of each order_detail.
+  def set_journal_for_order_details(journal, order_detail_ids)
+    array_slice(order_detail_ids) do |id_slice|
+      OrderDetail.where(id: id_slice).update_all(journal_id: journal.id)
+    end
+  end
+
+end

--- a/app/services/journal_row_builder.rb
+++ b/app/services/journal_row_builder.rb
@@ -121,7 +121,7 @@ class JournalRowBuilder
   def order_detail_to_journal_rows(order_detail)
     factory = Converters::ConverterFactory.new(account: order_detail.account)
     klass = factory.for("order_detail_to_journal_rows")
-    klass.new(journal, order_detail).to_a
+    klass.new(journal, order_detail).convert
   end
 
   # Given a product and total, return an array of one or more new JournalRow
@@ -129,7 +129,7 @@ class JournalRowBuilder
   def product_to_journal_rows(product, total)
     factory = Converters::ConverterFactory.new
     klass = factory.for("product_to_journal_rows")
-    klass.new(journal, product, total).to_a
+    klass.new(journal, product, total).convert
   end
 
   # If recharge_enabled, then sum up the product_recharges by product so each

--- a/app/services/journal_row_updater.rb
+++ b/app/services/journal_row_updater.rb
@@ -1,0 +1,36 @@
+class JournalRowUpdater
+
+  attr_accessor :order_detail, :journal_rows
+
+  def initialize(order_detail)
+    @order_detail = order_detail
+    @journal_rows = order_detail.journal_rows
+  end
+
+  def update
+    if recreate_journal_rows?
+      recreate_journal_rows
+    else
+      update_journal_rows
+    end
+    self
+  end
+
+  def update_journal_rows
+    journal_rows.each(&:update_amount)
+  end
+
+  def recreate_journal_rows
+    if journal_rows.present?
+      order_detail.journal_rows.destroy_all
+      JournalRowBuilder.new(order_detail.journal, [order_detail]).create
+    end
+  end
+
+  def recreate_journal_rows?
+    method = :recreate_journal_rows_on_order_detail_update
+    account = order_detail.account
+    account.respond_to?(method) && account.send(method)
+  end
+
+end

--- a/app/services/journal_row_updater.rb
+++ b/app/services/journal_row_updater.rb
@@ -28,9 +28,8 @@ class JournalRowUpdater
   end
 
   def recreate_journal_rows?
-    method = :recreate_journal_rows_on_order_detail_update
     account = order_detail.account
-    account.respond_to?(method) && account.send(method)
+    account && account.recreate_journal_rows_on_order_detail_update?
   end
 
 end

--- a/app/views/shared/_tabnav_account.html.haml
+++ b/app/views/shared/_tabnav_account.html.haml
@@ -1,6 +1,6 @@
 %ul.nav.nav-tabs
   = tab t('shared.tabnav_account.details'), account_path(@account), (secondary_tab == 'details')
   = tab t('shared.tabnav_account.transact'), transactions_account_path(@account), (secondary_tab == 'transactions')
-  - if @facility && !@account.is_a?(NufsAccount)
+  - if @facility && @account.class.using_statements?
     = tab t('shared.tabnav_account.statement'), account_facility_statement_path(@account, @facility, 'list'), (secondary_tab == 'statements')
   = tab t('shared.tabnav_account.members'), account_account_users_path(@account), (secondary_tab == 'members')

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,13 @@ financial:
     csv: true
     xml: true
 
+converters:
+  default:
+    product_to_journal_rows: Converters::ProductToJournalRows
+    order_detail_to_journal_rows: Converters::OrderDetailToJournalRows
+  split_accounts/split_account:
+    order_detail_to_journal_rows: SplitAccounts::Converters::OrderDetailToJournalRows
+
 reports:
   export_raw:
     class_name: Reports::ExportRaw

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,10 +14,10 @@ financial:
 
 converters:
   default:
-    product_to_journal_rows: Converters::ProductToJournalRows
-    order_detail_to_journal_rows: Converters::OrderDetailToJournalRows
+    product_to_journal_rows: Converters::ProductToJournalRowAttributes
+    order_detail_to_journal_rows: Converters::OrderDetailToJournalRowAttributes
   split_accounts/split_account:
-    order_detail_to_journal_rows: SplitAccounts::Converters::OrderDetailToJournalRows
+    order_detail_to_journal_rows: SplitAccounts::Converters::OrderDetailToJournalRowAttributes
 
 reports:
   export_raw:

--- a/lib/tasks/demo_seed.rake
+++ b/lib/tasks/demo_seed.rake
@@ -288,6 +288,65 @@ namespace :demo do
       nufsaccount.set_expires_at!
     end
 
+    # create a second nufsaccount for split accounts
+    nufsaccount2 = NufsAccount.find_by_account_number("111-2222222-44444444-01")
+
+    unless nufsaccount2
+      nufsaccount2 = NufsAccount.create!(account_number: "111-2222222-44444444-01",
+                                        description: "Paul PI's Other Chart String",
+                                        expires_at: Time.zone.now + 1.year,
+                                        created_by: user_director.id,
+                                        account_users_attributes: [
+                                          { user_id: user_pi.id, user_role: "Owner", created_by: user_director.id },
+                                          { user_id: user_student.id, user_role: "Purchaser", created_by: user_director.id },
+                                        ])
+      nufsaccount2.set_expires_at!
+    end
+
+    # create split account if the feature is enabled
+    if SettingsHelper.feature_on?(:split_accounts)
+      split_account = SplitAccounts::SplitAccount.find_by_account_number("111-2222222-55555555-01")
+      unless split_account
+
+        params = {
+          split_accounts_split_account: {
+            account_number: "111-2222222-55555555-01",
+            description: "Paul PI's 50/50 Split Account",
+            splits_attributes: [
+              {
+                subaccount_id: nufsaccount.id,
+                percent: 50,
+                extra_penny: true,
+              },
+              {
+                subaccount_id: nufsaccount2.id,
+                percent: 50,
+                extra_penny: false,
+              },
+            ]
+          }
+        }
+
+        builder = AccountBuilder.for("SplitAccounts::SplitAccount")
+
+        split_account = builder.new({
+          account_type: "SplitAccounts::SplitAccount",
+          current_user: user_director,
+          owner_user: user_pi,
+          params: params,
+        }).build
+
+        split_account.account_users.build({
+          user_id: user_student.id,
+          user_role: "Purchaser",
+          created_by: user_director.id
+        })
+
+        split_account.save
+      end
+    end
+
+
     other_affiliate = Affiliate.find_or_create_by_name("Other")
 
     if EngineManager.engine_loaded? :c2po

--- a/spec/services/converters/order_detail_to_journal_rows_spec.rb
+++ b/spec/services/converters/order_detail_to_journal_rows_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe Converters::OrderDetailToJournalRows, type: :service do
+
+  let(:converter) { described_class.new(journal, order_detail) }
+  let(:journal) { build_stubbed(:journal) }
+  let(:order_detail) do
+    build_stubbed(:order_detail).tap do |order_detail|
+      allow(order_detail).to receive_message_chain(:product, :account) { "product_account" }
+      allow(order_detail).to receive(:total) { 100 }
+      allow(order_detail).to receive(:long_description) { "long_description" }
+    end
+  end
+
+  it "initializes journal" do
+    expect(converter.journal).to eq(journal)
+  end
+
+  it "initializes order_detail" do
+    expect(converter.order_detail).to eq(order_detail)
+  end
+
+  describe "#to_a" do
+    let(:returned) { converter.to_a }
+
+    it "returns one journal row" do
+      expect(returned.size).to eq(1)
+    end
+
+    context "for first journal row" do
+      let(:row) { returned.first }
+
+      it "sets account" do
+        expect(row[:account]).to eq(order_detail.product.account)
+      end
+
+      it "sets amount" do
+        expect(row[:amount]).to eq(order_detail.total)
+      end
+
+      it "sets description" do
+        expect(row[:description]).to eq(order_detail.long_description)
+      end
+
+      it "sets order_detail_id" do
+        expect(row[:order_detail_id]).to eq(order_detail.id)
+      end
+
+      it "sets journal_id" do
+        expect(row[:journal_id]).to eq(journal.id)
+      end
+    end
+  end
+
+end

--- a/spec/services/converters/order_detail_to_journal_rows_spec.rb
+++ b/spec/services/converters/order_detail_to_journal_rows_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Converters::OrderDetailToJournalRowAttributes, type: :service do
     expect(converter.order_detail).to eq(order_detail)
   end
 
-  describe "#to_a" do
-    let(:returned) { converter.to_a }
+  describe "#convert" do
+    let(:returned) { converter.convert }
 
     it "returns one journal row" do
       expect(returned.size).to eq(1)

--- a/spec/services/converters/order_detail_to_journal_rows_spec.rb
+++ b/spec/services/converters/order_detail_to_journal_rows_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Converters::OrderDetailToJournalRows, type: :service do
+RSpec.describe Converters::OrderDetailToJournalRowAttributes, type: :service do
 
   let(:converter) { described_class.new(journal, order_detail) }
   let(:journal) { build_stubbed(:journal) }

--- a/spec/services/converters/product_to_journal_rows_spec.rb
+++ b/spec/services/converters/product_to_journal_rows_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Converters::ProductToJournalRowAttributes, type: :service do
     expect(converter.total).to eq(total)
   end
 
-  describe "#to_a" do
-    let(:returned) { converter.to_a }
+  describe "#convert" do
+    let(:returned) { converter.convert }
 
     it "returns one journal row" do
       expect(returned.size).to eq(1)

--- a/spec/services/converters/product_to_journal_rows_spec.rb
+++ b/spec/services/converters/product_to_journal_rows_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe Converters::ProductToJournalRows, type: :service do
+
+  let(:converter) { described_class.new(journal, product, total) }
+  let(:journal) { build_stubbed(:journal) }
+  let(:product) do
+    build_stubbed(:product).tap do |product|
+      allow(product).to receive_message_chain(:facility_account, :revenue_account) { "revenue_account" }
+    end
+  end
+  let(:total) { 100 }
+
+  it "initializes journal" do
+    expect(converter.journal).to eq(journal)
+  end
+
+  it "initializes product" do
+    expect(converter.product).to eq(product)
+  end
+
+  it "initializes total" do
+    expect(converter.total).to eq(total)
+  end
+
+  describe "#to_a" do
+    let(:returned) { converter.to_a }
+
+    it "returns one journal row" do
+      expect(returned.size).to eq(1)
+    end
+
+    context "for first journal row" do
+      let(:row) { returned.first }
+
+      it "sets account" do
+        expect(row[:account]).to eq(product.facility_account.revenue_account)
+      end
+
+      it "sets amount" do
+        expect(row[:amount]).to eq(-100)
+      end
+
+      it "sets description" do
+        expect(row[:description]).to eq(product.to_s)
+      end
+
+      it "sets journal_id" do
+        expect(row[:journal_id]).to eq(journal.id)
+      end
+    end
+  end
+
+end

--- a/spec/services/converters/product_to_journal_rows_spec.rb
+++ b/spec/services/converters/product_to_journal_rows_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Converters::ProductToJournalRows, type: :service do
+RSpec.describe Converters::ProductToJournalRowAttributes, type: :service do
 
   let(:converter) { described_class.new(journal, product, total) }
   let(:journal) { build_stubbed(:journal) }

--- a/spec/services/journal_row_builder_spec.rb
+++ b/spec/services/journal_row_builder_spec.rb
@@ -1,0 +1,116 @@
+require "rails_helper"
+
+RSpec.describe JournalRowBuilder, type: :service do
+
+  let(:builder) { described_class.new(journal, order_details) }
+  let(:order_details) { build_stubbed_list(:order_detail, 2) }
+  let(:journal) { build_stubbed(:journal) }
+
+  describe "initialize" do
+
+    it "assigns journal" do
+      expect(builder.journal).to eq(journal)
+    end
+
+    it "assigns order_details" do
+      expect(builder.order_details).to eq(order_details)
+    end
+
+    it "assigns empty errors" do
+      expect(builder.errors).to eq([])
+    end
+
+    it "assigns empty journal_rows" do
+      expect(builder.journal_rows).to eq([])
+    end
+
+    it "assigns empty product_recharges" do
+      expect(builder.product_recharges).to eq({})
+    end
+
+    context "when recharge_accounts enabled", feature_setting: {recharge_accounts: true} do
+      it "assigns recharge_enabled" do
+        expect(builder.recharge_enabled).to eq(true)
+      end
+    end
+
+    context "when recharge_accounts disabled", feature_setting: {recharge_accounts: false} do
+      it "assigns recharge_enabled" do
+        expect(builder.recharge_enabled).to eq(false)
+      end
+    end
+
+  end
+
+  describe "#build" do
+
+    let(:journal) do
+      build(:journal,
+        facility: facility,
+        created_by: 1,
+        journal_date: journal_date,
+      )
+    end
+
+    let(:facility) { create(:facility) }
+    let(:facility_account) { facility.facility_accounts.create(attributes_for(:facility_account)) }
+    let(:journal_date) { Time.zone.now }
+    let(:order) { create(:purchased_order, product: product) }
+    let(:order_details) { order.order_details }
+    let(:product) { create(:setup_item, facility: facility, facility_account: facility_account) }
+
+    before do
+      order_details.each(&:to_complete!)
+    end
+
+    context "when recharge_accounts enabled", feature_setting: {recharge_accounts: true} do
+
+      it "builds two journal_rows for each order_detail" do
+        expect(builder.build.journal_rows.size).to eq(order_details.size*2)
+      end
+
+      it "builds a product_recharge for each order_detail" do
+        expect(builder.build.product_recharges.size).to eq(order_details.size)
+      end
+
+    end
+
+    context "when recharge_accounts disabled", feature_setting: {recharge_accounts: false} do
+
+      it "builds a journal_row for each order_detail" do
+        expect(builder.build.journal_rows.size).to eq(order_details.size)
+      end
+
+      it "does not have product_recharges" do
+        expect(builder.build.product_recharges).to be_empty
+      end
+
+    end
+
+  end
+
+  describe "#valid?" do
+    context "when errors present" do
+      before { allow(builder).to receive(:errors).and_return(["fake error"]) }
+      it "returns true" do
+        expect(builder.valid?).to eq(false)
+      end
+    end
+
+    context "when errors blank" do
+      before { allow(builder).to receive(:errors).and_return([]) }
+      it "returns false" do
+        expect(builder.valid?).to eq(true)
+      end
+    end
+  end
+
+  describe "#pending_facility_ids" do
+    let(:fake_facility_ids) { ["fake id"] }
+    it "returns pending facility ids" do
+      allow(Journal).to receive(:facility_ids_with_pending_journals).and_return(fake_facility_ids)
+      expect(builder.pending_facility_ids).to eq(fake_facility_ids)
+    end
+  end
+
+end

--- a/spec/services/journal_row_updater_spec.rb
+++ b/spec/services/journal_row_updater_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe JournalRowUpdater, type: :service do
+
+  let(:updater) { described_class.new(order_detail) }
+  let(:order_detail) { build_stubbed(:order_detail, account: account, journal_rows: journal_rows) }
+  let(:account) { NufsAccount.new }
+  let(:journal_rows) { build_stubbed_list(:journal_row, 1) }
+
+  describe "initialize" do
+    it "assigns order_detail" do
+      expect(updater.order_detail).to eq(order_detail)
+    end
+
+    it "assigns journal_rows" do
+      expect(updater.journal_rows).to eq(journal_rows)
+    end
+  end
+
+end

--- a/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
@@ -40,5 +40,9 @@ module SplitAccounts
       subaccounts.sort_by(&:expires_at).first
     end
 
+    def recreate_journal_rows_on_order_detail_update
+      true
+    end
+
   end
 end

--- a/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
@@ -40,7 +40,7 @@ module SplitAccounts
       subaccounts.sort_by(&:expires_at).first
     end
 
-    def recreate_journal_rows_on_order_detail_update
+    def recreate_journal_rows_on_order_detail_update?
       true
     end
 

--- a/vendor/engines/split_accounts/app/services/split_accounts/converters/order_detail_to_journal_rows.rb
+++ b/vendor/engines/split_accounts/app/services/split_accounts/converters/order_detail_to_journal_rows.rb
@@ -13,11 +13,11 @@ module SplitAccounts
         @splits = options[:splits] || order_detail.account.splits
       end
 
-      def to_a
+      def convert
         build_split_amounts.map do |split_amount|
           factory = ::Converters::ConverterFactory.new(account: split_amount.split.subaccount)
           klass = factory.for("order_detail_to_journal_rows")
-          klass.new(journal, order_detail, total: split_amount.amount).to_a
+          klass.new(journal, order_detail, total: split_amount.amount).convert
         end.flatten
       end
 

--- a/vendor/engines/split_accounts/app/services/split_accounts/converters/order_detail_to_journal_rows.rb
+++ b/vendor/engines/split_accounts/app/services/split_accounts/converters/order_detail_to_journal_rows.rb
@@ -1,6 +1,6 @@
 module SplitAccounts
   module Converters
-    class OrderDetailToJournalRows
+    class OrderDetailToJournalRowAttributes
 
       SplitAmount = Struct.new(:split, :amount)
 

--- a/vendor/engines/split_accounts/app/services/split_accounts/converters/order_detail_to_journal_rows.rb
+++ b/vendor/engines/split_accounts/app/services/split_accounts/converters/order_detail_to_journal_rows.rb
@@ -1,0 +1,52 @@
+module SplitAccounts
+  module Converters
+    class OrderDetailToJournalRows
+
+      SplitAmount = Struct.new(:split, :amount)
+
+      attr_accessor :journal, :order_detail, :total, :splits
+
+      def initialize(journal, order_detail, options = {})
+        @journal = journal
+        @order_detail = order_detail
+        @total = options[:total] || order_detail.total
+        @splits = options[:splits] || order_detail.account.splits
+      end
+
+      def to_a
+        build_split_amounts.map do |split_amount|
+          factory = ::Converters::ConverterFactory.new(account: split_amount.split.subaccount)
+          klass = factory.for("order_detail_to_journal_rows")
+          klass.new(journal, order_detail, total: split_amount.amount).to_a
+        end.flatten
+      end
+
+      def build_split_amounts
+        split_amounts = splits.map { |split| build_split_amount(split) }
+        apply_remainder(split_amounts)
+      end
+
+      def build_split_amount(split)
+        SplitAmount.new(split, floored_amount(split.percent))
+      end
+
+      def apply_remainder(split_amounts)
+        adjustment = total - floored_total(split_amounts)
+        index = split_amounts.find_index { |split_amount| split_amount.split.extra_penny }
+        split_amounts[index].amount += adjustment
+        split_amounts
+      end
+
+      def floored_total(split_amounts)
+        split_amounts.reduce(0) { |sum, split_amount| sum + split_amount.amount }
+      end
+
+      def floored_amount(percent)
+        return 0 if percent == 0
+        cents = (total * 100) * (BigDecimal(percent) / 100)
+        cents.floor.to_f / 100
+      end
+
+    end
+  end
+end

--- a/vendor/engines/split_accounts/lib/split_accounts/engine.rb
+++ b/vendor/engines/split_accounts/lib/split_accounts/engine.rb
@@ -8,6 +8,7 @@ module SplitAccounts
 
         # Concat class variables in main rails app
         Account.config.account_types << "SplitAccounts::SplitAccount"
+        Account.config.journal_account_types << "SplitAccounts::SplitAccount"
 
         # Add views to view hooks in main rails app
         ViewHook.add_hook "facility_accounts.show", "after_end_of_form", "split_accounts/facility_accounts/show_splits"

--- a/vendor/engines/split_accounts/spec/services/converters/order_detail_to_journal_rows_spec.rb
+++ b/vendor/engines/split_accounts/spec/services/converters/order_detail_to_journal_rows_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require_relative "../../engine_helper"
 
-RSpec.describe SplitAccounts::Converters::OrderDetailToJournalRows, type: :service, split_accounts: true do
+RSpec.describe SplitAccounts::Converters::OrderDetailToJournalRowAttributes, type: :service, split_accounts: true do
 
   let(:converter) do
     described_class.new(journal, order_detail, total: total, splits: splits)

--- a/vendor/engines/split_accounts/spec/services/converters/order_detail_to_journal_rows_spec.rb
+++ b/vendor/engines/split_accounts/spec/services/converters/order_detail_to_journal_rows_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+require_relative "../../engine_helper"
+
+RSpec.describe SplitAccounts::Converters::OrderDetailToJournalRows, type: :service, split_accounts: true do
+
+  let(:converter) do
+    described_class.new(journal, order_detail, total: total, splits: splits)
+  end
+
+  let(:journal) { build_stubbed(:journal) }
+  let(:order_detail) { build_stubbed(:order_detail) }
+  let(:total) { BigDecimal("19.99") }
+  let(:splits) { build_stubbed_list(:split, 1) }
+
+  describe "initialize" do
+
+    it "sets journal" do
+      expect(converter.journal).to eq(journal)
+    end
+
+    it "sets order_detail" do
+      expect(converter.order_detail).to eq(order_detail)
+    end
+
+    it "sets total" do
+      expect(converter.total).to eq(total)
+    end
+
+    it "sets splits" do
+      expect(converter.splits).to eq(splits)
+    end
+
+  end
+
+  describe "#build_split_amount" do
+    let(:total) { BigDecimal("19.99") }
+    let(:percent) { 33.33 }
+    let(:floored_amount) { 6.66 }
+    let(:split) { build_stubbed(:split, percent: percent) }
+    let(:returned) { converter.build_split_amount(split) }
+
+    it "returns a SplitAmount instance" do
+      expect(returned).to be_a(described_class::SplitAmount)
+    end
+
+    it "sets split" do
+      expect(returned.split).to eq(split)
+    end
+
+    it "sets floored amount" do
+      expect(returned.amount).to eq(floored_amount)
+    end
+  end
+
+  context "with a three way $19.99 split that has a remainder of $0.01" do
+    let(:total) { BigDecimal("19.99") }
+    let(:remainder) { BigDecimal("0.01") }
+    let(:split_amounts) do
+      [
+        converter.build_split_amount(build_stubbed(:split, percent: 33.33, extra_penny: false)),
+        converter.build_split_amount(build_stubbed(:split, percent: 33.33, extra_penny: true)),
+        converter.build_split_amount(build_stubbed(:split, percent: 33.34, extra_penny: false)),
+      ]
+    end
+    let(:before_remainder_applied) { split_amounts.second }
+    let(:after_remainder_applied) { converter.apply_remainder(split_amounts).second }
+
+    describe "#apply_remainder" do
+
+      it "starts with a floored split amount" do
+        expect(before_remainder_applied.amount).to eq(6.66)
+      end
+
+      it "adds the remainder to the correct split" do
+        expect(after_remainder_applied.amount).to eq(6.67)
+      end
+    end
+
+    describe "#floored_total" do
+      it "sums up the floored amount without the remainder applied" do
+        expect(converter.floored_total(split_amounts)).to eq(19.98)
+      end
+    end
+  end
+
+  describe "#floored_amount" do
+    let(:total) { BigDecimal("19.99") }
+
+    it "returns 0 if percent is 0" do
+      expect(converter.floored_amount(0)).to eq(0)
+    end
+
+    it "returns floored value" do
+      expect(converter.floored_amount(50)).to eq(9.99)
+    end
+  end
+end


### PR DESCRIPTION
Add support for SplitAccount journal entries.  

Include a new `Converters::ConverterFactory` which is passed an `account` param and returns a converter service object.  For example, the `NufsAccount` will use the default `Converters::OrderDetailToJournalRows` converter, and the `SplitAccounts::SplitAccount` will use a special `SplitAccounts::Converters::OrderDetailToJournalRows` converter.  

Include new `converters` options in `config/settings.yml` so downstream repos can change the default converter to support their specific use case.  Change these settings to cause the `Converters::ConverterFactory` to return a different service object class for each account type.  If an account type is not defined, the factory will use the default.

Move the complex journal row creation and update logic to new `JournalRowBuilder` and `JournalRowUpdater` service objects.  This will allow us to more easily pivot our approach for handling journal row actions.  And it helped with modifying the logic without breaking existing tests.

The `JournaRowUpdater` will update journal row amounts for accounts by default.  Optionally add a `recreate_journal_rows_on_order_detail_update` method to any `Account` model to force the updater to delete and recreate journal rows instead; which is necessary to support split accounts if we do not add a nullable `split_id` column to the `journal_rows` table.