### PR TITLE
Date parsing updates

### DIFF
--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -105,7 +105,7 @@ module DateHelper
   end
 
   def parse_mmddyyyy_in_current_zone!(date_string)
-    DateTime.strptime(date_string, "%m/%d/%Y").to_time_in_current_zone
+    DateTime.strptime(date_string, "%m/%d/%Y").to_date.beginning_of_day
   end
 
 end

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe DateHelper do
     context "with valid dates" do
       %w(1/1/2014 3/31/2014 10/2/2014 12/31/2014).each do |date_string|
         it "considers '#{date_string}' a valid date" do
-          expect(parse_usa_import_date(date_string))
-            .to eq DateTime.strptime(date_string, "%m/%d/%Y").to_time_in_current_zone
+          expect(parse_usa_import_date(date_string)).to be_present
         end
       end
 

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -18,9 +18,14 @@ RSpec.describe DateHelper do
         end
       end
 
-      it "reads dates in USA-style MM/DD/YYYY format" do
-        expect(parse_usa_import_date("12/8/2014").month).to be 12
+      it "parses dates in USA-style MM/DD/YYYY format" do
+        expect(parse_usa_import_date("8/12/2014").day).to be 12
         expect(parse_usa_import_date("8/12/2014").month).to be 8
+        expect(parse_usa_import_date("8/12/2014").year).to be 2014
+
+        expect(parse_usa_import_date("12/8/2014").day).to be 8
+        expect(parse_usa_import_date("12/8/2014").month).to be 12
+        expect(parse_usa_import_date("12/8/2014").year).to be 2014
       end
     end
   end


### PR DESCRIPTION
I extracted this from the `rails4` branch for potential discussion. We don't necessarily need to merge it to `master` separately but it should work if we do.

The issue was in replacing the deprecated `to_time_in_current_zone` call in `date_helper` with `in_time_zone` as the deprecation notice suggests:

```
[1] pry(main)> DateTime.strptime("5/26/2016", "%m/%d/%Y").to_time_in_current_zone
=> Thu, 26 May 2016 00:00:00 CDT -05:00
[2] pry(main)> DateTime.strptime("5/26/2016", "%m/%d/%Y").in_time_zone
=> Wed, 25 May 2016 19:00:00 CDT -05:00
```

When importing dates, we want the time to be beginning-of-day in the current zone, so I went with this instead:

```
[3] pry(main)> DateTime.strptime("5/26/2016", "%m/%d/%Y").to_date.beginning_of_day
=> Thu, 26 May 2016 00:00:00 CDT -05:00
```

This works with Rails 3.2 and 4.0, with no deprecation notices.