### PR TITLE
[#124787] Feature flag user-based price groups

### DIFF
--- a/app/controllers/price_groups_controller.rb
+++ b/app/controllers/price_groups_controller.rb
@@ -28,7 +28,7 @@ class PriceGroupsController < ApplicationController
 
   # GET /facilities/:facility_id/price_groups/:id/users
   def users
-    unless @price_group_ability.can?(:read, UserPriceGroupMember)
+    unless SettingsHelper.feature_on?(:user_based_price_groups) && @price_group_ability.can?(:read, UserPriceGroupMember)
       raise ActiveRecord::RecordNotFound
     end
 

--- a/app/views/admin/shared/_tabnav_price_group.html.haml
+++ b/app/views/admin/shared/_tabnav_price_group.html.haml
@@ -1,6 +1,6 @@
 %ul.nav.nav-tabs
   = tab t('shared.tabnav_price_group.accounts'), accounts_facility_price_group_path(current_facility, @price_group), (secondary_tab == 'accounts')
-  - if @price_group_ability.can?(:read, UserPriceGroupMember)
+  - if SettingsHelper.feature_on?(:user_based_price_groups) && @price_group_ability.can?(:read, UserPriceGroupMember)
     = tab t('shared.tabnav_price_group.users'), users_facility_price_group_path(current_facility, @price_group), (secondary_tab == 'users')
   - unless @price_group.global?
     = tab t('shared.tabnav_price_group.edit'), edit_facility_price_group_path(current_facility, @price_group), (secondary_tab == 'edit')

--- a/app/views/price_groups/show.html.haml
+++ b/app/views/price_groups/show.html.haml
@@ -1,13 +1,13 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 = content_for :sidebar do
-  = render :partial => 'admin/shared/sidenav_admin', :locals => { :sidenav_tab => 'price_groups' }
+  = render "admin/shared/sidenav_admin", sidenav_tab: "price_groups"
 = content_for :tabnav do
-  = render :partial => 'admin/shared/tabnav_price_group', :locals => { :secondary_tab => @tab.to_s }
+  = render "admin/shared/tabnav_price_group", secondary_tab: @tab.to_s
 
-%h3=h @price_group.name
+%h3= @price_group.name
 - case @tab
 - when :accounts
-  = render(:partial => 'accounts')
+  = render "accounts"
 - when :users
-  = render(:partial => 'users')
+  = render "users"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -107,6 +107,7 @@ feature:
   daily_view_on: true
   split_accounts_on: false
   print_order_detail_on: false
+  user_based_price_groups_on: true
 
 # This may be overridden in settings.local.yml if your fork is using S3, so
 # be sure to check there for configuration

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -15,7 +15,9 @@ class Ability
 
     if user.administrator?
       if resource.is_a?(PriceGroup)
-        can :manage, UserPriceGroupMember if resource.admin_editable?
+        if SettingsHelper.feature_on?(:user_based_price_groups) && resource.admin_editable?
+          can :manage, UserPriceGroupMember
+        end
         can :manage, AccountPriceGroupMember
       else
         can :manage, :all
@@ -31,11 +33,12 @@ class Ability
 
     if resource.is_a?(PriceGroup)
       if !resource.global? && user.manager_of?(resource.facility)
-        can :manage, [AccountPriceGroupMember, UserPriceGroupMember]
+        can :manage, AccountPriceGroupMember
+        can :manage, UserPriceGroupMember if SettingsHelper.feature_on?(:user_based_price_groups)
       end
 
       if user_has_facility_role?(user) && editable_global_group?(resource)
-        can :read, UserPriceGroupMember
+        can :read, UserPriceGroupMember if SettingsHelper.feature_on?(:user_based_price_groups)
       end
     end
 
@@ -78,8 +81,9 @@ class Ability
           OrderDetail,
           ProductUser,
           TrainingRequest,
-          UserPriceGroupMember,
         ]
+
+        can :manage, UserPriceGroupMember if SettingsHelper.feature_on?(:user_based_price_groups)
 
         can :read, Notification
 

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -15,9 +15,7 @@ class Ability
 
     if user.administrator?
       if resource.is_a?(PriceGroup)
-        if SettingsHelper.feature_on?(:user_based_price_groups) && resource.admin_editable?
-          can :manage, UserPriceGroupMember
-        end
+        can :manage, UserPriceGroupMember if resource.admin_editable?
         can :manage, AccountPriceGroupMember
       else
         can :manage, :all
@@ -33,12 +31,11 @@ class Ability
 
     if resource.is_a?(PriceGroup)
       if !resource.global? && user.manager_of?(resource.facility)
-        can :manage, AccountPriceGroupMember
-        can :manage, UserPriceGroupMember if SettingsHelper.feature_on?(:user_based_price_groups)
+        can :manage, [AccountPriceGroupMember, UserPriceGroupMember]
       end
 
       if user_has_facility_role?(user) && editable_global_group?(resource)
-        can :read, UserPriceGroupMember if SettingsHelper.feature_on?(:user_based_price_groups)
+        can :read, UserPriceGroupMember
       end
     end
 
@@ -81,9 +78,8 @@ class Ability
           OrderDetail,
           ProductUser,
           TrainingRequest,
+          UserPriceGroupMember,
         ]
-
-        can :manage, UserPriceGroupMember if SettingsHelper.feature_on?(:user_based_price_groups)
 
         can :read, Notification
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -78,7 +78,13 @@ RSpec.describe Ability do
       context "when the price group has a facility" do
         let(:subject_resource) { create(:price_group, facility: facility) }
 
