### PR TITLE
Remove sanger sample ON UPDATE foreign key

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160720200222) do
+ActiveRecord::Schema.define(version: 20160802202924) do
 
   create_table "account_users", force: :cascade do |t|
     t.integer  "account_id", limit: 4,  null: false
@@ -723,7 +723,7 @@ ActiveRecord::Schema.define(version: 20160720200222) do
   add_foreign_key "reservations", "order_details"
   add_foreign_key "reservations", "products", name: "reservations_instrument_id_fk"
   add_foreign_key "sanger_sequencing_batches", "facilities"
-  add_foreign_key "sanger_sequencing_samples", "sanger_sequencing_submissions", column: "submission_id", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "sanger_sequencing_samples", "sanger_sequencing_submissions", column: "submission_id", on_delete: :cascade
   add_foreign_key "sanger_sequencing_submissions", "sanger_sequencing_batches", column: "batch_id", on_delete: :nullify
   add_foreign_key "schedule_rules", "products", column: "instrument_id"
   add_foreign_key "schedules", "facilities", name: "fk_schedules_facility"

--- a/vendor/engines/sanger_sequencing/db/migrate/20160519030413_create_sanger_sequencing_submissions.rb
+++ b/vendor/engines/sanger_sequencing/db/migrate/20160519030413_create_sanger_sequencing_submissions.rb
@@ -11,7 +11,7 @@ class CreateSangerSequencingSubmissions < ActiveRecord::Migration
     # sequence_start_value is oracle-specific, but mysql throws it away
     create_table :sanger_sequencing_samples, sequence_start_value: 11_111 do |t|
       t.integer :submission_id, null: false
-      t.foreign_key :sanger_sequencing_submissions, column: :submission_id, on_delete: :cascade, on_update: :cascade
+      t.foreign_key :sanger_sequencing_submissions, column: :submission_id, on_delete: :cascade
       t.timestamps
     end
 

--- a/vendor/engines/sanger_sequencing/db/migrate/20160802202924_fix_sanger_sequencing_submission_cascades_for_oracle.rb
+++ b/vendor/engines/sanger_sequencing/db/migrate/20160802202924_fix_sanger_sequencing_submission_cascades_for_oracle.rb
@@ -1,0 +1,10 @@
+class FixSangerSequencingSubmissionCascadesForOracle < ActiveRecord::Migration
+
+  def change
+    # Oracle does not support on_update so we need to remove and re-add it to keep
+    # consistent with the MySQL installations
+    remove_foreign_key :sanger_sequencing_samples, column: :submission_id
+    add_foreign_key :sanger_sequencing_samples, :sanger_sequencing_submissions, column: :submission_id, on_delete: :cascade
+  end
+
+end


### PR DESCRIPTION
Oracle doesn’t support ON UPDATE, and since it’s just the
auto-increment primary key, it’ll never change, so we don’t need to
worry about ON UPDATE.