### PR TITLE
[#130862] Facilty Admin/Directors did not have access to error reports

### DIFF
--- a/app/controllers/order_imports_controller.rb
+++ b/app/controllers/order_imports_controller.rb
@@ -7,7 +7,7 @@ class OrderImportsController < ApplicationController
   before_action :check_acting_as
   before_action :init_current_facility
 
-  authorize_resource class: Order
+  authorize_resource
 
   def initialize
     @active_tab = "admin_orders"

--- a/app/views/admin/shared/_tabnav_order.html.haml
+++ b/app/views/admin/shared/_tabnav_order.html.haml
@@ -4,5 +4,5 @@
     = display_tab "Problem Orders", show_problems_facility_orders_path, action: :show_problems
   - if SettingsHelper.has_review_period? && current_ability.can?(:disputed, Order)
     = display_tab "Disputed", disputed_facility_orders_path, action: :disputed
-  - if current_user.manager_of?(current_facility)
+  - if current_ability.can?(:new, OrderImport)
     = tab "Add New", new_facility_order_import_path(current_facility), (controller.controller_name == 'facility_orders_import')

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -138,7 +138,7 @@ class Ability
           Statement, StoredFile, PricePolicy, InstrumentPricePolicy,
           ItemPricePolicy, OrderStatus, PriceGroup, Reports::ReportsController,
           ScheduleRule, ServicePricePolicy, PriceGroupProduct, ProductAccessGroup,
-          ProductAccessory, Product, BundleProduct, TrainingRequest
+          ProductAccessory, Product, BundleProduct, TrainingRequest, OrderImport
         ]
 
         can :manage, User if controller.is_a?(FacilityUsersController)

--- a/spec/controllers/order_imports_controller_spec.rb
+++ b/spec/controllers/order_imports_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe OrderImportsController do
       @method = :get
     end
 
-    it_should_allow_operators_only do
+    it_should_allow_managers_only do
       expect(assigns :order_import).to be_new_record
       is_expected.to render_template "new"
     end
@@ -50,7 +50,7 @@ RSpec.describe OrderImportsController do
       let(:fail_on_error) { false }
       let(:send_receipts) { false }
 
-      it_should_allow_operators_only(:redirect) do
+      it_should_allow_managers_only(:redirect) do
         expect(flash[:error]).to be_blank
         expect(flash[:notice]).to be_present
         is_expected.to redirect_to new_facility_order_import_url
@@ -67,6 +67,28 @@ RSpec.describe OrderImportsController do
           expect { do_request }.to change(StoredFile, :count).from(0).to(1)
         end
       end
+    end
+  end
+
+  describe "downloading an error file" do
+    let(:stored_file) { FactoryGirl.create(:csv_stored_file) }
+    let!(:order_import) do
+      OrderImport.create!(
+        created_by: @director.id,
+        upload_file: stored_file,
+        error_file: stored_file,
+        facility: facility,
+      )
+    end
+
+    before do
+      @action = :error_report
+      @method = :get
+      @params.merge!(id: order_import.id)
+    end
+
+    it_should_allow_managers_only(:redirect) do
+      is_expected.to redirect_to order_import.error_file_download_url
     end
   end
 end


### PR DESCRIPTION
Also fixes an issue where facility staff/senior staff could access the
import if they had the URL. It was only protected by not showing the
tab.