### PR TITLE
[#120455] Ensure split percent is within range

### DIFF
--- a/vendor/engines/split_accounts/app/models/split_accounts/split.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/split.rb
@@ -8,6 +8,7 @@ module SplitAccounts
 
     validates :parent_split_account, presence: true
     validates :subaccount, presence: true
+    validates :percent, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
 
     validate :not_self_referential
     validate :not_split_subaccount

--- a/vendor/engines/split_accounts/spec/models/split_spec.rb
+++ b/vendor/engines/split_accounts/spec/models/split_spec.rb
@@ -21,6 +21,25 @@ RSpec.describe SplitAccounts::Split, type: :model, split_accounts: true do
         expect(split.errors).to include(:subaccount)
       end
     end
+
+    context "when percent is greater than 100" do
+      let(:split) { build_stubbed(:split, percent: 101) }
+
+      it "is invalid" do
+        expect(split).not_to be_valid
+        expect(split.errors).to include(:percent)
+      end
+    end
+
+    context "when percent is less than 0" do
+      let(:split) { build_stubbed(:split, percent: -1) }
+
+      it "is invalid" do
+        expect(split).not_to be_valid
+        expect(split.errors).to include(:percent)
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/114611681

Users should not be able to create splits with 200% and -100%; that add up to 100% but venture outside of a valid percentage range.