### PR TITLE
[#126102] Permission fixes

### DIFF
--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -203,7 +203,8 @@ class Ability
 
   def order_details_ability(user, resource)
     # Purchaser
-    can [:add_accessories, :sample_results, :show, :update, :cancel, :template_results], OrderDetail, order: { user_id: user.id }
+    can [:add_accessories, :sample_results, :show, :update, :cancel, :template_results,
+         :order_file, :upload_order_file, :remove_order_file], OrderDetail, order: { user_id: user.id }
     # Facility managers
     can :manage, OrderDetail, order: { facility_id: resource.order.facility_id } if user.operator_of?(resource.facility)
     # Account owners/business admins

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -203,11 +203,11 @@ class Ability
 
   def order_details_ability(user, resource)
     # Purchaser
-    can [:add_accessories, :sample_results, :show, :update, :template_results], OrderDetail, order: { user_id: user.id }
+    can [:add_accessories, :sample_results, :show, :update, :cancel, :template_results], OrderDetail, order: { user_id: user.id }
     # Facility managers
     can :manage, OrderDetail, order: { facility_id: resource.order.facility_id } if user.operator_of?(resource.facility)
     # Account owners/business admins
-    can [:show, :update, :cancel, :dispute], OrderDetail, account: { id: resource.account_id } if user.account_administrator_of?(resource.account)
+    can [:show, :update, :dispute], OrderDetail, account: { id: resource.account_id } if user.account_administrator_of?(resource.account)
   end
 
   def user_has_facility_role?(user)


### PR DESCRIPTION
In #543, we refactored some of the OrderDetailsController permissions and accidentally removed the order form actions and gave :cancel permission to the account admins instead of the purchaser.