### PR TITLE
[#102132] Select no payment source on new reservation forms

### DIFF
--- a/app/views/reservations/_account_field.html.haml
+++ b/app/views/reservations/_account_field.html.haml
@@ -3,7 +3,12 @@
     .container
       .row
         .span6
-          = simple_fields_for @order do |o|
-            = o.input :account, :collection => @order.user.accounts_for_product(@instrument), :input_html => { :name => 'order_account' }, :selected => @order.account_id || params[:order_account]
+          = simple_fields_for @order do |order_fields|
+            = order_fields.input :account,
+              collection: @order.user.accounts_for_product(@instrument),
+              input_html: { name: "order_account" },
+              include_blank: true,
+              selected: @order.account_id || params[:order_account]
+
         - if acting_as?
           .span6= f.input :note

--- a/app/views/reservations/_account_field.html.haml
+++ b/app/views/reservations/_account_field.html.haml
@@ -4,12 +4,6 @@
       .row
         .span6
           = simple_fields_for @order do |order_fields|
-            - accounts = @order.user.accounts_for_product(@instrument)
-
-            - selected_account_id = @order.account_id || params[:order_account]
-            - if selected_account_id.blank? && accounts.count == 1
-              - selected_account_id = accounts.first.id
-
             = order_fields.input :account,
               collection: accounts,
               input_html: { name: "order_account" },

--- a/app/views/reservations/_account_field.html.haml
+++ b/app/views/reservations/_account_field.html.haml
@@ -7,16 +7,3 @@
             = o.input :account, :collection => @order.user.accounts_for_product(@instrument), :input_html => { :name => 'order_account' }, :selected => @order.account_id || params[:order_account]
         - if acting_as?
           .span6= f.input :note
-
--# %ul.form.box
--#   %li.left
--#     = label_tag 'order_account', t('.label')
--#     - options=@order.user.accounts_for_product @instrument
--#     - options.collect!{|acct| [acct.to_s ,acct.id] }
--#     - options.unshift(Array.new(2)) if options.size > 1
--#     = select_tag 'order_account', options_for_select(options, @order.account_id)
--#   - if acting_as?
--#     %li.left
--#       = f.label       :note
--#       = f.text_field  :note, :size => 100, :maxlength => 100
--#   %li.clear

--- a/app/views/reservations/_account_field.html.haml
+++ b/app/views/reservations/_account_field.html.haml
@@ -4,6 +4,12 @@
       .row
         .span6
           = simple_fields_for @order do |order_fields|
+            - accounts = @order.user.accounts_for_product(@instrument)
+
+            - selected_account_id = @order.account_id || params[:order_account]
+            - if selected_account_id.blank? && accounts.count == 1
+              - selected_account_id = accounts.first.id
+
             = order_fields.input :account,
               collection: accounts,
               input_html: { name: "order_account" },

--- a/app/views/reservations/_account_field.html.haml
+++ b/app/views/reservations/_account_field.html.haml
@@ -4,11 +4,17 @@
       .row
         .span6
           = simple_fields_for @order do |order_fields|
+            - accounts = @order.user.accounts_for_product(@instrument)
+
+            - selected_account_id = @order.account_id || params[:order_account]
+            - if selected_account_id.blank? && accounts.count == 1
+              - selected_account_id = accounts.first.id
+
             = order_fields.input :account,
-              collection: @order.user.accounts_for_product(@instrument),
+              collection: accounts,
               input_html: { name: "order_account" },
               include_blank: true,
-              selected: @order.account_id || params[:order_account]
+              selected: selected_account_id
 
         - if acting_as?
           .span6= f.input :note

--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -25,14 +25,7 @@
 
 = simple_form_for([@order, @order_detail, @reservation]) do |f|
   = f.error_messages
-
-  - unless @order_detail.bundled?
-    - accounts = @order.user.accounts_for_product(@instrument)
-    - selected_account_id = @order.account_id || params[:order_account]
-    - if selected_account_id.blank? && accounts.count == 1
-      - selected_account_id = accounts.first.id
-
-    = render "account_field", accounts: accounts, selected_account_id: selected_account_id
+  = render partial: 'account_field', locals: { f: f } unless @order_detail.bundled?
 
   .row
     .well.span12

--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -25,7 +25,14 @@
 
 = simple_form_for([@order, @order_detail, @reservation]) do |f|
   = f.error_messages
-  = render partial: 'account_field', locals: { f: f } unless @order_detail.bundled?
+
+  - unless @order_detail.bundled?
+    - accounts = @order.user.accounts_for_product(@instrument)
+    - selected_account_id = @order.account_id || params[:order_account]
+    - if selected_account_id.blank? && accounts.count == 1
+      - selected_account_id = accounts.first.id
+
+    = render "account_field", accounts: accounts, selected_account_id: selected_account_id
 
   .row
     .well.span12


### PR DESCRIPTION
This adds a blank to the account drop-down on the new reservation form, and it should be selected by default. If the user selects an account and there's an error on `create`, the account should remain selected.