### PR TITLE
Ignore order of order details for journal remover spec

### DIFF
--- a/spec/app_support/order_detail_journal_remover_spec.rb
+++ b/spec/app_support/order_detail_journal_remover_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe OrderDetailJournalRemover do
       end
 
       it 'does not remove it from the old journal' do
-        expect(old_journal.reload.order_details).to eq(order_details)
+        expect(old_journal.reload.order_details).to contain_exactly(*order_details)
       end
     end
   end


### PR DESCRIPTION
Ignore order of order details for journal remover spec.
Cherry pick a commit from https://github.com/tablexi/nucore-nu/pull/121