### PR TITLE
[#119749091] Disable chosen dropdown for reconciled orders

### DIFF
--- a/app/assets/javascripts/app/manage_orders.coffee
+++ b/app/assets/javascripts/app/manage_orders.coffee
@@ -111,6 +111,8 @@ class OrderDetailManagement
     form_elements.prop 'disabled', ->
       leaveEnabled = $(this).hasClass('js-always-enabled') || $(this).is('[type=submit]') || obj.isRailsFormInput(this)
       !leaveEnabled
+    # TODO Change event to chosen:updated in chosen 1.X
+    @$element.find("select.js--chosen").trigger("liszt:updated")
 
     # remove the submit button if all form elements are disabled (and ignore
     # Rails hidden inputs)


### PR DESCRIPTION
The form gets disabled by JS, so this makes sure that any chosen
selects get updated from their `select`’s attributes.