### PR TITLE
Better handling of validator errors during expiration setting

### DIFF
--- a/app/models/nufs_account.rb
+++ b/app/models/nufs_account.rb
@@ -6,8 +6,13 @@ class NufsAccount < Account
 
   after_find :load_components
 
-  def set_expires_at!
+  def set_expires_at
     self.expires_at = ValidatorFactory.instance(account_number).latest_expiration
+    # If this Validator instance has an error, suppress it. The errors
+    # will be raised later.
+    rescue ValidatorError, AccountNumberFormatError
+      # Prevent the expires_at validation error message from appearing on the front end
+      self.expires_at ||= Time.current
   end
 
   def account_open?(account_num)

--- a/app/services/nufs_account_builder.rb
+++ b/app/services/nufs_account_builder.rb
@@ -15,14 +15,7 @@ class NufsAccountBuilder < AccountBuilder
 
   # Hooks into superclass's `build` method.
   def after_build
-    set_expires_at
-  end
-
-  # Sets `expires_at` via a factory.
-  def set_expires_at
-    account.set_expires_at!
-  rescue AccountNumberFormatError => e
-    account.expires_at = Time.current
+    account.set_expires_at
   end
 
 end

--- a/lib/tasks/demo_seed.rake
+++ b/lib/tasks/demo_seed.rake
@@ -285,7 +285,7 @@ namespace :demo do
                                           { user_id: user_pi.id, user_role: "Owner", created_by: user_director.id },
                                           { user_id: user_student.id, user_role: "Purchaser", created_by: user_director.id },
                                         ])
-      nufsaccount.set_expires_at!
+      nufsaccount.set_expires_at
     end
 
     other_affiliate = Affiliate.find_or_create_by_name("Other")

--- a/lib/validator/validator_factory.rb
+++ b/lib/validator/validator_factory.rb
@@ -21,6 +21,7 @@ class ValidatorFactory
 
 
   def self.respond_to?(method_sym, include_private = false)
+    return true if method_sym.in?([:validator_class, :instance])
     validator_class.respond_to? method_sym, include_private
   end
 end

--- a/spec/services/nufs_account_builder_spec.rb
+++ b/spec/services/nufs_account_builder_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe NufsAccountBuilder, type: :service do
   end
 
   describe "#build override" do
+    before { allow(ValidatorFactory).to receive(:validator_class).and_return(ValidatorDefault) }
+
     let(:options) do
       {
         account_type: "NufsAccount",
@@ -28,6 +30,19 @@ RSpec.describe NufsAccountBuilder, type: :service do
     end
 
     it "sets expired_at" do
+      expect(builder.build.expires_at).to be_present
+    end
+
+    it "sets the account_number" do
+      expect(builder.build.account_number).to eq("1234")
+    end
+
+    it "sets the description" do
+      expect(builder.build.description).to eq("foobar")
+    end
+
+    it "still sets the expiration date on a validator error" do
+      allow_any_instance_of(ValidatorDefault).to receive(:latest_expiration).and_raise(ValidatorError)
       expect(builder.build.expires_at).to be_present
     end
   end


### PR DESCRIPTION
Errors in NU such as BlacklistError were getting raised all the way up
to the view as opposed to caught and displayed in a pretty error
message. This changes the behavior so that `set_expires_at` will never
raise its own errors (I’m not clear why it did before).