### PR TITLE
Remove 2010 check when generating copyright dates

### DIFF
--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -3,4 +3,4 @@
     .span4
       %p= image_tag "logo-nu.jpg", :alt => t(".logo_alt")
     .span8
-      %p= t ".copyright_html", :to_date => Date.today.year > 2010 ? "&ndash;#{Date.today.year}".html_safe : ''
+      %p= t(".copyright_html", to_date: Date.today.year)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,7 +83,7 @@ en:
 
   shared:
     footer:
-      copyright_html: "&copy; Copyright 2010%{to_date} Northwestern University"
+      copyright_html: "&copy; Copyright 2010&ndash;%{to_date} Northwestern University"
       logo_alt: "Northwestern Logo"
     problem_order_details:
       actual_usage_missing: Actual Usage Missing


### PR DESCRIPTION
This is something I noticed when updating the footer for #516. Is there any reason to keep that 2010 check?