### PR TITLE
[#126813] Instrument Schedule tab lost header nav

### DIFF
--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -1,7 +1,7 @@
 class InstrumentsController < ProductsCommonController
 
-  customer_tab  :show, :public_schedule
-
+  customer_tab :show, :public_schedule
+  admin_tab :create, :new, :edit, :index, :manage, :update, :manage, :schedule
   before_action :store_fullpath_in_session, only: [:index, :show]
   before_action :set_default_lock_window, only: [:create, :update]
 


### PR DESCRIPTION
After the ProductsCommonController refactor of
https://github.com/tablexi/nucore-open/pull/643 the `:schedule` option
of `admin_tab` got lost.