### PR TITLE
[#125075] Manual reconciliation date updates

### DIFF
--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -100,8 +100,7 @@ class FacilityJournalsController < ApplicationController
   end
 
   def reconcile
-    reconciled_at = parse_usa_date(params[:reconciled_at])
-    reconciler = OrderDetails::Reconciler.new(@journal.order_details, params[:order_detail], reconciled_at)
+    reconciler = OrderDetails::Reconciler.new(@journal.order_details, params[:order_detail], @journal.journal_date)
 
     if reconciler.reconcile_all > 0
       count = reconciler.count

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -411,7 +411,7 @@ class OrderDetail < ActiveRecord::Base
   aasm_state            :new
   aasm_state            :inprocess
   aasm_state            :complete, enter: :make_complete
-  aasm_state            :reconciled
+  aasm_state            :reconciled, enter: :set_reconciled_at
   aasm_state            :canceled, enter: :clear_costs
 
   aasm_event :to_new do
@@ -1005,6 +1005,11 @@ class OrderDetail < ActiveRecord::Base
     if problem_changed? && !problem_order?
       self.fulfilled_at = reservation.reserve_end_at
     end
+  end
+
+  def set_reconciled_at
+    # Do not override it if it has been set by something already (e.g. journaling)
+    self.reconciled_at ||= Time.current
   end
 
 end

--- a/app/models/reports/export_raw.rb
+++ b/app/models/reports/export_raw.rb
@@ -129,6 +129,7 @@ class Reports::ExportRaw
       statemented_on: -> (od) { od.statement.created_at if od.statement },
       journal_date: -> (od) { od.journal.journal_date if od.journal },
       reconciled_note: :reconciled_note,
+      reconciled_at: :reconciled_at,
     }
   end
 

--- a/app/support/journals/closer.rb
+++ b/app/support/journals/closer.rb
@@ -62,7 +62,7 @@ class Journals::Closer
   end
 
   def reconciled_at
-    Time.current
+    @journal.journal_date
   end
 
 end

--- a/app/views/facility_journals/show.html.haml
+++ b/app/views/facility_journals/show.html.haml
@@ -37,10 +37,12 @@
 - else
   = form_tag facility_journal_reconcile_path(current_facility, @journal), method: :post do
     - journal_is_submittable = @journal.submittable?
-    - if journal_is_submittable
-      = render "facility_accounts_reconciliation/action_row", date: true, unreconciled_order_details: @order_details, starting: :all
     %table.table.table-striped.table-hover
       %thead
+        - if journal_is_submittable
+          %tr.borderless
+            %th{colspan: 3}= link_to "Select All", "JavaScript:void(0);", class: "select_all"
+            %th.currency{colspan: 3}= submit_tag t(".submit"), class: "btn btn-primary"
         %tr
           - if journal_is_submittable
             %th
@@ -64,5 +66,8 @@
             %td= order_detail.account
             %td= number_to_currency(order_detail.total)
             %td= order_detail.reconciled? ? t("boolean.true") : t("boolean.false")
-    - if journal_is_submittable
-      = render "facility_accounts_reconciliation/action_row", starting: :all
+        - if journal_is_submittable
+          %tr.borderless
+            %td{colspan: 3}
+            %td.currency{colspan: 3}= submit_tag t(".submit"), class: "btn btn-primary"
+

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -161,6 +161,7 @@ en:
         statemented_on: 'Statemented On'
         journal_date: 'Journal Date'
         reconciled_note: 'Reconciled Note'
+        reconciled_at: "Reconciled At"
 
     notifications:
       no_notices: "You have no notifications at this time"

--- a/db/migrate/20160426231556_add_reconciliation_date_to_order_detail.rb
+++ b/db/migrate/20160426231556_add_reconciliation_date_to_order_detail.rb
@@ -2,15 +2,8 @@ class AddReconciliationDateToOrderDetail < ActiveRecord::Migration
   def up
     add_column :order_details, :reconciled_at, :datetime
 
-    OrderDetail.where(state: "reconciled").find_each do |od|
-      if od.statement
-        od.update_attribute(:reconciled_at, od.statement.created_at)
-      elsif od.journal
-        od.update_attribute(:reconciled_at, od.journal.journal_date)
-      else
-        # TODO: What do we do with these
-        od.update_attribute(:reconciled_at, od.reviewed_at)
-      end
+    OrderDetail.where(state: "reconciled").where("journal_id IS NOT NULL").find_each do |od|
+      od.update_attribute(:reconciled_at, od.journal.journal_date)
     end
   end
 

--- a/vendor/engines/split_accounts/app/models/split_accounts/reports/export_raw_transformer.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/reports/export_raw_transformer.rb
@@ -9,7 +9,7 @@ module SplitAccounts
       include ActionView::Helpers::NumberHelper
 
       def transform(original_hash)
-        insert_into_hash_after(original_hash, :reconciled_note, split_percent: method(:split_percent))
+        insert_into_hash_after(original_hash, :actual_total, split_percent: method(:split_percent))
       end
 
       private


### PR DESCRIPTION
These are based on feedback from our last discussion with NU about the feature.

One big thing we decided was to leave historical non-journaled reconciliation dates blank. They'd rather have no data than incorrect data. Journaled orders' reconciled_at will always be set to the journal_date.

Also, they gave us the go ahead to change the export raw template so I moved the split percentage to a spot where it makes a little more logical grouping.

The migrations haven't gone out on NU & UIC, and there is no important data on DC, so I felt OK changing the migration in place.