### PR TITLE
[#120455] Hide insignificant zeros on instrument util reports

### DIFF
--- a/app/models/reports/instrument_day_report.rb
+++ b/app/models/reports/instrument_day_report.rb
@@ -44,6 +44,7 @@ class Reports::InstrumentDayReport
   end
 
   class DayValue
+
     include ActionView::Helpers::NumberHelper
 
     def initialize(reservation)

--- a/app/models/reports/instrument_day_report.rb
+++ b/app/models/reports/instrument_day_report.rb
@@ -44,6 +44,7 @@ class Reports::InstrumentDayReport
   end
 
   class DayValue
+    include ActionView::Helpers::NumberHelper
 
     def initialize(reservation)
       @reservation = reservation
@@ -71,6 +72,10 @@ class Reports::InstrumentDayReport
 
     def value
       @reservation.quantity
+    end
+
+    def transform(data)
+      number_with_precision(data, strip_insignificant_zeros: true)
     end
 
   end
@@ -119,6 +124,10 @@ class Reports::InstrumentDayReport
 
     def value
       @reservation.actual_start_at.present? ? @reservation.quantity : 0
+    end
+
+    def transform(data)
+      number_with_precision(data, strip_insignificant_zeros: true)
     end
 
   end

--- a/app/models/reports/instrument_utilization_report.rb
+++ b/app/models/reports/instrument_utilization_report.rb
@@ -35,6 +35,8 @@ class Reports::InstrumentUtilizationReport
   class DataRow
 
     include ReportsHelper
+    include ActionView::Helpers::NumberHelper
+
     attr_accessor :quantity, :reserved_mins, :actual_mins
     def initialize(quantity, reserved_mins, actual_mins)
       @quantity = quantity
@@ -61,7 +63,7 @@ class Reports::InstrumentUtilizationReport
 
     def row_with_percents(totals)
       percent = self / totals
-      [quantity,
+      [number_with_precision(quantity, strip_insignificant_zeros: true),
        to_hours(reserved_mins, 1),
        format_percent(percent.reserved_mins),
        to_hours(actual_mins, 1),

--- a/spec/controllers/instrument_day_reports_controller_spec.rb
+++ b/spec/controllers/instrument_day_reports_controller_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe InstrumentDayReportsController do
     ndx = @reservation.actual_start_at.wday
     assigns(:totals).each_with_index do |sum, i|
       if i == ndx
-        expect(sum).to be > 0
+        expect(sum.to_f).to be > 0
       else
-        expect(sum).to eq(0)
+        expect(sum.to_f).to eq(0)
       end
     end
 
@@ -48,7 +48,8 @@ RSpec.describe InstrumentDayReportsController do
     assigns(:rows).each do |row|
       expect(row.size).to eq(8)
       expect(instruments.collect(&:name)).to be_include(row[0])
-      row[1..-1].all? { |data| expect(data).to be_is_a(Numeric) }
+      # Float(data) will raise an error if it's not a valid number
+      row[1..-1].all? { |data| expect(Float(data)).to be_is_a(Numeric) }
     end
   end
 

--- a/spec/controllers/instrument_reports_controller_spec.rb
+++ b/spec/controllers/instrument_reports_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe InstrumentReportsController do
   def assert_report_init(_label)
     expect(assigns(:totals).size).to eq(5)
     reservations = Reservation.all
-    expect(assigns(:totals)[0]).to eq(reservations.size)
+    expect(assigns(:totals)[0].to_s).to eq(reservations.size.to_s)
 
     reserved_mins = reservations.map(&:duration_mins).inject(0, &:+)
     expect(assigns(:totals)[1]).to eq(to_hours(reserved_mins, 1))

--- a/spec/models/reports/instrument_utilization_report_spec.rb
+++ b/spec/models/reports/instrument_utilization_report_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe Reports::InstrumentUtilizationReport do
 
     it "has the correct totals" do
       totals = report.totals
-      expect(totals).to eq([5, 2.6, "100.0%", 0.9, "100.0%"])
+      expect(totals).to eq(["5", 2.6, "100.0%", 0.9, "100.0%"])
     end
 
     it "has the correct rows" do
       rows = report.rows
-      expect(rows[0]).to eq([product.name, 3, 1.8, "67.7%", 0.8, "81.8%"])
-      expect(rows[1]).to eq([product2.name, 2, 0.8, "32.3%", 0.2, "18.2%"])
+      expect(rows[0]).to eq([product.name, "3", 1.8, "67.7%", 0.8, "81.8%"])
+      expect(rows[1]).to eq([product2.name, "2", 0.8, "32.3%", 0.2, "18.2%"])
     end
   end
 
@@ -33,13 +33,13 @@ RSpec.describe Reports::InstrumentUtilizationReport do
 
     it "has the correct totals" do
       totals = report.totals
-      expect(totals).to eq([5, 2.9, "100.0%", 0, "0.0%"])
+      expect(totals).to eq(["5", 2.9, "100.0%", 0, "0.0%"])
     end
 
     it "has the correct rows" do
       rows = report.rows
-      expect(rows[0]).to eq([product.name, 3, 1.8, "60.0%", 0, "0.0%"])
-      expect(rows[1]).to eq([product2.name, 2, 1.2, "40.0%", 0, "0.0%"])
+      expect(rows[0]).to eq([product.name, "3", 1.8, "60.0%", 0, "0.0%"])
+      expect(rows[1]).to eq([product2.name, "2", 1.2, "40.0%", 0, "0.0%"])
     end
   end
 end


### PR DESCRIPTION
If there is 1 reservation on a split account, it is showing 1.0 in
quantity columns. We don’t need to show this, although, we should show
the decimals if they are there. We will continue showing 1 decimal
precision on the hours columns.