### PR TITLE
[#120869939] Download Sanger Sequencing template file

### DIFF
--- a/config/initializers/csv_renderer.rb
+++ b/config/initializers/csv_renderer.rb
@@ -1,0 +1,6 @@
+ActionController::Renderers.add :csv do |obj, options|
+  filename = options[:filename] || "data"
+  str = obj.respond_to?(:to_csv) ? obj.to_csv : obj.to_s
+  send_data str, type: Mime::CSV,
+    disposition: "attachment; filename=#{filename}.csv"
+end

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate.coffee
@@ -9,14 +9,10 @@ window.vue_sanger_sequencing_well_plate = {
     @colorBuilder = new SangerSequencing.WellPlateColors(@builder)
 
   methods:
-    handleCellClick: (cell) ->
-      # TODO: Remove
-      console.log "handleCellClick", cell
-
     sampleAtCell: (cellName, plateIndex) ->
       @builder.sampleAtCell(cellName, plateIndex)
 
     styleForCell: (cell, plateIndex) ->
-      @colorBuilder.styleForSubmissionId(@sampleAtCell(cell.name, plateIndex).submission_id())
+      @colorBuilder.styleForSubmissionId(@sampleAtCell(cell.name, plateIndex).submissionId())
 
 }

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_builder.js.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_builder.js.coffee
@@ -86,7 +86,13 @@ class SangerSequencing.WellPlateBuilder
         else
           new SangerSequencing.Sample.Blank
       else
-        new SangerSequencing.Sample.Reserved
+        # Reserved will actually take up a cell, while ReservedButUnused is
+        # for when we have not actually reached that cell in the fill order,
+        # so it will instead be treated as blank.
+        if samples.length > 0
+          new SangerSequencing.Sample.Reserved
+        else
+          new SangerSequencing.Sample.ReservedButUnused
 
        sample
 

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_sample.js.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_sample.js.coffee
@@ -7,14 +7,14 @@ class SangerSequencing.Sample
   displayId: ->
     @attributes.id
 
-  submission_id: ->
+  submissionId: ->
     @attributes.submission_id
 
   id: ->
     @attributes.id
 
   class @Blank
-    submission_id: ->
+    submissionId: ->
       ""
     customerSampleId: ->
       ""
@@ -23,8 +23,20 @@ class SangerSequencing.Sample
     id: ->
       ""
 
+  # Treated as blank in the backend, but displays like reserved
+  class @ReservedButUnused
+    submissionId: ->
+      ""
+    customerSampleId: ->
+      "reserved"
+    displayId: ->
+      ""
+    id: ->
+      ""
+
+
   class @Reserved
-    submission_id: ->
+    submissionId: ->
       ""
     customerSampleId: ->
       "reserved"

--- a/vendor/engines/sanger_sequencing/app/assets/stylesheets/sanger_sequencing/application.scss
+++ b/vendor/engines/sanger_sequencing/app/assets/stylesheets/sanger_sequencing/application.scss
@@ -22,3 +22,8 @@
   width: 1.7em;
   height: 1.7em;
 }
+
+.sangerSequencing--wellPlate__list {
+  margin: 0;
+  list-style: none;
+}

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/ability.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/ability.rb
@@ -11,7 +11,7 @@ module SangerSequencing
 
       if facility && user.operator_of?(facility)
         can [:index, :show], Submission
-        can [:index, :create, :destroy], [Batch, BatchForm]
+        can [:index, :create, :destroy, :well_plate], [Batch, BatchForm]
       end
     end
 

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/well_plate.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/well_plate.rb
@@ -35,7 +35,7 @@ module SangerSequencing
       end
 
       def customer_sample_id
-        "Control"
+        ""
       end
 
     end
@@ -46,6 +46,10 @@ module SangerSequencing
 
       def reserved?
         false
+      end
+
+      def blank?
+        true
       end
 
       def customer_sample_id

