### PR TITLE
[Rails4] AASM upgrade to 4.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "devise_ldap_authenticatable", "~> 0.8.5"
 gem "cancancan",        "1.10"
 
 ## models
-gem "aasm",             "2.2.0"
+gem "aasm",             "~> 4.10.1"
 gem "paperclip",        "~> 4.2.0"
 gem "vestal_versions",  "1.2.4.3", github: "elzoiddy/vestal_versions"
 gem "awesome_nested_set", "3.0.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
   specs:
     Ascii85 (1.0.2)
     CFPropertyList (2.3.2)
-    aasm (2.2.0)
+    aasm (4.10.1)
     actionmailer (4.0.13)
       actionpack (= 4.0.13)
       mail (~> 2.5, >= 2.5.4)
@@ -561,7 +561,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aasm (= 2.2.0)
+  aasm (~> 4.10.1)
   activerecord-oracle_enhanced-adapter (= 1.4.3)
   awesome_nested_set (= 3.0.3)
   awesome_print (= 1.1.0)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -34,29 +34,36 @@ class Order < ActiveRecord::Base
 
   attr_accessor :being_purchased_by_admin
 
-  # BEGIN acts_as_state_machhine
   include AASM
 
-  aasm_column           :state
-  aasm_initial_state    :new
-  aasm_state            :new
-  aasm_state            :validated
-  aasm_state            :purchased
+  aasm column: :state do
+    state :new, initial: true
+    state :validated
+    state :purchased
 
-  aasm_event :invalidate do
-    transitions to: :new, from: [:new, :validated]
+    event :invalidate do
+      transitions to: :new, from: [:new, :validated]
+    end
+
+    event :_validate_order do
+      transitions to: :validated, from: [:new, :validated], guard: :cart_valid?
+    end
+
+    event :purchase, success: :move_order_details_to_default_status do
+      transitions to: :purchased, from: :validated, guard: :place_order?
+    end
+
+    event :clear do
+      transitions to: :new, from: [:new, :validated], guard: :clear_cart?
+    end
   end
 
-  aasm_event :validate_order do
-    transitions to: :validated, from: [:new, :validated], guard: :cart_valid?
-  end
-
-  aasm_event :purchase, success: :move_order_details_to_default_status do
-    transitions to: :purchased, from: :validated, guard: :place_order?
-  end
-
-  aasm_event :clear do
-    transitions to: :new, from: [:new, :validated], guard: :clear_cart?
+  # In older versions of AASM, a guard condition failing would not raise an error.
+  # This is to maintain the previous API of simply returning false
+  def validate_order!
+    _validate_order!
+  rescue AASM::InvalidTransition => e
+    false
   end
 
   [:total, :cost, :subsidy, :estimated_total, :estimated_cost, :estimated_subsidy].each do |method_name|

--- a/app/views/facility_orders/show.html.haml
+++ b/app/views/facility_orders/show.html.haml
@@ -67,11 +67,11 @@
       %td
       %td
       %td.currency
-        %strong= number_to_currency @order_details.inject(0) {|sum,od| sum + od.cost.to_f}
+        %strong= number_to_currency @order_details.inject(0) { |sum,od| sum + od.cost }
       %td.currency
-        %strong= number_to_currency @order_details.inject(0) {|sum,od| sum + od.subsidy.to_f}
+        %strong= number_to_currency @order_details.inject(0) { |sum,od| sum + od.subsidy }
       %td.currency
-        %strong= number_to_currency @order_details.inject(0) {|sum,od| sum + od.total.to_f}
+        %strong= number_to_currency @order_details.inject(0) { |sum,od| sum + od.total }
       %td
 
 = render :partial => 'merge_order_form'

--- a/app/views/notifier/review_orders.html.haml
+++ b/app/views/notifier/review_orders.html.haml
@@ -1,1 +1,1 @@
-%p= html(".body_html", facility: @facility.to_s, account: @account.to_s, login_url: transactions_in_review_account_url(@account, facilities: [@facility.id]))
+= html("body_html", facility: @facility.to_s, account: @account.to_s, login_url: transactions_in_review_account_url(@account, facilities: [@facility.id]))

