### PR TITLE
[#102132] Retain Reservation duration value on error

### DIFF
--- a/app/views/reservations/_reservation_fields.html.haml
+++ b/app/views/reservations/_reservation_fields.html.haml
@@ -5,7 +5,9 @@
     .controls
       .string.optional.control-label &nbsp;
       = time_select f, :reserve_start, { minute_step: @instrument.reserve_interval }, disabled: start_disabled
-  = f.input :duration_mins, input_html: { value: f.object.new_record? ? default_duration : f.object.duration_mins, class: 'timeinput', disabled: end_time_disabled?(f.object) }
+
+  = f.input :duration_mins,
+    input_html: { value: f.object.duration_mins || default_duration, class: "timeinput", disabled: end_time_disabled?(f.object) }
 
   - if f.object.actual_start_at?
     .datetime-block


### PR DESCRIPTION
If the user changes the default duration time while making a `Reservation`, either directly or by changing the start/end times, the form should retain those values if the form has errors (such as choosing no payment source).