### PR TITLE
[#116373301] Add Projects index and new/create

### DIFF
--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -12,16 +12,20 @@ class NavTab::LinkCollection
     @ability = ability
   end
 
-  def admin
-    default + [
-      admin_orders,
-      admin_reservations,
-      admin_billing,
-      admin_products,
-      admin_users,
-      admin_reports,
-      admin_facility,
-    ].select(&:present?)
+  def self.tab_methods
+    @tab_methods ||= %i(
+      admin_orders
+      admin_reservations
+      admin_billing
+      admin_products
+      admin_users
+      admin_reports
+      admin_facility
+    )
+  end
+
+   def admin
+    default + admin_only
   end
 
   def customer
@@ -42,6 +46,12 @@ class NavTab::LinkCollection
     if single_facility? && ability.can?(:manage_billing, facility)
       NavTab::Link.new(tab: :admin_billing, url: billing_tab_landing_path)
     end
+  end
+
+  def admin_only
+    self.class.tab_methods.map do |tab_method|
+      send(tab_method)
+    end.select(&:present?)
   end
 
   def admin_orders

--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -24,7 +24,7 @@ class NavTab::LinkCollection
     )
   end
 
-   def admin
+  def admin
     default + admin_only
   end
 

--- a/vendor/engines/projects/app/controllers/projects/projects_controller.rb
+++ b/vendor/engines/projects/app/controllers/projects/projects_controller.rb
@@ -19,7 +19,7 @@ module Projects
       @project = current_facility.projects.new(project_params)
       if @project.save
         flash[:notice] =
-         I18n.t("controllers.projects.projects.create.success", project_name: @project.name)
+          I18n.t("controllers.projects.projects.create.success", project_name: @project.name)
         redirect_to facility_projects_path(current_facility)
       else
         render action: :new
@@ -33,4 +33,5 @@ module Projects
     end
 
   end
+
 end

--- a/vendor/engines/projects/app/controllers/projects/projects_controller.rb
+++ b/vendor/engines/projects/app/controllers/projects/projects_controller.rb
@@ -2,6 +2,9 @@ module Projects
 
   class ProjectsController < ApplicationController
 
+    admin_tab :all
+    before_filter { @active_tab = "admin_projects" }
+
     load_and_authorize_resource
 
     def index

--- a/vendor/engines/projects/app/controllers/projects/projects_controller.rb
+++ b/vendor/engines/projects/app/controllers/projects/projects_controller.rb
@@ -1,0 +1,26 @@
+module Projects
+
+  class ProjectsController < ApplicationController
+
+    load_and_authorize_resource
+
+    def index
+      @projects = current_facility.projects
+    end
+
+    def new
+      @project = Projects::Project.new(facility: current_facility)
+    end
+
+    def create
+      @project = current_facility.projects.new(params[:projects_project])
+      if @project.save
+        flash[:notice] =
+         I18n.t("controllers.projects.projects.create.success", project_name: @project.name)
+        redirect_to facility_projects_path(current_facility)
+      else
+        render action: :new
+      end
+    end
+  end
+end

--- a/vendor/engines/projects/app/controllers/projects/projects_controller.rb
+++ b/vendor/engines/projects/app/controllers/projects/projects_controller.rb
@@ -13,7 +13,7 @@ module Projects
     end
 
     def create
-      @project = current_facility.projects.new(params[:projects_project])
+      @project = current_facility.projects.new(project_params)
       if @project.save
         flash[:notice] =
          I18n.t("controllers.projects.projects.create.success", project_name: @project.name)
@@ -22,5 +22,12 @@ module Projects
         render action: :new
       end
     end
+
+    private
+
+    def project_params
+      params.require(:projects_project).permit("description", "name")
+    end
+
   end
 end

--- a/vendor/engines/projects/app/controllers/projects/projects_controller.rb
+++ b/vendor/engines/projects/app/controllers/projects/projects_controller.rb
@@ -8,7 +8,7 @@ module Projects
     load_and_authorize_resource
 
     def index
-      @projects = current_facility.projects
+      @projects = current_facility.projects.paginate(page: params[:page])
     end
 
     def new

