### PR TITLE
[#118597103] Move default revenue and product accounts to Settings

### DIFF
--- a/app/controllers/facility_facility_accounts_controller.rb
+++ b/app/controllers/facility_facility_accounts_controller.rb
@@ -21,7 +21,7 @@ class FacilityFacilityAccountsController < ApplicationController
 
   # GET /facilities/:facility_id/facility_accounts/new(.:format)
   def new
-    @facility_account = current_facility.facility_accounts.new(is_active: true, revenue_account: "50617")
+    @facility_account = current_facility.facility_accounts.new(is_active: true, revenue_account: Settings.accounts.revenue_account_default)
   end
 
   # POST /facilities/:facility_id/facility_accounts(.:format)

--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -100,7 +100,7 @@ class ProductsCommonController < ApplicationController
 
   # GET /services/new
   def new
-    @product = current_facility_products.new(account: NUCore::COMMON_ACCOUNT)
+    @product = current_facility_products.new(account: Settings.accounts.product_default)
     save_product_into_object_name_instance
   end
 

--- a/app/models/nufs_account.rb
+++ b/app/models/nufs_account.rb
@@ -34,7 +34,7 @@ class NufsAccount < Account
   # [_return_]
   #   The Validator from which the components were retrieved
   def load_components
-    validator = ValidatorFactory.instance(account_number, NUCore::COMMON_ACCOUNT)
+    validator = ValidatorFactory.instance(account_number, Settings.accounts.product_default)
     @components = validator.components
 
     @components.each do |k, v|

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,11 @@ price_group:
     external: 'External Rate'
     cancer_center: 'Cancer Center Rate'
 
+accounts:
+  # Most frequently used account by NU
+  product_default: 75340
+  revenue_account_default: 50617
+
 financial:
   # in the format MM-DD
   fiscal_year_begins: 09-01

--- a/lib/nucore.rb
+++ b/lib/nucore.rb
@@ -1,8 +1,5 @@
 module NUCore
 
-  # 'magic number'; is simply the most frequently used account by NU
-  COMMON_ACCOUNT = "75340".freeze
-
   class PermissionDenied < SecurityError
   end
 


### PR DESCRIPTION
There's one spec in the NU branch that uses `COMMON_ACCOUNT`, so we'll need to change that there.