### PR TITLE
Fix i18n route specs 119019273

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,7 +28,7 @@ en:
   Facility: "!activerecord.models.facility.one!"
   Facilities: "!activerecord.models.facility.other!"
   facility_downcase: facility
-  facilities_downcase: resources
+  facilities_downcase: facilities
 
   admin:
     shared:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,7 +28,7 @@ en:
   Facility: "!activerecord.models.facility.one!"
   Facilities: "!activerecord.models.facility.other!"
   facility_downcase: facility
-  facilities_downcase: facilities
+  facilities_downcase: resources
 
   admin:
     shared:

--- a/spec/controllers/facilities_controller_spec.rb
+++ b/spec/controllers/facilities_controller_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe FacilitiesController do
   render_views
 
   it "should route" do
-    expect(get: "/facilities").to route_to(controller: "facilities", action: "index")
-    expect(get: "/facilities/url_name").to route_to(controller: "facilities", action: "show", id: "url_name")
-    expect(get: "/facilities/url_name/manage").to route_to(controller: "facilities", action: "manage", id: "url_name")
+    expect(get: "/#{facilities_route}").to route_to(controller: "facilities", action: "index")
+    expect(get: "/#{facilities_route}/url_name").to route_to(controller: "facilities", action: "show", id: "url_name")
+    expect(get: "/#{facilities_route}/url_name/manage").to route_to(controller: "facilities", action: "manage", id: "url_name")
   end
 
   before(:all) { create_users }
@@ -58,7 +58,7 @@ RSpec.describe FacilitiesController do
 
     it_should_allow :admin do
       expect(facility).to be_valid
-      expect(response).to redirect_to "/facilities/anf/manage"
+      expect(response).to redirect_to manage_facility_path("anf")
     end
 
     describe "as an admin" do

--- a/spec/controllers/facilities_controller_spec.rb
+++ b/spec/controllers/facilities_controller_spec.rb
@@ -5,7 +5,7 @@ require "transaction_search_spec_helper"
 RSpec.describe FacilitiesController do
   render_views
 
-  it "should route" do
+  it "routes", :aggregate_failures do
     expect(get: "/#{facilities_route}").to route_to(controller: "facilities", action: "index")
     expect(get: "/#{facilities_route}/url_name").to route_to(controller: "facilities", action: "show", id: "url_name")
     expect(get: "/#{facilities_route}/url_name/manage").to route_to(controller: "facilities", action: "manage", id: "url_name")

--- a/spec/controllers/file_uploads_controller_spec.rb
+++ b/spec/controllers/file_uploads_controller_spec.rb
@@ -4,7 +4,7 @@ require "controller_spec_helper"
 RSpec.describe FileUploadsController do
   render_views
 
-  it "should route" do
+  it "routes", :aggregate_failures do
     expect(get: "/#{facilities_route}/alpha/services/1/files/upload").to route_to(controller: "file_uploads", action: "upload", facility_id: "alpha", product: "services", product_id: "1")
     expect(post: "/#{facilities_route}/alpha/services/1/files").to route_to(controller: "file_uploads", action: "create", facility_id: "alpha", product: "services", product_id: "1")
   end

--- a/spec/controllers/file_uploads_controller_spec.rb
+++ b/spec/controllers/file_uploads_controller_spec.rb
@@ -5,10 +5,8 @@ RSpec.describe FileUploadsController do
   render_views
 
   it "should route" do
-    expect(get: "/facilities/alpha/services/1/files/upload").to route_to(controller: "file_uploads", action: "upload", facility_id: "alpha", product: "services", product_id: "1")
-    expect(post: "/facilities/alpha/services/1/files").to route_to(controller: "file_uploads", action: "create", facility_id: "alpha", product: "services", product_id: "1")
-    # params_from(:post, "/facilities/alpha/services/1/yui_files").should ==
-    #   {:controller => 'file_uploads', :action => 'yui_create', :facility_id => 'alpha', :product => 'services', :product_id => '1'}
+    expect(get: "/#{facilities_route}/alpha/services/1/files/upload").to route_to(controller: "file_uploads", action: "upload", facility_id: "alpha", product: "services", product_id: "1")
+    expect(post: "/#{facilities_route}/alpha/services/1/files").to route_to(controller: "file_uploads", action: "create", facility_id: "alpha", product: "services", product_id: "1")
   end
 
   before(:all) { create_users }

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe InstrumentsController do
   render_views
 
   it "should route" do
