### PR TITLE
AASM upgrade to 4.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "devise_ldap_authenticatable", "~> 0.8.5"
 gem "cancancan",        "1.10"
 
 ## models
-gem "aasm",             "2.2.0"
+gem "aasm",             "~> 4.10.1"
 gem "paperclip",        "~> 4.2.0"
 gem "vestal_versions",  "1.2.4.3", github: "elzoiddy/vestal_versions"
 gem "awesome_nested_set", "2.1.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
   specs:
     Ascii85 (1.0.2)
     CFPropertyList (2.3.1)
-    aasm (2.2.0)
+    aasm (4.10.1)
     actionmailer (3.2.22.2)
       actionpack (= 3.2.22.2)
       mail (~> 2.5.4)
@@ -331,7 +331,7 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile2 (2.0.0)
-    multi_json (1.12.0)
+    multi_json (1.12.1)
     mysql2 (0.3.20)
     nenv (0.3.0)
     nested_form_fields (0.7.4)
@@ -517,7 +517,7 @@ GEM
     turbo-sprockets-rails3 (0.3.14)
       railties (> 3.2.8, < 4.0.0)
       sprockets (>= 2.2.0)
-    tzinfo (0.3.47)
+    tzinfo (0.3.49)
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -532,7 +532,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aasm (= 2.2.0)
+  aasm (~> 4.10.1)
   activerecord-oracle_enhanced-adapter (= 1.4.3)
   awesome_nested_set (= 2.1.6)
   awesome_print (= 1.1.0)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -34,29 +34,28 @@ class Order < ActiveRecord::Base
 
   attr_accessor :being_purchased_by_admin
 
-  # BEGIN acts_as_state_machhine
   include AASM
 
-  aasm_column           :state
-  aasm_initial_state    :new
-  aasm_state            :new
-  aasm_state            :validated
-  aasm_state            :purchased
+  aasm column: :state, whiny_transitions: false do
+    state :new, initial: true
+    state :validated
+    state :purchased
 
-  aasm_event :invalidate do
-    transitions to: :new, from: [:new, :validated]
-  end
+    event :invalidate do
+      transitions to: :new, from: [:new, :validated]
+    end
 
-  aasm_event :validate_order do
-    transitions to: :validated, from: [:new, :validated], guard: :cart_valid?
-  end
+    event :validate_order do
+      transitions to: :validated, from: [:new, :validated], guard: :cart_valid?
+    end
 
-  aasm_event :purchase, success: :move_order_details_to_default_status do
-    transitions to: :purchased, from: :validated, guard: :place_order?
-  end
+    event :purchase, success: :move_order_details_to_default_status do
+      transitions to: :purchased, from: :validated, guard: :place_order?
+    end
 
-  aasm_event :clear do
-    transitions to: :new, from: [:new, :validated], guard: :clear_cart?
+    event :clear do
+      transitions to: :new, from: [:new, :validated], guard: :clear_cart?
+    end
   end
 
   [:total, :cost, :subsidy, :estimated_total, :estimated_cost, :estimated_subsidy].each do |method_name|

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -405,45 +405,43 @@ class OrderDetail < ActiveRecord::Base
 
     query.where(sql, start: start_date, end: end_date)
   end
-  # BEGIN acts_as_state_machine
+
   include AASM
 
-  aasm_column           :state
-  aasm_initial_state    :new
-  aasm_state            :new
-  aasm_state            :inprocess
-  aasm_state            :complete, enter: :make_complete
-  aasm_state            :reconciled, enter: :set_reconciled_at
-  aasm_state            :canceled, enter: :clear_costs
-
-  aasm_event :to_new do
-    transitions to: :new, from: :inprocess
-  end
-
-  aasm_event :to_inprocess do
-    transitions to: :inprocess, from: :new
-  end
-
-  aasm_event :to_complete do
-    transitions to: :complete, from: [:new, :inprocess], guard: :has_completed_reservation?
-  end
-
-  aasm_event :to_reconciled do
-    transitions to: :reconciled, from: :complete, guard: :actual_total
-  end
-
   CANCELABLE_STATES = [:new, :inprocess, :complete].freeze
-  aasm_event :to_canceled do
-    transitions to: :canceled, from: CANCELABLE_STATES, guard: :cancelable?
-  end
+  aasm column: :state do
+    state :new, initial: true
+    state :inprocess
+    state :complete, enter: :make_complete
+    state :reconciled, enter: :set_reconciled_at
+    state :canceled, enter: :clear_costs
 
