### PR TITLE
[WIP] [#130628] Fragment Analysis

### DIFF
--- a/app/helpers/tab_count_helper.rb
+++ b/app/helpers/tab_count_helper.rb
@@ -29,7 +29,7 @@ module TabCountHelper
   end
 
   def tab(title, link, active = nil, options = {})
-    active ||= request.path == link
+    active = (request.path == link) if active.nil?
     classes = []
     classes << "active" if active
     classes.concat [*options[:class]]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160802202924) do
+ActiveRecord::Schema.define(version: 20160812230426) do
 
   create_table "account_users", force: :cascade do |t|
     t.integer  "account_id", limit: 4,  null: false
@@ -533,10 +533,19 @@ ActiveRecord::Schema.define(version: 20160802202924) do
   add_index "sanger_sequencing_batches", ["created_by_id"], name: "index_sanger_sequencing_batches_on_created_by_id", using: :btree
   add_index "sanger_sequencing_batches", ["facility_id"], name: "index_sanger_sequencing_batches_on_facility_id", using: :btree
 
-  create_table "sanger_sequencing_samples", force: :cascade do |t|
-    t.integer  "submission_id",      limit: 4,   null: false
+  create_table "sanger_sequencing_product_groups", force: :cascade do |t|
+    t.integer  "product_id", limit: 4,   null: false
+    t.string   "group",      limit: 255, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  add_index "sanger_sequencing_product_groups", ["product_id"], name: "index_sanger_sequencing_product_groups_on_product_id", unique: true, using: :btree
+
+  create_table "sanger_sequencing_samples", force: :cascade do |t|
+    t.integer  "submission_id",      limit: 4,   null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
     t.string   "customer_sample_id", limit: 255
   end
 
@@ -723,6 +732,7 @@ ActiveRecord::Schema.define(version: 20160802202924) do
   add_foreign_key "reservations", "order_details"
   add_foreign_key "reservations", "products", name: "reservations_instrument_id_fk"
   add_foreign_key "sanger_sequencing_batches", "facilities"
+  add_foreign_key "sanger_sequencing_product_groups", "products"
   add_foreign_key "sanger_sequencing_samples", "sanger_sequencing_submissions", column: "submission_id", on_delete: :cascade
   add_foreign_key "sanger_sequencing_submissions", "sanger_sequencing_batches", column: "batch_id", on_delete: :nullify
   add_foreign_key "schedule_rules", "products", column: "instrument_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -528,10 +528,12 @@ ActiveRecord::Schema.define(version: 20160812230426) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "facility_id",     limit: 4
+    t.string   "group",           limit: 255
   end
 
   add_index "sanger_sequencing_batches", ["created_by_id"], name: "index_sanger_sequencing_batches_on_created_by_id", using: :btree
   add_index "sanger_sequencing_batches", ["facility_id"], name: "index_sanger_sequencing_batches_on_facility_id", using: :btree
+  add_index "sanger_sequencing_batches", ["group"], name: "index_sanger_sequencing_batches_on_group", using: :btree
 
   create_table "sanger_sequencing_product_groups", force: :cascade do |t|
     t.integer  "product_id", limit: 4,   null: false

