### PR TITLE
[#127212] Cross-facility journal view inaccessible in rails 4.2

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -68,7 +68,7 @@ class Journal < ActiveRecord::Base
     allowed_ids = facilities.collect(&:id)
 
     if include_multi
-      Journal.includes(journal_rows: { order_detail: :order }).where("orders.facility_id IN (?)", allowed_ids).select("journals.*")
+      Journal.includes(journal_rows: { order_detail: :order }).references(:order).where("orders.facility_id IN (?)", allowed_ids).select("journals.*")
     else
       Journal.where(facility_id: allowed_ids)
     end

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -338,4 +338,29 @@ RSpec.describe Journal do
       journal.order_details_span_fiscal_years?([@order_details[3]])
     end
   end
+
+  describe ".for_facilities" do
+    let(:order_details) { order.order_details }
+    before do
+      order_details.each(&:to_complete!)
+      journal.save!
+      journal.create_journal_rows!(order_details)
+    end
+
+    describe "a normal journal" do
+      it "finds the facility" do
+        expect(described_class.for_facilities([facility])).to include(journal)
+      end
+    end
+
+    describe "multi-facility journal" do
+      subject(:journal) do
+        build(:journal, facility: nil, created_by: 1, journal_date: journal_date)
+      end
+
+      it "finds the facility" do
+        expect(described_class.for_facilities([order.facility], true)).to include(journal)
+      end
+    end
+  end
 end


### PR DESCRIPTION
```
Mysql2::Error: Unknown column 'orders.facility_id' in 'where clause':
SELECT  journals.* FROM `journals` WHERE (orders.facility_id IN (1, 2,
3) AND `journals`.`is_successful` IS NULL  ORDER BY journals.created_at
DESC LIMIT 10 OFFSET 0
```