### PR TITLE
Fix migrations for Rails 4.2

### DIFF
--- a/db/migrate/20100430184238_add_facility_order.rb
+++ b/db/migrate/20100430184238_add_facility_order.rb
@@ -3,13 +3,13 @@ class AddFacilityOrder < ActiveRecord::Migration
   def self.up
     change_table :orders do |t|
       t.references :facility
-      t.foreign_key :facilities
     end
+    add_foreign_key :orders, :facilities
   end
 
   def self.down
+    remove_foreign_key :orders, :facilities
     change_table :orders do |t|
-      t.remove_foreign_key :facilities
       t.remove :facility_id
     end
   end

--- a/db/migrate/20100430222700_change_reservations.rb
+++ b/db/migrate/20100430222700_change_reservations.rb
@@ -3,14 +3,15 @@ class ChangeReservations < ActiveRecord::Migration
   def self.up
     change_table :reservations do |t|
       t.references  :order_detail
-      t.foreign_key :order_details
       t.references  :instrument, null: false
-      t.foreign_key :products, column: :instrument_id
       t.datetime    :reserve_start_at, null: false
       t.datetime    :reserve_end_at,   null: false
       t.datetime    :actual_start_at
       t.datetime    :actual_end_at
     end
+
+    add_foreign_key :reservations, :order_details
+    add_foreign_key :reservations, :products, column: :instrument_id, name: "reservations_instrument_id_fk"
   end
 
   def self.down
@@ -22,6 +23,8 @@ class ChangeReservations < ActiveRecord::Migration
       t.remove   :actual_start_at
       t.remove   :actual_end_at
     end
+    remove_foreign_key :reservations, :order_details
+    remove_foreign_key :reservations, :products, name: "reservations_instrument_id_fk"
   end
 
 end

--- a/db/migrate/20100512222847_set_order_states.rb
+++ b/db/migrate/20100512222847_set_order_states.rb
@@ -1,12 +1,12 @@
 class SetOrderStates < ActiveRecord::Migration
 
   def self.up
-    Order.all(conditions: "ordered_at IS NULL").each { |o| o.state = "new"; o.save; }
-    Order.all(conditions: "ordered_at IS NOT NULL").each { |o| o.state = "purchased"; o.save; }
+    Order.where(ordered_at: nil).update_all(state: "new")
+    Order.where.not(ordered_at: nil).update_all(state: "purchased")
   end
 
   def self.down
-    Order.all.each { |o| o.state = nil; o.save; }
+    Order.update_all(state: nil)
   end
 
 end

--- a/db/migrate/20100701183019_create_facility_accounts.rb
+++ b/db/migrate/20100701183019_create_facility_accounts.rb
@@ -10,7 +10,7 @@ class CreateFacilityAccounts < ActiveRecord::Migration
     end
     add_foreign_key :facility_accounts, :facilities, name: "fk_facilities"
 
-    Facility.find(:all).each do |f|
+    Facility.find_each do |f|
       execute "INSERT INTO facility_accounts (id, facility_id, account_number, is_active, created_at, created_by) VALUES (FACILITY_ACCOUNTS_SEQ.nextVal, #{f.id}, #{f.account}, 1, SYSDATE, 1)"
     end
 

--- a/db/migrate/20100701232820_change_order_detail_status.rb
+++ b/db/migrate/20100701232820_change_order_detail_status.rb
@@ -12,7 +12,7 @@ class ChangeOrderDetailStatus < ActiveRecord::Migration
     # execute "UPDATE order_details od SET od.order_status_id = (SELECT * FROM (SELECT order_status_id FROM order_detail_statuses ods WHERE ods.order_detail_id = od.id ORDER BY ods.created_at DESC ) WHERE ROWNUM <= 1)"
 
     ## so instead we do this
