### PR TITLE
[#120455] Use HashHelper in SplitAccounts::Reports::ExportRawTransformer

### DIFF
--- a/vendor/engines/split_accounts/app/models/split_accounts/reports/export_raw_transformer.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/reports/export_raw_transformer.rb
@@ -1,6 +1,8 @@
+require "hash_helper"
 module SplitAccounts
   module Reports
     class ExportRawTransformer
+      include HashHelper
       include ActionView::Helpers::NumberHelper
 
       def transform(original_hash)
@@ -12,13 +14,6 @@ module SplitAccounts
       def split_percent(order_detail)
         if order_detail.respond_to?(:split) && order_detail.split
           number_with_precision(order_detail.split.percent, strip_insignificant_zeros: true) + "%"
-        end
-      end
-
-      def insert_into_hash_after(original_hash, after_column, additions)
-        original_hash.each_with_object({}) do |(k, v), new_hash|
-          new_hash[k] = v
-          new_hash.merge!(additions) if k == after_column
         end
       end
     end


### PR DESCRIPTION
This got lost in the rebase of #494 and #495