### PR TITLE
Explicitly require `csv` in ExportRaw

### DIFF
--- a/app/models/reports/export_raw.rb
+++ b/app/models/reports/export_raw.rb
@@ -1,3 +1,4 @@
+require 'csv'
 class Reports::ExportRaw
   include DateHelper
 


### PR DESCRIPTION
Some of the time, especially if export raw is the first thing I do on server start,
the CSV module is not loaded yet so `Array#to_csv` is undefined. I even found if
I started the rails console and ran `["a", "b"].to_csv` I would get `NoMethodError: undefined method `to_csv' for ["a", "b"]:Array`.

This makes sure CSV is loaded before trying to call `to_csv`.