### PR TITLE
[#127184] Suppress curl progress meter in cron

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -17,7 +17,7 @@ every 5.minutes, roles: [:db] do
 end
 
 every 1.minute, roles: [:db] do
-  command "curl -X POST #{Rails.application.routes.url_helpers.admin_services_cancel_reservations_for_offline_instruments_url}"
+  command "curl --silent -X POST #{Rails.application.routes.url_helpers.admin_services_cancel_reservations_for_offline_instruments_url}"
 end
 
 every :day, at: "4:17am", roles: [:db] do


### PR DESCRIPTION
This should prevent `curl` from producing progress output for the rolling-cancel `cron` job.