### PR TITLE
[#99279] Abort in-flight XHR when report parameters change

### DIFF
--- a/app/assets/javascripts/app/reports.coffee
+++ b/app/assets/javascripts/app/reports.coffee
@@ -34,10 +34,16 @@ class TabbableReports
         true
 
       beforeLoad: (_, ui) ->
+        @in_flight_xhr.abort() if @in_flight_xhr?
+        @in_flight_xhr = ui.jqXHR
+
         # Show a loading message so the user sees immediate feedback
         # that their action is being applied
         ui.panel.html('<span class="updating"></span> Loading...')
         ui.ajaxSettings.dataType = 'text/html'
+
+        ui.jqXHR.always => @in_flight_xhr = null if @in_flight_xhr == ui.jqXHR
+
         ui.jqXHR.error (xhr, status, error) ->
           # don't show error message if the user aborted the ajax request
           if status != 'abort'

--- a/app/assets/javascripts/app/reports.coffee
+++ b/app/assets/javascripts/app/reports.coffee
@@ -21,33 +21,34 @@ class TabbableReports
     current_tab = @$tabs.find('[role=tab]')[index]
 
   init_tabs: ->
-    @$tabs.find('a').each ->
-      $(this).parent('li').data('base-href', $(this).attr('href'))
+    @$tabs.find('a').each (_, tab_link) ->
+      $tab_link = $(tab_link)
+      $tab_link.parent('li').data('base-href', $tab_link.attr('href'))
 
-    self = this
-    @$tabs.tabs({
+    @$tabs.tabs(
       active: window.activeTab
-      beforeActivate: (event, ui) ->
+      beforeActivate: (_, ui) =>
         # if there was an old error message, fade it out now
         $('#error-msg').fadeOut()
-
-        self.update_href ui.newTab
+        @update_href(ui.newTab)
         true
 
-      beforeLoad: (event, ui) ->
+      beforeLoad: (_, ui) ->
         # Show a loading message so the user sees immediate feedback
         # that their action is being applied
         ui.panel.html('<span class="updating"></span> Loading...')
         ui.ajaxSettings.dataType = 'text/html'
         ui.jqXHR.error (xhr, status, error) ->
-          # don't show error message if it's because of user aborting ajax request
+          # don't show error message if the user aborted the ajax request
           if status != 'abort'
-            $('#error-msg').html('Sorry, but the tab could not load. Please try again soon.').show()
+            $('#error-msg').
+              html('Sorry, but the tab could not load. Please try again soon.').
+              show()
 
-      load: (event, ui) ->
-        self.fix_bad_dates(ui.panel)
-        self.update_export_urls()
-    })
+      load: (_, ui) =>
+        @fix_bad_dates(ui.panel)
+        @update_export_urls()
+    )
 
   build_query_string: ->
     "?" + @$element.serialize()
@@ -58,9 +59,7 @@ class TabbableReports
   init_form: ->
     $('#status_filter').chosen() if $('#status_filter').length
     $('.datepicker').datepicker()
-    self = this
-    @$element.find(':input').change ->
-      self.update_parameters()
+    @$element.find(':input').change => @update_parameters()
 
   update_href: (tab) ->
     tab.find('a').attr('href', @tab_url(tab))
@@ -71,11 +70,10 @@ class TabbableReports
     $('#date_end').val($(panel).find('.updated_values .date_end').text())
 
   init_pagination: ->
-    self = this
-    $(document).on 'click', '.pagination a', (evt) ->
+    $(document).on 'click', '.pagination a', (evt) =>
       evt.preventDefault()
-      $(self.current_tab()).find('a').attr('href', $(this).attr('href'))
-      self.refresh_tab()
+      $(@current_tab()).find('a').attr('href', $(evt.target).attr('href'))
+      @refresh_tab()
 
   update_export_urls: ->
     url = @tab_url(@current_tab())
@@ -89,13 +87,17 @@ class TabbableReports
       .click (event) => @export_all_email_confirm(event)
 
   export_all_email_confirm: (event) ->
-    new_to = prompt 'Have the report emailed to this address:', @$emailToAddressField.val()
+    new_to = prompt(
+      'Have the report emailed to this address:'
+      @$emailToAddressField.val()
+    )
 
     if new_to
       @$emailToAddressField.val(new_to)
       @update_export_urls()
       # Actual sending handled by remote: true
-      Flash.info("A report is being prepared and will be emailed to #{new_to} when complete")
+      Flash.info("A report is being prepared and will be emailed to #{new_to}
+        when complete")
     event.preventDefault()
 
 $ ->


### PR DESCRIPTION
Since all inputs on the reports form trigger a tab content load when changed, it was easy for a user to fire off a series of Ajax requests, even though the user likely only cared about the result of the one fired last.

It also caused some confusion, because after a successful XHR return, it would update the date start and end input fields, which may have been changed since.

8a8e5ec changes this behavior so if a request is in-flight (that is, triggered by a previous form input change), it should abort that old XHR before making a new one.

adfea82 is cleanup based on CoffeeLint suggestions.