### PR TITLE
[#116373897] Add edit and update actions for Projects

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,6 +164,7 @@ en:
     timeline:
       facility_tooltip:
         admin_reservation: Administrative Reservation
+    update: Update
 
   global_search:
     search: "Search"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,7 +164,6 @@ en:
     timeline:
       facility_tooltip:
         admin_reservation: Administrative Reservation
-    update: Update
 
   global_search:
     search: "Search"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160426231556) do
+ActiveRecord::Schema.define(:version => 20160503170055) do
 
   create_table "account_users", :force => true do |t|
     t.integer  "account_id",               :null => false
@@ -460,11 +460,12 @@ ActiveRecord::Schema.define(:version => 20160426231556) do
   add_index "products", ["url_name"], :name => "index_products_on_url_name"
 
   create_table "projects", :force => true do |t|
-    t.string   "name",        :null => false
+    t.string   "name",                          :null => false
     t.text     "description"
-    t.integer  "facility_id", :null => false
-    t.datetime "created_at",  :null => false
-    t.datetime "updated_at",  :null => false
+    t.integer  "facility_id",                   :null => false
+    t.datetime "created_at",                    :null => false
+    t.datetime "updated_at",                    :null => false
+    t.boolean  "active",      :default => true, :null => false
   end
 
   add_index "projects", ["facility_id", "name"], :name => "index_projects_on_facility_id_and_name", :unique => true

--- a/vendor/engines/projects/app/controllers/projects/projects_controller.rb
+++ b/vendor/engines/projects/app/controllers/projects/projects_controller.rb
@@ -16,13 +16,7 @@ module Projects
 
     def create
       @project = current_facility.projects.new(project_params)
-      if @project.save
-        flash[:notice] =
-          I18n.t("controllers.projects.projects.create.success", project_name: @project.name)
-        redirect_to facility_projects_path(current_facility)
-      else
-        render action: :new
-      end
+      render action: :new unless save_project
     end
 
     def edit
@@ -33,19 +27,21 @@ module Projects
 
     def update
       @project.attributes = project_params
-      if @project.save
-        flash[:notice] =
-          I18n.t("controllers.projects.projects.update.success", project_name: @project.name)
-        redirect_to facility_projects_path(@project.facility)
-      else
-        render action: :edit
-      end
+      render action: :edit unless save_project
     end
 
     private
 
     def project_params
       params.require(:projects_project).permit("description", "name")
+    end
+
+    def save_project
+      if @project.save
+        flash[:notice] =
+          I18n.t("controllers.projects.projects.#{action_name}.success", project_name: @project.name)
+        redirect_to facility_projects_path(@project.facility)
+      end
     end
 
   end

--- a/vendor/engines/projects/app/controllers/projects/projects_controller.rb
+++ b/vendor/engines/projects/app/controllers/projects/projects_controller.rb
@@ -33,7 +33,7 @@ module Projects
     private
 
     def project_params
-      params.require(:projects_project).permit("description", "name")
+      params.require(:projects_project).permit("active", "description", "name")
     end
 
     def save_project

--- a/vendor/engines/projects/app/controllers/projects/projects_controller.rb
+++ b/vendor/engines/projects/app/controllers/projects/projects_controller.rb
@@ -25,7 +25,21 @@ module Projects
       end
     end
 
+    def edit
+    end
+
     def show
+    end
+
+    def update
+      @project.attributes = project_params
+      if @project.save
+        flash[:notice] =
+          I18n.t("controllers.projects.projects.update.success", project_name: @project.name)
+        redirect_to facility_projects_path(@project.facility)
+      else
+        render action: :edit
+      end
     end
 
     private

--- a/vendor/engines/projects/app/models/projects/ability_extension.rb
+++ b/vendor/engines/projects/app/models/projects/ability_extension.rb
@@ -10,7 +10,7 @@ module Projects
 
     def extend(user, resource)
       if user.operator_of?(resource)
