### PR TITLE
[#115962443] Remove "NU" from payment option text

### DIFF
--- a/vendor/engines/c2po/config/locales/en.yml
+++ b/vendor/engines/c2po/config/locales/en.yml
@@ -26,7 +26,7 @@ en:
 
   facilities:
     facility_fields:
-      payment_options: "By default, all facilities accept NU Chart Strings; you may check additional payment options:"
+      payment_options: "By default, all facilities accept Chart Strings; you may check additional payment options:"
       accepts_po: "Accept Purchase Orders?"
       accepts_cc: "Accept Credit Cards?"
 


### PR DESCRIPTION
This would be overridden in the forks that use `c2po`.