### PR TITLE
[#121327715] Setting to allow skipping netid lookup

### DIFF
--- a/app/views/search/_create_new_user.html.haml
+++ b/app/views/search/_create_new_user.html.haml
@@ -1,4 +1,7 @@
 - if params[:create_link] == "true" && SettingsHelper.feature_on?(:create_users)
   %p
     = t(".prompt")
-    = link_to t(".link"), new_facility_user_path(@facility)
+    - if SettingsHelper.feature_on?(:netids)
+      = link_to t(".link"), new_facility_user_path(@facility)
+    - else
+      = link_to t(".link"), new_external_facility_users_path(@facility)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -94,6 +94,7 @@ api:
 feature:
   billing_administrator_on: true
   create_users_on: true
+  netids_on: true
   limit_short_description_on: true
   manage_payment_sources_with_users_on: true
   password_update_on: true


### PR DESCRIPTION
If the school doesn’t use a netid or other directory, then there’s no
need to go through that option when creating a user. This will now just
skip you straight to “Add External User”.

I didn’t think it was worth doing any additional disabling of routes
since it’s still fine if those routes work, this is just much more
efficient.

I’ll have another PR for DC that incorporates this change and changes some locales to make it less confusing for them.