### PR TITLE
Support for asynchronous file processing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ group :development, :test do
   gem "pry-byebug",        "~> 2.0.0"
   gem "quiet_assets"
   gem "rspec-rails",       "~> 3.4.2"
+  gem "rspec-activejob"
   gem "shoulda-matchers",  "~> 2.8.0", require: false
   gem "rspec-collection_matchers"
   gem "single_test", "0.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,6 +383,9 @@ GEM
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
       rspec-mocks (~> 3.4.0)
+    rspec-activejob (0.6.1)
+      activejob (>= 4.2)
+      rspec-mocks
     rspec-collection_matchers (1.1.2)
       rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.4.4)
@@ -556,6 +559,7 @@ DEPENDENCIES
   rails-observers
   rails_config (= 0.3.3)
   rake
+  rspec-activejob
   rspec-collection_matchers
   rspec-rails (~> 3.4.2)
   rspec_junit_formatter (= 0.2.3)

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,3 @@
+class ApplicationJob < ActiveJob::Base
+
+end

--- a/app/jobs/file_processing_job.rb
+++ b/app/jobs/file_processing_job.rb
@@ -7,8 +7,8 @@ class FileProcessingJob < ApplicationJob
     object.process_file!
     object.succeed!
   rescue => e
-    object.fail!(e.message)
-    raise e
+    message = e.message + e.backtrace.join("\n")
+    object.fail!(message)
   end
 
 end

--- a/app/jobs/file_processing_job.rb
+++ b/app/jobs/file_processing_job.rb
@@ -1,0 +1,14 @@
+# Used by models/concerns/async_file_processing in AsyncFileProcessing
+# This should only be used by a model including that class
+class FileProcessingJob < ApplicationJob
+
+  # process_file! is expected to raise an error if anything goes wrong
+  def perform(object)
+    object.process_file!
+    object.succeed!
+  rescue => e
+    object.fail!(e.message)
+    raise e
+  end
+
+end

--- a/app/models/concerns/async_file_processing.rb
+++ b/app/models/concerns/async_file_processing.rb
@@ -1,0 +1,60 @@
+# Include this module in one of your models to support asynchronous file processing
+# via ActiveJob. It will only allow one instance of the model to be in process at
+# a time.
+#
+# Requirements:
+# * Model must have `status`, `processed_at`, and `error_message` columns, and
+#   should have "processing" as the default for the `status` column
+#   `add_column :status, default: "processing", null: false
+# * Model must implement `process_file!` (see `FileProcessingJob`)
+#   * `process_file!` should raise an error if anything goes wrong
+#
+# Example:
+# class OrderImport < ActiveRecord::Base
+#   include AsyncFileProcessing
+#   def process_file!
+#     do_something(file.path)
+#   end
+# end
+#
+# Note: Race conditions could happen, especially if you don't prevent double clicks
+# on uploads, but they should be harmless outside of performance hits.
+module AsyncFileProcessing
+
+  extend ActiveSupport::Concern
+
+  included do
+    validates :status, inclusion: { in: %w(processing successful failed) }
+    validate :only_one_in_queue_at_a_time, on: :create
+  end
+
+  delegate :processing?, :successful?, :failed?, to: :status_inquirer
+
+  def enqueue
+    return unless save
+    FileProcessingJob.perform_later(self)
+  end
+
+  def another_in_queue?
+    self.class.where(status: :processing).any?
+  end
+
+  def succeed!
+    update_attributes!(status: "successful", processed_at: Time.current)
+  end
+
+  def fail!(message)
+    update_attributes!(status: "failed", processed_at: Time.current, error_message: message)
+  end
+
+  private
+
+  def status_inquirer
+    ActiveSupport::StringInquirer.new(status)
+  end
+
+  def only_one_in_queue_at_a_time
+    errors.add(:file, :already_in_queue) if another_in_queue?
+  end
+
+end

--- a/app/models/concerns/async_file_processing.rb
+++ b/app/models/concerns/async_file_processing.rb
@@ -36,7 +36,7 @@ module AsyncFileProcessing
   end
 
   def another_in_queue?
-    self.class.where(status: :processing).any?
+    self.class.where(status: "processing").any?
   end
 
   def succeed!

--- a/app/views/admin/shared/_sidenav_global.html.haml
+++ b/app/views/admin/shared/_sidenav_global.html.haml
@@ -2,3 +2,4 @@
   = tab t("pages.affiliates"), affiliates_path, sidenav_tab == "affiliates"
   = tab t("pages.global_user_roles"), global_user_roles_path, sidenav_tab == "global_user_roles"
   = tab JournalCutoffDate.model_name.human(count: 2), journal_cutoff_dates_path, sidenav_tab == "journal_cutoff_dates"
+  = render_view_hook "after", sidenav_tab: sidenav_tab

--- a/config/application.rb
+++ b/config/application.rb
@@ -75,6 +75,8 @@ module Nucore
     end
 
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.active_job.queue_adapter = :delayed_job
   end
 
 end

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -45,6 +45,7 @@ en:
         incorrect: "is incorrect"
         bad_payment_source_format: "must be in format %{pattern_format}"
         subsidy_greater_than_cost: "cannot be greater than the Usage cost"