-    OrderDetail.find(:all).each do |od|
+    OrderDetail.find_each do |od|
       ods = OrderDetailStatus.find(:first, conditions: { order_detail_id: od.id }, order: "created_at DESC")
       execute "UPDATE order_details SET order_status_id = #{ods.order_status_id}"
     end

--- a/db/migrate/20101015210647_edits_for_invoicing_and_journaling_refacting.rb
+++ b/db/migrate/20101015210647_edits_for_invoicing_and_journaling_refacting.rb
@@ -17,12 +17,12 @@ class EditsForInvoicingAndJournalingRefacting < ActiveRecord::Migration
     create_table :journal_rows do |t|
       t.integer   :journal_id,      null: false
       t.integer   :order_detail_id, null: false
-      t.integer   :account,         null: false, limit: 10
-      t.integer   :fund,            null: false, limit: 10
-      t.integer   :dept,            null: false, limit: 10
-      t.integer   :project,         null: false, limit: 10
-      t.integer   :activity,        null: true,  limit: 10
-      t.integer   :program,         null: true,  limit: 10
+      t.integer   :account,         null: false
+      t.integer   :fund,            null: false
+      t.integer   :dept,            null: false
+      t.integer   :project,         null: false
+      t.integer   :activity,        null: true
+      t.integer   :program,         null: true
       t.decimal   :amount,          null: false, precision: 9, scale: 2
       t.string    :description,     null: true,  limit: 200
       t.string    :reference,       null: true,  limit: 50

--- a/db/migrate/20110425225944_alter_order_details_drop_dispute_resolved_credit.rb
+++ b/db/migrate/20110425225944_alter_order_details_drop_dispute_resolved_credit.rb
@@ -1,7 +1,7 @@
 class AlterOrderDetailsDropDisputeResolvedCredit < ActiveRecord::Migration
 
   def self.up
-    details = OrderDetail.find(:all, conditions: "dispute_resolved_credit IS NOT NULL")
+    details = OrderDetail.where("dispute_resolved_credit IS NOT NULL")
 
     details.each do |detail|
       detail.actual_cost = detail_actual_cost - detail.dispute_resolved_credit

--- a/db/migrate/20130108221731_reservations_change_from_instrument_to_product.rb
+++ b/db/migrate/20130108221731_reservations_change_from_instrument_to_product.rb
@@ -1,15 +1,15 @@
 class ReservationsChangeFromInstrumentToProduct < ActiveRecord::Migration
 
   def self.up
-    remove_foreign_key :reservations, name: "reservations_instrument_id_fk"
+    # remove_foreign_key :reservations, name: "reservations_instrument_id_fk"
     rename_column :reservations, :instrument_id, :product_id
-    add_foreign_key :reservations, :products, name: "reservations_product_id_fk"
+    # add_foreign_key :reservations, :products, name: "reservations_product_id_fk"
   end
 
   def self.down
-    remove_foreign_key :reservations, name: "reservations_product_id_fk"
+    # remove_foreign_key :reservations, name: "reservations_product_id_fk"
     rename_column :reservations, :product_id, :instrument_id
-    add_foreign_key :reservations, :products, column: :instrument_id, name: "reservations_instrument_id_fk"
+    # add_foreign_key :reservations, :products, column: :instrument_id, name: "reservations_instrument_id_fk"
   end
 
 end

--- a/db/migrate/20140908192950_create_delayed_jobs.rb
+++ b/db/migrate/20140908192950_create_delayed_jobs.rb
@@ -11,7 +11,7 @@ class CreateDelayedJobs < ActiveRecord::Migration
       table.datetime :failed_at
       table.string   :locked_by
       table.string   :queue
-      table.timestamps
+      table.timestamps null: false
     end
 
     add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"

--- a/db/migrate/20150605165610_create_training_requests.rb
+++ b/db/migrate/20150605165610_create_training_requests.rb
@@ -5,7 +5,7 @@ class CreateTrainingRequests < ActiveRecord::Migration
       t.references :user
       t.references :product
 
