### PR TITLE
[#124331] Bulk Email returns duplicates on authorized user search

### DIFF
--- a/app/services/bulk_email_searcher.rb
+++ b/app/services/bulk_email_searcher.rb
@@ -40,7 +40,7 @@ class BulkEmailSearcher
   end
 
   def search_authorized_users
-    result = users.joins(:product_users)
+    result = users.joins(:product_users).uniq
     # if we don't have any products, listed get them all for the current facility
     product_ids = search_fields[:products].presence || Facility.find(search_fields[:facility_id]).products.map(&:id)
     result.where(product_users: { product_id: product_ids }).reorder(*self.class::DEFAULT_SORT)

--- a/spec/services/bulk_email_searcher_spec.rb
+++ b/spec/services/bulk_email_searcher_spec.rb
@@ -225,17 +225,22 @@ RSpec.describe BulkEmailSearcher do
 
     it "returns all authorized users for any instrument" do
       params[:products] = []
-      expect(users).to contain_all [user, user2, user3]
+      expect(users).to contain_exactly(user, user2, user3)
     end
 
     it "returns only the users for the first product" do
       params[:products] = [product.id]
-      expect(users).to contain_all [user, user2]
+      expect(users).to contain_exactly(user, user2)
     end
 
     it "returns only the users for the second product" do
       params[:products] = [product2.id]
-      expect(users).to contain_all [user2, user3]
+      expect(users).to contain_exactly(user2, user3)
+    end
+
+    it "returns only the users for both products and no more" do
+      params[:products] = [product.id, product2.id]
+      expect(users).to contain_exactly(user, user2, user3)
     end
   end
 


### PR DESCRIPTION
If a user is authorized on multiple products, they will be returned as
multiple rows in the results.