-        ability.can([:create, :index, :new, :show], Projects::Project)
+        ability.can([:create, :edit, :index, :new, :show, :update], Projects::Project)
       end
     end
 

--- a/vendor/engines/projects/app/views/projects/projects/edit.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/edit.html.haml
@@ -3,10 +3,12 @@
 = content_for :h1 do
   = @project.facility
 
+%h2= t(".update")
+
 = simple_form_for @project, url: facility_project_path(@project.facility, @project), method: :put do |f|
   .form-inputs
     = f.input :name, hint: t(".name")
     = f.input :description, hint: t(".description"), input_html: { class: :editor }
   .form-actions
-    = f.button :submit, t("shared.update"), class: "btn-primary"
+    = f.button :submit, t(".update"), class: "btn-primary"
     = link_to t("shared.cancel"), facility_projects_path(current_facility)

--- a/vendor/engines/projects/app/views/projects/projects/edit.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/edit.html.haml
@@ -7,6 +7,7 @@
 
 = simple_form_for @project, url: facility_project_path(@project.facility, @project), method: :put do |f|
   .form-inputs
+    = f.input :active
     = f.input :name, hint: t(".name")
     = f.input :description, hint: t(".description"), input_html: { class: :editor }
   .form-actions

--- a/vendor/engines/projects/app/views/projects/projects/edit.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/edit.html.haml
@@ -1,0 +1,12 @@
+= render "shared/headers/ckeditor"
+
+= content_for :h1 do
+  = @project.facility
+
+= simple_form_for @project, url: facility_project_path(@project.facility, @project), method: :put do |f|
+  .form-inputs
+    = f.input :name, hint: t(".name")
+    = f.input :description, hint: t(".description"), input_html: { class: :editor }
+  .form-actions
+    = f.button :submit, t("shared.update"), class: "btn-primary"
+    = link_to t("shared.cancel"), facility_projects_path(current_facility)

--- a/vendor/engines/projects/app/views/projects/projects/new.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/new.html.haml
@@ -1,12 +1,14 @@
 = render "shared/headers/ckeditor"
 
 = content_for :h1 do
-  = t(".head")
+  = @project.facility
 
-= simple_form_for @project, url: facility_projects_path(current_facility), method: :post do |f|
+%h2= t(".create")
+
+= simple_form_for @project, url: facility_projects_path(@project.facility), method: :post do |f|
   .form-inputs
     = f.input :name, hint: t(".name")
     = f.input :description, hint: t(".description"), input_html: { class: :editor }
   .form-actions
-    = f.button :submit, t(".add")
-    = link_to t(".cancel"), facility_projects_path(current_facility)
+    = f.button :submit, t(".add"), class: "btn-primary"
+    = link_to t("shared.cancel"), facility_projects_path(@project.facility)

--- a/vendor/engines/projects/app/views/projects/projects/show.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/show.html.haml
@@ -3,3 +3,7 @@
 
 %h2= @project.name
 %p= @project.description
+
+= link_to t(".edit"),
+  edit_facility_project_path(@project.facility, @project),
+  class: "btn btn-primary"

--- a/vendor/engines/projects/config/locales/en.yml
+++ b/vendor/engines/projects/config/locales/en.yml
@@ -29,3 +29,5 @@ en:
         description: Description as it will appear on the project's page
         head: Add Project
         name: Name of the label as displayed to the end user
+      show:
+        edit: Edit Project

--- a/vendor/engines/projects/config/locales/en.yml
+++ b/vendor/engines/projects/config/locales/en.yml
@@ -15,11 +15,16 @@ en:
 
   projects:
     projects:
+      edit:
+        description: Description as it will appear on the project's page
+        name: Name of the label as displayed to the end user
+        update: Update Project
       index:
         add: Add Project
         head: Manage Projects
       new:
         add: Add Project
+        create: Create a Project
         cancel: Cancel
         description: Description as it will appear on the project's page
         head: Add Project

