### PR TITLE
[#126916383] Show product name on submission lists

### DIFF
--- a/vendor/engines/sanger_sequencing/app/assets/stylesheets/sanger_sequencing/application.scss
+++ b/vendor/engines/sanger_sequencing/app/assets/stylesheets/sanger_sequencing/application.scss
@@ -38,5 +38,5 @@
 }
 
 .sangerSequencing--submissionTable__noteCell {
-  width: 50%;
+  width: 40%;
 }

--- a/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/admin/batches_controller.rb
+++ b/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/admin/batches_controller.rb
@@ -16,7 +16,7 @@ module SangerSequencing
       end
 
       def new
-        @submissions = Submission.ready_for_batch.for_facility(current_facility)
+        @submissions = Submission.ready_for_batch.includes(:samples, order_detail: :product).for_facility(current_facility)
       end
 
       def create

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
@@ -17,7 +17,7 @@ module SangerSequencing
 
     accepts_nested_attributes_for :samples, allow_destroy: true
 
-    delegate :order_id, :user, :order_status, :note, to: :order_detail
+    delegate :order_id, :user, :order_status, :note, :product, to: :order_detail
     delegate :purchased?, :ordered_at, to: :order
     alias purchased_at ordered_at
 

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/_submission_list.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/_submission_list.html.haml
@@ -7,6 +7,7 @@
       %th= OrderDetail.human_attribute_name(:ordered_at)
       %th= OrderDetail.human_attribute_name(:user)
       %th= OrderDetail.human_attribute_name(:quantity)
+      %th= Product.model_name.human
       %th= OrderDetail.human_attribute_name(:note)
   %tbody
     - @submissions.each do |submission|
@@ -24,4 +25,5 @@
         %td= format_usa_datetime(submission.purchased_at)
         %td= submission.user
         %td= submission.samples.count
+        %td= submission.product
         %td.sangerSequencing--submissionTable__noteCell= submission.note

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/submissions/index.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/submissions/index.html.haml
@@ -19,6 +19,7 @@
         %th= OrderDetail.human_attribute_name(:ordered_at)
         %th= OrderDetail.human_attribute_name(:user)
         %th= OrderDetail.human_attribute_name(:quantity)
+        %th= Product.model_name.human
         %th= OrderDetail.human_attribute_name(:order_status)
         %th= SangerSequencing::Batch.model_name.human
     %tbody
@@ -29,6 +30,7 @@
           %td= format_usa_datetime(submission.purchased_at)
           %td= submission.user
           %td= submission.samples.count
+          %td= submission.product
           %td= submission.order_status
           %td= link_to submission.batch_id, facility_sanger_sequencing_admin_batch_path(current_facility, submission.batch_id) if submission.batch_id?
 

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/submissions/show.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/submissions/show.html.haml
@@ -17,4 +17,8 @@
       = banner_date_label @submission.order, :ordered_at
       = banner_label @submission.order, :user
 
+  - if @submission.note.present?
+    %label= OrderDetail.human_attribute_name(:note)
+    %p= @submission.note
+
   = render "sanger_sequencing/submissions/samples_table", submission: @submission


### PR DESCRIPTION
This will allow the resource to identify if they need to do any special
handing such as always use full plate submissions as the only
submission in the batch.