### PR TITLE
Only reset locales in specs where necessary

### DIFF
--- a/spec/lib/nav_tab/link_spec.rb
+++ b/spec/lib/nav_tab/link_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe NavTab::Link do
   describe "#tab_id" do
     subject { link.tab_id }
 
-    context "when the tab is defined" do
+    context "when the tab is defined", :locales do
       before { set_translation("pages.a_named_tab", "A Tab") }
       let(:tab) { "a_named_tab" }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -88,7 +88,7 @@ RSpec.configure do |config|
     TextHelpers::RSpec.setup_spec_translations
   end
 
-  config.after(:each) do
+  config.after(:each, :locales) do
     TextHelpers::RSpec.reset_spec_translations
   end
 


### PR DESCRIPTION
Doing the `TextHelpers::RSpec.reset_spec_translations` on every single spec significantly increased the testing time on CI, especially for UIC, which went from around 18 minutes to 30-40. I'm not sure why it didn't have the same level of impact on open and NU. This drops the time back down to 17-18 minutes on UIC.