### PR TITLE
[#120455] Suspend a parent account if any subaccount is suspended

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -245,7 +245,7 @@ class Account < ActiveRecord::Base
   end
 
   def is_active?
-    expires_at > Time.zone.now && suspended_at.nil?
+    !expired? && !suspended?
   end
 
   def account_number_to_s

--- a/vendor/engines/split_accounts/app/models/split_accounts/account_extension.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/account_extension.rb
@@ -8,6 +8,27 @@ module SplitAccounts
       has_many :parent_split_accounts, through: :parent_splits
 
       scope :excluding_split_accounts, -> { where("accounts.type != ?", "SplitAccounts::SplitAccount") }
+
+      after_save :update_suspended_at_for_parent_split_accounts
+      after_save :update_expires_at_for_parent_split_accounts
+    end
+
+    def update_suspended_at_for_parent_split_accounts
+      if parent_split_accounts.any? && suspended_at_changed?
+        parent_split_accounts.each do |split_account|
+          split_account.set_suspended_at_from_subaccounts
+          split_account.save
+        end
+      end
+    end
+
+    def update_expires_at_for_parent_split_accounts
+      if parent_split_accounts.any? && expires_at_changed?
+        parent_split_accounts.each do |split_account|
+          split_account.set_expires_at_from_subaccounts
+          split_account.save
+        end
+      end
     end
 
     # Allows all account types to appropriately respond to a method that is

--- a/vendor/engines/split_accounts/spec/factories/split_accounts.rb
+++ b/vendor/engines/split_accounts/spec/factories/split_accounts.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
 
     sequence(:account_number) { |n| "account_number_#{n}" }
     sequence(:description) { |n| "split account #{n}" }
-    expires_at { Time.zone.now + 1.month }
+    expires_at { Time.current + 1.month }
     created_by 0
 
     trait :with_three_splits do


### PR DESCRIPTION
When suspending a subaccount, any parent split accounts will inherit the farthest out `suspended_at` timestamp from its subaccounts.  If all subaccounts become unsuspended for a suspended split account, the split account does **NOT** un-suspend.

When expiring a subaccount, any parent split accounts will inherit the most recent `expires_at` timestamp from its subaccounts.  If all subaccounts become unexpired for an expired split account, the split account will become unexpired as well.

https://www.pivotaltracker.com/story/show/114611945
https://www.pivotaltracker.com/story/show/114611905

This approach does have some potential pitfalls.  If the database fails or network fails during the `account_extension.rb` `after_save` callback (which would update the parent split account), then the database will could end up with inconsistent data.  

To prevent inconsistent data, we could override the `expired_at?`, `suspsended_at?`, `active`, etc. methods on the SplitAccount model instead.  This approach would be safer in terms of data integrity, but it would also be more difficult to maintain as the `Account` model changes in the future.