### PR TITLE
[#126377] Fix slow page load on products index

### DIFF
--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -12,14 +12,6 @@ class InstrumentsController < ProductsCommonController
 
   skip_before_filter :init_product, only: [:instrument_statuses]
 
-  # GET /facilities/:facility_id/instruments
-  def index
-    super
-    # find current and next upcoming reservations for each instrument
-    @reservations = {}
-    @instruments.each { |i| @reservations[i.id] = i.reservations.upcoming[0..2] }
-  end
-
   # GET /facilities/:facility_id/instruments/:instrument_id
   def show
     assert_product_is_accessible!

--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -9,7 +9,9 @@ class ProductsCommonController < ApplicationController
   before_filter :store_fullpath_in_session
 
   include TranslationHelper
-  load_and_authorize_resource except: [:show, :manage]
+
+  load_resource except: [:show, :manage, :index]
+  authorize_resource except: [:show, :manage]
 
   layout "two_column"
 


### PR DESCRIPTION
In #565, we refactored to share Products#index views. As part of this,
we got rid of the need for the specific `@instruments`, `@services`,
etc in the views. CanCan was still loading these variables, but without
a facility restriction.

There was some vestigial code in the instruments controller that loaded
from when we used to include a lot more information like upcoming
reservations and relay status. See
d4579e6b67419ff51a052a82bb5c93ed0626ead5. I believe this was removed
when we added the timeline/daily view.

This was now loading upcoming reservation status for _every_ instrument
in NUcore, not just the ones for the facility.