### PR TITLE
Explicitly set RAILS_ENV in schedule.rb

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,5 +1,5 @@
-rails = File.join Dir.getwd, "config", "environment.rb"
-require rails
+ENV['RAILS_ENV'] = @environment
+require File.expand_path(File.dirname(__FILE__) + "/environment")
 
 # IMPORTANT!!! You should never edit this file in your custom fork.
 # If you want to add custom jobs to your instance, add them to schedule_custom.rb


### PR DESCRIPTION
Without this, when rails loaded, it did not have an environment set, so
it was trying to load up the `development` database.