### PR TITLE
[#124333] Fix account change from cart

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -160,10 +160,7 @@ class OrdersController < ApplicationController
           begin
             @order.invalidate
             @order.update_attributes!(account_id: account.id)
-            @order.order_details.each do |order_detail|
-              order_detail.update_attributes!(account_id: account.id)
-            end
-          rescue => e
+          rescue ActiveRecord::ActiveRecordError => e
             success = false
             raise ActiveRecord::Rollback
           end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -186,13 +186,6 @@ class OrdersController < ApplicationController
       end
     end
 
-    if params[:reset_account]
-      @order.order_details.each do |od|
-        od.account = nil
-        od.save!
-      end
-    end
-
     if session[:add_to_cart].blank?
       @product = @order.order_details[0].try(:product)
     else

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -153,11 +153,7 @@ class OrdersController < ApplicationController
   # POST /orders/:id/choose_account
   def choose_account
     if request.post?
-      begin
-        account = Account.find(params[:account_id])
-        raise ActiveRecord::RecordNotFound unless account.can_be_used_by?(@order.user)
-      rescue
-      end
+      account = Account.find(params[:account_id])
       if account
         success = true
         @order.transaction do

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -163,7 +163,10 @@ class OrdersController < ApplicationController
         @order.transaction do
           begin
             @order.invalidate
-            @order.update_attributes!(:account => account)
+            @order.update_attributes!(account_id: account.id)
+            @order.order_details.each do |order_detail|
+              order_detail.update_attributes!(account_id: account.id)
+            end
           rescue => e
             success = false
             raise ActiveRecord::Rollback

--- a/app/views/orders/show.html.haml
+++ b/app/views/orders/show.html.haml
@@ -20,7 +20,7 @@
     %label= t('.label.account')
     = @order.account
     %br
-    = link_to t('.link.change_account'), choose_account_order_path(@order, :reset_account => true)
+    = link_to t(".link.change_account"), choose_account_order_path(@order)
 
   = form_for @order, :url => {:action => :update_or_purchase} do |f|
     %table.table.table-striped.table-hover#cart

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -209,21 +209,32 @@ RSpec.describe OrdersController do
     context "when selecting a different account" do
       before { @params.merge!(account_id: other_account.id) }
 
-      it "updates the account associated with the order" do
-        expect { do_request }
-          .to change { order.reload.account }
-          .from(account)
-          .to(other_account)
+      context "that the user is allowed to use" do
+        it "updates the account associated with the order" do
+          expect { do_request }
+            .to change { order.reload.account }
+            .from(account)
+            .to(other_account)
+        end
+
+        it "updates the account associated with the order_detail" do
+          expect { do_request }
+            .to change { order_detail.reload.account }
+            .from(account)
+            .to(other_account)
+        end
+
+        it_behaves_like "it uses add_to_cart to determine redirects"
       end
 
-      it "updates the account associated with the order_detail" do
-        expect { do_request }
-          .to change { order_detail.reload.account }
-          .from(account)
-          .to(other_account)
-      end
+      context "that the user is not allowed to use" do
+        let(:other_account) { create(:setup_account) }
 
-      it_behaves_like "it uses add_to_cart to determine redirects"
+        it "does not change the account while flashing an error message" do
+          expect { do_request }.not_to change { order.reload.account }
+          expect(flash[:error]).to include("error was encountered")
+        end
+      end
     end
 
     context "when selecting the same account" do

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -131,6 +131,19 @@ RSpec.describe OrdersController do
 
         it { expect(response).to redirect_to(cart_path) }
       end
+
+      context "with reset_account set to true" do
+        before { @params.merge!(reset_account: true) }
+
+        it "retains the account on the order" do
+          expect { do_request }.not_to change { order.reload.account }
+        end
+
+        it "clears the account on the order_details" do
+          expect { do_request }
+            .to change { order.reload.order_details.first.account }.to(nil)
+        end
+      end
     end
   end
 

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe OrdersController do
 
   end
 
-  it "should route" do
+  it "routes properly" do
     expect(get: "/orders/cart").to route_to(controller: "orders", action: "cart")
     expect(get: "/orders/1").to route_to(controller: "orders", action: "show", id: "1")
     expect(put: "/orders/1").to route_to(controller: "orders", action: "update", id: "1")
@@ -66,7 +66,7 @@ RSpec.describe OrdersController do
           @order.add(@item, 1)
         end
 
-        it "should redirect to the order" do
+        it "redirects to the order" do
           do_request
           expect(request).to redirect_to order_url(@order)
         end
@@ -79,7 +79,7 @@ RSpec.describe OrdersController do
           @res1 = FactoryGirl.create(:setup_reservation, order_detail: @order.order_details[0], product: @instrument)
         end
 
-        it "should redirect to a new cart" do
+        it "redirects to a new cart" do
           do_request
           expect(request).not_to redirect_to order_url(@order)
         end
@@ -91,7 +91,7 @@ RSpec.describe OrdersController do
             @res2 = FactoryGirl.create(:setup_reservation, order_detail: @order.order_details[2], product: @instrument)
           end
 
-          it "should redirect to the existing cart" do
+          it "redirects to the existing cart" do
             do_request
             expect(request).to redirect_to order_url(@order)
           end
@@ -202,18 +202,16 @@ RSpec.describe OrdersController do
         do_request
       end
 
-      it "should update the quantity" do
+      it "updates the quantity" do
         @order_detail.reload
         expect(@order_detail.quantity).to eq(5)
       end
 
-      it "should redirect to the cart" do
+      it "redirects to the cart" do
         is_expected.to redirect_to order_path(@order)
       end
 
-      it "should not purchase" do
-        expect(assigns[:order].state).not_to eq("purchased")
-      end
+      it { expect(assigns[:order].state).not_to eq("purchased") }
     end
 
     context "update quantities of multiple items while keeping total the same" do
@@ -236,20 +234,18 @@ RSpec.describe OrdersController do
         do_request
       end
 
-      it "should update the quantities" do
+      it "updates the quantities" do
         @order_detail1.reload
         expect(@order_detail1.quantity).to eq(3)
         @order_detail2.reload
         expect(@order_detail2.quantity).to eq(4)
       end
 
-      it "should redirect to the cart" do
+      it "redirects to the cart" do
         is_expected.to redirect_to order_path(@order)
       end
 
-      it "should not purchase" do
-        expect(assigns[:order].state).not_to eq("purchased")
-      end
+      it { expect(assigns[:order].state).not_to eq("purchased") }
     end
 
     context "update note" do
@@ -259,13 +255,13 @@ RSpec.describe OrdersController do
         do_request
       end
 
-      it "should update the note" do
+      it "updates the note" do
         order_detail = assigns[:order].order_details.first
         order_detail.reload
         expect(order_detail.note).not_to be_blank
       end
 
-      it "should purchase the order" do
+      it "sets the order state to purchased" do
         @order.reload
         expect(@order.state).to eq("purchased")
       end
@@ -314,20 +310,20 @@ RSpec.describe OrdersController do
         @params.merge!(id: @order.id, order_id: @order.id)
       end
 
-      it "should purchase the order" do
+      it "sets the order state to purchased" do
         sign_in @staff
         do_request
         expect(assigns[:order].state).to eq("purchased")
       end
 
-      it "should set the status of the order detail to the products default status" do
+      it "sets the order detail status to the product's default status" do
         sign_in @staff
         do_request
         expect(assigns[:order].order_details.size).to eq(1)
         expect(assigns[:order].order_details.first.order_status).to eq(OrderStatus.new_os.first)
       end
 
-      it "should set the status of the order detail to the products default status" do
+      it "sets the order detail status to the product's default status" do # TODO: reword this so it's not identical to the previous spec
         @order_status = FactoryGirl.create(:order_status, parent: OrderStatus.inprocess.first)
         @instrument.update_attributes!(initial_order_status_id: @order_status.id)
         sign_in @staff
@@ -336,14 +332,14 @@ RSpec.describe OrdersController do
         expect(assigns[:order].order_details.first.order_status).to eq(@order_status)
       end
 
-      it "should redirect to my reservations on a successful purchase of a single reservation" do
+      it "redirects to my reservations on a successful purchase of a single reservation" do
         sign_in @staff
         do_request
         expect(flash[:notice]).to eq("Reservation completed successfully")
         expect(response).to redirect_to reservations_path
       end
 
-      it "should redirect to switch on if the instrument has a relay" do
+      it "redirects to switch on if the instrument has a relay" do
         @instrument.update_attributes(relay: FactoryGirl.create(:relay_dummy, instrument: @instrument))
         sign_in @staff
         do_request
@@ -356,7 +352,7 @@ RSpec.describe OrdersController do
         )
       end
 
