### PR TITLE
[#115963269] Refactor footer for override

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -67,17 +67,22 @@ li.nav-spacer {
 /*
  footer
 */
-footer .container {
+.footer__container {
   border-top: 1px solid #ddd;
   padding-top: 1em;
   margin-top: 5em;
 }
 
-footer .span8 {
+.footer__copyright {
   font-size: 85%;
   color: #919191;
   text-align: right;
   line-height: 75px;
+  float: right;
+}
+
+.footer__logo {
+  float: left;
 }
 
 /* Acting As Banner */

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -1,6 +1,5 @@
-.container
+.container.footer__container
   .row
-    .span4
-      %p= image_tag "logo.jpg", alt: t(".logo_alt")
-    .span8
-      %p= t(".copyright_html", to_date: Date.today.year)
+    .span12
+      .footer__logo= image_tag "logo.jpg", alt: t(".logo_alt")
+      .footer__copyright= t(".copyright_html", to_date: Date.today.year)

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -1,5 +1,5 @@
 .container.footer__container
   .row
     .span12
-      .footer__logo= image_tag "logo.jpg", alt: t(".logo_alt")
+      .footer__logo= image_tag t(".logo_file"), alt: t(".logo_alt")
       .footer__copyright= t(".copyright_html", to_date: Date.today.year)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,6 +103,7 @@ en:
     footer:
       copyright_html: "&copy; Copyright 2010&ndash;%{to_date} Northwestern University"
       logo_alt: "Northwestern Logo"
+      logo_file: "logo.jpg"
     problem_order_details:
       actual_usage_missing: Actual Usage Missing
       assign_price_policies: Assign Price Policies


### PR DESCRIPTION
DC as a much wider logo. This will handle it much better, including breakpoints.

I'm planning to use a PNG for DC. It feels a little weird to put the filename in the locales, but I settled on there so that it’s right next to the `logo_alt` translation and will be
clean to override.