### PR TITLE
[#120455] Improve split account form errors

### DIFF
--- a/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
@@ -18,7 +18,9 @@ module SplitAccounts
     end
 
     def percent_total
-      splits.reduce(0) { |sum, split| sum + split.percent }
+      splits.reduce(0) do |sum, split|
+        split.percent.present? ? sum + split.percent : sum
+      end
     end
 
     def one_split_has_extra_penny
@@ -39,8 +41,9 @@ module SplitAccounts
 
     def duplicate_subaccounts?
       splits.map(&:subaccount_id)
-        .group_by { |e| e }
-        .any? { |k, v| v.size > 1 }
+        .group_by { |subaccount_id| subaccount_id }
+        .reject { |key, value| key.blank? }
+        .any? { |key, value| value.size > 1 }
     end
 
     def more_than_one_split

--- a/vendor/engines/split_accounts/app/services/split_accounts/split_account_builder.rb
+++ b/vendor/engines/split_accounts/app/services/split_accounts/split_account_builder.rb
@@ -27,6 +27,9 @@ module SplitAccounts
     # Make sure this happens after the splits are built.
     def set_expires_at
       account.expires_at = account.earliest_expiring_subaccount.try(:expires_at)
+      # Only set a fallback expires_at when subaccounts aren't present to help
+      # suppress unnecesary misleading errors.
+      account.expires_at ||= Time.current
       account
     end
 

--- a/vendor/engines/split_accounts/config/locales/en.yml
+++ b/vendor/engines/split_accounts/config/locales/en.yml
@@ -7,7 +7,7 @@ en:
           attributes:
             splits:
               percent_total: percent total must equal 100
-              only_one_extra_penny: must have one split with extra penny
+              only_one_extra_penny: must have exactly one split with the extra penny selected
               duplicate_subaccounts: must have unique subaccounts
               more_than_one_split: must have two or more subaccounts
         split_accounts/split:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/114804299

Includes small changes to improve the SplitAccount form errors.
- A blank `percent` input will no longer responds with a 500 error
- Minor enhancements to error message language
- Suppress unique subaccounts error if subaccount dropdowns are blank
- We'll no longer get an `expires at can not be blank` error message when submitting the form without a subaccount selected