### PR TITLE
[#126870] Do not error on blank product url names

### DIFF
--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -39,7 +39,7 @@ module ProductsHelper
   end
 
   def product_url_hint(product)
-    product_url_name = product.try(:url_name) || "url-name"
+    product_url_name = product.try(:url_name).presence || "url-name"
 
     url_name_hint = send("facility_#{product.class.name.downcase}_url",
                          current_facility.url_name,

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -169,6 +169,13 @@ RSpec.describe ServicesController do
       is_expected.to set_flash
       assert_redirected_to [:manage, @authable, assigns(:service)]
     end
+
+    it "does not raise error on blank url name" do
+      sign_in @admin
+      @params[:service][:url_name] = ""
+      do_request
+      expect(assigns(:service)).to be_invalid
+    end
   end
 
   context "update" do


### PR DESCRIPTION
If you submit the product form without a url_name, the form would error
while trying to build the hint.

```No route matches {:action=>"show", :controller=>"services",
:facility_id=>"nugene", :id=>""} missing required keys: [:id]
app/helpers/products_helper.rb:44:in `product_url_hint'
```