### PR TITLE
Statement spec should pass for newer pdf versions

### DIFF
--- a/spec/controllers/facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_accounts_controller_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe FacilityAccountsController do
       expect(assigns(:facility)).to eq(@authable)
       expect(assigns(:statement)).to eq(@statement)
       expect(response.content_type).to eq("application/pdf")
-      expect(response.body).to match(/%PDF-1.3/)
+      expect(response.body).to match(/%PDF-1.\d/)
       is_expected.to render_template "statements/show"
     end
 


### PR DESCRIPTION
UIC uses a PNG with transparency, which is only supported by PDF 1.4+.
Prawn is apparently smart enough to use the lowest compatibility level
based on the features that get used.

https://acrobatusers.com/tutorials/understanding-pdf-compatibility-levels