--- a/app/views/notifier/statement.html.haml
+++ b/app/views/notifier/statement.html.haml
@@ -1,3 +1,3 @@
-%p= t('.body_html', facility: @facility, account: @account)
+= html("body_html", facility: @facility, account: @account)
 
 = render_view_hook("end")

--- a/app/views/notifier/statement.text.erb
+++ b/app/views/notifier/statement.text.erb
@@ -1,3 +1,3 @@
-<%= t('.body', facility: @facility, account: @account) %>
+<%= text("body", facility: @facility, account: @account) %>
 
 <%= render_view_hook("end") %>

--- a/app/views/notifier/user_update.html.haml
+++ b/app/views/notifier/user_update.html.haml
@@ -1,1 +1,1 @@
-%p= html(".body_html", user: @user.to_s, account: @account.to_s, created_by: @created_by.to_s, login_url: new_user_session_url)
+= html("body_html", user: @user.to_s, account: @account.to_s, created_by: @created_by.to_s, login_url: new_user_session_url)

--- a/config/locales/en.notifier.yml
+++ b/config/locales/en.notifier.yml
@@ -23,7 +23,7 @@ en:
         subject: "!app_name! Orders For Review"
         body: "New transactions for %{facility} have been posted to \"%{account}\". Please log in to !app_name! and review these charges."
         body_html: |
-          New transactions for %{facility} have been posted to \"%{account}\".
+          New transactions for %{facility} have been posted to "%{account}".
 
           Please log in to [!app_name!](%{login_url}) and review these charges.
       statement:

--- a/lib/staging_mail_interceptor.rb
+++ b/lib/staging_mail_interceptor.rb
@@ -32,7 +32,8 @@ class StagingMailInterceptor
 
     return if all_addresses_whitelisted?
 
-    message.body = body
+    message.html_part.body = html_body if message.html_part
+    message.text_part.body = text_body if message.text_part
 
     message.to = whitelisted_addresses
     message.cc = nil
@@ -48,13 +49,27 @@ class StagingMailInterceptor
     "[#{I18n.t('app_name')} #{Rails.env.upcase}] #{message.subject}"
   end
 
-  # Internal: Get the content of this email, modified with a list of the email
+  # Internal: Get the html content of this email, modified with a list of the email
   # addresses to which the email was originally supposed to be delivered.
   #
   # Returns a String.
-  def body
-    intercepted_message = "<pre>Intercepted email:\n  to: #{message.to}\n  cc: #{message.cc}\n  bcc: #{message.bcc}</pre>"
-    "#{intercepted_message}\n\n#{message.body}"
+  def html_body
+    "<pre>#{intercepted_message}</pre>\n\n#{message.html_part.body}"
+  end
+
+  # Internal: Get the text content of this email, modified with a list of the email
+  # addresses to which the email was originally supposed to be delivered.
+  #
+  # Returns a String.
+  def text_body
+    "#{intercepted_message}\n\n#{message.text_part.body}"
+  end
+
+  # Internal: A message that includes the original recipients
+  #
+  # Returns a String.
+  def intercepted_message
+    "Intercepted email:\n  to: #{message.to}\n  cc: #{message.cc}\n  bcc: #{message.bcc}"
   end
 
   # Internal: Is the passed recipient whitelisted for communication? Permits

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -136,7 +136,8 @@ RSpec.describe FacilityOrdersController do
 
     describe "with an order detail with no cost assigned" do
       it "renders" do
-        expect(@order_detail.cost).to be_nil
+        expect(@order_detail.actual_cost).to be_nil
+        expect(@order_detail.estimated_cost).to be_nil
         expect { do_request }.not_to raise_error
       end
     end

