### PR TITLE
[#117475471] Include payment source in order notifications/receipts

### DIFF
--- a/app/views/notifier/order_receipt.html.haml
+++ b/app/views/notifier/order_receipt.html.haml
@@ -11,6 +11,9 @@
   %li
     %label= OrderDetail.human_attribute_name(:ordered_by)
     = @order.created_by_user.full_name
+  %li
+    %label= OrderDetail.human_attribute_name(:account)
+    = @order.account
 
 %table.table.table-striped.table-hover
   %thead

--- a/app/views/notifier/order_receipt.text.haml
+++ b/app/views/notifier/order_receipt.text.haml
@@ -5,6 +5,7 @@
 #{t(".label.ordered_at")}: #{l(@order.ordered_at, format: :receipt)}
 #{OrderDetail.human_attribute_name(:facility)}: #{@order.facility}
 #{OrderDetail.human_attribute_name(:ordered_by)}: #{@order.created_by_user.full_name}
+#{OrderDetail.human_attribute_name(:account)}: #{@order.account}
 ==
 = OrderDetail.model_name.titleize.pluralize
 = "========================================"

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Notifier do
       expect(email.subject).to include("Order Notification")
       expect(email.html_part.to_s).to match(/Ordered By.+\n#{user.full_name}/)
       expect(email.text_part.to_s).to include("Ordered By: #{user.full_name}")
+      expect(email.html_part.to_s).to match(/Payment Source.+#{order.account}/m)
+      expect(email.text_part.to_s).to include("Payment Source: #{order.account}")
       expect(email.html_part.to_s).not_to include("Thank you for your order")
       expect(email.text_part.to_s).not_to include("Thank you for your order")
     end
@@ -35,6 +37,8 @@ RSpec.describe Notifier do
       expect(email.subject).to include("Order Receipt")
       expect(email.html_part.to_s).to match(/Ordered By.+\n#{user.full_name}/)
       expect(email.text_part.to_s).to include("Ordered By: #{user.full_name}")
+      expect(email.html_part.to_s).to match(/Payment Source.+#{order.account}/m)
+      expect(email.text_part.to_s).to include("Payment Source: #{order.account}")
       expect(email.html_part.to_s).to include("Thank you for your order")
       expect(email.text_part.to_s).to include("Thank you for your order")
     end


### PR DESCRIPTION
This adds a payment source line to order notifications and receipts, taken from https://github.com/tablexi/nucore-dartmouth/pull/21.