### PR TITLE
[#120455] Only global admins can manage SplitAccounts

### DIFF
--- a/app/views/facility_accounts/show.html.haml
+++ b/app/views/facility_accounts/show.html.haml
@@ -34,7 +34,7 @@
   = render_view_hook("after_end_of_form", f: f, account: @account)
 
 %ul.inline
-  - if SettingsHelper.feature_on? :edit_accounts
+  - if SettingsHelper.feature_on?(:edit_accounts) && can?(:edit, @account)
     = link_to t(".link.edit"), edit_facility_account_path(current_facility, @account), class: "btn btn-primary"
 
   = render "accounts/suspend_button"

--- a/vendor/engines/split_accounts/app/controllers/split_accounts/facility_accounts_controller_extension.rb
+++ b/vendor/engines/split_accounts/app/controllers/split_accounts/facility_accounts_controller_extension.rb
@@ -1,0 +1,9 @@
+module SplitAccounts
+  module FacilityAccountsControllerExtension
+    extend ActiveSupport::Concern
+
+    def current_ability
+      SplitAccounts::SplitAccountAbility.new(current_user, current_facility, self)
+    end
+  end
+end

--- a/vendor/engines/split_accounts/app/models/split_accounts/split_account_ability.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/split_account_ability.rb
@@ -1,0 +1,11 @@
+module SplitAccounts
+  class SplitAccountAbility < Ability
+
+    def initialize(user, resource, controller)
+      super
+      unless user.administrator?
+        cannot :manage, SplitAccounts::SplitAccount
+      end
+    end
+  end
+end

--- a/vendor/engines/split_accounts/lib/split_accounts/engine.rb
+++ b/vendor/engines/split_accounts/lib/split_accounts/engine.rb
@@ -23,6 +23,7 @@ module SplitAccounts
     config.to_prepare do
       # Include modules in main rails app
       Account.send :include, SplitAccounts::AccountExtension
+      FacilityAccountsController.send :include, SplitAccounts::FacilityAccountsControllerExtension
 
       if SettingsHelper.feature_on?(:split_accounts)
         SplitAccounts::Engine.enable!

--- a/vendor/engines/split_accounts/spec/controllers/facility_accounts_controller_spec.rb
+++ b/vendor/engines/split_accounts/spec/controllers/facility_accounts_controller_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+require_relative "../split_accounts_spec_helper"
+
+RSpec.describe FacilityAccountsController, :enable_split_accounts do
+  render_views
+
+  let(:facility) { FactoryGirl.create(:setup_facility) }
+  before { sign_in user }
+
+  describe "as an admin" do
+    let(:user) { FactoryGirl.create(:user, :administrator) }
+
+    describe "default new" do
+      before { get :new, facility_id: facility.url_name, owner_user_id: user.id }
+
+      it "sees split account option" do
+        expect(response.code).to eq("200")
+        expect(response.body).to include("Chart String")
+        expect(response.body).to include("Split Account")
+      end
+    end
+
+    describe "new on split accounts" do
+      before { get :new, facility_id: facility.url_name, owner_user_id: user.id, account_type: "SplitAccounts::SplitAccount" }
+
+      it "renders successfully" do
+        expect(response.code).to eq("200")
+        expect(response.body).to include("Account Number")
+        expect(response.body).to include("Add another subaccount")
+      end
+
+      it "assigns the correct type of account" do
+        expect(assigns(:account)).to be_a(SplitAccounts::SplitAccount)
+      end
+    end
+
+    describe "show" do
+      let(:split_account) { FactoryGirl.create(:split_account) }
+
+      before { get :show, facility_id: facility.url_name, id: split_account.id }
+
+      it "includes edit/suspend buttons" do
+        expect(response.body).to include("Edit")
+        expect(response.body).to include("Suspend")
+      end
+    end
+
+    describe "edit" do
+      let(:split_account) { FactoryGirl.create(:split_account) }
+      before { get :edit, facility_id: facility.url_name, id: split_account.id }
+
+      it "has only the description field" do
+        expect(response.body).to include("Description")
+        expect(response.body).not_to include("Account Number")
+        expect(response.body).not_to include("Add another subaccount")
+      end
+    end
+
+    describe "update" do
+      let(:split_account) { FactoryGirl.create(:split_account) }
+      before { post :update, facility_id: facility.url_name, id: split_account.id, split_accounts_split_account: { description: "New Description" } }
+
+      it "updates the description" do
+        expect(split_account.reload.description).to eq("New Description")
+      end
+    end
+  end
+
+  describe "as a facility administrator" do
+    let(:user) { FactoryGirl.create(:user, :facility_administrator, facility: facility) }
+
+    describe "default new" do
+      before { get :new, facility_id: facility.url_name, owner_user_id: user.id }
+
+      it "does not see split account option" do
+        expect(response.code).to eq("200")
+        expect(response.body).to include("Chart String")
+        expect(response.body).not_to include("Split Account")
+      end
+    end
+
+    describe "new on split accounts" do
+      before { get :new, facility_id: facility.url_name, owner_user_id: user.id, account_type: "SplitAccounts::SplitAccount" }
+
+      it "falls back to the default account type" do
+        expect(assigns(:account)).to be_a(NufsAccount)
+      end
+    end
+
+    describe "show" do
+      let(:split_account) { FactoryGirl.create(:split_account) }
+
+      before { get :show, facility_id: facility.url_name, id: split_account.id }
+
+      it "does not show the edit/suspend buttons" do
+        expect(response.body).not_to include("Edit")
+        expect(response.body).not_to include("Suspend")
+      end
+    end
+
+    describe "edit" do
+      let(:split_account) { FactoryGirl.create(:split_account) }
+      before { get :edit, facility_id: facility.url_name, id: split_account.id }
+
+      it "returns a 403" do
+        expect(response.code).to eq("403")
+      end
+    end
+
+    describe "update" do
+      let(:split_account) { FactoryGirl.create(:split_account) }
+      before { post :update, facility_id: facility.url_name, id: split_account.id }
+
+      it "returns a 403" do
+        expect(response.code).to eq("403")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This prevents non-admins from being able to edit as well.

Pivotal #114612043