### PR TITLE
[#120455] Show error when trying to reactivate split with suspended child

### DIFF
--- a/app/controllers/account_suspend_actions.rb
+++ b/app/controllers/account_suspend_actions.rb
@@ -2,11 +2,10 @@ module AccountSuspendActions
 
   # GET /facilities/:facility_id/accounts/:account_id/suspend
   def suspend
-    begin
-      @account.suspend!
-      flash[:notice] = I18n.t "controllers.facility_accounts.suspend.success"
-    rescue => e
-      flash[:notice] = e.message || I18n.t("controllers.facility_accounts.suspend.failure")
+    if @account.suspend
+      flash[:notice] = I18n.t("controllers.facility_accounts.suspend.success")
+    else
+      flash[:alert] = I18n.t("controllers.facility_accounts.suspend.failure")
     end
 
     redirect_to open_or_facility_path("account", @account)
@@ -14,11 +13,10 @@ module AccountSuspendActions
 
   # GET /facilities/:facility_id/accounts/:account_id/unsuspend
   def unsuspend
-    begin
-      @account.unsuspend!
-      flash[:notice] = I18n.t "controllers.facility_accounts.unsuspend.success"
-    rescue => e
-      flash[:notice] = e.message || I18n.t("controllers.facility_accounts.unsuspend.failure")
+    if @account.unsuspend
+      flash[:notice] = I18n.t("controllers.facility_accounts.unsuspend.success")
+    else
+      flash[:alert] = I18n.t("controllers.facility_accounts.unsuspend.failure", errors: @account.errors.full_messages.join("\n"))
     end
 
     redirect_to open_or_facility_path("account", @account)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -138,14 +138,12 @@ class Account < ActiveRecord::Base
     [owner_user] + business_admin_users
   end
 
-  def suspend!
-    self.suspended_at = Time.zone.now
-    save!
+  def suspend
+    update_attributes(suspended_at: Time.current)
   end
 
-  def unsuspend!
-    self.suspended_at = nil
-    save!
+  def unsuspend
+    update_attributes(suspended_at: nil)
   end
 
   def display_status

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -29,7 +29,7 @@ en:
         failure: "An error was encountered while suspending the payment source"
       unsuspend:
         success: "Payment source activated successfully"
-        failure: "An error was encountered while activating the payment source"
+        failure: "Cannot activate. %{errors}"
 
     facility_notifications:
       no_selection: No orders selected

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -147,10 +147,10 @@ RSpec.describe Account do
   it "should set suspend_at on suspend and unsuspend" do
     @owner   = FactoryGirl.create(:user)
     @account = FactoryGirl.create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: @owner))
-    assert_nothing_raised { @account.suspend! }
-    expect(@account.suspended_at).not_to eq(nil)
-    assert_nothing_raised { @account.unsuspend! }
-    expect(@account.suspended_at).to eq(nil)
+    expect(@account.suspend).to be_truthy
+    expect(@account.suspended_at).to be_present
+    expect(@account.unsuspend).to be_truthy
+    expect(@account.suspended_at).to be_blank
   end
 
   context "account users" do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -147,10 +147,10 @@ RSpec.describe Account do
   it "should set suspend_at on suspend and unsuspend" do
     @owner   = FactoryGirl.create(:user)
     @account = FactoryGirl.create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: @owner))
-    expect(@account.suspend).to be_truthy
+    expect(@account.suspend).to be(true)
     expect(@account.suspended_at).to be_present
-    expect(@account.unsuspend).to be_truthy
-    expect(@account.suspended_at).to be_blank
+    expect(@account.unsuspend).to be(true)
+    expect(@account.suspended_at).to be_nil
   end
 
   context "account users" do

--- a/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
@@ -9,12 +9,11 @@ module SplitAccounts
     validate :one_split_has_apply_remainder
     validate :unique_split_subaccounts
     validate :more_than_one_split
-    validate :no_suspended_children
 
     accepts_nested_attributes_for :splits, allow_destroy: true
 
-    before_validation :set_expires_at_from_subaccounts
-    before_validation :set_suspended_at_from_subaccounts
+    before_save :set_expires_at_from_subaccounts
+    before_save :set_suspended_at_from_subaccounts
 
     def valid_percent_total
       errors.add(:splits, :percent_total) if percent_total != 100
@@ -81,9 +80,12 @@ module SplitAccounts
       true
     end
 