--- a/vendor/engines/sanger_sequencing/README.md
+++ b/vendor/engines/sanger_sequencing/README.md
@@ -29,3 +29,12 @@ Facility.find_by(url_name: "facility-name").update_attributes(sanger_sequencing_
 * Under "Order Forms", add a new Online Order Form
 * Use the URL `https://[yourdomain]/sanger_sequencing/submissions/new` and click "Add"
 * Click "Activate" to turn it on
+
+### Enable Fragment Analysis Well Plate Creation
+
+* Create a Fragment Analysis Product
+* Add a "fragment" group under `sanger_sequencing_product_group` that maps to
+  the new product
+
+A product can only be part of a single group. If they are not part of a group,
+they fall back to a "default" group, which is the standard Sanger Sequencing.

--- a/vendor/engines/sanger_sequencing/README.md
+++ b/vendor/engines/sanger_sequencing/README.md
@@ -33,8 +33,12 @@ Facility.find_by(url_name: "facility-name").update_attributes(sanger_sequencing_
 ### Enable Fragment Analysis Well Plate Creation
 
 * Create a Fragment Analysis Product
-* Add a "fragment" group under `sanger_sequencing_product_group` that maps to
-  the new product
+* Add a row "fragment" under `sanger_sequencing_product_groups` that maps to
+  the new product.
 
-A product can only be part of a single group. If they are not part of a group,
-they fall back to a "default" group, which is the standard Sanger Sequencing.
+  ```ruby
+  SangerSequencing::ProductGroup.create(product: product, group: "fragment")
+  ```
+
+A product can only be part of a single group. If it isnot part of a group,
+it fall back to a "default" group, which is the standard Sanger Sequencing.

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate_editor_app.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/vue_well_plate_editor_app.coffee
@@ -1,11 +1,12 @@
 window.vue_sanger_sequencing_well_plate_editor_app = {
-  props: ["submissions"]
+  props: ["submissions", "builder_config"]
 
   data: ->
     builder: new SangerSequencing.WellPlateBuilder
 
   beforeCompile: ->
     @colorBuilder = new SangerSequencing.WellPlateColors(@builder)
+    @builder.setReservedCells(@builder_config.reserved_cells)
 
   ready: ->
     new AjaxModal(".js--modal", ".js--submissionModal")

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_builder.js.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/well_plate_builder.js.coffee
@@ -9,8 +9,8 @@ class exports.SangerSequencing.WellPlateBuilder
     # This array maintains all of the submissions that have ever been added
     # in order to keep consistent colors when removing and adding samples.
     @allSubmissions = []
-    @reservedCells = ["A01", "A02"]
-    @orderingStrategy = new SangerSequencing.OddFirstOrderingStrategy
+    @_reservedCells = ["A01", "A02"]
+    @_orderingStrategy = new SangerSequencing.OddFirstOrderingStrategy
     @_render()
 
   addSubmission: (submission) ->
@@ -21,6 +21,10 @@ class exports.SangerSequencing.WellPlateBuilder
   removeSubmission: (submission) ->
     index = @submissions.indexOf(submission)
     @submissions.splice(index, 1) if index > -1
+    @_render()
+
+  setReservedCells: (cells) ->
+    @_reservedCells = cells if cells?
     @_render()
 
   isInPlate: (submission) ->
@@ -51,7 +55,7 @@ class exports.SangerSequencing.WellPlateBuilder
   # Private
 
   _render: ->
-    wellsInPlate = @_fillOrder().length - @reservedCells.length
+    wellsInPlate = @_fillOrder().length - @_reservedCells.length
     @_plateCount = Math.max(1, Math.ceil(@samples().length / wellsInPlate))
 
     samples = @samples()
@@ -66,7 +70,7 @@ class exports.SangerSequencing.WellPlateBuilder
     plate = {}
 
     for cellName in @_fillOrder()
-      plate[cellName] = if @reservedCells.indexOf(cellName) < 0
+      plate[cellName] = if @_reservedCells.indexOf(cellName) < 0
         if sample = samples.shift()
           sample
         else
@@ -85,4 +89,4 @@ class exports.SangerSequencing.WellPlateBuilder
     plate
 
   _fillOrder: ->
-    @orderingStrategy.fillOrder()
+    @_orderingStrategy.fillOrder()

--- a/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/admin/batches_controller.rb
+++ b/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/admin/batches_controller.rb
@@ -17,6 +17,7 @@ module SangerSequencing
 
       def new
         @submissions = Submission.ready_for_batch.includes(:samples, order_detail: :product).for_facility(current_facility)
+        @builder_config = WellPlateConfiguration.find(:default)
       end
 
       def create

--- a/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/admin/batches_controller.rb
+++ b/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/admin/batches_controller.rb
@@ -16,8 +16,8 @@ module SangerSequencing
       end
 
       def new
-        @submissions = Submission.ready_for_batch.includes(:samples, order_detail: :product).for_facility(current_facility)
-        @builder_config = WellPlateConfiguration.find(:default)
+        @submissions = Submission.ready_for_batch.includes(:samples, order_detail: :product).for_facility(current_facility).for_product_group(params[:product_group])
+        @builder_config = WellPlateConfiguration.find(params[:product_group])
       end
 
       def create

--- a/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/admin/batches_controller.rb
+++ b/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/admin/batches_controller.rb
@@ -30,7 +30,7 @@ module SangerSequencing
       def create
         # Whitelisting should happen in the form object
         if @batch.update_attributes(params[:batch].merge(created_by: current_user, facility: current_facility))
-          redirect_to [current_facility, :sanger_sequencing, :admin, :batches], notice: text("create.success")
+          redirect_to [current_facility, :sanger_sequencing, :admin, :batches, group: @batch.group], notice: text("create.success")
         else
           @submissions = Submission.ready_for_batch.for_facility(current_facility)
           flash.now[:alert] = @batch.errors.map { |_k, msg| msg }.to_sentence
@@ -56,7 +56,7 @@ module SangerSequencing
 
       def destroy
         @batch.destroy
-        redirect_to facility_sanger_sequencing_admin_batches_path, notice: text("destroy.success")
+        redirect_to facility_sanger_sequencing_admin_batches_path(group: @batch.group), notice: text("destroy.success")
       end
 
       def upload
@@ -79,7 +79,7 @@ module SangerSequencing
       private
 
       def validate_product_group
-        @product_group = params[:group]
+        @product_group = params[:group].presence
         raise ActiveRecord::RecordNotFound unless @product_group.blank? || ProductGroup::GROUPS.include?(@product_group)
       end
 

--- a/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/admin/batches_controller.rb
+++ b/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/admin/batches_controller.rb
@@ -14,16 +14,16 @@ module SangerSequencing
 
       def index
         @batches = Batch.for_facility(current_facility)
-          .order(created_at: :desc)
-          .for_product_group(params[:group])
-          .paginate(page: params[:page])
+                        .order(created_at: :desc)
+                        .for_product_group(params[:group])
+                        .paginate(page: params[:page])
       end
 
       def new
         @submissions = Submission.ready_for_batch
-          .includes(:samples, order_detail: :product)
-          .for_facility(current_facility)
-          .for_product_group(params[:group])
+                                 .includes(:samples, order_detail: :product)
+                                 .for_facility(current_facility)
+                                 .for_product_group(params[:group])
         @builder_config = WellPlateConfiguration.find(params[:group])
       end
 

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/batch.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/batch.rb
@@ -15,6 +15,10 @@ module SangerSequencing
       where(facility: facility)
     end
 
+    def self.for_product_group(group)
+      where(group: group)
+    end
+
     def well_plates
       well_plates_raw.map { |well_plate| WellPlate.new(well_plate, samples: samples) }
     end

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/batch_form.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/batch_form.rb
@@ -6,7 +6,7 @@ module SangerSequencing
 
     attr_reader :batch
 
-    delegate :submission_ids, to: :batch
+    delegate :submission_ids, :group, to: :batch
 
     validates :submission_ids, presence: true
     validate :samples_must_match_submissions
@@ -22,7 +22,8 @@ module SangerSequencing
         submission_ids: params[:submission_ids].to_s.split(","),
         well_plates_raw: params[:well_plate_data].to_h.values,
         created_by: params[:created_by],
-        facility: params[:facility])
+        facility: params[:facility],
+        group: params[:group])
     end
 
     def update_attributes(params = {})

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/batch_form.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/batch_form.rb
@@ -23,7 +23,8 @@ module SangerSequencing
         well_plates_raw: params[:well_plate_data].to_h.values,
         created_by: params[:created_by],
         facility: params[:facility],
-        group: params[:group])
+        group: params[:group],
+      )
     end
 
     def update_attributes(params = {})

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/product_group.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/product_group.rb
@@ -1,0 +1,15 @@
+module SangerSequencing
+
+  class ProductGroup < ActiveRecord::Base
+
+    self.table_name = "sanger_sequencing_product_groups"
+    GROUPS = WellPlateConfiguration::CONFIGS.keys
+
+    belongs_to :product
+
+    validates :group, presence: true, inclusion: { in: GROUPS }
+    validates :product, presence: true, uniqueness: true
+
+  end
+
+end

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
@@ -25,6 +25,14 @@ module SangerSequencing
     scope :ready_for_batch, -> { purchased.merge(OrderDetail.new_or_inprocess).where(batch_id: nil) }
     scope :for_facility, -> (facility) { where(orders: { facility_id: facility.id }) }
 
