### PR TITLE
[#124958] Update payment source link logic

### DIFF
--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -6,6 +6,14 @@ module AccountsHelper
     end
   end
 
+  def payment_source_link_or_text(account)
+    if current_ability.can?(:manage, account)
+      link_to account, facility_account_path(current_facility, account)
+    else
+      account.to_s
+    end
+  end
+
   private
 
   def available_accounts_array

--- a/app/views/admin/shared/_tabnav_payment_method.html.haml
+++ b/app/views/admin/shared/_tabnav_payment_method.html.haml
@@ -4,3 +4,4 @@
   - if @account.statements.any?
     = tab t(".statements"), facility_account_statement_path(current_facility, @account, "list"), (secondary_tab == "statements")
   = tab t(".members"), facility_account_members_path(current_facility, @account), (secondary_tab == "members")
+  = tab t(".orders"), facility_account_orders_path(current_facility, @account), (secondary_tab == "orders")

--- a/app/views/facility_account_orders/index.html.haml
+++ b/app/views/facility_account_orders/index.html.haml
@@ -1,7 +1,10 @@
-= render "facility_accounts/sidebar"
+= content_for :tabnav do
+  = render "admin/shared/tabnav_payment_method", secondary_tab: "orders"
 
 = content_for :h1 do
   = current_facility
+
+= render "facility_accounts/sidebar"
 
 %h2= @account
 

--- a/app/views/facility_accounts/_account_balances.html.haml
+++ b/app/views/facility_accounts/_account_balances.html.haml
@@ -11,7 +11,11 @@
     %tbody
       - @accounts.each do |account|
         %tr
-          %td= link_to account, facility_account_path(current_facility, account)
+          %td
+            - if current_ability.can?(:manage, account)
+              = link_to account, facility_account_path(current_facility, account)
+            - else
+              = account
           %td= account.owner_user.full_name if account.owner_user
           %td.currency
             = number_to_currency(account.unreconciled_total(current_facility))

--- a/app/views/facility_accounts/_account_balances.html.haml
+++ b/app/views/facility_accounts/_account_balances.html.haml
@@ -11,11 +11,7 @@
     %tbody
       - @accounts.each do |account|
         %tr
-          %td
-            - if current_ability.can?(:manage, account)
-              = link_to account, facility_account_path(current_facility, account)
-            - else
-              = account
+          %td= payment_source_link_or_text(account)
           %td= account.owner_user.full_name if account.owner_user
           %td.currency
             = number_to_currency(account.unreconciled_total(current_facility))

--- a/app/views/facility_accounts/_account_balances.html.haml
+++ b/app/views/facility_accounts/_account_balances.html.haml
@@ -1,21 +1,25 @@
 - if @accounts.blank?
-  %p.notice= t('facility_accounts.account_balances.notice')
+  %p.notice= t(".notice")
 
 - else
   %table.table.table-striped.table-hover
     %thead
       %tr
-        %th= t('facility_accounts.account_balances.th.account')
-        %th= t('facility_accounts.account_balances.th.owner')
-        %th.currency= t('facility_accounts.account_balances.th.total')
+        %th= t(".th.account")
+        %th= t(".th.owner")
+        %th.currency= t(".th.total")
     %tbody
       - @accounts.each do |account|
         %tr
           %td= link_to account, facility_account_path(current_facility, account)
-          %td=h account.owner_user.full_name if account.owner_user
-          %td.currency=h number_to_currency account.unreconciled_total(current_facility)
-  - if params[:search_term].nil?
-    = will_paginate(@accounts)
+          %td= account.owner_user.full_name if account.owner_user
+          %td.currency
+            = number_to_currency(account.unreconciled_total(current_facility))
+
+  - if params[:search_term].present?
+    = will_paginate(@accounts, class: "ajax_links",
+      params: { search_term: params[:search_term] })
   - else
-    = will_paginate(@accounts, :class => 'ajax_links', :params => {:search_term => params[:search_term]})
-  %p.footnote= t('facility_accounts.account_balances.foot')
+    = will_paginate(@accounts)
+
+  %p.footnote= t(".foot")

--- a/app/views/shared/_accounts_table.html.haml
+++ b/app/views/shared/_accounts_table.html.haml
@@ -6,11 +6,6 @@
   %tbody
     - @accounts.each do |account|
       %tr
-        %td
-          - if current_ability.can?(:manage, account)
-            = link_to account, facility_account_path(current_facility, account)
-          - else
-            = account
-
+        %td= payment_source_link_or_text(account)
         %td{style: "padding-left: 50px"}
           = account.facility || "<i>All</i>".html_safe

--- a/app/views/shared/_accounts_table.html.haml
+++ b/app/views/shared/_accounts_table.html.haml
@@ -7,16 +7,10 @@
     - @accounts.each do |account|
       %tr
         %td
-          - case
-          - when !current_ability.can?(:manage, account)
-            = account
-
-          - when current_facility.cross_facility?
+          - if current_ability.can?(:manage, account)
             = link_to account, facility_account_path(current_facility, account)
-
           - else
-            = link_to account,
-              facility_account_orders_path(current_facility, account)
+            = account
 
         %td{style: "padding-left: 50px"}
           = account.facility || "<i>All</i>".html_safe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,11 @@ en:
         reservations: "Reservations"
         accounts: "Payment Sources"
         access_list: "Access List"
+      tabnav_payment_method:
+        details: Details
+        members: Members
+        orders: Orders
+        statements: Statements
 
   pages:
     admin_billing: Billing
@@ -123,10 +128,6 @@ en:
       transact: "Transactions"
       statement: "Statements"
       members: "Members"
-    tabnav_payment_method:
-      details: Details
-      members: Members
-      statements: Statements
     tabnav_price_group:
       accounts: "Payment Sources"
       users: "Users"

--- a/spec/factories/abilities.rb
+++ b/spec/factories/abilities.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :ability do
+    skip_create
+
+    user
+    facility
+    stub_controller { OpenStruct.new }
+
+    initialize_with do
+      Ability.new(user, facility, stub_controller)
+    end
+  end
+end

--- a/spec/helpers/accounts_helper_spec.rb
+++ b/spec/helpers/accounts_helper_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe AccountsHelper do
+  describe "#payment_source_link_or_text" do
+    subject { payment_source_link_or_text(account) }
+    let(:account) { build_stubbed(:nufs_account) }
+    let(:current_ability) { create(:ability, facility: current_facility) }
+    let(:current_facility) { build_stubbed(:facility) }
+
+    before(:each) do
+      allow(current_ability)
+        .to receive(:can?)
+        .with(:manage, account)
+        .and_return(allowed?)
+    end
+
+    context "when allowed to manage the account" do
+      let(:allowed?) { true }
+      let(:expected_path) do
+        "/facilities/#{current_facility.url_name}/accounts/#{account.id}"
+      end
+
+      it { is_expected.to include(expected_path).and include(account.to_s) }
+    end
+
+    context "when not allowed to manage the account" do
+      let(:allowed?) { false }
+
+      it { is_expected.to eq(account.to_s) }
+    end
+  end
+end


### PR DESCRIPTION
When listing payment sources, if the user can manage the account, this should generate a link to the `facility_account_path`, as opposed to the account's orders index as before.