### PR TITLE
Sanger Sequencing: Don't delete blanks from end of sample list

### DIFF
--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/sample.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/sample.rb
@@ -9,6 +9,8 @@ module SangerSequencing
 
     validates :customer_sample_id, presence: true, on: :update
 
+    default_scope { order(:id) }
+
     def form_customer_sample_id
       customer_sample_id || default_customer_sample_id
     end

--- a/vendor/engines/sanger_sequencing/app/services/sanger_sequencing/submission_updater.rb
+++ b/vendor/engines/sanger_sequencing/app/services/sanger_sequencing/submission_updater.rb
@@ -9,7 +9,6 @@ module SangerSequencing
     def update_attributes(params)
       @submission.assign_attributes(params)
       mark_unused_samples_for_destruction(params)
-      mark_blank_samples_at_end_for_destruction
       @submission.save
     end
 
@@ -19,23 +18,9 @@ module SangerSequencing
       unused_samples(params).each(&:mark_for_destruction)
     end
 
-    def mark_blank_samples_at_end_for_destruction
-      blank_samples_at_end.each(&:mark_for_destruction)
-    end
-
     def unused_samples(params)
       ids_for_update = params[:samples_attributes].values.map { |a| a[:id].to_s }
       @submission.samples.select { |sample| !ids_for_update.include?(sample.id.to_s) }
-    end
-
-    def blank_samples_at_end
-      @submission.samples.reverse.each_with_object([]) do |sample, to_delete|
-        if sample.customer_sample_id.blank? || sample.marked_for_destruction?
-          to_delete << sample
-        else
-          break to_delete
-        end
-      end
     end
 
   end

--- a/vendor/engines/sanger_sequencing/spec/features/purchasing_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/features/purchasing_spec.rb
@@ -89,20 +89,6 @@ RSpec.describe "Purchasing a Sanger Sequencing service", :aggregate_failures do
           expect(page.first(customer_id_selector).value).to be_blank
           expect(SangerSequencing::Sample.pluck(:customer_sample_id)).not_to include("")
         end
-
-        it "deletes blanks from the end" do
-          page.all(customer_id_selector).last.set("")
-          click_button "Save Submission"
-
-          expect(SangerSequencing::Sample.count).to eq(4)
-        end
-
-        it "does not save if they are all blank" do
-          page.all(customer_id_selector).each { |textbox| textbox.set("") }
-          click_button "Save Submission"
-
-          expect(page).to have_content("You must have at least one sample")
-        end
       end
 
       describe "and more samples were created in another page" do


### PR DESCRIPTION
Now, if you have blank customer sample ids at the end of the form, they no longer
get deleted. Instead, they'll get an error for "may not be blank".

This will help make things simpler in NU where the user might not be using the
default IDs (the core sample id is irrelevant to them).

This also adds a default ordering to Sample. MySQL returns ordered by id if no
ORDER BY is specified. Oracle does not do this, so the samples were getting out
of order there.