### PR TITLE
Clean up recharge chart string partials and I18n

### DIFF
--- a/app/views/facility_facility_accounts/_facility_account_fields.html.haml
+++ b/app/views/facility_facility_accounts/_facility_account_fields.html.haml
@@ -1,8 +1,8 @@
 .well
-  = render :partial => 'shared/account_fields', :locals => { :f => f, :account_class => FacilityAccount }
-  = f.label :revenue_account, t('facility_facility_accounts.facility_account_fields.label.deposit_account'), :class => 'require'
-  = f.text_field :revenue_account, :maxLength => 5, :size => 10
+  = render "shared/account_fields", f: f, account_class: FacilityAccount
+  = f.label :revenue_account, t(".label.deposit_account"), class: "require"
+  = f.text_field :revenue_account, maxLength: 5, size: 10
 
   = f.label :is_active do
     = f.check_box :is_active
-    = t('facility_facility_accounts.facility_account_fields.active')
+    = t(".active")

--- a/app/views/facility_facility_accounts/new.html.haml
+++ b/app/views/facility_facility_accounts/new.html.haml
@@ -1,14 +1,14 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 = content_for :sidebar do
-  = render :partial => 'admin/shared/sidenav_admin', :locals => { :sidenav_tab => 'recharge_accounts' }
+  = render "admin/shared/sidenav_admin", sidenav_tab: "recharge_accounts"
 = content_for :head_content do
-  = javascript_include_tag 'accounts.js'
+  = javascript_include_tag "accounts.js"
 
-%h2= t('.head')
-= form_for @facility_account, :url => facility_facility_accounts_path do |f|
+%h2= t(".head")
+= form_for @facility_account, url: facility_facility_accounts_path do |f|
   = f.error_messages
-  = render :partial => 'facility_account_fields', :locals => {:f => f}
+  = render "facility_account_fields", f: f
   %ul.inline
-    %li= f.submit 'Create', :class => 'btn'
-    %li= link_to 'Cancel', facility_facility_accounts_path
+    %li= f.submit "Create", class: "btn"
+    %li= link_to "Cancel", facility_facility_accounts_path

--- a/app/views/shared/_account_fields.html.haml
+++ b/app/views/shared/_account_fields.html.haml
@@ -3,6 +3,13 @@
     - fields = account_class.new.account_number_fields
     - fields.each_with_index do |(section, options), i|
       %li.account_number_field
-        = p.label section, t("#{account_class.name.underscore}.account_fields.label.account_number.#{section}"), :class => options[:required] ? 'required' : ''
-        = p.text_field section, :size => (options[:length] || 30) + 2, :maxlength => options[:length] || 30, :tabindex => i+1
+        = p.label section,
+          t("#{account_class.name.underscore}.account_fields.label.account_number.#{section}"),
+          class: options[:required] ? "required" : ""
+
+        = p.text_field section,
+          size: (options[:length] || 30) + 2,
+          maxlength: options[:length] || 30,
+          tabindex: i + 1
+
         = "-&nbsp;".html_safe unless i >= fields.size - 1

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,12 @@ en:
       results: Search Results
       no_results: No results found
 
+  facility_account:
+    account_fields:
+      label:
+        account_number:
+          account_number: Account Number
+
   facility_accounts:
     edit:
       cancel: Cancel


### PR DESCRIPTION
This is extracted from https://github.com/tablexi/nucore-dartmouth/pull/22.

It does not address the odd taborder issue we've noticed when filling out a chart string (that's where halfway through, tabbing may bounce your cursor to the search input).