### PR TITLE
[#119570781] Add note to cart form for users

### DIFF
--- a/app/assets/stylesheets/app/cart.scss
+++ b/app/assets/stylesheets/app/cart.scss
@@ -1,0 +1,12 @@
+.cart__quantityField {
+  width: 4em;
+}
+
+.cart__noteField {
+  margin-top: 1em;
+  input {
+    margin-bottom: 0;
+    width: 80%;
+  }
+}
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,6 +26,7 @@ $baseFontSize: 12px;
 @import "app/user_product_access_list";
 @import "app/facility_accounts";
 @import "app/tables";
+@import "app/cart";
 @import "app/chosen-override";
 
 @import "uploadify";

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -1,7 +1,6 @@
 class InstrumentsController < ProductsCommonController
 
   customer_tab  :show, :public_schedule
-  admin_tab     :create, :edit, :index, :manage, :new, :schedule, :update
 
   before_action :store_fullpath_in_session, only: [:index, :show]
   before_action :set_default_lock_window, only: [:create, :update]
@@ -78,18 +77,6 @@ class InstrumentsController < ProductsCommonController
       acting_user.cart(session_user),
       order: { order_details: [{ product_id: @instrument.id, quantity: 1 }] },
     )
-  end
-
-  # PUT /facilities/:facility_id/instruments/:instrument_id
-  def update
-    @header_prefix = "Edit"
-
-    if @instrument.update_attributes(params[:instrument])
-      flash[:notice] = "Instrument was successfully updated."
-      return redirect_to(manage_facility_instrument_path(current_facility, @instrument))
-    end
-
-    render action: "edit"
   end
 
   # GET /facilities/:facility_id/instruments/:instrument_id/schedule

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -313,11 +313,6 @@ class OrdersController < ApplicationController
 
   private
 
-  def show_notes_field?(order_detail)
-    acting_as? || order_detail.product.note_available_to_users?
-  end
-  helper_method :show_notes_field?
-
   # Group into chunks by the group id. If group_id is nil, then it should get its
   # own chunk.
   def grouped_order_details

--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -103,7 +103,7 @@ class ProductsCommonController < ApplicationController
 
   # POST /services
   def create
-    @product = current_facility_products.new(params[:"#{singular_object_name}"])
+    @product = current_facility_products.new(product_params)
     @product.initial_order_status_id = OrderStatus.default_order_status.id
 
     save_product_into_object_name_instance
@@ -123,13 +123,18 @@ class ProductsCommonController < ApplicationController
   # PUT /services/1
   def update
     respond_to do |format|
-      if @product.update_attributes(params[:"#{singular_object_name}"])
+      if @product.update_attributes(product_params)
         flash[:notice] = "#{@product.class.name.capitalize} was successfully updated."
         format.html { redirect_to([:manage, current_facility, @product]) }
       else
         format.html { render action: "edit" }
       end
     end
+  end
+
+  def product_params
+    # TODO: Strong params
+    params[:"#{singular_object_name}"]
   end
 
   # DELETE /services/1

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -22,4 +22,8 @@ module OrdersHelper
     end
   end
 
+  def show_note_input_to_user?(order_detail)
+    acting_as? || order_detail.product.note_available_to_users?
+  end
+
 end

--- a/app/views/admin/products/_details_fields.haml
+++ b/app/views/admin/products/_details_fields.haml
@@ -21,3 +21,4 @@
 
 = f.input :is_archived, as: :boolean, label: false, inline_label: text(".hints.is_archived")
 = f.input :is_hidden, as: :boolean, label: false, inline_label: text(".hints.is_hidden", field: f.object.class.name.downcase)
+= f.input :note_available_to_users, label: false, inline_label: text(".hints.note_available_to_users")

--- a/app/views/admin/shared/_product_manage.haml
+++ b/app/views/admin/shared/_product_manage.haml
@@ -16,3 +16,4 @@
     = f.input :training_request_contacts
 = f.input :is_archived
 = f.input :is_hidden
+= f.input :note_available_to_users

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -4,7 +4,7 @@
 
   %td
     = render "#{order_detail.product.class.name.underscore}_desc", order_detail: order_detail
-    - if show_notes_field?(order_detail)
+    - if show_note_input_to_user?(order_detail)
       %label.inline.cart__noteField{ for: "note#{order_detail.id}" }
         Note:
         = text_field_tag("note#{order_detail.id}", order_detail.note, maxlength: 100, size: 100 )

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -1,30 +1,20 @@
 %tr
-  - if first_of_group
-    - row_span = @order.order_details.where(group_id: order_detail.group_id).count
-    %td.centered{ rowspan: row_span * (acting_as? ? 2 : 1) }= link_to "Remove", remove_order_path(@order, order_detail), method: :put
-  - elsif order_detail.group_id.nil?
-    %td.centered{ rowspan: (acting_as? ? 2 : 1) }= link_to "Remove", remove_order_path(@order, order_detail), method: :put
+  - if order_detail_iteration.first?
+    %td.centered{ rowspan: order_details.count }= link_to "Remove", remove_order_path(@order, order_detail), method: :put
 