--- a/vendor/engines/sanger_sequencing/app/presenters/sanger_sequencing/well_plate_presenter.rb
+++ b/vendor/engines/sanger_sequencing/app/presenters/sanger_sequencing/well_plate_presenter.rb
@@ -13,7 +13,7 @@ module SangerSequencing
       CSV.generate do |csv|
         csv << ["Container Name", "Plate ID", "Description", "ContainerType", "AppType", "Owner", "Operator", "PlateSealing", "SchedulingPref"]
         csv << ["",               "",         "",            "96-Well",       "Regular", "mb core", "mbcore", "Septa", "1234"]
-        csv << ["AppServer", "AppInstance"]
+        csv << %w(AppServer AppInstance)
         csv << ["SequencingAnalysis"]
         csv << ["Well", "Sample Name", "Comment", "Results Group 1", "Instrument Protocol 1", "Analysis Protocol 1"]
 
@@ -33,14 +33,14 @@ module SangerSequencing
 
     def cleaned_cells
       # Remove blank cells
-      sorted_cells.reject { |position, sample| sample.blank? }
+      sorted_cells.reject { |_position, sample| sample.blank? }
     end
 
     def sorted_cells
       well_plate.cells.sort_by do |position, _sample|
         # Order by A01, B01, C01, etc.
         position =~ /\A([A-H])(\d{2})\z/
-        [$2, $1]
+        [Regexp.last_match(2), Regexp.last_match(1)]
       end
     end
 

--- a/vendor/engines/sanger_sequencing/app/presenters/sanger_sequencing/well_plate_presenter.rb
+++ b/vendor/engines/sanger_sequencing/app/presenters/sanger_sequencing/well_plate_presenter.rb
@@ -1,0 +1,53 @@
+module SangerSequencing
+
+  class WellPlatePresenter
+
+    attr_reader :well_plate
+    delegate :samples, to: :well_plate
+
+    def initialize(well_plate)
+      @well_plate = well_plate
+    end
+
+    def to_csv
+      CSV.generate do |csv|
+        csv << ["Container Name", "Plate ID", "Description", "ContainerType", "AppType", "Owner", "Operator", "PlateSealing", "SchedulingPref"]
+        csv << ["",               "",         "",            "96-Well",       "Regular", "mb core", "mbcore", "Septa", "1234"]
+        csv << ["AppServer", "AppInstance"]
+        csv << ["SequencingAnalysis"]
+        csv << ["Well", "Sample Name", "Comment", "Results Group 1", "Instrument Protocol 1", "Analysis Protocol 1"]
+
+        sample_rows.each do |row|
+          csv << row
+        end
+      end
+    end
+
+    def sample_rows
+      cleaned_cells.map do |position, sample|
+        [position] + sample_row(sample)
+      end
+    end
+
+    private
+
+    def cleaned_cells
+      # Remove blank cells
+      sorted_cells.reject { |position, sample| sample.blank? }
+    end
+
+    def sorted_cells
+      well_plate.cells.sort_by do |position, _sample|
+        # Order by A01, B01, C01, etc.
+        position =~ /\A([A-H])(\d{2})\z/
+        [$2, $1]
+      end
+    end
+
+    def sample_row(sample)
+      [sample.id.to_s, sample.customer_sample_id.to_s, "50cm_POP7_BDv3", "XLR_50POP7", "XLR__50POP7_KBSeqAna"]
+    end
+
+  end
+
+end

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/index.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/index.html.haml
@@ -1,13 +1,16 @@
 = content_for :h1 do
   = current_facility
 
+= content_for :head_content do
+  = stylesheet_link_tag "sanger_sequencing/application"
+
 = content_for :sidebar do
   = render "sanger_sequencing/admin/shared/sidenav", sidenav_tab: "batches"
 
 %h2= text("sanger_sequencing.name")
 
 - if @batches.any?
-  %table.table.table-striped
+  %table.table.table-striped.sangerSequencing--batches__table
     %thead
       %tr
         %th
