### PR TITLE
[#115962501] More support of "Facility" overriding

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -88,7 +88,7 @@ class FacilitiesController < ApplicationController
     @facility = Facility.new(facility_params)
 
     if @facility.save
-      flash[:notice] = "The facility was successfully created."
+      flash[:notice] = text("create.success")
       redirect_to manage_facility_path(@facility)
     else
       render action: "new", layout: "application"
@@ -98,7 +98,7 @@ class FacilitiesController < ApplicationController
   # PUT /facilities/:facility_id
   def update
     if current_facility.update_attributes(facility_params)
-      flash[:notice] = "The facility was successfully updated."
+      flash[:notice] = text("update.success")
       redirect_to manage_facility_path(current_facility)
     else
       render action: "edit"

--- a/app/controllers/facility_facility_accounts_controller.rb
+++ b/app/controllers/facility_facility_accounts_controller.rb
@@ -30,7 +30,7 @@ class FacilityFacilityAccountsController < ApplicationController
     @facility_account.created_by = session_user.id
 
     if @facility_account.save
-      flash[:notice] = "Facility account was successfully created."
+      flash[:notice] = text("create.success", model: FacilityAccount.model_name.human)
       redirect_to facility_facility_accounts_path
     else
       render action: "new"
@@ -47,7 +47,7 @@ class FacilityFacilityAccountsController < ApplicationController
     @facility_account = current_facility.facility_accounts.find(params[:id])
 
     if @facility_account.update_attributes(params[:facility_account])
-      flash[:notice] = "Facility account was successfully updated."
+      flash[:notice] = text("update.success", model: FacilityAccount.model_name.human)
       redirect_to facility_facility_accounts_path
     else
       render action: "edit"

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -182,6 +182,12 @@ class InstrumentsController < ProductsCommonController
     end
   end
 
+  protected
+
+  def translation_scope
+    "controllers.instruments"
+  end
+
   private
 
   def acting_user_can_purchase?

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -29,8 +29,7 @@ class InstrumentsController < ProductsCommonController
     # does the product have active price policies and schedule rules?
     unless @instrument.available_for_purchase?
       add_to_cart = false
-      flash[:notice] =
-        t_model_error(@instrument.class, "not_available", instrument: @instrument)
+      flash[:notice] = text(".not_available", instrument: @instrument)
     end
 
     # is user logged in?
@@ -42,44 +41,37 @@ class InstrumentsController < ProductsCommonController
     if add_to_cart && !@instrument.can_be_used_by?(acting_user) && !session_user_can_override_restrictions?(@instrument)
       if SettingsHelper.feature_on?(:training_requests)
         if TrainingRequest.submitted?(current_user, @instrument)
-          flash[:notice] = t_model_error(Product, "already_requested_access", product: @instrument)
+          flash[:notice] = text("controllers.products_common.already_requested_access", product: @instrument)
           return redirect_to facility_path(current_facility)
         else
           return redirect_to new_facility_product_training_request_path(current_facility, @instrument)
         end
       else
         add_to_cart = false
-        flash[:notice] = t_model_error(
-          @instrument.class,
-          "requires_approval_html",
+        flash[:notice] = html(".requires_approval",
           email: @instrument.email,
           facility: @instrument.facility,
           instrument: @instrument,
-        ).html_safe
+        )
       end
     end
 
     # does the user have a valid payment source for purchasing this reservation?
     if add_to_cart && acting_user.accounts_for_product(@instrument).blank?
       add_to_cart = false
-      flash[:notice] = t_model_error(@instrument.class, "no_accounts")
+      flash[:notice] = text(".no_accounts")
     end
 
     # does the product have any price policies for any of the groups the user is a member of?
     if add_to_cart && !acting_user_can_purchase?
       add_to_cart = false
-      flash[:notice] = t_model_error(
-        @instrument.class,
-        "no_price_groups",
-        instrument_name: @instrument.to_s,
-      )
+      flash[:notice] = text(".no_price_groups", instrument_name: @instrument.to_s)
     end
 
     # when ordering on behalf of, does the staff have permissions for this facility?
     if add_to_cart && acting_as? && !session_user.operator_of?(@instrument.facility)
       add_to_cart = false
-      flash[:notice] =
-        t_model_error(@instrument.class, "not_authorized_to_order_on_behalf")
+      flash[:notice] = text(".not_authorized_to_order_on_behalf")
     end
 
     @add_to_cart = add_to_cart

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -49,10 +49,10 @@ class InstrumentsController < ProductsCommonController
       else
         add_to_cart = false
         flash[:notice] = html(".requires_approval",
-          email: @instrument.email,
-          facility: @instrument.facility,
-          instrument: @instrument,
-        )
+                              email: @instrument.email,
+                              facility: @instrument.facility,
+                              instrument: @instrument,
+                             )
       end
     end
 
