### PR TITLE
[#47665] Purchaser/Owner/BA can change change order detail account

### DIFF
--- a/app/assets/stylesheets/app/typography.scss
+++ b/app/assets/stylesheets/app/typography.scss
@@ -40,6 +40,10 @@ label {
   margin-bottom: 0;
 }
 
+.normal-weight {
+  font-weight: normal;
+}
+
 // Custom headers
 .header-tight {
   line-height: 1.1;

--- a/app/controllers/order_details_controller.rb
+++ b/app/controllers/order_details_controller.rb
@@ -25,7 +25,7 @@ class OrderDetailsController < ApplicationController
 
   # Put /orders/:order_id/order_details/:id
   def update
-    if @order_detail.update_attributes(order_detail_params)
+    if @order_detail.customer_editable? && @order_detail.update_attributes(order_detail_params)
       redirect_to [@order, @order_detail]
     else
       render :edit

--- a/app/controllers/order_details_controller.rb
+++ b/app/controllers/order_details_controller.rb
@@ -7,12 +7,8 @@ class OrderDetailsController < ApplicationController
   before_filter :authenticate_user!
   before_filter :check_acting_as, except: [:order_file, :upload_order_file, :remove_order_file]
   before_filter :init_order_detail
+  before_filter :set_active_tab
   authorize_resource
-
-  def initialize
-    @active_tab = "orders"
-    super
-  end
 
   # GET /orders/:order_id/order_details/:id
   def show
@@ -25,9 +21,11 @@ class OrderDetailsController < ApplicationController
 
   # Put /orders/:order_id/order_details/:id
   def update
-    if @order_detail.customer_editable? && @order_detail.update_attributes(order_detail_params)
+    if order_editable? && @order_detail.update_attributes(order_detail_params)
+      flash[:notice] = I18n.t("order_details.update.success")
       redirect_to [@order, @order_detail]
     else
+      flash.now[:error] = I18n.t("order_details.update.failure")
       render :edit
     end
   end
@@ -113,6 +111,11 @@ class OrderDetailsController < ApplicationController
   end
 
   private
+
+  def order_editable?
+    @order_detail.customer_editable?
+  end
+  helper_method :order_editable?
 
   def init_order_detail
     @order = Order.find(params[:order_id])

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -185,7 +185,7 @@ class OrdersController < ApplicationController
 
     redirect_to(cart_path) && return unless @product
 
-    @accounts = acting_user.accounts.for_facility(@product.facility).active
+    @accounts = AvailableAccountsFinder.new(acting_user, @product.facility).accounts
     @errors   = {}
     details   = @order.order_details
     @accounts.each do |account|

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -1,0 +1,19 @@
+module BreadcrumbHelper
+  def order_reservation_breadcrumb
+    link_to my_breadcrumb_label, my_breadcrumb_path
+  end
+
+  private
+
+  def my_breadcrumb_label
+    if @active_tab == "reservations"
+      t_my(Reservation)
+    else
+      t_my(Order)
+    end
+  end
+
+  def my_breadcrumb_path
+    public_send("#{@active_tab}_path")
+  end
+end

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -1,4 +1,5 @@
 module BreadcrumbHelper
+
   def order_reservation_breadcrumb
     link_to my_breadcrumb_label, my_breadcrumb_path
   end
@@ -16,4 +17,5 @@ module BreadcrumbHelper
   def my_breadcrumb_path
     public_send("#{@active_tab}_path")
   end
+
 end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -559,6 +559,10 @@ class OrderDetail < ActiveRecord::Base
     in_review?
   end
 
+  def customer_editable?
+    !reviewed? && !canceled?
+  end
+
   def validate_for_purchase
     # can purchase product
     return "The product may not be purchased" unless product.available_for_purchase?

--- a/app/services/available_accounts_finder.rb
+++ b/app/services/available_accounts_finder.rb
@@ -11,6 +11,6 @@ class AvailableAccountsFinder
     accounts += [@current_account] if @current_account
     accounts
   end
-  alias_method :to_a, :accounts
+  alias to_a accounts
 
 end

--- a/app/services/available_accounts_finder.rb
+++ b/app/services/available_accounts_finder.rb
@@ -1,12 +1,15 @@
 class AvailableAccountsFinder
 
-  def initialize(user, facility)
+  def initialize(user, facility, current: nil)
     @user = user
     @facility = facility
+    @current_account = current
   end
 
   def accounts
-    @user.accounts.for_facility(@facility).active
+    accounts = @user.accounts.for_facility(@facility).active
+    accounts += [@current_account] if @current_account
+    accounts
   end
   alias_method :to_a, :accounts
 

--- a/app/services/available_accounts_finder.rb
+++ b/app/services/available_accounts_finder.rb
@@ -1,0 +1,13 @@
+class AvailableAccountsFinder
+
+  def initialize(user, facility)
+    @user = user
+    @facility = facility
+  end
+
+  def accounts
+    @user.accounts.for_facility(@facility).active
+  end
+  alias_method :to_a, :accounts
+
+end

--- a/app/views/order_details/edit.html.haml
+++ b/app/views/order_details/edit.html.haml
@@ -1,6 +1,6 @@
 = content_for :breadcrumb do
   %ul.breadcrumb
-    %li= link_to t("order_details.show.link.orders"), orders_url
+    %li= order_reservation_breadcrumb
     %li &raquo;
     %li= link_to t("order_details.show.head.h1", order_number: @order_detail), [@order, @order_detail]
 
@@ -8,7 +8,9 @@
   = t("order_details.show.head.h1", order_number: @order_detail)
 
 = simple_form_for([@order, @order_detail]) do |f|
-  = f.input :account_id, collection: AvailableAccountsFinder.new(acting_user, @order_detail.facility), include_blank: false, label: Account.model_name.human
+  %p.alert.alert-warning= t(".warning")
+
+  = f.input :account_id, collection: AvailableAccountsFinder.new(acting_user, @order_detail.facility, current: @order_detail.account), include_blank: false, label: Account.model_name.human
 
   %ul.inline
     %li= f.submit t(".save"), class: ["btn", "btn-primary"]

--- a/app/views/order_details/edit.html.haml
+++ b/app/views/order_details/edit.html.haml
@@ -1,0 +1,15 @@
+= content_for :breadcrumb do
+  %ul.breadcrumb
+    %li= link_to t("order_details.show.link.orders"), orders_url
+    %li &raquo;
+    %li= link_to t("order_details.show.head.h1", order_number: @order_detail), [@order, @order_detail]
+
+= content_for :h1 do
+  = t("order_details.show.head.h1", order_number: @order_detail)
+
+= simple_form_for([@order, @order_detail]) do |f|
+  = f.input :account_id, collection: AvailableAccountsFinder.new(acting_user, @order_detail.facility), include_blank: false, label: Account.model_name.human
+
+  %ul.inline
+    %li= f.submit t(".save"), class: ["btn", "btn-primary"]
+    %li= link_to t(".cancel"), [@order, @order_detail]

--- a/app/views/order_details/show.html.haml
+++ b/app/views/order_details/show.html.haml
@@ -1,6 +1,6 @@
 = content_for :breadcrumb do
   %ul.breadcrumb
-    %li= link_to t('.link.orders'), orders_url
+    %li= order_reservation_breadcrumb
     %li &raquo;
     %li= t('.head.h1', :order_number => @order_detail.to_s)
 
@@ -14,7 +14,13 @@
 
     = readonly_form_for :order do |f|
       = f.input :facility
-      = f.input :account
+
+      .control-group
+        %label.control-label
+          = OrderDetail.human_attribute_name(:account)
+          = link_to t(".link.change_account"), [:edit, @order, @order_detail], class: "normal-weight"
+        .controls= @order_detail.account
+
       = f.input :ordered_at
       = f.input :user
       = f.input :created_by_user

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -685,19 +685,22 @@ en:
     edit:
       save: "Save"
       cancel: "Cancel"
+      warning: |
+        Changing the Payment Source could result in adjusted pricing. If you are
+        concerned about this or receive incorrect pricing, please contact the facility.
+    update:
+      success: "The order has been updated"
+      failure: "There was a problem updating the order"
     show:
       head:
         h1: "Order #%{order_number}"
         dispute: "Dispute Order"
         results: "Download Results"
-      label:
-        facility: "Facility"
-        account: "Payment Source"
       instruct:
         dispute: "If you wish to dispute the charges for this purchase, please explain the issue with the charges and click \"Dispute Purchase\"."
       link:
-        orders: "My Orders"
         receipt: "View Receipt"
+        change_account: "Change"
         reservation:
           cancel: "Cancel"
         view:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -682,9 +682,12 @@ en:
       error: Unable to place order.
 
   order_details:
+    edit:
+      save: "Save"
+      cancel: "Cancel"
     show:
       head:
-        h1: "Order # %{order_number}"
+        h1: "Order #%{order_number}"
         dispute: "Dispute Order"
         results: "Download Results"
       label:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -295,7 +295,7 @@ Nucore::Application.routes.draw do
       put   "clear"
     end
 
-    resources :order_details, only: [:show] do
+    resources :order_details, only: [:show, :edit, :update] do
       put :cancel, on: :member
       put :dispute, on: :member
       get :order_file

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -202,9 +202,12 @@ class Ability
   private
 
   def order_details_ability(user, resource)
-    can %i(add_accessories sample_results show template_results), OrderDetail, order: { user_id: user.id }
+    # Purchaser
+    can [:add_accessories, :sample_results, :show, :update, :template_results], OrderDetail, order: { user_id: user.id }
+    # Facility managers
     can :manage, OrderDetail, order: { facility_id: resource.order.facility_id } if user.operator_of?(resource.facility)
-    can :show, OrderDetail, account: { id: resource.account_id } if user.account_administrator_of?(resource.account)
+    # Account owners/business admins
+    can [:show, :update, :cancel, :dispute], OrderDetail, account: { id: resource.account_id } if user.account_administrator_of?(resource.account)
   end
 
   def user_has_facility_role?(user)

--- a/spec/controllers/order_details_controller_spec.rb
+++ b/spec/controllers/order_details_controller_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe OrderDetailsController do
         let(:signed_in_user) { FactoryGirl.create(:user) }
         before do
           FactoryGirl.create(:account_user, :business_administrator,
-            user: signed_in_user, account: order_detail.account)
+                             user: signed_in_user, account: order_detail.account)
           perform
         end
 
@@ -112,7 +112,7 @@ RSpec.describe OrderDetailsController do
         let(:signed_in_user) { FactoryGirl.create(:user) }
         before do
           FactoryGirl.create(:account_user, :purchaser,
-            user: signed_in_user, account: order_detail.account)
+                             user: signed_in_user, account: order_detail.account)
           perform
         end
 