--- a/vendor/engines/projects/app/controllers/projects/projects_controller.rb
+++ b/vendor/engines/projects/app/controllers/projects/projects_controller.rb
@@ -12,7 +12,6 @@ module Projects
     end
 
     def new
-
     end
 
     def create

--- a/vendor/engines/projects/app/controllers/projects/projects_controller.rb
+++ b/vendor/engines/projects/app/controllers/projects/projects_controller.rb
@@ -5,14 +5,14 @@ module Projects
     admin_tab :all
     before_filter { @active_tab = "admin_projects" }
 
-    load_and_authorize_resource
+    load_and_authorize_resource through: :current_facility
 
     def index
-      @projects = current_facility.projects.paginate(page: params[:page])
+      @projects = @projects.paginate(page: params[:page])
     end
 
     def new
-      @project = Projects::Project.new(facility: current_facility)
+
     end
 
     def create

--- a/vendor/engines/projects/app/models/projects/ability_extension.rb
+++ b/vendor/engines/projects/app/models/projects/ability_extension.rb
@@ -13,6 +13,7 @@ module Projects
         ability.can([:create, :index, :new], Projects::Project)
       end
     end
+
   end
 
 end

--- a/vendor/engines/projects/app/models/projects/ability_extension.rb
+++ b/vendor/engines/projects/app/models/projects/ability_extension.rb
@@ -9,7 +9,9 @@ module Projects
     end
 
     def extend(user, resource)
-      ability.can([:index, :new], Projects::Project) if user.operator_of?(resource)
+      if user.operator_of?(resource)
+        ability.can([:create, :index, :new], Projects::Project)
+      end
     end
   end
 

--- a/vendor/engines/projects/app/models/projects/ability_extension.rb
+++ b/vendor/engines/projects/app/models/projects/ability_extension.rb
@@ -1,0 +1,16 @@
+module Projects
+
+  class AbilityExtension
+
+    attr_reader :ability
+
+    def initialize(ability)
+      @ability = ability
+    end
+
+    def extend(user, resource)
+      ability.can([:index, :new], Projects::Project) if user.operator_of?(resource)
+    end
+  end
+
+end

--- a/vendor/engines/projects/app/presenters/projects/link_collection_extension.rb
+++ b/vendor/engines/projects/app/presenters/projects/link_collection_extension.rb
@@ -1,0 +1,23 @@
+module Projects
+
+  module LinkCollectionExtension
+
+    extend ActiveSupport::Concern
+
+    included do
+      tab_methods << :admin_projects
+    end
+
+    def admin_projects
+      if single_facility? && ability.can?(:index, Project)
+        NavTab::Link.new(
+          tab: :admin_projects,
+          text: Project.model_name.human(count: 2),
+          url: facility_projects_path(facility),
+        )
+      end
+    end
+
+  end
+
+end

--- a/vendor/engines/projects/app/presenters/projects/link_collection_extension.rb
+++ b/vendor/engines/projects/app/presenters/projects/link_collection_extension.rb
@@ -5,7 +5,8 @@ module Projects
     extend ActiveSupport::Concern
 
     included do
-      tab_methods << :admin_projects
+      insert_index = tab_methods.index(:admin_facility) || -1
+      tab_methods.insert(insert_index, :admin_projects)
     end
 
     def admin_projects

--- a/vendor/engines/projects/app/views/projects/projects/index.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/index.html.haml
@@ -13,3 +13,5 @@
       - @projects.each do |project|
         %tr
           %td= project.name
+
+  = will_paginate(@projects)

--- a/vendor/engines/projects/app/views/projects/projects/index.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/index.html.haml
@@ -1,0 +1,15 @@
+= content_for :h1 do
+  = t(".head")
+
+- if current_ability.can?(:create, Projects::Project)
+  %p= link_to t(".add"), new_facility_project_path, class: "btn-add"
+
+- if @projects.any?
+  %table.table.table-striped.table-hover
+    %thead
+      %tr
+        %th= Projects::Project.human_attribute_name(:name).titlecase
+    %tbody
+      - @projects.each do |project|
+        %tr
+          %td= project.name