@@ -144,12 +144,12 @@ class InstrumentsController < ProductsCommonController
         status = instrument.relay.get_status
         instrument_status = instrument.current_instrument_status
         # if the status hasn't changed, don't create a new status
-        if instrument_status && status == instrument_status.is_on?
-          @instrument_statuses << instrument_status
-        else
-          # || false will ensure that the value of is_on is not nil (causes a DB error)
-          @instrument_statuses << instrument.instrument_statuses.create!(is_on: status || NUCore::Database.boolean(false))
-        end
+        @instrument_statuses << if instrument_status && status == instrument_status.is_on?
+                                  instrument_status
+                                else
+                                  # || false will ensure that the value of is_on is not nil (causes a DB error)
+                                  instrument.instrument_statuses.create!(is_on: status || NUCore::Database.boolean(false))
+                                end
       rescue => e
         logger.error e.message
         @instrument_statuses << InstrumentStatus.new(instrument: instrument, error_message: e.message)

--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -74,7 +74,7 @@ class ProductsCommonController < ApplicationController
     end
 
     # is the user approved?
-    if true#add_to_cart && !@product.can_be_used_by?(acting_user) && !session_user_can_override_restrictions?(@product)
+    if add_to_cart && !@product.can_be_used_by?(acting_user) && !session_user_can_override_restrictions?(@product)
       if SettingsHelper.feature_on?(:training_requests)
         if TrainingRequest.submitted?(session_user, @product)
           flash[:notice] = text(".already_requested_access", product: @product)

--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -90,7 +90,7 @@ class ProductsCommonController < ApplicationController
 
     if @error
       flash.now[:notice] = text(@error, singular: @product.class.model_name.downcase,
-        plural: @product.class.model_name.human(count: 2).downcase)
+                                        plural: @product.class.model_name.human(count: 2).downcase)
     end
 
     @add_to_cart = add_to_cart

--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -74,10 +74,10 @@ class ProductsCommonController < ApplicationController
     end
 
     # is the user approved?
-    if add_to_cart && !@product.can_be_used_by?(acting_user) && !session_user_can_override_restrictions?(@product)
+    if true#add_to_cart && !@product.can_be_used_by?(acting_user) && !session_user_can_override_restrictions?(@product)
       if SettingsHelper.feature_on?(:training_requests)
         if TrainingRequest.submitted?(session_user, @product)
-          flash[:notice] = t_model_error(Product, "already_requested_access", product: @product)
+          flash[:notice] = text(".already_requested_access", product: @product)
           return redirect_to facility_path(current_facility)
         else
           return redirect_to new_facility_product_training_request_path(current_facility, @product)
@@ -88,7 +88,10 @@ class ProductsCommonController < ApplicationController
       end
     end
 
-    flash.now[:notice] = t_model_error(@product.class, @error) if @error
+    if @error
+      flash.now[:notice] = text(@error, singular: @product.class.model_name.downcase,
+        plural: @product.class.model_name.human(count: 2).downcase)
+    end
 
     @add_to_cart = add_to_cart
     @active_tab = "home"
@@ -145,6 +148,12 @@ class ProductsCommonController < ApplicationController
   def manage
     authorize! :view_details, @product
     @active_tab = "admin_products"
+  end
+
+  protected
+
+  def translation_scope
+    "controllers.products_common"
   end
 
   private

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -159,7 +159,7 @@ class ReservationsController < ApplicationController
     @reservation = next_available || default_reservation
     @reservation.round_reservation_times
     unless @instrument.can_be_used_by?(acting_user)
-      flash[:notice] = t_model_error(Instrument, "acting_as_not_on_approval_list")
+      flash[:notice] = text(".acting_as_not_on_approval_list")
     end
     set_windows
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -128,6 +128,7 @@ class UsersController < ApplicationController
   # GET /facilities/:facility_id/users/:id
   def show
     @user = User.find(params[:id])
+    save_user_success
   end
 
   # GET /facilities/:facility_id/users/:user_id/access_list
@@ -196,9 +197,10 @@ class UsersController < ApplicationController
   end
 
   def save_user_success
-    flash[:notice] = I18n.t("users.create.success")
+    flash[:notice] = text("create.success")
     if session_user.manager_of?(current_facility)
