### PR TITLE
[#120455] Maintain first suspended_at in split accounts

### DIFF
--- a/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
@@ -73,7 +73,7 @@ module SplitAccounts
     # become unsuspended.
     def set_suspended_at_from_subaccounts
       subaccount = earliest_suspended_subaccount
-      self.suspended_at = subaccount.suspended_at if subaccount
+      self.suspended_at ||= subaccount.suspended_at if subaccount
     end
 
     def recreate_journal_rows_on_order_detail_update?


### PR DESCRIPTION
If a sub account gets suspended and unsuspended and re-suspended, the
parent should use maintain the first suspension date.

If you set the suspended_at of a sub account to some time in the past
before the parent’s set suspended_at, it won’t update. The logic to
make this update was much uglier and harder to understand without
significant commenting, so I decided not to worry about it because the
act of `suspend!` always happens “now” in the context of the app.