### PR TITLE
[#120455] Nicer display of extra penny boolean

### DIFF
--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -2,16 +2,24 @@ module TranslationHelper
   def t_manage_models(clazz)
     I18n.t('pages.manage', :model => clazz.model_name.human.pluralize)
   end
+
   def t_create_model(clazz)
     I18n.t("pages.create", :model => clazz.model_name.human)
   end
+
   def t_create_models(clazz)
     I18n.t("pages.create", :model => clazz.model_name.human.pluralize)
   end
+
   def t_my(clazz)
     I18n.t('pages.my_tab', :model => clazz.model_name.human.pluralize)
   end
+
   def t_model_error(clazz, error, *options)
     I18n.t("activerecord.errors.models.#{clazz.model_name.underscore}.#{error}", *options)
+  end
+
+  def t_boolean(value)
+    I18n.t(value.to_s, scope: "boolean")
   end
 end

--- a/vendor/engines/split_accounts/app/views/split_accounts/shared/_show_splits.html.haml
+++ b/vendor/engines/split_accounts/app/views/split_accounts/shared/_show_splits.html.haml
@@ -14,4 +14,4 @@
         %tr
           %td= split.subaccount
           %td= split.percent
-          %td= split.extra_penny?
+          %td= t_boolean(split.extra_penny?)


### PR DESCRIPTION
I’d like to keep the ticket number of the redmine task since future people probably won’t have access to the pivotal queue we’re using. It’s all sub-parts of the same feature.