### PR TITLE
Remove NUCS-specific specs from the main app

### DIFF
--- a/spec/models/facility_account_spec.rb
+++ b/spec/models/facility_account_spec.rb
@@ -33,52 +33,5 @@ RSpec.describe FacilityAccount do
         assert @account.errors[:revenue_account]
       end
     end
-
-    it "should allow format fund3-dept7-project8" do
-      @options[:account_number] = "123-1234567-12345678"
-      define_open_account(@options[:revenue_account], @options[:account_number])
-      @account = FacilityAccount.create(@options)
-      assert @account.valid?
-    end
-
-    it "should allow format fund3-dept7-project8" do
-      @options[:account_number] = "123-1234567-12345678"
-      define_open_account(@options[:revenue_account], @options[:account_number])
-      @account = FacilityAccount.create(@options)
-      assert @account.valid?
-    end
-
-    it "should allow format fund3-dept7-project8-activity2" do
-      @options[:account_number] = "123-1234567-12345678-12"
-      define_open_account(@options[:revenue_account], @options[:account_number])
-      @account = FacilityAccount.create(@options)
-      assert @account.valid?
-    end
-
-    it "should allow format fund3-dept7-project8-activity2-program4" do
-      # create chart string without program value
-      @options[:account_number] = "123-1234567-12345678-12-1234"
-      define_open_account(@options[:revenue_account], @options[:account_number])
-      @account = FacilityAccount.create(@options)
-      assert @account.valid?
-    end
-
-    # we no longer validate facility accounts against BCS table
-    # it "should not allow account that has expired" do
-    #  @bcs = BudgetedChartString.create(:fund => '123', :dept => '1234567', :starts_at => @starts_at, :expires_at => @starts_at)
-    #  @options[:account_number] = '123-1234567'
-    #  @account = FacilityAccount.create(@options)
-    #  assert !@account.valid?
-    #  assert_equal "Account has expired", @account.errors[:base]
-    # end
-
-    # we no longer validate facility accounts against BCS table
-    # it "should not allow account that has not started" do
-    #  @bcs = BudgetedChartString.create(:fund => '123', :dept => '1234567', :starts_at => @starts_at+1.year, :expires_at => @expires_at)
-    #  @options[:account_number] = '123-1234567'
-    #  @account = FacilityAccount.create(@options)
-    #  assert !@account.valid?
-    #  assert_equal "Account is not active", @account.errors[:base]
-    # end
   end
 end


### PR DESCRIPTION
This cherry-picks one commit from https://github.com/tablexi/nucore-nu/pull/148 which consolidates NU-specific `FacilityAccount` specs in a fork-specific engine.