@@ -16,15 +19,21 @@
         %th= SangerSequencing::Batch.human_attribute_name(:created_by)
         %th= SangerSequencing::Batch.human_attribute_name(:submissions)
         %th= SangerSequencing::Batch.human_attribute_name(:samples)
+        %th
     %tbody
       - @batches.each do |batch|
         %tr
-          %td= link_to "Delete", facility_sanger_sequencing_admin_batch_path(current_facility, batch), method: :delete
+          %td
+            %ul.sangerSequencing--wellPlate__list
+              - batch.well_plates.count.times do |i|
+                %li= link_to text("download_plate", index: i + 1), well_plate_facility_sanger_sequencing_admin_batch_path(current_facility, batch, i + 1, format: :csv)
           %td= batch.id
           %td= format_usa_date(batch.created_at)
           %td= batch.created_by
           %td= batch.submissions.count
           %td= batch.samples.count
+          %td= link_to "Delete", facility_sanger_sequencing_admin_batch_path(current_facility, batch), method: :delete
+
 
   = will_paginate(@batches)
 

--- a/vendor/engines/sanger_sequencing/config/locales/en.yml
+++ b/vendor/engines/sanger_sequencing/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
             submit: Save Batch
           index:
             none: There are currently no batches
+            download_plate: "Download Plate %{index}"
 
   activerecord:
     attributes:

--- a/vendor/engines/sanger_sequencing/config/routes.rb
+++ b/vendor/engines/sanger_sequencing/config/routes.rb
@@ -11,7 +11,9 @@ Rails.application.routes.draw do
     namespace :sanger_sequencing do
       namespace :admin do
         resources :submissions, only: [:index, :show]
-        resources :batches, only: [:index, :new, :create, :destroy]
+        resources :batches, only: [:index, :new, :create, :destroy] do
+          get "well_plates/:well_plate_index", action: :well_plate, on: :member, as: :well_plate
+        end
       end
     end
   end

--- a/vendor/engines/sanger_sequencing/spec/features/batches/creating_a_batch_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/features/batches/creating_a_batch_spec.rb
@@ -32,13 +32,15 @@ RSpec.describe "Creating a batch", :js do
         click_button "Save Batch"
       end
 
-      it "Saves the batch", :aggregate_failures do
+      it "Saves the batch and takes you to the batches index", :aggregate_failures do
         expect(purchased_submission.reload.batch_id).to be_present
         expect(purchased_submission2.reload.batch_id).to be_present
 
         expect(SangerSequencing::Batch.last.sample_at(0, "A01")).to be_reserved
         expect(SangerSequencing::Batch.last.sample_at(0, "B01")).to eq(purchased_submission.samples.first)
         expect(SangerSequencing::Batch.last.sample_at(1, "B01")).to eq(purchased_submission2.samples[44])
+
+        expect(current_path).to eq(facility_sanger_sequencing_admin_batches_path(facility))
       end
     end
   end

--- a/vendor/engines/sanger_sequencing/spec/presenters/sanger_sequencing/well_plate_presenter_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/presenters/sanger_sequencing/well_plate_presenter_spec.rb
@@ -24,18 +24,18 @@ RSpec.describe SangerSequencing::WellPlatePresenter do
     let(:sample_rows) { presenter.sample_rows }
     let(:expected_results_group) { a_kind_of(String) }
     let(:expected_instrument_protocol) { a_kind_of(String) }
-    let(:expected_analysis_protocal) { a_kind_of(String) }
+    let(:expected_analysis_protocol) { a_kind_of(String) }
 
     it "renders" do
