### PR TITLE
[#125700] Hide reconciliation links from cross-facility

### DIFF
--- a/app/views/shared/sidenav_billing/_reconciliation.html.haml
+++ b/app/views/shared/sidenav_billing/_reconciliation.html.haml
@@ -1,4 +1,4 @@
-- if Account.config.reconcilable_account_types.any?
+- if current_facility.single_facility? && Account.config.reconcilable_account_types.any?
   %li.nav-spacer
   - Account.config.reconcilable_account_types.each do |account_type|
     - route_name = Account.config.account_type_to_route(account_type)


### PR DESCRIPTION
Reconciliation doesn’t work in the cross-facility context, so we should
hide it from the menu (similar to statements). We have a separate story
for enabling cross-facility statements (#125702), so we can look into
enabling this when we play that story.