-      t.timestamps
+      t.timestamps null: false
     end
     add_index :training_requests, :user_id
     add_index :training_requests, :product_id

--- a/db/migrate/20151113205331_create_payments_received.rb
+++ b/db/migrate/20151113205331_create_payments_received.rb
@@ -8,7 +8,7 @@ class CreatePaymentsReceived < ActiveRecord::Migration
       t.string :source_id
       t.decimal :amount, precision: 10, scale: 2, null: false
       t.references :paid_by, null: true
-      t.timestamps
+      t.timestamps null: false
     end
     add_foreign_key :payments, :statements
     add_index :payments, :statement_id

--- a/db/migrate/20160201171348_add_journal_cutoffs.rb
+++ b/db/migrate/20160201171348_add_journal_cutoffs.rb
@@ -3,7 +3,7 @@ class AddJournalCutoffs < ActiveRecord::Migration
   def change
     create_table :journal_cutoff_dates do |t|
       t.datetime :cutoff_date
-      t.timestamps
+      t.timestamps null: false
     end
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -187,9 +187,9 @@ ActiveRecord::Schema.define(version: 20160715220430) do
   create_table "journal_rows", force: :cascade do |t|
     t.integer "journal_id",      limit: 4,                           null: false
     t.integer "order_detail_id", limit: 4
+    t.string  "account",         limit: 5
     t.decimal "amount",                      precision: 9, scale: 2, null: false
     t.string  "description",     limit: 200
-    t.string  "account",         limit: 5
     t.integer "account_id",      limit: 4
   end
 
@@ -268,16 +268,16 @@ ActiveRecord::Schema.define(version: 20160715220430) do
   add_index "order_details", ["account_id"], name: "fk_od_accounts", using: :btree
   add_index "order_details", ["assigned_user_id"], name: "index_order_details_on_assigned_user_id", using: :btree
   add_index "order_details", ["bundle_product_id"], name: "fk_bundle_prod_id", using: :btree
-  add_index "order_details", ["dispute_by_id"], name: "order_details_dispute_by_id_fk", using: :btree
+  add_index "order_details", ["dispute_by_id"], name: "fk_rails_14de4f1c86", using: :btree
   add_index "order_details", ["group_id"], name: "index_order_details_on_group_id", using: :btree
   add_index "order_details", ["journal_id"], name: "index_order_details_on_journal_id", using: :btree
-  add_index "order_details", ["order_id"], name: "order_details_order_id_fk", using: :btree
+  add_index "order_details", ["order_id"], name: "fk_rails_e5976611fd", using: :btree
   add_index "order_details", ["order_status_id"], name: "index_order_details_on_order_status_id", using: :btree
-  add_index "order_details", ["parent_order_detail_id"], name: "order_details_parent_order_detail_id_fk", using: :btree
-  add_index "order_details", ["price_policy_id"], name: "order_details_price_policy_id_fk", using: :btree
+  add_index "order_details", ["parent_order_detail_id"], name: "fk_rails_cc2adae8c3", using: :btree
+  add_index "order_details", ["price_policy_id"], name: "fk_rails_555b721183", using: :btree
   add_index "order_details", ["problem"], name: "index_order_details_on_problem", using: :btree
-  add_index "order_details", ["product_accessory_id"], name: "order_details_product_accessory_id_fk", using: :btree
-  add_index "order_details", ["product_id"], name: "order_details_product_id_fk", using: :btree
+  add_index "order_details", ["product_accessory_id"], name: "fk_rails_e4f0ef56a6", using: :btree
+  add_index "order_details", ["product_id"], name: "fk_rails_4f2ac9473b", using: :btree
   add_index "order_details", ["response_set_id"], name: "index_order_details_on_response_set_id", using: :btree
   add_index "order_details", ["state"], name: "index_order_details_on_state", using: :btree
   add_index "order_details", ["statement_id"], name: "index_order_details_on_statement_id", using: :btree
