### PR TITLE
[#127295589] Add hook point in shared/head

### DIFF
--- a/app/views/shared/_head.html.haml
+++ b/app/views/shared/_head.html.haml
@@ -1,12 +1,13 @@
 %meta{ "http-equiv" => "content-type", "content" => "text/html; charset=UTF-8" }
 - # use gsub to strip out html tags in the title to prevent html from showing #62643
-= render :partial => '/shared/title', :locals => { :title => yield(:h1).gsub(/<[^>]*>/, ' ') }
-= stylesheet_link_tag 'application', :media => :all
-= stylesheet_link_tag 'print', media: :print
-= javascript_include_tag 'application'
+= render partial: "/shared/title", locals: { title: yield(:h1).gsub(/<[^>]*>/, " ") }
+= stylesheet_link_tag "application", media: :all
+= stylesheet_link_tag "print", media: :print
+= javascript_include_tag "application"
 = csrf_meta_tag
 :javascript
-  var ROOT_PATH = '#{root_path}';
-  var FACILITY_PATH = '#{current_facility ? facility_path(current_facility) : ''}';
+  var ROOT_PATH = "#{root_path}";
+  var FACILITY_PATH = "#{current_facility ? facility_path(current_facility) : ""}";
 = yield :head_content
-= render :partial => '/shared/google'
+= render partial: "/shared/google"
+= render_view_hook "head"


### PR DESCRIPTION
This will be used by DC for adding icon link tags. If we end up adding icons to other schools,
then I could see pulling the partial up and using a feature flag.