### PR TITLE
[#125568281] Send notification on results file upload

### DIFF
--- a/app/controllers/file_uploads_controller.rb
+++ b/app/controllers/file_uploads_controller.rb
@@ -63,6 +63,7 @@ class FileUploadsController < ApplicationController
     @upload = @product.stored_files.new(@options)
     authorize! :uploader_create, @upload
     @upload.save!
+    ResultsFileNotifier.new(@upload).notify if @upload.sample_result?
 
     render text: @upload.download_url
   end

--- a/app/mailers/results_file_notifier_mailer.rb
+++ b/app/mailers/results_file_notifier_mailer.rb
@@ -1,0 +1,8 @@
+class ResultsFileNotifierMailer < BaseMailer
+
+  def file_uploaded(file)
+    @order_detail = file.order_detail
+    mail(to: @order_detail.user.email, subject: text("results_file_notifier_mailer.file_uploaded.subject"))
+  end
+
+end

--- a/app/models/email_event.rb
+++ b/app/models/email_event.rb
@@ -1,0 +1,34 @@
+# Never instantiate this class directly. Use the `notify` method.
+class EmailEvent < ActiveRecord::Base
+
+  include ActiveModel::ForbiddenAttributesProtection
+
+  belongs_to :user
+  validates :user, presence: true
+  validates :key, presence: true, uniqueness: { scope: :user_id }
+
+  # Use this to avoid sending too many emails to a user within a given timeframe
+  # It accepts a block, and will yield if this method has not been called within
+  # the wait time.
+  #
+  # Example:
+  #
+  # EmailEvent.notify(file.user, [:some_mailer, :some_action], wait: 1.hour) do
+  #   SomeMailer.some_action(user).deliver_later
+  # end
+  #
+  def self.notify(user, keys, wait: 24.hours)
+    event = find_or_initialize_by(user: user, key: key_for(keys))
+
+    if event.last_sent_at.blank? || event.last_sent_at < wait.ago
+      event.last_sent_at = Time.current
+      yield
+    end
+    event.save!
+  end
+
+  def self.key_for(keys)
+    Array(keys).map(&:to_s).join("/")
+  end
+
+end

--- a/app/models/stored_file.rb
+++ b/app/models/stored_file.rb
@@ -11,6 +11,7 @@ class StoredFile < ActiveRecord::Base
   validates_inclusion_of  :file_type, in: %w(info template template_result sample_result import_error import_upload)
 
   delegate :user, to: :order_detail
+  delegate :sample_result?, :template_result?, to: :type_inquirer
 
   scope :import_error, -> { where(file_type: "import_error") }
   scope :import_upload, -> { where(file_type: "import_upload") }
@@ -31,6 +32,12 @@ class StoredFile < ActiveRecord::Base
   def swf_uploaded_data=(data)
     data.content_type = MIME::Types.type_for(data.original_filename).first.to_s
     self.file = data
+  end
+
+  private
+
+  def type_inquirer
+    ActiveSupport::StringInquirer.new(file_type)
   end
 
 end

--- a/app/models/stored_file.rb
+++ b/app/models/stored_file.rb
@@ -10,6 +10,8 @@ class StoredFile < ActiveRecord::Base
   validates_presence_of   :order_detail_id, if: ->(o) { o.file_type == "template_result" || o.file_type == "sample_result" }
   validates_inclusion_of  :file_type, in: %w(info template template_result sample_result import_error import_upload)
 
+  delegate :user, to: :order_detail
+
   scope :import_error, -> { where(file_type: "import_error") }
   scope :import_upload, -> { where(file_type: "import_upload") }
   scope :info, -> { where(file_type: "info") }

--- a/app/services/results_file_notifier.rb
+++ b/app/services/results_file_notifier.rb
@@ -7,9 +7,20 @@ class ResultsFileNotifier
   end
 
   def notify
-    if SettingsHelper.feature_on?(:my_files)
+    return unless SettingsHelper.feature_on?(:my_files)
+
+    EmailEvent.notify(file.user, debounce_key) do
       ResultsFileNotifierMailer.file_uploaded(file).deliver_later
     end
+  end
+
+  private
+
+  def debounce_key
+    # De-bounce emails based on the order detail so we don't overwhelm the user.
+    # This could easily be changed to just the user or just the facility by
+    # changing this key
+    [:results_file, :file_uploaded, :order_detail, file.order_detail]
   end
 
 end

--- a/app/services/results_file_notifier.rb
+++ b/app/services/results_file_notifier.rb
@@ -1,0 +1,15 @@
+class ResultsFileNotifier
+
+  attr_reader :file
+
+  def initialize(file)
+    @file = file
+  end
+
+  def notify
+    if SettingsHelper.feature_on?(:my_files)
+      ResultsFileNotifierMailer.file_uploaded(file).deliver_later
+    end
+  end
+
+end

--- a/app/views/results_file_notifier_mailer/file_uploaded.html.haml
+++ b/app/views/results_file_notifier_mailer/file_uploaded.html.haml
@@ -1,0 +1,3 @@
+= html("html", order_detail: @order_detail, facility: @order_detail.facility,
+  order_detail_path: order_order_detail_url(@order_detail.order, @order_detail),
+  my_files_path: my_files_url)

--- a/config/locales/views/en.results_file_notifier.yml
+++ b/config/locales/views/en.results_file_notifier.yml
@@ -1,0 +1,13 @@
+en:
+  results_file_notifier_mailer:
+    file_uploaded:
+      subject: "!app_name! Results Files Uploaded"
+
+  views:
+    results_file_notifier_mailer:
+      file_uploaded:
+        html: |
+          Results file(s) for your !app_name! order #[%{order_detail}](%{order_detail_path})
+          have been uploaded by %{facility}.
+
+          You may download them from [My Orders](%{order_detail_path}) or [My Files](%{my_files_path})

--- a/db/migrate/20160715220430_create_email_events.rb
+++ b/db/migrate/20160715220430_create_email_events.rb
@@ -1,0 +1,13 @@
+class CreateEmailEvents < ActiveRecord::Migration
+
+  def change
+    create_table :email_events do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :key, null: false
+      t.datetime :last_sent_at, null: false
+      t.timestamps
+      t.index [:user_id, :key], unique: true
+    end
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160706195345) do
+ActiveRecord::Schema.define(version: 20160715220430) do
 
   create_table "account_users", force: :cascade do |t|
     t.integer  "account_id", limit: 4,  null: false
