### PR TITLE
[#120455] Add chosen to split account dropdown

### DIFF
--- a/vendor/engines/split_accounts/app/views/facility_accounts/account_fields/split_accounts/_splits.html.haml
+++ b/vendor/engines/split_accounts/app/views/facility_accounts/account_fields/split_accounts/_splits.html.haml
@@ -5,7 +5,7 @@
 %div{data: {subaccounts: true}}
   = f.nested_fields_for :splits, class_name: "SplitAccounts::Split" do |ff|
     .well
-      = ff.input :subaccount_id, collection: SplitAccounts::Split.available_subaccounts, wrapper_html: {class: "input-inline"}
+      = ff.input :subaccount_id, collection: SplitAccounts::Split.available_subaccounts, wrapper_html: {class: "input-inline"}, input_html: {class: "js--chosen"}
       = ff.input :percent, input_html: {min: 0, max: 100, data: {percent: true}}, wrapper_html: {class: "input-inline"}
       = ff.input :extra_penny, wrapper_html: {class: "input-inline"}
       = ff.remove_nested_fields_link "Remove", class: "btn", wrapper_html: {class: "input-inline"}
@@ -14,3 +14,7 @@
   = f.add_nested_fields_link :splits, "Add another subaccount", class: "btn btn-success"
 
 %br
+
+:coffee
+  $(document).on "fields_added.nested_form_fields", (event, param) ->
+    $(event.target).find(".js--chosen").chosen()


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/114612023

The subaccount dropdown was unwieldy with a large data set, so we are now using `chosen` for that particular dropdown.

![screen shot 2016-03-01 at 1 18 57 pm](https://cloud.githubusercontent.com/assets/766787/13438806/398cd2f4-dfb0-11e5-8f1b-efa5b2fb34b6.png)

**Note:** The vertical alignment of the inputs is slightly off due to loading chosen.  This did not appear to be a trivial fix and will require some investigation.