-  # END acts_as_state_machine
+    event :to_new do
+      transitions to: :new, from: :inprocess
+    end
+
+    event :to_inprocess do
+      transitions to: :inprocess, from: :new
+    end
+
+    event :to_complete do
+      transitions to: :complete, from: [:new, :inprocess], guard: :has_completed_reservation?
+    end
+
+    event :to_reconciled do
+      transitions to: :reconciled, from: :complete, guard: :actual_total
+    end
+
+    event :to_canceled do
+      transitions to: :canceled, from: CANCELABLE_STATES, guard: :cancelable?
+    end
+  end
 
   # block will be called after the transition, but before the save
   def change_status!(new_status, &block)
     new_state = new_status.state_name
     # don't try to change state if it's not a valid state or it's the same as it was before
-    if OrderDetail.aasm_states.map(&:name).include?(new_state) && new_state != state.to_sym
+    if OrderDetail.aasm.states.map(&:name).include?(new_state) && new_state != state.to_sym
       raise AASM::InvalidTransition, "Event '#{new_state}' cannot transition from '#{state}'" unless send("to_#{new_state}!")
     end
     # don't try to change status if it's the same as before

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -691,7 +691,7 @@ RSpec.describe OrderDetail do
         @order_detail.to_inprocess!
         @order_detail.to_complete!
         @order_detail.to_reconciled!
-        expect { @order_detail.to_canceled! }.to raise_exception AASM::InvalidTransition
+        expect { @order_detail.to_canceled! }.to raise_error(AASM::InvalidTransition)
         expect(@order_detail.state).to eq("reconciled")
         expect(@order_detail.version).to eq(4)
       end
@@ -702,7 +702,7 @@ RSpec.describe OrderDetail do
         expect(@order_detail.reload.journal).to eq(journal)
         @order_detail.to_inprocess!
         @order_detail.to_complete!
-        @order_detail.to_canceled!
+        expect { @order_detail.to_canceled! }.to raise_error(AASM::InvalidTransition)
         expect(@order_detail.state).to eq("complete")
         expect(@order_detail.version).to eq(4)
       end
@@ -732,7 +732,7 @@ RSpec.describe OrderDetail do
           end
 
           it "should not transition to canceled" do
-            expect { order_detail.to_canceled! }.to raise_exception AASM::InvalidTransition
+            expect { order_detail.to_canceled! }.to raise_error(AASM::InvalidTransition)
           end
         end
       end
@@ -753,7 +753,7 @@ RSpec.describe OrderDetail do
         @order_detail.to_complete!
         expect(@order_detail.state).to eq("complete")
         expect(@order_detail.version).to eq(3)
-        @order_detail.to_reconciled!
+        expect { @order_detail.to_reconciled! }.to raise_error(AASM::InvalidTransition)
         expect(@order_detail.state).to eq("complete")
         expect(@order_detail.version).to eq(3)
       end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Order do
       @order.order_details.create(product_id: @service.id, quantity: 1)
       expect(@order.new?).to be true
       @order.save
-      expect(@order.purchase!).to be false
+      expect { @order.purchase! }.to raise_exception AASM::InvalidTransition
     end
 
     context "successfully moving to purchase" do
@@ -203,7 +203,7 @@ RSpec.describe Order do
       @facility.save!
       @order.reload
       @order.invalidate!
-      expect(@order.validate_order!).to be(false)
+      expect(@order.validate_order!).to be false
     end
 
     it "should check for product active/inactive changes before purchase" do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Order do
       @order.order_details.create(product_id: @service.id, quantity: 1)
       expect(@order.new?).to be true
       @order.save
-      expect { @order.purchase! }.to raise_exception AASM::InvalidTransition
+      expect(@order.purchase!).to be false
     end
 
     context "successfully moving to purchase" do
@@ -203,7 +203,7 @@ RSpec.describe Order do
       @facility.save!
       @order.reload
       @order.invalidate!
-      expect(@order.validate_order!).to be false
+      expect(@order.validate_order!).to be(false)
     end
 
     it "should check for product active/inactive changes before purchase" do


### PR DESCRIPTION
The syntax is the obvious change, but it's pretty straightforward.

The bigger issue is that prior to AASM 3.0, `AASM::InvalidTransition` would only be raised if the transition did not exist. In 3.0+, guard failures also raise the error. So for example

```ruby
event :validate_order do
  transitions to: :validated, from: [:new, :validated], guard: :cart_valid?
end

# order.state == "purchased"
order.validate_order! # Raises an error in both versions

# order.cart_valid? == false, order.state == "new"
order.validate_order! # Returns false in 2.X, raises in 3.0+
```

`validate_order!` is the big place where this problematic since it gets called several places with no `rescue`. I chose to keep the change minimal by defining my own `validate_order!` method that calls the event/transition, but swallows the error.

I'm going to create a branch off of `rails4` as well for testing.