+    def self.for_product_group(product_group)
+      if product_group
+        where(order_details: { product_id: ProductGroup.where(group: product_group).pluck(:product_id) })
+      else
+        where.not(order_details: { product_id: ProductGroup.pluck(:product_id) })
+      end
+    end
+
     def create_samples!(quantity)
       quantity = quantity.to_i
       raise ArgumentError, "quantity must be positive" if quantity <= 0

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/well_plate_configuration.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/well_plate_configuration.rb
@@ -7,8 +7,8 @@ module SangerSequencing
     end
 
     CONFIGS = ActiveSupport::HashWithIndifferentAccess.new(
-      default: new(reserved_cells: ["A01", "A02"]),
-      fragment: new(reserved_cells: [])
+      default: new(reserved_cells: %w(A01 A02)),
+      fragment: new(reserved_cells: []),
     ).freeze
 
     def self.find(key)
@@ -17,7 +17,7 @@ module SangerSequencing
 
     def to_json
       {
-        reserved_cells: Array(@reserved_cells)
+        reserved_cells: Array(@reserved_cells),
       }.to_json
     end
 

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/well_plate_configuration.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/well_plate_configuration.rb
@@ -1,0 +1,26 @@
+module SangerSequencing
+
+  class WellPlateConfiguration
+
+    def initialize(reserved_cells: [])
+      @reserved_cells = reserved_cells
+    end
+
+    CONFIGS = ActiveSupport::HashWithIndifferentAccess.new(
+      default: new(reserved_cells: ["A01", "A02"]),
+      fragment: new(reserved_cells: [])
+    ).freeze
+
+    def self.find(key)
+      CONFIGS[key]
+    end
+
+    def to_json
+      {
+        reserved_cells: Array(@reserved_cells)
+      }.to_json
+    end
+
+  end
+
+end

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/well_plate_configuration.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/well_plate_configuration.rb
@@ -12,7 +12,7 @@ module SangerSequencing
     ).freeze
 
     def self.find(key)