@@ -322,9 +322,8 @@ ActiveRecord::Schema.define(version: 20160715220430) do
     t.integer  "order_import_id",     limit: 4
   end
 
-  add_index "orders", ["account_id"], name: "orders_account_id_fk", using: :btree
+  add_index "orders", ["account_id"], name: "fk_rails_144e25bef6", using: :btree
   add_index "orders", ["facility_id"], name: "index_orders_on_facility_id", using: :btree
-  add_index "orders", ["facility_id"], name: "orders_facility_id_fk", using: :btree
   add_index "orders", ["order_import_id"], name: "index_orders_on_order_import_id", using: :btree
   add_index "orders", ["state"], name: "index_orders_on_state", using: :btree
   add_index "orders", ["user_id"], name: "index_orders_on_user_id", using: :btree
@@ -352,7 +351,7 @@ ActiveRecord::Schema.define(version: 20160715220430) do
     t.integer "account_id",     limit: 4
   end
 
-  add_index "price_group_members", ["price_group_id"], name: "price_group_members_price_group_id_fk", using: :btree
+  add_index "price_group_members", ["price_group_id"], name: "fk_rails_0425013e5b", using: :btree
   add_index "price_group_members", ["user_id"], name: "index_price_group_members_on_user_id", using: :btree
 
   create_table "price_group_products", force: :cascade do |t|
@@ -363,8 +362,8 @@ ActiveRecord::Schema.define(version: 20160715220430) do
     t.datetime "updated_at",                   null: false
   end
 
-  add_index "price_group_products", ["price_group_id"], name: "i_pri_gro_pro_pri_gro_id", using: :btree
-  add_index "price_group_products", ["product_id"], name: "i_pri_gro_pro_pro_id", using: :btree
+  add_index "price_group_products", ["price_group_id"], name: "index_price_group_products_on_price_group_id", using: :btree
+  add_index "price_group_products", ["product_id"], name: "index_price_group_products_on_product_id", using: :btree
 
   create_table "price_groups", force: :cascade do |t|
     t.integer "facility_id",    limit: 4
@@ -399,7 +398,7 @@ ActiveRecord::Schema.define(version: 20160715220430) do
     t.string   "charge_for",          limit: 255
   end
 
-  add_index "price_policies", ["price_group_id"], name: "price_policies_price_group_id_fk", using: :btree
+  add_index "price_policies", ["price_group_id"], name: "fk_rails_74aa223960", using: :btree
   add_index "price_policies", ["product_id"], name: "index_price_policies_on_product_id", using: :btree
 
   create_table "product_access_groups", force: :cascade do |t|
@@ -470,7 +469,7 @@ ActiveRecord::Schema.define(version: 20160715220430) do
   end
 
   add_index "products", ["facility_account_id"], name: "fk_facility_accounts", using: :btree
-  add_index "products", ["facility_id"], name: "products_facility_id_fk", using: :btree
+  add_index "products", ["facility_id"], name: "fk_rails_0c9fa1afbe", using: :btree
   add_index "products", ["schedule_id"], name: "i_instruments_schedule_id", using: :btree
   add_index "products", ["url_name"], name: "index_products_on_url_name", using: :btree
 
@@ -516,9 +515,7 @@ ActiveRecord::Schema.define(version: 20160715220430) do
   end
 
   add_index "reservations", ["order_detail_id"], name: "res_od_uniq_fk", unique: true, using: :btree
-  add_index "reservations", ["order_detail_id"], name: "res_ord_det_id_fk", using: :btree
   add_index "reservations", ["product_id", "reserve_start_at"], name: "index_reservations_on_product_id_and_reserve_start_at", using: :btree
-  add_index "reservations", ["product_id"], name: "reservations_instrument_id_fk", using: :btree
 
   create_table "roles", force: :cascade do |t|
     t.string "name", limit: 255
@@ -570,7 +567,7 @@ ActiveRecord::Schema.define(version: 20160715220430) do
     t.boolean "on_sat",                                                            null: false
   end
 
