### PR TITLE
Rails4: Fix accessories specs

### DIFF
--- a/spec/controllers/accessories_controller_spec.rb
+++ b/spec/controllers/accessories_controller_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe AccessoriesController do
   render_views
   before(:all) { create_users }
 
-  let(:instrument) { FactoryGirl.create(:setup_instrument) }
+  let(:instrument) { create(:instrument_with_accessory) }
   let(:facility) { instrument.facility }
-  let(:quantity_accessory) { FactoryGirl.create(:accessory, parent: instrument) }
+  let(:quantity_accessory) { instrument.accessories.first }
   let(:auto_accessory) { create(:accessory, parent: instrument, scaling_type: "auto") }
   let(:manual_accessory) { create(:accessory, parent: instrument, scaling_type: "manual") }
   let(:reservation) { create(:purchased_reservation, product: instrument, reserve_start_at: 1.day.ago) }

--- a/spec/factories/accessories.rb
+++ b/spec/factories/accessories.rb
@@ -1,4 +1,14 @@
 FactoryGirl.define do
+  factory :instrument_with_accessory, parent: :setup_instrument do
+    transient do
+      accessory { create :setup_item, facility: facility }
+    end
+
+    after(:create) do |instrument, evaluator|
+      instrument.accessories << evaluator.accessory
+    end
+  end
+
   factory :accessory, parent: :setup_item do
     transient do
       parent { create :setup_instrument, facility: facility }

--- a/spec/models/order_details/accessorized_order_detail_spec.rb
+++ b/spec/models/order_details/accessorized_order_detail_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe OrderDetail do
-  let(:instrument) { FactoryGirl.create(:setup_instrument) }
-  let(:accessory) { FactoryGirl.create(:accessory, parent: instrument) }
+  let(:instrument) { FactoryGirl.create(:instrument_with_accessory) }
+  let(:accessory) { instrument.accessories.first }
   let(:reservation) { FactoryGirl.create(:completed_reservation, product: instrument) }
   let(:order_detail) { reservation.order_detail }
   let(:accessorizer) { Accessories::Accessorizer.new(order_detail) }
@@ -103,7 +103,8 @@ RSpec.describe OrderDetail do
   end
 
   context "auto scaled accessory" do
-    let(:accessory_order_detail) { accessorizer.add_accessory(accessory) }
+    # reload in order to avoid timestamp truncation causing false-positives on `changes`
+    let(:accessory_order_detail) { accessorizer.add_accessory(accessory).reload }
     before :each do
       accessorizer.send(:product_accessory, accessory).update_attributes(scaling_type: "auto")
       accessory_order_detail # load

--- a/spec/services/accessorizer_spec.rb
+++ b/spec/services/accessorizer_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Accessories::Accessorizer do
-  let(:product) { FactoryGirl.create(:setup_instrument) }
-  let(:quantity_accessory) { FactoryGirl.create(:accessory, parent: product) }
+  let(:product) { create(:instrument_with_accessory) }
+  let(:quantity_accessory) { product.accessories.first }
   let!(:auto_scaled_accessory) { create(:accessory, parent: product, scaling_type: "auto") }
 
   let(:order) { build_stubbed :order }


### PR DESCRIPTION
This fixes failures in `spec/models/order_details/accessorized_order_detail_spec.rb` and `spec/controllers/accessories_controller_spec.rb`

This reverts "[REVISIT] Remove instrument_with_accessory factory" commit 1595724