### PR TITLE
[#121325] Prevent backdated journals after cutoff

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -242,8 +242,8 @@ th.currency {
   }
 }
 
-.table {
-  tr.row-warning td {
+.table tr.row-warning {
+   td, th {
     background-color: $errorBackground;
   }
 }

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -242,6 +242,12 @@ th.currency {
   }
 }
 
+.table {
+  tr.row-warning td {
+    background-color: $errorBackground;
+  }
+}
+
 .table .super-th {
   text-align: center;
 }

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -42,7 +42,7 @@ class FacilityJournalsController < ApplicationController
       redirect_to facility_journals_path(current_facility)
     else
       @order_details = OrderDetail.for_facility(current_facility).need_journal
-      set_soonest_journal_date
+      set_earliest_journal_date
       set_pending_journals
 
       # move error messages for pending journal into the flash
@@ -50,7 +50,7 @@ class FacilityJournalsController < ApplicationController
         flash[:error] = @journal.errors.full_messages.join("<br/>").html_safe
       end
 
-      @soonest_journal_date = params[:journal_date] || @soonest_journal_date
+      @earliest_journal_date = params[:journal_date] || @earliest_journal_date
       render :action => :index
     end
   end
@@ -145,21 +145,23 @@ class FacilityJournalsController < ApplicationController
     @pending_journals = @journals.where(:is_successful => nil)
   end
 
-  def set_soonest_journal_date
-    @soonest_journal_date=@order_details.collect{ |od| od.fulfilled_at }.max
-    @soonest_journal_date=Time.zone.now unless @soonest_journal_date
+  def set_earliest_journal_date
+    @earliest_journal_date = [
+      @order_details.collect { |od| od.fulfilled_at }.max,
+      JournalCutoffDate.first_valid_date
+    ].compact.max
   end
 
   def set_default_variables
     @order_details   = @order_details.need_journal
 
     set_pending_journals
-    set_soonest_journal_date
+    set_earliest_journal_date
 
     blocked_facility_ids = Journal.facility_ids_with_pending_journals
     if cross_facility? || !has_pending_journals?
       @order_detail_action = :create
-      @action_date_field = {:journal_date => @soonest_journal_date}
+      @action_date_field = {:journal_date => @earliest_journal_date}
     end
   end
 

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -161,7 +161,7 @@ class FacilityJournalsController < ApplicationController
     blocked_facility_ids = Journal.facility_ids_with_pending_journals
     if cross_facility? || !has_pending_journals?
       @order_detail_action = :create
-      @action_date_field = {:journal_date => @earliest_journal_date}
+      @action_date_field = { journal_date: @earliest_journal_date }
     end
   end
 

--- a/app/controllers/journal_cutoff_dates_controller.rb
+++ b/app/controllers/journal_cutoff_dates_controller.rb
@@ -1,0 +1,57 @@
+class JournalCutoffDatesController < ApplicationController
+  before_filter :authenticate_user!
+  load_and_authorize_resource
+
+  layout "two_column"
+  before_filter { @active_tab = "global_settings" }
+
+  def index
+    @journal_cutoff_dates = JournalCutoffDate.recent_and_upcoming
+    @first_valid_date = JournalCutoffDate.first_valid_date
+  end
+
+  def new
+    @journal_cutoff_date.cutoff_date = default_next_cutoff
+  end
+
+  def create
+    if @journal_cutoff_date.save
+      redirect_to journal_cutoff_dates_path, notice: t("journal_cutoff_dates.create.success")
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @journal_cutoff_date.update_attributes(journal_cutoff_date_params)
+      redirect_to journal_cutoff_dates_path, notice: t("journal_cutoff_dates.update.success")
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @journal_cutoff_date.destroy
+    redirect_to journal_cutoff_dates_path, notice: t("journal_cutoff_dates.destroy.success")
+  end
+
+  private
+
+  def default_next_cutoff
+    max_future_time = [JournalCutoffDate.maximum(:cutoff_date), Time.current].compact.max
+
+    hour, min = Settings.financial.default_journal_cutoff_time.split(":")
+    # in_time_zone is necessary to get beginning_of_month to respect timezones
+    max_future_time.in_time_zone.next_month.beginning_of_month.change(hour: hour, min: min)
+  end
+
+  def journal_cutoff_date_params
+    params.require(:journal_cutoff_date).permit(:cutoff_date, cutoff_date_time: [:hour, :minute, :ampm]).tap do |params|
+      # If we don't do this, we will interpret 1/10 as October 1.
+      params[:cutoff_date] = parse_usa_date(params[:cutoff_date]) if params[:cutoff_date].is_a?(String)
+    end
+  end
+end

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -110,7 +110,7 @@ class Journal < ActiveRecord::Base
   validate :must_have_order_details, :on => :create, :if => :order_details_for_creation
   validate :must_not_span_fiscal_years, :on => :create, :if => :has_order_details_for_creation?
   validate :journal_date_cannot_be_before_last_fulfillment, :on => :create, :if => :has_order_details_for_creation?
-  validate :journal_date_must_be_after_cutoffs, :on => :create, if: "journal_date.present?"
+  validates_with JournalDateMustBeAfterCutoffs, on: :create
   before_validation :set_facility_id, :on => :create, :if => :has_order_details_for_creation?
   after_create :create_new_journal_rows, :if => :has_order_details_for_creation?
 
@@ -237,13 +237,6 @@ class Journal < ActiveRecord::Base
     return unless journal_date.present?
     last_fulfilled = @order_details_for_creation.collect(&:fulfilled_at).max
     errors.add(:journal_date, :cannot_be_before_last_fulfillment) if journal_date.end_of_day < last_fulfilled
-  end
-
-  include DateHelper
-  def journal_date_must_be_after_cutoffs
-    return unless journal_date.present?
-    first_valid_date = JournalCutoffDate.first_valid_date
-    errors.add(:base, :must_be_after_cutoffs, cutoff: format_usa_date(first_valid_date), month: I18n.l(journal_date, format: "%B")) if first_valid_date && first_valid_date > journal_date.beginning_of_day
   end
 
   def set_facility_id

--- a/app/models/journal_cutoff_date.rb
+++ b/app/models/journal_cutoff_date.rb
@@ -1,0 +1,73 @@
+class JournalCutoffDate < ActiveRecord::Base
+  include ActiveModel::ForbiddenAttributesProtection
+
+  validates :cutoff_date, presence: true
+  validate :unique_month_for_cutoff_date, if: :cutoff_date?
+
+  def self.recent_and_upcoming
+    where("cutoff_date > ?", 1.month.ago.beginning_of_month).order(:cutoff_date)
+  end
+
+  def self.past
+    where("cutoff_date < ?", Time.current).order(:cutoff_date)
+  end
+
+  def self.first_valid_date
+    past.last.try(:cutoff_date).try(:beginning_of_month)
+  end
+
+  def last_valid_date
+    cutoff_date.prev_month.end_of_month
+  end
+
+  def past?
+    cutoff_date < Time.current
+  end
+
+  # TODO consider turning this into a reusable module
+  def cutoff_date_time=(hash)
+    formatted = "#{cutoff_date.to_date} #{hash[:hour]}:#{hash[:minute]}#{hash[:ampm]}"
+    self.cutoff_date = Time.zone.parse(formatted)
+  end
+
+  def cutoff_date_time
+    {
+      hour: cutoff_date.strftime("%-l"),
+      minute:  "%02d" % cutoff_date.min,
+      ampm: cutoff_date.strftime("%p")
+    }
+  end
+
+  private
+
+  def unique_month_for_cutoff_date
+    query = self.class
+      .month_equal(cutoff_date.month)
+      .year_equal(cutoff_date.year)
+
+    # Do not conflict with itself
+    query = query.where("id != ?", id) if persisted?
+
+    if query.exists?
+      errors.add(:cutoff_date, :month_taken, month: I18n.l(cutoff_date, format: "%B"))
+    end
+  end
+
+  def self.month_equal(month)
+    time_section_equal("MONTH", month)
+  end
+
+  def self.year_equal(year)
+    time_section_equal("YEAR", year)
+  end
+
+  def self.time_section_equal(section, time)
+    if NUCore::Database.oracle?
+      # EXTRACT(MONTH from cutoff_date)
+      where("EXTRACT(#{section} FROM cutoff_date) = ?", time)
+    else
+      # MONTH(cutoff_date)
+      where("#{section}(cutoff_date) = ?", time)
+    end
+  end
+end

--- a/app/models/journal_cutoff_date.rb
+++ b/app/models/journal_cutoff_date.rb
@@ -4,13 +4,8 @@ class JournalCutoffDate < ActiveRecord::Base
   validates :cutoff_date, presence: true
   validate :unique_month_for_cutoff_date, if: :cutoff_date?
 
-  def self.recent_and_upcoming
-    where("cutoff_date > ?", 1.month.ago.beginning_of_month).order(:cutoff_date)
-  end
-
-  def self.past
-    where("cutoff_date < ?", Time.current).order(:cutoff_date)
-  end
+  scope :recent_and_upcoming, -> { where("cutoff_date > ?", 1.month.ago.beginning_of_month).order(:cutoff_date) }
+  scope :past, -> { where("cutoff_date < ?", Time.current).order(:cutoff_date) }
 
   def self.first_valid_date
     past.last.try(:cutoff_date).try(:beginning_of_month)

--- a/app/validators/journal_date_must_be_after_cutoffs.rb
+++ b/app/validators/journal_date_must_be_after_cutoffs.rb
@@ -1,0 +1,43 @@
+class JournalDateMustBeAfterCutoffs < ActiveModel::Validator
+
+  def validate(record)
+    Validator.new(record).validate
+  end
+
+  # This class is so we can encapsulate `record` in an instance variable so it's
+  # not necessary to pass it around as an argument everywhere.
+  class Validator
+    include DateHelper
+
+    delegate :journal_date, :errors, to: :record
+    attr_reader :record
+
+    def initialize(record)
+      @record = record
+    end
+
+    def validate
+      return unless journal_date.present?
+      add_error if first_valid_date && first_valid_date > journal_date.beginning_of_day
+    end
+
+    private
+
+    def add_error
+      errors.add(:base, :must_be_after_cutoffs, cutoff: formatted_cutoff, month: attempted_month)
+    end
+
+    def attempted_month
+      I18n.l(journal_date, format: "%B")
+    end
+
+    def formatted_cutoff
+      format_usa_date(first_valid_date)
+    end
+
+    def first_valid_date
+      @first_valid_date ||= JournalCutoffDate.first_valid_date
+    end
+  end
+
+end

--- a/app/views/admin/shared/_sidenav_global.html.haml
+++ b/app/views/admin/shared/_sidenav_global.html.haml
@@ -1,3 +1,4 @@
 %ul.sidebar-nav
   = tab t("pages.affiliates"), affiliates_path, sidenav_tab == "affiliates"
   = tab t("pages.global_user_roles"), global_user_roles_path, sidenav_tab == "global_user_roles"
+  = tab JournalCutoffDate.model_name.human(count: 2), journal_cutoff_dates_path, sidenav_tab == "journal_cutoff_dates"

--- a/app/views/facility_journals/new.html.haml
+++ b/app/views/facility_journals/new.html.haml
@@ -1,10 +1,11 @@
 = content_for :head_content do
   :javascript
     $(function(){
-      var today = "#{l Time.zone.now.to_date, format: :usa}";
+      var today = "#{l(Time.zone.now.to_date, format: :usa)}";
 
       $("#journal_date").val(today).datepicker({
-        "minDate": "#{l @soonest_journal_date, format: :usa}", "maxDate": today
+        "minDate": "#{l(@earliest_journal_date, format: :usa)}",
+        "maxDate": today
       });
     });
 

--- a/app/views/journal_cutoff_dates/_form.html.haml
+++ b/app/views/journal_cutoff_dates/_form.html.haml
@@ -1,7 +1,7 @@
 = simple_form_for(@journal_cutoff_date) do |f|
   = f.input :cutoff_date, as: :string, input_html: { class: "datepicker", value: format_usa_date(f.object.cutoff_date) }
   .time-select= time_select_tag "journal_cutoff_date[cutoff_date_time]", f.object.cutoff_date
-  = f.button :submit, t(".submit"), :class => ['btn', 'btn-primary']
+  = f.button :submit, t(".submit"), class: ["btn", "btn-primary"]
   = link_to t(".cancel"), journal_cutoff_dates_path
 
   :javascript

--- a/app/views/journal_cutoff_dates/_form.html.haml
+++ b/app/views/journal_cutoff_dates/_form.html.haml
@@ -1,0 +1,8 @@
+= simple_form_for(@journal_cutoff_date) do |f|
+  = f.input :cutoff_date, as: :string, input_html: { class: "datepicker", value: format_usa_date(f.object.cutoff_date) }
+  .time-select= time_select_tag "journal_cutoff_date[cutoff_date_time]", f.object.cutoff_date
+  = f.button :submit, t(".submit"), :class => ['btn', 'btn-primary']
+  = link_to t(".cancel"), journal_cutoff_dates_path
+
+  :javascript
+    $(function () { $(".datepicker").datepicker(); });

--- a/app/views/journal_cutoff_dates/edit.html.haml
+++ b/app/views/journal_cutoff_dates/edit.html.haml
@@ -1,0 +1,12 @@
+= content_for :h1 do
+  = t("pages.global_settings")
+
+= content_for :sidebar do
+  = render "admin/shared/sidenav_global", sidenav_tab: "journal_cutoff_dates"
+
+%h2= t(".header")
+
+= link_to t(".delete"), journal_cutoff_date_path(@journal_cutoff_date), confirm: t(".delete_confirm"), class: "btn btn-danger pull-right", method: :delete
+
+= render "form"
+

--- a/app/views/journal_cutoff_dates/index.html.haml
+++ b/app/views/journal_cutoff_dates/index.html.haml
@@ -1,0 +1,32 @@
+= content_for :h1 do
+  = t("pages.global_settings")
+
+= content_for :sidebar do
+  = render "admin/shared/sidenav_global", sidenav_tab: "journal_cutoff_dates"
+
+%h2= JournalCutoffDate.model_name.human(count: 2)
+
+- if @first_valid_date
+  %p= t(".valid_date", date: format_usa_date(@first_valid_date))
+- else
+  %p= t(".no_available_dates")
+
+= link_to t(".new"), new_journal_cutoff_date_path, class: "btn-add"
+
+%table.table
+  %thead
+    %th
+    %th= t(".month")
+    %th= t(".cutoff_date")
+    %th= t(".day")
+  %tbody
+    - @journal_cutoff_dates.each do |journal_cutoff_date|
+      %tr{class: journal_cutoff_date.past? ? "row-warning" : "" }
+        %td= link_to t(".edit"), edit_journal_cutoff_date_path(journal_cutoff_date)
+        %td= l(journal_cutoff_date.last_valid_date, format: "%B")
+        %td= format_usa_datetime journal_cutoff_date.cutoff_date
+        %td= l(journal_cutoff_date.cutoff_date, format: "%A")
+
+%p
+  %em= t(".recency")
+

--- a/app/views/journal_cutoff_dates/new.html.haml
+++ b/app/views/journal_cutoff_dates/new.html.haml
@@ -1,0 +1,9 @@
+= content_for :h1 do
+  = t("pages.global_settings")
+
+= content_for :sidebar do
+  = render "admin/shared/sidenav_global", sidenav_tab: "journal_cutoff_dates"
+
+%h2= t(".header")
+
+= render "form"

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -105,6 +105,7 @@ en:
           no_orders: "No orders were selected to journal"
           cannot_be_in_future: may not be in the future.
           cannot_be_before_last_fulfillment: may not be before the latest fulfillment date.
+          must_be_after_cutoffs: "The cutoff date for %{month} has passed. Journal date must be after %{cutoff}"
         journal_cutoff_date:
           month_taken: There is already a cutoff date for %{month}
         nufs_account:

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -105,6 +105,8 @@ en:
           no_orders: "No orders were selected to journal"
           cannot_be_in_future: may not be in the future.
           cannot_be_before_last_fulfillment: may not be before the latest fulfillment date.
+        journal_cutoff_date:
+          month_taken: There is already a cutoff date for %{month}
         nufs_account:
           missing_expires_at: "The chart string appears to be invalid. Either the fund, department, project, or activity could not be found."
 
@@ -117,12 +119,27 @@ en:
         statuses:
           active: Active
           suspended: Suspended
+      account_user:
+        one: Account User
+        other: Account Users
+      bundle:
+        one: Bundle
+        other: Bundles
+      facility:
+        one: Facility
+        other: Facilities
+      instrument:
+        one: Instrument
+        other: Instruments
+      item:
+        one: Item
+        other: Items
+      journal_cutoff_date:
+        one: Journal Cutoff Date
+        other: Journal Cutoff Dates
       nufs_account:
         one: Chart String
         other: Chart Strings
-      account user:
-        one: Account User
-        other: Account Users
       reservation:
         one: Reservation
         other: Reservations
@@ -135,25 +152,13 @@ en:
       order_status:
         one: Order Status
         other: Order Statuses
-      facility:
-        one: Facility
-        other: Facilities
       product:
         one: Product
         other: Products
-      instrument:
-        one: Instrument
-        other: Instruments
+      product_access_group: Scheduling Group
       service:
         one: Services
         other: Services
-      item:
-        one: Item
-        other: Items
-      bundle:
-        one: Bundle
-        other: Bundles
-      product_access_group: Scheduling Group
       training_request:
         one: Training Request
         other: Training Requests

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -418,6 +418,32 @@ en:
       failure: Global role assignment for %{user} failed.
       success: Global role assignment for %{user} succeeded.
 
+  journal_cutoff_dates:
+    index:
+      new: Add Cutoff Date
+      month: Month
+      cutoff_date: Cutoff Date
+      day: Day of Week
+      edit: Edit
+      valid_date: Journals must currently be dated after %{date}
+      no_available_dates: All dates are currently valid. Add a cutoff in the past to restrict the valid dates.
+      recency: "Note: only the last two months of cutoffs are displayed."
+    create:
+      success: Cutoff date successfully added
+    destroy:
+      success: Cutoff date successfully deleted
+    edit:
+      delete: delete
+      delete_confirm: Are you sure you want to delete this cutoff date?
+      header: Edit Journal Cutoff Date
+    form:
+      submit: Submit
+      cancel: Cancel
+    new:
+      header: New Journal Cutoff Date
+    update:
+      success: Cutoff date successfully updated
+
   order_imports:
     new:
       h2: "Bulk Import"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,9 +49,6 @@ Nucore::Application.routes.draw do
   # transaction searches
   match '/transactions', :to => 'transaction_history#my_history', :as => 'transaction_history'
 
-  # global settings
-  resources :affiliates, :except => :show
-
   resources :facilities, :except => [:delete] do
     collection do
       get 'list'
@@ -274,10 +271,11 @@ Nucore::Application.routes.draw do
     end
   end
 
+  # global settings
+  resources :affiliates, :except => :show
+  resources :journal_cutoff_dates
   resources :global_user_roles do
-    collection do
-      get "search"
-    end
+    get "search", on: :collection
   end
 
   # order process

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,6 +11,7 @@ financial:
     xls: true
     csv: true
     xml: true
+  default_journal_cutoff_time: "16:45"
 
 reports:
   export_raw:

--- a/db/migrate/20160201171348_add_journal_cutoffs.rb
+++ b/db/migrate/20160201171348_add_journal_cutoffs.rb
@@ -1,0 +1,8 @@
+class AddJournalCutoffs < ActiveRecord::Migration
+  def change
+    create_table :journal_cutoff_dates do |t|
+      t.datetime :cutoff_date
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160120162354) do
+ActiveRecord::Schema.define(:version => 20160201171348) do
 
   create_table "account_users", :force => true do |t|
     t.integer  "account_id",               :null => false
