### PR TITLE
[#116374821] Present project selection if there are selectable projects

### DIFF
--- a/vendor/engines/projects/app/views/projects/shared/_select_project.html.haml
+++ b/vendor/engines/projects/app/views/projects/shared/_select_project.html.haml
@@ -1,10 +1,11 @@
-.row
-  .span10
-    = f.input :project_id,
-      collection: order_detail.selectable_projects,
-      input_html: { class: "js--chosen", data: { placeholder: t(".placeholder") } },
-      selected: order_detail.project_id,
-      include_blank: true
+- if order_detail.selectable_projects.any?
+  .row
+    .span10
+      = f.input :project_id,
+        collection: order_detail.selectable_projects,
+        input_html: { class: "js--chosen", data: { placeholder: t(".placeholder") } },
+        selected: order_detail.project_id,
+        include_blank: true
 
-:javascript
-  ChosenActivator.activate();
+  :javascript
+    ChosenActivator.activate();


### PR DESCRIPTION
This is a loose end from #574: if there are no projects available to select, it shouldn't show a selection widget.