### PR TITLE
[#125075] Manually set reconciliation date when reconciling

### DIFF
--- a/app/assets/javascripts/account_mgmt.js
+++ b/app/assets/javascripts/account_mgmt.js
@@ -1,5 +1,0 @@
-$(function() {
-  $('#selected_account').change(function(){
-    $(this).closest('form').submit();
-  });
-});

--- a/app/assets/javascripts/app/datepicker-data.coffee
+++ b/app/assets/javascripts/app/datepicker-data.coffee
@@ -1,0 +1,9 @@
+$ ->
+  # This will set up a datepicker based on data attributes
+  # Make sure you call `to_s` or `iso8601` on any dates you set in the views to
+  # ensure the proper format.
+  picker = $(".datepicker__data")
+  picker.datepicker(
+    minDate: new Date(picker.data("min-date")) # will be unbounded if not provided
+    maxDate: new Date(picker.data("max-date")) # will be unbounded if not provided
+  )

--- a/app/assets/javascripts/app/datepicker-data.coffee
+++ b/app/assets/javascripts/app/datepicker-data.coffee
@@ -2,8 +2,8 @@ $ ->
   # This will set up a datepicker based on data attributes
   # Make sure you call `to_s` or `iso8601` on any dates you set in the views to
   # ensure the proper format.
-  picker = $(".datepicker__data")
-  picker.datepicker(
-    minDate: new Date(picker.data("min-date")) # will be unbounded if not provided
-    maxDate: new Date(picker.data("max-date")) # will be unbounded if not provided
+  $picker = $(".datepicker__data")
+  $picker.datepicker(
+    minDate: new Date($picker.data("min-date")) # will be unbounded if not provided
+    maxDate: new Date($picker.data("max-date")) # will be unbounded if not provided
   )

--- a/app/assets/javascripts/reconciliation.js.coffee
+++ b/app/assets/javascripts/reconciliation.js.coffee
@@ -1,3 +1,3 @@
 $ ->
   $('#selected_account').change ->
-    $(this).closest('form').submit();
+    $(@).closest('form').submit()

--- a/app/assets/javascripts/reconciliation.js.coffee
+++ b/app/assets/javascripts/reconciliation.js.coffee
@@ -1,0 +1,3 @@
+$ ->
+  $('#selected_account').change ->
+    $(this).closest('form').submit();

--- a/app/controllers/facility_accounts_reconciliation_controller.rb
+++ b/app/controllers/facility_accounts_reconciliation_controller.rb
@@ -72,10 +72,7 @@ class FacilityAccountsReconciliationController < ApplicationController
       count = reconciler.count
       flash[:notice] = "#{count} payment#{count == 1 ? '' : 's'} successfully reconciled" if count > 0
     else
-      errors = ["There was an error processing the #{account_class.name.underscore.humanize.downcase} payments"] +
-        Array(reconciler.persist_errors) +
-        reconciler.errors.full_messages
-      flash[:error] = errors.join("<br />").html_safe
+      flash[:error] = reconciler.full_errors.join("<br />").html_safe
     end
   end
 

--- a/app/controllers/facility_accounts_reconciliation_controller.rb
+++ b/app/controllers/facility_accounts_reconciliation_controller.rb
@@ -1,4 +1,5 @@
 class FacilityAccountsReconciliationController < ApplicationController
+
   include DateHelper
 
   admin_tab :all

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -100,9 +100,8 @@ class FacilityJournalsController < ApplicationController
   end
 
   def reconcile
-    unreconciled_details = OrderDetail.for_facility(current_facility)
     reconciled_at = parse_usa_date(params[:reconciled_at])
-    reconciler = OrderDetails::Reconciler.new(unreconciled_details, params[:order_detail], reconciled_at)
+    reconciler = OrderDetails::Reconciler.new(@journal.order_details, params[:order_detail], reconciled_at)
 
     if reconciler.reconcile_all > 0
       count = reconciler.count

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -100,21 +100,17 @@ class FacilityJournalsController < ApplicationController
   end
 
   def reconcile
-    if params[:order_detail_ids].blank?
-      flash[:error] = "No orders were selected to reconcile"
-      redirect_to(facility_journal_path(current_facility, @journal)) && return
+    unreconciled_details = OrderDetail.for_facility(current_facility)
+    reconciled_at = parse_usa_date(params[:reconciled_at])
+    reconciler = OrderDetails::Reconciler.new(unreconciled_details, params[:order_detail], reconciled_at)
+
+    if reconciler.reconcile_all > 0
+      count = reconciler.count
+      flash[:notice] = "#{count} payment#{count == 1 ? '' : 's'} successfully reconciled" if count > 0
+    else
+      flash[:error] = reconciler.full_errors.join("<br />").html_safe
     end
-    rec_status = OrderStatus.reconciled.first
-    order_details = OrderDetail.for_facility(current_facility).where(id: params[:order_detail_ids]).readonly(false)
-    order_details.each do |od|
-      if od.journal_id != @journal.id
-        flash[:error] = "Order detail #{od} does not belong to this journal! Please reconcile without it."
-        redirect_to(facility_journal_path(current_facility, @journal)) && return
-      end
-      od.change_status!(rec_status)
-    end
-    flash[:notice] = "The selected orders have been reconciled successfully"
-    redirect_to(facility_journal_path(current_facility, @journal)) && return
+    redirect_to [current_facility, @journal]
   end
 
   private

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -1,6 +1,7 @@
 module OrderDetails
 
   class Reconciler
+
     include ActiveModel::Validations
 
     attr_reader :persist_errors, :count, :order_details, :reconciled_at
@@ -36,7 +37,7 @@ module OrderDetails
     # The params hash comes in with the unchecked IDs as well. Filter out to only
     # those we're going to reconcile. Returns an array of IDs.
     def to_be_reconciled
-      Hash(@params).select { |order_detail_id, params| params[:reconciled] == "1" }
+      Hash(@params).select { |_order_detail_id, params| params[:reconciled] == "1" }
     end
 
     def reconcile(order_detail, params)
@@ -67,6 +68,7 @@ module OrderDetails
         errors.add(:reconciled_at, :after_all_journal_dates)
       end
     end
+
   end
 
 end

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -1,14 +1,21 @@
 module OrderDetails
 
   class Reconciler
-    attr_reader :errors, :count
+    include ActiveModel::Validations
 
-    def initialize(order_detail_scope, params)
+    attr_reader :persist_errors, :count, :reconciled_at
+
+    validate :reconciliation_must_be_in_past
+    validate :all_journals_and_statements_must_be_before_reconciliation_date
+
+    def initialize(order_detail_scope, params, reconciled_at)
       @order_details = order_detail_scope.readonly(false).find(params.keys)
       @params = params
+      @reconciled_at = reconciled_at || Time.current
     end
 
     def reconcile_all
+      return 0 unless valid?
       @count = 0
       OrderDetail.transaction do
         @order_details.each do |od|
@@ -24,13 +31,14 @@ module OrderDetails
     def reconcile(order_detail, params)
       return unless params[:reconciled] == "1"
 
+      order_detail.reconciled_at = @reconciled_at
       order_detail.assign_attributes(allowed(params))
       order_detail.change_status!(OrderStatus.reconciled_status)
       @count += 1
     rescue => e
       @error_fields = { order_detail.id => order_detail.errors.collect { |field, _error| field } }
-      @errors = order_detail.errors.full_messages
-      @errors = [e.message] if @errors.empty?
+      @persist_errors = order_detail.errors.full_messages
+      @persist_errors = [e.message] if @persist_errors.empty?
       @count = 0
       raise ActiveRecord::Rollback
     end
@@ -39,6 +47,17 @@ module OrderDetails
       params.permit(:reconciled_note)
     end
 
+    def reconciliation_must_be_in_past
+      errors.add(:reconciled_at, :must_be_in_past) if @reconciled_at > Time.current.end_of_day
+    end
+
+    # You cannot set the reconciliation date for a date before the journal/statement date,
+    # but we do need to make sure to allow them on the same day.
+    def all_journals_and_statements_must_be_before_reconciliation_date
+      if @order_details.any? { |od| od.journal_or_statement_date.beginning_of_day > @reconciled_at }
+        errors.add(:reconciled_at, :after_all_journal_dates)
+      end
+    end
   end
 
 end

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -1,0 +1,44 @@
+module OrderDetails
+
+  class Reconciler
+    attr_reader :errors, :count
+
+    def initialize(order_detail_scope, params)
+      @order_details = order_detail_scope.readonly(false).find(params.keys)
+      @params = params
+    end
+
+    def reconcile_all
+      @count = 0
+      OrderDetail.transaction do
+        @order_details.each do |od|
+          od_params = @params[od.id.to_s]
+          reconcile(od, od_params)
+        end
+      end
+      @count
+    end
+
+    private
+
+    def reconcile(order_detail, params)
+      return unless params[:reconciled] == "1"
+
+      order_detail.assign_attributes(allowed(params))
+      order_detail.change_status!(OrderStatus.reconciled_status)
+      @count += 1
+    rescue => e
+      @error_fields = { order_detail.id => order_detail.errors.collect { |field, _error| field } }
+      @errors = order_detail.errors.full_messages
+      @errors = [e.message] if @errors.empty?
+      @count = 0
+      raise ActiveRecord::Rollback
+    end
+
+    def allowed(params)
+      params.permit(:reconciled_note)
+    end
+
+  end
+
+end

--- a/app/support/journals/closer.rb
+++ b/app/support/journals/closer.rb
@@ -5,7 +5,7 @@ class Journals::Closer
   def initialize(journal, params)
     @journal = journal
     # It's like strong_params...
-    @params = params.slice(:reference, :description, :updated_by)
+    @params = params.permit(:reference, :description, :updated_by)
   end
 
   def perform(status)
@@ -45,8 +45,7 @@ class Journals::Closer
 
   def mark_as_succeeded
     if journal.update_attributes(params.merge(is_successful: true))
-      reconciled_status = OrderStatus.reconciled.first
-      journal.order_details.update_all(state: "reconciled", order_status_id: reconciled_status.id)
+      journal.order_details.update_all(state: "reconciled", order_status_id: OrderStatus.reconciled_status.id, reconciled_at: reconciled_at)
     else
       false
     end
@@ -60,6 +59,10 @@ class Journals::Closer
         raise ActiveRecord::Rollback
       end
     end
+  end
+
+  def reconciled_at
+    Time.current
   end
 
 end

--- a/app/views/facility_accounts_reconciliation/_action_row.html.haml
+++ b/app/views/facility_accounts_reconciliation/_action_row.html.haml
@@ -1,10 +1,10 @@
 .row.table-actions.form-horizontal
-  .span2.select_all_none= link_to("Select None", "", class: "select_all")
+  .span2.select_all_none= link_to(local_assigns[:starting] == :all ? "Select All" : "Select None", "", class: "select_all")
 
   - if local_assigns[:date]
     .span5.control-group.fields
       %label.control-label{ for: :reconciled_at }= OrderDetail.human_attribute_name(:reconciled_at)
       .controls
-        = text_field_tag :reconciled_at, format_usa_date(Time.current), class: :datepicker__data, data: { min_date: @unreconciled_details.map(&:statement_date).min.to_s, max_date: Time.current.iso8601 }
+        = text_field_tag :reconciled_at, format_usa_date(Time.current), class: :datepicker__data, data: { min_date: unreconciled_order_details.map(&:journal_or_statement_date).min.to_s, max_date: Time.current.iso8601 }
 
   .span1.pull-right= submit_tag t("facility_journals.show.submit"), class: ["btn", "btn-primary"]

--- a/app/views/facility_accounts_reconciliation/_action_row.html.haml
+++ b/app/views/facility_accounts_reconciliation/_action_row.html.haml
@@ -1,5 +1,10 @@
-%thead
-  %tr
-    %th{colspan: 4}= link_to("Select None", "JavaScript:void(0);", class: "select_all")
-    %th
-      .pull-right= submit_tag t("facility_journals.show.submit"), class: ["btn", "btn-primary"]
+.row.table-actions.form-horizontal
+  .span2.select_all_none= link_to("Select None", "", class: "select_all")
+
+  - if local_assigns[:date]
+    .span5.control-group.fields
+      %label.control-label{ for: :reconciled_at }= OrderDetail.human_attribute_name(:reconciled_at)
+      .controls
+        = text_field_tag :reconciled_at, format_usa_date(Time.current), class: :datepicker__data, data: { min_date: @unreconciled_details.map(&:statement_date).min.to_s, max_date: Time.current.iso8601 }
+
+  .span1.pull-right= submit_tag t("facility_journals.show.submit"), class: ["btn", "btn-primary"]

--- a/app/views/facility_accounts_reconciliation/_table.html.haml
+++ b/app/views/facility_accounts_reconciliation/_table.html.haml
@@ -21,4 +21,4 @@
               .order-detail-extra.order-detail-note= order_detail.note
 
         %td= show_actual_total(order_detail)
-        %td= text_field_tag "order_detail[#{order_detail.id}][reconciled_note]", begin params[:order_detail][order_detail.id.to_s][:reconciled_note] rescue "" end
+        %td= text_field_tag "order_detail[#{order_detail.id}][reconciled_note]"

--- a/app/views/facility_accounts_reconciliation/_table.html.haml
+++ b/app/views/facility_accounts_reconciliation/_table.html.haml
@@ -1,5 +1,4 @@
 %table.table.table-striped.table-hover
-  = render partial: "action_row"
   %thead
     %tr
       %th
@@ -23,4 +22,3 @@
 
         %td= show_actual_total(order_detail)
         %td= text_field_tag "order_detail[#{order_detail.id}][reconciled_note]", begin params[:order_detail][order_detail.id.to_s][:reconciled_note] rescue "" end
-  = render partial: "action_row"

--- a/app/views/facility_accounts_reconciliation/_table.html.haml
+++ b/app/views/facility_accounts_reconciliation/_table.html.haml
@@ -22,5 +22,5 @@
               .order-detail-extra.order-detail-note= order_detail.note
 
         %td= show_actual_total(order_detail)
-        %td= text_field_tag "order_detail[#{order_detail.id}][notes]", begin params[:order_detail][order_detail.id.to_s][:notes] rescue "" end
+        %td= text_field_tag "order_detail[#{order_detail.id}][reconciled_note]", begin params[:order_detail][order_detail.id.to_s][:reconciled_note] rescue "" end
   = render partial: "action_row"

--- a/app/views/facility_accounts_reconciliation/index.html.haml
+++ b/app/views/facility_accounts_reconciliation/index.html.haml
@@ -22,7 +22,7 @@
   %p= t(".instructions")
 
   = form_tag([:update, account_route, FacilityAccount], method: :post) do
-    = render "action_row", date: true
+    = render "action_row", date: true, unreconciled_order_details: @unreconciled_details
     = hidden_field_tag :selected_account, @selected_account.id
     = render partial: "table"
     = render partial: "action_row"

--- a/app/views/facility_accounts_reconciliation/index.html.haml
+++ b/app/views/facility_accounts_reconciliation/index.html.haml
@@ -1,4 +1,4 @@
-= javascript_include_tag "account_mgmt"
+= javascript_include_tag "reconciliation"
 
 = content_for :h1 do
   = current_facility
@@ -22,7 +22,9 @@
   %p= t(".instructions")
 
   = form_tag([:update, account_route, FacilityAccount], method: :post) do
+    = render "action_row", date: true
     = hidden_field_tag :selected_account, @selected_account.id
     = render partial: "table"
+    = render partial: "action_row"
 
   %p= will_paginate(@unreconciled_details)

--- a/app/views/facility_journals/show.html.haml
+++ b/app/views/facility_journals/show.html.haml
@@ -37,12 +37,10 @@
 - else
   = form_tag facility_journal_reconcile_path(current_facility, @journal), method: :post do
     - journal_is_submittable = @journal.submittable?
+    - if journal_is_submittable
+      = render "facility_accounts_reconciliation/action_row", date: true, unreconciled_order_details: @order_details, starting: :all
     %table.table.table-striped.table-hover
       %thead
-        - if journal_is_submittable
-          %tr.borderless
-            %th{colspan: 3}= link_to "Select All", "JavaScript:void(0);", class: "select_all"
-            %th.currency{colspan: 3}= submit_tag t(".submit"), class: "btn btn-primary"
         %tr
           - if journal_is_submittable
             %th
@@ -56,7 +54,7 @@
           - disable = order_detail.reconciled? || @journal.open?
           %tr
             - if journal_is_submittable
-              %td= check_box_tag "order_detail_ids[]", order_detail.id, (order_detail.reconciled? ? true : false), disabled: (order_detail.reconciled? ? true : false), class: (order_detail.reconciled? ? "" : "toggle")
+              %td= check_box_tag "order_detail[#{order_detail.id}][reconciled]", "1", order_detail.reconciled?, disabled: order_detail.reconciled?, class: (order_detail.reconciled? ? "" : "toggle")
             %td
               = link_to order_detail, facility_order_path(order_detail.order.facility.url_name, order_detail.order_id)
               - if order_detail.note?
@@ -66,7 +64,5 @@
             %td= order_detail.account
             %td= number_to_currency(order_detail.total)
             %td= order_detail.reconciled? ? t("boolean.true") : t("boolean.false")
-        - if journal_is_submittable
-          %tr.borderless
-            %td{colspan: 3}
-            %td.currency{colspan: 3}= submit_tag t(".submit"), class: "btn btn-primary"
+    - if journal_is_submittable
+      = render "facility_accounts_reconciliation/action_row", starting: :all

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -7,11 +7,13 @@ en:
 
   activemodel:
     errors:
-      messages:
-        must_be_in_past: "must be in the past"
       models:
         order_details/reconciler:
-          after_all_journal_dates: "must be after all journal or statement dates"
+          must_be_in_past: "Reconciliation Date cannot be in the future"
+          after_all_journal_dates: "Reconciliation Date must be after all journal or statement dates"
+          attributes:
+            order_details:
+              blank: No orders were selected to reconcile
 
   activerecord:
     errors:

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -5,6 +5,14 @@ en:
     order:
       auto_assign_account: "Could not find a valid payment source for purchasing %{product_name}"
 
+  activemodel:
+    errors:
+      messages:
+        must_be_in_past: "must be in the past"
+      models:
+        order_details/reconciler:
+          after_all_journal_dates: "must be after all journal or statement dates"
+
   activerecord:
     errors:
       # The values :model, :attribute and :value are always available for interpolation
@@ -244,6 +252,7 @@ en:
         product: Product
         quantity: Quantity
         reconciled_note: Reconciliation Note
+        reconciled_at: Reconciliation Date
         reviewed_at: Review Closes
         reviewed_at_past: Review Closed
         status: Status

--- a/db/migrate/20160426231556_add_reconciliation_date_to_order_detail.rb
+++ b/db/migrate/20160426231556_add_reconciliation_date_to_order_detail.rb
@@ -8,7 +8,8 @@ class AddReconciliationDateToOrderDetail < ActiveRecord::Migration
       elsif od.journal
         od.update_attribute(:reconciled_at, od.journal.journal_date)
       else
-        puts "No statement or journal! #{od.id}"
+        # TODO: What do we do with these
+        od.update_attribute(:reconciled_at, od.reviewed_at)
       end
     end
   end

--- a/db/migrate/20160426231556_add_reconciliation_date_to_order_detail.rb
+++ b/db/migrate/20160426231556_add_reconciliation_date_to_order_detail.rb
@@ -1,0 +1,19 @@
+class AddReconciliationDateToOrderDetail < ActiveRecord::Migration
+  def up
+    add_column :order_details, :reconciled_at, :datetime
+
+    OrderDetail.where(state: "reconciled").find_each do |od|
+      if od.statement
+        od.update_attribute(:reconciled_at, od.statement.created_at)
+      elsif od.journal
+        od.update_attribute(:reconciled_at, od.journal.journal_date)
+      else
+        puts "No statement or journal! #{od.id}"
+      end
+    end
+  end
+
+  def down
+    remove_column :order_details, :reconciled_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160415231343) do
+ActiveRecord::Schema.define(:version => 20160426231556) do
 
   create_table "account_users", :force => true do |t|
     t.integer  "account_id",               :null => false
@@ -249,6 +249,7 @@ ActiveRecord::Schema.define(:version => 20160415231343) do
     t.integer  "created_by",                                                                               :null => false
     t.integer  "product_accessory_id"
     t.boolean  "problem",                                                               :default => false, :null => false
+    t.datetime "reconciled_at"
   end
 
   add_index "order_details", ["account_id"], :name => "fk_od_accounts"

--- a/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
+++ b/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
@@ -103,8 +103,7 @@ RSpec.describe FacilityAccountsReconciliationController do
         let(:reconciled_at) { 1.day.from_now }
 
         it "does not reconcile the order" do
-          expect { perform }.not_to change { order_detail.reload.state }
-          expect(order_detail.state).to eq("complete")
+          expect { perform }.not_to change { order_detail.reload.state }.from("complete")
         end
 
         it "has a flash message" do
@@ -117,8 +116,7 @@ RSpec.describe FacilityAccountsReconciliationController do
         let(:reconciled_at) { 10.days.ago }
 
         it "does not reconcile the order" do
-          expect { perform }.not_to change { order_detail.reload.state }
-          expect(order_detail.state).to eq("complete")
+          expect { perform }.not_to change { order_detail.reload.state }.from("complete")
         end
 
         it "has a flash message" do

--- a/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
+++ b/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe FacilityAccountsReconciliationController do
 
         it "has a flash message" do
           perform
-          expect(flash[:error]).to include("must be in the past")
+          expect(flash[:error]).to include("cannot be in the future")
         end
       end
 

--- a/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
+++ b/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe FacilityAccountsReconciliationController do
 
   class ReconciliationTestAccount < Account
+
     include ReconcilableAccount
+
   end
 
   FactoryGirl.define do
@@ -24,10 +26,12 @@ RSpec.describe FacilityAccountsReconciliationController do
   let(:facility) { FactoryGirl.create(:setup_facility) }
   let(:account) { FactoryGirl.create(:reconciliation_test_account, :with_account_owner) }
   let(:product) { FactoryGirl.create(:setup_item, facility: facility) }
-  let(:order) { FactoryGirl.create(:purchased_order, product: product, account: account ) }
+  let(:order) { FactoryGirl.create(:purchased_order, product: product, account: account) }
   let(:order_detail) { order.order_details.first }
-  let(:statement) { FactoryGirl.create(:statement, account: account, facility: facility,
-    created_by_user: admin, created_at: 5.days.ago) }
+  let(:statement) do
+    FactoryGirl.create(:statement, account: account, facility: facility,
+                                   created_by_user: admin, created_at: 5.days.ago)
+  end
   let(:admin) { FactoryGirl.create(:user, :administrator) }
 
   before do
@@ -61,13 +65,13 @@ RSpec.describe FacilityAccountsReconciliationController do
 
     def perform
       post :update, facility_id: facility.url_name, account_type: "ReconciliationTestAccount",
-          reconciled_at: format_usa_date(reconciled_at),
-          order_detail: {
-            order_detail.id.to_s => {
-              reconciled: "1",
-              reconciled_note: "A note"
-            }
-          }
+                    reconciled_at: format_usa_date(reconciled_at),
+                    order_detail: {
+                      order_detail.id.to_s => {
+                        reconciled: "1",
+                        reconciled_note: "A note",
+                      },
+                    }
     end
 
     describe "reconciliation date", :timecop_freeze do

--- a/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
+++ b/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
@@ -1,0 +1,136 @@
+require "rails_helper"
+
+RSpec.describe FacilityAccountsReconciliationController do
+
+  class ReconciliationTestAccount < Account
+    include ReconcilableAccount
+  end
+
+  FactoryGirl.define do
+    factory :reconciliation_test_account, class: ReconciliationTestAccount, parent: :nufs_account do
+    end
+  end
+
+  before(:all) do
+    Account.config.statement_account_types << "ReconciliationTestAccount"
+    Nucore::Application.reload_routes!
+  end
+
+  after(:all) do
+    Account.config.statement_account_types.delete("ReconciliationTestAccount")
+    Nucore::Application.reload_routes!
+  end
+
+  let(:facility) { FactoryGirl.create(:setup_facility) }
+  let(:account) { FactoryGirl.create(:reconciliation_test_account, :with_account_owner) }
+  let(:product) { FactoryGirl.create(:setup_item, facility: facility) }
+  let(:order) { FactoryGirl.create(:purchased_order, product: product, account: account ) }
+  let(:order_detail) { order.order_details.first }
+  let(:statement) { FactoryGirl.create(:statement, account: account, facility: facility,
+    created_by_user: admin, created_at: 5.days.ago) }
+  let(:admin) { FactoryGirl.create(:user, :administrator) }
+
+  before do
+    order_detail.change_status!(OrderStatus.complete_status)
+    order_detail.update_attributes(reviewed_at: 5.minutes.ago, statement: statement)
+  end
+
+  describe "index" do
+    def perform
+      get :index, facility_id: facility.url_name, account_type: "ReconciliationTestAccount"
+    end
+
+    before { sign_in admin }
+
+    it "assigns the default account" do
+      perform
+      expect(response).to be_success
+      expect(assigns(:selected_account)).to eq(account)
+    end
+
+    it "has the order" do
+      perform
+      expect(assigns(:unreconciled_details)).to eq([order_detail])
+    end
+  end
+
+  describe "update" do
+    include DateHelper
+
+    before { sign_in admin }
+
+    def perform
+      post :update, facility_id: facility.url_name, account_type: "ReconciliationTestAccount",
+          reconciled_at: format_usa_date(reconciled_at),
+          order_detail: {
+            order_detail.id.to_s => {
+              reconciled: "1",
+              reconciled_note: "A note"
+            }
+          }
+    end
+
+    describe "reconciliation date", :timecop_freeze do
+      describe "a nil reconciliation date" do
+        let(:reconciled_at) { nil }
+
+        it "updates the reconciled_at" do
+          expect { perform }.to change { order_detail.reload.reconciled_at }.to(Time.current.change(usec: 0))
+        end
+      end
+
+      describe "with a reconciliation date of today" do
+        let(:reconciled_at) { Time.current }
+
+        it "updates the reconciled_at" do
+          expect { perform }.to change { order_detail.reload.reconciled_at }.to(Time.current.beginning_of_day)
+        end
+      end
+
+      describe "with a reconciliation date of yesterday" do
+        let(:reconciled_at) { 1.day.ago }
+
+        it "updates the reconciled_at" do
+          expect { perform }.to change { order_detail.reload.reconciled_at }.to(1.day.ago.beginning_of_day)
+        end
+      end
+
+      describe "with a reconciliation date after today" do
+        let(:reconciled_at) { 1.day.from_now }
+
+        it "does not reconcile the order" do
+          expect { perform }.not_to change { order_detail.reload.state }
+          expect(order_detail.state).to eq("complete")
+        end
+
+        it "has a flash message" do
+          perform
+          expect(flash[:error]).to include("must be in the past")
+        end
+      end
+
+      describe "with a reconciliation date before the statement" do
+        let(:reconciled_at) { 10.days.ago }
+
+        it "does not reconcile the order" do
+          expect { perform }.not_to change { order_detail.reload.state }
+          expect(order_detail.state).to eq("complete")
+        end
+
+        it "has a flash message" do
+          perform
+          expect(flash[:error]).to include("must be after all journal or statement dates")
+        end
+      end
+
+      describe "with the reconciliation date on the same day as the statement" do
+        let(:reconciled_at) { 5.days.ago - 1.hour }
+
+        it "updates the reconciled_at" do
+          expect { perform }.to change { order_detail.reload.reconciled_at }.to(reconciled_at.beginning_of_day)
+        end
+      end
+    end
+  end
+
+end

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -493,6 +493,24 @@ RSpec.describe FacilityJournalsController do
       end
     end
 
+    describe "when submitting an order detail on another journal" do
+      let(:journal2) { create(:journal, facility: facility, created_by: @admin.id, journal_date: 2.days.ago) }
+      before { journal2.create_journal_rows!([@order_detail2]) }
+
+      let(:order_detail_params) do
+        {
+          @order_detail1.id.to_s => { reconciled: "1" },
+          @order_detail2.id.to_s => { reconciled: "1" }
+        }
+      end
+
+      it "does not reconcile either" do
+        perform
+        expect(@order_detail1.reload.state).to eq("complete")
+        expect(@order_detail2.reload.state).to eq("complete")
+      end
+    end
+
     describe "when submitting nothing checked" do
       let(:order_detail_params) do
         {

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe FacilityJournalsController do
   let(:admin_user) { @admin }
   let(:facility) { @authable }
   let(:user) { @user }
+  let(:journal) { @journal }
 
   include DateHelper
 
@@ -33,7 +34,7 @@ RSpec.describe FacilityJournalsController do
   before(:each) do
     @authable = create(:facility)
     @account = create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: @admin), facility_id: facility.id)
