### PR TITLE
[#88683] Maintain report parameters on export raw

### DIFF
--- a/app/assets/javascripts/app/flash.coffee
+++ b/app/assets/javascripts/app/flash.coffee
@@ -13,14 +13,14 @@ class exports.Flash
   @flash: (level, message, location_selector = '#js--flash') ->
     new Flash(location_selector).flash(level, message)
 
-  constructor: (@location_selector) ->
+  constructor: (location_selector) ->
     @location_selector = $(location_selector)
 
   flash: (level, message) ->
     # existing flashes
     @location_selector.find(".alert").remove()
 
-    flash = $("<p>#{message}</p>").addClass('alert').addClass("alert-#{level}")
+    flash = $("<p></p>").text(message).addClass('alert').addClass("alert-#{level}")
     @location_selector.append(flash)
 
     setTimeout ->

--- a/app/assets/javascripts/app/reports.coffee
+++ b/app/assets/javascripts/app/reports.coffee
@@ -84,15 +84,19 @@ class TabbableReports
 
   init_export_all_handler: ->
     @$emailToAddressField = $('#email_to_address')
-    $('#export-all').click (event) => @export_all_email_confirm(event)
+    $('#export-all')
+      .attr("data-remote", true)
+      .click (event) => @export_all_email_confirm(event)
 
   export_all_email_confirm: (event) ->
     new_to = prompt 'Have the report emailed to this address:', @$emailToAddressField.val()
+
     if new_to
       @$emailToAddressField.val(new_to)
       @update_export_urls()
-    else
-      event.preventDefault()
+      # Actual sending handled by remote: true
+      Flash.info("A report is being prepared and will be emailed to #{new_to} when complete")
+    event.preventDefault()
 
 $ ->
   window.report = new TabbableReports($('#refresh-form'))

--- a/app/controllers/general_reports_controller.rb
+++ b/app/controllers/general_reports_controller.rb
@@ -42,8 +42,12 @@ class GeneralReportsController < ReportsController
 
   def generate_report_data_csv
     ExportRawReportMailer.delay.raw_report_email(email_to_address, raw_report)
-    flash[:notice] = I18n.t('controllers.reports.mail_queued', email: email_to_address)
-    redirect_to send("#{action_name}_facility_general_reports_path", current_facility)
+    if request.xhr?
+      render nothing: true
+    else
+      flash[:notice] = I18n.t('controllers.reports.mail_queued', email: email_to_address)
+      redirect_to send("#{action_name}_facility_general_reports_path", current_facility)
+    end
   end
 
   def raw_report


### PR DESCRIPTION
Before, export raw was submitting a normal request so it would reload
the page. This makes the export raw request via ajax so the page does
not do a full reload.