### PR TITLE
Exclude spec directories from codeclimate duplication checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,6 +10,9 @@ engines:
     config: .coffeelint.json
   duplication:
     enabled: true
+    exclude_paths:
+      - "spec/**"
+      - "vendor/engines/**/spec/**"
     config:
       languages:
       - ruby


### PR DESCRIPTION
duplication in specs is not really a sign of a problem.