### PR TITLE
[#126392] Handle empty facility email in offline notifications

### DIFF
--- a/app/mailers/concerns/offline_reservation_arguments.rb
+++ b/app/mailers/concerns/offline_reservation_arguments.rb
@@ -13,7 +13,7 @@ module OfflineReservationArguments
       facility_url: facility_url(reservation.facility),
       product: reservation.product,
       reservation_time: I18n.l(reservation.reserve_start_at, format: :timeonly),
-      order_detail_url: order_order_detail_url(reservation.order, reservation.order_detail)
+      order_detail_url: order_order_detail_url(reservation.order, reservation.order_detail),
     }
   end
 

--- a/app/mailers/concerns/offline_reservation_arguments.rb
+++ b/app/mailers/concerns/offline_reservation_arguments.rb
@@ -1,0 +1,30 @@
+module OfflineReservationArguments
+
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :offline_notification_arguments
+  end
+
+  def offline_notification_arguments
+    {
+      facility_contact: facility_contact_text(reservation.facility.email),
+      facility_name: reservation.facility.name,
+      facility_url: facility_url(reservation.facility),
+      product: reservation.product,
+      reservation_time: I18n.l(reservation.reserve_start_at, format: :timeonly),
+      order_detail_url: order_order_detail_url(reservation.order, reservation.order_detail)
+    }
+  end
+
+  private
+
+  def facility_contact_text(email)
+    if email.present?
+      text("views.offline_cancellation_mailer.send_notification.facility_contact", email: email)
+    else
+      ""
+    end
+  end
+
+end

--- a/app/mailers/offline_cancellation_mailer.rb
+++ b/app/mailers/offline_cancellation_mailer.rb
@@ -1,5 +1,7 @@
 class OfflineCancellationMailer < BaseMailer
 
+  include OfflineReservationArguments
+
   attr_reader :reservation
 
   def send_notification(reservation)

--- a/app/mailers/upcoming_offline_reservation_mailer.rb
+++ b/app/mailers/upcoming_offline_reservation_mailer.rb
@@ -1,5 +1,7 @@
 class UpcomingOfflineReservationMailer < BaseMailer
 
+  include OfflineReservationArguments
+
   attr_reader :reservation
 
   def send_offline_instrument_warning(reservation)

--- a/app/views/offline_cancellation_mailer/send_notification.html.haml
+++ b/app/views/offline_cancellation_mailer/send_notification.html.haml
@@ -1,8 +1,1 @@
-%p
-  = html "body.html",
-    facility_contact: @reservation.facility.email.present? ? text("views.offline_cancellation_mailer.send_notification.facility_contact", email: @reservation.facility.email) : "",
-    facility_name: @reservation.facility.name,
-    facility_url: facility_url(@reservation.facility),
-    product: @reservation.product,
-    reservation_time: I18n.l(@reservation.reserve_start_at, format: :timeonly),
-    order_detail_url: order_order_detail_url(@reservation.order, @reservation.order_detail)
+%p= html "body.html", offline_notification_arguments

--- a/app/views/offline_cancellation_mailer/send_notification.html.haml
+++ b/app/views/offline_cancellation_mailer/send_notification.html.haml
@@ -1,6 +1,6 @@
 %p
   = html "body.html",
-    facility_email: @reservation.facility.email,
+    facility_contact: @reservation.facility.email.present? ? text("views.offline_cancellation_mailer.send_notification.facility_contact", email: @reservation.facility.email) : "",
     facility_name: @reservation.facility.name,
     facility_url: facility_url(@reservation.facility),
     product: @reservation.product,

--- a/app/views/offline_cancellation_mailer/send_notification.text.erb
+++ b/app/views/offline_cancellation_mailer/send_notification.text.erb
@@ -1,9 +1,1 @@
-<%=
-  text "body.text",
-    facility_contact: @reservation.facility.email.present? ? text("views.offline_cancellation_mailer.send_notification.facility_contact", email: @reservation.facility.email) : "",
-    facility_name: @reservation.facility.name,
-    facility_url: facility_url(@reservation.facility),
-    product: @reservation.product,
-    reservation_time: I18n.l(@reservation.reserve_start_at, format: :timeonly),
-    order_detail_url: order_order_detail_url(@reservation.order, @reservation.order_detail)
-%>
+<%= text "body.text", offline_notification_arguments %>

--- a/app/views/offline_cancellation_mailer/send_notification.text.erb
+++ b/app/views/offline_cancellation_mailer/send_notification.text.erb
@@ -1,6 +1,6 @@
 <%=
   text "body.text",
-    facility_email: @reservation.facility.email,
+    facility_contact: @reservation.facility.email.present? ? text("views.offline_cancellation_mailer.send_notification.facility_contact", email: @reservation.facility.email) : "",
     facility_name: @reservation.facility.name,
     facility_url: facility_url(@reservation.facility),
     product: @reservation.product,

