### PR TITLE
[#115962679] Use `app_name` so the name is more easily overridable 

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,7 @@ class UsersController < ApplicationController
   end
 
   include Overridable
+  include TextHelpers::Translation
 
   customer_tab :password
   admin_tab     :all
@@ -79,7 +80,7 @@ class UsersController < ApplicationController
       flash[:error] = I18n.t("users.search.notice1")
       redirect_to facility_users_path
     elsif @user.persisted?
-      flash[:error] = I18n.t("users.search.user_already_exists", username: @user.username)
+      flash[:error] = text("users.search.user_already_exists", username: @user.username)
       redirect_to facility_users_path
     elsif @user.save
       save_user_success

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,0 +1,8 @@
+class DeviseMailer < Devise::Mailer
+
+  # Allow us to use interpolations like `!app_name!` in the subject
+  def subject_for(key)
+    text("devise.mailer.#{key}.subject", default: super)
+  end
+
+end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -13,16 +13,7 @@ class Notifier < ActionMailer::Base
   def new_user(args)
     @user = args[:user]
     @password = args[:password]
-    send_nucore_mail args[:user].email, t("notifier.new_user.subject")
-  end
-
-  # When a new chart string/PO/CC is added to CoreFac, an email is sent
-  # out to the PI, Departmental Administrators, and that particular
-  # account's administrator(s)
-  def new_account(args)
-    @user = args[:user]
-    @account = args[:account]
-    send_nucore_mail args[:user].email, t("notifier.new_account.subject")
+    send_nucore_mail args[:user].email, text("views.notifier.new_user.subject")
   end
 
   # Changes to the user affecting the PI or department will alert their
@@ -31,7 +22,7 @@ class Notifier < ActionMailer::Base
     @user = args[:user]
     @account = args[:account]
     @created_by = args[:created_by]
-    send_nucore_mail @account.owner.user.email, t("notifier.user_update.subject")
+    send_nucore_mail @account.owner.user.email, text("views.notifier.user_update.subject")
   end
 
   # Any changes to the financial accounts will alert the PI(s), admin(s)
@@ -40,12 +31,12 @@ class Notifier < ActionMailer::Base
   def account_update(args)
     @user = args[:user]
     @account = args[:account]
-    send_nucore_mail args[:user].email, t("notifier.account_update.subject")
+    send_nucore_mail args[:user].email, text("views.notifier.account_update.subject")
   end
 
   def order_notification(order, recipient)
     @order = order
-    send_nucore_mail recipient, t("notifier.order_notification.subject"), "order_receipt"
+    send_nucore_mail recipient, text("views.notifier.order_notification.subject"), "order_receipt"
   end
 
   # Custom order forms send out a confirmation email when filled out by a
@@ -53,15 +44,15 @@ class Notifier < ActionMailer::Base
   def order_receipt(args)
     @user = args[:user]
     @order = args[:order]
-    @greeting = t("notifier.order_receipt.intro")
-    send_nucore_mail args[:user].email, t("notifier.order_receipt.subject")
+    @greeting = text("views.notifier.order_receipt.intro")
+    send_nucore_mail args[:user].email, text("views.notifier.order_receipt.subject")
   end
 
   def review_orders(args)
     @user = User.find(args[:user_id])
     @facility = Facility.find(args[:facility_id])
     @account = Account.find(args[:account_id])
-    send_nucore_mail @user.email, t("notifier.review_orders.subject")
+    send_nucore_mail @user.email, text("views.notifier.review_orders.subject")
   end
 
   # Billing sends out the statement for the month. Appropriate users get
@@ -73,7 +64,7 @@ class Notifier < ActionMailer::Base
     @account = args[:account]
     @statement = args[:statement]
     attach_statement_pdf
-    send_nucore_mail args[:user].email, t("notifier.statement.subject")
+    send_nucore_mail args[:user].email, text("views.notifier.statement.subject")
   end
 
   def order_detail_status_change(order_detail, old_status, new_status, to)
@@ -81,7 +72,7 @@ class Notifier < ActionMailer::Base
     @old_status = old_status
     @new_status = new_status
     template = "order_status_changed_to_#{new_status.downcase_name}"
-    send_nucore_mail to, t("notifier.#{template}.subject", order_detail: order_detail, user: order_detail.order.user, product: order_detail.product), template
+    send_nucore_mail to, t("views.notifier.#{template}.subject", order_detail: order_detail, user: order_detail.order.user, product: order_detail.product), template
   end
 
   private

--- a/app/models/reports/account_transactions_report.rb
+++ b/app/models/reports/account_transactions_report.rb
@@ -4,6 +4,7 @@ class Reports::AccountTransactionsReport
 
   include ApplicationHelper
   include ERB::Util
+  include TextHelpers::Translation
 
   def initialize(order_details, options = {})
     @order_details = order_details
@@ -27,15 +28,19 @@ class Reports::AccountTransactionsReport
   end
 
   def description
-    I18n.t("reports.account_transactions.subject")
+    text(".subject")
   end
 
   def text_content
-    I18n.t("reports.account_transactions.body")
+    text(".body")
   end
 
   def has_attachment?
     true
+  end
+
+  def translation_scope
+    "reports.account_transactions"
   end
 
   private

--- a/app/views/file_uploads/product_survey.html.haml
+++ b/app/views/file_uploads/product_survey.html.haml
@@ -9,7 +9,7 @@
 %p= t('.intro')
 .box_no_fill.margin_bottom
   %h3= t('.order_form.head')
-  %p= t('.order_form.main')
+  %p= text('file_uploads.product_survey.order_form.main')
   = simple_form_for(@survey, :url => create_product_survey_path(current_facility, @product.parameterize, @product), :html => { :multipart => true }) do |f|
     = f.error_messages
     = f.input :location, :label => 'Service URL', :required => true, :input_html => { :size => 60 }

--- a/app/views/notifier/new_user.html.haml
+++ b/app/views/notifier/new_user.html.haml
@@ -1,9 +1,9 @@
-%p= t(".intro_html", :first_name => @user.first_name, :last_name => @user.last_name, :login_url => new_user_session_url)
+= html(".intro_html", first_name: @user.first_name, last_name: @user.last_name, login_url: new_user_session_url)
 
 - if @password
   %p
-    =h "#{User.human_attribute_name(:username)}: #{@user.username}"
+    = "#{User.human_attribute_name(:username)}: #{@user.username}"
     %br
-    =h "#{User.human_attribute_name(:password)}: #{@password}"
+    = "#{User.human_attribute_name(:password)}: #{@password}"
 - else
-  %p= t(".no_password")
+  %p= text(".no_password")

--- a/app/views/notifier/new_user.text.haml
+++ b/app/views/notifier/new_user.text.haml
@@ -1,7 +1,7 @@
-= t(".intro", :first_name => @user.first_name, :last_name => @user.last_name, :login_url => new_user_session_url)
+= text(".intro", first_name: @user.first_name, last_name: @user.last_name, login_url: new_user_session_url)
 
 = "#{User.human_attribute_name(:username)}: #{@user.username}"
 - if @password
   = "#{User.human_attribute_name(:password)}: #{@password}"
 - else
-  = t(".no_password")
+  = text(".no_password")

--- a/app/views/notifier/order_receipt.html.haml
+++ b/app/views/notifier/order_receipt.html.haml
@@ -3,7 +3,7 @@
 
 %ul
   %li
-    %label= t(".label.ordered_at")
+    %label= text(".label.ordered_at")
     = l(@order.ordered_at, format: :receipt)
   %li
     %label= OrderDetail.human_attribute_name(:facility)
@@ -47,9 +47,9 @@
             = order_detail.note
     %tr
       %td{colspan: 6}
-        %strong= t(".total")
+        %strong= text(".total")
       %td.currency= number_to_currency(@order.order_details.sum { |d| d.total || 0 })
       %td
 
 - if @order.any_details_estimated?
-  %p= t(".outro")
+  %p= text(".outro")

--- a/app/views/notifier/order_receipt.text.haml
+++ b/app/views/notifier/order_receipt.text.haml
@@ -2,7 +2,7 @@
   #{@greeting}
 ==
 
-#{t(".label.ordered_at")}: #{l(@order.ordered_at, format: :receipt)}
+#{text(".label.ordered_at")}: #{l(@order.ordered_at, format: :receipt)}
 #{OrderDetail.human_attribute_name(:facility)}: #{@order.facility}
 #{OrderDetail.human_attribute_name(:ordered_by)}: #{@order.created_by_user.full_name}
 #{OrderDetail.human_attribute_name(:account)}: #{@order.account}
@@ -28,4 +28,4 @@
 ==
 
 - if @order.any_details_estimated?
-  * #{t(".outro")}
+  * #{text(".outro")}

--- a/app/views/notifier/review_orders.html.haml
+++ b/app/views/notifier/review_orders.html.haml
@@ -1,1 +1,1 @@
-%p= t('.body_html', :facility => @facility.to_s, :account => @account.to_s, :login_link => link_to('log in to ' + t('app_name'), transactions_in_review_account_url(@account, :facilities => [@facility.id])))
+%p= html(".body_html", facility: @facility.to_s, account: @account.to_s, login_url: transactions_in_review_account_url(@account, facilities: [@facility.id]))

--- a/app/views/notifier/review_orders.text.erb
+++ b/app/views/notifier/review_orders.text.erb
@@ -1,3 +1,3 @@
-<%= t('.body', :facility => @facility.to_s, :account => @account.to_s) %>
+<%= text(".body", facility: @facility.to_s, account: @account.to_s) %>
 
-<%=h transactions_in_review_account_url(@account, :facilities => [@facility.id]) %>
+<%= transactions_in_review_account_url(@account, facilities: [@facility.id]) %>

--- a/app/views/notifier/user_update.html.haml
+++ b/app/views/notifier/user_update.html.haml
@@ -1,1 +1,1 @@
-%p= t('.body_html', :user => @user.to_s, :account => @account.to_s, :created_by => @created_by.to_s, :login_link => link_to('log in to ' + t('app_name'), new_user_session_url))
+%p= html(".body_html", user: @user.to_s, account: @account.to_s, created_by: @created_by.to_s, login_url: new_user_session_url)

--- a/app/views/notifier/user_update.text.erb
+++ b/app/views/notifier/user_update.text.erb
@@ -1,1 +1,1 @@
-<%= t('.body', :user => @user.to_s, :account => @account.to_s, :created_by => @created_by.to_s, :login_link => new_user_session_url) %>
+<%= text(".body", user: @user.to_s, account: @account.to_s, created_by: @created_by.to_s, login_url: new_user_session_url) %>

--- a/app/views/users/new_external.html.haml
+++ b/app/views/users/new_external.html.haml
@@ -1,12 +1,12 @@
 = content_for :head_content do
   :javascript
     $(document).ready(function() {
-      $('input#user_email').keyup(function(e) {
-        $('input#user_username').val(this.value);
+      $("input#user_email").keyup(function(e) {
+        $("input#user_username").val(this.value);
       });
 
-      $('input#user_email').change(function(e) {
-        $('input#user_username').val(this.value);
+      $("input#user_email").change(function(e) {
+        $("input#user_username").val(this.value);
       });
     });
 
@@ -14,16 +14,16 @@
   =h current_facility
 
 = content_for :sidebar do
-  = render :partial => 'admin/shared/sidenav_users', :locals => { :sidenav_tab => 'users' }
+  = render "admin/shared/sidenav_users", sidenav_tab: "users"
 
-%h2= t('.head')
-%p= t('.main')
-= simple_form_for(@user, :url => facility_users_path, :method => :post) do |f|
+%h2= t(".head")
+%p= text("users.new_external.main")
+= simple_form_for(@user, url: facility_users_path, method: :post) do |f|
   .form-inputs
     = f.input :first_name
     = f.input :last_name
     = f.input :email
     = f.input :username, :readonly => true
-    = f.button :submit, 'Create', :class => ['btn', 'btn-primary']
+    = f.button :submit, text("shared.create"), class: ["btn", "btn-primary"]
     &nbsp;
-    = link_to 'Cancel', facility_users_path
+    = link_to text("shared.cancel"), facility_users_path

--- a/app/views/users/search.html.haml
+++ b/app/views/users/search.html.haml
@@ -4,9 +4,9 @@
   %p.alert.alert-info= t('.email_not_found')
   %p= t('.main_html', :link => new_external_facility_users_path(current_facility, :email => params[:username_lookup]))
 - elsif @user.persisted?
-  %p.alert.alert-info= t('.user_already_exists', username: @user.username)
+  %p.alert.alert-info= text('users.search.user_already_exists', username: @user.username)
 - else
-  %p.notice= t('.found')
+  %p.notice= text('users.search.found')
   %table.table.table-striped.table-hover
     %thead
       %tr

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,6 +3,9 @@ require "devise/orm/active_record"
 # Use this hook to configure devise mailer, warden hooks and so forth. The first
 # four configuration values can also be set straight in your models.
 Devise.setup do |config|
+
+  config.mailer = "::DeviseMailer"
+
   # Configure the e-mail address which will be shown in DeviseMailer.
   config.mailer_sender = Settings.email.from
 

--- a/config/locales/en.notifier.yml
+++ b/config/locales/en.notifier.yml
@@ -1,0 +1,44 @@
+en:
+  views:
+    notifier:
+      account_update:
+        subject: "!app_name! Payment Method Updated"
+      new_user:
+        intro_html: "Congratulations, %{first_name}. A !app_name! account has been created for you. You may log in at <a href=\"%{login_url}\">%{login_url}</a>."
+        intro: "Congratulations, %{first_name}. A !app_name! account has been created for you. You may log in at %{login_url}."
+        no_password: You may log in with your username and password.
+        subject: "Welcome to !app_name!"
+      order_notification:
+        subject: "!app_name! Order Notification"
+      order_receipt:
+        subject: "!app_name! Order Receipt"
+        intro: "Thank you for your order on the !app_name! website."
+        label:
+          ordered_at: Ordered at
+        outro: "All prices are estimates. Actual cost is assigned when the order is complete."
+        total: Total
+      order_status_changed_to_approved:
+        subject: "Reservation #%{order_detail} has been approved"
+      order_status_changed_to_pending_approval:
+        subject: "%{user} has made a reservation for %{product}. Please approve."
+      review_orders:
+        subject: "!app_name! Orders For Review"
+        body: "New transactions for %{facility} have been posted to \"%{account}\". Please log in to !app_name! and review these charges."
+        body_html: |
+          New transactions for %{facility} have been posted to \"%{account}\".
+
+          Please log in to [!app_name!](%{login_url}) and review these charges.
+      statement:
+        subject: "!app_name! Statement"
+        body: "A new statement from %{facility} has been created for your payment source, \"%{account}\"."
+        body_html: "A new statement from %{facility} has been created for your payment source, \"%{account}\"."
+      user_update:
+        subject: "!app_name! User Updated"
+        body: |
+          The following user %{user} has been added to your payment source %{account} by administrator %{created_by}.
+          If this is incorrect you may log in to !app_name! at %{login_url} and remove this user or contact the administrator named above.
+        body_html: |
+          The following user %{user} has been added to your payment source "%{account}" by administrator %{created_by}.
+
+          If this is incorrect you may [log in to !app_name!](%{login_url}) and remove this user or contact the administrator named above.
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -878,46 +878,6 @@ en:
     no_results: No users found
     export_html: Export
 
-  notifier:
-    new_user:
-      intro_html: "Congratulations, %{first_name}. A NUcore account has been created for you. You may log in at <a href=\"%{login_url}\">%{login_url}</a>."
-      intro: "Congratulations, %{first_name}. A NUcore account has been created for you. You may log in at %{login_url}."
-      no_password: You may log in with your username and password.
-      subject: "Welcome to NUcore"
-    new_account:
-      subject: "NUcore New Payment Method"
-    order_notification:
-      subject: "NUcore Order Notification"
-    order_receipt:
-      subject: "NUcore Order Receipt"
-      intro: "Thank you for your order on the NUcore website."
-      label:
-        ordered_at: Ordered at
-      outro: "All prices are estimates. Actual cost is assigned when the order is complete."
-      total: Total
-    review_orders:
-      subject: "NUcore Orders For Review"
-      body: "New transactions for %{facility} have been posted to \"%{account}\". Please log in to NUcore and review these charges."
-      body_html: "New transactions for %{facility} have been posted to \"%{account}\".<br/><br/>Please %{login_link} and review these charges."
-    statement:
-      subject: "NUcore Statement"
-      body: "A new statement from %{facility} has been created for your payment source, \"%{account}\"."
-      body_html: "A new statement from %{facility} has been created for your payment source, \"%{account}\"."
-    user_update:
-      subject: "NUcore User Updated"
-      body: |
-        The following user %{user} has been added to your payment source %{account} by administrator %{created_by}.
-        If this is incorrect you may log in to NUcore at %{login_link} and remove this user or contact the administrator named above.
-      body_html: |
-        The following user %{user} has been added to your payment source "%{account}" by administrator %{created_by}.<br/><br/>
-        If this is incorrect you may %{login_link} and remove this user or contact the administrator named above.
-    account_update:
-      subject: "NUcore Payment Method Updated"
-    order_status_changed_to_approved:
-      subject: "Reservation #%{order_detail} has been approved"
-    order_status_changed_to_pending_approval:
-      subject: "%{user} has made a reservation for %{product}. Please approve."
-
   file_uploads:
     widget:
       error_loading: Please enable Javascript and install Adobe Flash Player.
@@ -932,7 +892,7 @@ en:
       intro: "You may provide an Online Order Form and/or an Order File Template.  If provided, the user must complete one before placing an order."
       order_form:
         head: "Online Order Form"
-        main: "Online Order Forms are external Surveyor services. Multiple Online Order Forms may be added, but only one may be active at a time. Please contact the NUcore support specialist for more information."
+        main: "Online Order Forms are external Surveyor services. Multiple Online Order Forms may be added, but only one may be active at a time. Please contact the !app_name! support specialist for more information."
         notice: "No Online Order Forms have been added."
       download_form:
         head: "Downloadable Order Form"
@@ -969,7 +929,7 @@ en:
       success: "The import completed successfully. %{successes} line items were created."
     account_transactions:
       export: Export as CSV
-      subject: NUcore Transaction Export
+      subject: "!app_name! Transaction Export"
       body: Your export is ready. Please see the attached file.
 
   users:
@@ -984,7 +944,7 @@ en:
 
     new_external:
       head: "Add External User"
-      main: "You may use this to grant NUcore access to external users. The email address and username must match."
+      main: "You may use this to grant !app_name! access to external users. The email address and username must match."
     new:
       js:
         id: "NetID"
@@ -1005,8 +965,8 @@ en:
       main_html: "You may add a new external user by clicking <a href=\"%{link}\">Add a new external user</a>."
       netid_not_found: "The user could not be located in the university database.  Please make sure you typed the NetID correctly."
       email_not_found: "No user information was found in the university databases."
-      found: "The following user was found.  Click \"Add User\" to allow this user access to NUcore."
-      user_already_exists: The user %{username} already exists in NUcore
+      found: "The following user was found.  Click \"Add User\" to allow this user access to !app_name!."
+      user_already_exists: "The user %{username} already exists in !app_name!"
     search_form:
       head:
         h2: "Search Users"
@@ -1124,8 +1084,9 @@ en:
       not_found_in_database: "Invalid username or password."
       inactive: "Invalid username or password."
     mailer:
+      # TODO
       reset_password_instructions:
-        subject: "NUcore Password Reset Instructions"
+        subject: "!app_name! Password Reset Instructions"
 
   testing:
     overriding: This should be overriden in override/en.yml

--- a/config/locales/views/en.facilities.yml
+++ b/config/locales/views/en.facilities.yml
@@ -5,6 +5,6 @@ en:
         recently_used: Recently Used !Facilities!
         all: All !Facilities!
         welcome: |
-          Welcome to NUcore, the centralized ordering system for shared !facilities_downcase!.
+          Welcome to !app_name!, the centralized ordering system for shared !facilities_downcase!.
           Please select the shared !facility_downcase! below to view and purchase services
           and products offered by the !facility_downcase!.

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe FacilityOrdersController do
       expect(flash[:notice]).to be_present
       expect(ActionMailer::Base.deliveries.size).to eq(1)
       mail = ActionMailer::Base.deliveries.first
-      expect(mail.subject).to eq(I18n.t("notifier.order_receipt.subject"))
+      expect(mail.subject).to include("Order Receipt")
       expect(mail.from.first).to eq(Settings.email.from)
       assert_redirected_to facility_order_path(@authable, @order)
     end


### PR DESCRIPTION
The definition of `app_name` should be the only place "NUcore" appears in the locales. Once this is in, we should be able to clean up a lot of the overrides in UIC.