### PR TITLE
[#120455] Do not double count reservations in utilization reports

### DIFF
--- a/app/models/reports/instrument_day_report.rb
+++ b/app/models/reports/instrument_day_report.rb
@@ -70,7 +70,7 @@ class Reports::InstrumentDayReport
     end
 
     def value
-      1
+      @reservation.quantity
     end
 
   end
@@ -102,7 +102,7 @@ class Reports::InstrumentDayReport
     end
 
     def value
-      @reservation.actual_start_at.present? ? @reservation.duration_mins : 0
+      @reservation.actual_start_at.present? ? @reservation.actual_duration_mins : 0
     end
 
     def transform(data)
@@ -118,7 +118,7 @@ class Reports::InstrumentDayReport
     end
 
     def value
-      @reservation.actual_start_at.present? ? 1 : 0
+      @reservation.actual_start_at.present? ? @reservation.quantity : 0
     end
 
   end

--- a/vendor/engines/split_accounts/spec/controllers/instrument_day_reports_controller_spec.rb
+++ b/vendor/engines/split_accounts/spec/controllers/instrument_day_reports_controller_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+require_relative "../split_accounts_spec_helper"
+
+RSpec.describe InstrumentDayReportsController, :enable_split_accounts do
+  let(:account) { FactoryGirl.create(:split_account, owner: user) }
+  let(:instrument) { FactoryGirl.create(:setup_instrument, :always_available, facility: facility) }
+  let(:facility) { FactoryGirl.create(:setup_facility) }
+  let!(:reservation) do
+    # This is a Thursday
+    FactoryGirl.create(:completed_reservation, product: instrument,
+                                               reserve_start_at: Time.zone.local(2016, 3, 17, 10, 30),
+                                               reserve_end_at: Time.zone.local(2016, 3, 17, 12, 30),
+                                               actual_start_at: Time.zone.local(2016, 3, 17, 10, 30),
+                                               actual_end_at: Time.zone.local(2016, 3, 17, 12, 0)
+                      )
+  end
+  let(:user) { reservation.order_detail.account.owner_user }
+  let(:admin) { FactoryGirl.create(:user, :administrator) }
+
+  before { reservation.order_detail.update_attributes!(account: account) }
+  before { sign_in admin }
+
+  def do_request(action)
+    xhr :get, action, facility_id: facility.url_name, date_start: "03/01/2016", date_end: "03/31/2016"
+  end
+
+  describe "reserved_quantity" do
+    it "has the correct data" do
+      do_request(:reserved_quantity)
+      expect(assigns(:rows).first).to eq([instrument.name, 0, 0, 0, 0, 1, 0, 0])
+    end
+  end
+
+  describe "reserved_hours" do
+    it "has the correct data" do
+      do_request(:reserved_hours)
+      expect(assigns(:rows).first).to eq([instrument.name, 0, 0, 0, 0, 2, 0, 0])
+    end
+  end
+
+  describe "actual_quantity" do
+    it "has the correct data" do
+      do_request(:actual_quantity)
+      expect(assigns(:rows).first).to eq([instrument.name, 0, 0, 0, 0, 1, 0, 0])
+    end
+  end
+
+  describe "actual_hours" do
+    it "has the correct data" do
+      do_request(:actual_hours)
+      expect(assigns(:rows).first).to eq([instrument.name, 0, 0, 0, 0, 1.5, 0, 0])
+    end
+  end
+end


### PR DESCRIPTION
This also fixes a bug where the actual hours report was using the
reservation hours. It got changed, by what appears to be an accident in
978ac8a