-      it "should redirect to receipt when purchasing multiple reservations" do
+      it "redirects to the receipt when purchasing multiple reservations" do
         @order.add(@instrument, 1)
         expect(@order.order_details.size).to eq(2)
         @reservation2 = FactoryGirl.create(:reservation, order_detail: @order.order_details[1], product: @instrument)
@@ -366,7 +362,8 @@ RSpec.describe OrdersController do
         do_request
         expect(response).to redirect_to receipt_order_url(@order)
       end
-      it "should redirect to receipt when acting as and ordering a single reservation" do
+
+      it "redirects to the receipt when ordering a single reservation as staff" do
         sign_in @admin
         switch_to @staff
         do_request
@@ -374,20 +371,20 @@ RSpec.describe OrdersController do
       end
 
       describe "notification sending" do
-        it "should send a notification" do
+        it "sends a notification" do
           expect(Notifier).to receive(:order_receipt).once.and_return(DummyNotifier.new)
           sign_in @admin
           do_request
         end
 
-        it "should not send an email by default if you're acting as" do
+        it "does not send an email by default when acting as" do
           expect(Notifier).to receive(:order_receipt).never
           sign_in @admin
           switch_to @staff
           do_request
         end
 
-        it "should not send an email if you're acting as and have the checkbox unchecked" do
+        it "does not send an email when acting as and unchecks the checkbox" do
           expect(Notifier).to receive(:order_receipt).never
           sign_in @admin
           switch_to @staff
@@ -395,7 +392,7 @@ RSpec.describe OrdersController do
           do_request
         end
 
-        it "should send an email if you're acting as and set the parameter" do
+        it "sends an email when acting as and checks the checkbox" do
           expect(Notifier).to receive(:order_receipt).once.and_return(DummyNotifier.new)
           sign_in @admin
           switch_to @staff
@@ -412,30 +409,30 @@ RSpec.describe OrdersController do
         @params.merge!(id: @order.id)
       end
 
-      it "should be set up correctly" do
+      it "sets up state correctly" do
         expect(@order.state).to eq("new")
         expect(@order_detail.state).to eq("new")
       end
 
-      it "should validate the order properly" do
+      it "validates the order properly" do
         expect(@order).to be_has_details
         expect(@order).to be_has_valid_payment
         expect(@order).to be_cart_valid
       end
 
-      it "should validate and place order" do
+      it "validates and places the order" do
         @order.validate_order!
         expect(@order).to be_place_order
       end
 
-      it "should redirect to order receipt on a successful purchase" do
+      it "redirects to the order receipt on a successful purchase" do
         sign_in @staff
         do_request
         expect(flash[:error]).to be_nil
         expect(response).to redirect_to receipt_order_path(@order)
       end
 
-      it "should set the ordered at to the past" do
+      it "sets ordered_at to a time in the past" do
         maybe_grant_always_sign_in :director
         switch_to @staff
         @params.merge!(order_date: format_usa_date(1.day.ago), order_time: { hour: "10", minute: "12", ampm: "AM" })
@@ -443,7 +440,7 @@ RSpec.describe OrdersController do
         expect(assigns[:order].reload.ordered_at).to match_date 1.day.ago.change(hour: 10, min: 12)
       end
 
-      it "should set the ordered at to now if not acting_as" do
+      it "sets ordered_at to now if not acting_as" do
         maybe_grant_always_sign_in :director
         @params.merge!(order_date: format_usa_date(1.day.ago))
         do_request
@@ -456,18 +453,18 @@ RSpec.describe OrdersController do
           switch_to @staff
         end
 
-        it "should leave as new by default" do
+        it "leaves the order_detail states as new by default" do
           do_request
           assigns[:order].reload.order_details.all? { |od| expect(od.state).to eq("new") }
         end
 
-        it "should leave as new if new is set as the param" do
+        it "leave the order_detail states as new if new is set as the param" do
           @params.merge!(order_status_id: OrderStatus.new_os.first.id)
           do_request
           assigns[:order].reload.order_details.all? { |od| expect(od.state).to eq("new") }
         end
 
-        it "should be able to set to canceled" do
+        it "can set the order_detail states to canceled" do
           @params.merge!(order_status_id: OrderStatus.canceled.first.id)
           do_request
           assigns[:order].reload.order_details.all? { |od| expect(od.state).to eq("canceled") }
@@ -477,26 +474,27 @@ RSpec.describe OrdersController do
           before :each do
             @params.merge!(order_status_id: OrderStatus.complete.first.id)
           end
-          it "should be able to set to completed" do
+
+          it "can set order_detail states to completed" do
             do_request
             assigns[:order].reload.order_details.all? { |od| expect(od.state).to eq("complete") }
           end
 
-          it "should set reviewed_at if there is zero review period" do
+          it "sets order_detail states to reviewed_at if there is zero review period" do
             Settings.billing.review_period = 0.days
             do_request
             assigns[:order].reload.order_details.all? { |od| expect(od.reviewed_at).not_to be_nil }
             Settings.reload!
           end
 
-          it "should leave reviewed_at as nil if there is a review period" do
+          it "leaves order_detail reviewed_at as nil if there is a review period" do
             Settings.billing.review_period = 7.days
             do_request
             assigns[:order].reload.order_details.all? { |od| expect(od.reviewed_at).to be_nil }
             Settings.reload!
           end
 
-          it "should set the fulfilled date to the order time" do
+          it "sets the order_detail fulfilled dates to the order time" do
             @item_pp = @item.item_price_policies.create!(FactoryGirl.attributes_for(:item_price_policy, price_group_id: @price_group.id, start_date: 1.day.ago, expire_date: 1.day.from_now))
             @params.merge!(order_date: format_usa_date(1.day.ago), order_time: { hour: "10", minute: "13", ampm: "AM" })
             do_request
@@ -511,20 +509,20 @@ RSpec.describe OrdersController do
               @params.merge!(order_time: { hour: "10", minute: "00", ampm: "AM" })
             end
 
-            it "should use the current price policy for dates in that policy" do
+            it "uses the current price policy if the order date falls in the policy's date range" do
               @params.merge!(order_date: format_usa_date(1.day.ago))
               do_request
               assigns[:order].reload.order_details.all? { |od| expect(od.price_policy).to eq(@item_pp) }
             end
 
-            it "should use an old price policy for the past" do
+            it "uses an old price policy if the order date falls in the old policy's date range" do
               @params.merge!(order_date: format_usa_date(5.days.ago))
               do_request
               assigns[:order].reload.order_details.all? { |od| expect(od.price_policy).to eq(@item_past_pp) }
             end
 
             # when backdating was initially set up, this would cause an error, but behavior changed as of ticket #51239
-            it "should not have a problem even if there is no policy set for the date in the past" do
+            it "does not error if there is no policy set for the date in the past" do
               @params.merge!(order_date: format_usa_date(9.days.ago))
               do_request
               assigns[:order].reload.order_details.all? do |od|
@@ -556,12 +554,12 @@ RSpec.describe OrdersController do
           @submitted_date = 2.days.ago.change(hour: 14, min: 27)
         end
 
-        it "should completed by default because it's in the past" do
+        it "sets the order_detail states to completed because it's in the past" do
           do_request
           assigns[:order].order_details.all? { |od| expect(od.state).to eq("complete") }
         end
 
-        it "should set the fulfilment date to the order time" do
+        it "sets the order_detail fulfilment dates to the order time" do
           do_request
           assigns[:order].order_details.all? do |od|
             expect(od.fulfilled_at).not_to be_nil
@@ -569,13 +567,13 @@ RSpec.describe OrdersController do
           end
         end
 
-        it "should set the actual times to the reservation times for completed" do
+        it "sets the actual times to the completed reservation times" do
           do_request
           expect(@reservation.reload.actual_start_at).to match_date @reservation.reserve_start_at
           expect(@reservation.actual_end_at).to match_date(@reservation.reserve_start_at + 60.minutes)
         end
 
-        it "should assign a price policy and cost" do
+        it "assigns a price policy and cost" do
           do_request
           expect(@order_detail.reload.price_policy).not_to be_nil
           expect(@order_detail.actual_cost).not_to be_nil
@@ -587,11 +585,11 @@ RSpec.describe OrdersController do
             do_request
           end
 
-          it "should be able to be set to canceled" do
+          it "is able to set order_detail states to canceled" do
             assigns[:order].order_details.all? { |od| expect(od.state).to eq("canceled") }
           end
 