@@ -125,7 +125,7 @@ RSpec.describe OrderDetailsController do
         let(:signed_in_user) { FactoryGirl.create(:user) }
         before do
           FactoryGirl.create(:account_user, :purchaser,
-            user: signed_in_user, account: order_detail.account)
+                             user: signed_in_user, account: order_detail.account)
           order.update_attributes(user: signed_in_user)
           perform
         end

--- a/spec/controllers/order_details_controller_spec.rb
+++ b/spec/controllers/order_details_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe OrderDetailsController do
   let(:user) { order_detail.user }
 
   describe "#dispute" do
-    let(:params) { { order_id: order.id, order_detail_id: order_detail.id } }
+    let(:params) { { order_id: order.id, id: order_detail.id } }
     before { sign_in user }
 
     context "when the order is not disputable" do
@@ -43,17 +43,17 @@ RSpec.describe OrderDetailsController do
   describe "#show" do
     before(:each) do
       sign_in user
-      get :show, order_id: order.id, order_detail_id: order_detail.id
+      get :show, order_id: order.id, id: order_detail.id
     end
 
     context "when logged in as the user who owns the order" do
-      it { expect(response.code).to eq("200") }
+      it { expect(response).to access_the_page }
     end
 
     context "when logged in as a user that does not own the order" do
       let(:user) { create(:user) }
 