--- a/app/views/upcoming_offline_reservation_mailer/send_offline_instrument_warning.html.haml
+++ b/app/views/upcoming_offline_reservation_mailer/send_offline_instrument_warning.html.haml
@@ -1,8 +1,1 @@
-%p
-  = html "body.html",
-    facility_contact: @reservation.facility.email.present? ? text("views.offline_cancellation_mailer.send_notification.facility_contact", email: @reservation.facility.email) : "",
-    facility_name: @reservation.facility.name,
-    facility_url: facility_url(@reservation.facility),
-    product: @reservation.product,
-    reservation_time: I18n.l(@reservation.reserve_start_at, format: :timeonly),
-    order_detail_url: order_order_detail_url(@reservation.order, @reservation.order_detail)
+%p= html "body.html", offline_notification_arguments

--- a/app/views/upcoming_offline_reservation_mailer/send_offline_instrument_warning.html.haml
+++ b/app/views/upcoming_offline_reservation_mailer/send_offline_instrument_warning.html.haml
@@ -1,6 +1,6 @@
 %p
   = html "body.html",
-    facility_email: @reservation.facility.email,
+    facility_contact: @reservation.facility.email.present? ? text("views.offline_cancellation_mailer.send_notification.facility_contact", email: @reservation.facility.email) : "",
     facility_name: @reservation.facility.name,
     facility_url: facility_url(@reservation.facility),
     product: @reservation.product,

--- a/app/views/upcoming_offline_reservation_mailer/send_offline_instrument_warning.text.erb
+++ b/app/views/upcoming_offline_reservation_mailer/send_offline_instrument_warning.text.erb
@@ -1,9 +1,1 @@
-<%=
-  text "body.text",
-    facility_contact: @reservation.facility.email.present? ? text("views.offline_cancellation_mailer.send_notification.facility_contact", email: @reservation.facility.email) : "",
-    facility_name: @reservation.facility.name,
-    facility_url: facility_url(@reservation.facility),
-    product: @reservation.product,
-    reservation_time: I18n.l(@reservation.reserve_start_at, format: :timeonly),
-    order_detail_url: order_order_detail_url(@reservation.order, @reservation.order_detail)
-%>
+<%= text "body.text", offline_notification_arguments %>

--- a/app/views/upcoming_offline_reservation_mailer/send_offline_instrument_warning.text.erb
+++ b/app/views/upcoming_offline_reservation_mailer/send_offline_instrument_warning.text.erb
@@ -1,6 +1,6 @@
 <%=
   text "body.text",
-    facility_email: @reservation.facility.email,
+    facility_contact: @reservation.facility.email.present? ? text("views.offline_cancellation_mailer.send_notification.facility_contact", email: @reservation.facility.email) : "",
     facility_name: @reservation.facility.name,
     facility_url: facility_url(@reservation.facility),
     product: @reservation.product,

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,7 @@ module Nucore
     config.autoload_paths += Dir["#{config.root}/lib/**/"]
     config.autoload_paths += Dir["#{config.root}/app/models/**/"]
     config.autoload_paths += Dir["#{config.root}/app/controllers/concerns"]
+    config.autoload_paths += Dir["#{config.root}/app/mailers/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/models/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/validators"]
 

--- a/config/locales/views/en.offline_cancellation_mailer.yml
+++ b/config/locales/views/en.offline_cancellation_mailer.yml
@@ -2,6 +2,7 @@ en:
   views:
     offline_cancellation_mailer:
       send_notification:
+        facility_contact: at <%{email}>
         subject: Your reservation for %{product} has been canceled
         body:
           html: |
@@ -10,12 +11,12 @@ en:
             Your reservation has been canceled at no cost.
 
             Please contact [%{facility_name}](%{facility_url})
-            at <%{facility_email}> for more information.
+            %{facility_contact} for more information.
           text: |
             %{product}, the instrument you have reserved for %{reservation_time},
             is down. Your reservation has been canceled at no cost.
 
             Please contact %{facility_name} for more information.
 
-            %{facility_name}: %{facility_url} %{facility_email}
+            %{facility_name}: %{facility_url} %{facility_contact}
             Your order: %{order_detail_url}

--- a/config/locales/views/en.upcoming_offline_reservation_mailer.yml
+++ b/config/locales/views/en.upcoming_offline_reservation_mailer.yml
@@ -11,7 +11,7 @@ en:
               will be canceled at no cost.
 
               Please contact [%{facility_name}](%{facility_url})
-              at <%{facility_email}> for more information.
+              %{facility_contact} for more information.
           text: |
             %{product}, the instrument you have reserved for today at %{reservation_time},
             is down. If %{product} is still down at your scheduled time, your reservation
@@ -19,5 +19,5 @@ en:
 
             Please contact %{facility_name} for more information.
 
-            %{facility_name}: %{facility_url} %{facility_email}
+            %{facility_name}: %{facility_url} %{facility_contact}
             Your order: %{order_detail_url}


### PR DESCRIPTION
This updates the offline notifications to handle the case where `Facility#email` is `nil`.

When `email` has a value, the emails should read "Please contact _Facility_ for more information at _address@example.com_" as before. If the `email` field is unset, it should read "Please contact _Facility_ for more information."

This change also consolidates common argument hashes into a helper.