### PR TITLE
[#117175831] Missing argument on reports routing error

### DIFF
--- a/app/controllers/reports/reports_controller.rb
+++ b/app/controllers/reports/reports_controller.rb
@@ -23,7 +23,7 @@ module Reports
     def index
       @report_by = params[:report_by].presence
       index = reports.keys.find_index(@report_by)
-      raise ActionController::RoutingError unless index
+      raise ActionController::RoutingError, "Invalid report_by" unless index
       render_report(index + tab_offset, &reports[@report_by])
     end
 

--- a/spec/controllers/reports/general_reports_controller_spec.rb
+++ b/spec/controllers/reports/general_reports_controller_spec.rb
@@ -198,6 +198,22 @@ RSpec.describe Reports::GeneralReportsController do
     end
   end
 
+  describe "an invalid report type" do
+    let(:facility) { FactoryGirl.create(:facility) }
+    let(:user) { FactoryGirl.create(:user, :administrator) }
+    before { sign_in user }
+
+    it "returns a 404" do
+      get :index, report_by: "asdfasdf", facility_id: facility
+      expect(response.code).to eq("404")
+    end
+
+    it "returns a 404 for a blank report_by" do
+      get :index, facility_id: facility
+      expect(response.code).to eq("404")
+    end
+  end
+
   private
 
   def setup_extra_params(params)


### PR DESCRIPTION
RoutingError requires a message. The message should not get displayed
to the user, so it’s just for developers.