### PR TITLE
[#127220] Could not create price groups for facility

### DIFF
--- a/app/controllers/price_groups_controller.rb
+++ b/app/controllers/price_groups_controller.rb
@@ -57,7 +57,7 @@ class PriceGroupsController < ApplicationController
 
   # GET /price_groups/new
   def new
-    @price_group = current_facility.price_groups.new
+    @price_group = PriceGroup.new(facility: current_facility)
   end
 
   # GET /price_groups/:id/edit
@@ -65,7 +65,7 @@ class PriceGroupsController < ApplicationController
 
   # POST /price_groups
   def create
-    @price_group = current_facility.price_groups.new(params[:price_group])
+    @price_group = PriceGroup.new(params[:price_group].merge(facility: current_facility))
 
     if @price_group.save
       flash[:notice] = I18n.t("controllers.price_groups.create.notice")

--- a/spec/controllers/price_groups_controller_spec.rb
+++ b/spec/controllers/price_groups_controller_spec.rb
@@ -28,32 +28,6 @@ RSpec.describe PriceGroupsController do
     end
   end
 
-  describe "GET #new" do
-    before(:each) do
-      @method = :get
-      @action = :new
-    end
-
-    it_should_allow_managers_only do
-      expect(assigns(:price_group)).to be_kind_of(PriceGroup).and be_new_record
-      is_expected.to render_template("new")
-    end
-  end
-
-  describe "POST #create" do
-    before(:each) do
-      @method = :post
-      @action = :create
-      @params.merge!(price_group: attributes_for(:price_group, facility_id: facility.id))
-    end
-
-    it_should_allow_managers_only :redirect do
-      expect(assigns(:price_group)).to be_kind_of(PriceGroup).and be_persisted
-      expect(flash[:notice]).to include("successfully created")
-      assert_redirected_to [facility, assigns(:price_group)]
-    end
-  end
-
   context "with a price group id parameter" do
     let(:price_group) { create(:price_group, facility: facility) }
 

--- a/spec/features/admin/price_group_management_spec.rb
+++ b/spec/features/admin/price_group_management_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "Managing Price Groups", :aggregate_failures do
+
+  let(:facility) { FactoryGirl.create(:facility) }
+
+  describe "create" do
+    describe "as a facility admin" do
+      let(:user) { FactoryGirl.create(:user, :facility_director, facility: facility) }
+
+      before do
+        login_as user
+        visit facility_price_groups_path(facility)
+        click_link "Add Price Group"
+        fill_in "Name", with: "New Price Group"
+        check "Is Internal?"
+      end
+
+      it "creates a price group and brings you back to the index" do
+        expect { click_button "Create" }.to change(PriceGroup, :count).by(1)
+        expect(current_path).to eq(accounts_facility_price_group_path(facility, PriceGroup.reorder(:id).last))
+      end
+    end
+
+    describe "as a facility senior staff" do
+      let(:user) { FactoryGirl.create(:user, :senior_staff, facility: facility) }
+
+      before do
+        login_as user
+        visit new_facility_price_group_path(facility)
+      end
+
+      it "does not allow access" do
+        expect(page.status_code).to eq(403)
+      end
+    end
+  end
+
+  # TODO: Move tests out of price_groups_controller_spce.rb
+end

--- a/spec/features/admin/price_group_management_spec.rb
+++ b/spec/features/admin/price_group_management_spec.rb
@@ -36,5 +36,5 @@ RSpec.describe "Managing Price Groups", :aggregate_failures do
     end
   end
 
-  # TODO: Move tests out of price_groups_controller_spce.rb
+  # TODO: Move tests out of price_groups_controller_spec.rb
 end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -192,6 +192,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:batch_update, Order) }
     it { is_expected.to be_allowed_to(:batch_update, Reservation) }
     it { is_expected.to be_allowed_to(:administer, User) }
+    it { is_expected.to be_allowed_to(:manage, PriceGroup) }
 
     it_behaves_like "it can destroy admistrative reservations"
     it_behaves_like "it allows switch_to on active, but not deactivated users"
@@ -226,6 +227,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:show_problems, Reservation) }
     it { is_expected.to be_allowed_to(:disputed, Order) }
     it { is_expected.to be_allowed_to(:batch_update, Order) }
+    it { is_expected.to be_allowed_to(:manage, PriceGroup) }
     it { is_expected.to be_allowed_to(:batch_update, Reservation) }
     it { is_expected.to be_allowed_to(:administer, User) }
     it { is_expected.not_to be_allowed_to(:manage_accounts, Facility.cross_facility) }
@@ -244,6 +246,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:read, Notification) }
     it { is_expected.to be_allowed_to(:administer, User) }
     it { is_expected.to be_allowed_to(:read, UserPriceGroupMember) }
+    it { is_expected.not_to be_allowed_to(:manage, PriceGroup) }
 
     it_behaves_like "it can destroy admistrative reservations"
     it_behaves_like "it allows switch_to on active, but not deactivated users"


### PR DESCRIPTION
Users were receiving “Facility cannot be blank”. Appears to be an issue
stemming from removing `has_many :price_groups, finder_sql: …` into a
regular method.

https://github.com/tablexi/nucore-open/pull/631/commits/f0eb065598f716acbb06fc14cf94cad39191bb9d

Looks like we handled this for `OrderStatus`es in
https://github.com/tablexi/nucore-open/pull/631/commits/39c2c4f773484aced489d2146ea6822bd0642234

I chose to do one success feature spec at the lowest possible
permissions level and one failure spec at the highest possible level,
and left the rest of the levels to be handled by the Ability spec. I
would probably have only done the success feature spec, but there’s
some weird ability stuff in PriceGroup controller where new/create use
Facility as the ability’s resource, while the member actions on an
existing PriceGroup use the price group itself as the resource.