### PR TITLE
[#116374821] Assign a project to an OrderDetail

### DIFF
--- a/app/assets/javascripts/activate_chosen.js.coffee
+++ b/app/assets/javascripts/activate_chosen.js.coffee
@@ -1,1 +1,3 @@
-$ -> $(".js--chosen").chosen()
+$ ->
+  $(".js--chosen").not(".optional").chosen()
+  $(".js--chosen.optional").chosen(allow_single_deselect: true)

--- a/app/assets/javascripts/activate_chosen.js.coffee
+++ b/app/assets/javascripts/activate_chosen.js.coffee
@@ -1,3 +1,6 @@
-$ ->
-  $(".js--chosen").not(".optional").chosen()
-  $(".js--chosen.optional").chosen(allow_single_deselect: true)
+class window.ChosenActivator
+  @activate: ->
+    $(".js--chosen").not(".optional").chosen()
+    $(".js--chosen.optional").chosen(allow_single_deselect: true)
+
+$ -> ChosenActivator.activate()

--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -1,5 +1,29 @@
 class OrderDetails::ParamUpdater
 
+  def self.permitted_attributes
+    @permitted_attributes ||=
+      [
+        :account_id,
+        :resolve_dispute,
+        :dispute_resolved_reason,
+        :quantity,
+        :note,
+        reservation: [
+          :reserve_start_date,
+          :reserve_start_hour,
+          :reserve_start_min,
+          :reserve_start_meridian,
+          :duration_mins,
+          :actual_start_date,
+          :actual_start_hour,
+          :actual_start_min,
+          :actual_start_meridian,
+          :actual_duration_mins,
+        ],
+      ]
+  end
+
+
   def initialize(order_detail, options = {})
     @order_detail = order_detail
     @editing_user = options[:user]
@@ -49,11 +73,7 @@ class OrderDetails::ParamUpdater
   end
 
   def permitted_params(params)
-    params.permit(:account_id, :resolve_dispute, :dispute_resolved_reason, :quantity, :note,
-                  reservation: [:reserve_start_date, :reserve_start_hour,
-                                :reserve_start_min, :reserve_start_meridian, :duration_mins,
-                                :actual_start_date, :actual_start_hour,
-                                :actual_start_min, :actual_start_meridian, :actual_duration_mins])
+    params.permit(*self.class.permitted_attributes)
   end
 
   def assign_self_and_reservation_attributes(params)

--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -23,7 +23,6 @@ class OrderDetails::ParamUpdater
       ]
   end
 
-
   def initialize(order_detail, options = {})
     @order_detail = order_detail
     @editing_user = options[:user]

--- a/app/views/order_management/order_details/edit.html.haml
+++ b/app/views/order_management/order_details/edit.html.haml
@@ -7,13 +7,14 @@
   %h3= "Order ##{@order_detail} #{@order_detail.product}"
 
 = simple_form_for @order_detail,
-    :url => manage_facility_order_order_detail_path(current_facility, @order, @order_detail),
-    :remote => modal?,
-    :html => { :class => ['manage_order_detail', edit_disabled? ? 'disabled' : ''] } do |f|
+    url: manage_facility_order_order_detail_path(current_facility, @order, @order_detail),
+    remote: modal?,
+    html: { class: ["manage_order_detail", edit_disabled? ? "disabled" : ""] } do |f|
+
   %div{class: modal? ? "modal-body" : ""}
     .row
       .span10
-        = render :partial => 'warnings'
+        = render "warnings"
 
     .banner-list
       .row
@@ -31,53 +32,55 @@
 
         - if @order_detail.removable_from_journal?
           .row
-            = link_to t('.remove_from_journal'),
+            = link_to t(".remove_from_journal"),
               remove_from_journal_facility_order_order_detail_path(current_facility, @order, @order_detail),
               method: :post
 
     .row
-      .span5
-        = account_input(f)
+      .span5= account_input(f)
 
       .span3
         - if @order_statuses
