### PR TITLE
Support MySQL 5.7

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,11 @@ require File.expand_path('../application', __FILE__)
 
 # Initialize the rails application
 Nucore::Application.initialize!
+
+# TODO:
+# MySQL 5.7+ does not allow NULL primary keys, but older versions of Rails
+# create primary key columns DEFAULT NULL.
+#
+# Remove this require and the patch file itself after upgrading to Rails 4.
+# https://github.com/rails/rails/pull/13247#issuecomment-32425844
+require File.expand_path('../../lib/patches/abstract_mysql_adapter', __FILE__)

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -10,4 +10,8 @@ Nucore::Application.initialize!
 #
 # Remove this require and the patch file itself after upgrading to Rails 4.
 # https://github.com/rails/rails/pull/13247#issuecomment-32425844
-require File.expand_path('../../lib/patches/abstract_mysql_adapter', __FILE__)
+if Rails.version < "4"
+  require File.expand_path('../../lib/patches/abstract_mysql_adapter', __FILE__)
+else
+  raise "Remove the reference to the abstract_mysql_adapter patch in #{__FILE__} for Rails 4+"
+end

--- a/lib/patches/abstract_mysql_adapter.rb
+++ b/lib/patches/abstract_mysql_adapter.rb
@@ -5,6 +5,9 @@
 # Remove this file and its environment.rb reference after upgrading to Rails 4.
 #
 # https://github.com/rails/rails/pull/13247#issuecomment-32425844
+
+raise "Remove #{__FILE__} for Rails 4+" unless Rails.version < "4"
+
 class ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter
   NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
 end

--- a/lib/patches/abstract_mysql_adapter.rb
+++ b/lib/patches/abstract_mysql_adapter.rb
@@ -6,7 +6,7 @@
 #
 # https://github.com/rails/rails/pull/13247#issuecomment-32425844
 
-raise "Remove #{__FILE__} for Rails 4+" unless Rails.version < "4"
+raise "Remove #{__FILE__} for Rails 4+" if Rails.version >= "4"
 
 class ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter
   NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"

--- a/lib/patches/abstract_mysql_adapter.rb
+++ b/lib/patches/abstract_mysql_adapter.rb
@@ -1,0 +1,10 @@
+# TODO:
+# MySQL 5.7+ does not allow NULL primary keys, but older versions of Rails
+# create primary key columns DEFAULT NULL.
+#
+# Remove this file and its environment.rb reference after upgrading to Rails 4.
+#
+# https://github.com/rails/rails/pull/13247#issuecomment-32425844
+class ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter
+  NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
+end


### PR DESCRIPTION
Migrations recently started breaking for me because MySQL 5.7+ does not allow `NULL` primary keys, and older versions of Rails create primary key columns `DEFAULT NULL`. See https://github.com/rails/rails/pull/13247 for background.

This workaround should not be necessary after upgrading the application to Rails 4.