-    @journal = create(:journal, facility: facility, created_by: @admin.id, journal_date: Time.zone.now)
+    @journal = create(:journal, facility: facility, created_by: @admin.id, journal_date: 2.days.ago)
   end
 
   describe "#index" do
@@ -122,6 +123,11 @@ RSpec.describe FacilityJournalsController do
           reconciled_status = OrderStatus.reconciled.first
           expect(@order_detail1.reload.order_status).to eq(reconciled_status)
           expect(@order_detail3.reload.order_status).to eq(reconciled_status)
+        end
+
+        it "sets the reconciled_at for all order details", :timecop_freeze do
+          expect(@order_detail1.reload.reconciled_at).to eq(Time.current.change(usec: 0))
+          expect(@order_detail3.reload.reconciled_at).to eq(Time.current.change(usec: 0))
         end
       end
 
@@ -451,6 +457,54 @@ RSpec.describe FacilityJournalsController do
         @user = @admin
       end
       it_should_support_searching
+    end
+  end
+
+  describe "#reconcile" do
+    def perform
+      post :reconcile, facility_id: facility.url_name, order_detail: order_detail_params, journal_id: journal.id, reconciled_at: format_usa_date(1.day.ago)
+    end
+
+    before do
+      sign_in admin_user
+      ignore_account_validations
+      create_order_details
+      @journal.create_journal_rows!([@order_detail1, @order_detail3])
+    end
+
+    describe "submitting a single order detail" do
+      let(:order_detail_params) do
+        {
+          @order_detail1.id.to_s => { reconciled: "1" },
+          @order_detail3.id.to_s => { reconciled: "0" }
+        }
+      end
+
+      it "sets it to reconciled" do
+        expect { perform }.to change { @order_detail1.reload.state }.to eq("reconciled")
+      end
+
+      it "does not reconcile the one not selected" do
+        expect { perform }.not_to change { @order_detail3.reload.state }
+      end
+
+      it "sets the reconciled_at" do
+        expect { perform }.to change { @order_detail1.reload.reconciled_at }
+      end
+    end
+
+    describe "when submitting nothing checked" do
+      let(:order_detail_params) do
+        {
+          @order_detail1.id.to_s => { reconciled: "0" },
+          @order_detail3.id.to_s => { reconciled: "0" }
+        }
+      end
+
+      it "sets a flash message" do
+        perform
+        expect(flash[:error]).to include("No orders")
+      end
     end
   end
 

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -476,7 +476,7 @@ RSpec.describe FacilityJournalsController do
       let(:order_detail_params) do
         {
           @order_detail1.id.to_s => { reconciled: "1" },
-          @order_detail3.id.to_s => { reconciled: "0" }
+          @order_detail3.id.to_s => { reconciled: "0" },
         }
       end
 
