### PR TITLE
[#124331] Fix broken search result

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -5,7 +5,6 @@ class SearchController < ApplicationController
 
   ## return users of portal 'nucore'
   def user_search_results
-    raise NUCore::PermissionDenied if session_user.blank?
     @limit = 25
     load_facility
     @price_group = PriceGroup.find(params[:price_group_id]) if params[:price_group_id].present?

--- a/app/views/search/_user_product_approval_link.html.haml
+++ b/app/views/search/_user_product_approval_link.html.haml
@@ -1,2 +1,2 @@
-# TODO: I18n confirmation
+-# TODO: I18n confirmation
 = link_to user.last_first_name, self.send("new_facility_#{@product.class.name.downcase}_user_path", @facility, @product, user: user.id), :confirm => "Are you sure you wish to authorize this user to order this #{@product.class.name.downcase}?"

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -119,7 +119,7 @@ class Ability
         end
 
         can [:administer], User
-        if controller.is_a?(UsersController)
+        if controller.is_a?(UsersController) || controller.is_a?(SearchController)
           can :manage, User
           cannot(:switch_to, User) { |target_user| !target_user.active? }
         end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe SearchController do
+  render_views
+
+  let(:facility) { FactoryGirl.create(:setup_facility) }
+  let!(:user) { FactoryGirl.create(:user, first_name: "Firstname", last_name: "Lastname") }
+
+  shared_examples_for "searching" do |action|
+    let(:session_user) { FactoryGirl.create(:user, :facility_administrator, facility: facility) }
+    let(:params) { {} }
+    before do
+      sign_in session_user
+      post :user_search_results, params.merge(search_type: action, search_term: user.username)
+    end
+
+    it "#{action} finds the user" do
+      expect(response.body).to include(user.email)
+      expect(response.body).to include(user.first_name)
+      expect(response.body).to include(user.last_name)
+    end
+
+    it "#{action} renders the link" do
+      expect(response).to render_template("search/_#{action}_link")
+    end
+  end
+
+  describe "user_search_results" do
+    it "does not allow a non-logged in user" do
+      get :user_search_results
+      expect(response.code).to redirect_to(new_user_session_path)
+    end
+
+    it_behaves_like "searching", "account_account_user" do
+      let(:account) { FactoryGirl.create(:setup_account) }
+      let(:params) { { account_id: account.id } }
+    end
+
+    it_behaves_like "searching", "facility_account_account_user" do
+      let(:account) { FactoryGirl.create(:setup_account) }
+      let(:params) { { account_id: account.id } }
+    end
+
+    # This is safe for a non-admin to see because the links themselves are protected
+    it_behaves_like "searching", "global_user_role"
+
+    it_behaves_like "searching", "manage_user" do
+      let(:params) { { facility_id: facility.id } }
+
+      it "has order for", :focus do
+        expect(response.body).to include("Order For")
+      end
+    end
+
+    it_behaves_like "searching", "map_user"
+
+    it_behaves_like "searching", "user_accounts"
+
+    it_behaves_like "searching", "user_new_account"
+
+    it_behaves_like "searching", "user_price_group_member" do
+      let(:price_group) { FactoryGirl.create(:price_group, facility: facility) }
+      let(:params) { { price_group_id: price_group.id } }
+    end
+
+    it_behaves_like "searching", "user_product_approval" do
+      let(:product) { FactoryGirl.create(:setup_item, facility: facility) }
+      let(:params) { { product_id: product.id } }
+    end
+  end
+end


### PR DESCRIPTION
The user approval search was broken because of a syntax error. This was
broken by the refactoring in #534 for supporting deactivated users.

While writing tests, I also discovered that this causes a problem where
facility admins cannot order for after a search. I never noticed it
because I was always testing as a global admin.