-  - if order_detail.product.is_a?(Instrument)
-    %td
-      = render partial: "instrument_desc", locals: { order_detail: order_detail }
-    %td
+  %td
+    = render "#{order_detail.product.class.name.underscore}_desc", order_detail: order_detail
+    - if show_notes_field?(order_detail)
+      %label.inline.cart__noteField{ for: "note#{order_detail.id}" }
+        Note:
+        = text_field_tag("note#{order_detail.id}", order_detail.note, maxlength: 100, size: 100 )
 
-  - elsif order_detail.product.is_a?(Service)
-    %td
-      = render partial: "service_desc", locals: { order_detail: order_detail }
-    - if order_detail.bundle
+    - if order_detail.product.is_a?(Instrument)
+      %td
+    - elsif order_detail.bundle
       %td.centered= order_detail.quantity
     - else
-      %td.centered= text_field_tag "quantity#{order_detail.id}", order_detail.quantity, value: order_detail.quantity, size: 3, disabled: order_detail.quantity_locked_by_survey?
-
-  - elsif order_detail.product.is_a?(Item)
-    %td
-      = render partial: "item_desc", locals: { order_detail: order_detail }
-    - if order_detail.bundle
-      %td.centered= order_detail.quantity
-    - else
-      %td.centered= text_field_tag "quantity#{order_detail.id}", order_detail.quantity, value: order_detail.quantity, size: 3
+      %td.centered= text_field_tag "quantity#{order_detail.id}", order_detail.quantity, value: order_detail.quantity, size: 3, class: "cart__quantityField", disabled: order_detail.quantity_locked_by_survey?
 
   - if order_detail.cost_estimated?
     %td.currency= show_estimated_cost(order_detail)
@@ -36,8 +26,3 @@
     - if @order.has_subsidies?
       %td.currency Unassigned
     %td.currency Unassigned
-- if acting_as?
-  %tr
-    %td{ colspan: 4 }
-      %label.inline Note:
-      = text_field_tag("note#{order_detail.id}", order_detail.note, maxlength: 100, size: 100 )

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -1,6 +1,6 @@
 %tr
   - if order_detail_iteration.first?
-    %td.centered{ rowspan: order_details.count }= link_to "Remove", remove_order_path(@order, order_detail), method: :put
+    %td.centered{ rowspan: order_details.count }= link_to text("shared.remove"), remove_order_path(@order, order_detail), method: :put
 
   %td
     = render "#{order_detail.product.class.name.underscore}_desc", order_detail: order_detail
@@ -22,7 +22,7 @@
       %td.currency= show_estimated_subsidy(order_detail)
     %td.currency= show_estimated_total(order_detail)
   - else
-    %td.currency Unassigned
+    %td.currency= text("shared.unassigned")
     - if @order.has_subsidies?
-      %td.currency Unassigned
-    %td.currency Unassigned
+      %td.currency= text("shared.unassigned")
+    %td.currency= text("shared.unassigned")

--- a/app/views/orders/_form.html.haml
+++ b/app/views/orders/_form.html.haml
@@ -11,13 +11,10 @@
         %th.currency= t(".th.extend")
 
     %tbody
-      - prev_group_id = nil
-      - order.order_details.order(:group_id).each do |order_detail|
-        = render "cart_row",
-          order_detail: order_detail,
-          first_of_group: order_detail.group_id && (prev_group_id != order_detail.group_id)
-        - prev_group_id = order_detail.group_id
+      - grouped_order_details.each do |order_details|
+        = render partial: "cart_row", collection: order_details, as: :order_detail, locals: { order_details: order_details }
 
+    %tfoot
       %tr
         %td.currency{colspan: "3"}
           %b= t(".td.total")

--- a/app/views/orders/receipt.html.haml
+++ b/app/views/orders/receipt.html.haml
@@ -40,6 +40,8 @@
           .order-detail-description= order_detail_description(order_detail)
           - if res
             .order-detail-extra= res
+          - if order_detail.note.present?
+            .order-detail-extra.order-detail-note= "Note: #{order_detail.note}"
         %td.currency=order_detail.wrapped_cost
         - if @order.has_subsidies?
           %td.currency= order_detail.wrapped_subsidy

--- a/app/views/reservations/_account_field.html.haml
+++ b/app/views/reservations/_account_field.html.haml
@@ -19,5 +19,5 @@
           - if acting_as?
             = render_view_hook "after_account", f: f, order_detail: @order_detail
 
-        - if acting_as?
+        - if show_note_input_to_user?(@order_detail)
           .span6= f.input :note

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,7 @@ en:
     create: Create
     select_all: Select All
     select_none: Select None
+    unassigned: Unassigned
     footer:
       copyright_html: "&copy; Copyright 2010&ndash;%{to_date} Northwestern University"
       logo_alt: "Northwestern Logo"

