### PR TITLE
[#126391] Flag ongoing reservations as problem orders when taking an instrument offline

### DIFF
--- a/app/controllers/offline_reservations_controller.rb
+++ b/app/controllers/offline_reservations_controller.rb
@@ -8,7 +8,6 @@ class OfflineReservationsController < ApplicationController
   before_action :init_current_facility
   before_action :load_instrument
   before_action :load_reservation, only: %i(edit update)
-  after_action :flag_ongoing_reservations_as_problem, only: %i(create)
 
   load_and_authorize_resource class: Reservation
 
@@ -20,6 +19,7 @@ class OfflineReservationsController < ApplicationController
     @reservation = @instrument.offline_reservations.new(new_offline_reservation_params)
 
     if @reservation.save
+      flag_ongoing_reservations_as_problem
       flash[:notice] = text("create.success")
       redirect_to facility_instrument_schedule_path
     else

--- a/app/controllers/offline_reservations_controller.rb
+++ b/app/controllers/offline_reservations_controller.rb
@@ -8,6 +8,7 @@ class OfflineReservationsController < ApplicationController
   before_action :init_current_facility
   before_action :load_instrument
   before_action :load_reservation, only: %i(edit update)
+  after_action :flag_ongoing_reservations_as_problem, only: %i(create)
 
   load_and_authorize_resource class: Reservation
 
@@ -51,6 +52,12 @@ class OfflineReservationsController < ApplicationController
   end
 
   private
+
+  def flag_ongoing_reservations_as_problem
+    OrderDetail
+      .where(id: @instrument.reservations.ongoing.pluck(:order_detail_id))
+      .update_all(problem: true)
+  end
 
   def load_instrument
     @instrument = current_facility.instruments.find_by!(url_name: params[:instrument_id])

--- a/app/controllers/offline_reservations_controller.rb
+++ b/app/controllers/offline_reservations_controller.rb
@@ -56,7 +56,7 @@ class OfflineReservationsController < ApplicationController
   def flag_ongoing_reservations_as_problem
     OrderDetail
       .where(id: @instrument.reservations.ongoing.pluck(:order_detail_id))
-      .update_all(problem: true)
+      .each(&:force_complete!)
   end
 
   def load_instrument

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -465,6 +465,10 @@ class OrderDetail < ActiveRecord::Base
     change_status!(OrderStatus.complete_status)
   end
 
+  def force_complete!
+    update(state: "complete", order_status: OrderStatus.complete.first)
+  end
+
   def backdate_to_complete!(event_time = Time.zone.now)
     # if we're setting it to compete, automatically set the actuals for a reservation
     if reservation

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -466,7 +466,7 @@ class OrderDetail < ActiveRecord::Base
   end
 
   def force_complete!
-    update(state: "complete", order_status: OrderStatus.complete.first)
+    update(state: "complete", order_status: OrderStatus.complete_status)
   end
 
   def backdate_to_complete!(event_time = Time.zone.now)

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -60,17 +60,9 @@ class Reservation < ActiveRecord::Base
       .joins("LEFT JOIN orders ON orders.id = order_details.order_id")
   end
 
-  def self.not_canceled
-    where(canceled_at: nil)
-  end
-
-  def self.not_started
-    where(actual_start_at: nil)
-  end
-
-  def self.not_ended
-    where(actual_end_at: nil)
-  end
+  scope :not_canceled, -> { where(canceled_at: nil) }
+  scope :not_started, -> { where(actual_start_at: nil) }
+  scope :not_ended, -> { where(actual_end_at: nil) }
 
   def self.not_this_reservation(reservation)
     if reservation.id
@@ -80,9 +72,7 @@ class Reservation < ActiveRecord::Base
     end
   end
 
-  scope :ongoing, -> {
-    where("actual_start_at <= ?", Time.current).where(actual_end_at: nil)
-  }
+  scope :ongoing, -> { not_ended.where("actual_start_at <= ?", Time.current) }
 
   def self.today
     for_date(Time.zone.now)

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -80,6 +80,10 @@ class Reservation < ActiveRecord::Base
     end
   end
 
+  scope :ongoing, -> {
+    where("actual_start_at <= ?", Time.current).where(actual_end_at: nil)
+  }
+
   def self.today
     for_date(Time.zone.now)
   end

--- a/spec/controllers/offline_reservations_controller_spec.rb
+++ b/spec/controllers/offline_reservations_controller_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe OfflineReservationsController do
+  let(:admin) { FactoryGirl.create(:user, :administrator) }
+  let(:instrument) { FactoryGirl.create(:setup_instrument) }
+
+  before { sign_in admin }
+
+  describe "POST #create" do
+    let(:params) do
+      {
+        facility_id: instrument.facility.url_name,
+        instrument_id: instrument.url_name,
+        offline_reservation: { admin_note: "The instrument is down" },
+      }
+    end
+
+    context "when an ongoing reservation exists for the instrument" do
+      let!(:reservation) do
+        FactoryGirl.create(:setup_reservation, :running, product: instrument)
+      end
+
+      it "becomes a problem reservation" do
+        expect { post :create, params }
+          .to change { reservation.reload.problem? }
+          .from(false)
+          .to(true)
+      end
+    end
+  end
+end

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -1631,6 +1631,13 @@ RSpec.describe OrderDetail do
     end
   end
 
+  describe "#force_complete!" do
+    it "forces a transition from new to complete" do
+      expect { order_detail.force_complete! }
+        .to change { order_detail.reload.state }.from("new").to("complete")
+    end
+  end
+
   def set_cancellation_cost_for_all_policies(cost)
     PricePolicy.all.each do |price_policy|
       price_policy.update_attribute :cancellation_cost, cost


### PR DESCRIPTION
This replaces #695.