### PR TITLE
Improve Sanger Sequencing form design

### DIFF
--- a/app/assets/stylesheets/app/tables.scss
+++ b/app/assets/stylesheets/app/tables.scss
@@ -1,0 +1,8 @@
+.table-tight {
+  width: inherit;
+
+  input,
+  .control-group {
+    margin-bottom: 0;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,7 +12,7 @@ $baseFontSize: 12px;
 
 @import "app/typography";
 @import "app/reservation_edit";
-@import "app/header.scss";
+@import "app/header";
 @import "app/collapsable";
 @import "app/sortable";
 @import "app/tab_count";
@@ -25,6 +25,7 @@ $baseFontSize: 12px;
 @import "app/reservations";
 @import "app/user_product_access_list";
 @import "app/facility_accounts";
+@import "app/tables";
 @import "app/chosen-override";
 
 @import "uploadify";

--- a/app/views/orders/show.html.haml
+++ b/app/views/orders/show.html.haml
@@ -3,7 +3,7 @@
 
 = content_for :breadcrumb do
   %ul.breadcrumb
-    %li= link_to t(".crumbs.home"), :root
+    %li= link_to t("pages.home"), :root
 
     - order_detail = @order.order_details.first
     - if order_detail.present?
@@ -13,7 +13,7 @@
           facility_path(order_detail.product.facility)
 
     %li &raquo;
-    %li= t(".crumbs.cart")
+    %li= t("pages.cart")
 
 %p= t(".intro")
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -629,9 +629,6 @@ en:
       h1: "Cart"
       intro: "Your cart will be saved between visits and can be added to, or your order completed at a later time."
       notice: "Your cart is empty."
-      crumbs:
-        home: "Home"
-        cart: "Cart"
       label:
         account: "Payment Source"
       link:

--- a/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/submissions_controller.rb
+++ b/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/submissions_controller.rb
@@ -4,6 +4,9 @@ module SangerSequencing
 
     NEW_IDS_COUNT = 5
 
+    customer_tab :all
+    before_filter { @active_tab = "orders" }
+
     load_and_authorize_resource only: [:edit, :update, :fetch_ids]
 
     def new
@@ -38,6 +41,10 @@ module SangerSequencing
     end
 
     private
+
+    def current_facility
+      @current_facility ||= @submission.order_detail.facility
+    end
 
     def clean_samples
       # Clean up from abandoned submissions that might have requested extra IDs

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/submissions/edit.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/submissions/edit.html.haml
@@ -4,12 +4,18 @@
 = content_for :head_content do
   = javascript_include_tag "sanger_sequencing/submission"
 
-= "Submission ##{@submission.id}"
+= content_for :breadcrumb do
+  %ul.breadcrumb
+    %li= link_to t("pages.home"), :root
+    %li &raquo;
+    %li= link_to current_facility, facility_path(current_facility)
+    %li &raquo;
+    %li= link_to t("pages.cart"), :cart
 
 = simple_form_for @submission, html: { data: { fetch_ids_url: fetch_ids_sanger_sequencing_submission_path(@submission) } } do |f|
   = hidden_field_tag :referer, params[:referer]
   = hidden_field_tag :success_url, params[:success_url]
-  %table.table.table-striped
+  %table.table.table-striped.table-tight
     %thead
       %tr
         %th= SangerSequencing::Sample.human_attribute_name(:customer_sample_id)
@@ -21,7 +27,7 @@
           = sf.input :id, as: :hidden, input_html: { class: "js--sampleId" }
         %td.js--sampleId= sf.object.id
         %td
-          = sf.remove_nested_fields_link text("remove"), class: "btn"
+          = sf.remove_nested_fields_link text("remove"), tabindex: -1
           = sf.input :_destroy, as: :hidden
     %tfoot
       %td{colspan: 2}

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/submissions/edit.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/submissions/edit.html.haml
@@ -30,7 +30,6 @@
           = sf.remove_nested_fields_link text("remove"), tabindex: -1
           = sf.input :_destroy, as: :hidden
     %tfoot
-      %td{colspan: 2}
-      %td= f.add_nested_fields_link :samples, text("add"), class: "btn btn-success"
+      %td{colspan: 3}= f.add_nested_fields_link :samples, text("add"), class: "btn btn-success"
 
   = f.submit text("submit"), class: "btn btn-primary"


### PR DESCRIPTION
Extends from #641. Only the last commit is relevant.

* Tightens up the form
* Adds breadcrumbs
* Maintains the My Orders, My Reservations tabs while in the form