### PR TITLE
[#130559] Exclude non-purchased "add-to" orders from export raw

### DIFF
--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -131,7 +131,6 @@ class FacilityOrdersController < ApplicationController
       account_id: @order.account_id,
       user_id: @order.user_id,
       created_by: current_user.id,
-      ordered_at: Time.zone.now,
     )
   end
 

--- a/app/services/reports/querier.rb
+++ b/app/services/reports/querier.rb
@@ -29,6 +29,7 @@ module Reports
                  .for_facility(current_facility)
                  .action_in_date_range(date_range_field, date_range_start, date_range_end)
                  .includes(*includes)
+                 .merge(Order.purchased)
     end
 
     def default_includes

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -365,7 +365,7 @@ RSpec.describe FacilityOrdersController do
       expect(merge_order.account_id).to eq(original_order.account_id)
       expect(merge_order.user_id).to eq(original_order.user_id)
       expect(merge_order.created_by).to eq(@director.id)
-      expect(merge_order.ordered_at).not_to be_blank
+      expect(merge_order.ordered_at).to be_blank
       expect(merge_order.order_details.size).to eq(detail_count)
       expect(MergeNotification.count).to eq(detail_count)
       assert_update_success merge_order, product

--- a/spec/services/reports/querier_spec.rb
+++ b/spec/services/reports/querier_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Reports::Querier do
+
+  let(:user) { FactoryGirl.create(:user) }
+  let(:facility) { FactoryGirl.create(:setup_facility) }
+  let(:item) { FactoryGirl.create(:setup_item, facility: facility) }
+  let(:account) { FactoryGirl.create(:setup_account, :with_account_owner, owner: user) }
+  let!(:order_detail) { place_product_order(user, facility, item, account) }
+
+  let(:options) do
+    {
+      order_status_id: OrderStatus.new_status.id,
+      current_facility: facility,
+      date_range_field: :ordered_at,
+      date_range_start: 1.day.ago,
+      date_range_end: 1.day.from_now,
+    }
+  end
+  let(:querier) { described_class.new(options) }
+
+  it "includes the order detail" do
+    expect(querier.perform).to include(order_detail)
+  end
+
+  describe "with a merge order" do
+    let(:order) { order_detail.order }
+    let(:merge_order) { FactoryGirl.create(:merge_order, merge_with_order: order) }
+    let!(:merge_order_detail) do
+      FactoryGirl.create(:order_detail, product: item,
+                                        order_status: OrderStatus.new_status, order: merge_order)
+    end
+
+    it "excludes the merge order detail" do
+      expect(querier.perform).not_to include(merge_order_detail)
+    end
+  end
+
+end

--- a/spec/services/reports/querier_spec.rb
+++ b/spec/services/reports/querier_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe Reports::Querier do
 
   let(:user) { FactoryGirl.create(:user) }
-  let(:facility) { FactoryGirl.create(:setup_facility) }
-  let(:item) { FactoryGirl.create(:setup_item, facility: facility) }
+  let(:item) { FactoryGirl.create(:setup_item) }
+  let(:facility) { item.facility }
   let(:account) { FactoryGirl.create(:setup_account, :with_account_owner, owner: user) }
   let!(:order_detail) { place_product_order(user, facility, item, account) }
 


### PR DESCRIPTION
Prevent order details that were “added to” another order by the
facility staff, but were not complete from appearing in export raw.
These would be instrument orders that don’t have a reservation or
service orders where the order form has not been uploaded.

This takes care of it in two ways, either one would work on its own:
* Remove the `ordered_at` from the merge order. Now the querier won’t
find an ordered_at to search. Once the merge order
is ready, the order details are moved onto the main order and then the order is destroyed. So that `ordered_at` that got set when we created the merge order goes away.
* Force the query to only return purchased orders. The merge order is in `new` state.

The only thing I’d like to figure out is how to have it keep a null
order status until the purchase is complete (this is how carts work).
This seemed more tricky than it was worth in dealing with the
OrderDetailObserver.