### PR TITLE
Fix specs when My Files is disabled

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -109,6 +109,7 @@ feature:
   print_order_detail_on: false
   user_based_price_groups_on: true
   my_files_on: true
+  # results file notifications requires that my_files be on as well
   results_file_notifications_on: true
 
 # This may be overridden in settings.local.yml if your fork is using S3, so

--- a/spec/services/results_file_notifier_spec.rb
+++ b/spec/services/results_file_notifier_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ResultsFileNotifier do
   let(:stored_file) { FactoryGirl.create(:stored_file, :results, order_detail: order.order_details.first) }
   let(:notifier) { described_class.new(stored_file) }
 
-  describe "with notifications enabled", feature_setting: { results_file_notifications: true } do
+  describe "with notifications enabled", feature_setting: { results_file_notifications: true, my_files: true } do
     it "sends a notification" do
       expect { notifier.notify }.to change(ActionMailer::Base.deliveries, :count).by(1)
     end


### PR DESCRIPTION
The results_file_notifications uses my_files_url in the mailer, so if notifications
are enabled, My Files needs to be as well. This fixes a broken spec when my files
was off.

It might be good at some point to address this so the mailer only includes the
my files link if it's enabled, but that's for another time.