### PR TITLE
Enable features in specs where necessary

### DIFF
--- a/spec/controllers/facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_accounts_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "controller_spec_helper"
 
-RSpec.describe FacilityAccountsController do
+RSpec.describe FacilityAccountsController, feature_setting: { edit_accounts: true } do
   let(:facility) { @authable }
 
   render_views

--- a/spec/controllers/training_requests_controller_spec.rb
+++ b/spec/controllers/training_requests_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe TrainingRequestsController do
+RSpec.describe TrainingRequestsController, feature_setting: { training_requests: true } do
   let(:facility) { FactoryGirl.create(:setup_facility) }
   let(:product) do
     FactoryGirl.create(:setup_item, facility: facility,


### PR DESCRIPTION
These are testing features that can be disabled with a feature flag which removes the routes.

I haven't found any documentation around this, but it seems like Rails 3 controller specs didn't check the routes, it just called methods directly on the controller. Now Rails 4 does check. This should fix some of the tests in UIC.