--- a/vendor/engines/projects/app/views/projects/projects/new.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/new.html.haml
@@ -1,0 +1,12 @@
+= render "shared/headers/ckeditor"
+
+= content_for :h1 do
+  = t(".head")
+
+= simple_form_for @project, url: facility_projects_path(current_facility), method: :post do |f|
+  .form-inputs
+    = f.input :name, hint: t(".name")
+    = f.input :description, hint: t(".description"), input_html: { class: :editor }
+  .form-actions
+    = f.button :submit, t(".add")
+    = link_to t(".cancel"), facility_projects_path(current_facility)

--- a/vendor/engines/projects/config/locales/en.yml
+++ b/vendor/engines/projects/config/locales/en.yml
@@ -1,0 +1,17 @@
+en:
+  controllers:
+    projects:
+      projects:
+        create:
+          success: "New project %{project_name} was created."
+  projects:
+    projects:
+      index:
+        add: Add Project
+        head: Manage Projects
+      new:
+        add: Add Project
+        cancel: Cancel
+        description: Description as it will appear on the project's page
+        head: Add Project
+        name: Name of the label as displayed to the end user

--- a/vendor/engines/projects/config/locales/en.yml
+++ b/vendor/engines/projects/config/locales/en.yml
@@ -1,4 +1,10 @@
 en:
+  activerecord:
+    models:
+      projects/project:
+        one: Project
+        other: Projects
+
   controllers:
     projects:
       projects:

--- a/vendor/engines/projects/config/routes.rb
+++ b/vendor/engines/projects/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   resources :facilities, only: [] do
-    resources :projects, controller: "Projects::Projects", only: %i(create index new)
+    resources :projects, controller: "projects/projects", only: %i(create index new)
   end
 end

--- a/vendor/engines/projects/config/routes.rb
+++ b/vendor/engines/projects/config/routes.rb
@@ -1,0 +1,5 @@
+Rails.application.routes.draw do
+  resources :facilities, only: [] do
+    resources :projects, controller: "Projects::Projects", only: %i(create index new)
+  end
+end

--- a/vendor/engines/projects/lib/projects/engine.rb
+++ b/vendor/engines/projects/lib/projects/engine.rb
@@ -8,6 +8,7 @@ module Projects
 
     config.to_prepare do
       Facility.send :include, Projects::FacilityExtension
+      NavTab::LinkCollection.send :include, Projects::LinkCollectionExtension
     end
 
     initializer :append_migrations do |app|

--- a/vendor/engines/projects/lib/projects/engine.rb
+++ b/vendor/engines/projects/lib/projects/engine.rb
@@ -2,6 +2,10 @@ module Projects
 
   class Engine < Rails::Engine
 
+    def self.enable!
+      ::AbilityExtensionManager.extensions << "Projects::AbilityExtension"
+    end
+
     config.to_prepare do
       Facility.send :include, Projects::FacilityExtension
     end

--- a/vendor/engines/projects/lib/projects/engine.rb
+++ b/vendor/engines/projects/lib/projects/engine.rb
@@ -2,11 +2,8 @@ module Projects
 
   class Engine < Rails::Engine
 
-    def self.enable!
-      ::AbilityExtensionManager.extensions << "Projects::AbilityExtension"
-    end
-
     config.to_prepare do
+      ::AbilityExtensionManager.extensions << "Projects::AbilityExtension"
       Facility.send :include, Projects::FacilityExtension
       NavTab::LinkCollection.send :include, Projects::LinkCollectionExtension
     end

--- a/vendor/engines/projects/spec/controllers/projects/projects_controller_spec.rb
+++ b/vendor/engines/projects/spec/controllers/projects/projects_controller_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-require_relative "../../projects_spec_helper"
 
 RSpec.describe Projects::ProjectsController, type: :controller do
   let(:facility) { FactoryGirl.create(:facility) }