-          = f.association :order_status, :collection => @order_statuses, :label_method => :name_with_level, :include_blank => false
+          = f.association :order_status, collection: @order_statuses, label_method: :name_with_level, include_blank: false
         - else
           = f.label :order_status
           = @order_detail.order_status
+
       - if @order_detail.reservation
         .cancel-fee-option.span2
-          = label_tag 'with_cancel_fee', :class => 'checkbox' do
-            = check_box_tag 'with_cancel_fee', 1, false, data: { connect: '#order_detail_order_status_id', show_on: OrderStatus.canceled.first.id }
-            = t('facility_order_details.edit.label.with_cancel_fee')
+          = label_tag "with_cancel_fee", class: "checkbox" do
+            = check_box_tag "with_cancel_fee",
+              1,
+              false,
+              data: { connect: "#order_detail_order_status_id", show_on: OrderStatus.canceled.first.id }
+            = t("facility_order_details.edit.label.with_cancel_fee")
 
     .row
       - if @order_detail.reservation
-        .span5= render :partial => 'reservation', :locals => { :f => f, :reservation => @order_detail.reservation }
+        .span5= render "reservation", f: f, reservation: @order_detail.reservation
       - else
         .span5
-          = f.input :quantity, :as => :order_detail_quantity, :hint_html => { :class => 'help-inline' }
+          = f.input :quantity, as: :order_detail_quantity, hint_html: { class: "help-inline" }
 
       .span5
-        = render :partial => 'costs', :locals => { :f => f }
+        = render "costs", f: f
 
     .row
       .span5
-        = f.input :note, :input_html => { :class => 'note' }
-        = render :partial => 'reconcile_note', :locals => { :f => f }
+        = f.input :note, input_html: { class: "note" }
+        = render "reconcile_note", f: f
 
       .span4
-        = render :partial => 'assigned_user', :locals => { :f => f }
-      .span1= render :partial => 'facility_orders/order_file_icon', :locals => { :od => @order_detail }
+        = render "assigned_user", f: f
+      .span1= render "facility_orders/order_file_icon", od: @order_detail
 
     - if @order_detail.dispute_at
-      .row
-        = render :partial => 'dispute', :locals => { :f => f }
+      .row= render "dispute", f: f
 
   .modal-footer.hide-from-print
     - if modal? && SettingsHelper.feature_on?(:print_order_detail)
       = link_to manage_facility_order_order_detail_path(current_facility, @order, @order_detail, anchor: "print"), target: "_blank" do
         %i.icon-print.pull-left
-    .hidden.updating-message= t('facility_order_details.edit.label.updating')
-    = f.submit 'Save', :class => ['btn', 'btn-primary']
+    .hidden.updating-message= t("facility_order_details.edit.label.updating")
+    = f.submit "Save", class: ["btn", "btn-primary"]
     = modal_cancel_button

--- a/app/views/order_management/order_details/edit.html.haml
+++ b/app/views/order_management/order_details/edit.html.haml
@@ -55,6 +55,9 @@
               data: { connect: "#order_detail_order_status_id", show_on: OrderStatus.canceled.first.id }
             = t("facility_order_details.edit.label.with_cancel_fee")
 
+    = render_view_hook "after_order_status",
+      f: f, modal: modal?, order_detail: @order_detail
+
     .row
       - if @order_detail.reservation
         .span5= render "reservation", f: f, reservation: @order_detail.reservation

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160503170055) do
+ActiveRecord::Schema.define(:version => 20160503184205) do
 
   create_table "account_users", :force => true do |t|
     t.integer  "account_id",               :null => false
@@ -250,6 +250,7 @@ ActiveRecord::Schema.define(:version => 20160503170055) do
     t.integer  "product_accessory_id"
     t.boolean  "problem",                                                               :default => false, :null => false
     t.datetime "reconciled_at"
+    t.integer  "project_id"
   end
 
   add_index "order_details", ["account_id"], :name => "fk_od_accounts"

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe OrderManagement::OrderDetailsController do
   describe "update reservation" do
     before :each do
       @action = :update
