### PR TITLE
[#127182] Use different feature flag for notification on results file upload

### DIFF
--- a/app/services/results_file_notifier.rb
+++ b/app/services/results_file_notifier.rb
@@ -7,7 +7,7 @@ class ResultsFileNotifier
   end
 
   def notify
-    return unless SettingsHelper.feature_on?(:my_files)
+    return unless SettingsHelper.feature_on?(:results_file_notifications)
 
     EmailEvent.notify(file.user, debounce_key) do
       ResultsFileNotifierMailer.file_uploaded(file).deliver_later

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -109,6 +109,7 @@ feature:
   print_order_detail_on: false
   user_based_price_groups_on: true
   my_files_on: true
+  results_file_notifications_on: true
 
 # This may be overridden in settings.local.yml if your fork is using S3, so
 # be sure to check there for configuration

--- a/spec/services/results_file_notifier_spec.rb
+++ b/spec/services/results_file_notifier_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ResultsFileNotifier do
   let(:stored_file) { FactoryGirl.create(:stored_file, :results, order_detail: order.order_details.first) }
   let(:notifier) { described_class.new(stored_file) }
 
-  describe "with My Files enabled", feature_setting: { my_files: true } do
+  describe "with notifications enabled", feature_setting: { results_file_notifications: true } do
     it "sends a notification" do
       expect { notifier.notify }.to change(ActionMailer::Base.deliveries, :count).by(1)
     end
@@ -30,7 +30,7 @@ RSpec.describe ResultsFileNotifier do
     end
   end
 
-  describe "with My Files disabled", feature_setting: { my_files: false } do
+  describe "with notifications disabled", feature_setting: { results_file_notifications: false } do
     it "does not send a notification" do
       expect { notifier.notify }.not_to change(ActionMailer::Base.deliveries, :count)
     end


### PR DESCRIPTION
Originally it used `my_files`, but NU will keep `my_files` on and turn these
notifications off. If we can find a good way to add a checkbox or somehow make
the notifications optional, then NU might want it.