--- a/vendor/engines/projects/spec/controllers/projects/projects_controller_spec.rb
+++ b/vendor/engines/projects/spec/controllers/projects/projects_controller_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe Projects::ProjectsController, type: :controller do
+  let(:facility) { create(:facility) }
+
+  let(:administrator) { create(:user, :administrator) }
+  let(:facility_administrator) { create(:user, :facility_administrator, facility: facility) }
+  let(:facility_director) { create(:user, :facility_director, facility: facility) }
+  let(:senior_staff) { create(:user, :senior_staff, facility: facility) }
+  let(:staff) { create(:user, :staff, facility: facility) }
+
+  describe "GET #index" do
+    def do_request
+      get :index, facility_id: facility.url_name
+    end
+
+    describe "when not logged in" do
+      before { do_request }
+
+      it { is_expected.to redirect_to new_user_session_path }
+    end
+
+    describe "when logged in" do
+      shared_examples_for "it allows index views" do
+        before(:each) do
+          sign_in user
+          do_request
+        end
+
+        it "shows the index view", :aggregate_failures do
+          expect(response.code).to eq("200")
+          expect(assigns(:projects)).to match_array(facility.projects)
+        end
+      end
+
+      context "as a facility_administrator" do
+        let(:user) { facility_administrator }
+        it_behaves_like "it allows index views"
+      end
+
+      context "as a facility_director" do
+        let(:user) { facility_director }
+        it_behaves_like "it allows index views"
+      end
+
+      context "as facility senior_staff" do
+        let(:user) { senior_staff }
+        it_behaves_like "it allows index views"
+      end
+
+      context "as facility staff" do
+        let(:user) { staff }
+        it_behaves_like "it allows index views"
+      end
+    end
+  end
+
+  describe "GET #new" do
+  end
+
+  describe "POST #create" do
+  end
+end

--- a/vendor/engines/projects/spec/controllers/projects/projects_controller_spec.rb
+++ b/vendor/engines/projects/spec/controllers/projects/projects_controller_spec.rb
@@ -1,13 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Projects::ProjectsController, type: :controller do
-  let(:facility) { create(:facility) }
-
-  let(:administrator) { create(:user, :administrator) }
-  let(:facility_administrator) { create(:user, :facility_administrator, facility: facility) }
-  let(:facility_director) { create(:user, :facility_director, facility: facility) }
-  let(:senior_staff) { create(:user, :senior_staff, facility: facility) }
-  let(:staff) { create(:user, :staff, facility: facility) }
+  let(:facility) { FactoryGirl.create(:facility) }
 
   before(:all) { Projects::Engine.enable! }
 
@@ -23,7 +17,9 @@ RSpec.describe Projects::ProjectsController, type: :controller do
     end
 
     describe "when logged in" do
-      shared_examples_for "it allows index views" do
+      shared_examples_for "it allows index views" do |role|
+        let(:user) { FactoryGirl.create(:user, role, facility: facility) }
+
         before(:each) do
           sign_in user
           do_request
@@ -35,24 +31,10 @@ RSpec.describe Projects::ProjectsController, type: :controller do
         end
       end
 
-      context "as a facility_administrator" do
-        let(:user) { facility_administrator }
-        it_behaves_like "it allows index views"
-      end
-
-      context "as a facility_director" do
-        let(:user) { facility_director }
-        it_behaves_like "it allows index views"
-      end
-
-      context "as facility senior_staff" do
-        let(:user) { senior_staff }
-        it_behaves_like "it allows index views"
-      end
-
-      context "as facility staff" do
-        let(:user) { staff }
-        it_behaves_like "it allows index views"
+      %i(facility_administrator facility_director senior_staff staff).each do |role|
+        context "as #{role}" do
+          it_behaves_like "it allows index views", role
+        end
       end
     end
   end
@@ -69,7 +51,9 @@ RSpec.describe Projects::ProjectsController, type: :controller do
     end
 
     describe "when logged in" do
-      shared_examples_for "it allows new views" do
+      shared_examples_for "it allows new views" do |role|
+        let(:user) { FactoryGirl.create(:user, role, facility: facility) }
+
         before(:each) do
           sign_in user
           do_request
@@ -81,24 +65,10 @@ RSpec.describe Projects::ProjectsController, type: :controller do
         end
       end
 