-          it "should set the canceled time on the reservation" do
+          it "sets the canceled time on the reservation" do
             assigns[:order].order_details.all? { |od| expect(od.reservation.canceled_at).not_to be_nil }
             expect(@reservation.reload.canceled_at).not_to be_nil
             # Should this match the date put in the form, or the date when the action took place
@@ -659,7 +657,7 @@ RSpec.describe OrdersController do
         expect(response).to redirect_to "/orders/#{@order.id}"
       end
 
-      it_should_allow :staff, "should assign an estimated price if there is a policy" do
+      it_should_allow :staff, "and assign an estimated price if there is a policy" do
         expect(@item.price_policies).not_to be_empty
         expect(@order.reload.order_details.first.estimated_cost).not_to be_nil
       end
@@ -721,11 +719,9 @@ RSpec.describe OrdersController do
         do_request
       end
 
-      it "should redirect to choose account" do
-        expect(response).to redirect_to("/orders/#{@order.id}/choose_account")
-      end
+      it { expect(response).to redirect_to("/orders/#{@order.id}/choose_account") }
 
-      it "should set session with contents of params[:order][:order_details]" do
+      it "sets the session with contents of params[:order][:order_details]" do
         expect(session[:add_to_cart]).not_to be_empty
         expect(session[:add_to_cart]).to match_array([{ "product_id" => @item.id.to_s, "quantity" => 1 }])
       end
@@ -738,7 +734,7 @@ RSpec.describe OrdersController do
       end
 
       context "mixed facility" do
-        it "should flash error message containing another" do
+        it "should flash error message containing another" do # TODO: reword this
           @facility2          = FactoryGirl.create(:facility)
           @facility_account2  = @facility2.facility_accounts.create!(FactoryGirl.attributes_for(:facility_account))
           @account2           = FactoryGirl.create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: @staff))
@@ -774,7 +770,7 @@ RSpec.describe OrdersController do
         end
 
         facility_operators.each do |role|
-          it "should allow #{role} to purchase" do
+          it "allows #{role} to purchase" do
             maybe_grant_always_sign_in role
             switch_to @guest
             do_request
@@ -784,7 +780,7 @@ RSpec.describe OrdersController do
           end
         end
 
-        it "should not allow guest" do
+        it "does not allow guest" do
           maybe_grant_always_sign_in :guest
           @guest2 = FactoryGirl.create(:user)
           switch_to @guest2
@@ -801,7 +797,7 @@ RSpec.describe OrdersController do
           @params.merge!(order: { order_details: [{ quantity: 1, product_id: @item2.id }] })
         end
 
-        it "should not allow ordering" do
+        it "does not allow ordering" do
           do_request
           expect(@order.reload.order_details).to be_empty
           is_expected.to set_flash.to(/You are not authorized to place an order on behalf of another user for the facility/)
@@ -823,12 +819,12 @@ RSpec.describe OrdersController do
 
     it_should_require_login
 
-    it_should_allow :staff, "should delete an order_detail when /remove/:order_detail_id is called" do
+    it_should_allow :staff, "and delete an order_detail when /remove/:order_detail_id is called" do
       expect(@order.reload.order_details.size).to eq(0)
       expect(response).to redirect_to "/orders/#{@order.id}"
     end
 
-    it "should 404 it the order_detail to be removed is not in the current cart" do
+    it "404s if the order_detail to be removed is not in the current cart" do
       @account2 = FactoryGirl.create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: @director))
       @order2   = @director.orders.create(FactoryGirl.attributes_for(:order, user: @director, created_by: @director.id, account: @account2))
       @order2.add(@item)
@@ -840,7 +836,7 @@ RSpec.describe OrdersController do
     end
 
     context "removing last item in cart" do
-      it "should nil out the payment source in the order/session" do
+      it "nils out the payment source in the order/session" do
         maybe_grant_always_sign_in :staff
         do_request
 
@@ -852,7 +848,7 @@ RSpec.describe OrdersController do
       end
     end
 
-    it "should redirect to the value of the redirect_to param if available" do
+    it "redirects to the value of the redirect_to param if available" do
       maybe_grant_always_sign_in :staff
       overridden_redirect = facility_url(@item.facility)
 
@@ -879,7 +875,7 @@ RSpec.describe OrdersController do
     end
 
     context "bad input" do
-      it "should show an error on not an integer" do
+      it "errors when quantity is not an integer" do
         @params.merge!("quantity#{@order_detail.id}" => "1.5")
         maybe_grant_always_sign_in :guest
         do_request
@@ -945,7 +941,7 @@ RSpec.describe OrdersController do
         @params.merge!(id: @order.id)
       end
 
-      it "should not allow purchasing a restricted item" do
+      it "does not allow purchasing a restricted item" do
         maybe_grant_always_sign_in :guest
         place_reservation(@authable, @order.order_details.first, Time.zone.now)
         # place reservation makes the @order purchased
@@ -955,7 +951,7 @@ RSpec.describe OrdersController do
         expect(assigns[:order]).not_to be_validated
       end
 
-      it "should allow purchasing a restricted item the user isn't authorized for" do
+      it "allows purchasing a restricted item the user isn't authorized for" do
         place_reservation(@authable, @order.order_details.first, Time.zone.now)
         # place reservation makes the @order purchased
         @order.reload.update_attributes!(state: "new")
@@ -967,7 +963,7 @@ RSpec.describe OrdersController do
         expect(assigns[:order]).to be_validated
       end
 
-      it "should not be validated if there is no reservation" do
+      it "is not validated if there is no reservation" do
         maybe_grant_always_sign_in :director
         do_request
         expect(response).to be_success
@@ -1003,7 +999,7 @@ RSpec.describe OrdersController do
 
     it_should_require_login
 
-    it "should disallow viewing of cart that is purchased" do
+    it "does not allow viewing of a cart that is purchased" do
       FactoryGirl.create(:price_group_product, product: @item, price_group: @price_group, reservation_window: nil)
       define_open_account(@item.account, @account.account_number)
       @order.validate_order!
@@ -1024,7 +1020,7 @@ RSpec.describe OrdersController do
       # TODO: add, etc.
     end
 
-    it "should set the potential order_statuses from this facility and only this facility" do
+    it "sets the potential order_statuses from this facility and only this facility" do
       maybe_grant_always_sign_in :staff
       @facility2 = FactoryGirl.create(:facility)
       @order_status = FactoryGirl.create(:order_status, facility: @authable, parent: OrderStatus.new_os.first)

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
-require 'controller_spec_helper'
+require "controller_spec_helper"
 
 RSpec.describe OrdersController do
   include DateHelper
@@ -9,21 +9,22 @@ RSpec.describe OrdersController do
   before(:all) { create_users }
 
   class DummyNotifier
+
     def deliver; end
+
   end
 
-
   it "should route" do
-    expect({ :get => "/orders/cart" }).to route_to(:controller => "orders", :action => "cart")
-    expect({ :get => "/orders/1" }).to route_to(:controller => "orders", :action => "show", :id => "1")
-    expect({ :put => "/orders/1" }).to route_to(:controller => "orders", :action => "update", :id => "1")
-    expect({ :put => "/orders/1/add" }).to route_to(:controller => "orders", :action => "add", :id => "1")
-    expect({ :put => "/orders/1/remove/3" }).to route_to(:controller => "orders", :action => "remove", :id => "1", :order_detail_id => "3")
-    expect({ :put => "/orders/1" }).to route_to(:controller => "orders", :action => "update", :id => "1")
-    expect({ :put => "/orders/1/clear" }).to route_to(:controller => "orders", :action => "clear", :id => "1")
-    expect({ :put => "/orders/1/purchase" }).to route_to(:controller => "orders", :action => "purchase", :id => "1")
-    expect({ :get => "/orders/1/receipt" }).to route_to(:controller => "orders", :action => "receipt", :id => "1")
-    expect({ :get => "/orders/1/choose_account" }).to route_to(:controller => "orders", :action => "choose_account", :id => "1")
+    expect(get: "/orders/cart").to route_to(controller: "orders", action: "cart")
+    expect(get: "/orders/1").to route_to(controller: "orders", action: "show", id: "1")
+    expect(put: "/orders/1").to route_to(controller: "orders", action: "update", id: "1")
+    expect(put: "/orders/1/add").to route_to(controller: "orders", action: "add", id: "1")
+    expect(put: "/orders/1/remove/3").to route_to(controller: "orders", action: "remove", id: "1", order_detail_id: "3")
+    expect(put: "/orders/1").to route_to(controller: "orders", action: "update", id: "1")
+    expect(put: "/orders/1/clear").to route_to(controller: "orders", action: "clear", id: "1")
+    expect(put: "/orders/1/purchase").to route_to(controller: "orders", action: "purchase", id: "1")
+    expect(get: "/orders/1/receipt").to route_to(controller: "orders", action: "receipt", id: "1")
+    expect(get: "/orders/1/choose_account").to route_to(controller: "orders", action: "choose_account", id: "1")
   end
 
   before :each do