--- a/vendor/engines/projects/config/locales/en.yml
+++ b/vendor/engines/projects/config/locales/en.yml
@@ -10,6 +10,9 @@ en:
       projects:
         create:
           success: "New project %{project_name} was created."
+        update:
+          success: "Project %{project_name} was updated."
+
   projects:
     projects:
       index:

--- a/vendor/engines/projects/config/routes.rb
+++ b/vendor/engines/projects/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   resources :facilities, only: [] do
-    resources :projects, controller: "projects/projects", only: %i(create index new show)
+    resources :projects,
+              controller: "projects/projects",
+              only: %i(create edit index new show update)
   end
 end

--- a/vendor/engines/projects/config/routes.rb
+++ b/vendor/engines/projects/config/routes.rb
@@ -1,7 +1,5 @@
 Rails.application.routes.draw do
   resources :facilities, only: [] do
-    resources :projects,
-              controller: "projects/projects",
-              only: %i(create edit index new show update)
+    resources :projects, controller: "projects/projects", except: [:destroy]
   end
 end

--- a/vendor/engines/projects/db/migrate/20160503170055_add_active_flag_to_projects.rb
+++ b/vendor/engines/projects/db/migrate/20160503170055_add_active_flag_to_projects.rb
@@ -1,0 +1,7 @@
+class AddActiveFlagToProjects < ActiveRecord::Migration
+
+  def change
+    add_column :projects, :active, :boolean, null: false, default: true
+  end
+
+end

--- a/vendor/engines/projects/spec/controllers/projects/projects_controller_spec.rb
+++ b/vendor/engines/projects/spec/controllers/projects/projects_controller_spec.rb
@@ -187,6 +187,7 @@ RSpec.describe Projects::ProjectsController, type: :controller do
           is_expected.to redirect_to facility_projects_path(facility)
           expect(created_project.name).to eq(name)
           expect(created_project.description).to eq(description)
+          expect(created_project).to be_active
         end
       end
 
@@ -199,6 +200,7 @@ RSpec.describe Projects::ProjectsController, type: :controller do
   end
 
   describe "PUT #update" do
+    let(:active?) { true }
     let(:project) { FactoryGirl.create(:project, name: "Old name", facility: facility) }
     let(:new_description) { "New project description" }
     let(:new_name) { "New project name" }
@@ -208,6 +210,7 @@ RSpec.describe Projects::ProjectsController, type: :controller do
           facility_id: facility.url_name,
           id: project.id,
           projects_project: {
+            active: active?,
             description: new_description,
             name: new_name,
           }
@@ -233,9 +236,16 @@ RSpec.describe Projects::ProjectsController, type: :controller do
           it "updates the project" do
             expect(project.name).to eq(new_name)
             expect(project.description).to eq(new_description)
+            expect(project).to be_active
             is_expected.to redirect_to facility_projects_path(facility)
             expect(flash[:notice]).to include("was updated")
           end
+        end
+
+        context "when unsetting the active flag" do
+          let(:active?) { false }
+
+          it { expect(project).not_to be_active }
         end
 
         context "when the project name is blank" do

--- a/vendor/engines/projects/spec/controllers/projects/projects_controller_spec.rb
+++ b/vendor/engines/projects/spec/controllers/projects/projects_controller_spec.rb
@@ -51,6 +51,42 @@ RSpec.describe Projects::ProjectsController, type: :controller do
     end
   end
 
