### PR TITLE
Fix 95-96 samples would not show second plate

### DIFF
--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_builder.js.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_builder.js.coffee
@@ -66,7 +66,8 @@ class SangerSequencing.WellPlateBuilder
   # Private
 
   _render: ->
-    @_plateCount = Math.max(1, Math.ceil(@samples().length / @_fillOrder().length))
+    wellsInPlate = @_fillOrder().length - @reservedCells.length
+    @_plateCount = Math.max(1, Math.ceil(@samples().length / wellsInPlate))
 
     samples = @samples()
     allPlates = []

--- a/vendor/engines/sanger_sequencing/spec/javascripts/well_plate_builder_spec.js.coffee
+++ b/vendor/engines/sanger_sequencing/spec/javascripts/well_plate_builder_spec.js.coffee
@@ -67,6 +67,33 @@ describe "SangerSequencing.WellPlateBuilder", ->
         # 89 because 96 - 5(already added) - 2 (reserved) = 89
         expect(@wellPlate.sampleAtCell("B01", 1)).toEqual(@submission3.samples[89])
 
+  describe "plateCount()", ->
+    beforeEach ->
+      @wellPlate = new SangerSequencing.WellPlateBuilder
+
+    it "has one plate when empty", ->
+      expect(@wellPlate.plateCount()).toEqual(1)
+
+    it "has one plate when less than 96 cells", ->
+      @submission = { id: 542, samples: sampleList(40) }
+      @wellPlate.addSubmission(@submission)
+      expect(@wellPlate.plateCount()).toEqual(1)
+
+    it "has one plates when it is completely full", ->
+      @submission = { id: 542, samples: sampleList(94) }
+      @wellPlate.addSubmission(@submission)
+      expect(@wellPlate.plateCount()).toEqual(1)
+
+    it "has two plates when it is just over full", ->
+      @submission = { id: 542, samples: sampleList(95) }
+      @wellPlate.addSubmission(@submission)
+      expect(@wellPlate.plateCount()).toEqual(2)
+
+    it "has three plates when it gets really big", ->
+      @submission = { id: 542, samples: sampleList(280) }
+      @wellPlate.addSubmission(@submission)
+      expect(@wellPlate.plateCount()).toEqual(3)
+
   describe "plates", ->
     beforeEach ->
       @wellPlate = new SangerSequencing.WellPlateBuilder


### PR DESCRIPTION
In the plate count, we weren’t accounting for the two reserved cells,
so if you had 95 or 96 samples added to a plate, the next plate was not
appearing.