@@ -32,21 +33,20 @@ RSpec.describe OrdersController do
     @price_group      = @authable.price_groups.create(FactoryGirl.attributes_for(:price_group))
     @item = @authable.items.create(attributes_for(:item, facility_account_id: @facility_account.id))
     @account = add_account_for_user(:staff, @item, @price_group)
-    @order            = @staff.orders.create(FactoryGirl.attributes_for(:order, :created_by => @staff.id, :account => @account))
+    @order = @staff.orders.create(FactoryGirl.attributes_for(:order, created_by: @staff.id, account: @account))
 
-    @item_pp=@item.item_price_policies.create!(FactoryGirl.attributes_for(:item_price_policy, :price_group_id => @price_group.id, :start_date => 1.hour.ago))
+    @item_pp = @item.item_price_policies.create!(FactoryGirl.attributes_for(:item_price_policy, price_group_id: @price_group.id, start_date: 1.hour.ago))
 
-    @params={ :id => @order.id, :order_id => @order.id }
+    @params = { id: @order.id, order_id: @order.id }
   end
 
   let(:params) { @params }
   let(:order) { @order }
 
-  context 'cart' do
-
+  context "cart" do
     before :each do
-      @method=:get
-      @action=:cart
+      @method = :get
+      @action = :cart
     end
 
     it_should_require_login
@@ -55,40 +55,40 @@ RSpec.describe OrdersController do
       assert_redirected_to order_url(@order)
     end
 
-    context 'signed in' do
+    context "signed in" do
       before(:each) { sign_in @staff }
 
-      context 'with an item' do
+      context "with an item" do
         before :each do
           @order.add(@item, 1)
         end
 
-        it 'should redirect to the order' do
+        it "should redirect to the order" do
           do_request
           expect(request).to redirect_to order_url(@order)
         end
       end
 
-      context 'cart with one reservation' do
+      context "cart with one reservation" do
         before :each do
-          @instrument = FactoryGirl.create(:setup_instrument, :facility => @authable)
+          @instrument = FactoryGirl.create(:setup_instrument, facility: @authable)
           @order.add(@instrument, 1)
-          @res1 = FactoryGirl.create(:setup_reservation, :order_detail => @order.order_details[0], :product => @instrument)
+          @res1 = FactoryGirl.create(:setup_reservation, order_detail: @order.order_details[0], product: @instrument)
         end
 
-        it 'should redirect to a new cart' do
+        it "should redirect to a new cart" do
           do_request
           expect(request).not_to redirect_to order_url(@order)
         end
 
-        context 'with a second reservation' do
+        context "with a second reservation" do
           before :each do
-            @instrument2 = FactoryGirl.create(:setup_instrument, :facility => @authable)
+            @instrument2 = FactoryGirl.create(:setup_instrument, facility: @authable)
             @order.add(@instrument2, 1)
-            @res2 = FactoryGirl.create(:setup_reservation, :order_detail => @order.order_details[2], :product => @instrument)
+            @res2 = FactoryGirl.create(:setup_reservation, order_detail: @order.order_details[2], product: @instrument)
           end
 
-          it 'should redirect to the existing cart' do
+          it "should redirect to the existing cart" do
             do_request
             expect(request).to redirect_to order_url(@order)
           end
@@ -97,16 +97,14 @@ RSpec.describe OrdersController do
     end
   end
 
-
-  context 'choose_account' do
-
+  context "choose_account" do
     before :each do
       @order.add(@item, 1)
       expect(@order.order_details.size).to eq(1)
 
-      @method=:get
-      @action=:choose_account
-      @params.merge!(:account_id => @account.id)
+      @method = :get
+      @action = :choose_account
+      @params.merge!(account_id: @account.id)
     end
 
     it_should_require_login
@@ -114,23 +112,23 @@ RSpec.describe OrdersController do
     it_should_allow :staff do
       expect(assigns(:order)).to be_kind_of Order
       expect(assigns(:order)).to eq(@order)
-      is_expected.to render_template 'choose_account'
+      is_expected.to render_template "choose_account"
     end
 
-    context 'staff logged in' do
+    context "staff logged in" do
       before :each do
         sign_in @staff
       end
-      it 'should redirect to cart url if the cart is empty' do
-        @order2 = @staff.orders.create(FactoryGirl.attributes_for(:order, :created_by => @staff.id, :account => @account))
+
+      it "should redirect to cart url if the cart is empty" do
+        @order2 = @staff.orders.create(FactoryGirl.attributes_for(:order, created_by: @staff.id, account: @account))
         expect(@order2.order_details).to be_empty
-        @params = { :id => @order2.id }
+        @params = { id: @order2.id }
         do_request
         expect(response).to redirect_to cart_path
       end
     end
   end
-
 
   context "update on purchase" do
     before :each do
@@ -143,14 +141,14 @@ RSpec.describe OrdersController do
       # setup params
       @action = :purchase
       @method = :put
-      @params={ :id => @order.id, :order_id => @order.id }
+      @params = { id: @order.id, order_id: @order.id }
 
       sign_in @staff
     end
 
     context "update quantity" do
       before :each do
-        #setup quantity update params
+        # setup quantity update params
         @params["quantity#{@order_detail.id}"] = 5
         do_request
       end
@@ -169,12 +167,11 @@ RSpec.describe OrdersController do
       end
     end
 
-
     context "update quantities of multiple items while keeping total the same" do
       before :each do
         # modify first od quantity behind the scenes
         @order_detail1 = @order_detail
-        @order_detail1.update_attributes(:quantity => 4)
+        @order_detail1.update_attributes(quantity: 4)
 
         # add another item
         @order_detail2 = @order_detail1.order.add(@item, 3).first
@@ -208,7 +205,7 @@ RSpec.describe OrdersController do
 
     context "update note" do
       before :each do
-        #setup note update params (have to also setup quantity params)
+        # setup note update params (have to also setup quantity params)
         @params["note#{@order_detail.id}"] = "note set on purchase"
         do_request
       end
@@ -221,30 +218,29 @@ RSpec.describe OrdersController do
 
       it "should purchase the order" do
         @order.reload
-        expect(@order.state).to eq('purchased')
+        expect(@order.state).to eq("purchased")
       end
     end
 
-    context 'remove note' do
+    context "remove note" do
       let(:order_detail) { order.order_details.first }
       before do
-        order_detail.update_attributes(note: 'old note')
+        order_detail.update_attributes(note: "old note")
         @action = :update
         params["note#{@order_detail.id}"] = ""
       end
 
-      it 'removes the note' do
+      it "removes the note" do
         do_request
         expect(order_detail.reload.note).to be_blank
       end
     end
   end
 
-  context 'purchase' do
-
+  context "purchase" do
     before :each do
-      @method=:put
-      @action=:update_or_purchase
+      @method = :put
+      @action = :update_or_purchase
     end
 
     it_should_require_login
@@ -255,81 +251,81 @@ RSpec.describe OrdersController do
       is_expected.to respond_with :redirect
     end
 
-    context 'success' do
+    context "success" do
       before :each do
         @instrument = FactoryGirl.create(:instrument,
-                                            :facility => @authable,
-                                            :facility_account => @facility_account,
-                                            :no_relay => true)
-        @instrument_pp = create :instrument_price_policy, :price_group => @nupg, product: @instrument
+                                         facility: @authable,
+                                         facility_account: @facility_account,
+                                         no_relay: true)
+        @instrument_pp = create :instrument_price_policy, price_group: @nupg, product: @instrument
         define_open_account(@instrument.account, @account.account_number)
         @reservation = place_reservation_for_instrument(@staff, @instrument, @account, Time.zone.now)
         @order = @reservation.order_detail.order
         expect(@reservation.order_detail.order_status).to be_nil
-        @params.merge!({:id => @order.id, :order_id => @order.id})
+        @params.merge!(id: @order.id, order_id: @order.id)
       end
 
-      it 'should purchase the order' do
+      it "should purchase the order" do
         sign_in @staff
         do_request
-        expect(assigns[:order].state).to eq('purchased')
+        expect(assigns[:order].state).to eq("purchased")
       end
 
