### PR TITLE
Update Capfile

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,7 +1,15 @@
-load "deploy" if respond_to?(:namespace) # cap2 differentiator
-Dir["vendor/plugins/*/recipes/*.rb"].each { |plugin| load(plugin) }
+# Load DSL and Setup Up Stages
+require "capistrano/setup"
 
-set :stages, %w(prod_server)
-require "capistrano/ext/multistage"
+# Includes default deployment tasks
+require "capistrano/deploy"
 
-# load 'config/deploy' # remove this line to skip loading any of the default tasks
+# Includes tasks from other gems included in your Gemfile
+require "capistrano/rvm"
+require "capistrano/bundler"
+require "capistrano/rails/assets"
+require "capistrano/rails/migrations"
+require "whenever/capistrano"
+
+# Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
+Dir.glob("lib/capistrano/tasks/*.cap").each { |r| import r }


### PR DESCRIPTION
Found this while pulling the rubocop changes into NU. This is the
capfle for capistrano 3, which we are now using in our projects.

In NU and UIC, there’s a
require "rollbar/capistrano3"
require "eye/patch/capistrano3"

that should stay there. But open doesn’t have those dependencies