### PR TITLE
Upgrade sass-rails to 5.0.6 to prevent deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,7 @@ group :test do
 end
 
 group :assets do
-  gem "sass-rails", "~> 5.0.4"
+  gem "sass-rails", "~> 5.0.6"
   gem "coffee-rails", "~> 4.1.1"
   gem "uglifier",     "~> 2.7.2"
   gem "therubyracer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,8 +421,8 @@ GEM
     ruby_dep (1.3.1)
     rubyzip (1.2.0)
     sass (3.4.22)
-    sass-rails (5.0.4)
-      railties (>= 4.0.0, < 5.0)
+    sass-rails (5.0.6)
+      railties (>= 4.0.0, < 6)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
@@ -474,7 +474,7 @@ GEM
       rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (2.0.4)
+    tilt (2.0.5)
     timecop (0.6.3)
     ttfunk (1.0.3)
     tzinfo (1.2.2)
@@ -567,7 +567,7 @@ DEPENDENCIES
   ruby-oci8 (~> 2.2.0)
   rubyzip
   sanger_sequencing (~> 0.0.1)!
-  sass-rails (~> 5.0.4)
+  sass-rails (~> 5.0.6)
   shoulda-matchers (~> 2.8.0)
   simple_form (~> 3.2.1)
   single_test (= 0.4.0)


### PR DESCRIPTION
```
DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
Please register a mime type using `register_mime_type` then
use `register_compressor` or `register_transformer`.
```