-      it 'should set the status of the order detail to the products default status' do
+      it "should set the status of the order detail to the products default status" do
         sign_in @staff
         do_request
         expect(assigns[:order].order_details.size).to eq(1)
         expect(assigns[:order].order_details.first.order_status).to eq(OrderStatus.new_os.first)
       end
 
-      it 'should set the status of the order detail to the products default status' do
-        @order_status = FactoryGirl.create(:order_status, :parent => OrderStatus.inprocess.first)
-        @instrument.update_attributes!(:initial_order_status_id => @order_status.id)
+      it "should set the status of the order detail to the products default status" do
+        @order_status = FactoryGirl.create(:order_status, parent: OrderStatus.inprocess.first)
+        @instrument.update_attributes!(initial_order_status_id: @order_status.id)
         sign_in @staff
         do_request
         expect(assigns[:order].order_details.size).to eq(1)
         expect(assigns[:order].order_details.first.order_status).to eq(@order_status)
       end
 
-      it 'should redirect to my reservations on a successful purchase of a single reservation' do
+      it "should redirect to my reservations on a successful purchase of a single reservation" do
         sign_in @staff
         do_request
-        expect(flash[:notice]).to eq('Reservation completed successfully')
+        expect(flash[:notice]).to eq("Reservation completed successfully")
         expect(response).to redirect_to reservations_path
       end
 
-      it 'should redirect to switch on if the instrument has a relay' do
-        @instrument.update_attributes(:relay => FactoryGirl.create(:relay_dummy, :instrument => @instrument))
+      it "should redirect to switch on if the instrument has a relay" do
+        @instrument.update_attributes(relay: FactoryGirl.create(:relay_dummy, instrument: @instrument))
         sign_in @staff
         do_request
         expect(response).to redirect_to order_order_detail_reservation_switch_instrument_path(
           @order,
           @order_detail,
           @reservation,
-          :switch => 'on',
-          :redirect_to => reservations_path
-          )
+          switch: "on",
+          redirect_to: reservations_path,
+        )
       end
 
-      it 'should redirect to receipt when purchasing multiple reservations' do
+      it "should redirect to receipt when purchasing multiple reservations" do
         @order.add(@instrument, 1)
         expect(@order.order_details.size).to eq(2)
-        @reservation2 = FactoryGirl.create(:reservation, :order_detail => @order.order_details[1], :product => @instrument)
+        @reservation2 = FactoryGirl.create(:reservation, order_detail: @order.order_details[1], product: @instrument)
         expect(Reservation.all.size).to eq(2)
 
         sign_in @staff
         do_request
         expect(response).to redirect_to receipt_order_url(@order)
       end
-      it 'should redirect to receipt when acting as and ordering a single reservation' do
+      it "should redirect to receipt when acting as and ordering a single reservation" do
         sign_in @admin
         switch_to @staff
         do_request
         expect(response).to redirect_to receipt_order_url(@order)
       end
 
-      describe 'notification sending' do
-        it 'should send a notification' do
+      describe "notification sending" do
+        it "should send a notification" do
           expect(Notifier).to receive(:order_receipt).once.and_return(DummyNotifier.new)
           sign_in @admin
           do_request
@@ -346,7 +342,7 @@ RSpec.describe OrdersController do
           expect(Notifier).to receive(:order_receipt).never
           sign_in @admin
           switch_to @staff
-          @params.merge!(:send_notification => '0')
+          @params.merge!(send_notification: "0")
           do_request
         end
 
@@ -354,178 +350,199 @@ RSpec.describe OrdersController do
           expect(Notifier).to receive(:order_receipt).once.and_return(DummyNotifier.new)
           sign_in @admin
           switch_to @staff
-          @params.merge!(:send_notification => '1')
+          @params.merge!(send_notification: "1")
           do_request
         end
       end
     end
 
-    context 'backdating' do
+    context "backdating" do
       before :each do
         @order_detail = place_product_order(@staff, @authable, @item, @account, false)
         @order.update_attribute(:ordered_at, nil)
-        @params.merge!({:id => @order.id})
+        @params.merge!(id: @order.id)
       end
-      it 'should be set up correctly' do
-        expect(@order.state).to eq('new')
-        expect(@order_detail.state).to eq('new')
+
+      it "should be set up correctly" do
+        expect(@order.state).to eq("new")
+        expect(@order_detail.state).to eq("new")
       end
-      it 'should validate the order properly' do
+
+      it "should validate the order properly" do
         expect(@order).to be_has_details
         expect(@order).to be_has_valid_payment
         expect(@order).to be_cart_valid
       end
-      it 'should validate and place order' do
+
+      it "should validate and place order" do
         @order.validate_order!
         expect(@order).to be_place_order
       end
-      it 'should redirect to order receipt on a successful purchase' do
+
+      it "should redirect to order receipt on a successful purchase" do
         sign_in @staff
         do_request
         expect(flash[:error]).to be_nil
         expect(response).to redirect_to receipt_order_path(@order)
       end
-      it 'should set the ordered at to the past' do
+
+      it "should set the ordered at to the past" do
         maybe_grant_always_sign_in :director
         switch_to @staff
-        @params.merge!({:order_date => format_usa_date(1.day.ago), :order_time => {:hour => '10', :minute => '12', :ampm => 'AM'}})
+        @params.merge!(order_date: format_usa_date(1.day.ago), order_time: { hour: "10", minute: "12", ampm: "AM" })
         do_request
-        expect(assigns[:order].reload.ordered_at).to match_date 1.day.ago.change(:hour => 10, :min => 12)
+        expect(assigns[:order].reload.ordered_at).to match_date 1.day.ago.change(hour: 10, min: 12)
       end
-      it 'should set the ordered at to now if not acting_as' do
+
+      it "should set the ordered at to now if not acting_as" do
         maybe_grant_always_sign_in :director
-        @params.merge!({:order_date => format_usa_date(1.day.ago)})
+        @params.merge!(order_date: format_usa_date(1.day.ago))
         do_request
         expect(assigns[:order].reload.ordered_at).to match_date Time.zone.now
       end
 
-      context 'setting status of order details' do
+      context "setting status of order details" do
         before :each do
           maybe_grant_always_sign_in :director
           switch_to @staff
         end
-        it 'should leave as new by default' do
+
+        it "should leave as new by default" do
           do_request
-          assigns[:order].reload.order_details.all? { |od| expect(od.state).to eq('new') }
-        end
-        it 'should leave as new if new is set as the param' do
-          @params.merge!({:order_status_id => OrderStatus.new_os.first.id})
-          do_request
-          assigns[:order].reload.order_details.all? { |od| expect(od.state).to eq('new') }
-        end
-        it 'should be able to set to canceled' do
-          @params.merge!({:order_status_id => OrderStatus.canceled.first.id})
-          do_request
-          assigns[:order].reload.order_details.all? { |od| expect(od.state).to eq('canceled') }
+          assigns[:order].reload.order_details.all? { |od| expect(od.state).to eq("new") }
         end
 
-        context 'completed' do
+        it "should leave as new if new is set as the param" do
+          @params.merge!(order_status_id: OrderStatus.new_os.first.id)
+          do_request
+          assigns[:order].reload.order_details.all? { |od| expect(od.state).to eq("new") }
+        end
+
+        it "should be able to set to canceled" do
+          @params.merge!(order_status_id: OrderStatus.canceled.first.id)
+          do_request
+          assigns[:order].reload.order_details.all? { |od| expect(od.state).to eq("canceled") }
+        end
+
+        context "completed" do
           before :each do
-            @params.merge!({:order_status_id => OrderStatus.complete.first.id})
+            @params.merge!(order_status_id: OrderStatus.complete.first.id)
           end
-          it 'should be able to set to completed' do
+          it "should be able to set to completed" do
             do_request
-            assigns[:order].reload.order_details.all? { |od| expect(od.state).to eq('complete') }
+            assigns[:order].reload.order_details.all? { |od| expect(od.state).to eq("complete") }
           end
-          it 'should set reviewed_at if there is zero review period' do
+
+          it "should set reviewed_at if there is zero review period" do
             Settings.billing.review_period = 0.days
             do_request
             assigns[:order].reload.order_details.all? { |od| expect(od.reviewed_at).not_to be_nil }
             Settings.reload!
           end
-          it 'should leave reviewed_at as nil if there is a review period' do
+
+          it "should leave reviewed_at as nil if there is a review period" do
             Settings.billing.review_period = 7.days
             do_request
             assigns[:order].reload.order_details.all? { |od| expect(od.reviewed_at).to be_nil }
             Settings.reload!
           end
