### PR TITLE
[#122397] Prevent multiple reservations on the same order detail

### DIFF
--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -40,7 +40,7 @@
           = t('reservations.new.notify')
 
   %ul.inline
-    %li= f.submit 'Create', class: 'btn', id: 'reservation_submit'
+    %li= f.submit 'Create', class: 'btn', id: 'reservation_submit', data: { disable_with: 'Create' }
     - url_after_action = facility_path(@instrument.facility)
     - if @order_detail.bundled?
       %li= link_to 'Cancel', url_after_action

--- a/db/migrate/20160415231343_clean_duplicate_reservations.rb
+++ b/db/migrate/20160415231343_clean_duplicate_reservations.rb
@@ -1,0 +1,27 @@
+class CleanDuplicateReservations < ActiveRecord::Migration
+  class Reservation < ActiveRecord::Base
+  end
+
+  def up
+    order_details_with_multiple_reservations = Reservation
+      .where("order_detail_id is not null")
+      .group(:order_detail_id)
+      .having("count(*) > 1")
+      .pluck(:order_detail_id)
+
+    order_details_with_multiple_reservations.each do |order_detail_id|
+      Reservation.where(order_detail_id: order_detail_id).last.destroy
+    end
+    if NUCore::Database.oracle?
+      remove_index :reservations, :order_detail_id
+    end
+    add_index :reservations, :order_detail_id, unique: true, name: "res_od_uniq_fk"
+  end
+
+  def down
+    remove_index :reservations, name: "res_od_uniq_fk"
+    if NUCore::Database.oracle?
+      add_index :reservations, :order_detail_id, name: "i_reservations_order_detail_id", tablespace: "bc_nucore"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160405203240) do
+ActiveRecord::Schema.define(:version => 20160415231343) do
 
   create_table "account_users", :force => true do |t|
     t.integer  "account_id",               :null => false
@@ -175,9 +175,9 @@ ActiveRecord::Schema.define(:version => 20160405203240) do
   create_table "journal_rows", :force => true do |t|
     t.integer "journal_id",                                                   :null => false
     t.integer "order_detail_id"
+    t.string  "account",         :limit => 5
     t.decimal "amount",                         :precision => 9, :scale => 2, :null => false
     t.string  "description",     :limit => 200
-    t.string  "account",         :limit => 5
     t.integer "account_id"
   end
 
@@ -486,7 +486,7 @@ ActiveRecord::Schema.define(:version => 20160405203240) do
     t.string   "admin_note"
   end
 
-  add_index "reservations", ["order_detail_id"], :name => "reservations_order_detail_id_fk"
+  add_index "reservations", ["order_detail_id"], :name => "res_od_uniq_fk", :unique => true
   add_index "reservations", ["product_id", "reserve_start_at"], :name => "index_reservations_on_product_id_and_reserve_start_at"
 
   create_table "roles", :force => true do |t|


### PR DESCRIPTION
It is possible for two reservations to be created for the same user if
they double click the “Create” button in quick succession and the
transactions overlap. This only happens on a multi-threaded server like
unicorn.

This also cleans up duplicates and adds a unique constraint on
`reservations.order_detail_id`. All duplicates I found in practice are
exact duplicates.

Also related to NU #124969, UIC #122397.