@@ -164,6 +164,12 @@ ActiveRecord::Schema.define(:version => 20160120162354) do
   end
 
   add_index "instrument_statuses", ["instrument_id"], :name => "fk_int_stats_product"
+
+  create_table "journal_cutoff_dates", :force => true do |t|
+    t.datetime "cutoff_date"
+    t.datetime "created_at",  :null => false
+    t.datetime "updated_at",  :null => false
+  end
 
   create_table "journal_rows", :force => true do |t|
     t.integer "journal_id",                                                   :null => false

--- a/spec/controllers/journal_cutoff_dates_controller_spec.rb
+++ b/spec/controllers/journal_cutoff_dates_controller_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+
+RSpec.describe JournalCutoffDatesController do
+  describe "as a normal user" do
+    let(:user) { FactoryGirl.create(:user) }
+    before { sign_in user }
+
+    it "does not give access to index" do
+      get :index
+      expect(response.code).to eq("403")
+    end
+
+    it "does not give access to create" do
+      post :create, journal_cutoff_date: { cutoff_date: 1.month.ago }
+      expect(response.code).to eq("403")
+    end
+
+    it "does not give access to update" do
+      cutoff = JournalCutoffDate.create(cutoff_date: 1.month.from_now)
+      put :update, id: cutoff.id, journal_cutoff_date: {}
+      expect(response.code).to eq("403")
+    end
+  end
+
+  describe "as a global admin" do
+    let(:user) { FactoryGirl.create(:user, :administrator) }
+    before { sign_in user }
+
+    describe "#new" do
+      describe "default dates", :timecop_freeze do
+        let(:now) { Time.zone.parse("2016-02-02") }
+        let(:time_setting) { "14:30" }
+        before { allow(Settings).to receive_message_chain(:financial, :default_journal_cutoff_time).and_return(time_setting) }
+
+        context "with no existing cutoffs" do
+          it "defaults to the beginning of next month" do
+            get :new
+            expect(assigns(:journal_cutoff_date).cutoff_date).to eq(Time.zone.parse("2016-03-01 14:30"))
+          end
+        end
+
+        context "with an existing cutoff in the past" do
+          let!(:existing) { JournalCutoffDate.create(cutoff_date: Time.zone.parse("2015-06-04 14:30")) }
+
+          it "defaults to the beginning of next month" do
+            get :new
+            expect(assigns(:journal_cutoff_date).cutoff_date).to eq(Time.zone.parse("2016-03-01 14:30"))
+          end
+        end
+
+        context "with an existing cutoffs in the future" do
+          let!(:existing) { JournalCutoffDate.create(cutoff_date: Time.zone.parse("2016-06-04")) }
+          let!(:existing2) { JournalCutoffDate.create(cutoff_date: Time.zone.parse("2016-05-04")) }
+
+          it "defaults to the beginning of month following the existing cutoff" do
+            get :new
+            expect(assigns(:journal_cutoff_date).cutoff_date).to eq(Time.zone.parse("2016-07-01 14:30"))
+          end
+        end
+      end
+    end
+
+    describe "#create" do
+      def do_request
+        post :create, journal_cutoff_date: { cutoff_date: cutoff_date }
+      end
+
+      describe "success" do
+        describe "with a string param" do
+          let(:cutoff_date) { "06/10/2016" }
+
+          it "interprets month/day correctly" do
+            do_request
+            expect(JournalCutoffDate.last.cutoff_date).to eq(Time.zone.parse("2016-06-10"))
+          end
+        end
+      end
+
+      describe "with an empty cutoff date" do
+        let(:cutoff_date) { "" }
+
+        it "does not create a new cutoff date" do
+          expect { do_request }.not_to change(JournalCutoffDate, :count)
+        end
+
+        it "renders the form again" do
+          do_request
+          expect(response).to render_template :new
+        end
+      end
+    end
+
+    describe "#update" do
+      let!(:journal_cutoff_date) { JournalCutoffDate.create(cutoff_date: 1.month.from_now) }
+
+      def do_request
+        put :update, id: journal_cutoff_date.id, journal_cutoff_date: { cutoff_date: new_cutoff_date }
+      end
+
+      describe "success" do
+        let(:new_cutoff_date) { 2.months.from_now.change(usec: 0) }
+
+        it "updates the model" do
+          expect { do_request }.to change { journal_cutoff_date.reload.cutoff_date }.to(new_cutoff_date)
+        end
+      end
+
+      describe "failure" do
+        let(:new_cutoff_date) { "" }
+
+        it "does not update the model" do
+          expect { do_request }.not_to change { journal_cutoff_date.reload.cutoff_date }
+        end
+
+        it "renders the edit view again" do
+          do_request
+          expect(response).to render_template :edit
+          expect(assigns(:journal_cutoff_date)).to eq(journal_cutoff_date)
+        end
+      end
+    end
+
+    describe "#destroy" do
+      let!(:journal_cutoff_date) { JournalCutoffDate.create(cutoff_date: 1.month.from_now) }
+
+      it "destroys the cutoff date" do
+        expect { delete :destroy, id: journal_cutoff_date.id }.to change(JournalCutoffDate, :count).by(-1)
+      end
+    end
+  end
+end