-          it 'should set the fulfilled date to the order time' do
-            @item_pp = @item.item_price_policies.create!(FactoryGirl.attributes_for(:item_price_policy, :price_group_id => @price_group.id, :start_date => 1.day.ago, :expire_date => 1.day.from_now))
-            @params.merge!({:order_date => format_usa_date(1.day.ago), :order_time => {:hour => '10', :minute => '13', :ampm => 'AM'}})
+
+          it "should set the fulfilled date to the order time" do
+            @item_pp = @item.item_price_policies.create!(FactoryGirl.attributes_for(:item_price_policy, price_group_id: @price_group.id, start_date: 1.day.ago, expire_date: 1.day.from_now))
+            @params.merge!(order_date: format_usa_date(1.day.ago), order_time: { hour: "10", minute: "13", ampm: "AM" })
             do_request
-            assigns[:order].reload.order_details.all? { |od| expect(od.fulfilled_at).to match_date 1.day.ago.change(:hour => 10, :min => 13) }
+            assigns[:order].reload.order_details.all? { |od| expect(od.fulfilled_at).to match_date 1.day.ago.change(hour: 10, min: 13) }
           end
-          context 'price policies' do
+
+          context "price policies" do
             before :each do
               @item.item_price_policies.clear
-              @item_pp = @item.item_price_policies.create!(FactoryGirl.attributes_for(:item_price_policy, :price_group_id => @price_group.id, :start_date => 1.day.ago, :expire_date => 1.day.from_now))
-              @item_past_pp=@item.item_price_policies.create!(FactoryGirl.attributes_for(:item_price_policy, :price_group_id => @price_group.id, :start_date => 7.days.ago, :expire_date => 1.day.ago))
-              @params.merge!(:order_time => {:hour => '10', :minute => '00', :ampm => 'AM'})
+              @item_pp = @item.item_price_policies.create!(FactoryGirl.attributes_for(:item_price_policy, price_group_id: @price_group.id, start_date: 1.day.ago, expire_date: 1.day.from_now))
+              @item_past_pp = @item.item_price_policies.create!(FactoryGirl.attributes_for(:item_price_policy, price_group_id: @price_group.id, start_date: 7.days.ago, expire_date: 1.day.ago))
+              @params.merge!(order_time: { hour: "10", minute: "00", ampm: "AM" })
             end
-            it 'should use the current price policy for dates in that policy' do
-              @params.merge!({:order_date => format_usa_date(1.day.ago)})
+
+            it "should use the current price policy for dates in that policy" do
+              @params.merge!(order_date: format_usa_date(1.day.ago))
               do_request
               assigns[:order].reload.order_details.all? { |od| expect(od.price_policy).to eq(@item_pp) }
             end
-            it 'should use an old price policy for the past' do
-              @params.merge!({:order_date => format_usa_date(5.days.ago)})
+
+            it "should use an old price policy for the past" do
+              @params.merge!(order_date: format_usa_date(5.days.ago))
               do_request
               assigns[:order].reload.order_details.all? { |od| expect(od.price_policy).to eq(@item_past_pp) }
             end
 
             # when backdating was initially set up, this would cause an error, but behavior changed as of ticket #51239
-            it 'should not have a problem even if there is no policy set for the date in the past' do
-              @params.merge!({:order_date => format_usa_date(9.days.ago)})
+            it "should not have a problem even if there is no policy set for the date in the past" do
+              @params.merge!(order_date: format_usa_date(9.days.ago))
               do_request
               assigns[:order].reload.order_details.all? do |od|
                 expect(od.price_policy).to be_nil
                 expect(od.actual_cost).to be_nil
                 expect(od.actual_subsidy).to be_nil
-                expect(od.state).to eq('complete')
+                expect(od.state).to eq("complete")
               end
               expect(flash[:error]).to be_nil
               expect(response).to redirect_to receipt_order_url(@order)
             end
           end
-
         end
       end
 
-      context 'backdating a reservation' do
+      context "backdating a reservation" do
         before :each do
           @instrument = FactoryGirl.create(:instrument,
-                                              :facility => @authable,
-                                              :facility_account => @facility_account)
-          @instrument_pp = create :instrument_price_policy, price_group: @price_group, start_date: 7.day.ago, expire_date: 1.day.from_now, product: @instrument
+                                           facility: @authable,
+                                           facility_account: @facility_account)
+          @instrument_pp = create :instrument_price_policy, price_group: @price_group, start_date: 7.days.ago, expire_date: 1.day.from_now, product: @instrument
           define_open_account(@instrument.account, @account.account_number)
           @reservation = place_reservation_for_instrument(@staff, @instrument, @account, 3.days.ago)
           expect(@reservation).not_to be_nil
-          @params.merge!(:id => @reservation.order_detail.order.id)
+          @params.merge!(id: @reservation.order_detail.order.id)
           maybe_grant_always_sign_in :director
           switch_to @staff
-          @params.merge!({:order_date => format_usa_date(2.days.ago), :order_time => {:hour => '2', :minute => '27', :ampm => 'PM'}})
-          @submitted_date = 2.days.ago.change(:hour => 14, :min => 27)
+          @params.merge!(order_date: format_usa_date(2.days.ago), order_time: { hour: "2", minute: "27", ampm: "PM" })
+          @submitted_date = 2.days.ago.change(hour: 14, min: 27)
         end
+
         it "should completed by default because it's in the past" do
           do_request
-          assigns[:order].order_details.all? { |od| expect(od.state).to eq('complete') }
+          assigns[:order].order_details.all? { |od| expect(od.state).to eq("complete") }
         end
-        it 'should set the fulfilment date to the order time' do
+
+        it "should set the fulfilment date to the order time" do
           do_request
           assigns[:order].order_details.all? do |od|
             expect(od.fulfilled_at).not_to be_nil
             expect(od.fulfilled_at).to match_date @reservation.reserve_end_at
           end
         end
-        it 'should set the actual times to the reservation times for completed' do
+
+        it "should set the actual times to the reservation times for completed" do
           do_request
           expect(@reservation.reload.actual_start_at).to match_date @reservation.reserve_start_at
           expect(@reservation.actual_end_at).to match_date(@reservation.reserve_start_at + 60.minutes)
         end
-        it 'should assign a price policy and cost' do
+
+        it "should assign a price policy and cost" do
           do_request
           expect(@order_detail.reload.price_policy).not_to be_nil
           expect(@order_detail.actual_cost).not_to be_nil
         end
-        context 'canceled' do
+
+        context "canceled" do
           before :each do
-            @params.merge!({:order_status_id => OrderStatus.canceled.first.id})
+            @params.merge!(order_status_id: OrderStatus.canceled.first.id)
             do_request
           end
-          it 'should be able to be set to canceled' do
-            assigns[:order].order_details.all? { |od| expect(od.state).to eq('canceled') }
+
+          it "should be able to be set to canceled" do
+            assigns[:order].order_details.all? { |od| expect(od.state).to eq("canceled") }
           end
-          it 'should set the canceled time on the reservation' do
+
+          it "should set the canceled time on the reservation" do
             assigns[:order].order_details.all? { |od| expect(od.reservation.canceled_at).not_to be_nil }
             expect(@reservation.reload.canceled_at).not_to be_nil
             # Should this match the date put in the form, or the date when the action took place
@@ -536,15 +553,13 @@ RSpec.describe OrdersController do
     end
   end
 
-
-  context 'receipt' do
-
+  context "receipt" do
     before :each do
       # for receipt to work, order needs to have order_details
       @complete_order = place_and_complete_item_order(@staff, @authable, @account).order.reload
-      @method=:get
-      @action=:receipt
-      @params={:id => @complete_order.id}
+      @method = :get
+      @action = :receipt
+      @params = { id: @complete_order.id }
     end
 
     it_should_require_login
@@ -552,35 +567,30 @@ RSpec.describe OrdersController do
     it_should_allow :staff do
       expect(assigns(:order)).to be_kind_of Order
       expect(assigns(:order)).to eq(@complete_order)
-      is_expected.to render_template 'receipt'
+      is_expected.to render_template "receipt"
     end
-
   end
 
-
-  context 'index' do
-
+  context "index" do
     before :each do
-      @method=:get
-      @action=:index
-      @params={:status => 'pending'}
+      @method = :get
+      @action = :index
+      @params = { status: "pending" }
     end
 
     it_should_require_login
 
     it_should_allow :staff do
       expect(assigns(:order_details)).to be_kind_of ActiveRecord::Relation
-      is_expected.to render_template 'index'
+      is_expected.to render_template "index"
     end
