### PR TITLE
[#118500913] Ability to disable creation of certain account types

### DIFF
--- a/app/controllers/facility_accounts_controller.rb
+++ b/app/controllers/facility_accounts_controller.rb
@@ -175,7 +175,7 @@ class FacilityAccountsController < ApplicationController
   private
 
   def available_account_types
-    Account.config.account_types_for_facility(current_facility).select do |account_type|
+    Account.config.account_types_for_facility(current_facility, :create).select do |account_type|
       current_ability.can?(:create, account_type.constantize)
     end
   end

--- a/app/models/account_config.rb
+++ b/app/models/account_config.rb
@@ -43,6 +43,11 @@ class AccountConfig
     @journal_account_types ||= ["NufsAccount"]
   end
 
+  # An array of account types where creation should be disabled
+  def creation_disabled_types
+    @creation_disabled_types ||= []
+  end
+
   # Given an subclassed `Account` name return a param-friendly string. Replaces
   # any backslashes with underscore to support namespaced class names.
   def account_type_to_param(account_type)
@@ -58,9 +63,11 @@ class AccountConfig
   # Returns an array of subclassed Account objects given a facility.
   # Facility can be a NullObject (used when not in the context of a facility)
   # and the NullObject always returns `true` for cross_facility?.
-  def account_types_for_facility(facility)
-    return account_types.select { |type| type.constantize.cross_facility? } if facility.try(:cross_facility?)
-    account_types
+  def account_types_for_facility(facility, action)
+    types = account_types
+    types = account_types.select { |type| type.constantize.cross_facility? } if facility.try(:cross_facility?)
+    types = account_types - creation_disabled_types if action == :create
+    types
   end
 
   # Returns true if multiple account types are available

--- a/app/services/account_builder.rb
+++ b/app/services/account_builder.rb
@@ -125,7 +125,7 @@ class AccountBuilder
   # or a null object and this should still work. Throws an
   # ActionController::RoutingError if the account type is invalid.
   def validate_account_type!
-    valid_account_types = Account.config.account_types_for_facility(facility)
+    valid_account_types = Account.config.account_types_for_facility(facility, action)
     unless valid_account_types.include?(account_type)
       raise ActionController::RoutingError, "invalid account_type"
     end


### PR DESCRIPTION
This will be used to disable the creation of NufsAccounts in branches where we are using other custom account types. Disabling just the interface for creation instead of completely is much simpler than fixing all of the tests that would be broken.