### PR TITLE
[#126393] Support offline reservation categories

### DIFF
--- a/app/controllers/offline_reservations_controller.rb
+++ b/app/controllers/offline_reservations_controller.rb
@@ -69,7 +69,7 @@ class OfflineReservationsController < ApplicationController
 
   def new_offline_reservation_params
     params[:offline_reservation]
-      .permit(:admin_note)
+      .permit(:admin_note, :category)
       .merge(reserve_start_at: Time.current)
   end
 

--- a/app/helpers/facility_reservations_helper.rb
+++ b/app/helpers/facility_reservations_helper.rb
@@ -1,5 +1,11 @@
 module FacilityReservationsHelper
 
+  def offline_category_collection
+    OfflineReservation::CATEGORIES.map do |c|
+      [I18n.t("offline_reservations.categories.#{c}"), c]
+    end
+  end
+
   def reservation_links(reservation)
     links = []
     if reservation.admin?

--- a/app/helpers/facility_reservations_helper.rb
+++ b/app/helpers/facility_reservations_helper.rb
@@ -6,12 +6,8 @@ module FacilityReservationsHelper
     end
   end
 
-  def reservation_category_label(reservation_category)
-    if reservation_category.present?
-      I18n.t("offline_reservations.categories.#{reservation_category}")
-    else
-      ""
-    end
+  def reservation_category_label(category)
+    t(category.presence, scope: "offline_reservations.categories", default: "")
   end
 
   def reservation_links(reservation)

--- a/app/helpers/facility_reservations_helper.rb
+++ b/app/helpers/facility_reservations_helper.rb
@@ -1,8 +1,16 @@
 module FacilityReservationsHelper
 
   def offline_category_collection
-    OfflineReservation::CATEGORIES.map do |c|
-      [I18n.t("offline_reservations.categories.#{c}"), c]
+    OfflineReservation::CATEGORIES.map do |category|
+      [reservation_category_label(category), category]
+    end
+  end
+
+  def reservation_category_label(reservation_category)
+    if reservation_category.present?
+      I18n.t("offline_reservations.categories.#{reservation_category}")
+    else
+      ""
     end
   end
 

--- a/app/models/offline_reservation.rb
+++ b/app/models/offline_reservation.rb
@@ -1,5 +1,11 @@
 class OfflineReservation < Reservation
 
+  CATEGORIES = %w(
+    operator_unavailable
+    out_of_order
+    scheduled_maintenance
+  ).freeze
+
   include ActiveModel::ForbiddenAttributesProtection
 
   validates :admin_note, presence: true

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -21,21 +21,17 @@ module Reservations::Validations
 
     validate :starts_before_ends
     validate :duration_is_interval
-    validate :category_is_valid
+
+    validates :category,
+              inclusion: { in: -> (r) { r.class::CATEGORIES }, allow_blank: true },
+              if: -> (r) { r.class.const_defined?(:CATEGORIES) }
+
+    validates :category,
+              absence: true,
+              unless: -> (r) { r.class.const_defined?(:CATEGORIES) }
   end
 
   # Validation Methods
-
-  def category_is_valid
-    return if category.blank?
-    if self.class.const_defined?(:CATEGORIES)
-      unless self.class::CATEGORIES.include?(category)
-        errors.add(:category, "must be a defined category")
-      end
-    else
-      errors.add(:category, "must be blank")
-    end
-  end
 
   def starts_before_ends
     if reserve_start_at && reserve_end_at

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -21,9 +21,21 @@ module Reservations::Validations
 
     validate :starts_before_ends
     validate :duration_is_interval
+    validate :category_is_valid
   end
 
   # Validation Methods
+
+  def category_is_valid
+    return if category.blank?
+    if self.class.const_defined?(:CATEGORIES)
+      unless self.class::CATEGORIES.include?(category)
+        errors.add(:category, "must be a defined category")
+      end
+    else
+      errors.add(:category, "must be blank")
+    end
+  end
 
   def starts_before_ends
     if reserve_start_at && reserve_end_at

--- a/app/views/instruments/schedule.html.haml
+++ b/app/views/instruments/schedule.html.haml
@@ -49,6 +49,7 @@
         %th
         %th= Reservation.human_attribute_name(:type)
         %th= Reservation.model_name.human
+        %th= Reservation.human_attribute_name(:category)
         %th= Reservation.human_attribute_name(:admin_note)
     %tbody
       - @admin_reservations.each do |reservation|
@@ -66,6 +67,7 @@
               = link_to reservation,
                 facility_instrument_reservation_edit_admin_path(current_facility, @instrument, reservation)
 
+            %td= reservation_category_label(reservation.category)
             %td= reservation.admin_note
 
           - else
@@ -76,6 +78,7 @@
               %td
                 = link_to reservation,
                   edit_facility_instrument_offline_reservation_path(current_facility, @instrument, reservation)
+              %td= reservation_category_label(reservation.category)
               %td= reservation.admin_note
 
 %h3= t(".reservations_calendar")

--- a/app/views/offline_reservations/_form.html.haml
+++ b/app/views/offline_reservations/_form.html.haml
@@ -11,7 +11,13 @@
 
 = simple_form_for([@instrument, @reservation], url: url) do |f|
   = f.error_messages
-  = f.input :admin_note, input_html: { class: "span6" }
+
+  %ul.inline
+    %li= f.input :admin_note, input_html: { class: "span4" }
+    %li
+      = f.input :category,
+        collection: offline_category_collection,
+        input_html: { class: "span2" }
 
   .clearfix
   %ul.inline

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -272,7 +272,9 @@ en:
         auto_logout: Auto-Relay Shutoff?
         auto_logout_minutes: Auto-Relay Shutoff After X Minutes
       reservation:
+        admin_note: Admin Note
         base: '' #handled by actual messages
+        category: Category
         to_s: Reservation
         reserve_to_s: Reservation
         reserve_start_date: Reserve Start

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -513,6 +513,11 @@ en:
         default: "* Changing the quantity will automatically update the price fields"
 
   offline_reservations:
+    categories:
+      operator_unavailable: Operator unavailable
+      out_of_order: Out of order
+      scheduled_maintenance: Scheduled maintenance
+
     edit:
       update: Update the note
     new:

--- a/db/migrate/20160720200222_add_category_to_reservations.rb
+++ b/db/migrate/20160720200222_add_category_to_reservations.rb
@@ -1,0 +1,7 @@
+class AddCategoryToReservations < ActiveRecord::Migration
+
+  def change
+    add_column :reservations, :category, :string, null: true
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160715220430) do
+ActiveRecord::Schema.define(version: 20160720200222) do
 
   create_table "account_users", force: :cascade do |t|
     t.integer  "account_id", limit: 4,  null: false
