### PR TITLE
[#126687] AM/PM and Date changes did not trigger pricing update

### DIFF
--- a/app/assets/javascripts/app/manage_orders.coffee
+++ b/app/assets/javascripts/app/manage_orders.coffee
@@ -45,7 +45,7 @@ class OrderDetailManagement
   initPriceUpdating: ->
     self = this
     @$element.find('[name^="order_detail[reservation]"]:not([name$=_display]),[name="order_detail[quantity]"],[name="order_detail[account_id]"]').bind "change keyup", (evt) ->
-      self.updatePricing(evt) if this.value.match(/^\d+$/)
+      self.updatePricing(evt) if this.value.match(/.+/)
 
   updatePricing: (e) ->
     self = this

--- a/app/assets/javascripts/app/manage_orders.coffee
+++ b/app/assets/javascripts/app/manage_orders.coffee
@@ -45,7 +45,7 @@ class OrderDetailManagement
   initPriceUpdating: ->
     self = this
     @$element.find('[name^="order_detail[reservation]"]:not([name$=_display]),[name="order_detail[quantity]"],[name="order_detail[account_id]"]').bind "change keyup", (evt) ->
-      self.updatePricing(evt) if this.value.match(/.+/)
+      self.updatePricing(evt) if @.value.length > 0
 
   updatePricing: (e) ->
     self = this


### PR DESCRIPTION
See https://github.com/tablexi/nucore-open/pull/155 for where this
broke. We were trying to fix a 500 error when the ajax was triggering
with an empty quantity. However, this then ignored the call for AM/PM
and date changes.

This now just makes sure there is at least something in the field. If
you do something silly like type in a non-numeric into quantity, the
quantity and pricing changes get thrown away by the backend (see the
change in PR #155).