### PR TITLE
[#120455] Improve performance of OrderDetail split transformer

### DIFF
--- a/vendor/engines/split_accounts/app/services/split_accounts/order_detail_list_transformer.rb
+++ b/vendor/engines/split_accounts/app/services/split_accounts/order_detail_list_transformer.rb
@@ -9,15 +9,15 @@ module SplitAccounts
     end
 
     def perform
-      order_details.map do |order_detail|
+      order_details.each_with_object([]) do |order_detail, results|
         # We will need to refactor the general_reports_controller_spec in
         # order to remove the `try` methods below.
         if order_detail.account.try(:splits).try(:present?)
-          SplitAccounts::OrderDetailSplitter.new(order_detail).build_split_order_details
+          results.concat SplitAccounts::OrderDetailSplitter.new(order_detail).build_split_order_details
         else
-          order_detail
+          results << order_detail
         end
-      end.flatten
+      end
     end
 
   end


### PR DESCRIPTION
Testing against NU/Oracle with 1000 OrderDetails all being on a
SplitAccounts, using each_with_object instead of the map/flatten had a
30% speed increase (~7.2 seconds down to ~4.7).

I also tried order_details.flat_map and while that's an improvement
over the map/flatten, it still tended to be slower than the
each_with_object, running around ~5.2 seconds.