### PR TITLE
[#120455] Fix Purchase Order creation after AccountBuilder refactor

### DIFF
--- a/vendor/engines/c2po/app/services/purchase_order_account_builder.rb
+++ b/vendor/engines/c2po/app/services/purchase_order_account_builder.rb
@@ -12,7 +12,7 @@ class PurchaseOrderAccountBuilder < AccountBuilder
       :affiliate_id,
       :affiliate_other,
       :remittance_information,
-      :expires_at,
+      :formatted_expires_at,
     ]
   end
 
@@ -24,7 +24,7 @@ class PurchaseOrderAccountBuilder < AccountBuilder
       :affiliate_id,
       :affiliate_other,
       :remittance_information,
-      :expires_at,
+      :formatted_expires_at,
     ]
   end
 

--- a/vendor/engines/c2po/spec/controllers/facility_accounts_controller_extension_spec.rb
+++ b/vendor/engines/c2po/spec/controllers/facility_accounts_controller_extension_spec.rb
@@ -115,11 +115,12 @@ RSpec.describe FacilityAccountsController do
 
     context 'PurchaseOrderAccount' do
       before :each do
-        @acct_attrs[:expires_at] = "12/5/#{@expiration_year}"
+        # December 5
+        @acct_attrs[:formatted_expires_at] = "12/5/#{@expiration_year}"
       end
 
       it_should_allow :director do
-        expect(assigns(:account).expires_at).to eq(Time.zone.parse("#{@expiration_year}-5-12").end_of_day)
+        expect(assigns(:account).expires_at).to eq(Time.zone.parse("#{@expiration_year}-12-05").end_of_day)
         expect(assigns(:account).facility_id).to eq(@authable.id)
         expect(assigns(:account)).to be_kind_of PurchaseOrderAccount
         expect(assigns(:account).affiliate).to eq(Affiliate.find(@acct_attrs[:affiliate_id]))


### PR DESCRIPTION
This field uses `formatted_expires_at` to get the correct formatting. It was not
being allowed by strong params. I also discovered a bug in the spec where it
was testing for inverted month/day (May 12 v Dec 5), otherwise we should have
seen this bug.