### PR TITLE
[#116375253] Restrict Projects by Facility abilities

### DIFF
--- a/vendor/engines/projects/app/services/projects/global_search/project_searcher.rb
+++ b/vendor/engines/projects/app/services/projects/global_search/project_searcher.rb
@@ -18,6 +18,12 @@ module Projects
         end
       end
 
+      def restrict(projects)
+        projects.select do |project|
+          Ability.new(user, project.facility).can?(:show, project)
+        end
+      end
+
       def search
         query_object.where("lower(name) LIKE ?", "%#{query.downcase}%")
       end

--- a/vendor/engines/projects/spec/controllers/global_search_controller_spec.rb
+++ b/vendor/engines/projects/spec/controllers/global_search_controller_spec.rb
@@ -7,4 +7,34 @@ RSpec.describe GlobalSearchController do
         .to include(Projects::GlobalSearch::ProjectSearcher)
     end
   end
+
+  describe "a facility staff" do
+    let(:facility) { project.facility }
+    let(:project) { FactoryGirl.create(:project) }
+    let(:user) { FactoryGirl.create(:user, :staff, facility: facility) }
+    let(:results) { assigns[:searchers].find { |s| s.template == "projects" }.results }
+    before { sign_in user }
+
+    context "while not in the facility" do
+      it "finds the project" do
+        get :index, search: project.name
+        expect(results).to include(project)
+      end
+    end
+
+    context "while in another facility" do
+      let(:facility2) { FactoryGirl.create(:facility) }
+      it "does not find the project" do
+        get :index, facility_id: facility2, search: project.name
+        expect(results).not_to include(project)
+      end
+    end
+
+    context "while in the facility" do
+      it "finds the project" do
+        get :index, facility: facility, search: project.name
+        expect(results).to include(project)
+      end
+    end
+  end
 end


### PR DESCRIPTION
When determining permissions for the `show` view of a `Project`, it uses the project's `facility` as its base resource. When restricting global searches, it should use the same.

This means that of the 3 current global search types, only one, `OrderSearcher`, would be using the `restrict` method from the base class. It still felt general enough to belong there so I left it.