-      CONFIGS[key]
+      CONFIGS[key] || CONFIGS[:default]
     end
 
     def to_json

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/index.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/index.html.haml
@@ -5,11 +5,11 @@
   = stylesheet_link_tag "sanger_sequencing/application"
 
 = content_for :sidebar do
-  = render "sanger_sequencing/admin/shared/sidenav", sidenav_tab: "batches"
+  = render "sanger_sequencing/admin/shared/sidenav", sidenav_tab: [@product_group, "batches"].compact.join("_")
 
-%h2= text("sanger_sequencing.name")
+%h2= text(@product_group || :default, scope: "sanger_sequencing.product_groups")
 
-%p= link_to text("new_batch"), new_facility_sanger_sequencing_admin_batches_path, class: "btn btn-add"
+%p= link_to text("new_batch"), new_facility_sanger_sequencing_admin_batch_path(group: params[:group]), class: "btn btn-add"
 
 - if @batches.any?
   %table.table.table-striped.sangerSequencing--batches__table

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/index.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/index.html.haml
@@ -36,7 +36,6 @@
           %td= batch.samples.count
           %td= link_to "Delete", facility_sanger_sequencing_admin_batch_path(current_facility, batch), method: :delete
 
-
   = will_paginate(@batches)
 
 - else

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/index.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/index.html.haml
@@ -9,7 +9,7 @@
 
 %h2= text("sanger_sequencing.name")
 