@@ -500,7 +500,7 @@ RSpec.describe FacilityJournalsController do
       let(:order_detail_params) do
         {
           @order_detail1.id.to_s => { reconciled: "1" },
-          @order_detail2.id.to_s => { reconciled: "1" }
+          @order_detail2.id.to_s => { reconciled: "1" },
         }
       end
 
@@ -515,7 +515,7 @@ RSpec.describe FacilityJournalsController do
       let(:order_detail_params) do
         {
           @order_detail1.id.to_s => { reconciled: "0" },
-          @order_detail3.id.to_s => { reconciled: "0" }
+          @order_detail3.id.to_s => { reconciled: "0" },
         }
       end
 

--- a/vendor/engines/c2po/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
+++ b/vendor/engines/c2po/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
@@ -127,12 +127,24 @@ RSpec.describe FacilityAccountsReconciliationController do
     it_should_deny_all [:staff, :senior_staff]
 
     it_should_allow_all facility_managers do
-      expect(assigns(:error_fields)).to be_empty
+      expect(flash.now[:error]).to be_blank
       is_expected.to set_flash
       assert_redirected_to credit_cards_facility_accounts_path
       @order_detail.reload
       expect(@order_detail.state).to eq("reconciled")
       expect(@order_detail.reconciled_note).not_to be_nil
