### PR TITLE
Do not display sanger submission form errors in flash message

### DIFF
--- a/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/submissions_controller.rb
+++ b/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/submissions_controller.rb
@@ -39,7 +39,6 @@ module SangerSequencing
       if SubmissionUpdater.new(@submission).update_attributes(submission_params)
         redirect_to "#{params[:success_url]}&#{external_return_options.to_query}"
       else
-        flash.now[:alert] = @submission.errors.messages.values.join(". ")
         render :edit
       end
     end


### PR DESCRIPTION
If there are relevant validation errors, they will be displayed by simple form
near the appropriate field. In open, the only validation is the customer_sample_id,
but NU will have a few more.