### PR TITLE
[rails4] Clean up deprecations

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,6 +6,9 @@ Nucore::Application.configure do
   # since you don't have to restart the webserver when you make code changes.
   config.cache_classes = false
 
+  # Do not eager load code on boot.
+  config.eager_load = false
+
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
@@ -24,10 +27,6 @@ Nucore::Application.configure do
 
   # Raise exception on mass assignment protection for Active Record models
   config.active_record.mass_assignment_sanitizer = :logger #:strict
-
-  # Log the query plan for queries taking more than this (works
-  # with SQLite, MySQL, and PostgreSQL)
-  config.active_record.auto_explain_threshold_in_seconds = 0.5
 
   # Do not compress assets
   config.assets.compress = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,6 +5,12 @@ Nucore::Application.configure do
   # Code is not reloaded between requests
   config.cache_classes = true
 
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
   # Full error reports are disabled and caching is turned on
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,6 +7,11 @@ Nucore::Application.configure do
   # and recreated between test runs.  Don't rely on the data there!
   config.cache_classes = true
 
+  # Do not eager load code on boot. This avoids loading your whole application
+  # just for the purpose of running a single test. If you are using a tool that
+  # preloads Rails for running tests, you may have to set it to true.
+  config.eager_load = false
+
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/lib/engine_manager.rb
+++ b/lib/engine_manager.rb
@@ -2,7 +2,9 @@
 class EngineManager
 
   def self.loaded_engines
-    Rails.application.railties.engines.map { |e| e.class.name }.to_set
+    Rails.application.railties
+      .select { |r| r.class < Rails::Engine }
+      .map { |e| e.class.name }.to_set
   end
 
   def self.engine_loaded?(engine_name)


### PR DESCRIPTION
`rails server` will now boot without deprecations, and this takes care of a deprecation on how we test if engines are loaded.