### PR TITLE
Fixes for AccountBuilder

### DIFF
--- a/app/controllers/facility_accounts_controller.rb
+++ b/app/controllers/facility_accounts_controller.rb
@@ -66,7 +66,9 @@ class FacilityAccountsController < ApplicationController
       params: params,
     ).build
 
-    if @account.save
+    # The builder might add some errors to base. If those exist,
+    # we don't want to try saving as that would clear the original errors
+    if @account.errors[:base].empty? && @account.save
       flash[:notice] = I18n.t("controllers.facility_accounts.create.success")
       redirect_to facility_user_accounts_path(current_facility, @account.owner_user)
     else

--- a/app/services/nufs_account_builder.rb
+++ b/app/services/nufs_account_builder.rb
@@ -15,7 +15,20 @@ class NufsAccountBuilder < AccountBuilder
 
   # Hooks into superclass's `build` method.
   def after_build
+    begin
+      # This will populate virtual fields like fund, dept
+      account.load_components
+    rescue AccountNumberFormatError
+      # do nothing
+    rescue ValidatorError => e
+      account.errors.add(:base, e.message)
+    end
+
     account.set_expires_at
+    # This is kind of a weird message to be adding here (the message is about)
+    # not finding the fund, dept, activity, etc, but leaving here to preserve
+    # existing behavior
+    account.errors.add(:base, :missing_expires_at) unless account.expires_at
   end
 
 end

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -22,7 +22,6 @@ en:
           failure: "No transactions were reassigned. %{reassignment_error} on Order Detail #%{order_detail_id}."
     facility_accounts:
       create:
-        expires_at_missing: "The chart string appears to be invalid. Either the fund, department, project, or activity could not be found."
         success: "Account was successfully created."
       update: "The payment source was successfully updated."
       suspend:

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -105,6 +105,8 @@ en:
           no_orders: "No orders were selected to journal"
           cannot_be_in_future: may not be in the future.
           cannot_be_before_last_fulfillment: may not be before the latest fulfillment date.
+        nufs_account:
+          missing_expires_at: "The chart string appears to be invalid. Either the fund, department, project, or activity could not be found."
 
     # Model Names
     models:


### PR DESCRIPTION
Move load_components call to only be for NufsAccount. This should fix problems
with the call for credit cards and purchase orders.

Correct error messages on account creation

There were extra error messages appearing for invalid accounts such as
“Expiration cannot be blank” and longer text when the GL066 could not
be found. This should revert to the behavior prior to the account
builder refactor

Cherry-pick and rebase of the main-app changes of https://github.com/tablexi/nucore-nu/pull/116