### PR TITLE
{#126389] Show reservation "begin now" link only if the instrument is online

### DIFF
--- a/app/presenters/reservation_user_action_presenter.rb
+++ b/app/presenters/reservation_user_action_presenter.rb
@@ -3,7 +3,7 @@ class ReservationUserActionPresenter
   attr_accessor :reservation, :controller
   delegate :order_detail, :order,
            :can_switch_instrument?, :can_switch_instrument_on?, :can_switch_instrument_off?,
-           :can_cancel?, :can_move?, :can_customer_edit?, :started?, :ongoing?, to: :reservation
+           :can_cancel?, :startable_now?, :can_customer_edit?, :started?, :ongoing?, to: :reservation
 
   delegate :current_facility, to: :controller
 
@@ -23,7 +23,7 @@ class ReservationUserActionPresenter
 
     if can_switch_instrument?
       actions << switch_actions
-    elsif can_move?
+    elsif startable_now?
       actions << move_link
     end
 

--- a/app/support/reservations/moving_up.rb
+++ b/app/support/reservations/moving_up.rb
@@ -33,10 +33,7 @@ module Reservations::MovingUp
     false
   end
 
-  #
-  # returns true if this reservation can be moved to
-  # an earlier time slot, false otherwise
-  def can_move?
+  def startable_now?
     product.online? &&
       !(canceled? || order_detail.complete? || in_grace_period? || earliest_possible.nil?) # TODO: refactor?
   end

--- a/app/support/reservations/moving_up.rb
+++ b/app/support/reservations/moving_up.rb
@@ -37,7 +37,8 @@ module Reservations::MovingUp
   # returns true if this reservation can be moved to
   # an earlier time slot, false otherwise
   def can_move?
-    !(canceled? || order_detail.complete? || in_grace_period? || earliest_possible.nil?) # TODO: refactor?
+    product.online? &&
+      !(canceled? || order_detail.complete? || in_grace_period? || earliest_possible.nil?) # TODO: refactor?
   end
 
 end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -581,6 +581,16 @@ RSpec.describe Reservation do
 
       before(:each) { @morning = Time.zone.parse("#{Date.today} 10:31:00") }
 
+      context "when the reserved instrument is online" do
+        it { is_expected.to be_can_move }
+      end
+
+      context "when the reserved instrument is offline" do
+        let(:instrument) { FactoryGirl.create(:setup_instrument, :offline) }
+
+        it { is_expected.not_to be_can_move }
+      end
+
       it "should return the earliest possible time slot" do
         expect(human_date(@reservation1.reserve_start_at)).to eq(human_date(@morning + 1.day))
 

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -582,13 +582,13 @@ RSpec.describe Reservation do
       before(:each) { @morning = Time.zone.parse("#{Date.today} 10:31:00") }
 
       context "when the reserved instrument is online" do
-        it { is_expected.to be_can_move }
+        it { is_expected.to be_startable_now }
       end
 
       context "when the reserved instrument is offline" do
         let(:instrument) { FactoryGirl.create(:setup_instrument, :offline) }
 
-        it { is_expected.not_to be_can_move }
+        it { is_expected.not_to be_startable_now }
       end
 
       it "should return the earliest possible time slot" do
@@ -613,20 +613,20 @@ RSpec.describe Reservation do
         @instrument.update_attributes(reserve_interval: 1)
         @reservation1.duration_mins = 1
         Timecop.freeze(@reservation1.reserve_start_at - 4.minutes) do
-          expect(@reservation1).to_not be_can_move
+          expect(@reservation1).to_not be_startable_now
         end
       end
 
       it "should not be moveable if the reservation is canceled" do
-        expect(@reservation1).to be_can_move
+        expect(@reservation1).to be_startable_now
         @reservation1.canceled_at = Time.zone.now
-        expect(@reservation1).not_to be_can_move
+        expect(@reservation1).not_to be_startable_now
       end
 
       it "should not be moveable if there is not a time slot earlier than this one" do
-        expect(@reservation1).to be_can_move
+        expect(@reservation1).to be_startable_now
         expect(@reservation1.move_to_earliest).to be true
-        expect(@reservation1).not_to be_can_move
+        expect(@reservation1).not_to be_startable_now
         expect(@reservation1.move_to_earliest).to be false
         expect(@reservation1.errors.messages).to eq(base: ["Sorry, but your reservation can no longer be moved."])
       end

--- a/spec/presenters/reservation_user_action_presenter_spec.rb
+++ b/spec/presenters/reservation_user_action_presenter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ReservationUserActionPresenter do
     allow(reservation).to receive(:can_switch_instrument?).and_return true
     allow(reservation).to receive(:can_switch_instrument_off?).and_return false
     allow(reservation).to receive(:can_switch_instrument_on?).and_return false
-    allow(reservation).to receive(:can_move?).and_return false
+    allow(reservation).to receive(:startable_now?).and_return false
     allow(reservation).to receive(:can_cancel?).and_return false
     allow(reservation).to receive(:ongoing?).and_return false
   end
@@ -212,7 +212,7 @@ RSpec.describe ReservationUserActionPresenter do
 
       before do
         expect(reservation).to receive(:can_switch_instrument?).and_return false
-        expect(reservation).to receive(:can_move?).and_return true
+        expect(reservation).to receive(:startable_now?).and_return true
       end
 
       it "includes the move link" do


### PR DESCRIPTION
Commit cba973e should address the specific issue @nutodd brought up: if the instrument is down, the user should not see a "Begin Now" link.

Since `Reservation#can_move?` was only being used to determine if "Begin Now" should appear or not, this changes the method name in 8a54658 to `#startable_now?`, which sounded more appropriate to how we use it (it reads a bit less awkwardly in tests too).