-    expect(get: "/facilities/alpha/instruments").to route_to(controller: "instruments", action: "index", facility_id: "alpha")
-    expect(get: "/facilities/alpha/instruments/1/manage").to route_to(controller: "instruments", action: "manage", id: "1", facility_id: "alpha")
+    expect(get: "/#{I18n.t('facilities_downcase')}/alpha/instruments").to route_to(controller: "instruments", action: "index", facility_id: "alpha")
+    expect(get: "/#{I18n.t('facilities_downcase')}/alpha/instruments/1/manage").to route_to(controller: "instruments", action: "manage", id: "1", facility_id: "alpha")
   end
 
   before(:all) { create_users }

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe ItemsController do
   render_views
 
   it "should route" do
-    expect(get: "/facilities/url_name/items").to route_to(controller: "items", action: "index", facility_id: "url_name")
-    expect(get: "/facilities/url_name/items/1").to route_to(controller: "items", action: "show", facility_id: "url_name", id: "1")
+    expect(get: "/#{I18n.t('facilities_downcase')}/url_name/items").to route_to(controller: "items", action: "index", facility_id: "url_name")
+    expect(get: "/#{I18n.t('facilities_downcase')}/url_name/items/1").to route_to(controller: "items", action: "show", facility_id: "url_name", id: "1")
   end
 
   before(:all) { create_users }

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ServicesController do
 
   render_views
 
-  it "should route" do
+  it "routes", :aggregate_failures do
     expect(get: "/#{facilities_route}/alpha/services").to route_to(controller: "services", action: "index", facility_id: "alpha")
     expect(get: "/#{facilities_route}/alpha/services/1/manage").to route_to(controller: "services", action: "manage", id: "1", facility_id: "alpha")
   end

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe ServicesController do
   render_views
 
   it "should route" do
-    expect(get: "/facilities/alpha/services").to route_to(controller: "services", action: "index", facility_id: "alpha")
-    expect(get: "/facilities/alpha/services/1/manage").to route_to(controller: "services", action: "manage", id: "1", facility_id: "alpha")
+    expect(get: "/#{facilities_route}/alpha/services").to route_to(controller: "services", action: "index", facility_id: "alpha")
+    expect(get: "/#{facilities_route}/alpha/services/1/manage").to route_to(controller: "services", action: "manage", id: "1", facility_id: "alpha")
   end
 
   before(:all) { create_users }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -188,10 +188,10 @@ RSpec.describe UsersController do
     context "disabled" do
       include_context "feature disabled", :create_users
       it "doesn't route route" do
-        expect(get: "/facilities/url_name/users/new").not_to be_routable
-        expect(post: "/facilities/url_name/users").not_to be_routable
-        expect(get: "/facilities/url_name/users/new_external").not_to be_routable
-        expect(post: "/facilities/url_name/users/search").not_to be_routable
+        expect(get: "/#{facilities_route}/url_name/users/new").not_to be_routable
+        expect(post: "/#{facilities_route}/url_name/users").not_to be_routable
+        expect(get: "/#{facilities_route}/url_name/users/new_external").not_to be_routable
+        expect(post: "/#{facilities_route}/url_name/users/search").not_to be_routable
       end
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -49,11 +49,11 @@ RSpec.describe UsersController do
     context "enabled" do
       include_context "feature enabled", :create_users
 
-      it "routes" do
-        expect(get: "/facilities/url_name/users/new").to route_to(controller: "users", action: "new", facility_id: "url_name")
-        expect(post: "/facilities/url_name/users").to route_to(controller: "users", action: "create", facility_id: "url_name")
-        expect(get: "/facilities/url_name/users/new_external").to route_to(controller: "users", action: "new_external", facility_id: "url_name")
-        expect(post: "/facilities/url_name/users/search").to route_to(controller: "users", action: "search", facility_id: "url_name")
+      it "routes", :aggregate_failures do
+        expect(get: "/#{facilities_route}/url_name/users/new").to route_to(controller: "users", action: "new", facility_id: "url_name")
+        expect(post: "/#{facilities_route}/url_name/users").to route_to(controller: "users", action: "create", facility_id: "url_name")
+        expect(get: "/#{facilities_route}/url_name/users/new_external").to route_to(controller: "users", action: "new_external", facility_id: "url_name")
+        expect(post: "/#{facilities_route}/url_name/users/search").to route_to(controller: "users", action: "search", facility_id: "url_name")
       end
 
       context "search" do

--- a/spec/helpers/accounts_helper_spec.rb
+++ b/spec/helpers/accounts_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe AccountsHelper do
     context "when allowed to manage the account" do
       let(:allowed?) { true }
       let(:expected_path) do
-        "/facilities/#{current_facility.url_name}/accounts/#{account.id}"
+        facility_account_path(current_facility, account)
       end
 
       it { is_expected.to include(expected_path).and include(account.to_s) }

