### PR TITLE
[#119570693] Disable quantity editing when survey controls quantity

### DIFF
--- a/app/models/external_service/survey_response.rb
+++ b/app/models/external_service/survey_response.rb
@@ -15,8 +15,11 @@ class SurveyResponse
       receiver.receiver = od # must assign so receiver type is stored
       receiver.response_data = response_data
       receiver.external_id = params[:survey_id].presence
+      if params[:quantity].present?
+        receiver.manages_quantity = true
+        od.quantity = params[:quantity].to_i
+      end
       receiver.save!
-      od.quantity = params[:quantity].to_i if params[:quantity].present?
       od.merge!
       receiver
     end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -549,7 +549,11 @@ class OrderDetail < ActiveRecord::Base
 
   # returns true if the associated survey response set has been completed
   def survey_completed?
-    !external_service_receiver.nil?
+    external_service_receiver.present?
+  end
+
+  def quantity_locked_by_survey?
+    survey_completed? && external_service_receiver.manages_quantity?
   end
 
   def account_usable_by_order_owner?

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -16,7 +16,7 @@
     - if order_detail.bundle
       %td.centered= order_detail.quantity
     - else
-      %td.centered= text_field_tag "quantity#{order_detail.id}", order_detail.quantity, value: order_detail.quantity, size: 3
+      %td.centered= text_field_tag "quantity#{order_detail.id}", order_detail.quantity, value: order_detail.quantity, size: 3, disabled: order_detail.quantity_locked_by_survey?
 
   - elsif order_detail.product.is_a?(Item)
     %td

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -1,30 +1,30 @@
 %tr
   - if first_of_group
-    - row_span = @order.order_details.find(:all, :conditions => {:group_id => order_detail.group_id}).length
-    %td.centered{:rowspan => row_span * (acting_as? ? 2 : 1) }= link_to 'Remove', remove_order_path(@order, order_detail), :method => :put
+    - row_span = @order.order_details.find(:all, conditions: { group_id: order_detail.group_id}).length
+    %td.centered{ rowspan: row_span * (acting_as? ? 2 : 1) }= link_to "Remove", remove_order_path(@order, order_detail), method: :put
   - elsif order_detail.group_id.nil?
-    %td.centered{:rowspan => (acting_as? ? 2 : 1) }= link_to 'Remove', remove_order_path(@order, order_detail), :method => :put
+    %td.centered{ rowspan: (acting_as? ? 2 : 1) }= link_to "Remove", remove_order_path(@order, order_detail), method: :put
 
   - if order_detail.product.is_a?(Instrument)
     %td
-      = render :partial => 'instrument_desc', :locals => { :order_detail => order_detail }
+      = render partial: "instrument_desc", locals: { order_detail: order_detail }
     %td
 
   - elsif order_detail.product.is_a?(Service)
     %td
-      = render :partial => 'service_desc', :locals => { :order_detail => order_detail }
+      = render partial: "service_desc", locals: { order_detail: order_detail }
     - if order_detail.bundle
       %td.centered= order_detail.quantity
     - else
-      %td.centered= text_field_tag "quantity#{order_detail.id}", order_detail.quantity, :value => order_detail.quantity, :size => 3
+      %td.centered= text_field_tag "quantity#{order_detail.id}", order_detail.quantity, value: order_detail.quantity, size: 3
 
   - elsif order_detail.product.is_a?(Item)
     %td
-      = render :partial => 'item_desc', :locals => { :order_detail => order_detail }
+      = render partial: "item_desc", locals: { order_detail: order_detail }
     - if order_detail.bundle
       %td.centered= order_detail.quantity
     - else
-      %td.centered= text_field_tag "quantity#{order_detail.id}", order_detail.quantity, :value => order_detail.quantity, :size => 3
+      %td.centered= text_field_tag "quantity#{order_detail.id}", order_detail.quantity, value: order_detail.quantity, size: 3
 
   - if order_detail.cost_estimated?
     %td.currency= show_estimated_cost(order_detail)
@@ -38,7 +38,7 @@
     %td.currency Unassigned
 - if acting_as?
   %tr
-    %td{:colspan => 4 }
+    %td{ colspan: 4 }
       %label.inline Note:
-      = text_field_tag("note#{order_detail.id}", order_detail.note, :maxlength => 100, :size => 100 )
+      = text_field_tag("note#{order_detail.id}", order_detail.note, maxlength: 100, size: 100 )
 

--- a/db/migrate/20160601214939_add_quantity_lock_to_external_service_receivers.rb
+++ b/db/migrate/20160601214939_add_quantity_lock_to_external_service_receivers.rb
@@ -1,0 +1,5 @@
+class AddQuantityLockToExternalServiceReceivers < ActiveRecord::Migration
+  def change
+    add_column :external_service_receivers, :manages_quantity, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160526192926) do
+ActiveRecord::Schema.define(:version => 20160601214939) do
 
   create_table "account_users", :force => true do |t|
     t.integer  "account_id",               :null => false
