### PR TITLE
[#126567] Fix infinite loop while ordering reservation on behalf of

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,7 @@ group :test do
   gem "codeclimate_circle_ci_coverage"
   gem "capybara"
   gem "poltergeist"
+  gem "database_cleaner"
 end
 
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
     columnize (0.9.0)
     concurrent-ruby (1.0.2)
     daemons (1.1.9)
+    database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     debugger-linecache (1.2.0)
     delayed_job (4.0.6)
@@ -632,6 +633,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.1)
   coffeelint
   daemons (= 1.1.9)
+  database_cleaner
   dataprobe (~> 1.0.0)!
   delayed_job_active_record (~> 4.0.1)
   devise (~> 3.5.10)

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -308,8 +308,9 @@ class ReservationsController < ApplicationController
   end
 
   def load_basic_resources
-    @order_detail = Order.find(params[:order_id]).order_details.find(params[:order_detail_id])
-    @order = @order_detail.order
+    @order = Order.find(params[:order_id])
+    # It's important that the order_detail be the same object as the one in @order.order_details.first
+    @order_detail = @order.order_details.find { |od| od.id.to_i == params[:order_detail_id].to_i }
     @reservation = @order_detail.reservation
     @instrument = @order_detail.product
     @facility = @instrument.facility
@@ -337,7 +338,7 @@ class ReservationsController < ApplicationController
 
   def save_reservation_and_order_detail
     @reservation.save_as_user!(session_user)
-    @order_detail.reload.assign_estimated_price(nil, @reservation.reserve_end_at)
+    @order_detail.assign_estimated_price(nil, @reservation.reserve_end_at)
     @order_detail.save_as_user!(session_user)
   end
 

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -22,14 +22,13 @@ class Reservation < ActiveRecord::Base
   # Represents a resevation time that is unavailable, but is not an admin reservation
   # Used by timeline view
   attr_accessor     :blackout
-  attr_writer       :note
 
   # used for overriding certain restrictions
   attr_accessor :reserved_by_admin
 
   # Delegations
   #####
-  delegate :note, :ordered_on_behalf_of?, :complete?, :account, :order,
+  delegate :note, :note=, :ordered_on_behalf_of?, :complete?, :account, :order,
            :problem?, :complete!, to: :order_detail, allow_nil: true
 
   delegate :account, :in_cart?, :user, to: :order, allow_nil: true
@@ -38,7 +37,6 @@ class Reservation < ActiveRecord::Base
   delegate :owner, to: :account, allow_nil: true
 
   ## AR Hooks
-  after_save :save_note
   after_update :auto_save_order_detail, if: :order_detail
 
   # Scopes
@@ -281,13 +279,6 @@ class Reservation < ActiveRecord::Base
 
   def auto_save_order_detail
     if (%w(actual_start_at actual_end_at reserve_start_at reserve_end_at) & changes.keys).any?
-      order_detail.save
-    end
-  end
-
-  def save_note
-    if order_detail && @note
-      order_detail.note = @note
       order_detail.save
     end
   end

--- a/spec/features/purchasing_a_reservation.rb
+++ b/spec/features/purchasing_a_reservation.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "Purchasing a reservation" do
+  fixtures :all
+
+  let(:facility) { facilities(:facility) }
+  let(:instrument) { products(:reservation_only_instrument) }
+  let(:user) { users(:normal_user) }
+
+  before do
+    login_as user
+    visit root_path
+    click_link facility.name
+    click_link instrument.name
+    select user.accounts.first.description, from: "Payment Source"
+    click_button "Create"
+  end
+
+  it "is on the My Reservations page" do
+    expect(page).to have_content "My Reservations"
+  end
+end