-      context "as a facility_administrator" do
-        let(:user) { facility_administrator }
-        it_behaves_like "it allows new views"
-      end
-
-      context "as a facility_director" do
-        let(:user) { facility_director }
-        it_behaves_like "it allows new views"
-      end
-
-      context "as facility senior_staff" do
-        let(:user) { senior_staff }
-        it_behaves_like "it allows new views"
-      end
-
-      context "as facility staff" do
-        let(:user) { staff }
-        it_behaves_like "it allows new views"
+      %i(facility_administrator facility_director senior_staff staff).each do |role|
+        context "as #{role}" do
+          it_behaves_like "it allows new views", role
+        end
       end
     end
   end
@@ -120,13 +90,14 @@ RSpec.describe Projects::ProjectsController, type: :controller do
     end
 
     describe "when logged in" do
-      shared_examples_for "it allows project creation" do
+      shared_examples_for "it allows project creation" do |role|
+        let(:created_project) { Projects::Project.last }
+        let(:user) { FactoryGirl.create(:user, role, facility: facility) }
+
         before(:each) do
           sign_in user
           do_request
         end
-
-        let(:created_project) { Projects::Project.last }
 
         it "creates a new project" do
           is_expected.to redirect_to facility_projects_path(facility)
@@ -135,24 +106,10 @@ RSpec.describe Projects::ProjectsController, type: :controller do
         end
       end
 
-      context "as a facility_administrator" do
-        let(:user) { facility_administrator }
-        it_behaves_like "it allows project creation"
-      end
-
-      context "as a facility_director" do
-        let(:user) { facility_director }
-        it_behaves_like "it allows project creation"
-      end
-
-      context "as facility senior_staff" do
-        let(:user) { senior_staff }
-        it_behaves_like "it allows project creation"
-      end
-
-      context "as facility staff" do
-        let(:user) { staff }
-        it_behaves_like "it allows project creation"
+      %i(facility_administrator facility_director senior_staff staff).each do |role|
+        context "as #{role}" do
+          it_behaves_like "it allows project creation", role
+        end
       end
     end
   end

--- a/vendor/engines/projects/spec/controllers/projects/projects_controller_spec.rb
+++ b/vendor/engines/projects/spec/controllers/projects/projects_controller_spec.rb
@@ -1,9 +1,8 @@
 require "rails_helper"
+require_relative "../../projects_spec_helper"
 
 RSpec.describe Projects::ProjectsController, type: :controller do
   let(:facility) { FactoryGirl.create(:facility) }
-
-  before(:all) { Projects::Engine.enable! }
 
   describe "GET #index" do
     def do_request

--- a/vendor/engines/projects/spec/controllers/projects/projects_controller_spec.rb
+++ b/vendor/engines/projects/spec/controllers/projects/projects_controller_spec.rb
@@ -1,4 +1,18 @@
 require "rails_helper"
+require "controller_spec_helper" # for the #facility_operators helper method
+
+def facility_operator_roles # Translates helper roles to User factory traits
+  facility_operators.map do |role|
+    case role
+    when :admin
+      :facility_administrator
+    when :senior_staff, :staff
+      role
+    else
+      "facility_#{role}".to_sym
+    end
+  end
+end
 
 RSpec.describe Projects::ProjectsController, type: :controller do
   let(:facility) { FactoryGirl.create(:facility) }
@@ -29,7 +43,7 @@ RSpec.describe Projects::ProjectsController, type: :controller do
         end
       end
 
-      %i(facility_administrator facility_director senior_staff staff).each do |role|
+      facility_operator_roles.each do |role|
         context "as #{role}" do
           it_behaves_like "it allows index views", role
         end
@@ -63,7 +77,7 @@ RSpec.describe Projects::ProjectsController, type: :controller do
         end
       end
 
-      %i(facility_administrator facility_director senior_staff staff).each do |role|
+      facility_operator_roles.each do |role|
         context "as #{role}" do
           it_behaves_like "it allows new views", role
         end
@@ -104,7 +118,7 @@ RSpec.describe Projects::ProjectsController, type: :controller do
         end
       end
 
-      %i(facility_administrator facility_director senior_staff staff).each do |role|
+      facility_operator_roles.each do |role|
         context "as #{role}" do
           it_behaves_like "it allows project creation", role
         end