-      @method = :post
+      @method = :put
       @params = { facility_id: facility.url_name, order_id: order_detail.order_id, id: order_detail.id }
     end
 
@@ -361,7 +361,7 @@ RSpec.describe OrderManagement::OrderDetailsController do
 
         before :each do
           @action = :update
-          @method = :post
+          @method = :put
           @params = { facility_id: facility.url_name, order_id: order_detail.order_id, id: order_detail.id }
         end
 
@@ -477,7 +477,7 @@ RSpec.describe OrderManagement::OrderDetailsController do
     before :each do
       sign_in @admin
       @action = :update
-      @method = :post
+      @method = :put
       @params = { facility_id: facility.url_name, order_id: order_detail.order_id, id: order_detail.id }
     end
 

--- a/vendor/engines/projects/app/models/projects/order_detail_extension.rb
+++ b/vendor/engines/projects/app/models/projects/order_detail_extension.rb
@@ -33,6 +33,7 @@ module Projects
         errors.add(:project_id, :project_is_inactive)
       end
     end
+
   end
 
 end

--- a/vendor/engines/projects/app/models/projects/order_detail_extension.rb
+++ b/vendor/engines/projects/app/models/projects/order_detail_extension.rb
@@ -1,0 +1,26 @@
+module Projects
+
+  module OrderDetailExtension
+
+    extend ActiveSupport::Concern
+
+    included do
+      belongs_to :project,
+                 class_name: "Projects::Project",
+                 foreign_key: :project_id,
+                 inverse_of: :order_details
+
+      validate :project_facility_matches?
+    end
+
+    private
+
+    def project_facility_matches?
+      if project_id.present? && project.facility != facility
+        errors.add(:project_id, :project_facility_mismatch)
+      end
+    end
+
+  end
+
+end

--- a/vendor/engines/projects/app/models/projects/order_detail_extension.rb
+++ b/vendor/engines/projects/app/models/projects/order_detail_extension.rb
@@ -13,11 +13,11 @@ module Projects
       validate :project_facility_must_match
       validate :project_must_be_active, if: :project_id_changed?
 
-      delegate :projects, to: :facility, allow_nil: true
+      delegate :projects, to: :facility, prefix: true
     end
 
     def selectable_projects
-      (projects.active + [project]).uniq.compact
+      (facility_projects.active + [project]).uniq.compact
     end
 
     private

--- a/vendor/engines/projects/app/models/projects/order_detail_extension.rb
+++ b/vendor/engines/projects/app/models/projects/order_detail_extension.rb
@@ -11,6 +11,12 @@ module Projects
                  inverse_of: :order_details
 
       validate :project_facility_matches?
+
+      delegate :projects, to: :facility, allow_nil: true
+    end
+
+    def selectable_projects
+      (projects.active + [project]).uniq.compact
     end
 
     private

--- a/vendor/engines/projects/app/models/projects/order_detail_extension.rb
+++ b/vendor/engines/projects/app/models/projects/order_detail_extension.rb
@@ -10,7 +10,8 @@ module Projects
                  foreign_key: :project_id,
                  inverse_of: :order_details
 
-      validate :project_facility_matches?
+      validate :project_facility_must_match
+      validate :project_must_be_active, if: :project_id_changed?
 
       delegate :projects, to: :facility, allow_nil: true
     end
@@ -21,12 +22,17 @@ module Projects
 
     private
 
-    def project_facility_matches?
+    def project_facility_must_match
       if project_id.present? && project.facility != facility
         errors.add(:project_id, :project_facility_mismatch)
       end
     end
 
+    def project_must_be_active
+      if project.present? && !project.active?
+        errors.add(:project_id, :project_is_inactive)
+      end
+    end
   end
 
 end

--- a/vendor/engines/projects/app/models/projects/project.rb
+++ b/vendor/engines/projects/app/models/projects/project.rb
@@ -5,6 +5,7 @@ module Projects
     include ActiveModel::ForbiddenAttributesProtection
 
     belongs_to :facility, foreign_key: :facility_id