--- a/spec/presenters/order_detail_presenter_spec.rb
+++ b/spec/presenters/order_detail_presenter_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe OrderDetailPresenter do
     include_context "order with a reservation"
 
     let(:expected_path) do
-      "/facilities/#{facility.url_name}/orders/#{order.id}/order_details/"\
+      "/#{facilities_route}/#{facility.url_name}/orders/#{order.id}/order_details/"\
       "#{order_detail.id}/reservations/#{reservation.id}/edit"
     end
 
@@ -140,7 +140,7 @@ RSpec.describe OrderDetailPresenter do
 
     include_context "order with a reservation"
 
-    it { is_expected.to eq("/facilities/#{facility.url_name}/orders/#{order.id}") }
+    it { is_expected.to eq("/#{facilities_route}/#{facility.url_name}/orders/#{order.id}") }
   end
 
   describe "#show_reservation_path" do
@@ -149,7 +149,7 @@ RSpec.describe OrderDetailPresenter do
     include_context "order with a reservation"
 
     let(:expected_path) do
-      "/facilities/#{facility.url_name}/orders/#{order.id}/order_details/"\
+      "/#{facilities_route}/#{facility.url_name}/orders/#{order.id}/order_details/"\
       "#{order_detail.id}/reservations/#{reservation.id}"
     end
 

--- a/spec/presenters/statement_presenter_spec.rb
+++ b/spec/presenters/statement_presenter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe StatementPresenter do
     it "returns a download path to the PDF version of the statement" do
       if Account.config.statements_enabled?
         expect(subject.download_path)
-          .to eq("/facilities/#{facility.url_name}/accounts/#{account.id}/statements/#{statement.id}.pdf")
+          .to eq("/#{facilities_route}/#{facility.url_name}/accounts/#{account.id}/statements/#{statement.id}.pdf")
       end
     end
   end

--- a/spec/price_policies_controller_shared_examples.rb
+++ b/spec/price_policies_controller_shared_examples.rb
@@ -463,7 +463,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
   private
 
   def price_policy_index_path
-    "/facilities/#{@authable.url_name}/#{@product_type.to_s.pluralize}/#{@product.url_name}/price_policies"
+    send("facility_#{@product_type.to_s}_price_policies_path", @authable, @product)
   end
 
   def make_price_policy(price_group, extra_attr = {})

--- a/spec/price_policies_controller_shared_examples.rb
+++ b/spec/price_policies_controller_shared_examples.rb
@@ -463,7 +463,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
   private
 
   def price_policy_index_path
-    send("facility_#{@product_type.to_s}_price_policies_path", @authable, @product)
+    send("facility_#{@product_type}_price_policies_path", @authable, @product)
   end
 
   def make_price_policy(price_group, extra_attr = {})

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -92,6 +92,10 @@ RSpec.configure do |config|
     TextHelpers::RSpec.reset_spec_translations
   end
 
+  def facilities_route
+    I18n.t("facilities_downcase")
+  end
+
 end
 
 FactoryGirl::SyntaxRunner.class_eval do

--- a/vendor/engines/c2po/spec/routing/reconciliation_spec.rb
+++ b/vendor/engines/c2po/spec/routing/reconciliation_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "FacilityAccountsReconciliationController" do
   it "routes credit_cards" do
-    expect(get("/facilities/test-facility/accounts/credit_cards"))
+    expect(get("/#{facilities_route}/test-facility/accounts/credit_cards"))
       .to route_to(controller: "facility_accounts_reconciliation",
                    action: "index",
                    facility_id: "test-facility",
@@ -10,7 +10,7 @@ RSpec.describe "FacilityAccountsReconciliationController" do
   end
 
   it "routes purchase_orders" do
-    expect(get("/facilities/test-facility/accounts/purchase_orders"))
+    expect(get("/#{facilities_route}/test-facility/accounts/purchase_orders"))
       .to route_to(controller: "facility_accounts_reconciliation",
                    action: "index",
                    facility_id: "test-facility",
@@ -18,7 +18,7 @@ RSpec.describe "FacilityAccountsReconciliationController" do
   end
 
   it "does not allow overriding the account_type" do
-    expect(get("/facilities/test-facility/accounts/purchase_orders?account_type=CreditCardAccount"))
+    expect(get("/#{facilities_route}/test-facility/accounts/purchase_orders?account_type=CreditCardAccount"))
       .to route_to(controller: "facility_accounts_reconciliation",
                    action: "index",
                    facility_id: "test-facility",


### PR DESCRIPTION
I tried to only use the I18n version in routing specs and elsewhere
switch to the url helper methods. I also kept them using string routes
in presenters because switching to the helpers ends up just asserting
exactly what the methods do.

DC’s latest pull.