-      expect(sample_rows[0]).to match(["A01", "", "", expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
-      expect(sample_rows[1]).to match(["B01", samples[0].id.to_s, samples[0].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
-      expect(sample_rows[2]).to match(["C01", samples[1].id.to_s, samples[1].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
-      expect(sample_rows[3]).to match(["D01", samples[2].id.to_s, samples[2].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
-      expect(sample_rows[4]).to match(["E01", samples[3].id.to_s, samples[3].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
-      expect(sample_rows[5]).to match(["F01", samples[4].id.to_s, samples[4].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
-      expect(sample_rows[6]).to match(["G01", samples[5].id.to_s, samples[5].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
-      expect(sample_rows[7]).to match(["H01", samples[6].id.to_s, samples[6].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
-      expect(sample_rows[8]).to match(["A03", samples[7].id.to_s, samples[7].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
+      expect(sample_rows[0]).to match(["A01", "", "", expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
+      expect(sample_rows[1]).to match(["B01", samples[0].id.to_s, samples[0].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
+      expect(sample_rows[2]).to match(["C01", samples[1].id.to_s, samples[1].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
+      expect(sample_rows[3]).to match(["D01", samples[2].id.to_s, samples[2].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
+      expect(sample_rows[4]).to match(["E01", samples[3].id.to_s, samples[3].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
+      expect(sample_rows[5]).to match(["F01", samples[4].id.to_s, samples[4].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
+      expect(sample_rows[6]).to match(["G01", samples[5].id.to_s, samples[5].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
+      expect(sample_rows[7]).to match(["H01", samples[6].id.to_s, samples[6].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
+      expect(sample_rows[8]).to match(["A03", samples[7].id.to_s, samples[7].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
     end
   end
 end

--- a/vendor/engines/sanger_sequencing/spec/presenters/sanger_sequencing/well_plate_presenter_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/presenters/sanger_sequencing/well_plate_presenter_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe SangerSequencing::WellPlatePresenter do
+  let(:samples) { FactoryGirl.build_stubbed_list(:sanger_sequencing_sample, 10) }
+
+  describe "sample_rows" do
+    let(:mapping) do
+      {
+        "A01" => "reserved",
+        "A03" => samples[7].id,
+        "B01" => samples[0].id,
+        "B02" => "",
+        "C01" => samples[1].id,
+        "D01" => samples[2].id,
+        "E01" => samples[3].id,
+        "F01" => samples[4].id,
+        "G01" => samples[5].id,
+        "H01" => samples[6].id,
+      }
+    end
+
+    let(:well_plate) { SangerSequencing::WellPlate.new(mapping, samples: samples) }
+    let(:presenter) { described_class.new(well_plate) }
+    let(:sample_rows) { presenter.sample_rows }
+    let(:expected_results_group) { a_kind_of(String) }
+    let(:expected_instrument_protocol) { a_kind_of(String) }
+    let(:expected_analysis_protocal) { a_kind_of(String) }
+
+    it "renders" do
+      expect(sample_rows[0]).to match(["A01", "", "", expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
+      expect(sample_rows[1]).to match(["B01", samples[0].id.to_s, samples[0].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
+      expect(sample_rows[2]).to match(["C01", samples[1].id.to_s, samples[1].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
+      expect(sample_rows[3]).to match(["D01", samples[2].id.to_s, samples[2].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
+      expect(sample_rows[4]).to match(["E01", samples[3].id.to_s, samples[3].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
+      expect(sample_rows[5]).to match(["F01", samples[4].id.to_s, samples[4].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
+      expect(sample_rows[6]).to match(["G01", samples[5].id.to_s, samples[5].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
+      expect(sample_rows[7]).to match(["H01", samples[6].id.to_s, samples[6].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
+      expect(sample_rows[8]).to match(["A03", samples[7].id.to_s, samples[7].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocal])
+    end
+  end
+end


### PR DESCRIPTION
This modifies the batch creation so that reserved wells in unused rows don't get persisted: they appear as if they're blank in the well-plate export. But they still show up as "reserved" when creating the well plate.

It also adds a `ActionController::Renderer` for CSV to the root app so we can do `render csv: ObjectRespondingToToCSV.new, filename: "somefilename"`. There are a few places elsewhere in the app I'd like to swap this in in place of CSVHelper, but that seemed outside the scope of this PR.

There are a few fields in the CSV that I'm not really sure if they're supposed to be dynamic or not. I figure we can address those when we meet with Chris next week.