+    has_many :order_details, inverse_of: :project
 
     validates :facility_id, presence: true
     validates :name,

--- a/vendor/engines/projects/app/models/projects/project.rb
+++ b/vendor/engines/projects/app/models/projects/project.rb
@@ -13,6 +13,7 @@ module Projects
               uniqueness: { case_sensitive: false, scope: :facility_id }
 
     scope :active, conditions: { active: true }
+
   end
 
 end

--- a/vendor/engines/projects/app/models/projects/project.rb
+++ b/vendor/engines/projects/app/models/projects/project.rb
@@ -12,6 +12,7 @@ module Projects
               presence: true,
               uniqueness: { case_sensitive: false, scope: :facility_id }
 
+    scope :active, conditions: { active: true }
   end
 
 end

--- a/vendor/engines/projects/app/models/projects/project.rb
+++ b/vendor/engines/projects/app/models/projects/project.rb
@@ -12,7 +12,7 @@ module Projects
               presence: true,
               uniqueness: { case_sensitive: false, scope: :facility_id }
 
-    scope :active, conditions: { active: true }
+    scope :active, -> { where(active: true) }
 
   end
 

--- a/vendor/engines/projects/app/services/projects/order_details/param_updater_extension.rb
+++ b/vendor/engines/projects/app/services/projects/order_details/param_updater_extension.rb
@@ -1,0 +1,17 @@
+module Projects
+
+  module OrderDetails
+
+    module ParamUpdaterExtension
+
+      extend ActiveSupport::Concern
+
+      included do
+        permitted_attributes.unshift(:project_id)
+      end
+
+    end
+
+  end
+
+end

--- a/vendor/engines/projects/app/views/projects/shared/_select_project.html.haml
+++ b/vendor/engines/projects/app/views/projects/shared/_select_project.html.haml
@@ -6,4 +6,5 @@
       selected: order_detail.project_id,
       include_blank: true
 
-= javascript_include_tag "activate_chosen" if modal
+:javascript
+  ChosenActivator.activate();

--- a/vendor/engines/projects/app/views/projects/shared/_select_project.html.haml
+++ b/vendor/engines/projects/app/views/projects/shared/_select_project.html.haml
@@ -1,0 +1,9 @@
+.row
+  .span10
+    = f.input :project_id,
+      collection: order_detail.selectable_projects,
+      input_html: { class: "js--chosen", data: { placeholder: t(".placeholder") } },
+      selected: order_detail.project_id,
+      include_blank: true
+
+= javascript_include_tag "activate_chosen" if modal

--- a/vendor/engines/projects/config/locales/en.yml
+++ b/vendor/engines/projects/config/locales/en.yml
@@ -39,3 +39,7 @@ en:
         name: Name of the label as displayed to the end user
       show:
         edit: Edit Project
+
+    shared:
+      select_project:
+        placeholder: Choose a project...

--- a/vendor/engines/projects/config/locales/en.yml
+++ b/vendor/engines/projects/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
           attributes:
             project_id:
               project_facility_mismatch: The project belongs to another facility
+              project_is_inactive: The project is inactive
 
     models:
       projects/project:

--- a/vendor/engines/projects/config/locales/en.yml
+++ b/vendor/engines/projects/config/locales/en.yml
@@ -1,5 +1,12 @@
 en:
   activerecord:
+    errors:
+      models:
+        order_detail:
+          attributes:
+            project_id:
+              project_facility_mismatch: The project belongs to another facility
+
     models:
       projects/project:
         one: Project

--- a/vendor/engines/projects/db/migrate/20160503184205_add_project_id_to_order_detail.rb
+++ b/vendor/engines/projects/db/migrate/20160503184205_add_project_id_to_order_detail.rb
@@ -1,0 +1,7 @@
+class AddProjectIdToOrderDetail < ActiveRecord::Migration
+
+  def change
+    add_column :order_details, :project_id, :integer, null: true
+  end
+
+end