-%p= link_to text("new_batch"), new_facility_sanger_sequencing_admin_batch_path, class: "btn btn-add"
+%p= link_to text("new_batch"), new_facility_sanger_sequencing_admin_batches_path, class: "btn btn-add"
 
 - if @batches.any?
   %table.table.table-striped.sangerSequencing--batches__table

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/new.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/new.html.haml
@@ -5,7 +5,7 @@
   = javascript_include_tag "sanger_sequencing/well_plate"
   = stylesheet_link_tag "sanger_sequencing/application"
 
-%vue-sanger-sequencing-well-plate-editor-app(inline-template){ ":submissions" => @submissions.to_json(include: :samples) }
+%vue-sanger-sequencing-well-plate-editor-app(inline-template){ ":submissions" => @submissions.to_json(include: :samples), ":builder_config" => @builder_config.to_json }
 
   = simple_form_for :batch, url: facility_sanger_sequencing_admin_batches_path do |f|
     = hidden_field_tag "batch[submission_ids]", "{{submissionIds()}}"

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/new.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/new.html.haml
@@ -8,6 +8,7 @@
 %vue-sanger-sequencing-well-plate-editor-app(inline-template){ ":submissions" => @submissions.to_json(include: :samples), ":builder_config" => @builder_config.to_json }
 
   = simple_form_for :batch, url: facility_sanger_sequencing_admin_batches_path do |f|
+    = f.input :group
     = hidden_field_tag "batch[submission_ids]", "{{submissionIds()}}"
     %vue-sanger-sequencing-well-plate(v-for="plateIndex in builder.plateCount()"){":builder" => "builder", ":plate-index" => "$index" }
 

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/new.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/batches/new.html.haml
@@ -8,7 +8,7 @@
 %vue-sanger-sequencing-well-plate-editor-app(inline-template){ ":submissions" => @submissions.to_json(include: :samples), ":builder_config" => @builder_config.to_json }
 
   = simple_form_for :batch, url: facility_sanger_sequencing_admin_batches_path do |f|
-    = f.input :group
+    = f.input :group, as: :hidden
     = hidden_field_tag "batch[submission_ids]", "{{submissionIds()}}"
     %vue-sanger-sequencing-well-plate(v-for="plateIndex in builder.plateCount()"){":builder" => "builder", ":plate-index" => "$index" }
 

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/shared/_sidenav.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/shared/_sidenav.html.haml
@@ -1,4 +1,4 @@
 %ul.sidebar-nav
   = tab SangerSequencing::Submission.model_name.human(count: 2), facility_sanger_sequencing_admin_submissions_path(current_facility), sidenav_tab == "submissions"
-  = tab SangerSequencing::Batch.model_name.human(count: 2), facility_sanger_sequencing_admin_batches_path(current_facility), sidenav_tab == "batches"
+  = tab text("sanger_sequencing.product_groups.default"), facility_sanger_sequencing_admin_batches_path(current_facility), sidenav_tab == "batches"
   = tab text("sanger_sequencing.product_groups.fragment"), facility_sanger_sequencing_admin_batches_path(current_facility, group: "fragment"), sidenav_tab == "fragment_batches"

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/shared/_sidenav.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/shared/_sidenav.html.haml
@@ -1,4 +1,4 @@
 %ul.sidebar-nav
   = tab SangerSequencing::Submission.model_name.human(count: 2), facility_sanger_sequencing_admin_submissions_path(current_facility), sidenav_tab == "submissions"
   = tab SangerSequencing::Batch.model_name.human(count: 2), facility_sanger_sequencing_admin_batches_path(current_facility), sidenav_tab == "batches"