--- a/spec/lib/staging_mail_interceptor_spec.rb
+++ b/spec/lib/staging_mail_interceptor_spec.rb
@@ -3,7 +3,11 @@ require "rails_helper"
 RSpec.describe StagingMailInterceptor do
   let(:to) { [] }
   let(:interceptor) { StagingMailInterceptor.new(message) }
-  subject(:message) { OpenStruct.new to: to, subject: "A message" }
+  subject(:message) do
+    Mail::Message.new(to: to, subject: "A message").tap do |msg|
+      msg.text_part = Mail::Part.new(body: "testing")
+    end
+  end
 
   describe "whitelisting" do
     let(:whitelist) { ["allowed@example.org", "allowed2@example.org", "allowed3@example.org"] }
@@ -57,8 +61,8 @@ RSpec.describe StagingMailInterceptor do
       end
 
       it "includes the blocked addresses in the message" do
-        expect(message.body).to include("Intercepted email")
-        expect(message.body).to include(*to)
+        expect(message.text_part.body).to include("Intercepted email")
+        expect(message.text_part.body).to include(*to)
       end
     end
 
@@ -70,8 +74,8 @@ RSpec.describe StagingMailInterceptor do
       end
 
       it "includes the blocked addresses in the message" do
-        expect(message.body).to include("Intercepted email")
-        expect(message.body).to include(*to)
+        expect(message.text_part.body).to include("Intercepted email")
+        expect(message.text_part.body).to include(*to)
       end
     end
   end

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -577,6 +577,7 @@ RSpec.describe OrderDetail do
 
       context "with no price policy" do
         before :each do
+          product.price_policies.destroy_all
           Timecop.travel(2.days.from_now) do
             order_detail.change_status!(OrderStatus.find_by_name("In Process"))
             order_detail.change_status!(OrderStatus.find_by_name("Complete"))
@@ -690,7 +691,7 @@ RSpec.describe OrderDetail do
         @order_detail.to_inprocess!
         @order_detail.to_complete!
         @order_detail.to_reconciled!
-        expect { @order_detail.to_canceled! }.to raise_exception AASM::InvalidTransition
+        expect { @order_detail.to_canceled! }.to raise_error(AASM::InvalidTransition)
         expect(@order_detail.state).to eq("reconciled")
         expect(@order_detail.version).to eq(4)
       end
@@ -701,7 +702,7 @@ RSpec.describe OrderDetail do
         expect(@order_detail.reload.journal).to eq(journal)
         @order_detail.to_inprocess!
         @order_detail.to_complete!
-        @order_detail.to_canceled!
+        expect { @order_detail.to_canceled! }.to raise_error(AASM::InvalidTransition)
         expect(@order_detail.state).to eq("complete")
         expect(@order_detail.version).to eq(4)
       end
@@ -731,7 +732,7 @@ RSpec.describe OrderDetail do
           end
 
           it "should not transition to canceled" do
-            expect { order_detail.to_canceled! }.to raise_exception AASM::InvalidTransition
+            expect { order_detail.to_canceled! }.to raise_error(AASM::InvalidTransition)
           end
         end
       end
@@ -752,7 +753,7 @@ RSpec.describe OrderDetail do
         @order_detail.to_complete!
         expect(@order_detail.state).to eq("complete")
         expect(@order_detail.version).to eq(3)
-        @order_detail.to_reconciled!
+        expect { @order_detail.to_reconciled! }.to raise_error(AASM::InvalidTransition)
         expect(@order_detail.state).to eq("complete")
         expect(@order_detail.version).to eq(3)
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,19 +25,24 @@ RSpec.describe User do
 
   it { is_expected.to be_valid }
 
-  context "when the username does not contain an '@' symbol" do
-    before { expect(user.username).not_to include("@") }
+  describe "Default #price_groups" do
+    # Only run if we're using the default implementation
+    if User.new.method(:price_groups).owner == User::Overridable
+      context "when the username does not contain an '@' symbol" do
+        before { expect(user.username).not_to include("@") }
 
