### PR TITLE
[#126394] Rename I18n key to use "_" rather than "-"

### DIFF
--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -63,7 +63,7 @@ module ProductsHelper
         title: text("instruments.public_schedule.available") }
     else
       { class: ["icon-calendar", "in-use"],
-        title: text("instruments.public_schedule.in-use") }
+        title: text("instruments.public_schedule.in_use") }
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1055,7 +1055,7 @@ en:
       place_reservation: Place Reservation
       icon: Public Schedule
       available: Available
-      in-use: In Use
+      in_use: In Use
     schedule:
       administrative_reservations: Administrative Reservations
       add_admin_reservation: Add Admin Reservation


### PR DESCRIPTION
`text_helpers` was not translating "-".