--- a/spec/features/purchasing_a_reservation_on_behalf_of.rb
+++ b/spec/features/purchasing_a_reservation_on_behalf_of.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe "Purchasing a reservation on behalf of another user" do
+  fixtures :all
+
+  let(:facility) { facilities(:facility) }
+  let(:instrument) { products(:reservation_only_instrument) }
+  let(:facility_admin) { users(:facility_admin) }
+  let(:user) { users(:normal_user) }
+
+  before do
+    login_as facility_admin
+    visit facility_users_path(facility)
+    fill_in "search_term", with: user.first_name
+    click_button "Search"
+    click_link "Order For"
+  end
+
+  it "is now on the facility page" do
+    expect(current_path).to eq(facility_path(facility))
+    expect(page).to have_content("You are ordering for #{user.full_name}")
+  end
+
+  describe "and you create a reservation" do
+    before do
+      click_link instrument.name
+      select user.accounts.first.description, from: "Payment Source"
+      fill_in "Note", with: "A note"
+      click_button "Create"
+    end
+
+    it "returns to My Reservations" do
+      expect(page).to have_content "My Reservations"
+      expect(Reservation.last.note).to eq("A note")
+    end
+  end
+end

--- a/spec/fixtures/account_users.yml
+++ b/spec/fixtures/account_users.yml
@@ -1,5 +1,5 @@
 normal_user_nufs_account:
   account: nufs_account
-  user: user
+  user: normal_user
   user_role: Owner
   created_by: 0

--- a/spec/fixtures/price_group_products.yml
+++ b/spec/fixtures/price_group_products.yml
@@ -1,0 +1,4 @@
+reservation_only_external_price_group_product:
+  product: reservation_only_instrument
+  price_group_id: <%= PriceGroup.external.first.id %>
+  reservation_window: 14

--- a/spec/fixtures/price_policies.yml
+++ b/spec/fixtures/price_policies.yml
@@ -1,8 +1,6 @@
 DEFAULTS: &DEFAULTS
   price_group_id: <%= PriceGroup.external.first.id %>
   can_purchase: true
-  unit_cost: 10
-  unit_subsidy: 0
   start_date: <%= Time.current.beginning_of_day %>
   expire_date: <%= PricePolicy.generate_expire_date(Date.today) %>
 
@@ -10,8 +8,21 @@ standard_item_price_policy:
   <<: *DEFAULTS
   type: ItemPricePolicy
   product: standard_item
+  unit_cost: 10
+  unit_subsidy: 0
 
 standard_service_price_policy:
   <<: *DEFAULTS
   type: ServicePricePolicy
   product: standard_service
+  unit_cost: 10
+  unit_subsidy: 0
+
+reservation_only_instrument_price_policy:
+  <<: *DEFAULTS
+  type: InstrumentPricePolicy
+  product: reservation_only_instrument
+  charge_for: <%= InstrumentPricePolicy::CHARGE_FOR[:reservation] %>
+  usage_rate: 1
+  usage_subsidy: 0
+  minimum_cost: 0

--- a/spec/fixtures/products.yml
+++ b/spec/fixtures/products.yml
@@ -21,3 +21,12 @@ standard_service:
   url_name: "standard-service"
   description: "Standard service"
 
+reservation_only_instrument:
+  <<: *DEFAULTS
+  type: Instrument
+  name: Reservation Only Instrument
+  url_name: "reservation-only-instrument"
+  description: "Reservation only instrument"
+  reserve_interval: 10
+  schedule: reservation_only_instrument_schedule
+

--- a/spec/fixtures/schedule_rules.yml
+++ b/spec/fixtures/schedule_rules.yml
@@ -1,0 +1,14 @@
+reservation_only_schedule_rules:
+  instrument: reservation_only_instrument
+  discount_percent: 0
+  start_hour: 0
+  start_min: 0
+  end_hour: 24
+  end_min: 0
+  on_sun: true
+  on_mon: true
+  on_tue: true
+  on_wed: true
+  on_thu: true
+  on_fri: true
+  on_sat: true

--- a/spec/fixtures/schedules.yml
+++ b/spec/fixtures/schedules.yml
@@ -1,0 +1,3 @@
+reservation_only_instrument_schedule:
+  name: Reservation Only Shared Schedule
+  facility: facility

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,6 +27,10 @@ RSpec.configure do |config|
   require "capybara/poltergeist"
   Capybara.javascript_driver = :poltergeist
 
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
   config.include Devise::TestHelpers, type: :controller
   config.include FactoryGirl::Syntax::Methods
 


### PR DESCRIPTION
The callbacks when ordering on behalf of (specifically with a note) was
causing an infinite loop in Rails 4. We weren’t catching it before
because we were never submitting a note in the tests.