### PR TITLE
Spec updates via the DC fork

### DIFF
--- a/spec/controllers/facility_facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_facility_accounts_controller_spec.rb
@@ -78,12 +78,15 @@ RSpec.describe FacilityFacilityAccountsController, if: SettingsHelper.feature_on
       @params.merge!(id: facility_account.id)
     end
 
+    let(:document) { Nokogiri::HTML(response.body) }
+
     it_should_allow_managers_only do
       expect(assigns(:facility_account))
         .to be_kind_of(FacilityAccount).and eq(facility_account)
 
       assigns(:facility_account).account_number_parts.to_h.each do |key, value|
-        expect(response.body).to match(/\[account_number_parts\]\[#{key}\].+value="#{value}"/)
+        expect(document.css("#facility_account_account_number_parts_#{key}").first[:value])
+          .to eq(value)
       end
 
       is_expected.to render_template "edit"

--- a/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
+++ b/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
   let!(:price_policy) { FactoryGirl.create(:instrument_price_policy, price_group: PriceGroup.base.first, product: instrument) }
   let(:user) { FactoryGirl.create(:user) }
   let(:facility_admin) { FactoryGirl.create(:user, :facility_administrator, facility: facility) }
+  let!(:account_price_group_member) do
+    FactoryGirl.create(:account_price_group_member, account: account, price_group: price_policy.price_group)
+  end
 
   before do
     login_as facility_admin

--- a/spec/features/purchasing_a_reservation_spec.rb
+++ b/spec/features/purchasing_a_reservation_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe "Purchasing a reservation" do
   let!(:account) { FactoryGirl.create(:nufs_account, :with_account_owner, owner: user) }
   let!(:price_policy) { FactoryGirl.create(:instrument_price_policy, price_group: PriceGroup.base.first, product: instrument) }
   let(:user) { FactoryGirl.create(:user) }
+  let!(:account_price_group_member) do
+    FactoryGirl.create(:account_price_group_member, account: account, price_group: price_policy.price_group)
+  end
 
   before do
     login_as user

--- a/vendor/engines/sanger_sequencing/spec/features/purchasing_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/features/purchasing_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe "Purchasing a Sanger Sequencing service", :aggregate_failures do
   let(:user) { FactoryGirl.create(:user) }
   let(:external_service) { create(:external_service, location: new_sanger_sequencing_submission_path) }
   let!(:sanger_order_form) { create(:external_service_passer, external_service: external_service, active: true, passer: service) }
+  let!(:account_price_group_member) do
+    FactoryGirl.create(:account_price_group_member, account: account, price_group: price_policy.price_group)
+  end
 
   before do
     login_as user


### PR DESCRIPTION
These are cherry-picked from https://github.com/tablexi/nucore-dartmouth/pull/50

* bd6183f and 880b56f set up `AccountPriceGroupMember`s in feature specs.
* 7db8273 replaces an unreliable regular expression with Nokogiri to test for HTML attribute values