### PR TITLE
[#47665] Fix edit account permissions based on state

### DIFF
--- a/app/controllers/order_details_controller.rb
+++ b/app/controllers/order_details_controller.rb
@@ -8,6 +8,7 @@ class OrderDetailsController < ApplicationController
   before_filter :check_acting_as, except: [:order_file, :upload_order_file, :remove_order_file]
   before_filter :init_order_detail
   before_filter :set_active_tab
+  before_filter :prevent_edit_based_on_state, only: [:edit, :update]
   authorize_resource
 
   # GET /orders/:order_id/order_details/:id
@@ -21,9 +22,9 @@ class OrderDetailsController < ApplicationController
 
   # Put /orders/:order_id/order_details/:id
   def update
-    if order_editable? && @order_detail.update_attributes(order_detail_params)
+    if @order_detail.update_attributes(order_detail_params)
       flash[:notice] = I18n.t("order_details.update.success")
-      redirect_to [@order, @order_detail]
+      redirect_to action: :show
     else
       flash.now[:error] = I18n.t("order_details.update.failure")
       render :edit
@@ -111,6 +112,13 @@ class OrderDetailsController < ApplicationController
   end
 
   private
+
+  def prevent_edit_based_on_state
+    unless order_editable?
+      flash[:notice] = I18n.t("order_details.edit.failure")
+      redirect_to action: :show
+    end
+  end
 
   def order_editable?
     @order_detail.customer_editable?

--- a/app/views/order_details/show.html.haml
+++ b/app/views/order_details/show.html.haml
@@ -18,7 +18,7 @@
       .control-group
         %label.control-label
           = OrderDetail.human_attribute_name(:account)
-          = link_to t(".link.change_account"), [:edit, @order, @order_detail], class: "normal-weight"
+          = link_to t(".link.change_account"), [:edit, @order, @order_detail], class: "normal-weight" if order_editable?
         .controls= @order_detail.account
 
       = f.input :ordered_at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -694,6 +694,7 @@ en:
       warning: |
         Changing the Payment Source could result in adjusted pricing. If you are
         concerned about this or receive incorrect pricing, please contact the facility.
+      failure: This order is not currently editable.
     update:
       success: "The order has been updated"
       failure: "There was a problem updating the order"


### PR DESCRIPTION
#update was already using logic to determine whether you could modify
the order. This adds the logic to edit and the “Change” link.