### PR TITLE
[#125686] Remove JS flash removal after 10 seconds

### DIFF
--- a/app/assets/javascripts/app/flash.coffee
+++ b/app/assets/javascripts/app/flash.coffee
@@ -22,7 +22,3 @@ class exports.Flash
 
     flash = $("<p></p>").text(message).addClass('alert').addClass("alert-#{level}")
     @location_selector.append(flash)
-
-    setTimeout ->
-      flash.fadeOut('slow').remove()
-    , 10000


### PR DESCRIPTION
While testing some issues around the credit card provider for NU, it
felt that hiding the flash after 10 seconds could obscure the errors.
This will leave the flash message in place until the page is refreshed.
If a new flash is added, the old one is still removed, so we don’t have
to worry about flash messages piling up.