--- a/vendor/engines/projects/lib/projects/engine.rb
+++ b/vendor/engines/projects/lib/projects/engine.rb
@@ -6,6 +6,7 @@ module Projects
       ::AbilityExtensionManager.extensions << "Projects::AbilityExtension"
       Facility.send :include, Projects::FacilityExtension
       NavTab::LinkCollection.send :include, Projects::LinkCollectionExtension
+      ::OrderDetails::ParamUpdater.send :include, Projects::OrderDetails::ParamUpdaterExtension
       OrderDetail.send :include, Projects::OrderDetailExtension
     end
 

--- a/vendor/engines/projects/lib/projects/engine.rb
+++ b/vendor/engines/projects/lib/projects/engine.rb
@@ -6,6 +6,7 @@ module Projects
       ::AbilityExtensionManager.extensions << "Projects::AbilityExtension"
       Facility.send :include, Projects::FacilityExtension
       NavTab::LinkCollection.send :include, Projects::LinkCollectionExtension
+      OrderDetail.send :include, Projects::OrderDetailExtension
     end
 
     initializer :append_migrations do |app|

--- a/vendor/engines/projects/lib/projects/engine.rb
+++ b/vendor/engines/projects/lib/projects/engine.rb
@@ -8,6 +8,10 @@ module Projects
       NavTab::LinkCollection.send :include, Projects::LinkCollectionExtension
       ::OrderDetails::ParamUpdater.send :include, Projects::OrderDetails::ParamUpdaterExtension
       OrderDetail.send :include, Projects::OrderDetailExtension
+
+      ViewHook.add_hook "order_management.order_details.edit",
+                        "after_order_status",
+                        "projects/shared/select_project"
     end
 
     initializer :append_migrations do |app|

--- a/vendor/engines/projects/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/vendor/engines/projects/spec/controllers/order_management/order_details_controller_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe OrderManagement::OrderDetailsController do
+  let(:order_detail) { order.order_details.first }
+  let(:facility) { order.facility }
+  let(:item) { FactoryGirl.create(:setup_item) }
+  let(:order) { FactoryGirl.create(:purchased_order, product: item) }
+  let(:active_project) { FactoryGirl.create(:project, facility: facility) }
+  let(:inactive_project) { FactoryGirl.create(:project, :inactive, facility: facility) }
+
+  describe "PUT #update" do
+    def perform_request
+      put :update,
+          facility_id: facility.url_name,
+          order_id: order.id,
+          id: order_detail.id,
+          order_detail: { project_id: project_id }
+    end
+
+    before(:each) do
+      sign_in FactoryGirl.create(:user, :administrator)
+      perform_request
+      order_detail.reload
+    end
+
+    context "when the order_detail had no project" do
+      context "and it updates specifying a project" do
+        context "that is associated with the same facility" do
+          context "and is active" do
+            let(:project_id) { active_project.id }
+            it { expect(order_detail.project_id).to eq(project_id) }
+          end
+
+          context "and is inactive" do
+            let(:project_id) { inactive_project.id }
+            it { expect(order_detail.project_id).to be_blank }
+          end
+        end
+
+        context "that is associated with a different facility" do
+          let(:project_id) { FactoryGirl.create(:project).id }
+          it { expect(order_detail.project_id).to be_blank }
+        end
+      end
+
+      context "and it updates specifying no project" do
+        let(:project_id) { nil }
+        it { expect(order_detail.project_id).to be_blank }
+      end
+    end
+
+    context "when the order_detail had a project" do
+      context "that is currently active" do
+        before { order_detail.update_attribute(:project_id, active_project.id) }
+
+        context "and it updates to a project" do
+          context "that is associated with the same facility" do
+            context "and is active" do
+              let(:project_id) { active_project.id }
+              it { expect(order_detail.project_id).to eq(project_id) }
+            end
+
+            context "and is inactive" do
+              let(:project_id) { inactive_project.id }
+              it { expect(order_detail.project_id).to eq(active_project.id) }
+            end
+          end
+
+          context "that is associated with a different facility" do
+            let(:project_id) { FactoryGirl.create(:project).id }
+            it { expect(order_detail.project_id).to eq(active_project.id) }
+          end
+        end
+      end
+
+      context "that is currently inactive" do
+        before(:each) do
+          order_detail.update_attribute(:project_id, inactive_project.id)
+        end
+
+        context "and it updates using this same inactive project_id" do
+          let(:project_id) { inactive_project.id }
+          it { expect(order_detail.project_id).to eq(inactive_project.id) }
+        end
+      end
+    end
+  end
+end