+        already_in_queue: Only one file may be in process at a time
         # Append your own errors here or at the model/attributes scope.
       full_messages:
         format: "%{attribute} %{message}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,15 +90,16 @@ en:
 
   shared:
     cancel: Cancel
+    create: Create
     confirm_message: Are you sure?
     delete: Delete
     edit: Edit
     not_applicable: N/A
     remove: Remove
     save: Save
-    create: Create
     select_all: Select All
     select_none: Select None
+    upload: Upload
     unassigned: Unassigned
     footer:
       copyright_html: "&copy; Copyright 2010&ndash;%{to_date} Northwestern University"

--- a/spec/models/concerns/async_file_processing_spec.rb
+++ b/spec/models/concerns/async_file_processing_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe AsyncFileProcessing do
     describe "failure" do
       it "sets the status to failed" do
         expect(instance).to receive(:process_file!).and_raise("Testing failure")
-        expect { perform_enqueued_jobs { instance.enqueue } }.to raise_error("Testing failure")
+        perform_enqueued_jobs { instance.enqueue } }
         expect(instance).to be_failed
       end
     end

--- a/spec/models/concerns/async_file_processing_spec.rb
+++ b/spec/models/concerns/async_file_processing_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe AsyncFileProcessing do
   include ActiveJob::TestHelper
   class TestClass
+
     include ActiveModel::Model
     include ActiveRecord::AttributeAssignment
     include GlobalID::Identification
@@ -20,7 +21,7 @@ RSpec.describe AsyncFileProcessing do
 
     def initialize
       @status = "processing"
-      @id = rand(10000000)
+      @id = rand(10_000_000)
       self.class.repo[@id] = self
     end
 
@@ -28,13 +29,13 @@ RSpec.describe AsyncFileProcessing do
       assign_attributes(params)
     end
 
-
     def save
       true
     end
 
     def process_file!
     end
+
   end
 
   describe "#enqueue" do

--- a/spec/models/concerns/async_file_processing_spec.rb
+++ b/spec/models/concerns/async_file_processing_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe AsyncFileProcessing do
+  include ActiveJob::TestHelper
+  class TestClass
+    include ActiveModel::Model
+    include ActiveRecord::AttributeAssignment
+    include GlobalID::Identification
+    include AsyncFileProcessing
+
+    attr_accessor :status, :processed_at, :error_message, :file, :id
+
+    def self.find(id)
+      @repo[id.to_i]
+    end
+
+    def self.repo
+      @repo ||= []
+    end
+
+    def initialize
+      @status = "processing"
+      @id = rand(10000000)
+      self.class.repo[@id] = self
+    end
+
+    def update_attributes!(params)
+      assign_attributes(params)
+    end
+
+
+    def save
+      true
+    end
+
+    def process_file!
+    end
+  end
+
+  describe "#enqueue" do
+    subject(:instance) { TestClass.new }
+
+    describe "before job runs" do
+      it "enqueues the job " do
+        expect { instance.enqueue }.to enqueue_a(FileProcessingJob)
+      end
+
+      it "sets the status to processing" do
+        instance.enqueue
+        expect(instance).to be_processing
+      end
+    end
+
+    describe "on success" do
+      it "sets the status to success" do
+        perform_enqueued_jobs { instance.enqueue }
+        expect(instance).to be_successful
+      end
+    end
+
+    describe "failure" do
+      it "sets the status to failed" do
+        expect(instance).to receive(:process_file!).and_raise("Testing failure")
+        expect { perform_enqueued_jobs { instance.enqueue } }.to raise_error("Testing failure")
+        expect(instance).to be_failed
+      end
+    end
+  end
+end

--- a/spec/models/concerns/async_file_processing_spec.rb
+++ b/spec/models/concerns/async_file_processing_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe AsyncFileProcessing do
     describe "failure" do
       it "sets the status to failed" do
         expect(instance).to receive(:process_file!).and_raise("Testing failure")
-        perform_enqueued_jobs { instance.enqueue } }
+        perform_enqueued_jobs { instance.enqueue }
         expect(instance).to be_failed
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -109,6 +109,9 @@ RSpec.configure do |config|
     Warden.test_reset!
   end
 
+  require "rspec/active_job"
+  config.include(RSpec::ActiveJob)
+
 end
 
 FactoryGirl::SyntaxRunner.class_eval do


### PR DESCRIPTION
This is going to be used by DC for their account uploads (it takes a minute or two to run). It will only allow one file to be in process at a time.

This also makes sure we're using the delayed job adapter for ActiveJob. Turns out that any of the emails we were sending using `deliver_later` were going out synchronously because we didn't turn this on.

I chose to have the job not raise an error on failure because it will continue to retry and we don't really want that in the case of bad input. I'm not currently exposing the error message as it's a backtrace. We'll see if errors become problematic, and if so then we can deal with it then.

I could see order imports being a good candidate to use this as well.