### PR TITLE
[rails4] Clean up deprecation notices from simple_form

### DIFF
--- a/app/inputs/currency_input.rb
+++ b/app/inputs/currency_input.rb
@@ -2,7 +2,7 @@ class CurrencyInput < SimpleForm::Inputs::Base
 
   include ActionView::Helpers::NumberHelper
 
-  def input
+  def input(wrapper_options)
     set_value
 
     out = template.content_tag :div, class: ["input-prepend", "currency-input"] do

--- a/app/inputs/order_detail_quantity_input.rb
+++ b/app/inputs/order_detail_quantity_input.rb
@@ -1,11 +1,11 @@
 class OrderDetailQuantityInput < SimpleForm::Inputs::FileInput
 
-  def input
+  def input(wrapper_options)
     input_html_options[:class] << "timeinput" if object.quantity_as_time?
     @builder.text_field(attribute_name, input_html_options).html_safe
   end
 
-  def hint
+  def hint(wrapper_options = nil)
     if object.scaling_type && !object.quantity_editable?
       @hint ||= I18n.t("product_accessories.type.#{object.scaling_type}")
     end

--- a/app/inputs/readonly_input.rb
+++ b/app/inputs/readonly_input.rb
@@ -4,7 +4,7 @@ class ReadonlyInput < SimpleForm::Inputs::Base
 
   disable :required
 
-  def input
+  def input(wrapper_options)
     classes = [*input_html_options[:class]]
     template.content_tag :div, class: classes do
       value = input_html_options[:value] || object.send(attribute_name)

--- a/app/inputs/transaction_chosen_input.rb
+++ b/app/inputs/transaction_chosen_input.rb
@@ -2,7 +2,7 @@ class TransactionChosenInput < SimpleForm::Inputs::Base # CollectionSelectInput
 
   disable :required
 
-  def input
+  def input(wrapper_options)
     options[:label_method] ||= :name
     options[:value_method] ||= :id
 
@@ -23,7 +23,7 @@ class TransactionChosenInput < SimpleForm::Inputs::Base # CollectionSelectInput
     template.select_tag(attribute_name, option_data, select_options).html_safe
   end
 
-  def label
+  def label(wrapper_options)
     options[:label] ||= model_label
     super
   end


### PR DESCRIPTION
These methods now accept a `wrappers_options` argument.

https://github.com/plataformatec/simple_form/pull/997