### PR TITLE
[#120869561] Sanger sequencing - support multiple plates

### DIFF
--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_bootstrap.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_bootstrap.coffee
@@ -1,5 +1,6 @@
 window.vue_sanger_sequencing_bootstrap = ->
   Vue.component "vue-sanger-sequencing-well-plate-app", window.vue_sanger_sequencing_well_plate_app
+  Vue.component "vue-sanger-sequencing-well-plate", window.vue_sanger_sequencing_well_plate
 
   window.vueBus = new Vue
 

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate.coffee
@@ -2,7 +2,7 @@ window.vue_sanger_sequencing_well_plate = {
   props: ["builder", "plate-index"]
   template: "#vue-sanger-sequencing-well-plate"
   data: ->
-    plateGrid: SangerSequencing.WellPlateBuilder.rows()
+    plateGrid: SangerSequencing.WellPlateBuilder.grid()
 
   methods:
     handleCellClick: (cell) ->
@@ -13,16 +13,7 @@ window.vue_sanger_sequencing_well_plate = {
       @builder.sampleAtCell(cellName, plateIndex)
 
     colorForCell: (cell, plateIndex) ->
-      @colorForSubmissionId(@sampleAtCell(cell.name, plateIndex).submission_id())
+      @colorBuilder ||= new SangerSequencing.WellPlateColors(@builder)
+      @colorBuilder.colorForSubmissionId(@sampleAtCell(cell.name, plateIndex).submission_id())
 
-    colorForSubmissionId: (submissionId) ->
-      # 18 is a magic number coming from the number of colors we have defined in
-      # our CSS classes
-      index = (@submissionIndex(submissionId) % 18) + 1
-      "sangerSequencing--colorCoded__color#{index}"
-
-    submissionIndex: (submissionId) ->
-      @builder.allSubmissions.map((submission) ->
-        submission.id
-      ).indexOf(submissionId)
 }

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate.coffee
@@ -1,0 +1,28 @@
+window.vue_sanger_sequencing_well_plate = {
+  props: ["builder", "plate-index"]
+  template: "#vue-sanger-sequencing-well-plate"
+  data: ->
+    plateGrid: SangerSequencing.WellPlateBuilder.rows()
+
+  methods:
+    handleCellClick: (cell) ->
+      # TODO: Remove
+      console.log "handleCellClick", cell
+
+    sampleAtCell: (cellName, plateIndex) ->
+      @builder.sampleAtCell(cellName, plateIndex)
+
+    colorForCell: (cell, plateIndex) ->
+      @colorForSubmissionId(@sampleAtCell(cell.name, plateIndex).submission_id())
+
+    colorForSubmissionId: (submissionId) ->
+      # 18 is a magic number coming from the number of colors we have defined in
+      # our CSS classes
+      index = (@submissionIndex(submissionId) % 18) + 1
+      "sangerSequencing--colorCoded__color#{index}"
+
+    submissionIndex: (submissionId) ->
+      @builder.allSubmissions.map((submission) ->
+        submission.id
+      ).indexOf(submissionId)
+}

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate.coffee
@@ -12,8 +12,8 @@ window.vue_sanger_sequencing_well_plate = {
     sampleAtCell: (cellName, plateIndex) ->
       @builder.sampleAtCell(cellName, plateIndex)
 
-    colorForCell: (cell, plateIndex) ->
+    styleForCell: (cell, plateIndex) ->
       @colorBuilder ||= new SangerSequencing.WellPlateColors(@builder)
-      @colorBuilder.colorForSubmissionId(@sampleAtCell(cell.name, plateIndex).submission_id())
+      @colorBuilder.styleForSubmissionId(@sampleAtCell(cell.name, plateIndex).submission_id())
 
 }

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate.coffee
@@ -1,8 +1,12 @@
 window.vue_sanger_sequencing_well_plate = {
   props: ["builder", "plate-index"]
   template: "#vue-sanger-sequencing-well-plate"
+
   data: ->
     plateGrid: SangerSequencing.WellPlateBuilder.grid()
+
+  beforeCompile: ->
+    @colorBuilder = new SangerSequencing.WellPlateColors(@builder)
 
   methods:
     handleCellClick: (cell) ->
@@ -13,7 +17,6 @@ window.vue_sanger_sequencing_well_plate = {
       @builder.sampleAtCell(cellName, plateIndex)
 
     styleForCell: (cell, plateIndex) ->
-      @colorBuilder ||= new SangerSequencing.WellPlateColors(@builder)
       @colorBuilder.styleForSubmissionId(@sampleAtCell(cell.name, plateIndex).submission_id())
 
 }

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate_app.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate_app.coffee
@@ -19,19 +19,9 @@ window.vue_sanger_sequencing_well_plate_app = {
         submission.id == submissionId
       )[0]
 
-    colorForCell: (cell) ->
-      @colorForSubmissionId(@sampleAtCell(cell.name).submission_id())
-
     colorForSubmissionId: (submissionId) ->
-      # 18 is a magic number coming from the number of colors we have defined in
-      # our CSS classes
-      index = (@submissionIndex(submissionId) % 18) + 1
-      "sangerSequencing--colorCoded__color#{index}"
-
-    submissionIndex: (submissionId) ->
-      @builder.allSubmissions.map((submission) ->
-        submission.id
-      ).indexOf(submissionId)
+      @colorBuilder ||= new SangerSequencing.WellPlateColors(@builder)
+      @colorBuilder.colorForSubmissionId(submissionId)
 
     isInPlate: (submissionId) ->
       @builder.isInPlate(@findSubmission(submissionId))

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate_app.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate_app.coffee
@@ -1,10 +1,13 @@
 window.vue_sanger_sequencing_well_plate_app = {
   props: ["submissions"]
+
   data: ->
     builder: new SangerSequencing.WellPlateBuilder
 
+  beforeCompile: ->
+    @colorBuilder = new SangerSequencing.WellPlateColors(@builder)
+
   ready: ->
-    vueBus.$on "submission-added", @addSubmission
     new AjaxModal(".js--modal", ".js--submissionModal")
 
   methods:
@@ -20,7 +23,6 @@ window.vue_sanger_sequencing_well_plate_app = {
       )[0]
 
     styleForSubmissionId: (submissionId) ->
-      @colorBuilder ||= new SangerSequencing.WellPlateColors(@builder)
       @colorBuilder.styleForSubmissionId(submissionId)
 
     isInPlate: (submissionId) ->

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate_app.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate_app.coffee
@@ -19,9 +19,9 @@ window.vue_sanger_sequencing_well_plate_app = {
         submission.id == submissionId
       )[0]
 
-    colorForSubmissionId: (submissionId) ->
+    styleForSubmissionId: (submissionId) ->
       @colorBuilder ||= new SangerSequencing.WellPlateColors(@builder)
-      @colorBuilder.colorForSubmissionId(submissionId)
+      @colorBuilder.styleForSubmissionId(submissionId)
 
     isInPlate: (submissionId) ->
       @builder.isInPlate(@findSubmission(submissionId))

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate_app.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate_app.coffee
@@ -1,7 +1,6 @@
 window.vue_sanger_sequencing_well_plate_app = {
   props: ["submissions"]
   data: ->
-    plate: SangerSequencing.WellPlateBuilder.rows()
     builder: new SangerSequencing.WellPlateBuilder
 
   ready: ->
@@ -9,18 +8,11 @@ window.vue_sanger_sequencing_well_plate_app = {
     new AjaxModal(".js--modal", ".js--submissionModal")
 
   methods:
-    handleCellClick: (cell) ->
-      # TODO: Remove
-      console.log "handleCellClick", cell
-
     addSubmission: (submissionId) ->
       @builder.addSubmission @findSubmission(submissionId)
 
     removeSubmission: (submissionId) ->
       @builder.removeSubmission @findSubmission(submissionId)
-
-    sampleAtCell: (cellName) ->
-      @builder.sampleAtCell(cellName)
 
     findSubmission: (submissionId) ->
       @submissions.filter((submission) =>

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate.js
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate.js
@@ -1,6 +1,7 @@
 //= require vue
 //= require sanger_sequencing/well_plate_builder
 //= require sanger_sequencing/well_plate_sample
+//= require sanger_sequencing/well_plate_colors
 //= require sanger_sequencing/vue_bootstrap
 //= require sanger_sequencing/vue_well_plate_app
 //= require sanger_sequencing/vue_well_plate

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate.js
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate.js
@@ -3,3 +3,4 @@
 //= require sanger_sequencing/well_plate_sample
 //= require sanger_sequencing/vue_bootstrap
 //= require sanger_sequencing/vue_well_plate_app
+//= require sanger_sequencing/vue_well_plate

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_builder.js.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_builder.js.coffee
@@ -8,6 +8,17 @@ class SangerSequencing.WellPlateBuilder
         total.concat submission
       arrays.reduce(concatFunction, [])
 
+  class OddFirstOrderingStrategy
+    fillOrder: ->
+      odds = (column for column, i in @_cellsByColumn() when i % 2 == 0)
+      evens = (column for column, i in @_cellsByColumn() when i % 2 == 1)
+      Util.flattenArray(odds.concat(evens))
+
+    _cellsByColumn: ->
+      cells = for num in ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]
+        for ch in "ABCDEFGH"
+          "#{ch}#{num}"
+
   constructor: ->
     @submissions = []
     # This array maintains all of the submissions that have ever been added
@@ -45,6 +56,13 @@ class SangerSequencing.WellPlateBuilder
   plateCount: ->
     @_plateCount
 
+  @grid: ->
+    for ch in "ABCDEFGH"
+      name: ch
+      cells: for num in ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]
+        column: num
+        name: "#{ch}#{num}"
+
   # Private
 
   _render: ->
@@ -75,22 +93,6 @@ class SangerSequencing.WellPlateBuilder
     plate
 
   _fillOrder: ->
-    @orderingStrategy.fillOrder(@cellArray())
+    @orderingStrategy.fillOrder()
 
-  @rows: ->
-    for ch in "ABCDEFGH"
-      name: ch
-      cells: for num in ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]
-        column: num
-        name: "#{ch}#{num}"
 
-  cellArray: ->
-    cells = for num in ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]
-      for ch in "ABCDEFGH"
-        "#{ch}#{num}"
-
-  class OddFirstOrderingStrategy
-    fillOrder: (cellsByColumn) ->
-      odds = (column for column, i in cellsByColumn when i % 2 == 0)
-      evens = (column for column, i in cellsByColumn when i % 2 == 1)
-      Util.flattenArray(odds.concat(evens))

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_builder.js.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_builder.js.coffee
@@ -17,7 +17,6 @@ class SangerSequencing.WellPlateBuilder
     @orderingStrategy = new OddFirstOrderingStrategy
 
   addSubmission: (submission) ->
-
     @submissions.push(submission) unless @isInPlate(submission)
     @allSubmissions.push(submission) unless @hasBeenAddedBefore(submission)
 
@@ -37,28 +36,35 @@ class SangerSequencing.WellPlateBuilder
         if s instanceof SangerSequencing.Sample then s else new SangerSequencing.Sample(s)
     )
 
-  sampleAtCell: (cell) ->
-    @render()[cell]
+  sampleAtCell: (cell, plateIndex = 0) ->
+    @render()[plateIndex][cell]
 
   render: ->
     fillOrder = @orderingStrategy.fillOrder(@cellArray())
 
     samples = @samples()
-    results = {}
+    platesNeeded = Math.ceil(samples.length / fillOrder.length)
 
-    for cellName in fillOrder
-      sample = null
-      if @reservedCells.indexOf(cellName) < 0
-        if sample = samples.shift()
-          sample = sample
+    allPlates = []
+
+    for plate in [0..platesNeeded]
+      plate = {}
+
+      for cellName in fillOrder
+        sample = null
+        if @reservedCells.indexOf(cellName) < 0
+          if sample = samples.shift()
+            sample = sample
+          else
+            sample = new SangerSequencing.Sample.Blank
         else
-          sample = new SangerSequencing.Sample.Blank
-      else
-        sample = new SangerSequencing.Sample.Reserved
+          sample = new SangerSequencing.Sample.Reserved
 
-      results[cellName] = sample
+        plate[cellName] = sample
 
-    results
+      allPlates.push(plate)
+
+    allPlates
 
   @rows: ->
     for ch in "ABCDEFGH"

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_builder.js.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_builder.js.coffee
@@ -94,5 +94,3 @@ class SangerSequencing.WellPlateBuilder
 
   _fillOrder: ->
     @orderingStrategy.fillOrder()
-
-

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_builder.js.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_builder.js.coffee
@@ -39,12 +39,14 @@ class SangerSequencing.WellPlateBuilder
   sampleAtCell: (cell, plateIndex = 0) ->
     @render()[plateIndex][cell]
 
+  plateCount: ->
+    Math.max(1, Math.ceil(@samples().length / @fillOrder().length))
+
   render: ->
     samples = @samples()
-    platesNeeded = Math.ceil(samples.length / @fillOrder().length)
     allPlates = []
 
-    for plate in [0..platesNeeded]
+    for plate in [0..@plateCount()]
       allPlates.push(@renderPlate(samples))
 
     allPlates

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_builder.js.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_builder.js.coffee
@@ -40,31 +40,33 @@ class SangerSequencing.WellPlateBuilder
     @render()[plateIndex][cell]
 
   render: ->
-    fillOrder = @orderingStrategy.fillOrder(@cellArray())
-
     samples = @samples()
-    platesNeeded = Math.ceil(samples.length / fillOrder.length)
-
+    platesNeeded = Math.ceil(samples.length / @fillOrder().length)
     allPlates = []
 
     for plate in [0..platesNeeded]
-      plate = {}
-
-      for cellName in fillOrder
-        sample = null
-        if @reservedCells.indexOf(cellName) < 0
-          if sample = samples.shift()
-            sample = sample
-          else
-            sample = new SangerSequencing.Sample.Blank
-        else
-          sample = new SangerSequencing.Sample.Reserved
-
-        plate[cellName] = sample
-
-      allPlates.push(plate)
+      allPlates.push(@renderPlate(samples))
 
     allPlates
+
+  renderPlate: (samples) ->
+    plate = {}
+
+    for cellName in @fillOrder()
+      plate[cellName] = if @reservedCells.indexOf(cellName) < 0
+        if sample = samples.shift()
+          sample
+        else
+          new SangerSequencing.Sample.Blank
+      else
+        new SangerSequencing.Sample.Reserved
+
+       sample
+
+    plate
+
+  fillOrder: ->
+    @orderingStrategy.fillOrder(@cellArray())
 
   @rows: ->
     for ch in "ABCDEFGH"

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_colors.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_colors.coffee
@@ -2,11 +2,30 @@ class SangerSequencing.WellPlateColors
 
   constructor: (@builder) -> undefined
 
-  colorForSubmissionId: (submissionId) ->
-    # 18 is a magic number coming from the number of colors we have defined in
-    # our CSS classes
-    index = (@submissionIndex(submissionId) % 18) + 1
-    "sangerSequencing--colorCoded__color#{index}"
+  colors = ["#1F77B4", # blue
+            "#98DF8A", # green
+            "#9467BD", # purple
+            "#FFBB78", # light orange
+            "#AEC7E8", # light blue
+            "#C7C7C7", # grey
+            "#D62728", # red
+            "#C49C94", # light brown
+            "#FF7F0E", # orange
+            "#BCBD22", # pea green
+            "#8C564B", # brown
+            "#FF9896", # rose
+            "#E377C2", # pink/perple
+            "#17BECF", # teal
+            "#2CA02C", # green
+            "#C5B0D5", # light purple
+            "#7F7F7F", # dark grey
+            "#9EDAE5" # light teal
+          ]
+
+
+  styleForSubmissionId: (submissionId) ->
+    index = (@submissionIndex(submissionId) % colors.length)
+    { "background-color": colors[index] } if index >= 0
 
   submissionIndex: (submissionId) ->
     @builder.allSubmissions.map((submission) ->

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_colors.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_colors.coffee
@@ -1,0 +1,14 @@
+class SangerSequencing.WellPlateColors
+
+  constructor: (@builder) -> undefined
+
+  colorForSubmissionId: (submissionId) ->
+    # 18 is a magic number coming from the number of colors we have defined in
+    # our CSS classes
+    index = (@submissionIndex(submissionId) % 18) + 1
+    "sangerSequencing--colorCoded__color#{index}"
+
+  submissionIndex: (submissionId) ->
+    @builder.allSubmissions.map((submission) ->
+      submission.id
+    ).indexOf(submissionId)

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_colors.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_colors.coffee
@@ -14,7 +14,7 @@ class SangerSequencing.WellPlateColors
             "#BCBD22", # pea green
             "#8C564B", # brown
             "#FF9896", # rose
-            "#E377C2", # pink/perple
+            "#E377C2", # pink/purple
             "#17BECF", # teal
             "#2CA02C", # green
             "#C5B0D5", # light purple

--- a/vendor/engines/sanger_sequencing/app/assets/stylesheets/sanger_sequencing/application.scss
+++ b/vendor/engines/sanger_sequencing/app/assets/stylesheets/sanger_sequencing/application.scss
@@ -22,30 +22,3 @@
   width: 1.7em;
   height: 1.7em;
 }
-
-$colors:  #1F77B4, // blue
-          #98DF8A, // green
-          #9467BD, // purple
-          #FFBB78, // light orange
-          #AEC7E8, // light blue
-          #C7C7C7, // grey
-          #D62728, // red
-          #C49C94, // light brown
-          #FF7F0E, // orange
-          #BCBD22, // pea green
-          #8C564B, // brown
-          #FF9896, // rose
-          #E377C2, // pink/perple
-          #17BECF, // teal
-          #2CA02C, // green
-          #C5B0D5, // light purple
-          #7F7F7F, // dark grey
-          #9EDAE5; // light teal
-
-@for $i from 1 through length($colors) {
-  $color: nth($colors, $i);
-  .sangerSequencing--colorCoded__color#{$i} {
-    background-color: $color
-  }
-}
-

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/new.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/new.html.haml
@@ -8,18 +8,7 @@
 %vue-sanger-sequencing-well-plate-app(inline-template){ ":submissions" => @submissions.to_json(include: :samples) }
 
   = simple_form_for :batch, url: facility_sanger_sequencing_admin_batches_path do |f|
-    %table.table.table-bordered(v-cloak)
-      %tr
-        %th
-        - (1..12).each do |col|
-          %th.centered= col
-      %tr(v-for="row in plate")
-        %th {{row.name}}
-        %td.sangerSequencing--cell(v-for="cell in row.cells" v-on:click="handleCellClick(cell)" v-bind:data-submission-id="sampleAtCell(cell.name).submission_id()" v-bind:class="colorForCell(cell)")
-          = f.input "{{cell.name}}", input_html: { value: "{{sampleAtCell(cell.name).id()}}" }, as: :hidden
-          {{sampleAtCell(cell.name)}}
-          %br
-          {{sampleAtCell(cell.name).id()}}
+    %vue-sanger-sequencing-well-plate(v-for="plateIndex in builder.plateCount()"){":builder" => "builder", ":plate-index" => "$index" }
 
     = f.submit text("submit"), class: "btn btn-primary"
 
@@ -44,6 +33,20 @@
           %td= submission.user
           %td= submission.samples.count
 
+
+%script#vue-sanger-sequencing-well-plate{type: "x-template"}
+  %table.table.table-bordered(v-cloak)
+    %tr
+      %th
+      - (1..12).each do |col|
+        %th.centered= col
+    %tr(v-for="row in plateGrid")
+      %th {{row.name}}
+      %td.sangerSequencing--cell(v-for="cell in row.cells" v-on:click="handleCellClick(cell)" v-bind:class="colorForCell(cell, plateIndex)")
+        {{plateIndex}}
+        {{sampleAtCell(cell.name, plateIndex)}}
+        %br
+        {{sampleAtCell(cell.name, plateIndex).id()}}
+
 :javascript
   window.vue_sanger_sequencing_bootstrap();
-

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/new.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/new.html.haml
@@ -25,7 +25,7 @@
         %tr
           %td
             %div(v-if="isInPlate(#{submission.id})")
-              .sangerSequencing--colorCoded__box(v-bind:class="colorForSubmissionId(#{submission.id})")
+              .sangerSequencing--colorCoded__box(v-bind:style="styleForSubmissionId(#{submission.id})")
               = link_to text("remove"), "#", "@click.prevent" => "removeSubmission(#{submission.id})"
             = link_to text("add"), "#", "@click.prevent" => "addSubmission(#{submission.id})", "v-if" => "isNotInPlate(#{submission.id})"
           %td= link_to submission.id, facility_sanger_sequencing_admin_submission_path(current_facility, submission), class: "js--modal"
@@ -42,7 +42,7 @@
         %th.centered= col
     %tr(v-for="row in plateGrid")
       %th {{row.name}}
-      %td.sangerSequencing--cell(v-for="cell in row.cells" v-on:click="handleCellClick(cell)" v-bind:class="colorForCell(cell, plateIndex)")
+      %td.sangerSequencing--cell(v-for="cell in row.cells" v-on:click="handleCellClick(cell)" v-bind:style="styleForCell(cell, plateIndex)")
         {{sampleAtCell(cell.name, plateIndex)}}
         %br
         {{sampleAtCell(cell.name, plateIndex).id()}}

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/new.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/new.html.haml
@@ -43,7 +43,6 @@
     %tr(v-for="row in plateGrid")
       %th {{row.name}}
       %td.sangerSequencing--cell(v-for="cell in row.cells" v-on:click="handleCellClick(cell)" v-bind:class="colorForCell(cell, plateIndex)")
-        {{plateIndex}}
         {{sampleAtCell(cell.name, plateIndex)}}
         %br
         {{sampleAtCell(cell.name, plateIndex).id()}}

--- a/vendor/engines/sanger_sequencing/spec/javascripts/well_plate_builder_spec.js.coffee
+++ b/vendor/engines/sanger_sequencing/spec/javascripts/well_plate_builder_spec.js.coffee
@@ -55,6 +55,18 @@ describe "SangerSequencing.WellPlateBuilder", ->
     it "finds the first sample at B01 (because the A01 is blank", ->
       expect(@wellPlate.sampleAtCell("B01")).toEqual(@submission1.samples[0])
 
+    describe "when it rolls over into a second plate", ->
+      beforeEach ->
+        @submission3 = { id: 544, samples: sampleList(92) }
+        @wellPlate.addSubmission(@submission3)
+
+      it "finds the first sample at B01", ->
+        expect(@wellPlate.sampleAtCell("B01", 0)).toEqual(@submission1.samples[0])
+
+      it "finds the sample in the second plate at B01", ->
+        # 89 because 96 - 5(already added) - 2 (reserved) = 89
+        expect(@wellPlate.sampleAtCell("B01", 1)).toEqual(@submission3.samples[89])
+
   describe "render()", ->
     beforeEach ->
       @wellPlate = new SangerSequencing.WellPlateBuilder
@@ -62,11 +74,11 @@ describe "SangerSequencing.WellPlateBuilder", ->
       @wellPlate.addSubmission(@submission)
 
     it "has 96 cells", ->
-      results = @wellPlate.render()
+      results = @wellPlate.render()[0]
       expect(Object.keys(results).length).toEqual(96)
 
     it "renders odd rows first", ->
-      results = @wellPlate.render()
+      results = @wellPlate.render()[0]
       for expected in [
         ["A01", "reserved" ],
         ["B01", "Testing 0" ],

--- a/vendor/engines/sanger_sequencing/spec/javascripts/well_plate_builder_spec.js.coffee
+++ b/vendor/engines/sanger_sequencing/spec/javascripts/well_plate_builder_spec.js.coffee
@@ -67,18 +67,18 @@ describe "SangerSequencing.WellPlateBuilder", ->
         # 89 because 96 - 5(already added) - 2 (reserved) = 89
         expect(@wellPlate.sampleAtCell("B01", 1)).toEqual(@submission3.samples[89])
 
-  describe "render()", ->
+  describe "plates", ->
     beforeEach ->
       @wellPlate = new SangerSequencing.WellPlateBuilder
       @submission = { id: 542, samples: sampleList(8) }
       @wellPlate.addSubmission(@submission)
 
     it "has 96 cells", ->
-      results = @wellPlate.render()[0]
+      results = @wellPlate.plates[0]
       expect(Object.keys(results).length).toEqual(96)
 
     it "renders odd rows first", ->
-      results = @wellPlate.render()[0]
+      results = @wellPlate.plates[0]
       for expected in [
         ["A01", "reserved" ],
         ["B01", "Testing 0" ],


### PR DESCRIPTION
This extends from #669 and adds some refactoring including moving the color array into JS. This allowed me to get rid of the magic number that needed to be know between CSS and JS.

It also changes how the rendering of a well plate works so we only "render" whenever we add or remove a submission vs what it was doing before of rendering on every cell when called with `sampleAtCell`. Once we got into multiple plates, I was starting to see some UI slowness. This is much snappier.