-    it "belongs to the NU price group" do
-      expect(user.price_groups.include?(@nupg)).to eq(true)
-    end
-  end
+        it "belongs to the NU price group" do
+          expect(user.price_groups.include?(@nupg)).to eq(true)
+        end
+      end
 
-  context "when the username contains an '@' symbol" do
-    subject(:user) { create(:user, username: "ext@example.net") }
+      context "when the username contains an '@' symbol" do
+        subject(:user) { create(:user, username: "ext@example.net") }
 
-    it "belongs to the External price group" do
-      expect(user.price_groups.include?(@epg)).to eq(true)
+        it "belongs to the External price group" do
+          expect(user.price_groups.include?(@epg)).to eq(true)
+        end
+      end
     end
   end
 

--- a/vendor/engines/projects/app/models/projects/project.rb
+++ b/vendor/engines/projects/app/models/projects/project.rb
@@ -20,6 +20,12 @@ module Projects
       name
     end
 
+    # This returns the total cost using actual cost if the order has it, otherwise
+    # uses the estimated cost.
+    def total_cost
+      order_details.inject(0) { |sum, od| sum += od.total }
+    end
+
   end
 
 end

--- a/vendor/engines/projects/app/views/projects/projects/edit.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/edit.html.haml
@@ -7,9 +7,9 @@
 
 = simple_form_for @project, url: facility_project_path(@project.facility, @project), method: :put do |f|
   .form-inputs
-    = f.input :active
     = f.input :name, hint: t(".name")
     = f.input :description, hint: t(".description"), input_html: { class: :editor }
+    = f.input :active
   .form-actions
     = f.button :submit, t(".update"), class: "btn-primary"
     = link_to t("shared.cancel"), facility_projects_path(current_facility)

--- a/vendor/engines/projects/app/views/projects/projects/show.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/show.html.haml
@@ -4,11 +4,13 @@
 %h2= @project.name
 = sanitize @project.description
 
-= link_to t(".edit"),
-  edit_facility_project_path(@project.facility, @project),
-  class: "btn btn-primary"
-
 - if @project.order_details.any?
+  %h3= "Total Cost: #{number_to_currency(@project.total_cost)}"
+
   - @date_range_field = :ordered_at
   = render "shared/transactions/table",
     order_details: @project.order_details.by_ordered_at.paginate(page: params[:page])
+
+= link_to t(".edit"),
+  edit_facility_project_path(@project.facility, @project),
+  class: "btn btn-primary"

--- a/vendor/engines/projects/spec/models/projects/project_spec.rb
+++ b/vendor/engines/projects/spec/models/projects/project_spec.rb
@@ -26,4 +26,16 @@ RSpec.describe Projects::Project, type: :model do
       is_expected.to be_destroyed
     end
   end
+
+  describe "#total_cost" do
+    before do
+      project.order_details.build(estimated_cost: nil, estimated_subsidy: nil)
+      project.order_details.build(estimated_cost: 1.5, estimated_subsidy: 0.25)
+      project.order_details.build(estimated_cost: 2.3, estimated_subsidy: 0, actual_cost: 3.24, actual_subsidy: 0.03)
+    end
+
+    it "finds the total" do
+      expect(project.total_cost).to eq(4.46)
+    end
+  end
 end


### PR DESCRIPTION
This merges #621 into the Rails 4 branch *This also includes a few other updates from master*

The syntax is the obvious change, but it's pretty straightforward.

The bigger issue is that prior to AASM 3.0, `AASM::InvalidTransition` would only be raised if the transition did not exist. In 3.0+, guard failures also raise the error. So for example

```ruby
event :validate_order do
  transitions to: :validated, from: [:new, :validated], guard: :cart_valid?
end

# order.state == "purchased"
order.validate_order! # Raises an error in both versions

# order.cart_valid? == false, order.state == "new"
order.validate_order! # Returns false in 2.X, raises in 3.0+
```

`validate_order!` is the big place where this problematic since it gets called several places with no `rescue`. I chose to keep the change minimal by defining my own `validate_order!` method that calls the event/transition, but swallows the error.
