### PR TITLE
[#123935371] Handle duplicate filenames in zip download

### DIFF
--- a/app/services/stored_file_zipper.rb
+++ b/app/services/stored_file_zipper.rb
@@ -29,7 +29,7 @@ class StoredFileZipper
   # If a filename has already been used, append a -X to the end of the name
   # before the extension. E.g. 12345_B07.ab1 => 12345_B07-1.ab1
   def filename(file)
-    if @filenames.has_key?(file.name)
+    if @filenames.key?(file.name)
       @filenames[file.name] += 1
       file.name.sub(/\.(\w+)\z/, "-#{@filenames[file.name]}.\\1")
     else

--- a/app/services/stored_file_zipper.rb
+++ b/app/services/stored_file_zipper.rb
@@ -16,11 +16,25 @@ class StoredFileZipper
   private
 
   def build_zip
+    @filenames = {}
+
     Zip::OutputStream.write_buffer do |stream|
       files.each do |file|
-        stream.put_next_entry(file.name)
+        stream.put_next_entry(filename(file))
         stream << file.read
       end
+    end
+  end
+
+  # If a filename has already been used, append a -X to the end of the name
+  # before the extension. E.g. 12345_B07.ab1 => 12345_B07-1.ab1
+  def filename(file)
+    if @filenames.has_key?(file.name)
+      @filenames[file.name] += 1
+      file.name.sub(/\.(\w+)\z/, "-#{@filenames[file.name]}.\\1")
+    else
+      @filenames[file.name] = 0
+      file.name
     end
   end
 


### PR DESCRIPTION
If there are duplicate filenames being downloaded, the mac unarchiver
will break with “Error 1 - Operation not permitted”. If you use the
command line `unzip`, it will expand it, but will be missing a file.

This appends a -N to the end of the filename before the extension. I’m
planning another PR that will prevent duplicate filenames at upload
time.