--- a/vendor/engines/projects/spec/factories/projects.rb
+++ b/vendor/engines/projects/spec/factories/projects.rb
@@ -2,5 +2,9 @@ FactoryGirl.define do
   factory :project, class: Projects::Project do
     sequence(:name) { |n| "Project #{n}" }
     facility
+
+    trait :inactive do
+      active false
+    end
   end
 end

--- a/vendor/engines/projects/spec/models/projects/order_detail_extension_spec.rb
+++ b/vendor/engines/projects/spec/models/projects/order_detail_extension_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe Projects::OrderDetailExtension do
+  subject(:order_detail) { FactoryGirl.build(:order_detail) }
+  let(:project) { FactoryGirl.create(:project, facility: facility) }
+
+  context "validations" do
+    it "can belong_to a Project" do
+      is_expected
+        .to belong_to(:project)
+        .with_foreign_key(:project_id)
+        .inverse_of(:order_details)
+    end
+
+    describe "Facility scoping" do
+      subject(:order_detail) { order.order_details.first }
+      let(:item) { FactoryGirl.create(:setup_item) }
+      let(:order) { FactoryGirl.create(:setup_order, product: item) }
+
+      before { order_detail.update_attribute(:project_id, project.id) }
+
+      context "when the Project belongs to the same facility as the OrderDetail" do
+        let(:facility) { order_detail.facility }
+        it { is_expected.to be_valid }
+      end
+
+      context "when the Project belongs to a different facility than the OrderDetail" do
+        let(:facility) { FactoryGirl.create(:facility) }
+
+        it "is invalid" do
+          is_expected.not_to be_valid
+          expect(order_detail.errors[:project_id])
+            .to include("The project belongs to another facility")
+        end
+      end
+    end
+  end
+end

--- a/vendor/engines/projects/spec/models/projects/project_spec.rb
+++ b/vendor/engines/projects/spec/models/projects/project_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Projects::Project, type: :model do
   context "validations" do
     it { is_expected.to validate_presence_of(:facility_id) }
     it { is_expected.to belong_to(:facility).with_foreign_key(:facility_id) }
+    it { is_expected.to have_many(:order_details).inverse_of(:project) }
 
     it "enforces unique names per facility" do
       is_expected

--- a/vendor/engines/projects/spec/services/projects/order_details/param_updater_extension_spec.rb
+++ b/vendor/engines/projects/spec/services/projects/order_details/param_updater_extension_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe Projects::OrderDetails::ParamUpdaterExtension do
+  describe ".permitted_attributes" do
+    it "injects the :project_id attribute when the engine is active" do
+      expect(::OrderDetails::ParamUpdater.permitted_attributes)
+        .to include(:project_id)
+    end
+  end
+end


### PR DESCRIPTION
This injects Project selection into the order detail edit screen (modal, typically).

Highlights:

* The `order_details` table gets another attribute: `project_id`. There are related changes to the order detail updater for the Projects engine to make changes to permitted params.
* There are validations to check that the project:
  - belongs to the same facility as the order/order detail
  - is active, unless the project was already associated (presumably when it was active)
* There's some cleanup of the edit view partial
* The project selection is injected through a view hook
* There's a change to how it activates `chosen`, in that if the `<select>` is optional, you should be able to "x" out a previous selection.