-      it { expect(response.code).to eq("404") }
+      it { expect(response.code).to eq("403") }
     end
   end
 
@@ -65,7 +65,7 @@ RSpec.describe OrderDetailsController do
         context "and the reservation is cancelable" do
           before(:each) do
             expect(reservation).to be_can_cancel
-            put :cancel, order_id: order.id, order_detail_id: order_detail.id
+            put :cancel, order_id: order.id, id: order_detail.id
           end
 
           it { expect(order_detail.reload).to be_canceled }
@@ -74,11 +74,113 @@ RSpec.describe OrderDetailsController do
         context "and the reservation is not cancelable" do
           before do
             reservation.update_attributes(actual_start_at: Time.current)
-            put :cancel, order_id: order.id, order_detail_id: order_detail.id
+            put :cancel, order_id: order.id, id: order_detail.id
           end
 
           it { expect(order_detail.reload).not_to be_canceled }
           it { expect(response.code).to eq("404") }
+        end
+      end
+    end
+  end
+
+  describe "edit/update" do
+    shared_examples_for "allows the proper users" do
+      describe "as the account owner" do
+        let(:signed_in_user) { order_detail.account.owner_user }
+        before { perform }
+
+        it "succeeds" do
+          expect(response).to access_the_page
+        end
+      end
+
+      describe "as a business admin" do
+        let(:signed_in_user) { FactoryGirl.create(:user) }
+        before do
+          FactoryGirl.create(:account_user, :business_administrator,
+            user: signed_in_user, account: order_detail.account)
+          perform
+        end
+
+        it "succeeds" do
+          expect(response).to access_the_page
+        end
+      end
+
+      describe "as an account purchaser" do
+        let(:signed_in_user) { FactoryGirl.create(:user) }
+        before do
+          FactoryGirl.create(:account_user, :purchaser,
+            user: signed_in_user, account: order_detail.account)
+          perform
+        end
+
+        it "does not load" do
+          expect(response.code).to eq("403")
+        end
+      end
+
+      describe "as the purchaser" do
+        let(:signed_in_user) { FactoryGirl.create(:user) }
+        before do
+          FactoryGirl.create(:account_user, :purchaser,
+            user: signed_in_user, account: order_detail.account)
+          order.update_attributes(user: signed_in_user)
+          perform
+        end
+
+        it "succeeds" do
+          expect(response).to access_the_page
+        end
+      end
+
+      describe "as a random user" do
+        let(:signed_in_user) { FactoryGirl.create(:user) }
+        before { perform }
+
+        it "does not load" do
+          expect(response.code).to eq("403")
+        end
+      end
+    end
+
+    describe "#edit" do
+      def perform
+        sign_in signed_in_user
+        get :edit, order_id: order.id, id: order_detail.id
+      end
+
+      it_behaves_like "allows the proper users"
+    end
+
+    describe "#update" do
+      # need some params to satisfy strong params
+      let(:params) { { field: "dummy" } }
+      def perform
+        sign_in signed_in_user
+        put :update, order_id: order.id, id: order_detail.id, order_detail: params
+      end
+
+      it_behaves_like "allows the proper users"
+
+      describe "updating the account" do
+        let(:signed_in_user) { user }
+        let(:account2) { FactoryGirl.create(:setup_account, owner: user) }
+        let(:params) { { account_id: account2.id } }
+
+        it "changes the account" do
+          expect { perform }.to change { order_detail.reload.account }.to(account2)
+        end
+      end
+
+      describe "does not update other fields" do
+        let(:signed_in_user) { user }
+        let(:params) { { actual_cost: 113, product_id: 999, user_id: 111, dispute_reason: "Dispute" } }
+
+        it "is successful, but does not change any fields" do
+          expect { perform }.not_to change { order_detail.reload.attributes }
+          expect(response).to be_redirect
         end
       end
     end

