### PR TITLE
Make types consistent when creating AdminReservations

### DIFF
--- a/app/controllers/facility_reservations_controller.rb
+++ b/app/controllers/facility_reservations_controller.rb
@@ -112,7 +112,9 @@ class FacilityReservationsController < ApplicationController
   # GET /facilities/:facility_id/instruments/:instrument_id/reservations/new
   def new
     @instrument   = current_facility.instruments.find_by_url_name!(params[:instrument_id])
-    @reservation  = @instrument.next_available_reservation || @instrument.reservations.build(duration_value: @instrument.min_reserve_mins, duration_unit: "minutes")
+    @reservation = @instrument.next_available_reservation ||
+                   @instrument.admin_reservations.build(duration_value: @instrument.min_reserve_mins, duration_unit: "minutes")
+    @reservation = @reservation.becomes(AdminReservation)
     @reservation.round_reservation_times
     set_windows
 
@@ -124,8 +126,8 @@ class FacilityReservationsController < ApplicationController
     @instrument =
       current_facility.instruments.find_by!(url_name: params[:instrument_id])
     @reservation = @instrument.admin_reservations.new
-    @reservation.assign_attributes(params[:reservation])
-    @reservation.assign_times_from_params(params[:reservation])
+    @reservation.assign_attributes(params[:admin_reservation])
+    @reservation.assign_times_from_params(params[:admin_reservation])
 
     if @reservation.save
       flash[:notice] = "The reservation has been created successfully."

--- a/spec/controllers/facility_reservations_controller_spec.rb
+++ b/spec/controllers/facility_reservations_controller_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe FacilityReservationsController do
   end
 
   describe "POST #create" do
-    let(:reservation_params) do
+    let(:admin_reservation_params) do
       {
         reserve_start_date: reserve_start_at.strftime("%m/%d/%Y"),
         reserve_start_hour: reserve_start_at.hour.to_s,
@@ -120,7 +120,7 @@ RSpec.describe FacilityReservationsController do
       @params = {
         facility_id: facility.url_name,
         instrument_id: product.url_name,
-        reservation: reservation_params,
+        admin_reservation: admin_reservation_params,
       }
     end
 


### PR DESCRIPTION
This should correct the issue where correcting a form after a failed `create` would raise an exception.

To reproduce:
* As an administrator, visit `/facilities/:id/instruments/:id/reservations/new`
* Specify a zero-length reservation
* Submit the form
* Get an error screen
* Fill in a valid reservation length
* Submit the form