+    end
+
+    describe "errors" do
+      describe "an exception" do
+        before do
+          allow_any_instance_of(OrderDetail).to receive(:change_status!).and_raise("Some error")
+        end
+
+        it_should_allow :admin do
+          expect(flash.now[:error]).to include("Some error")
+        end
+      end
     end
   end
 
@@ -147,7 +159,7 @@ RSpec.describe FacilityAccountsReconciliationController do
     it_should_deny_all [:staff, :senior_staff]
 
     it_should_allow_all facility_managers do |_user|
-      expect(assigns(:error_fields)).to be_empty
+      expect(flash.now[:error]).to be_blank
       is_expected.to set_flash
       assert_redirected_to purchase_orders_facility_accounts_path
       @order_detail.reload
@@ -183,7 +195,7 @@ RSpec.describe FacilityAccountsReconciliationController do
       order_detail: {
         @order_detail.id.to_s => {
           reconciled: "1",
-          notes: "this transaction is fake",
+          reconciled_note: "this transaction is fake",
         },
       },
     }


### PR DESCRIPTION
This handles both reconciling CC/PO and "succeeded, with errors" journals. It also sets the reconciled_at to the current time for "succeeded, no errors".

There is still an open question around what we want to do with the historical manually-reconciled details (those that are not part of a statement or PR). Currently I have them being set to `reviewed_at`, but that may change.