### PR TITLE
Fix problems with external service receivers

### DIFF
--- a/app/models/external_service/external_service_receiver.rb
+++ b/app/models/external_service/external_service_receiver.rb
@@ -4,8 +4,6 @@
 # (the receiver).
 class ExternalServiceReceiver < ActiveRecord::Base
 
-  attr_accessor :receiver_id, :response_data # TODO: why are these necessary for Rails 4?
-
   belongs_to :external_service
   belongs_to :receiver, polymorphic: true
 
@@ -24,7 +22,7 @@ class ExternalServiceReceiver < ActiveRecord::Base
   end
 
   def parsed_response_data
-    JSON.parse(response_data).symbolize_keys
+    JSON.parse(self[:response_data]).symbolize_keys
   rescue TypeError, JSON::ParserError
     {}
   end


### PR DESCRIPTION
Rails 4 uses method_missing to dynamically define attribute names. So
`response_data` is not defined yet, so when we try to use it inside
`method_missing`, it triggers the stack overflow. If we grab the
attribute directly, we’re good.

http://stackoverflow.com/questions/16088392/defining-method-missing-on-active-record-in-rails-4-throws-systemstackerror-sta

Cuts out about 30 test failures.