### PR TITLE
Fix Sanger migration for Oracle

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -709,7 +709,7 @@ ActiveRecord::Schema.define(:version => 20160526192926) do
   add_foreign_key "reservations", "order_details", name: "reservations_order_detail_id_fk"
   add_foreign_key "reservations", "products", name: "reservations_product_id_fk"
 
-  add_foreign_key "sanger_sequencing_samples", "sanger_sequencing_submissions", name: "sanger_sequencing_samples_submission_id_fk", column: "submission_id", dependent: :delete, options: "ON UPDATE CASCADE"
+  add_foreign_key "sanger_sequencing_samples", "sanger_sequencing_submissions", name: "sanger_sequencing_samples_submission_id_fk", column: "submission_id", dependent: :delete
 
   add_foreign_key "schedule_rules", "products", name: "schedule_rules_instrument_id_fk", column: "instrument_id"
 

--- a/vendor/engines/sanger_sequencing/db/migrate/20160519030413_create_sanger_sequencing_submissions.rb
+++ b/vendor/engines/sanger_sequencing/db/migrate/20160519030413_create_sanger_sequencing_submissions.rb
@@ -11,7 +11,7 @@ class CreateSangerSequencingSubmissions < ActiveRecord::Migration
     # sequence_start_value is oracle-specific, but mysql throws it away
     create_table :sanger_sequencing_samples, sequence_start_value: 11_111 do |t|
       t.integer :submission_id, null: false
-      t.foreign_key :sanger_sequencing_submissions, column: :submission_id, dependent: :delete, options: "ON UPDATE CASCADE"
+      t.foreign_key :sanger_sequencing_submissions, column: :submission_id, dependent: :delete
       t.timestamps
     end
 


### PR DESCRIPTION
Oracle doesn't support ON UPDATE CASCADE. We don't really need it for MySQL either since our primary keys will never change, so it's easier to just get rid of it.

This has not been released yet, so it shouldn't cause any problems, although devs
should roll back and re-run it to make sure their schema.rb is in sync.