### PR TITLE
Don't exclude vendor from RSpec's stack traces

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ RSpec.configure do |config|
 
   # rspec-rails by default excludes stack traces from within vendor Lots of our
   # engines are under vendor, so we don't want to exclude them
-  config.backtrace_exclusion_patterns.delete /vendor\//
+  config.backtrace_exclusion_patterns.delete(%r{vendor/})
 
   config.use_transactional_fixtures = true
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,6 +20,10 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
 
+  # rspec-rails by default excludes stack traces from within vendor Lots of our
+  # engines are under vendor, so we don't want to exclude them
+  config.backtrace_exclusion_patterns.delete /vendor\//
+
   config.use_transactional_fixtures = true
 
   require "capybara/poltergeist"


### PR DESCRIPTION
This is why our stack traces in engine test failures are so unhelpful.
All we were seeing was the `rails_helper.rb` line, but nothing within
the engine.