### PR TITLE
[#126390] Zero-cost cancellation of reservations for offline instruments

### DIFF
--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -1,0 +1,12 @@
+module Admin
+
+  class ServicesController < ApplicationController
+
+    def cancel_reservations_for_offline_instruments
+      InstrumentOfflineReservationCanceler.new.cancel!
+      render nothing: true
+    end
+
+  end
+
+end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -68,7 +68,12 @@ class Notifier < ActionMailer::Base
   end
 
   def offline_cancellation_notification(reservation)
-    # TODO: implement!
+    @instrument = reservation.product
+    @reservation = reservation
+    send_nucore_mail(
+      reservation.user.email,
+      text("views.notifier.offline_cancellation_notification.subject", instrument: @instrument),
+    )
   end
 
   def order_detail_status_change(order_detail, old_status, new_status, to)

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -67,6 +67,10 @@ class Notifier < ActionMailer::Base
     send_nucore_mail args[:user].email, text("views.notifier.statement.subject", facility: @facility)
   end
 
+  def offline_cancellation_notification(reservation)
+    # TODO: implement!
+  end
+
   def order_detail_status_change(order_detail, old_status, new_status, to)
     @order_detail = order_detail
     @old_status = old_status

--- a/app/services/instrument_offline_reservation_canceler.rb
+++ b/app/services/instrument_offline_reservation_canceler.rb
@@ -1,0 +1,44 @@
+class InstrumentOfflineReservationCanceler
+
+  def cancel!
+    reservations_to_cancel.each do |reservation|
+      reservation.transaction do
+        cancel_reservation(reservation)
+        Notifier.offline_cancellation_notification(reservation)
+      end
+    end
+  end
+
+  private
+
+  def admin
+    # OrderDetail#cancel_reservation needs an object that responds to #id
+    @admin ||= OpenStruct.new(id: 0)
+  end
+
+  def cancel_reservation(reservation)
+    reservation
+      .order_detail
+      .cancel_reservation(admin, OrderStatus.canceled.first, true, false)
+    reservation
+      .update_attribute(:canceled_reason, "The instrument was offline")
+  end
+
+  def reservations_to_cancel
+    Reservation
+      .not_offline
+      .where(product_id: offline_instrument_ids)
+      .not_canceled
+      .not_ended
+      .where("reserve_start_at <= ?", 1.minute.from_now)
+  end
+
+  def offline_instrument_ids
+    Instrument.where(schedule_id: offline_schedule_ids)
+  end
+
+  def offline_schedule_ids
+    OfflineReservation.current.joins(:product).pluck(:schedule_id)
+  end
+
+end

--- a/app/views/notifier/offline_cancellation_notification.html.haml
+++ b/app/views/notifier/offline_cancellation_notification.html.haml
@@ -1,0 +1,4 @@
+-# TODO: content needs fleshing out
+
+Because #{@instrument} is unavailable, your reservation for
+#{@reservation.reserve_start_at} has been canceled.

--- a/app/views/notifier/offline_cancellation_notification.text.erb
+++ b/app/views/notifier/offline_cancellation_notification.text.erb
@@ -1,0 +1,4 @@
+%# TODO: content needs fleshing out
+
+Because <%= @instrument %> is unavailable, your reservation for
+<%= @reservation.reserve_start_at %> has been canceled.

--- a/config/locales/en.notifier.yml
+++ b/config/locales/en.notifier.yml
@@ -8,6 +8,8 @@ en:
         intro: "Congratulations, %{first_name}. A !app_name! account has been created for you. You may log in at %{login_url}."
         no_password: You may log in with your username and password.
         subject: "Welcome to !app_name!"
+      offline_cancellation_notification:
+        subject: "Your reservation for %{instrument} has been canceled"
       order_notification:
         subject: "!app_name! Order Notification"
       order_receipt:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -538,7 +538,7 @@ en:
       notify: Send Notification
       offline_notice: |
         This instrument is currently offline. If it is not back online before
-        your scheduled time, you will receive at notice and your reservation
+        your scheduled time, you will receive a notice and your reservation
         will be canceled.
     list:
       status:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -364,6 +364,12 @@ Nucore::Application.routes.draw do
   put   "/#{I18n.t("facilities_downcase")}/:facility_id/services/:service_id/surveys/:external_service_passer_id/deactivate", to: 'surveys#deactivate',               as: "deactivate_survey"
   get "/#{I18n.t("facilities_downcase")}/:facility_id/services/:service_id/surveys/:external_service_id/complete", to: "surveys#complete", as: "complete_survey"
 
+  namespace :admin do
+    namespace :services do
+      post "cancel_reservations_for_offline_instruments"
+    end
+  end
+
   # api
   namespace :api do
     resources :order_details, only: [:show]

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -105,6 +105,14 @@ FactoryGirl.define do
         product.reload
       end
     end
+
+    trait :offline do
+      after(:create) do |product|
+        product
+          .offline_reservations
+          .create!(reserve_start_at: 1.month.ago, admin_note: "Offline")
+      end
+    end
   end
 
   factory :instrument_requiring_approval, parent: :setup_instrument do

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -7,6 +7,29 @@ RSpec.describe Notifier do
   let(:product) { create(:setup_instrument, facility: facility) }
   let(:user) { order.user }
 
+  describe ".offline_cancellation_notification" do
+    before(:each) do
+      allow(reservation).to receive(:user) { user }
+      allow(reservation).to receive(:product) { product }
+      Notifier.offline_cancellation_notification(reservation).deliver_now
+    end
+
+    let(:reservation) { FactoryGirl.build_stubbed(:reservation) }
+    let(:user) { FactoryGirl.build_stubbed(:user) }
+
+    it "generates an offline cancellation notification", :aggregate_failures do
+      expect(email.to).to eq [user.email]
+
+      # TODO: Email content is TBD and therefore subject to change:
+      expect(email.subject)
+        .to eq("Your reservation for #{product} has been canceled")
+      expect(email.html_part.to_s)
+        .to include("#{product} is unavailable")
+      expect(email.text_part.to_s)
+        .to include("#{product} is unavailable")
+    end
+  end
+
   describe ".order_notification" do
     before { Notifier.order_notification(order, recipient).deliver_now }
 

--- a/spec/services/instrument_offline_reservation_canceler_spec.rb
+++ b/spec/services/instrument_offline_reservation_canceler_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe InstrumentOfflineReservationCanceler do
+  subject { described_class.new }
+
+  let(:order_detail) { reservation.order_detail }
+  let(:price_policy) { instrument.price_policies.first }
+  let(:user) { order_detail.user }
+
+  describe "#cancel!" do
+    shared_context "the instrument is offline" do
+      context "when a reservation starting now exists" do
+        let!(:reservation) do
+          FactoryGirl.create(:purchased_reservation,
+                             product: instrument,
+                             reserve_start_at: Time.current)
+        end
+
+        before(:each) do
+          allow(Notifier).to receive(:offline_cancellation_notification)
+          subject.cancel!
+        end
+
+        it "cancels the reservation", :aggregate_failures do
+          expect(reservation.reload).to be_canceled
+          expect(reservation.canceled_reason)
+            .to eq("The instrument was offline")
+        end
+
+        context "when the instrument normally imposes a cancellation cost" do
+          before { price_policy.update(cancellation_cost: 10) }
+
+          it "does not charge the user" do
+            expect(order_detail.reload.actual_cost).to be_blank
+          end
+        end
+
+        context "when the instrument normally imposes a reservation cost" do
+          before { price_policy.update(reservation_rate: 10) }
+
+          it "does not charge the user" do
+            expect(order_detail.reload.actual_cost).to be_blank
+          end
+        end
+
+        it "sends a cancellation notification to the user" do
+          expect(Notifier)
+            .to have_received(:offline_cancellation_notification)
+            .with(reservation)
+        end
+      end
+    end
+
+    context "when the instrument is offline" do
+      let!(:instrument) { FactoryGirl.create(:setup_instrument, :offline) }
+
+      it_behaves_like "the instrument is offline"
+    end
+
+    context "when the instrument is online" do
+      let!(:instrument) { FactoryGirl.create(:setup_instrument, schedule: nil) }
+
+      context "but shares a schedule with an instrument that is offline" do
+        let!(:offline_instrument_on_shared_schedule) do
+          FactoryGirl.create(:setup_instrument,
+                             :offline,
+                             schedule: instrument.schedule)
+        end
+
+        it_behaves_like "the instrument is offline"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds `InstrumentOfflineReservationCanceler`, a service object to:
* find reservations about to start for instruments that are offline
* cancel these reservations without cost, and
* mail a notification to the user about the cancellation

It also adds a `POST` endpoint to run the canceler under a new `/admin/services` namespace, with authentication/authorization methods TBD. Basic auth with credentials in `/config`?

Caveat: the email content is placeholder text; real content TBD in a future story