@@ -513,6 +513,7 @@ ActiveRecord::Schema.define(version: 20160715220430) do
     t.string   "canceled_reason",  limit: 50
     t.string   "admin_note",       limit: 255
     t.string   "type",             limit: 255
+    t.string   "category",         limit: 255
   end
 
   add_index "reservations", ["order_detail_id"], name: "res_od_uniq_fk", unique: true, using: :btree

--- a/spec/features/managing_instrument_offline_spec.rb
+++ b/spec/features/managing_instrument_offline_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Managing Instrument Offline Reservations" do
         end
 
         it "does not update the note" do
-          expect(page).to have_content "Admin note may not be blank"
+          expect(page).to have_content "Admin Note may not be blank"
           expect(current_path)
             .to eq(facility_instrument_offline_reservation_path(facility, instrument, offline_reservation))
           expect(offline_reservation.reload.admin_note)

--- a/spec/models/offline_reservation_spec.rb
+++ b/spec/models/offline_reservation_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe OfflineReservation do
   describe "validations" do
     it { is_expected.to validate_presence_of(:admin_note) }
     it { is_expected.to validate_presence_of(:reserve_start_at) }
+
+    it "allows optional designated categories" do
+      is_expected
+        .to validate_inclusion_of(:category)
+        .in_array(%w(operator_unavailable out_of_order scheduled_maintenance))
+        .allow_nil
+    end
   end
 
   describe "#admin_removable?" do

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe Reservation do
     allow_any_instance_of(Reservation).to receive(:admin?).and_return(false)
   end
 
+  describe "validations" do
+    it { is_expected.to validate_absence_of :category }
+  end
+
   describe "#admin_editable?" do
     context "when the reservation has been persisted" do
       context "and has been canceled" do


### PR DESCRIPTION
`OfflineReservation::CATEGORIES` is a hardcoded list but the idea is to eventually turn this into something more flexible (and admin-editable).

The categories for offline reservations appear in the CRUD interface as well as the admin reservation list, but nowhere else yet. They will appear in reports.