### PR TITLE
[#116374977] Enable pagination of order_details for Project "show" views

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -94,6 +94,7 @@ class OrderDetail < ActiveRecord::Base
   ## TODO validate order status is global or a member of the product's facility
   ## TODO validate which fields can be edited for which states
 
+  scope :by_ordered_at, -> { joins(:order).order("orders.ordered_at") }
   scope :with_product_type, ->(s) { { joins: :product, conditions: ["products.type = ?", s.to_s.capitalize] } }
 
   scope :batch_updatable, -> { where(dispute_at: nil, state: %w(new inprocess)) }

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -94,7 +94,7 @@ class OrderDetail < ActiveRecord::Base
   ## TODO validate order status is global or a member of the product's facility
   ## TODO validate which fields can be edited for which states
 
-  scope :by_ordered_at, -> { joins(:order).order("orders.ordered_at") }
+  scope :by_ordered_at, -> { joins(:order).order("orders.ordered_at DESC") }
   scope :with_product_type, ->(s) { { joins: :product, conditions: ["products.type = ?", s.to_s.capitalize] } }
 
   scope :batch_updatable, -> { where(dispute_at: nil, state: %w(new inprocess)) }

--- a/vendor/engines/projects/app/views/projects/projects/show.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/show.html.haml
@@ -10,4 +10,5 @@
 
 - if @project.order_details.any?
   - @date_range_field = :created_at
-  = render "shared/transactions/table", order_details: @project.order_details
+  = render "shared/transactions/table",
+    order_details: @project.order_details.paginate(page: params[:page])

--- a/vendor/engines/projects/app/views/projects/projects/show.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/show.html.haml
@@ -11,4 +11,4 @@
 - if @project.order_details.any?
   - @date_range_field = :ordered_at
   = render "shared/transactions/table",
-    order_details: @project.order_details.paginate(page: params[:page])
+    order_details: @project.order_details.by_ordered_at.paginate(page: params[:page])

--- a/vendor/engines/projects/app/views/projects/projects/show.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/show.html.haml
@@ -9,6 +9,6 @@
   class: "btn btn-primary"
 
 - if @project.order_details.any?
-  - @date_range_field = :created_at
+  - @date_range_field = :ordered_at
   = render "shared/transactions/table",
     order_details: @project.order_details.paginate(page: params[:page])


### PR DESCRIPTION
The shared partial this uses is already set up for pagination, but it was not calling `paginate` on the collection of order details. This change should fix that.

The `order_details` are not ordered by `ordered_at`. Should they be?