### PR TITLE
[#125502] Hide deleted AccountUsers

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -16,7 +16,7 @@ class AccountsController < ApplicationController
 
   # GET /accounts
   def index
-    @account_users = session_user.account_users.active
+    @account_users = session_user.account_users
   end
 
   # GET /accounts/1

--- a/app/models/account_user.rb
+++ b/app/models/account_user.rb
@@ -3,8 +3,6 @@ class AccountUser < ActiveRecord::Base
   belongs_to :user
   belongs_to :account, inverse_of: :account_users
 
-  scope :active, conditions: { deleted_at: nil }
-
   ACCOUNT_PURCHASER = "Purchaser".freeze
   ACCOUNT_OWNER = "Owner".freeze
   ACCOUNT_ADMINISTRATOR = "Business Administrator".freeze

--- a/spec/controllers/facility_account_users_controller_spec.rb
+++ b/spec/controllers/facility_account_users_controller_spec.rb
@@ -99,9 +99,8 @@ RSpec.describe FacilityAccountUsersController, if: SettingsHelper.feature_on?(:e
           expect(assigns(:account_user).user_role).to eq(AccountUser::ACCOUNT_OWNER)
           expect(assigns(:account_user).user).to eq(@purchaser)
           expect(assigns(:account_user).created_by).to eq(@director.id)
-          # there will be two because the old owner record will have been expired
-          expect(@account.reload.account_users.owners.count).to eq(2)
-          expect(@account.account_users.owners.active).to be_one
+          expect(@account.reload.account_users.owners.count).to eq(1)
+          expect(@account.deleted_account_users.count).to eq(1)
           expect(assigns(:account).reload.owner_user).to eq(@purchaser)
           is_expected.to set_flash
           assert_redirected_to facility_account_members_path(@authable, @account)

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -354,4 +354,19 @@ RSpec.describe Account do
       end
     end
   end
+
+  describe ".for_user" do
+    let(:owner) { account.owner_user }
+    it "finds the account for the owner" do
+      expect(Account.for_user(owner)).to include(account)
+    end
+
+    describe "and there is a deleted owner" do
+      before { FactoryGirl.create(:account_user, :inactive, user: owner, account: account) }
+
+      it "only has the one account" do
+        expect(Account.for_user(owner)).to eq([account])
+      end
+    end
+  end
 end


### PR DESCRIPTION
In the order detail modal, the payment source dropdown was showing
duplicate payment sources if the user had deleted AccountUsers.

This now makes the association always exclude `deleted_at`. The
association from the User side was already ready doing this