@@ -88,6 +88,16 @@ ActiveRecord::Schema.define(version: 20160706195345) do
   end
 
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
+
+  create_table "email_events", force: :cascade do |t|
+    t.integer  "user_id",      limit: 4,   null: false
+    t.string   "key",          limit: 255, null: false
+    t.datetime "last_sent_at",             null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "email_events", ["user_id", "key"], name: "index_email_events_on_user_id_and_key", unique: true, using: :btree
 
   create_table "external_service_passers", force: :cascade do |t|
     t.integer  "external_service_id", limit: 4
@@ -687,6 +697,7 @@ ActiveRecord::Schema.define(version: 20160706195345) do
   add_foreign_key "accounts", "facilities", name: "fk_account_facility_id"
   add_foreign_key "bundle_products", "products", column: "bundle_product_id", name: "fk_bundle_prod_prod"
   add_foreign_key "bundle_products", "products", name: "fk_bundle_prod_bundle"
+  add_foreign_key "email_events", "users"
   add_foreign_key "facility_accounts", "facilities", name: "fk_facilities"
   add_foreign_key "instrument_statuses", "products", column: "instrument_id", name: "fk_int_stats_product"
   add_foreign_key "order_details", "accounts", name: "fk_od_accounts"

--- a/spec/mailers/previews/results_file_notifier_preview.rb
+++ b/spec/mailers/previews/results_file_notifier_preview.rb
@@ -1,0 +1,8 @@
+class ResultsFileNotifierPreview < ActionMailer::Preview
+
+  def file_uploaded
+    file = StoredFile.sample_result.last
+    ResultsFileNotifierMailer.file_uploaded(file)
+  end
+
+end

