### PR TITLE
[rails4] Kill `remove_ugly_params` filter

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -194,19 +194,4 @@ class ApplicationController < ActionController::Base
     current_facility
   end
 
-  def remove_ugly_params_and_redirect
-    if params[:commit] && request.get?
-      remove_ugly_params
-      # redirect to self
-      redirect_to params
-      return false
-    end
-  end
-
-  def remove_ugly_params
-    [:commit, :utf8, :authenticity_token].each do |p|
-      params.delete(p)
-    end
-  end
-
 end

--- a/app/controllers/bulk_email_controller.rb
+++ b/app/controllers/bulk_email_controller.rb
@@ -6,7 +6,6 @@ class BulkEmailController < ApplicationController
   layout "two_column"
 
   before_filter { @active_tab = "admin_users" }
-  before_filter :remove_ugly_params_and_redirect
   before_filter :authenticate_user!
   before_filter :check_acting_as
   before_filter :init_current_facility

--- a/lib/transaction_search.rb
+++ b/lib/transaction_search.rb
@@ -17,20 +17,13 @@ module TransactionSearch
 
   module ClassMethods
 
-    def transaction_search(*actions)
-      before_filter :remove_ugly_params_and_redirect, only: actions
-    end
-
     # If a method is tagged with _with_search at the end, then define the normal controller
     # action to be wrapped in the search.
     # e.g. index_with_search will define #index, which will init_order_details before passing
     # control to the controller method. Then it will further filter @order_details after the controller
     # method has run
     def method_added(name)
-      @@methods_with_remove_ugly_filter ||= []
       if name.to_s =~ /(.*)_with_search$/
-        @@methods_with_remove_ugly_filter << Regexp.last_match(1)
-        before_filter :remove_ugly_params_and_redirect, only: @@methods_with_remove_ugly_filter
         define_search_method(Regexp.last_match(1), $&)
       end
     end


### PR DESCRIPTION
This was a “nice” feature I added when I first created the transaction
search which strips the hidden field parts a GET search to make URL query strings
look just a little nicer.

In Rails 4, the `redirect_to params` raises an "Cannot redirect to a parameter hash!"
error, which seems like a reasonable security feature. It seems the easiest way
to fix the error is to kill the feature altogether. I don’t think anyone will notice.