### PR TITLE
[#119570751] Sanger sample listing on receipt

### DIFF
--- a/app/views/notifier/order_receipt.html.haml
+++ b/app/views/notifier/order_receipt.html.haml
@@ -3,17 +3,21 @@
 
 %table{ border: 0 }
   %tr
-    %td= Order.human_attribute_name(:ordered_at)
+    %td
+      %strong= Order.human_attribute_name(:ordered_at)
     %td= l(@order.ordered_at, format: :receipt)
 
   %tr
-    %td= Facility.model_name.human
-    %td= @order.facility
+    %td
+      %strong= Facility.model_name.human
+    %td= link_to @order.facility, @order.facility
   %tr
-    %td= OrderDetail.human_attribute_name(:ordered_by)
+    %td
+      %strong= OrderDetail.human_attribute_name(:ordered_by)
     %td= @order.created_by_user.full_name
   %tr
-    %td= Account.model_name.human
+    %td
+      %strong= Account.model_name.human
     %td= @order.account
 
 %hr
@@ -34,7 +38,7 @@
     - @order.order_details.each do |order_detail|
       - order_detail.send(:extend, PriceDisplayment)
       %tr
-        %td= order_detail
+        %td= link_to(order_detail, [order_detail.order, order_detail])
         %td
           = order_detail_description_as_html(order_detail)
           - if order_detail.reservation
@@ -48,6 +52,7 @@
         %td
           - if order_detail.note.present?
             = order_detail.note
+          = render_view_hook "after_note", order_detail: order_detail
     %tr
       %td{colspan: 6}
         %strong= text(".total")

--- a/app/views/orders/receipt.html.haml
+++ b/app/views/orders/receipt.html.haml
@@ -42,6 +42,7 @@
             .order-detail-extra= res
           - if order_detail.note.present?
             .order-detail-extra.order-detail-note= "Note: #{order_detail.note}"
+          = render_view_hook "after_note", order_detail: order_detail
         %td.currency=order_detail.wrapped_cost
         - if @order.has_subsidies?
           %td.currency= order_detail.wrapped_subsidy

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
@@ -33,6 +33,10 @@ module SangerSequencing
       end
     end
 
+    def has_results_files?
+      order_detail.sample_results_files.present?
+    end
+
     private
 
     def savable_samples

--- a/vendor/engines/sanger_sequencing/app/presenters/sanger_sequencing/receipt_submission_presenter.rb
+++ b/vendor/engines/sanger_sequencing/app/presenters/sanger_sequencing/receipt_submission_presenter.rb
@@ -11,7 +11,7 @@ module SangerSequencing
     end
 
     def to_s
-      return unless submission
+      return "" unless submission
       render("sanger_sequencing/submissions/samples_table", submission: submission, caption: caption)
         .safe_concat(render(body: print_me_text))
     end

--- a/vendor/engines/sanger_sequencing/app/presenters/sanger_sequencing/receipt_submission_presenter.rb
+++ b/vendor/engines/sanger_sequencing/app/presenters/sanger_sequencing/receipt_submission_presenter.rb
@@ -1,0 +1,39 @@
+module SangerSequencing
+
+  class ReceiptSubmissionPresenter
+
+    attr_reader :view_context, :order_detail
+    delegate :render, :link_to, to: :view_context
+
+    def initialize(view_context, order_detail)
+      @view_context = view_context
+      @order_detail = order_detail
+    end
+
+    def to_s
+      return unless submission
+      render("sanger_sequencing/submissions/samples_table", submission: submission, caption: caption)
+        .safe_concat(render(body: print_me_text))
+    end
+
+    private
+
+    def print_me_text
+      I18n.t("views.sanger_sequencing.orders.receipt.print")
+    end
+
+    def caption
+      text = "#{SangerSequencing::Submission.human_attribute_name(:id)}#{submission.id}"
+      submission_path = submission.order_detail.external_service_receiver.show_url
+
+      link_to text, submission_path
+    end
+
+    def submission
+      return @submission if defined?(@submission)
+      @submission = SangerSequencing::Submission.find_by(order_detail: order_detail)
+    end
+
+  end
+
+end

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/submissions/show.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/submissions/show.html.haml
@@ -17,4 +17,4 @@
       = banner_date_label @submission.order, :ordered_at
       = banner_label @submission.order, :user
 
-  = render "sanger_sequencing/submissions/samples_table"
+  = render "sanger_sequencing/submissions/samples_table", submission: @submission

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/orders/_samples_on_receipt.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/orders/_samples_on_receipt.html.haml
@@ -1,0 +1,1 @@
+= SangerSequencing::ReceiptSubmissionPresenter.new(self, order_detail)

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/submissions/_samples_table.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/submissions/_samples_table.html.haml
@@ -1,17 +1,21 @@
 %div
   %table.table.table-striped.table-tight
+    - if local_assigns[:caption]
+      %caption= local_assigns[:caption]
     %thead
       %tr
         %th= SangerSequencing::Sample.human_attribute_name(:customer_sample_id)
         %th= SangerSequencing::Sample.human_attribute_name(:id)
-        %th= SangerSequencing::Sample.human_attribute_name(:results_files)
+        - if submission.has_results_files?
+          %th= SangerSequencing::Sample.human_attribute_name(:results_files)
     %tbody
-      - @submission.samples.each do |sample|
+      - submission.samples.each do |sample|
         %tr
           %td= sample.customer_sample_id
           %td= sample.id
-          %td
-            %ul.unstyled
-              - sample.results_files.each do |file|
-                %li= link_to file.name, sample_result_path(file)
+          - if submission.has_results_files?
+            %td
+              %ul.unstyled
+                - sample.results_files.each do |file|
+                  %li= link_to file.name, sample_result_path(file)
 

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/submissions/show.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/submissions/show.html.haml
@@ -21,4 +21,4 @@
   %label= OrderDetail.human_attribute_name(:note)
   %p= @submission.order_detail.note
 
-= render "samples_table"
+= render "samples_table", submission: @submission

--- a/vendor/engines/sanger_sequencing/config/locales/en.yml
+++ b/vendor/engines/sanger_sequencing/config/locales/en.yml
@@ -16,6 +16,9 @@ en:
           submit: "Save Submission"
           add: Add
           remove: Remove
+      orders:
+        receipt:
+          print: Please print this receipt to accompany your submission.
       admin:
         submissions:
           index:

--- a/vendor/engines/sanger_sequencing/lib/sanger_sequencing/engine.rb
+++ b/vendor/engines/sanger_sequencing/lib/sanger_sequencing/engine.rb
@@ -4,6 +4,8 @@ module SangerSequencing
 
     config.to_prepare do
       NavTab::LinkCollection.send :include, SangerSequencing::LinkCollectionExtension
+
+      ViewHook.add_hook "orders.receipt", "after_note", "sanger_sequencing/orders/samples_on_receipt"
     end
 
     config.generators do |g|

--- a/vendor/engines/sanger_sequencing/lib/sanger_sequencing/engine.rb
+++ b/vendor/engines/sanger_sequencing/lib/sanger_sequencing/engine.rb
@@ -6,6 +6,7 @@ module SangerSequencing
       NavTab::LinkCollection.send :include, SangerSequencing::LinkCollectionExtension
 
       ViewHook.add_hook "orders.receipt", "after_note", "sanger_sequencing/orders/samples_on_receipt"
+      ViewHook.add_hook "notifier.order_receipt", "after_note", "sanger_sequencing/orders/samples_on_receipt"
     end
 
     config.generators do |g|

--- a/vendor/engines/sanger_sequencing/spec/features/purchasing_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/features/purchasing_spec.rb
@@ -135,6 +135,7 @@ RSpec.describe "Purchasing a Sanger Sequencing service", :aggregate_failures do
 
       describe "after purchasing" do
         before do
+          page.first(customer_id_selector).set("TEST123")
           click_button "Save Submission"
           click_button "Purchase"
           expect(Order.first).to be_purchased
@@ -146,6 +147,11 @@ RSpec.describe "Purchasing a Sanger Sequencing service", :aggregate_failures do
 
           visit edit_sanger_sequencing_submission_path(SangerSequencing::Submission.last)
           expect(page.status_code).to eq(404)
+        end
+
+        it "renders the sample ID on the receipt" do
+          expect(page).to have_content "Receipt"
+          expect(page).to have_content "TEST123"
         end
       end
     end


### PR DESCRIPTION
Includes the commits from #690 

This adds the sample listing to both the displayed order receipt and the one that is emailed out. I added a couple additional links to the facility and order. At some point, we really should do some styling to the email receipt.