@@ -105,10 +105,11 @@ ActiveRecord::Schema.define(:version => 20160526192926) do
     t.integer  "external_service_id"
     t.integer  "receiver_id"
     t.string   "receiver_type"
-    t.datetime "created_at",          :null => false
-    t.datetime "updated_at",          :null => false
+    t.datetime "created_at",                             :null => false
+    t.datetime "updated_at",                             :null => false
     t.string   "external_id"
     t.text     "response_data"
+    t.boolean  "manages_quantity",    :default => false, :null => false
   end
 
   add_index "external_service_receivers", ["external_service_id"], :name => "index_external_service_receivers_on_external_service_id"

--- a/spec/models/external_service/survey_response_spec.rb
+++ b/spec/models/external_service/survey_response_spec.rb
@@ -83,6 +83,24 @@ RSpec.describe SurveyResponse do
       receiver = survey_response.save!
       expect(receiver.receiver.quantity).to eq quantity
     end
+
+    it "locks the quantity for order if there is a quantity param" do
+      params[:quantity] = order_detail.quantity
+      receiver = survey_response.save!
+      expect(order_detail.reload).to be_quantity_locked_by_survey
+    end
+
+    it "does not lock the quantity for order detail if no quantity" do
+      params[:quantity] = nil
+      receiver = survey_response.save!
+      expect(order_detail.reload).not_to be_quantity_locked_by_survey
+    end
+
+    it "does not lock the quantity for order detail if no quantity" do
+      params.delete(:quantity)
+      receiver = survey_response.save!
+      expect(order_detail.reload).not_to be_quantity_locked_by_survey
+    end
   end
 
 end

--- a/spec/models/external_service/survey_response_spec.rb
+++ b/spec/models/external_service/survey_response_spec.rb
@@ -86,20 +86,23 @@ RSpec.describe SurveyResponse do
 
     it "locks the quantity for order if there is a quantity param" do
       params[:quantity] = order_detail.quantity
-      receiver = survey_response.save!
-      expect(order_detail.reload).to be_quantity_locked_by_survey
+      expect { survey_response.save! }
+        .to change { order_detail.reload.quantity_locked_by_survey? }
+        .to(true)
     end
 
     it "does not lock the quantity for order detail if no quantity" do
       params[:quantity] = nil
-      receiver = survey_response.save!
-      expect(order_detail.reload).not_to be_quantity_locked_by_survey
+      expect { survey_response.save! }
+        .not_to change { order_detail.reload.quantity_locked_by_survey? }
+        .from(false)
     end
 
     it "does not lock the quantity for order detail if no quantity" do
       params.delete(:quantity)
-      receiver = survey_response.save!
-      expect(order_detail.reload).not_to be_quantity_locked_by_survey
+      expect { survey_response.save! }
+        .not_to change { order_detail.reload.quantity_locked_by_survey? }
+        .from(false)
     end
   end
 


### PR DESCRIPTION
If a quantity is returned by the outside application, then disable the quantity box. This will also affect IMSERC, but this appears to be the correct behavior there as well.