--- a/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
+++ b/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Projects::AbilityExtension do
   subject(:ability) { Ability.new(user, facility, stub_controller) }
   let(:facility) { project.facility }
-  let(:project) { build(:project) }
+  let(:project) { FactoryGirl.build(:project) }
   let(:stub_controller) { OpenStruct.new }
 
   before(:all) { Projects::Engine.enable! }
@@ -25,42 +25,42 @@ RSpec.describe Projects::AbilityExtension do
   end
 
   describe "account manager" do
-    let(:user) { create(:user, :account_manager) }
+    let(:user) { FactoryGirl.create(:user, :account_manager) }
     it_behaves_like "it has no access"
   end
 
   describe "administrator" do
-    let(:user) { create(:user, :administrator) }
+    let(:user) { FactoryGirl.create(:user, :administrator) }
     it_behaves_like "it has full access"
   end
 
   describe "billing administrator", feature_setting: { billing_administrator: true } do
-    let(:user) { create(:user, :billing_administrator) }
+    let(:user) { FactoryGirl.create(:user, :billing_administrator) }
     it_behaves_like "it has no access"
   end
 
   describe "facility administrator" do
-    let(:user) { create(:user, :facility_administrator, facility: project.facility) }
+    let(:user) { FactoryGirl.create(:user, :facility_administrator, facility: facility) }
     it_behaves_like "it has full access"
   end
 
   describe "facility director" do
-    let(:user) { create(:user, :facility_director, facility: project.facility) }
+    let(:user) { FactoryGirl.create(:user, :facility_director, facility: facility) }
     it_behaves_like "it has full access"
   end
 
   describe "senior staff" do
-    let(:user) { create(:user, :senior_staff, facility: project.facility) }
+    let(:user) { FactoryGirl.create(:user, :senior_staff, facility: facility) }
     it_behaves_like "it has full access"
   end
 
   describe "staff" do
-    let(:user) { create(:user, :staff, facility: project.facility) }
+    let(:user) { FactoryGirl.create(:user, :staff, facility: facility) }
     it_behaves_like "it has full access"
   end
 
   describe "unprivileged user" do
-    let(:user) { create(:user) }
+    let(:user) { FactoryGirl.create(:user) }
     it_behaves_like "it has no access"
   end
 end

--- a/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
+++ b/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe Projects::AbilityExtension do
+  subject(:ability) { Ability.new(user, facility, stub_controller) }
+  let(:facility) { project.facility }
+  let(:project) { build(:project) }
+  let(:stub_controller) { OpenStruct.new }
+
+  before(:all) { Projects::Engine.enable! }
+
+  describe "account manager" do
+    let(:user) { create(:user, :account_manager) }
+    it { is_expected.not_to be_allowed_to(:index, Projects::Project) }
+  end
+
+  describe "administrator" do
+    let(:user) { create(:user, :administrator) }
+    it { is_expected.to be_allowed_to(:index, Projects::Project) }
+  end
+
+  describe "billing administrator", feature_setting: { billing_administrator: true } do
+    let(:user) { create(:user, :billing_administrator) }
+    it { is_expected.not_to be_allowed_to(:index, Projects::Project) }
+  end
+
+  describe "facility administrator" do
+    let(:user) { create(:user, :facility_administrator, facility: project.facility) }
+    it { is_expected.to be_allowed_to(:index, Projects::Project) }
+  end
+
+  describe "facility director" do
+    let(:user) { create(:user, :facility_director, facility: project.facility) }
+    it { is_expected.to be_allowed_to(:index, Projects::Project) }
+  end
+
+  describe "senior staff" do
+    let(:user) { create(:user, :senior_staff, facility: project.facility) }
+    it { is_expected.to be_allowed_to(:index, Projects::Project) }
+  end
+
+  describe "staff" do
+    let(:user) { create(:user, :staff, facility: project.facility) }
+    it { is_expected.to be_allowed_to(:index, Projects::Project) }
+  end
+
+  describe "unprivileged user" do
+    let(:user) { create(:user) }
+    it { is_expected.not_to be_allowed_to(:index, Projects::Project) }
+  end
+end

