### PR TITLE
[#125047] Remove "Add Payment Source" button from user

### DIFF
--- a/app/views/users/accounts.html.haml
+++ b/app/views/users/accounts.html.haml
@@ -8,8 +8,7 @@
   = render :partial => 'admin/shared/tabnav_users', :locals => { :secondary_tab => 'accounts' }
 
 %h1= t('.h1', :user_name => @user.full_name)
-- if SettingsHelper.feature_on? :recharge_accounts
-  %p= link_to t('.link'), new_facility_account_path(current_facility, :owner_user_id => @user.id), :class => 'btn-add'
+
 - if @user.accounts.empty?
   %p.notice= t('.notice', :user_name => @user.full_name)
 - else


### PR DESCRIPTION
Facility directors were using this button thinking they were going to
add the user as a purchaser and instead adding them as the owner.

Also of note, the feature flag check was probably referencing the wrong
flag.