--- a/spec/models/journal_cutoff_date_spec.rb
+++ b/spec/models/journal_cutoff_date_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.describe JournalCutoffDate do
+  it { is_expected.to validate_presence_of(:cutoff_date) }
+
+  describe "cutoff_date" do
+    subject(:hash) { described_class.new(cutoff_date: cutoff_date).cutoff_date_time }
+    describe "am" do
+      let(:cutoff_date) { Time.zone.parse("2016-01-01 08:45") }
+      it { is_expected.to eq(hour: "8", minute: "45", ampm: "AM") }
+    end
+
+    describe "pm" do
+      let(:cutoff_date) { Time.zone.parse("2016-01-01 16:37") }
+      it { is_expected.to eq(hour: "4", minute: "37", ampm: "PM") }
+    end
+
+    describe "midnight" do
+      let(:cutoff_date) { Time.zone.parse("2016-01-01 00:10") }
+      it { is_expected.to eq(hour: "12", minute: "10", ampm: "AM") }
+    end
+
+    describe "noon" do
+      let(:cutoff_date) { Time.zone.parse("2016-01-01 12:00") }
+      it { is_expected.to eq(hour: "12", minute: "00", ampm: "PM") }
+    end
+  end
+
+  describe "cutoff_date=" do
+    let(:model) do
+      described_class.new(cutoff_date: Time.zone.parse("2016-02-01")).tap do |model|
+        model.cutoff_date_time = cutoff_date_hash
+      end
+    end
+
+    subject(:cutoff_date) { model.cutoff_date }
+
+    describe "am" do
+      let(:cutoff_date_hash) { { hour: "8", minute: "45", ampm: "AM" } }
+      it { is_expected.to eq(Time.zone.parse("2016-02-01 08:45")) }
+    end
+
+    describe "pm" do
+      let(:cutoff_date_hash) { { hour: "4", minute: "37", ampm: "PM" }  }
+      it { is_expected.to eq(Time.zone.parse("2016-02-01 16:37")) }
+    end
+
+    describe "midnight" do
+      let(:cutoff_date_hash) { { hour: "12", minute: "10", ampm: "AM" } }
+      it { is_expected.to eq(Time.zone.parse("2016-02-01 00:10")) }
+    end
+
+    describe "noon" do
+      let(:cutoff_date_hash) { { hour: "12", minute: "00", ampm: "PM" } }
+      it { is_expected.to eq(Time.zone.parse("2016-02-01 12:00")) }
+    end
+  end
+
+  describe "month validation" do
+    it "does not allow more than in the same month" do
+      existing = described_class.create(cutoff_date: Time.zone.parse("2016-02-03 12:00"))
+
+      new_date = described_class.new(cutoff_date: Time.zone.parse("2016-02-07 12:00"))
+      expect(new_date).to be_invalid
+      expect(new_date.errors[:cutoff_date]).to include("There is already a cutoff date for February")
+    end
+
+    it "allows more than one in separate months" do
+      existing = described_class.create(cutoff_date: Time.zone.parse("2016-02-03 12:00"))
+
+      new_date = described_class.new(cutoff_date: Time.zone.parse("2016-03-03 12:00"))
+      expect(new_date).to be_valid
+    end
+
+    it "allows more than one of the same month, but different years" do
+      existing = described_class.create(cutoff_date: Time.zone.parse("2016-02-03 12:00"))
+
+      new_date = described_class.new(cutoff_date: Time.zone.parse("2017-02-03 12:00"))
+      expect(new_date).to be_valid
+    end
+
+    it "allows an already persisted record not to conflict with itself" do
+      existing = described_class.create(cutoff_date: Time.zone.parse("2016-02-03 12:00"))
+      expect(existing).to be_valid
+    end
+  end
+
+  describe "#last_valid_date" do
+    subject(:last_valid_date) { described_class.new(cutoff_date: cutoff_date).last_valid_date }
+
+    describe "early in the month" do
+      let(:cutoff_date) { Time.zone.parse("2016-04-02") }
+      it { is_expected.to eq(Time.zone.parse("2016-03-31").end_of_day) }
+    end
+
+    describe "late in the month" do
+      let(:cutoff_date) { Time.zone.parse("2016-06-30") }
+      it { is_expected.to eq(Time.zone.parse("2016-05-31").end_of_day) }
+    end
+
+    describe "leap year" do
+      let(:cutoff_date) { Time.zone.parse("2016-03-02") }
+      it { is_expected.to eq(Time.zone.parse("2016-02-29").end_of_day) }
+    end
+
+    describe "january" do
+      let(:cutoff_date) { Time.zone.parse("2016-01-02") }
+      it { is_expected.to eq(Time.zone.parse("2015-06-01").end_of_year) }
+    end
+  end
+end


### PR DESCRIPTION
I did not feature flag this because if you don't add any `JournalCutoffDate`, then the existing behavior remains the same of being able to backdate a journal as far as you want (well, you can't backdate to before the earliest fulfilled_at).

Basically, the point of this is if you set a cutoff for which you can no longer backdate journals into the previous month. For example, if you set a cutoff for March 3, then after March 3 at 4:45, you can no longer create journals with a February date.

I'm not 100% I love the extraction of the journal validation into a validator class. The API is a little awkward because only a single instance of the Validator is created because that's how rails does it. That's why I left that as its own commit.