### PR TITLE
DO NOT MERGE: Reduce spec to one failing case

### DIFF
--- a/spec/services/accessories_child_updater_spec.rb
+++ b/spec/services/accessories_child_updater_spec.rb
@@ -1,77 +1,29 @@
 require "rails_helper"
 
 RSpec.describe Accessories::ChildUpdater do
-  let(:order) { Order.new }
-  let(:order_detail) do
-    build_stubbed :order_detail,
-                  order: order,
-                  child_order_details: [],
-                  attributes: {
-                    order_id: order.id,
-                  }
+  let!(:child_order_detail) do
+    FactoryGirl.create(
+      :order_detail,
+      order: order,
+      parent_order_detail_id: parent_order_detail.id,
+      product: product,
+    )
   end
 
-  describe "update_children" do
-    let(:child_order_detail) { build_stubbed :order_detail, order: order }
-    before { allow(order_detail).to receive(:child_order_details).and_return [child_order_detail] }
+  let(:order) { FactoryGirl.create(:purchased_order, product: product) }
+  let(:parent_order_detail) { order.order_details.first }
+  let(:product) { FactoryGirl.create(:setup_item) }
+  let(:user) { order.user }
 
-    it "updates the child" do
-      expect(child_order_detail).to receive(:assign_actual_price)
-      expect(child_order_detail).to receive(:save)
-      expect(order_detail.update_children).to eq([child_order_detail])
-    end
-  end
-
-  describe "updating children save hooks" do
-    let(:reservation) { create :purchased_reservation }
-    let(:order_detail) { reservation.order_detail }
-    let(:order) { order_detail.order }
-    let(:product) { create :setup_item, facility: order_detail.facility }
-    let(:user) { reservation.user }
-    let!(:child_order_detail) { order_detail.child_order_details.create(attributes_for :order_detail, product: product, order: order) }
-
-    context "when the parent moves from new to in process" do
-      before do
-        order_detail.update_order_status! user, OrderStatus.inprocess.first
-      end
-
-      it "moves the child to in process as well" do
-        expect(child_order_detail).to be_inprocess
-      end
+  context "when transitioning the parent from new to inprocess" do
+    before(:each) do
+      expect(parent_order_detail.reload.child_order_details).to eq [child_order_detail]
+      parent_order_detail.update_order_status!(user, OrderStatus.inprocess.first)
     end
 
-    context "when the parent moves from new to complete" do
-      before do
-        reservation.end_reservation!
-      end
-
-      it "moves the child to complete as well" do
-        expect(child_order_detail).to be_complete
-        expect(child_order_detail.fulfilled_at).to eq(order_detail.fulfilled_at)
-      end
-    end
-
-    context "when the parent moves from complete to canceled" do
-      before do
-        allow_any_instance_of(Reservation).to receive(:can_cancel?).and_return true
-        reservation.end_reservation!
-        order_detail.update_order_status! user, OrderStatus.canceled.first
-      end
-
-      it "moves the child to canceled" do
-        expect(child_order_detail).to be_canceled
-      end
-    end
-
-    context "when the child has been canceled, but the parent is still new and moves to completed" do
-      before do
-        child_order_detail.update_order_status! user, OrderStatus.canceled.first
-        reservation.end_reservation!
-      end
-
-      it "does not move the child" do
-        expect(child_order_detail).to be_canceled
-      end
+    it "transitions parent and child to inprocess" do
+      expect(parent_order_detail).to be_inprocess
+      expect(child_order_detail).to be_inprocess
     end
   end
 end

--- a/spec/services/accessories_child_updater_spec.rb
+++ b/spec/services/accessories_child_updater_spec.rb
@@ -1,14 +1,16 @@
 require "rails_helper"
 
 RSpec.describe Accessories::ChildUpdater do
-  let!(:child_order_detail) do
+  let(:child_order_detail) do
     FactoryGirl.create(
       :order_detail,
       order: order,
+      order_status: OrderStatus.new_status,
       parent_order_detail_id: parent_order_detail.id,
       product: product,
     )
   end
+
 
   let(:order) { FactoryGirl.create(:purchased_order, product: product) }
   let(:parent_order_detail) { order.order_details.first }
@@ -23,7 +25,7 @@ RSpec.describe Accessories::ChildUpdater do
 
     it "transitions parent and child to inprocess" do
       expect(parent_order_detail).to be_inprocess
-      expect(child_order_detail).to be_inprocess
+      expect(child_order_detail.reload).to be_inprocess
     end
   end
 end


### PR DESCRIPTION
I'm opening this PR to debug, not merge.

I rewrote this to isolate one case: transitioning from `new` to `inprocess` when an `OrderDetail` has an accessory (child `OrderDetail`). The existing tests did some stubbing, but this version attempts to create real objects persisted to disk. From the web app, these transitions seem to work as expected, but this spec fails in Rails 3.2 and Rails 4.1.