### PR TITLE
[#126619] Set relay "switch" param to checked value

### DIFF
--- a/app/assets/javascripts/timeline.js
+++ b/app/assets/javascripts/timeline.js
@@ -88,8 +88,7 @@ $(function() {
           updateRelayStatus(data.instrument_status);
         },
         data: {
-          // This is what we're switching to, not what we currently display
-          switch: $(this).is(":checked") ? 'off' : 'on'
+          switch: $(this).is(":checked") ? "on" : "off"
         },
         dataType: 'json'
       });


### PR DESCRIPTION
This sets the `switch` param on relay Ajax requests to "on" if the relay checkbox (switch) is checked, and "off" if it is not.

Before Rails 4 and related jQuery upgrades, this needed to be the opposite; the `:checked` value of the checkbox did not appear to be updated immediately on click, so this used the opposite value.