-
   end
-
 
   context "add to cart" do
     before(:each) do
-      @method=:put
-      @action=:add
-      @params.merge!(:order => {:order_details => [{:quantity => 1, :product_id => @item.id}]})
+      @method = :put
+      @action = :add
+      @params.merge!(order: { order_details: [{ quantity: 1, product_id: @item.id }] })
       @order.clear_cart?
     end
 
@@ -600,22 +610,22 @@ RSpec.describe OrdersController do
         expect(response).to redirect_to "/orders/#{@order.id}"
       end
 
-      it_should_allow :staff, 'should assign an estimated price if there is a policy' do
+      it_should_allow :staff, "should assign an estimated price if there is a policy" do
         expect(@item.price_policies).not_to be_empty
         expect(@order.reload.order_details.first.estimated_cost).not_to be_nil
       end
 
     end
 
-    context 'instrument' do
+    context "instrument" do
       before :each do
         @order.clear_cart?
-        @instrument=FactoryGirl.create(:instrument,
-                                          :facility => @authable,
-                                          :facility_account => @facility_account,
-                                          :min_reserve_mins => 60,
-                                          :max_reserve_mins => 60)
-        @params[:id]=@order.id
+        @instrument = FactoryGirl.create(:instrument,
+                                         facility: @authable,
+                                         facility_account: @facility_account,
+                                         min_reserve_mins: 60,
+                                         max_reserve_mins: 60)
+        @params[:id] = @order.id
         @params[:order][:order_details].first[:product_id] = @instrument.id
       end
 
@@ -668,7 +678,7 @@ RSpec.describe OrdersController do
 
       it "should set session with contents of params[:order][:order_details]" do
         expect(session[:add_to_cart]).not_to be_empty
-        expect(session[:add_to_cart]).to match_array([{"product_id" => @item.id.to_s, "quantity" => 1}])
+        expect(session[:add_to_cart]).to match_array([{ "product_id" => @item.id.to_s, "quantity" => 1 }])
       end
     end
 
@@ -682,14 +692,14 @@ RSpec.describe OrdersController do
         it "should flash error message containing another" do
           @facility2          = FactoryGirl.create(:facility)
           @facility_account2  = @facility2.facility_accounts.create!(FactoryGirl.attributes_for(:facility_account))
-          @account2           = FactoryGirl.create(:nufs_account, :account_users_attributes => account_users_attributes_hash(:user => @staff))
-          @item2              = @facility2.items.create!(FactoryGirl.attributes_for(:item, :facility_account_id => @facility_account2.id))
+          @account2           = FactoryGirl.create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: @staff))
+          @item2              = @facility2.items.create!(FactoryGirl.attributes_for(:item, facility_account_id: @facility_account2.id))
           # add first item to cart
           maybe_grant_always_sign_in :staff
           do_request
 
           # add second item to cart
-          @params.merge!(:order => {:order_details => [{:quantity => 1, :product_id => @item2.id}]})
+          @params.merge!(order: { order_details: [{ quantity: 1, product_id: @item2.id }] })
           do_request
 
           is_expected.to set_flash.to(/can not/)
@@ -705,13 +715,15 @@ RSpec.describe OrdersController do
         @order.save!
         @facility2          = FactoryGirl.create(:facility)
         @facility_account2  = @facility2.facility_accounts.create!(FactoryGirl.attributes_for(:facility_account))
-        @account2           = FactoryGirl.create(:nufs_account, :account_users_attributes => account_users_attributes_hash(:user => @staff))
-        @item2              = @facility2.items.create!(FactoryGirl.attributes_for(:item, :facility_account_id => @facility_account2.id))
+        @account2           = FactoryGirl.create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: @staff))
+        @item2              = @facility2.items.create!(FactoryGirl.attributes_for(:item, facility_account_id: @facility_account2.id))
       end
+
       context "in the right facility" do
         before :each do
-          @params.merge!(:order => {:order_details => [{:quantity => 1, :product_id => @item.id}]})
+          @params.merge!(order: { order_details: [{ quantity: 1, product_id: @item.id }] })
         end
+
         facility_operators.each do |role|
           it "should allow #{role} to purchase" do
             maybe_grant_always_sign_in role
@@ -722,6 +734,7 @@ RSpec.describe OrdersController do
             expect(response).to redirect_to "/orders/#{@order.id}"
           end
         end
+
         it "should not allow guest" do
           maybe_grant_always_sign_in :guest
           @guest2 = FactoryGirl.create(:user)
@@ -731,11 +744,12 @@ RSpec.describe OrdersController do
           expect(@order.reload.order_details).to be_empty
         end
       end
+
       context "in the another facility" do
         before :each do
           maybe_grant_always_sign_in :director
           switch_to @guest
-          @params.merge!(:order => {:order_details => [{:quantity => 1, :product_id => @item2.id}]})
+          @params.merge!(order: { order_details: [{ quantity: 1, product_id: @item2.id }] })
         end
 
         it "should not allow ordering" do
@@ -753,9 +767,9 @@ RSpec.describe OrdersController do
       expect(@order.order_details.size).to eq(1)
       @order_detail = @order.order_details[0]
 
-      @method=:put
-      @action=:remove
-      @params.merge!(:order_detail_id => @order_detail.id)
+      @method = :put
+      @action = :remove
+      @params.merge!(order_detail_id: @order_detail.id)
     end
 
     it_should_require_login
@@ -766,11 +780,11 @@ RSpec.describe OrdersController do
     end
 
     it "should 404 it the order_detail to be removed is not in the current cart" do
-      @account2 = FactoryGirl.create(:nufs_account, :account_users_attributes => account_users_attributes_hash(:user => @director))
-      @order2   = @director.orders.create(FactoryGirl.attributes_for(:order, :user => @director, :created_by => @director.id, :account => @account2))
+      @account2 = FactoryGirl.create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: @director))
+      @order2   = @director.orders.create(FactoryGirl.attributes_for(:order, user: @director, created_by: @director.id, account: @account2))
       @order2.add(@item)
       @order_detail2 = @order2.order_details[0]
-      @params[:order_detail_id]=@order_detail2.id
+      @params[:order_detail_id] = @order_detail2.id
       maybe_grant_always_sign_in :staff
       do_request
       expect(response.response_code).to eq(404)
@@ -793,20 +807,18 @@ RSpec.describe OrdersController do
       maybe_grant_always_sign_in :staff
       overridden_redirect = facility_url(@item.facility)
 
-      @params.merge!(:redirect_to => overridden_redirect)
+      @params.merge!(redirect_to: overridden_redirect)
       do_request
 
       expect(response).to redirect_to overridden_redirect
       is_expected.to set_flash.to /removed/
     end
-
   end
-
 
   context "update order_detail quantities" do
     before(:each) do
-      @method=:put
-      @action=:update
+      @method = :put
+      @action = :update
       @order_detail = @order.add(@item, 1).first
       @params.merge!("quantity#{@order_detail.id}" => "6")
     end
@@ -826,48 +838,45 @@ RSpec.describe OrdersController do
         is_expected.to set_flash.to(/integer/i)
         is_expected.to render_template :show
       end
-
-
     end
-
   end
 
   context "update order_detail notes" do
     before(:each) do
-      @method=:put
-      @action=:update
+      @method = :put
+      @action = :update
       @order_detail = @order.add(@item, 1).first
       @params.merge!(
         "quantity#{@order_detail.id}" => "6",
-        "note#{@order_detail.id}" => "new note"
+        "note#{@order_detail.id}" => "new note",
       )
     end
 
     it_should_require_login
 
     it_should_allow :staff, "to update the note field of order_details" do
-      expect(@order_detail.reload.note).to eq('new note')
+      expect(@order_detail.reload.note).to eq("new note")
     end
   end
 
   context "cart meta data" do
     before(:each) do
-      @instrument   = FactoryGirl.create(:instrument,
-                                          :facility => @authable,
-                                          :facility_account => @facility_account)
+      @instrument = FactoryGirl.create(:instrument,
+                                       facility: @authable,
+                                       facility_account: @facility_account)
 
-      @instrument.schedule_rules.create(FactoryGirl.attributes_for(:schedule_rule, :start_hour => 0, :end_hour => 24))
-      @instrument_pp = @instrument.instrument_price_policies.create(FactoryGirl.attributes_for(:instrument_price_policy, :price_group_id => @price_group.id))
+      @instrument.schedule_rules.create(FactoryGirl.attributes_for(:schedule_rule, start_hour: 0, end_hour: 24))
+      @instrument_pp = @instrument.instrument_price_policies.create(FactoryGirl.attributes_for(:instrument_price_policy, price_group_id: @price_group.id))
       @instrument_pp.restrict_purchase = false
       define_open_account(@instrument.account, @account.account_number)
