### PR TITLE
Ensure tmp exists at app root, and use it

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -10,9 +10,6 @@ class Journal < ActiveRecord::Base
       rows = journal_rows
       return false if rows.empty?
 
-      # write journal spreadsheet to tmp directory
-      # temp_file   = Tempfile.new("journalspreadsheet")
-      temp_file   = File.new("#{Dir.tmpdir}/journal.spreadsheet.#{Time.zone.now.strftime('%Y%m%dT%H%M%S')}.xls", "w")
       output_file = JournalSpreadsheet.write_journal_entry(rows, output_file: temp_file.path)
       # add/import journal spreadsheet
       status      = add_spreadsheet(output_file)
@@ -23,6 +20,16 @@ class Journal < ActiveRecord::Base
         nil
       end
       status
+    end
+
+    private
+
+    def temp_file
+      @temp_file ||= File.new(spreadsheet_filename, "w")
+    end
+
+    def spreadsheet_filename
+      Rails.root.join("tmp/journal.spreadsheet.#{Time.current.strftime('%Y%m%dT%H%M%S')}.xls")
     end
 
   end


### PR DESCRIPTION
This is partially from https://github.com/tablexi/nucore-dartmouth/pull/38. We need `tmp` to exist at the app root, and it does, though it seems it's only because gems like `sprockets` and `letter_opener` will create it if it's not there.

This also reworks the only code I'm aware of that was relying on `Dir.tmpdir`, in journal creation. With this in place, some of the overrides in the DC fork may become redundant.