-
+  = tab text("sanger_sequencing.product_groups.fragment"), facility_sanger_sequencing_admin_batches_path(current_facility, group: "fragment"), sidenav_tab == "fragment_batches"

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/shared/_sidenav.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/shared/_sidenav.html.haml
@@ -1,3 +1,4 @@
 %ul.sidebar-nav
   = tab SangerSequencing::Submission.model_name.human(count: 2), facility_sanger_sequencing_admin_submissions_path(current_facility), sidenav_tab == "submissions"
   = tab SangerSequencing::Batch.model_name.human(count: 2), facility_sanger_sequencing_admin_batches_path(current_facility), sidenav_tab == "batches"
+

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/submissions/index.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/submissions/index.html.haml
@@ -8,8 +8,6 @@
 
 %h2= text("sanger_sequencing.name")
 
-%p= link_to text("new_batch"), new_facility_sanger_sequencing_admin_batch_path, class: "btn btn-add"
-
 - if @submissions.any?
   %table.table.table-striped
     %thead

--- a/vendor/engines/sanger_sequencing/config/locales/en.yml
+++ b/vendor/engines/sanger_sequencing/config/locales/en.yml
@@ -2,6 +2,9 @@ en:
   sanger_sequencing:
     name: Sanger Sequencing
     route: "sanger_sequencing"
+    product_groups:
+      default: Sanger Sequencing
+      fragment: Fragment Analysis
 
   controllers:
     sanger_sequencing/admin/batches:

--- a/vendor/engines/sanger_sequencing/config/routes.rb
+++ b/vendor/engines/sanger_sequencing/config/routes.rb
@@ -11,8 +11,7 @@ Rails.application.routes.draw do
     namespace :sanger_sequencing do
       namespace :admin do
         resources :submissions, only: [:index, :show]
