### PR TITLE
Revenue account validations

### DIFF
--- a/app/models/facility_account.rb
+++ b/app/models/facility_account.rb
@@ -4,7 +4,7 @@ class FacilityAccount < ActiveRecord::Base
 
   belongs_to :facility
 
-  validates_numericality_of :revenue_account, only_integer: true, greater_than_or_equal_to: 10_000, less_than_or_equal_to: 99_999
+  validates :revenue_account, numericality: { only_integer: true }
   validates_uniqueness_of   :account_number, scope: [:revenue_account, :facility_id]
   validate :validate_chartstring
 

--- a/app/models/facility_account.rb
+++ b/app/models/facility_account.rb
@@ -5,7 +5,7 @@ class FacilityAccount < ActiveRecord::Base
   belongs_to :facility
 
   validates :revenue_account, numericality: { only_integer: true }
-  validates_uniqueness_of   :account_number, scope: [:revenue_account, :facility_id]
+  validates_uniqueness_of :account_number, scope: [:revenue_account, :facility_id]
   validate :validate_chartstring
 
   scope :active,   conditions: { is_active: true }

--- a/spec/factories/facility_accounts.rb
+++ b/spec/factories/facility_accounts.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :facility_account do
+    facility
     revenue_account 51_234
     sequence(:account_number) do |n|
       # This sequence was often running into blacklist problems

--- a/spec/models/facility_account_spec.rb
+++ b/spec/models/facility_account_spec.rb
@@ -1,37 +1,9 @@
 require "rails_helper"
 
 RSpec.describe FacilityAccount do
-  context "valid account number" do
-    before(:each) do
-      @user     = FactoryGirl.create(:user)
-      @facility = FactoryGirl.create(:facility)
-      assert @facility.valid?
-      @options = Hash[is_active: 1, created_by: @user.id, facility_id: @facility.id, revenue_account: 51_234]
-      @starts_at  = Time.zone.now - 3.days
-      @expires_at = Time.zone.now + 3.days
-    end
-
-    it "should create using factory" do
-      attrs = FactoryGirl.attributes_for(:facility_account)
-      define_open_account(attrs[:revenue_account], attrs[:account_number])
-      @facility_account = @facility.facility_accounts.create(attrs)
-      assert @facility_account.valid?
-    end
-
-    context "revenue_account" do
-      it "should not allow account < 5 digits" do
-        @options[:revenue_account] = "9999"
-        @account = FacilityAccount.create(@options)
-        assert @account.invalid?
-        assert @account.errors[:revenue_account]
-      end
-
-      it "should not allow account > 5 digits" do
-        @options[:revenue_account] = "111111"
-        @account = FacilityAccount.create(@options)
-        assert @account.invalid?
-        assert @account.errors[:revenue_account]
-      end
+  describe "#revenue_account" do
+    it "is an integer" do
+      is_expected.to validate_numericality_of(:revenue_account).only_integer
     end
   end
 end


### PR DESCRIPTION
This pulls in the parts of https://github.com/tablexi/nucore-nu/pull/151 that are not specific to NU, to generalize the `revenue_account` validations to allow integers. Number ranges and format validations, if any, would be up to the forks to implement.