### PR TITLE
[#116374999] Fix Project Filter on Transactions view

### DIFF
--- a/app/inputs/transaction_chosen_input.rb
+++ b/app/inputs/transaction_chosen_input.rb
@@ -11,10 +11,14 @@ class TransactionChosenInput < SimpleForm::Inputs::Base # CollectionSelectInput
     # which were slowing down the page.
     collection_size = collection_items.to_a.size
 
-    search_fields[attribute_name] = [collection_items.first.send(options[:value_method].to_sym)] if collection_size == 1
-
     select_options = { :multiple => true, :"data-placeholder" => placeholder_label }
-    select_options[:disabled] = :disabled unless collection_size > 1
+
+    # If there is only one possible value, then we want to show it, and not allow
+    # selection, but only if it's not a nullable field
+    if collection_size <= 1 && !options[:allow_blank]
+      search_fields[attribute_name] = [collection_items.first.send(options[:value_method].to_sym)]
+      select_options[:disabled] = :disabled
+    end
 
     template.select_tag(attribute_name, option_data, select_options).html_safe
   end

--- a/app/inputs/transaction_chosen_input.rb
+++ b/app/inputs/transaction_chosen_input.rb
@@ -15,7 +15,7 @@ class TransactionChosenInput < SimpleForm::Inputs::Base # CollectionSelectInput
 
     # If there is only one possible value, then we want to show it, and not allow
     # selection, but only if it's not a nullable field
-    if collection_size <= 1 && !options[:allow_blank]
+    if collection_size == 1 && !options[:allow_blank]
       search_fields[attribute_name] = [collection_items.first.send(options[:value_method].to_sym)]
       select_options[:disabled] = :disabled
     end

--- a/lib/transaction_search.rb
+++ b/lib/transaction_search.rb
@@ -95,9 +95,10 @@ module TransactionSearch
   end
 
   def set_default_start_date
-    params[:date_range].try(:merge!,
-                            start: format_usa_date(1.month.ago.beginning_of_month),
-                           ) unless params[:date_range].try(:[], :start).present?
+    params[:date_range] ||= {}
+    if params[:date_range][:start].blank?
+      params[:date_range][:start] = format_usa_date(1.month.ago.beginning_of_month)
+    end
   end
 
   private

--- a/spec/controllers/facilities_controller_spec.rb
+++ b/spec/controllers/facilities_controller_spec.rb
@@ -308,7 +308,13 @@ RSpec.describe FacilitiesController do
   end
 
   context "transactions" do
-    it_behaves_like "transactions", :transactions
+    it_behaves_like "transactions", :transactions do
+      it "has a default date set" do
+        sign_in @admin
+        do_request
+        expect(controller.params[:date_range][:start]).to be_present
+      end
+    end
   end
 
   context "disputed_orders" do

--- a/vendor/engines/projects/app/views/projects/shared/transactions/_search.html.haml
+++ b/vendor/engines/projects/app/views/projects/shared/transactions/_search.html.haml
@@ -1,1 +1,1 @@
-= f.input :projects, as: :transaction_chosen, label: Projects::Project.model_name.human(count: 2)
+= f.input :projects, as: :transaction_chosen, label: Projects::Project.model_name.human(count: 2), allow_blank: true


### PR DESCRIPTION
If the page (all transaction, send notifications, etc) only has one
unique project, then that one project was being shown in the box and
the box was disabled. The logic was relying on the fact that all of the
other select fields were non-nullable.