### PR TITLE
[#119031765] New email interceptor that allows a whitelist

### DIFF
--- a/app/mailers/base_mailer.rb
+++ b/app/mailers/base_mailer.rb
@@ -3,7 +3,6 @@ class BaseMailer < ActionMailer::Base
   default from: Settings.email.from
 
   def mail(arguments)
-    arguments[:to] = Settings.email.fake.to if Settings.email.fake.enabled
     super
   end
 

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -89,7 +89,7 @@ class Notifier < ActionMailer::Base
   end
 
   def send_nucore_mail(to, subject, template_name = nil)
-    mail(subject: subject, to: Settings.email.fake.enabled ? Settings.email.fake.to : to, template_name: template_name)
+    mail(subject: subject, to: to, template_name: template_name)
   end
 
 end

--- a/config/initializers/action_mailer_interceptors.rb
+++ b/config/initializers/action_mailer_interceptors.rb
@@ -1,0 +1,1 @@
+ActionMailer::Base.register_interceptor(StagingMailInterceptor) if Settings.email.fake.enabled

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,6 +36,7 @@ email:
   fake:
     enabled: false
     to:
+    whitelist:
   exceptions:
     sender: 'noreply@example.com'
     recipients: [ 'warn@example.com', 'error@example.com' ]

--- a/lib/staging_mail_interceptor.rb
+++ b/lib/staging_mail_interceptor.rb
@@ -65,9 +65,7 @@ class StagingMailInterceptor
   def whitelisted?(recipient)
     recipient = Mail::Address.new(recipient)
     recipient.domain == "tablexi.com" ||
-      send_to_addresses.include?(recipient.address) ||
-      whitelist.include?(recipient.address) ||
-      exception_recipients.include?(recipient.address)
+      full_whitelist.map(&:downcase).include?(recipient.address.downcase)
   end
 
   # Internal: Get a list of the whitelisted email addresses for this message.
@@ -87,6 +85,13 @@ class StagingMailInterceptor
     message.to.all? { |recipient| whitelisted?(recipient) } &&
       message.cc.blank? &&
       message.bcc.blank?
+  end
+
+  # Internal: The list of all users that will be able to receive emails
+  #
+  # Returns an Array of strings
+  def full_whitelist
+    send_to_addresses + whitelist + exception_recipients
   end
 
   def send_to_addresses

--- a/lib/staging_mail_interceptor.rb
+++ b/lib/staging_mail_interceptor.rb
@@ -1,0 +1,108 @@
+# MailInterceptor intercepts email delivery, preventing messages from being sent
+# to non-developers, and re-routing messages intended for other recipients to
+# the development team. This allows us to play around in the staging and testing
+# environments without fear of emails going to production customers.
+#
+# http://thepugautomatic.com/2012/08/abort-mail-delivery-with-rails-3-interceptors/
+class StagingMailInterceptor
+
+  attr_accessor :message
+
+  # Public: A hook invoked by Rails when delivering an email. Initializes and
+  # processes a new interceptor.
+  #
+  # Returns nothing.
+  def self.delivering_email(message)
+    new(message).process
+  end
+
+  # Public: Initialize a new StagingMailInterceptor for the passed message.
+  #
+  # message - A Mail::Message.
+  def initialize(message)
+    @message = message
+  end
+
+  # Public: Process the StagingMailInterceptor, modifying the message object
+  # to avoid sending email to actual customers in non-production environments.
+  #
+  # Returns nothing.
+  def process
+    message.subject = subject
+
+    return if all_addresses_whitelisted?
+
+    message.body = body
+
+    message.to = whitelisted_addresses
+    message.cc = nil
+    message.bcc = nil
+  end
+
+  private
+
+  # Internal: Get the message's subject line, prefixed for this environment.
+  #
+  # Returns a String.
+  def subject
+    "[#{I18n.t('app_name')} #{Rails.env.upcase}] #{message.subject}"
+  end
+
+  # Internal: Get the content of this email, modified with a list of the email
+  # addresses to which the email was originally supposed to be delivered.
+  #
+  # Returns a String.
+  def body
+    intercepted_message = "<pre>Intercepted email:\n  to: #{message.to}\n  cc: #{message.cc}\n  bcc: #{message.bcc}</pre>"
+    "#{intercepted_message}\n\n#{message.body}"
+  end
+
+  # Internal: Is the passed recipient whitelisted for communication? Permits
+  # communication only with either Table XI employees or emails listed in
+  # secrets in the staging environment.
+  #
+  # Returns a Boolean.
+  def whitelisted?(recipient)
+    recipient = Mail::Address.new(recipient)
+    recipient.domain == "tablexi.com" ||
+      send_to_addresses.include?(recipient.address) ||
+      whitelist.include?(recipient.address) ||
+      exception_recipients.include?(recipient.address)
+  end
+
+  # Internal: Get a list of the whitelisted email addresses for this message.
+  # If no email addresses are whitelisted, defaults to the configured exception
+  # notification email address.
+  #
+  # Returns a String or Array of Strings.
+  def whitelisted_addresses
+    message.to.select { |recipient| whitelisted?(recipient) }.presence ||
+      send_to_addresses
+  end
+
+  # Internal: Are all target email addresses whitelisted?
+  #
+  # Returns a Boolean.
+  def all_addresses_whitelisted?
+    message.to.all? { |recipient| whitelisted?(recipient) } &&
+      message.cc.blank? &&
+      message.bcc.blank?
+  end
+
+  def send_to_addresses
+    Array(settings[:to])
+  end
+
+  def whitelist
+    Array(settings[:whitelist])
+  end
+
+  def exception_recipients
+    Array(Settings[:exceptions].try(:[], :recipients))
+  end
+
+  def settings
+    Settings.email.fake || raise("Settings.email.fake is not configured!")
+  end
+
+end

--- a/spec/lib/staging_mail_interceptor_spec.rb
+++ b/spec/lib/staging_mail_interceptor_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe StagingMailInterceptor do
         end
       end
 
+      describe "case insensitivity" do
+        let(:to) { ["ALLOWED@example.org"] }
+
+        it "lets the message through" do
+          expect(message.to).to eq(to)
+        end
+      end
+
       describe "multiple addresses" do
         let(:to) { whitelist.first(2) }
 

--- a/spec/lib/staging_mail_interceptor_spec.rb
+++ b/spec/lib/staging_mail_interceptor_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe StagingMailInterceptor do
+  let(:to) { [] }
+  let(:interceptor) { StagingMailInterceptor.new(message) }
+  subject(:message) { OpenStruct.new to: to, subject: "A message" }
+
+  describe "whitelisting" do
+    let(:whitelist) { ["allowed@example.org", "allowed2@example.org", "allowed3@example.org"] }
+    let(:send_to) { ["sendto@example.org"] }
+
+    before do
+      allow(interceptor).to receive(:whitelist) { whitelist }
+      allow(interceptor).to receive(:send_to_addresses) { send_to }
+      interceptor.process
+    end
+
+    describe "when the email is sent to someone on the list" do
+      describe "single address" do
+        let(:to) { ["allowed@example.org"] }
+
+        it "lets the email through" do
+          expect(message.to).to eq(to)
+        end
+      end
+
+      describe "multiple addresses" do
+        let(:to) { whitelist.first(2) }
+
+        it "lets the email through" do
+          expect(message.to).to eq(to)
+        end
+      end
+
+      describe "an email is included twice" do
+        let(:to) { ["allowed@example.org", "allowed@example.org"] }
+
+        it "lets the email through" do
+          expect(message.to).to eq(to)
+        end
+      end
+    end
+
+    describe "when the email is not on the list" do
+      let(:to) { ["notallowed@example.org"] }
+
+      it "sends to the whitelist" do
+        expect(message.to).to eq(send_to)
+      end
+
+      it "includes the blocked addresses in the message" do
+        expect(message.body).to include("Intercepted email")
+        expect(message.body).to include(*to)
+      end
+    end
+
+    describe "when multiple emails are not on the list" do
+      let(:to) { ["allowed@example.org", "notallowed@example.org", "notallowed2@example.org"] }
+
+      it "sends to the allowed list" do
+        expect(message.to).to eq(["allowed@example.org"])
+      end
+
+      it "includes the blocked addresses in the message" do
+        expect(message.body).to include("Intercepted email")
+        expect(message.body).to include(*to)
+      end
+    end
+  end
+
+  describe "subject manipulation" do
+    before { interceptor.process }
+    it "puts the site name as the prefix" do
+      expect(message.subject).to eq("[#{I18n.t('app_name')} TEST] A message")
+    end
+  end
+end


### PR DESCRIPTION
As opposed to capturing everything and sending it to a list, this sets up a
whitelist of people who can receive emails. If an email is sent to someone not
on the list, it is captured and redirected to a list of developers.

This should require no configuration changes unless we want to add people to the whitelist that shouldn’t receive the intercepted emails.