### PR TITLE
Test the user_based_price_groups flag in the PriceGroupsController specs

### DIFF
--- a/spec/controllers/price_groups_controller_spec.rb
+++ b/spec/controllers/price_groups_controller_spec.rb
@@ -1,154 +1,137 @@
 require "rails_helper"
-require 'controller_spec_helper'
+require "controller_spec_helper"
 
 RSpec.describe PriceGroupsController do
   render_views
 
+  let(:facility) { create(:facility) }
+
   before(:all) { create_users }
 
-  before :each do
-    @authable=FactoryGirl.create(:facility)
-    @price_group=FactoryGirl.create(:price_group, :facility => @authable)
-    @params={ :facility_id => @authable.url_name }
+  before(:each) do
+    @authable = facility # Required to be set for controller_spec_helper
+    @params = { facility_id: facility.url_name }
   end
 
-  context 'index' do
-    before :each do
+  describe "GET #index" do
+    let!(:price_groups) { create_list(:price_group, 3, facility: facility) }
+
+    before(:each) do
       @method = :get
       @action = :index
     end
 
     it_should_allow_managers_only do
-      expect(assigns(:price_groups)).to be_kind_of Array
-      expect(assigns(:price_groups)).to eq(@authable.price_groups)
+      expect(assigns(:price_groups)).to be_kind_of(Array).and eq(facility.price_groups)
     end
   end
 
-  context 'new' do
-    before :each do
-      @method=:get
-      @action=:new
+  describe "GET #new" do
+    before(:each) do
+      @method = :get
+      @action = :new
     end
 
     it_should_allow_managers_only do
-      expect(assigns(:price_group)).to be_kind_of PriceGroup
-      is_expected.to render_template 'new'
+      expect(assigns(:price_group)).to be_kind_of(PriceGroup).and be_new_record
+      is_expected.to render_template("new")
     end
   end
 
-  context 'create' do
-    before :each do
+  describe "POST #create" do
+    before(:each) do
       @method = :post
       @action = :create
-      @params.merge!(:price_group => FactoryGirl.attributes_for(:price_group, :facility_id => @authable.id))
+      @params.merge!(price_group: attributes_for(:price_group, facility_id: facility.id))
     end
 
     it_should_allow_managers_only :redirect do
-      expect(assigns(:price_group)).to be_kind_of PriceGroup
-      is_expected.to set_flash
-      assert_redirected_to [@authable, assigns(:price_group)]
+      expect(assigns(:price_group)).to be_kind_of(PriceGroup).and be_persisted
+      expect(flash[:notice]).to include("successfully created")
+      assert_redirected_to [facility, assigns(:price_group)]
     end
   end
 
-  context 'with price group id' do
-    before(:each) { @params.merge!(:id => @price_group.id) }
+  context "with a price group id parameter" do
+    let(:price_group) { create(:price_group, facility: facility) }
 
-    context 'show' do
+    before { @params.merge!(id: price_group.id) }
 
-      before :each do
+    describe "GET #show" do
+      before(:each) do
         @method = :get
         @action = :show
       end
 
       it_should_allow_managers_only :redirect do
-        expect(assigns(:price_group)).to be_kind_of PriceGroup
-        expect(assigns(:price_group)).to eq(@price_group)
-        assert_redirected_to accounts_facility_price_group_path(@authable, assigns(:price_group))
+        expect(assigns(:price_group)).to be_kind_of(PriceGroup).and eq(price_group)
+        is_expected.to redirect_to(accounts_facility_price_group_path(facility, price_group))
       end
-
     end
 
-
-    context 'users' do
-
-      before :each do
+    describe "GET #users" do
+      before(:each) do
         @method = :get
         @action = :users
       end
 
       it_should_allow_managers_only do
-        expect(assigns(:user_members)).to be_kind_of ActiveRecord::Relation
+        expect(assigns(:user_members)).to be_kind_of(ActiveRecord::Relation)
         expect(assigns(:tab)).to eq(:users)
-        is_expected.to render_template 'show'
+        is_expected.to render_template("show")
       end
-
     end
 
-
-    context 'accounts' do
-
-      before :each do
+    describe "GET #accounts" do
+      before(:each) do
         @method = :get
-        @action=:accounts
+        @action = :accounts
       end
 
       it_should_allow_managers_only do
-        expect(assigns(:account_members)).to be_kind_of ActiveRecord::Relation
+        expect(assigns(:account_members)).to be_kind_of(ActiveRecord::Relation)
         expect(assigns(:tab)).to eq(:accounts)
-        is_expected.to render_template 'show'
+        is_expected.to render_template("show")
       end
-
     end
 
-
-    context 'edit' do
-
-      before :each do
+    describe "GET #edit" do
+      before(:each) do
         @method = :get
         @action = :edit
       end
 
       it_should_allow_managers_only do
-        expect(assigns(:price_group)).to be_kind_of PriceGroup
-        expect(assigns(:price_group)).to eq(@price_group)
-        is_expected.to render_template 'edit'
+        expect(assigns(:price_group)).to be_kind_of(PriceGroup).and eq(price_group)
+        is_expected.to render_template("edit")
       end
-
     end
 
-
-    context 'update' do
-
-      before :each do
+    describe "PUT #update" do
+      before(:each) do
         @method = :put
         @action = :update
-        @params.merge!(:price_group => FactoryGirl.attributes_for(:price_group, :facility_id => @authable.id))
+        @params.merge!(price_group: attributes_for(:price_group, facility_id: facility.id))
       end
 
       it_should_allow_managers_only :redirect do
-        expect(assigns(:price_group)).to be_kind_of PriceGroup
-        expect(assigns(:price_group)).to eq(@price_group)
-        is_expected.to set_flash
-        assert_redirected_to [@authable, @price_group]
+        expect(assigns(:price_group)).to be_kind_of(PriceGroup).and eq(price_group)
+        expect(flash[:notice]).to include("successfully updated")
+        is_expected.to redirect_to([facility, price_group])
       end
-
     end
 
-
-    context 'destroy' do
-
-      before :each do
+    describe "DELETE #destroy" do
+      before(:each) do
         @method = :delete
         @action = :destroy
       end
 
       it_should_allow_managers_only :redirect do
-        expect(assigns(:price_group)).to be_kind_of PriceGroup
-        expect(assigns(:price_group)).to eq(@price_group)
-        should_be_destroyed @price_group
-        assert_redirected_to facility_price_groups_url
+        expect(assigns(:price_group)).to be_kind_of(PriceGroup).and eq(price_group)
+        should_be_destroyed price_group
+        is_expected.to redirect_to(facility_price_groups_url)
       end
-
     end
   end
 end


### PR DESCRIPTION
There's a lot of spec cleanup here but the change to handle the feature flag is in 41479f3. The specs should pass no matter how `user_based_price_groups_on` is set in `config/settings.yml`.