### PR TITLE
[#126814] Instrument link should take you to schedule, not details

### DIFF
--- a/app/views/admin/products/index.html.haml
+++ b/app/views/admin/products/index.html.haml
@@ -25,5 +25,8 @@
       - @products.each do |product|
         %tr
           %td
-            = link_to product.name, [:manage, current_facility, product]
+            - if product.is_a?(Instrument)
+              = link_to product.name, [current_facility, product, :schedule]
+            - else
+              = link_to product.name, [:manage, current_facility, product]
             = price_policy_errors(product) unless params[:archived] == "true"


### PR DESCRIPTION
This was broken in https://github.com/tablexi/nucore-open/pull/565 when
we went to share the index view between the different product types.