### PR TITLE
[#47665] Customer can change account until journaled or statement

### DIFF
--- a/app/controllers/order_details_controller.rb
+++ b/app/controllers/order_details_controller.rb
@@ -121,7 +121,7 @@ class OrderDetailsController < ApplicationController
   end
 
   def order_editable?
-    @order_detail.customer_editable?
+    @order_detail.customer_account_changeable?
   end
   helper_method :order_editable?
 

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -563,6 +563,10 @@ class OrderDetail < ActiveRecord::Base
     !reviewed? && !canceled?
   end
 
+  def customer_account_changeable?
+    journal_id.blank? && statement_id.blank? && !canceled?
+  end
+
   def validate_for_purchase
     # can purchase product
     return "The product may not be purchased" unless product.available_for_purchase?

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -559,10 +559,6 @@ class OrderDetail < ActiveRecord::Base
     in_review?
   end
 
-  def customer_editable?
-    !reviewed? && !canceled?
-  end
-
   def customer_account_changeable?
     journal_id.blank? && statement_id.blank? && !canceled?
   end

--- a/spec/controllers/order_details_controller_spec.rb
+++ b/spec/controllers/order_details_controller_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe OrderDetailsController do
 
         describe "when the review period is over" do
           before { order_detail.update_attributes!(reviewed_at: 1.day.ago) }
-          it_behaves_like "cannot modify the account"
+          it_behaves_like "can modify the account"
         end
 
         describe "when the review period is over, but it is being disputed" do
@@ -258,7 +258,7 @@ RSpec.describe OrderDetailsController do
 
         describe "when the dispute has been resolved" do
           before { order_detail.update_attributes!(reviewed_at: 1.day.ago, dispute_at: 2.days.ago, dispute_resolved_at: Time.current, dispute_reason: "reason", dispute_resolved_reason: "notes") }
-          it_behaves_like "cannot modify the account"
+          it_behaves_like "can modify the account"
         end
 
         describe "when the order is statemented" do


### PR DESCRIPTION
Per NU’s request, a customer should be allowed to change the payment
source up until the time the order detail is journaled or statemented.