--- a/spec/support/matchers/controller_matchers.rb
+++ b/spec/support/matchers/controller_matchers.rb
@@ -1,0 +1,9 @@
+RSpec::Matchers.define :access_the_page do |expected|
+  failure_message do |actual|
+    "render successfully with a 200 or 302, but was #{actual.code}"
+  end
+
+  match do |actual|
+    actual.code.in?("200", "302")
+  end
+end

--- a/spec/support/matchers/controller_matchers.rb
+++ b/spec/support/matchers/controller_matchers.rb
@@ -1,4 +1,4 @@
-RSpec::Matchers.define :access_the_page do |expected|
+RSpec::Matchers.define :access_the_page do
   failure_message do |actual|
     "render successfully with a 200 or 302, but was #{actual.code}"
   end


### PR DESCRIPTION
I’ve implemented this so that a user may change the account up to the end of the review period (unless it gets disputed, then the feature continues to work until the dispute gets resolved). I've also set it up so the user can only select non-expired, non-suspended accounts. I agree that it could be problematic if users are given the ability to assign it to an expired account. We could implement logic that takes fulfillment date into account, but that logic will get messy, and I'm not sure that it's worth the effort and additional complexity. If a user need to move the order to an expired account, they can always contact the facility directly.

The original purchaser, account owners and business admins have this interface. Account Purchasers don't have access (they currently can't even see other users purchases).

I’m awaiting final confirmation of these decisions from NU, but the code is still reviewable (especially some of the controller refactoring).