### PR TITLE
[rails4] Fix affiliate spec

### DIFF
--- a/app/services/account_builder.rb
+++ b/app/services/account_builder.rb
@@ -164,11 +164,14 @@ class AccountBuilder
   # param is present, and the affiliate exists. Also ensure affiliate_other
   # gets wiped out if the affiliate_id does not point to `Other`.
   def set_affiliate
-    return account unless account.class.using_affiliate? && account_params.key?(:affiliate_id)
-
-    affiliate = Affiliate.find_by_id(account_params[:affiliate_id])
-    account.affiliate_id = affiliate.try(:id)
-    account.affiliate_other = nil if affiliate.try(:id) != Affiliate.OTHER.id
+    if account.class.using_affiliate? && account_params.key?(:affiliate_id)
+      affiliate = Affiliate.find_by_id(account_params[:affiliate_id])
+      account.affiliate_id = affiliate.try(:id)
+      account.affiliate_other = nil if affiliate.try(:id) != Affiliate.OTHER.id
+    else
+      account.affiliate_id = nil
+      account.affiliate_other = nil
+    end
     account
   end
 

--- a/spec/services/account_builder_spec.rb
+++ b/spec/services/account_builder_spec.rb
@@ -133,10 +133,11 @@ RSpec.describe AccountBuilder, type: :service do
     end
 
     context "when affilate supported" do
-      let(:affiliate) { Affiliate.new(id: Affiliate.OTHER.id + 1) }
+      let(:affiliate) { Affiliate.create!(name: "New Affiliate") }
 
       before do
         allow(NufsAccount).to receive(:using_affiliate?).and_return(true)
+        allow(builder).to receive(:account_params_for_build).and_return([:affiliate_id])
       end
 
       context "and affiliate param blank" do
@@ -153,13 +154,14 @@ RSpec.describe AccountBuilder, type: :service do
         end
 
         it "sets affiliate" do
+          expect(affiliate.id).to be_present
           expect(builder.build.affiliate_id).to eq(affiliate.id)
         end
       end
     end
 
     context "when affilate unsupported" do
-      let(:affiliate) { Affiliate.new(id: Affiliate.OTHER.id + 1) }
+      let(:affiliate) { Affiliate.create!(name: "New Affiliate") }
 
       before do
         allow(NufsAccount).to receive(:using_affiliate?).and_return(false)


### PR DESCRIPTION
This is kind of a weird one. We’re testing some affiliate code in the
base builder, but NufsAccount don’t support affiliates, so they’re
excluded from the `account_params_for_build` and get filtered out by
strong params. CreditCardAccountBuilder & PurchaseOrderAccountBuilder
include affiliate_id and affiliate_other.

Turns out the `using_affiliate? && account_params.key?(:affiliate_id)`
is somewhat redundant, but I like keeping it in there, but this keeps
the data clean.