### PR TITLE
[#126389] Prevent reservation start when the instrument is offline

### DIFF
--- a/app/assets/javascripts/app/reservations.coffee
+++ b/app/assets/javascripts/app/reservations.coffee
@@ -23,7 +23,7 @@ $ ->
         picked = new Date(date_string)
 
         # change reservation creation button based on Reservation
-        text = if picked.between(now, future) then 'Create & Start' else 'Create'
+        text = if instrumentOnline && picked.between(now, future) then 'Create & Start' else 'Create'
         $('#reservation_submit').attr('value', text)
 
       .trigger('change')

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -222,6 +222,14 @@ class Product < ActiveRecord::Base
     product_users.find_by_user_id(user.id)
   end
 
+  def offline?
+    false
+  end
+
+  def online?
+    !offline?
+  end
+
   def training_request_contacts
     CsvArrayString.new(self[:training_request_contacts])
   end

--- a/app/support/products/scheduling_support.rb
+++ b/app/support/products/scheduling_support.rb
@@ -94,12 +94,16 @@ module Products::SchedulingSupport
     end
   end
 
+  def offline?
+    offline_reservations.current.any?
+  end
+
   def online!
     offline_reservations.current.update_all(reserve_end_at: Time.current)
   end
 
   def online?
-    offline_reservations.current.none?
+    !offline?
   end
 
   private

--- a/app/support/reservations/relay_support.rb
+++ b/app/support/reservations/relay_support.rb
@@ -3,6 +3,7 @@ module Reservations::RelaySupport
   def can_switch_instrument_on?(check_off = true)
     return false if canceled?
     return false unless product.relay # is relay controlled
+    return false if product.offline?
     return false if check_off && can_switch_instrument_off?(false) # mutually exclusive
     return false unless actual_start_at.nil?   # already turned on
     return false unless actual_end_at.nil?     # already turned off

--- a/app/views/reservations/_js_variables.html.haml
+++ b/app/views/reservations/_js_variables.html.haml
@@ -13,4 +13,4 @@
   var reserveInterval = #{@instrument.reserve_interval};
   var reserveMinimum  = #{@instrument.min_reserve_mins || 0};
   var reserveMaximum  = #{@instrument.max_reserve_mins || 0};
-  var instrumentOnline = #{@instrument.online? || false};
+  var instrumentOnline = #{@instrument.online?};

--- a/app/views/reservations/_js_variables.html.haml
+++ b/app/views/reservations/_js_variables.html.haml
@@ -13,3 +13,4 @@
   var reserveInterval = #{@instrument.reserve_interval};
   var reserveMinimum  = #{@instrument.min_reserve_mins || 0};
   var reserveMaximum  = #{@instrument.max_reserve_mins || 0};
+  var instrumentOnline = #{@instrument.online? || false};

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -821,20 +821,24 @@ RSpec.describe Instrument do
   describe "#offline? and #online?" do
     before { instrument.save! }
 
-    context "when an offline reservation does not exist", :aggregate_failures do
-      it { is_expected.to be_online }
-      it { is_expected.not_to be_offline }
+    context "when an offline reservation does not exist" do
+      it "is online", :aggregate_failures do
+        is_expected.to be_online
+        is_expected.not_to be_offline
+      end
     end
 
-    context "when an offline reservation exists", :aggregate_failures do
+    context "when an offline reservation exists" do
       let!(:offline_reservation) do
         instrument
           .offline_reservations
           .create!(admin_note: "Down", reserve_start_at: 1.day.ago)
       end
 
-      it { is_expected.to be_offline }
-      it { is_expected.not_to be_online }
+      it "is offline", :aggregate_failures do
+        is_expected.to be_offline
+        is_expected.not_to be_online
+      end
     end
   end
 

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -818,20 +818,22 @@ RSpec.describe Instrument do
     end
   end
 
-  describe "#online?" do
+  describe "#offline? and #online?" do
     before { instrument.save! }
 
-    context "when an offline reservation does not exist" do
+    context "when an offline reservation does not exist", :aggregate_failures do
       it { is_expected.to be_online }
+      it { is_expected.not_to be_offline }
     end
 
-    context "when an offline reservation exists" do
+    context "when an offline reservation exists", :aggregate_failures do
       let!(:offline_reservation) do
         instrument
           .offline_reservations
           .create!(admin_note: "Down", reserve_start_at: 1.day.ago)
       end
 
+      it { is_expected.to be_offline }
       it { is_expected.not_to be_online }
     end
   end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -519,6 +519,14 @@ RSpec.describe Product do
     end
   end
 
+  describe "#offline?" do
+    it { is_expected.not_to be_offline }
+  end
+
+  describe "#online?" do
+    it { is_expected.to be_online }
+  end
+
   describe "#training_request_contacts" do
     let(:product) { build(:item, training_request_contacts: contacts) }
     subject(:emails) { product.training_request_contacts.to_a }


### PR DESCRIPTION
This should prevent "Create & Start" as well as starting reservations for an instrument that is offline. It includes cherry-picks from #696 to bring in the `Product#online?` and `#offline?` methods.