### PR TITLE
Allow HTML in Project descriptions to display as HTML

### DIFF
--- a/config/initializers/sanitized_allowed.rb
+++ b/config/initializers/sanitized_allowed.rb
@@ -1,0 +1,1 @@
+ActionView::Base.sanitized_allowed_attributes << "style"

--- a/vendor/engines/projects/app/views/projects/projects/show.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/show.html.haml
@@ -2,4 +2,4 @@
   = @project.facility
 
 %h2= @project.name
-%p= @project.description
+%p= @project.description.html_safe

--- a/vendor/engines/projects/app/views/projects/projects/show.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/show.html.haml
@@ -2,4 +2,4 @@
   = @project.facility
 
 %h2= @project.name
-%p= @project.description.html_safe
+= sanitize @project.description


### PR DESCRIPTION
This is a loose end from #569: we're allowing HTML in `Project#description` but the "show" view was escaping it. This marks the string as "safe", though it does mean trusting that a privileged user (facility operator) wouldn't do anything malicious.