### PR TITLE
[#115962501] Do not show save success strings on Users#show

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -128,7 +128,6 @@ class UsersController < ApplicationController
   # GET /facilities/:facility_id/users/:id
   def show
     @user = User.find(params[:id])
-    save_user_success
   end
 
   # GET /facilities/:facility_id/users/:user_id/access_list


### PR DESCRIPTION
I added this to make testing easier for #578 so I didn't have to go through the
full user creation process while testing the strings, but forgot to take it out
when I was done.