--- a/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
+++ b/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
@@ -8,43 +8,59 @@ RSpec.describe Projects::AbilityExtension do
 
   before(:all) { Projects::Engine.enable! }
 
+  shared_examples_for "it has full access" do
+    it "has full access" do
+      is_expected.to be_allowed_to(:create, Projects::Project)
+      is_expected.to be_allowed_to(:index, Projects::Project)
+      is_expected.to be_allowed_to(:new, Projects::Project)
+    end
+  end
+
+  shared_examples_for "it has no access" do
+    it "has no access" do
+      is_expected.not_to be_allowed_to(:create, Projects::Project)
+      is_expected.not_to be_allowed_to(:index, Projects::Project)
+      is_expected.not_to be_allowed_to(:new, Projects::Project)
+    end
+  end
+
   describe "account manager" do
     let(:user) { create(:user, :account_manager) }
-    it { is_expected.not_to be_allowed_to(:index, Projects::Project) }
+    it_behaves_like "it has no access"
   end
 
   describe "administrator" do
     let(:user) { create(:user, :administrator) }
-    it { is_expected.to be_allowed_to(:index, Projects::Project) }
+    it_behaves_like "it has full access"
   end
 
   describe "billing administrator", feature_setting: { billing_administrator: true } do
     let(:user) { create(:user, :billing_administrator) }
-    it { is_expected.not_to be_allowed_to(:index, Projects::Project) }
+    it_behaves_like "it has no access"
   end
 
   describe "facility administrator" do
     let(:user) { create(:user, :facility_administrator, facility: project.facility) }
-    it { is_expected.to be_allowed_to(:index, Projects::Project) }
+    it_behaves_like "it has full access"
   end
 
   describe "facility director" do
     let(:user) { create(:user, :facility_director, facility: project.facility) }
-    it { is_expected.to be_allowed_to(:index, Projects::Project) }
+    it_behaves_like "it has full access"
   end
 
   describe "senior staff" do
     let(:user) { create(:user, :senior_staff, facility: project.facility) }
-    it { is_expected.to be_allowed_to(:index, Projects::Project) }
+    it_behaves_like "it has full access"
   end
 
   describe "staff" do
     let(:user) { create(:user, :staff, facility: project.facility) }
-    it { is_expected.to be_allowed_to(:index, Projects::Project) }
+    it_behaves_like "it has full access"
   end
 
   describe "unprivileged user" do
     let(:user) { create(:user) }
-    it { is_expected.not_to be_allowed_to(:index, Projects::Project) }
+    it_behaves_like "it has no access"
   end
 end

--- a/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
+++ b/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-require_relative "../../projects_spec_helper"
 
 RSpec.describe Projects::AbilityExtension do
   subject(:ability) { Ability.new(user, facility, stub_controller) }

--- a/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
+++ b/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
@@ -1,12 +1,11 @@
 require "rails_helper"
+require_relative "../../projects_spec_helper"
 
 RSpec.describe Projects::AbilityExtension do
   subject(:ability) { Ability.new(user, facility, stub_controller) }
   let(:facility) { project.facility }
   let(:project) { FactoryGirl.build(:project) }
   let(:stub_controller) { OpenStruct.new }
-
-  before(:all) { Projects::Engine.enable! }
 
   shared_examples_for "it has full access" do
     it "has full access" do

--- a/vendor/engines/projects/spec/projects_spec_helper.rb
+++ b/vendor/engines/projects/spec/projects_spec_helper.rb
@@ -1,3 +1,0 @@
-RSpec.configure do |config|
-  config.before(:all) { Projects::Engine.enable! }
-end

--- a/vendor/engines/projects/spec/projects_spec_helper.rb
+++ b/vendor/engines/projects/spec/projects_spec_helper.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.before(:all) { Projects::Engine.enable! }
+end


### PR DESCRIPTION
This adds a new facility admin tab for viewing lists of Projects and and creating new ones.

I initially had the tab display at the end of the admin's tab list, but committed e80bc0b to place it second to last. I think it works better there.