### PR TITLE
Rework OrderStatus factory to eliminate helper

### DIFF
--- a/spec/factories/order_statuses.rb
+++ b/spec/factories/order_statuses.rb
@@ -1,5 +1,15 @@
 FactoryGirl.define do
   factory :order_status do
+    facility { nil }
+    parent { nil }
     sequence(:name) { |n| "Status #{n}" }
+
+    initialize_with do
+      OrderStatus.find_or_create_by(
+        facility: facility,
+        name: name,
+        parent: parent,
+      )
+    end
   end
 end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     requires_approval false
     is_archived false
     is_hidden false
-    initial_order_status_id { |_o| find_order_status("New").id }
+    initial_order_status_id { FactoryGirl.create(:order_status, name: "New").id }
 
     factory :instrument, class: Instrument do
       transient do
@@ -50,7 +50,7 @@ FactoryGirl.define do
     requires_approval false
     is_archived false
     is_hidden false
-    initial_order_status { find_order_status("New") }
+    initial_order_status { FactoryGirl.create(:order_status, name: "New") }
     min_reserve_mins 60
     max_reserve_mins 120
 

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -1,8 +1,3 @@
-# used by factory to find or create order status
-def find_order_status(status)
-  OrderStatus.find_or_create_by(name: status)
-end
-
 def assert_true(x)
   assert(x)
 end


### PR DESCRIPTION
The factory change allows `FactoryGirl.create(:setup_instrument)` to work from the Rails console without having to load helper methods.