-        resources :batches, only: [:index, :show, :create, :destroy] do
-          get "(:product_group)/new", on: :collection, action: :new, constraints: { product_group: /#{SangerSequencing::ProductGroup::GROUPS.join("|")}/ }, as: :new
+        resources :batches, only: [:index, :show, :new, :create, :destroy] do
           get "well_plates/:well_plate_index", action: :well_plate, on: :member, as: :well_plate
           post :upload, on: :member
         end

--- a/vendor/engines/sanger_sequencing/config/routes.rb
+++ b/vendor/engines/sanger_sequencing/config/routes.rb
@@ -11,7 +11,8 @@ Rails.application.routes.draw do
     namespace :sanger_sequencing do
       namespace :admin do
         resources :submissions, only: [:index, :show]
-        resources :batches, only: [:index, :show, :new, :create, :destroy] do
+        resources :batches, only: [:index, :show, :create, :destroy] do
+          get "(:product_group)/new", on: :collection, action: :new, constraints: { product_group: /#{SangerSequencing::ProductGroup::GROUPS.join("|")}/ }, as: :new
           get "well_plates/:well_plate_index", action: :well_plate, on: :member, as: :well_plate
           post :upload, on: :member
         end

--- a/vendor/engines/sanger_sequencing/db/migrate/20160812230426_add_sanger_product_groups.rb
+++ b/vendor/engines/sanger_sequencing/db/migrate/20160812230426_add_sanger_product_groups.rb
@@ -1,0 +1,12 @@
+class AddSangerProductGroups < ActiveRecord::Migration
+
+  def change
+    create_table :sanger_sequencing_product_groups do |t|
+      t.references :product, null: false, foreign_key: true
+      t.index :product_id, unique: true
+      t.string :group, null: false
+      t.timestamps
+    end
+  end
+
+end

--- a/vendor/engines/sanger_sequencing/db/migrate/20160812230426_add_sanger_product_groups.rb
+++ b/vendor/engines/sanger_sequencing/db/migrate/20160812230426_add_sanger_product_groups.rb
@@ -7,6 +7,9 @@ class AddSangerProductGroups < ActiveRecord::Migration
       t.string :group, null: false
       t.timestamps
     end
+
+    add_column :sanger_sequencing_batches, :group, :string
+    add_index :sanger_sequencing_batches, :group
   end
 
 end

--- a/vendor/engines/sanger_sequencing/spec/features/batches/creating_a_batch_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/features/batches/creating_a_batch_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Creating a batch", :js do
 
   describe "creating a well-plate" do
     before do
-      visit facility_sanger_sequencing_admin_submissions_path(facility)
+      visit facility_sanger_sequencing_admin_batches_path(facility)
       click_link "Create New Batch"
     end
 
@@ -42,6 +42,50 @@ RSpec.describe "Creating a batch", :js do
 
         expect(current_path).to eq(facility_sanger_sequencing_admin_batches_path(facility))
       end
+    end
+  end
+
+  describe "creating a fragment analysis well-plate" do
+    describe "listing the products" do
+      before do
+        visit facility_sanger_sequencing_admin_batches_path(facility, group: "fragment")
+        click_link "Create New Batch"
+      end
+
+      it "does not have the submissions" do
+        expect(page).to have_content("There are no submissions available to be added.")
+      end
+    end
+
+    describe "when the service is mapped to the fragment group" do
+      before do
+        SangerSequencing::ProductGroup.create!(product: service, group: "fragment")
+        visit facility_sanger_sequencing_admin_batches_path(facility, group: "fragment")
+        click_link "Create New Batch"
+      end
+
+      describe "adding the first submissions" do
+        def click_add(submission_id)
+          within("[data-submission-id='#{submission_id}']") do
+            click_link "Add"
+          end
+        end
+
+        before do
+          click_add(purchased_submission.id)
+          click_button "Save Batch"
+        end
+
+        it "Saves the batch with no reserved cells", :aggregate_failures do
+          expect(purchased_submission.reload.batch_id).to be_present
+
+          expect(SangerSequencing::Batch.last.sample_at(0, "A01")).to eq(purchased_submission.samples.first)
+          expect(SangerSequencing::Batch.last.sample_at(0, "B01")).to eq(purchased_submission.samples.second)
+          expect(SangerSequencing::Batch.last.sample_at(0, "A02")).to eq(purchased_submission.samples[48])
+        end
+      end
+
+
     end
   end
 end

--- a/vendor/engines/sanger_sequencing/spec/features/batches/creating_a_batch_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/features/batches/creating_a_batch_spec.rb
@@ -86,8 +86,6 @@ RSpec.describe "Creating a batch", :js do
           expect(SangerSequencing::Batch.last.group).to eq("fragment")
         end
       end
-
-
     end
   end
 end

--- a/vendor/engines/sanger_sequencing/spec/features/batches/creating_a_batch_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/features/batches/creating_a_batch_spec.rb
@@ -82,6 +82,8 @@ RSpec.describe "Creating a batch", :js do
           expect(SangerSequencing::Batch.last.sample_at(0, "A01")).to eq(purchased_submission.samples.first)
           expect(SangerSequencing::Batch.last.sample_at(0, "B01")).to eq(purchased_submission.samples.second)
           expect(SangerSequencing::Batch.last.sample_at(0, "A02")).to eq(purchased_submission.samples[48])
+
+          expect(SangerSequencing::Batch.last.group).to eq("fragment")
         end
       end
 


### PR DESCRIPTION
This adds a new table that associates a Product with a "group", which in this case will only be "fragment", or nothing. The batches#new splits out the submissions based on which group the product is in. This will allow us to have multiple products in a group if we need to allow separate pricing. Fragment Analysis does not include control wells.

Once the batch is submitted it now has a group associated as well so it can be split into two separate views. 

The piece that is not done is a different plate file. I wanted to get some eyes and feedback on this before I moved forward to that piece.