--- a/config/locales/views/admin/en.products.yml
+++ b/config/locales/views/admin/en.products.yml
@@ -23,6 +23,7 @@ en:
             is_archived: "Inactivate the product, disallowing purchase and viewing"
             is_hidden: "Hide %{field} from end users; visible to staff when \"ordering on behalf\" of another user"
             training_request_contacts: Comma separated list of email addresses to be notified when a training request is placed.
+            note_available_to_users: Users may submit a note when purchasing
           deposit_account:
             label: "Recharge Chart String and Account"
             add: "Add Chart String"

--- a/db/migrate/20160602232926_add_note_available_to_products.rb
+++ b/db/migrate/20160602232926_add_note_available_to_products.rb
@@ -1,0 +1,5 @@
+class AddNoteAvailableToProducts < ActiveRecord::Migration
+  def change
+    add_column :products, :note_available_to_users, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -456,6 +456,7 @@ ActiveRecord::Schema.define(version: 20160606205228) do
     t.integer  "reserve_interval",          limit: 4
     t.integer  "lock_window",               limit: 4,     default: 0,     null: false
     t.text     "training_request_contacts", limit: 65535
+    t.boolean  "note_available_to_users",                 default: false, null: false
   end
 
   add_index "products", ["facility_account_id"], name: "fk_facility_accounts", using: :btree

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -469,7 +469,6 @@ RSpec.describe InstrumentsController do
     end
 
     def assert_successful_update
-      expect(assigns(:header_prefix)).to eq("Edit")
       expect(assigns(:instrument)).to eq(@instrument)
       yield
       is_expected.to set_flash

--- a/spec/features/placing_an_order_spec.rb
+++ b/spec/features/placing_an_order_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe "Placing an item order" do
                        price_group: PriceGroup.base.first, product: product,
                        unit_cost: 33.25)
   end
+  let!(:account_price_group_member) do
+    FactoryGirl.create(:account_price_group_member, account: account, price_group: price_policy.price_group)
+  end
   let(:user) { FactoryGirl.create(:user) }
 
   before do

--- a/spec/features/placing_an_order_spec.rb
+++ b/spec/features/placing_an_order_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe "Placing an item order" do
+  let!(:product) { FactoryGirl.create(:setup_item) }
+  let!(:account) { FactoryGirl.create(:nufs_account, :with_account_owner, owner: user) }
+  let(:facility) { product.facility }
+  let!(:price_policy) do
+    FactoryGirl.create(:item_price_policy,
+                       price_group: PriceGroup.base.first, product: product,
+                       unit_cost: 33.25)
+  end
+  let(:user) { FactoryGirl.create(:user) }
+
+  before do
+    login_as user
+  end
+
+  describe "adding an item to the cart" do
+    def add_to_cart
+      visit "/"
+      click_link facility.name
+      click_link product.name
+      click_link "Add to cart"
+      choose account.to_s
+      click_button "Continue"
+    end
+
+    it "can place an order", :aggregate_failures do
+      add_to_cart
+      click_button "Purchase"
+      expect(page).to have_content "Order Receipt"
+      expect(page).to have_content "Ordered By#{user.full_name}"
+      expect(page).to have_content "$33.25"
+    end
+
+    it "can place an order with a note if the feature is enabled for the product" do
+      product.update_attributes(note_available_to_users: true)
+      add_to_cart
+      fill_in "Note", with: "This is a note"
+      click_button "Purchase"
+      expect(page).to have_content "This is a note"
+    end
+  end
+end

--- a/spec/features/purchasing_a_reservation_spec.rb
+++ b/spec/features/purchasing_a_reservation_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Purchasing a reservation" do
 
-  let!(:instrument) { FactoryGirl.create(:setup_instrument) }
+  let!(:instrument) { FactoryGirl.create(:setup_instrument, note_available_to_users: true) }
   let!(:facility) { instrument.facility }
   let!(:account) { FactoryGirl.create(:nufs_account, :with_account_owner, owner: user) }
   let!(:price_policy) { FactoryGirl.create(:instrument_price_policy, price_group: PriceGroup.base.first, product: instrument) }
@@ -14,10 +14,12 @@ RSpec.describe "Purchasing a reservation" do
     click_link facility.name
     click_link instrument.name
     select user.accounts.first.description, from: "Payment Source"
+    fill_in "Note", with: "A note about my reservation"
     click_button "Create"
   end
 
   it "is on the My Reservations page" do
     expect(page).to have_content "My Reservations"
+    expect(page).to have_content "Note: A note about my reservation"
   end
 end


### PR DESCRIPTION
* Refactor cart form
* Show note on order receipt
* Clean up unnecessary method on InstrumentsController (ProductsCommon could handle it)
* Move note field into same cart row. This enhances the visual connection between
  the note and the order detail. It was getting a little confusing when you have
  bundles where one item has a note field, and another doesn't.