### PR TITLE
[#127148] Do not show not authorized message when adding to an order

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -164,7 +164,7 @@ class ReservationsController < ApplicationController
     next_available = @instrument.next_available_reservation(1.minute.from_now, default_reservation_mins.minutes, options)
     @reservation = next_available || default_reservation
     @reservation.round_reservation_times
-    unless @instrument.can_be_used_by?(acting_user)
+    unless @instrument.can_be_used_by?(@order_detail.user)
       flash[:notice] = text(".acting_as_not_on_approval_list")
     end
     set_windows


### PR DESCRIPTION
As a facility admin, if you add a reservation to an existing order, the
“The user you are ordering for is not on the authorized list for this
instrument” message was checking the acting user (i.e. the facility
admin’s access) instead of the order’s user.