-      flash[:notice] = (flash[:notice] + "  You may wish to <a href=\"#{facility_facility_user_map_user_path(current_facility, @user)}\">add a facility role</a> for this user.").html_safe
+      add_role = html("create.add_role", link: facility_facility_user_map_user_path(current_facility, @user), inline: true)
+      flash[:notice].safe_concat(add_role)
     end
     Notifier.delay.new_user(user: @user, password: nil)
     redirect_to facility_users_path(user: @user.id)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,5 @@
 class Product < ActiveRecord::Base
+
   include TextHelpers::Translation
 
   belongs_to :facility

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,5 @@
 class Product < ActiveRecord::Base
+  include TextHelpers::Translation
 
   belongs_to :facility
   belongs_to :initial_order_status, class_name: "OrderStatus"
@@ -25,7 +26,7 @@ class Product < ActiveRecord::Base
 
   # Use lambda so we can dynamically enable/disable in specs
   validate if: -> { SettingsHelper.feature_on?(:product_specific_contacts) } do
-    errors.add(:contact_email, :required) unless email.present?
+    errors.add(:contact_email, text("errors.models.product.attributes.contact_email.required")) unless email.present?
   end
 
   validate do |record|
@@ -224,6 +225,12 @@ class Product < ActiveRecord::Base
 
   def training_request_contacts=(str)
     self[:training_request_contacts] = CsvArrayString.new(str).to_s
+  end
+
+  protected
+
+  def translation_scope
+    self.class.i18n_scope
   end
 
   private

--- a/app/views/notifier/order_receipt.html.haml
+++ b/app/views/notifier/order_receipt.html.haml
@@ -1,19 +1,22 @@
 - if @greeting.present?
   %p= @greeting
 
-%ul
-  %li
-    %label= text(".label.ordered_at")
-    = l(@order.ordered_at, format: :receipt)
-  %li
-    %label= OrderDetail.human_attribute_name(:facility)
-    = @order.facility
-  %li
-    %label= OrderDetail.human_attribute_name(:ordered_by)
-    = @order.created_by_user.full_name
-  %li
-    %label= OrderDetail.human_attribute_name(:account)
-    = @order.account
+%table{ border: 0 }
+  %tr
+    %td= Order.human_attribute_name(:ordered_at)
+    %td= l(@order.ordered_at, format: :receipt)
+
+  %tr
+    %td= Facility.model_name.human
+    %td= @order.facility
+  %tr
+    %td= OrderDetail.human_attribute_name(:ordered_by)
+    %td= @order.created_by_user.full_name
+  %tr
+    %td= Account.model_name.human
+    %td= @order.account
+
+%hr
 
 %table.table.table-striped.table-hover
   %thead

--- a/app/views/notifier/order_receipt.text.haml
+++ b/app/views/notifier/order_receipt.text.haml
@@ -2,10 +2,10 @@
   #{@greeting}
 ==
 
-#{text(".label.ordered_at")}: #{l(@order.ordered_at, format: :receipt)}
-#{OrderDetail.human_attribute_name(:facility)}: #{@order.facility}
+#{Order.human_attribute_name(:ordered_at)}: #{l(@order.ordered_at, format: :receipt)}
+#{Facility.model_name.human}: #{@order.facility}
 #{OrderDetail.human_attribute_name(:ordered_by)}: #{@order.created_by_user.full_name}
-#{OrderDetail.human_attribute_name(:account)}: #{@order.account}
+#{Account.model_name.human}: #{@order.account}
 ==
 = OrderDetail.model_name.titleize.pluralize
 = "========================================"

--- a/app/views/training_requests/new.html.haml
+++ b/app/views/training_requests/new.html.haml
@@ -1,7 +1,7 @@
 = content_for :h1 do
   = current_facility
 
-= t("activerecord.errors.models.product.requires_approval", product: @product)
+= text(".requires_approval", product: @product)
 
 = form_tag facility_product_training_requests_path do
   = submit_tag t("boolean.true"), class: "btn"

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -58,42 +58,12 @@ en:
           password_too_short: must be at least 6 characters long
           invalid_token: The token is either invalid or has expired.
         product:
-          already_requested_access: You have requested that the core contact you regarding access or training for %{product}.
           attributes:
             contact_email:
               required: must be set on either the product or the facility
-          requires_approval: The %{product} requires approval to reserve. Would you like to be contacted by the core for access or training?
         instrument:
-          not_available: The %{instrument} instrument is currently unavailable for reservation online.
-          requires_approval_html: |
-            The %{instrument} instrument requires approval to reserve;
-            please contact the facility for further information:<br/><br/>
-            %{facility}<br/>
-            <a href=\"mailto:%{email}\">%{email}</a>
-          acting_as_not_on_approval_list: The user you are ordering for is not on the authorized list for this instrument.
-          no_accounts: "Sorry, but we could not find a valid payment source that you can use to reserve this instrument"
-          no_price_groups: "You are not in a price group that may reserve instrument %{instrument_name}; please contact the facility."
-          not_authorized_to_order_on_behalf: You are not authorized to order instruments from this facility on behalf of a user.
           not_interval: "must be a multiple of the interval (%{reserve_interval})"
           max_less_than_min: "must be greater than or equal to minimum reservation minutes"
-        item:
-          not_available: This item is currently unavailable for purchase online.
-          requires_approval: This item requires approval to purchase; please contact the facility.
-          not_in_price_group: You are not in a price group that may purchase this item; please contact the facility.
-          not_authorized_acting_as: You are not authorized to order items from this facility on behalf of a user.
-          no_accounts: "Sorry, but we could not find a valid payment source that you can use to purchase this item"
-        service:
-          not_available: This service is currently unavailable for purchase online.
-          requires_approval: This service requires approval to purchase; please contact the facility.
-          not_in_price_group: You are not in a price group that may purchase this service; please contact the facility.
-          not_authorized_acting_as: You are not authorized to order services from this facility on behalf of a user.
-          no_accounts: "Sorry, but we could not find a valid payment source that you can use to purchase this service"
-        bundle:
-          not_available: This bundle is currently unavailable for purchase online.
-          requires_approval: This bundle requires approval to purchase; please contact the facility.
-          not_in_price_group: You are not in a price group that may purchase this bundle; please contact the facility.
-          not_authorized_acting_as: You are not authorized to order bundles from this facility on behalf of a user.
-          no_accounts: "Sorry, but we could not find a valid payment source that you can use to purchase this bundle"
         order_detail:
           changing_status: There was an error trying to change the status of the order.
         reservation:

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -60,7 +60,7 @@ en:
         product:
           attributes:
             contact_email:
-              required: must be set on either the product or the facility
+              required: must be set on either the product or the !facility_downcase!
         instrument:
           not_interval: "must be a multiple of the interval (%{reserve_interval})"
           max_less_than_min: "must be greater than or equal to minimum reservation minutes"
@@ -222,7 +222,6 @@ en:
         estimated_cost: Estimated Price
         estimated_subsidy: Estimated Adjustment
         estimated_total: Estimated Total
-        facility: Facility
         fulfilled_at: Fulfilled Date
         id: "Order #"
         journal_date: Journal Date

--- a/config/locales/en.notifier.yml
+++ b/config/locales/en.notifier.yml
@@ -13,8 +13,6 @@ en:
       order_receipt:
         subject: "!app_name! Order Receipt"
         intro: "Thank you for your order on the !app_name! website."
-        label:
-          ordered_at: Ordered at
         outro: "All prices are estimates. Actual cost is assigned when the order is complete."
         total: Total
       order_status_changed_to_approved:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -957,9 +957,8 @@ en:
       label:
         id: "NetID"
         have_id: "Does the new user have a NetID?"
-    create:
-      error: There was an error creating the user.
-      success: The user has been added successfully.
+
+
 
     search:
       main_html: "You may add a new external user by clicking <a href=\"%{link}\">Add a new external user</a>."

--- a/config/locales/views/admin/en.facilities.yml
+++ b/config/locales/views/admin/en.facilities.yml
@@ -18,3 +18,10 @@ en:
         order_notification: |
           This email address will be notified when an order is placed by a user
           (if left blank, notifications will not be sent)
+
+  controllers:
+    facilities:
+      create:
+        success: "The !facility_downcase! was successfully created."
+      update:
+        success: "The !facility_downcase! was successfully updated."

--- a/config/locales/views/admin/en.facility_facility_accounts.yml
+++ b/config/locales/views/admin/en.facility_facility_accounts.yml
@@ -11,3 +11,11 @@ en:
         inactive: "(inactive)"
       new:
         head: "Add Recharge Chart String"
+
+  controllers:
+    facility_facility_accounts:
+      create:
+        success: "%{model} was successfully created"
+      update:
+        success: "%{model} was successfully updated."
+