-  add_index "schedule_rules", ["instrument_id"], name: "schedule_rules_instrument_id_fk", using: :btree
+  add_index "schedule_rules", ["instrument_id"], name: "fk_rails_6966bf4c0d", using: :btree
 
   create_table "schedules", force: :cascade do |t|
     t.string   "name",        limit: 255
@@ -643,7 +640,7 @@ ActiveRecord::Schema.define(version: 20160715220430) do
     t.string  "role",        limit: 255, null: false
   end
 
-  add_index "user_roles", ["user_id", "facility_id", "role"], name: "i_use_rol_use_id_fac_id_rol", using: :btree
+  add_index "user_roles", ["user_id", "facility_id", "role"], name: "index_user_roles_on_user_id_and_facility_id_and_role", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "username",               limit: 255,              null: false
@@ -688,10 +685,10 @@ ActiveRecord::Schema.define(version: 20160715220430) do
   add_index "versions", ["commit_label"], name: "index_versions_on_commit_label", using: :btree
   add_index "versions", ["created_at"], name: "index_versions_on_created_at", using: :btree
   add_index "versions", ["tag"], name: "index_versions_on_tag", using: :btree
-  add_index "versions", ["user_id", "user_type"], name: "i_versions_user_id_user_type", using: :btree
+  add_index "versions", ["user_id", "user_type"], name: "index_versions_on_user_id_and_user_type", using: :btree
   add_index "versions", ["user_name"], name: "index_versions_on_user_name", using: :btree
-  add_index "versions", ["version_number"], name: "index_versions_on_number", using: :btree
-  add_index "versions", ["versioned_id", "versioned_type"], name: "i_ver_ver_id_ver_typ", using: :btree
+  add_index "versions", ["version_number"], name: "index_versions_on_version_number", using: :btree
+  add_index "versions", ["versioned_id", "versioned_type"], name: "index_versions_on_versioned_id_and_versioned_type", using: :btree
 
   add_foreign_key "account_users", "accounts", name: "fk_accounts"
   add_foreign_key "accounts", "facilities", name: "fk_account_facility_id"
@@ -701,33 +698,33 @@ ActiveRecord::Schema.define(version: 20160715220430) do
   add_foreign_key "facility_accounts", "facilities", name: "fk_facilities"
   add_foreign_key "instrument_statuses", "products", column: "instrument_id", name: "fk_int_stats_product"
   add_foreign_key "order_details", "accounts", name: "fk_od_accounts"
-  add_foreign_key "order_details", "order_details", column: "parent_order_detail_id", name: "order_details_parent_order_detail_id_fk"
-  add_foreign_key "order_details", "orders", name: "sys_c009172"
-  add_foreign_key "order_details", "price_policies", name: "sys_c009175"
-  add_foreign_key "order_details", "product_accessories", name: "order_details_product_accessory_id_fk"
+  add_foreign_key "order_details", "order_details", column: "parent_order_detail_id"
+  add_foreign_key "order_details", "orders"
+  add_foreign_key "order_details", "price_policies"
+  add_foreign_key "order_details", "product_accessories"
+  add_foreign_key "order_details", "products"
   add_foreign_key "order_details", "products", column: "bundle_product_id", name: "fk_bundle_prod_id"
-  add_foreign_key "order_details", "products", name: "sys_c009173"
-  add_foreign_key "order_details", "users", column: "dispute_by_id", name: "order_details_dispute_by_id_fk"
+  add_foreign_key "order_details", "users", column: "dispute_by_id"
   add_foreign_key "order_imports", "facilities", name: "fk_order_imports_facilities"