-      @service          = @authable.services.create(FactoryGirl.attributes_for(:service, :facility_account_id => @facility_account.id))
-      @method=:get
-      @action=:show
+      @service = @authable.services.create(FactoryGirl.attributes_for(:service, facility_account_id: @facility_account.id))
+      @method = :get
+      @action = :show
     end
 
     it_should_require_login
 
-    context 'staff' do
+    context "staff" do
       before :each do
         @order.add(@instrument)
         @order_detail = @order.order_details.first
@@ -880,32 +889,35 @@ RSpec.describe OrdersController do
 
     context "restricted instrument" do
       before :each do
-        @instrument.update_attributes(:requires_approval => true)
-        @order.update_attributes(:created_by_user => @director, :account => @account)
+        @instrument.update_attributes(requires_approval: true)
+        @order.update_attributes(created_by_user: @director, account: @account)
         @order.add(@instrument)
         expect(@order.order_details.size).to eq(1)
-        @params.merge!(:id => @order.id)
+        @params.merge!(id: @order.id)
       end
-      it 'should not allow purchasing a restricted item' do
+
+      it "should not allow purchasing a restricted item" do
         maybe_grant_always_sign_in :guest
         place_reservation(@authable, @order.order_details.first, Time.zone.now)
-        #place reservation makes the @order purchased
-        @order.reload.update_attributes!(:state => 'new')
+        # place reservation makes the @order purchased
+        @order.reload.update_attributes!(state: "new")
         do_request
         expect(assigns[:order]).to eq(@order)
         expect(assigns[:order]).not_to be_validated
       end
+
       it "should allow purchasing a restricted item the user isn't authorized for" do
         place_reservation(@authable, @order.order_details.first, Time.zone.now)
-        #place reservation makes the @order purchased
-        @order.reload.update_attributes!(:state => 'new')
+        # place reservation makes the @order purchased
+        @order.reload.update_attributes!(state: "new")
         maybe_grant_always_sign_in :director
         switch_to @guest
         do_request
-        expect(response.code).to eq('200')
+        expect(response.code).to eq("200")
         expect(assigns[:order]).to eq(@order)
         expect(assigns[:order]).to be_validated
       end
+
       it "should not be validated if there is no reservation" do
         maybe_grant_always_sign_in :director
         do_request
@@ -917,11 +929,10 @@ RSpec.describe OrdersController do
     end
   end
 
-
   context "clear" do
     before(:each) do
-      @method=:put
-      @action=:clear
+      @method = :put
+      @action = :clear
     end
 
     it_should_require_login
@@ -930,23 +941,21 @@ RSpec.describe OrdersController do
       @order.order_details.size == 0
       assert_redirected_to order_path(@order)
     end
-
   end
-
 
   context "checkout" do
     before(:each) do
-      #@item_pp          = FactoryGirl.create(:item_price_policy, :item => @item, :price_group => @price_group)
-      #@pg_member        = FactoryGirl.create(:user_price_group_member, :user => @staff, :price_group => @price_group)
+      # @item_pp          = FactoryGirl.create(:item_price_policy, :item => @item, :price_group => @price_group)
+      # @pg_member        = FactoryGirl.create(:user_price_group_member, :user => @staff, :price_group => @price_group)
       @order.add(@item, 10)
-      @method=:get
-      @action=:show
+      @method = :get
+      @action = :show
     end
 
     it_should_require_login
 
     it "should disallow viewing of cart that is purchased" do
-      FactoryGirl.create(:price_group_product, :product => @item, :price_group =>@price_group, :reservation_window => nil)
+      FactoryGirl.create(:price_group_product, product: @item, price_group: @price_group, reservation_window: nil)
       define_open_account(@item.account, @account.account_number)
       @order.validate_order!
       @order.purchase!
@@ -954,28 +963,26 @@ RSpec.describe OrdersController do
       do_request
       expect(response).to redirect_to "/orders/#{@order.id}/receipt"
 
-      @action=:choose_account
+      @action = :choose_account
       do_request
       expect(response).to redirect_to "/orders/#{@order.id}/receipt"
 
-      @method=:put
-      @action=:purchase
+      @method = :put
+      @action = :purchase
       do_request
       expect(response).to redirect_to "/orders/#{@order.id}/receipt"
 
       # TODO: add, etc.
     end
 
-    it 'should set the potential order_statuses from this facility and only this facility' do
+    it "should set the potential order_statuses from this facility and only this facility" do
       maybe_grant_always_sign_in :staff
       @facility2 = FactoryGirl.create(:facility)
-      @order_status = FactoryGirl.create(:order_status, :facility => @authable, :parent => OrderStatus.new_os.first)
-      @order_status_other = FactoryGirl.create(:order_status, :facility => @facility2, :parent => OrderStatus.new_os.first)
+      @order_status = FactoryGirl.create(:order_status, facility: @authable, parent: OrderStatus.new_os.first)
+      @order_status_other = FactoryGirl.create(:order_status, facility: @facility2, parent: OrderStatus.new_os.first)
       do_request
       expect(assigns[:order_statuses]).to be_include @order_status
       expect(assigns[:order_statuses]).not_to be_include @order_status_other
     end
-
   end
-
 end

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -190,6 +190,27 @@ RSpec.describe OrdersController do
         expect { do_request }.not_to change { order_detail.reload.account }
       end
     end
+
+    context "when the accounts for the order_details were previously reset" do
+      before(:each) do
+        order_detail.account = nil
+        order_detail.save!
+        @params.merge!(account_id: account.id)
+      end
+
+      context "when selecting the same account" do
+        it "does not change the account associated with the order" do
+          expect { do_request }.not_to change { order.reload.account }
+        end
+
+        it "updates the account associated with the order_detail" do
+          expect { do_request }
+            .to change { order_detail.reload.account }
+            .from(nil)
+            .to(account)
+        end
+      end
+    end
   end
 
   context "update on purchase" do

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -131,19 +131,6 @@ RSpec.describe OrdersController do
 
         it { expect(response).to redirect_to(cart_path) }
       end
-
-      context "with reset_account set to true" do
-        before { @params.merge!(reset_account: true) }
-
-        it "retains the account on the order" do
-          expect { do_request }.not_to change { order.reload.account }
-        end
-
-        it "clears the account on the order_details" do
-          expect { do_request }
-            .to change { order.reload.order_details.first.account }.to(nil)
-        end
-      end
     end
   end
 
@@ -188,27 +175,6 @@ RSpec.describe OrdersController do
 
       it "does not change the account associated with the order_detail" do
         expect { do_request }.not_to change { order_detail.reload.account }
-      end
-    end
-
-    context "when the accounts for the order_details were previously reset" do
-      before(:each) do
-        order_detail.account = nil
-        order_detail.save!
-        @params.merge!(account_id: account.id)
-      end
-
-      context "when selecting the same account" do
-        it "does not change the account associated with the order" do
-          expect { do_request }.not_to change { order.reload.account }
-        end
-
-        it "updates the account associated with the order_detail" do
-          expect { do_request }
-            .to change { order_detail.reload.account }
-            .from(nil)
-            .to(account)
-        end
       end
     end
   end


### PR DESCRIPTION
While this appears to fix the issue in changing the account but keeping it the same (as happens when only one account is available), I have some questions.

The scenario is this:
* Add a product to your cart
* From the `/orders/:order_id` page, click "Change Payment Source".
* Arrive at `/orders/:order_id/choose_account?reset_account=true`
* Choose the same account you used when adding to the cart
* Arrive back to `/orders/:order_id`; note the "You must select a payment method" warning

The `GET  /orders/:order_id/choose_account?reset_account=true` request sets the `account_id` of the `order_details` to `nil`, but retains the `account_id` of the `order`. I'm not sure why we need to `nil` these out at all, but if we do, I would think we should clear the `account_id` on the `order` to match. Ideally I'd get rid of `reset_account` completely; it's a `GET` and is only resetting things partially anyway. But I didn't change this behavior and added specs to document it.

The `POST` on choosing an account is interesting too, in that it would only set `account_id` on the `order`, but not `order_details`. That is, if they've just been reset, they remain `nil`. This patch should set the `account_id`s on `order_details` to match their parent `order`. But then should that even be happening in the controller? While it doesn't happen currently, should changing an `order`'s `account_id` automatically update the accounts for its `order_details`? Are there reasons why we don't want that to happen?