### PR TITLE
Add custom Code Climate configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,30 @@
+engines:
+  brakeman:
+    enabled: true
+  bundler-audit:
+    enabled: true
+  csslint:
+    enabled: true
+  coffeelint:
+    enabled: true
+    config: .coffeelint.json
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+      - javascript
+  rubocop:
+    enabled: true
+ratings:
+  paths:
+  - "app/**"
+  - "lib/**"
+  - "spec/**"
+  - "vendor/engines/**"
+  - Gemfile.lock
+exclude_paths:
+- bin/
+- config/
+- db/
+- script/


### PR DESCRIPTION
Code Climate is not currently looking at `/vendor/engines`, but should for this project.
This also should make Code Climate's coffelinter use `.coffeelint.json` (added in #445).

https://www.pivotaltracker.com/story/show/115736563