-        it { is_expected.to be_allowed_to(:manage, UserPriceGroupMember) }
+        context "when user-based price groups are active", feature_setting: { user_based_price_groups: true } do
+          it { is_expected.to be_allowed_to(:manage, UserPriceGroupMember) }
+        end
+
+        context "when user-based price groups are inactive", feature_setting: { user_based_price_groups: false } do
+          it { is_expected.not_to be_allowed_to(:manage, UserPriceGroupMember) }
+        end
       end
 
       context "when the price group is global" do
@@ -89,7 +95,13 @@ RSpec.describe Ability do
         context "when it's the cancer center price group" do
           let(:subject_resource) { create(:price_group, :cancer_center) }
 
-          it { is_expected.to be_allowed_to(:manage, UserPriceGroupMember) }
+          context "when user-based price groups are active", feature_setting: { user_based_price_groups: true } do
+            it { is_expected.to be_allowed_to(:manage, UserPriceGroupMember) }
+          end
+
+          context "when user-based price groups are inactive", feature_setting: { user_based_price_groups: false } do
+            it { is_expected.not_to be_allowed_to(:manage, UserPriceGroupMember) }
+          end
         end
       end
     end
@@ -191,7 +203,13 @@ RSpec.describe Ability do
       context "when the price group has a facility" do
         let(:subject_resource) { create(:price_group, facility: facility) }
 
-        it { is_expected.to be_allowed_to(:manage, UserPriceGroupMember) }
+        context "when user-based price groups are active", feature_setting: { user_based_price_groups: true } do
+          it { is_expected.to be_allowed_to(:manage, UserPriceGroupMember) }
+        end
+
+        context "when user-based price groups are inactive", feature_setting: { user_based_price_groups: false } do
+          it { is_expected.not_to be_allowed_to(:manage, UserPriceGroupMember) }
+        end
       end
 
       context "when the price group is global" do
@@ -231,6 +249,15 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:read, Notification) }
     it { is_expected.to be_allowed_to(:administer, User) }
     it { is_expected.to be_allowed_to(:switch_to, User) }
+
+    context "when user-based price groups are active", feature_setting: { user_based_price_groups: true } do
+      it { is_expected.to be_allowed_to(:read, UserPriceGroupMember) }
+    end
+
+    context "when user-based price groups are inactive", feature_setting: { user_based_price_groups: false } do
+      it { is_expected.not_to be_allowed_to(:read, UserPriceGroupMember) }
+    end
+
     it_behaves_like "it can destroy admistrative reservations"
   end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -78,13 +78,7 @@ RSpec.describe Ability do
       context "when the price group has a facility" do
         let(:subject_resource) { create(:price_group, facility: facility) }
 
-        context "when user-based price groups are active", feature_setting: { user_based_price_groups: true } do
-          it { is_expected.to be_allowed_to(:manage, UserPriceGroupMember) }
-        end
-
-        context "when user-based price groups are inactive", feature_setting: { user_based_price_groups: false } do
-          it { is_expected.not_to be_allowed_to(:manage, UserPriceGroupMember) }
-        end
+        it { is_expected.to be_allowed_to(:manage, UserPriceGroupMember) }
       end
 
       context "when the price group is global" do
@@ -95,13 +89,7 @@ RSpec.describe Ability do
         context "when it's the cancer center price group" do
           let(:subject_resource) { create(:price_group, :cancer_center) }
 
-          context "when user-based price groups are active", feature_setting: { user_based_price_groups: true } do
-            it { is_expected.to be_allowed_to(:manage, UserPriceGroupMember) }
-          end
-
-          context "when user-based price groups are inactive", feature_setting: { user_based_price_groups: false } do
-            it { is_expected.not_to be_allowed_to(:manage, UserPriceGroupMember) }
-          end
+          it { is_expected.to be_allowed_to(:manage, UserPriceGroupMember) }
         end
       end
     end
@@ -203,13 +191,7 @@ RSpec.describe Ability do
       context "when the price group has a facility" do
         let(:subject_resource) { create(:price_group, facility: facility) }
 
-        context "when user-based price groups are active", feature_setting: { user_based_price_groups: true } do
-          it { is_expected.to be_allowed_to(:manage, UserPriceGroupMember) }
-        end
-
-        context "when user-based price groups are inactive", feature_setting: { user_based_price_groups: false } do
-          it { is_expected.not_to be_allowed_to(:manage, UserPriceGroupMember) }
-        end
+        it { is_expected.to be_allowed_to(:manage, UserPriceGroupMember) }
       end
 
       context "when the price group is global" do
@@ -249,14 +231,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:read, Notification) }
     it { is_expected.to be_allowed_to(:administer, User) }
     it { is_expected.to be_allowed_to(:switch_to, User) }
-
-    context "when user-based price groups are active", feature_setting: { user_based_price_groups: true } do
-      it { is_expected.to be_allowed_to(:read, UserPriceGroupMember) }
-    end
-
-    context "when user-based price groups are inactive", feature_setting: { user_based_price_groups: false } do
-      it { is_expected.not_to be_allowed_to(:read, UserPriceGroupMember) }
-    end
+    it { is_expected.to be_allowed_to(:read, UserPriceGroupMember) }
 
     it_behaves_like "it can destroy admistrative reservations"
   end


### PR DESCRIPTION
This adds a `user_based_price_groups` feature flag that is on by default, but would be off for UIC.

It became an issue because UIC, which does not have user-based price groups, still had a "Users" tab when admining price groups. There already was [an ability check to hide the tab](https://github.com/tablexi/nucore-open/blob/2d1ce5bb18ab3570c84198e66b8a145d62266202/app/views/admin/shared/_tabnav_price_group.html.haml#L3-L4), but `Ability` was not disallowing it.

Note this would be the first time we have feature flag checks directly inside `Ability`.