--- a/config/locales/views/admin/en.users.yml
+++ b/config/locales/views/admin/en.users.yml
@@ -7,3 +7,11 @@ en:
           Active users are users which have placed an order or had an order placed
           on their behalf at this !facility_downcase! in the last year.
         no_users: There are no active users for this !facility_downcase!.
+
+  controllers:
+    users:
+      create:
+        error: There was an error creating the user.
+        success: The user has been added successfully.
+        add_role: |
+          You may wish to [add a !facility_downcase! role](%{link}) for this user.

--- a/config/locales/views/en.products.yml
+++ b/config/locales/views/en.products.yml
@@ -1,0 +1,37 @@
+en:
+  controllers:
+    instruments:
+      requires_approval: |
+        The %{instrument} instrument requires approval to reserve;
+        please contact the !facility_downcase! for further information:
+
+        %{facility}
+
+        [%{email}](mailto:%{email})
+      not_available: |
+        The %{instrument} instrument is currently unavailable for reservation online.
+      no_accounts: "Sorry, but we could not find a valid payment source that you can use to reserve this instrument"
+      no_price_groups: |
+        You are not in a price group that may reserve instrument %{instrument_name};
+        please contact the !facility_downcase!.
+      not_authorized_to_order_on_behalf: |
+        You are not authorized to order instruments from this !facility_downcase!
+        on behalf of a user.
+
+    products_common:
+      already_requested_access: |
+        You have requested that the !facility_downcase! contact you regarding
+        access or training for %{product}.
+      not_available: "This %{singular} is currently unavailable for purchase online."
+      not_authorized_acting_as: |
+        You are not authorized to order %{plural} from this !facility_downcase!
+        on behalf of a user.
+      no_accounts: |
+        Sorry, but we could not find a valid payment source that you can use to
+        purchase this %{singular}
+      not_in_price_group: |
+        You are not in a price group that may purchase this %{singular}; please contact
+        the !facility_downcase!.
+      requires_approval: |
+        This %{singular} requires approval to purchase; please contact the !facility_downcase!.
+

--- a/config/locales/views/en.reservations.yml
+++ b/config/locales/views/en.reservations.yml
@@ -1,0 +1,4 @@
+en:
+  controllers:
+    reservations:
+      acting_as_not_on_approval_list: The user you are ordering for is not on the authorized list for this instrument.

--- a/config/locales/views/en.training_requests.yml
+++ b/config/locales/views/en.training_requests.yml
@@ -1,0 +1,7 @@
+en:
+  views:
+    training_requests:
+      new:
+        requires_approval: |
+          The %{product} requires approval to reserve. Would you like to be
+          contacted by the !facility_downcase! for access or training?

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Notifier do
     it "generates an order notification", :aggregate_failures do
       expect(email.to).to eq [recipient]
       expect(email.subject).to include("Order Notification")
-      expect(email.html_part.to_s).to match(/Ordered By.+\n#{user.full_name}/)
+      expect(email.html_part.to_s).to match(/Ordered By.+#{user.full_name}/m)
       expect(email.text_part.to_s).to include("Ordered By: #{user.full_name}")
       expect(email.html_part.to_s).to match(/Payment Source.+#{order.account}/m)
       expect(email.text_part.to_s).to include("Payment Source: #{order.account}")
@@ -35,7 +35,7 @@ RSpec.describe Notifier do
     it "generates a receipt", :aggregate_failures do
       expect(email.to).to eq [user.email]
       expect(email.subject).to include("Order Receipt")
-      expect(email.html_part.to_s).to match(/Ordered By.+\n#{user.full_name}/)
+      expect(email.html_part.to_s).to match(/Ordered By.+#{user.full_name}/m)
       expect(email.text_part.to_s).to include("Ordered By: #{user.full_name}")
       expect(email.html_part.to_s).to match(/Payment Source.+#{order.account}/m)
       expect(email.text_part.to_s).to include("Payment Source: #{order.account}")
@@ -49,7 +49,7 @@ RSpec.describe Notifier do
 
       it "mentions who placed the order in the receipt", :aggregate_failures do
         expect(email.html_part.to_s)
-          .to match(/Ordered By.+\n#{administrator.full_name}/)
+          .to match(/Ordered By.+#{administrator.full_name}/m)
         expect(email.text_part.to_s)
           .to include("Ordered By: #{administrator.full_name}")
       end


### PR DESCRIPTION
This takes care of what #566 did not. After this, there should be no more references to "facility" or "facilities" directly in any strings. They should all go through `facility_downcase` or `model_name.human`.