+  describe "GET #edit" do
+    let(:project) { FactoryGirl.create(:project, facility: facility) }
+
+    def do_request
+      get :edit, facility_id: facility.url_name, id: project.id
+    end
+
+    describe "when not logged in" do
+      before { do_request }
+
+      it { is_expected.to redirect_to new_user_session_path }
+    end
+
+    describe "when logged in" do
+      shared_examples_for "it allows edit views" do |role|
+        let(:user) { FactoryGirl.create(:user, role, facility: facility) }
+
+        before(:each) do
+          sign_in user
+          do_request
+        end
+
+        it "shows the edit view" do
+          expect(response.code).to eq("200")
+          expect(assigns(:project)).to eq(project)
+        end
+      end
+
+      facility_operator_roles.each do |role|
+        context "as #{role}" do
+          it_behaves_like "it allows edit views", role
+        end
+      end
+    end
+  end
+
   describe "GET #new" do
     def do_request
       get :new, facility_id: facility.url_name
@@ -157,6 +193,65 @@ RSpec.describe Projects::ProjectsController, type: :controller do
       facility_operator_roles.each do |role|
         context "as #{role}" do
           it_behaves_like "it allows project creation", role
+        end
+      end
+    end
+  end
+
+  describe "PUT #update" do
+    let(:project) { FactoryGirl.create(:project, name: "Old name", facility: facility) }
+    let(:new_description) { "New project description" }
+    let(:new_name) { "New project name" }
+
+    def do_request
+      put :update,
+          facility_id: facility.url_name,
+          id: project.id,
+          projects_project: {
+            description: new_description,
+            name: new_name,
+          }
+    end
+
+    describe "when not logged in" do
+      before { do_request }
+
+      it { is_expected.to redirect_to new_user_session_path }
+    end
+
+    describe "when logged in" do
+      shared_examples_for "it allows update" do |role|
+        let(:user) { FactoryGirl.create(:user, role, facility: facility) }
+
+        before(:each) do
+          sign_in user
+          do_request
+          project.reload
+        end
+
+        context "when providing a project name" do
+          it "updates the project" do
+            expect(project.name).to eq(new_name)
+            expect(project.description).to eq(new_description)
+            is_expected.to redirect_to facility_projects_path(facility)
+            expect(flash[:notice]).to include("was updated")
+          end
+        end
+
+        context "when the project name is blank" do
+          let(:new_name) { "" }
+
+          it "does not update the project" do
+            expect(project.reload.name).to eq("Old name")
+            expect(assigns[:project].errors[:name]).to include("may not be blank")
+            is_expected.to render_template(:edit)
+          end
+        end
+      end
+
+      facility_operator_roles.each do |role|
+        context "as #{role}" do
+          it_behaves_like "it allows update", role
         end
       end
     end

--- a/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
+++ b/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
@@ -2,25 +2,24 @@ require "rails_helper"
 
 RSpec.describe Projects::AbilityExtension do
   subject(:ability) { Ability.new(user, facility, stub_controller) }
+  let(:common_actions) { %i(create edit index new show update) }
   let(:facility) { project.facility }
   let(:project) { FactoryGirl.build(:project) }
   let(:stub_controller) { OpenStruct.new }
 
   shared_examples_for "it has full access" do
     it "has full access" do
-      is_expected.to be_allowed_to(:create, Projects::Project)
-      is_expected.to be_allowed_to(:index, Projects::Project)
-      is_expected.to be_allowed_to(:new, Projects::Project)
-      is_expected.to be_allowed_to(:show, Projects::Project)
+      common_actions.each do |action|
+        is_expected.to be_allowed_to(action, Projects::Project)
+      end
     end
   end
 
   shared_examples_for "it has no access" do
     it "has no access" do
-      is_expected.not_to be_allowed_to(:create, Projects::Project)
-      is_expected.not_to be_allowed_to(:index, Projects::Project)
-      is_expected.not_to be_allowed_to(:new, Projects::Project)
-      is_expected.not_to be_allowed_to(:show, Projects::Project)
+      common_actions.each do |action|
+        is_expected.not_to be_allowed_to(action, Projects::Project)
+      end
     end
   end
 


### PR DESCRIPTION
This adds a basic interface for editing projects by adding an edit button to the project show view.

It also includes a few `active` flag to the `Project` model. A checkbox appears on the edit form to toggle `active` but the flag has no impact on anything else yet.