-    def no_suspended_children
-      if !suspended? && splits.map(&:subaccount).any?(&:suspended?)
+    def unsuspend
+      if subaccounts.any?(&:suspended?)
         errors.add(:base, :suspended_child)
+        false
+      else
+        super
       end
     end
 

--- a/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
@@ -13,8 +13,8 @@ module SplitAccounts
 
     accepts_nested_attributes_for :splits, allow_destroy: true
 
-    before_save :set_expires_at_from_subaccounts
-    before_save :set_suspended_at_from_subaccounts
+    before_validation :set_expires_at_from_subaccounts
+    before_validation :set_suspended_at_from_subaccounts
 
     def valid_percent_total
       errors.add(:splits, :percent_total) if percent_total != 100

--- a/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
@@ -9,6 +9,7 @@ module SplitAccounts
     validate :one_split_has_apply_remainder
     validate :unique_split_subaccounts
     validate :more_than_one_split
+    validate :no_suspended_children
 
     accepts_nested_attributes_for :splits, allow_destroy: true
 
@@ -78,6 +79,12 @@ module SplitAccounts
 
     def recreate_journal_rows_on_order_detail_update?
       true
+    end
+
+    def no_suspended_children
+      if !suspended? && splits.map(&:subaccount).any?(&:suspended?)
+        errors.add(:base, :suspended_child)
+      end
     end
 
   end

--- a/vendor/engines/split_accounts/config/locales/en.yml
+++ b/vendor/engines/split_accounts/config/locales/en.yml
@@ -4,6 +4,7 @@ en:
     errors:
       models:
         split_accounts/split_account:
+          suspended_child: "One or more sub-accounts are currently suspended. All sub-accounts must be reactivated prior to split payment source activation."
           attributes:
             splits:
               percent_total: percent total must equal 100

--- a/vendor/engines/split_accounts/spec/models/split_account_spec.rb
+++ b/vendor/engines/split_accounts/spec/models/split_account_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe SplitAccounts::SplitAccount, :enable_split_accounts, type: :model
         build(:split_account, without_splits: true).tap do |split_account|
           split_account.splits << build(:split, percent: 50, apply_remainder: true, parent_split_account: split_account, subaccount: create(:setup_account))
           split_account.splits << build(:split, percent: 50, apply_remainder: false, parent_split_account: split_account, subaccount: create(:setup_account))
-          split_account.save
+          split_account.save!
         end
       end
 
@@ -158,13 +158,12 @@ RSpec.describe SplitAccounts::SplitAccount, :enable_split_accounts, type: :model
       end
     end
 
-    context "when parent account is suspended" do
+    context "when parent account is suspended, but the children are not" do
       let(:split_account) do
-        build(:split_account, without_splits: true).tap do |split_account|
-          split_account.suspended_at = Time.current
+        build(:split_account, without_splits: true, suspended_at: Time.current).tap do |split_account|
           split_account.splits << build(:split, percent: 50, apply_remainder: true, parent_split_account: split_account, subaccount: create(:setup_account))
           split_account.splits << build(:split, percent: 50, apply_remainder: false, parent_split_account: split_account, subaccount: create(:setup_account))
-          split_account.save
+          split_account.save!
         end
       end
 
@@ -181,7 +180,7 @@ RSpec.describe SplitAccounts::SplitAccount, :enable_split_accounts, type: :model
         build(:split_account, without_splits: true).tap do |split_account|
           split_account.splits << build(:split, percent: 50, apply_remainder: true, parent_split_account: split_account, subaccount: suspended_subaccount)
           split_account.splits << build(:split, percent: 50, apply_remainder: false, parent_split_account: split_account, subaccount: create(:setup_account))
-          split_account.save
+          split_account.save!
         end
       end
 
@@ -193,7 +192,7 @@ RSpec.describe SplitAccounts::SplitAccount, :enable_split_accounts, type: :model
       context "when subaccount unsuspends" do
         before do
           split_account
-          suspended_subaccount.unsuspend!
+          suspended_subaccount.unsuspend
         end
 
         it "keeps parent split_account suspended" do
@@ -202,7 +201,7 @@ RSpec.describe SplitAccounts::SplitAccount, :enable_split_accounts, type: :model
 
         context "and the child gets re-suspend" do
           before do
-            suspended_subaccount.reload.suspend!
+            suspended_subaccount.reload.suspend
           end
 
           it "keeps the original suspended_at" do


### PR DESCRIPTION
I tried to use a validation, but ended up not just overriding the `unsuspend` method because the ordering gets complicated between the validation and `:set_suspended_at_from_subaccounts`.