### PR TITLE
Use Ruby 2.2.4 for Circle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ group :development, :test do
   gem 'spring'
   gem 'spring-commands-rspec'
   gem 'teaspoon-jasmine'
+  gem 'test-unit', '~> 3.0'
   gem 'thin'
   gem 'timecop',           '~> 0.6.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,6 +345,7 @@ GEM
       ruby-rc4
       ttfunk
     polyglot (0.3.5)
+    power_assert (0.2.7)
     powerpack (0.1.1)
     prawn (0.12.0)
       pdf-reader (>= 0.9.0)
@@ -469,6 +470,8 @@ GEM
       railties (>= 3.2.5, < 5)
     teaspoon-jasmine (2.2.0)
       teaspoon (>= 1.0.0)
+    test-unit (3.1.7)
+      power_assert
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
@@ -567,6 +570,7 @@ DEPENDENCIES
   strong_parameters
   synaccess_connect (= 0.2.2)!
   teaspoon-jasmine
+  test-unit (~> 3.0)
   therubyracer
   thin
   timecop (~> 0.6.3)
@@ -577,4 +581,4 @@ DEPENDENCIES
   will_paginate (~> 3.0.5)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: 2.1.7
+    version: 2.2.4
   timezone: "America/Chicago"
 
 


### PR DESCRIPTION
I'd like to upgrade nucore to Ruby 2.2.4 as part of the next staging release, partly to see if it resolves occasional segfaults we get from our cronjobs (order_details:expire_reservations, order_details:auto_logout, etc).

```
[BUG] Segmentation fault at 0x00000000000630
ruby 2.1.6p336 (2015-04-13 revision 50298) [x86_64-linux]

-- C level backtrace information -------------------------------------------
```