### PR TITLE
[#119754369] Project dropdown had project if sister detail did

### DIFF
--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -282,8 +282,8 @@ RSpec.describe OrdersController do
         expect(@order_detail.quantity).to eq(5)
       end
 
-      it "redirects to the cart" do
-        is_expected.to redirect_to order_path(@order)
+      it "renders the show view" do
+        is_expected.to render_template(:show)
       end
 
       it { expect(assigns[:order].state).not_to eq("purchased") }
@@ -316,8 +316,12 @@ RSpec.describe OrdersController do
         expect(@order_detail2.quantity).to eq(4)
       end
 
-      it "redirects to the cart" do
-        is_expected.to redirect_to order_path(@order)
+      it "has a flash message" do
+        expect(flash[:notice]).to include("Quantities have changed")
+      end
+
+      it "renders the show view" do
+        is_expected.to render_template(:show)
       end
 
       it { expect(assigns[:order].state).not_to eq("purchased") }

--- a/vendor/engines/projects/app/models/projects/order_extension.rb
+++ b/vendor/engines/projects/app/models/projects/order_extension.rb
@@ -6,11 +6,7 @@ module Projects
 
     included do
       before_save :assign_project_to_order_details
-      attr_writer :project_id
-    end
-
-    def project_id
-      @project_id ||= order_details.where("project_id IS NOT NULL").pluck(:project_id).first
+      attr_accessor :project_id
     end
 
     private

--- a/vendor/engines/projects/app/views/projects/shared/_select_project.html.haml
+++ b/vendor/engines/projects/app/views/projects/shared/_select_project.html.haml
@@ -2,7 +2,6 @@
   = f.input :project_id,
     collection: order_detail.selectable_projects,
     input_html: { class: "js--chosen", data: { placeholder: t(".placeholder") } },
-    selected: order_detail.project_id || order_detail.order.project_id,
     include_blank: true
 
   :javascript

--- a/vendor/engines/projects/spec/models/projects/order_extension_spec.rb
+++ b/vendor/engines/projects/spec/models/projects/order_extension_spec.rb
@@ -5,20 +5,6 @@ RSpec.describe Projects::OrderExtension do
   let(:item) { FactoryGirl.create(:setup_item) }
   let(:project_id) { FactoryGirl.create(:project, facility: order.facility).id }
 
-  describe "#project_id" do
-    context "when none of its order_details has a project" do
-      it { expect(order.project_id).to be_blank }
-    end
-
-    context "when at least one of its order_details has a project" do
-      let(:order_detail) { order.order_details.last }
-
-      before { order_detail.update_attribute(:project_id, project_id) }
-
-      it { expect(order.project_id).to eq(project_id) }
-    end
-  end
-
   describe "#project_id=" do
     before(:each) do
       order.project_id = project_id


### PR DESCRIPTION
If an order detail did not have a project, but the first detail in the
same order does, that project was appearing in the dropdown.

This also now renders on purchase with quantity changes rather than
redirects. This makes sure the project and the “more options” fields
don’t get lost.