### PR TITLE
[#120455] Hide insignificant decimals on reports

### DIFF
--- a/app/views/general_reports/_report_rows.html.haml
+++ b/app/views/general_reports/_report_rows.html.haml
@@ -2,11 +2,19 @@
   - @rows.each do |row|
     %tr
       - row.each_with_index do |col, i|
-        %td{:class => i == 0 ? '' : 'currency'}= i == 2 ? number_to_currency(col) : i == 3 ? number_to_percentage(col, :precision => 1) : col
+        %td{class: i == 0 ? '' : 'currency'}
+          - if i == 2
+            = number_to_currency(col)
+          - elsif i == 3
+            = number_to_percentage(col, precision: 1)
+          - elsif col.is_a?(Numeric)
+            = number_with_precision(col, strip_insignificant_zeros: true)
+          - else
+            = col
 
   - if @rows.size > 1
     %tr
       %td.bold Total
-      %td.bold.currency= @total_quantity
+      %td.bold.currency= number_with_precision(@total_quantity, strip_insignificant_zeros: true)
       %td.bold.currency= number_to_currency(@total_cost)
       %td.bold.currency 100%


### PR DESCRIPTION
Only show decimals in quantities where needed on reports. Don’t show if
it’s .0 (which will be the majority of time since split accounts will
be the special case).

Pivotal #115081495