### PR TITLE
Fix timezone spec

### DIFF
--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe DateHelper do
       end
 
       context "when running in the Eastern time zone" do
-        Time.use_zone("Eastern Time (US & Canada)") do
-          it "returns beginning_of_day (midnight) in the local zone" do
+        it "returns beginning_of_day (midnight) in the local zone" do
+          Time.use_zone("Eastern Time (US & Canada)") do
             expect(parse_usa_import_date("05/01/2014").to_s)
-              .to eq("2014-05-01 00:00:00 -0500")
+              .to eq("2014-05-01 00:00:00 -0400")
           end
         end
       end


### PR DESCRIPTION
The `Time.use_zone` needs to be within the `it` block in order to work. The test
was failing in DC where the app is in Eastern time.