### PR TITLE
Add DatabaseCleaner to make sure fixtures are cleaned before the suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,7 @@ group :test do
   gem "codeclimate_circle_ci_coverage"
   gem "capybara"
   gem "poltergeist"
+  gem "database_cleaner"
 end
 
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
     columnize (0.9.0)
     concurrent-ruby (1.0.2)
     daemons (1.1.9)
+    database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     debugger-linecache (1.2.0)
     delayed_job (4.0.6)
@@ -632,6 +633,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.1)
   coffeelint
   daemons (= 1.1.9)
+  database_cleaner
   dataprobe (~> 1.0.0)!
   delayed_job_active_record (~> 4.0.1)
   devise (~> 3.5.10)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,6 +27,10 @@ RSpec.configure do |config|
   require "capybara/poltergeist"
   Capybara.javascript_driver = :poltergeist
 
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
   config.include Devise::TestHelpers, type: :controller
   config.include FactoryGirl::Syntax::Methods
 


### PR DESCRIPTION
Depending on the ordering of specs, fixtures might get left in the test database for the next time. This makes sure to clean everything out ahead of time.