### PR TITLE
[#114611969] Default to having two splits on #new

### DIFF
--- a/vendor/engines/split_accounts/app/services/split_accounts/split_account_builder.rb
+++ b/vendor/engines/split_accounts/app/services/split_accounts/split_account_builder.rb
@@ -18,13 +18,21 @@ module SplitAccounts
     # Hooks into superclass's `build` method.
     def after_build
       set_expires_at
+      setup_default_splits if account.splits.none?
     end
+
+    private
 
     # Sets `expires_at` to match the earliest expiring subaccount.
     # Make sure this happens after the splits are built.
     def set_expires_at
       account.expires_at = account.earliest_expiring_subaccount.try(:expires_at)
       account
+    end
+
+    def setup_default_splits
+      account.splits.build(percent: 50, extra_penny: true)
+      account.splits.build(percent: 50)
     end
 
   end


### PR DESCRIPTION
I considered `params[:action] == “new”` as another option, but think I
like this better. If you remove all the sub accounts and try to create,
this rebuilds them, and since the account is blank on them, it’s
invalid. The messaging does get a little funky in that it shows “Splits
subaccount may not be blank” and “Splits must have unique subaccounts”,
but maybe that can be addressed in #114804299. I’m not sure where you’re at with that, @benlinton.

Also addresses #114611991.