-  add_foreign_key "orders", "accounts", name: "sys_c008808"
-  add_foreign_key "orders", "facilities", name: "orders_facility_id_fk"
-  add_foreign_key "payments", "accounts", name: "payments_account_id_fk"
-  add_foreign_key "payments", "statements", name: "payments_statement_id_fk"
-  add_foreign_key "payments", "users", column: "paid_by_id", name: "payments_paid_by_id_fk"
-  add_foreign_key "price_group_members", "price_groups", name: "sys_c008583"
-  add_foreign_key "price_groups", "facilities", name: "sys_c008578"
-  add_foreign_key "price_policies", "price_groups", name: "sys_c008589"
+  add_foreign_key "orders", "accounts"
+  add_foreign_key "orders", "facilities"
+  add_foreign_key "payments", "accounts"
+  add_foreign_key "payments", "statements"
+  add_foreign_key "payments", "users", column: "paid_by_id"
+  add_foreign_key "price_group_members", "price_groups"
+  add_foreign_key "price_groups", "facilities"
+  add_foreign_key "price_policies", "price_groups"
   add_foreign_key "product_users", "products", name: "fk_products"
-  add_foreign_key "products", "facilities", name: "sys_c008556"
+  add_foreign_key "products", "facilities"
   add_foreign_key "products", "facility_accounts", name: "fk_facility_accounts"
   add_foreign_key "products", "schedules", name: "fk_instruments_schedule"
-  add_foreign_key "projects", "facilities", name: "projects_facility_id_fk"
-  add_foreign_key "reservations", "order_details", name: "res_ord_det_id_fk"
-  add_foreign_key "reservations", "products", name: "reservations_product_id_fk"
+  add_foreign_key "projects", "facilities"
+  add_foreign_key "reservations", "order_details"
+  add_foreign_key "reservations", "products", name: "reservations_instrument_id_fk"
   add_foreign_key "sanger_sequencing_batches", "facilities"
-  add_foreign_key "sanger_sequencing_samples", "sanger_sequencing_submissions", column: "submission_id"
+  add_foreign_key "sanger_sequencing_samples", "sanger_sequencing_submissions", column: "submission_id", on_update: :cascade, on_delete: :cascade
   add_foreign_key "sanger_sequencing_submissions", "sanger_sequencing_batches", column: "batch_id", on_delete: :nullify
-  add_foreign_key "schedule_rules", "products", column: "instrument_id", name: "sys_c008573"
+  add_foreign_key "schedule_rules", "products", column: "instrument_id"
   add_foreign_key "schedules", "facilities", name: "fk_schedules_facility"
   add_foreign_key "statements", "facilities", name: "fk_statement_facilities"
   add_foreign_key "stored_files", "order_details", name: "fk_files_od"

--- a/vendor/engines/projects/db/migrate/20160328144628_create_projects.rb
+++ b/vendor/engines/projects/db/migrate/20160328144628_create_projects.rb
@@ -6,7 +6,7 @@ class CreateProjects < ActiveRecord::Migration
       t.text :description
       t.references :facility, null: false
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :projects, [:facility_id, :name], unique: true

--- a/vendor/engines/sanger_sequencing/db/migrate/20160519030413_create_sanger_sequencing_submissions.rb
+++ b/vendor/engines/sanger_sequencing/db/migrate/20160519030413_create_sanger_sequencing_submissions.rb
@@ -11,7 +11,7 @@ class CreateSangerSequencingSubmissions < ActiveRecord::Migration
     # sequence_start_value is oracle-specific, but mysql throws it away
     create_table :sanger_sequencing_samples, sequence_start_value: 11_111 do |t|
       t.integer :submission_id, null: false
-      t.foreign_key :sanger_sequencing_submissions, column: :submission_id, dependent: :delete
+      t.foreign_key :sanger_sequencing_submissions, column: :submission_id, on_delete: :cascade, on_update: :cascade
       t.timestamps
     end
 


### PR DESCRIPTION
So we can do a full rake db:migrate from scratch.

This adds a few `null: false` to timestamp creations because that was the default in older rails versions. This will keep the schema diff minimal.

The big difference is in index names. I’m not sure there’s a good way to go about fixing that.