### PR TITLE
[#126615] Restore User access list

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -61,7 +61,7 @@ class Product < ActiveRecord::Base
   end
 
   def self.group_by_type
-    scoped.order(:type, :name).group_by(&:type)
+    order(:type, :name).group_by(&:type)
   end
 
   ## AR Hooks


### PR DESCRIPTION
This removes a stray `scope` missed during the Rails upgrade. It also adds some tests for `UsersController#access_list`, which relies on `Product.group_by_type`.