### PR TITLE
Improve performance of Account General Report

### DIFF
--- a/app/controllers/general_reports_controller.rb
+++ b/app/controllers/general_reports_controller.rb
@@ -7,7 +7,7 @@ class GeneralReportsController < ReportsController
 
 
   def account
-    render_report(1, 'Description') {|od| od.account.to_s }
+    render_report(1, 'Description') { |od| od.account }
   end
 
 

--- a/spec/controllers/general_reports_controller_spec.rb
+++ b/spec/controllers/general_reports_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GeneralReportsController do
 
   run_report_tests([
     { :action => :product, :index => 0, :report_on_label => 'Name', :report_on => Proc.new{|od| od.product.name} },
-    { :action => :account, :index => 1, :report_on_label => 'Description', :report_on => Proc.new{|od| od.account.to_s} },
+    { :action => :account, :index => 1, :report_on_label => 'Description', :report_on => Proc.new{|od| od.account} },
     { :action => :account_owner, :index => 2, :report_on_label => 'Name', :report_on => Proc.new{|od| owner=od.account.owner.user; "#{owner.last_name}, #{owner.first_name} (#{owner.username})"} },
     { :action => :purchaser, :index => 3, :report_on_label => 'Name', :report_on => Proc.new{|od| usr=od.order.user; "#{usr.last_name}, #{usr.first_name} (#{usr.username})"} },
     { :action => :price_group, :index => 4, :report_on_label => 'Name', :report_on => Proc.new{|od| od.price_policy ? od.price_policy.price_group.name : 'Unassigned'} }


### PR DESCRIPTION
This has negligible performance implications in open, but in NU where
`to_s` does a query to pmu_department, this saves quite a bit of time
when many OrderDetails use the same account. Testing against 1000 order
details on the same account, it cuts the load time from ~3.2 seconds
down to ~2.5 due to the savings of N+1 queries.

This really only works because the report view itself will call `to_s`
implicitly when outputting the account as the first column, but it does
improve performance, so I think it’s worth it.

I'll let the rubocop changes later deal with the spacing and 1.9 syntax on the spec.