--- a/spec/models/email_event_spec.rb
+++ b/spec/models/email_event_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe EmailEvent do
+
+  describe ".notify" do
+    let(:user) { FactoryGirl.create(:user) }
+
+    it "yields on the first invocation" do
+      expect { |b| described_class.notify(user, "key", &b) }.to yield_control
+    end
+
+    describe "on second invocation" do
+      before do
+        described_class.notify(user, "key") {}
+      end
+
+      it "does not yield on second quick invocation" do
+        expect { |b| described_class.notify(user, "key", &b) }.not_to yield_control
+      end
+
+      it "does not yield on second invocation if before the wait time" do
+        Timecop.travel(1.hour.from_now)
+        expect { |b| described_class.notify(user, "key", wait: 2.hours, &b) }.not_to yield_control
+      end
+
+      it "yields on second invocation after the wait time" do
+        Timecop.travel(3.hours.from_now)
+        expect { |b| described_class.notify(user, "key", wait: 2.hours, &b) }.to yield_control
+      end
+
+      it "yields on an invocation for a different key" do
+        expect { |b| described_class.notify(user, "anotherkey", &b) }.to yield_control
+      end
+
+      it "yields on an invocation for a different user with the same key" do
+        user2 = FactoryGirl.create(:user)
+        expect { |b| described_class.notify(user2, "key", &b) }.to yield_control
+      end
+    end
+  end
+
+  describe ".key_for" do
+    it "renders a plain string" do
+      expect(described_class.key_for("testing")).to eq("testing")
+    end
+
+    it "accepts an array of strings" do
+      expect(described_class.key_for(%w(test abc))).to eq("test/abc")
+    end
+
+    it "accepts strings and symbols" do
+      expect(described_class.key_for([:test_sym, "test_string"])).to eq("test_sym/test_string")
+    end
+
+    it "takes an arbitrary object with a to_s method" do
+      class TestingClass
+
+        def to_s
+          "test_me"
+        end
+
+      end
+
+      expect(described_class.key_for([:test, TestingClass.new])).to eq("test/test_me")
+    end
+  end
+end

--- a/spec/services/results_file_notifier_spec.rb
+++ b/spec/services/results_file_notifier_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ResultsFileNotifier do
       end
 
       describe "a day later" do
-        before { Timecop.travel(1.day.from_now) }
+        before { Timecop.travel(25.hours.from_now) }
 
         it "does send" do
           expect { notifier.notify }.to change(ActionMailer::Base.deliveries, :count).by(1)

--- a/spec/services/results_file_notifier_spec.rb
+++ b/spec/services/results_file_notifier_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe ResultsFileNotifier do
+  let(:service) { FactoryGirl.create(:setup_service) }
+  let(:order) { create(:purchased_order, product: service) }
+  let(:stored_file) { FactoryGirl.create(:stored_file, :results, order_detail: order.order_details.first) }
+  let(:notifier) { described_class.new(stored_file) }
+
+  describe "with My Files enabled", feature_setting: { my_files: true } do
+    it "sends a notification" do
+      expect { notifier.notify }.to change(ActionMailer::Base.deliveries, :count).by(1)
+    end
+
+    describe "notifying a second time" do
+      before { notifier.notify }
+
+      describe "shortly after the first one" do
+        it "does not send" do
+          expect { notifier.notify }.not_to change(ActionMailer::Base.deliveries, :count)
+        end
+      end
+
+      describe "a day later" do
+        before { Timecop.travel(1.day.from_now) }
+
+        it "does send" do
+          expect { notifier.notify }.to change(ActionMailer::Base.deliveries, :count).by(1)
+        end
+      end
+    end
+  end
+
+  describe "with My Files disabled", feature_setting: { my_files: false } do
+    it "does not send a notification" do
+      expect { notifier.notify }.not_to change(ActionMailer::Base.deliveries, :count)
+    end
+  end
+
+end

--- a/vendor/engines/sanger_sequencing/app/services/sanger_sequencing/sample_result_file_saver.rb
+++ b/vendor/engines/sanger_sequencing/app/services/sanger_sequencing/sample_result_file_saver.rb
@@ -23,7 +23,9 @@ module SangerSequencing
                                    file_type: "sample_result", created_by: current_user.id,
                                    order_detail: sample.submission.order_detail,
                                    product_id: sample.submission.order_detail.product_id)
-      stored_file.save
+      success = stored_file.save
+      trigger_notification(stored_file) if success
+      success
     end
 
     def filename
@@ -36,6 +38,10 @@ module SangerSequencing
     end
 
     private
+
+    def trigger_notification(stored_file)
+      ResultsFileNotifier.new(stored_file).notify
+    end
 
     def has_valid_sample
       return unless filename_has_sample_id?


### PR DESCRIPTION
I decided to debounce email sending based on the order detail so that I could include the order detail link in the email. If we went with a per-facility or global per-user then it wouldn't be a good idea to include the OD link; only the My Files link would be good. 

I also debounced it at 24 hours. That could pretty easily be extracted into a setting if we want.

This is feature-flagged on My Files right now (mainly because I wanted to include the my files links), but that could change as well.

