### PR TITLE
[#126394] Add warning icon to offline instruments in product listings

### DIFF
--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -14,3 +14,6 @@
           - if acting_user.present? && !product.can_be_used_by?(acting_user)
             %i.icon-lock
             = " (#{product.class.human_attribute_name(:requires_approval_show)})"
+
+          - if product.offline?
+            = tooltip_icon "icon-warning-sign", t("instruments.offline.note")


### PR DESCRIPTION
This adds the same red warning icon (with tooltip)  to the product listing page for offline instruments as seen on the daily view:

<img width="248" alt="downtime-warning-icon" src="https://cloud.githubusercontent.com/assets/46662/17744625/3b18b988-646e-11e6-8945-599676e2609b.png">
