### PR TITLE
[#120455] Ensure split accounts have two or more splits

### DIFF
--- a/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
@@ -7,6 +7,7 @@ module SplitAccounts
     validate :valid_percent_total
     validate :one_split_has_extra_penny
     validate :unique_split_subaccounts
+    validate :more_than_one_split
 
     accepts_nested_attributes_for :splits, allow_destroy: true
 
@@ -40,6 +41,12 @@ module SplitAccounts
       splits.map(&:subaccount_id)
         .group_by { |e| e }
         .any? { |k, v| v.size > 1 }
+    end
+
+    def more_than_one_split
+      if splits.size <= 1
+        errors.add(:splits, :more_than_one_split)
+      end
     end
 
     # Stopped using SQL because that didn't seem to work until the built splits

--- a/vendor/engines/split_accounts/config/locales/en.yml
+++ b/vendor/engines/split_accounts/config/locales/en.yml
@@ -9,6 +9,7 @@ en:
               percent_total: percent total must equal 100
               only_one_extra_penny: must have one split with extra penny
               duplicate_subaccounts: must have unique subaccounts
+              more_than_one_split: must have two or more subaccounts
         split_accounts/split:
           attributes:
             subaccount:

--- a/vendor/engines/split_accounts/spec/factories/split_accounts.rb
+++ b/vendor/engines/split_accounts/spec/factories/split_accounts.rb
@@ -11,13 +11,6 @@ FactoryGirl.define do
     expires_at { Time.zone.now + 1.month }
     created_by 0
 
-    trait :with_two_splits do
-      callback(:after_build, :before_create) do |split_account, evalutor|
-        split_account.splits << build(:split, percent: 50, extra_penny: true, parent_split_account: split_account)
-        split_account.splits << build(:split, percent: 50, extra_penny: false, parent_split_account: split_account)
-      end
-    end
-
     trait :with_three_splits do
       callback(:after_build, :before_create) do |split_account, evalutor|
         split_account.splits << build(:split, percent: 33.33, extra_penny: true, parent_split_account: split_account)
@@ -27,10 +20,11 @@ FactoryGirl.define do
     end
 
     # Leave this at the bottom of the factory.
-    # Add a split if none exist and if transient `without_splits` is false.
+    # Add valid splits if none exist and if transient `without_splits` is false.
     callback(:after_build, :before_create) do |split_account, evaluator|
       unless split_account.splits.present? || evaluator.without_splits
-        split_account.splits << build(:split, percent: 100, extra_penny: true, parent_split_account: split_account)
+        split_account.splits << build(:split, percent: 50, extra_penny: true, parent_split_account: split_account)
+        split_account.splits << build(:split, percent: 50, extra_penny: false, parent_split_account: split_account)
       end
     end
 

--- a/vendor/engines/split_accounts/spec/models/split_account_spec.rb
+++ b/vendor/engines/split_accounts/spec/models/split_account_spec.rb
@@ -17,6 +17,19 @@ RSpec.describe SplitAccounts::SplitAccount, type: :model, split_accounts: true d
     let(:subaccount_1) { build_stubbed(:setup_account) }
     let(:subaccount_2) { build_stubbed(:setup_account) }
 
+    context "when only one split" do
+      let(:split_account) do
+        build(:split_account, without_splits: true).tap do |split_account|
+          split_account.splits << build(:split, percent: 100, extra_penny: true, parent_split_account: split_account)
+        end
+      end
+
+      it "is invalid" do
+        expect(split_account).not_to be_valid
+        expect(split_account.errors[:splits]).to include(I18n.t("activerecord.errors.models.split_accounts/split_account.attributes.splits.more_than_one_split"))
+      end
+    end
+
     context "when splits total 100 and one split has extra_penny" do
       let(:split_account) do
         build(:split_account, without_splits: true).tap do |split_account|
@@ -129,7 +142,7 @@ RSpec.describe SplitAccounts::SplitAccount, type: :model, split_accounts: true d
     let(:split_account) { create(:split_account) }
 
     it "returns subaccounts" do
-      expect(split_account.subaccounts).to contain_exactly(split_account.splits.first.subaccount)
+      expect(split_account.subaccounts).to contain_exactly(*split_account.splits.map(&:subaccount))
     end
   end
 


### PR DESCRIPTION
The split account form should gracefully error out if a user attempts to create a split account with only one 100% split.  We will display an error message that they must have two or more subaccounts.

https://www.pivotaltracker.com/story/show/114612937