### PR TITLE
[#120455] Prevent 500 when submitting split account without any splits

### DIFF
--- a/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
@@ -36,8 +36,9 @@ module SplitAccounts
     #   subaccounts.where("expires_at IS NOT NULL").order(expires_at: :asc).first
     #
     def earliest_expiring_subaccount
-      subaccounts = splits.map{ |split| split.subaccount }.select(&:expires_at)
-      subaccounts.sort_by(&:expires_at).first
+      if subaccounts.present?
+        subaccounts.sort_by(&:expires_at).first
+      end
     end
 
     def recreate_journal_rows_on_order_detail_update?


### PR DESCRIPTION
The `earliest_expiring_subaccount` method in the `split_account` model was expecting valid subaccounts which was resulting in 500 errors when submitting a split account without any subaccounts selected.  This PR fixes the issue.

https://www.pivotaltracker.com/story/show/114804481