### PR TITLE
[#131810] Permit assigned user parameter

### DIFF
--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -4,6 +4,7 @@ class OrderDetails::ParamUpdater
     @permitted_attributes ||=
       [
         :account_id,
+        :assigned_user_id,
         :resolve_dispute,
         :dispute_resolved_reason,
         :quantity,

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -523,6 +523,14 @@ RSpec.describe OrderManagement::OrderDetailsController do
       end
     end
 
+    describe "assigning to a user" do
+      it "updates the assigned user" do
+        @params[:order_detail] = { assigned_user_id: @staff.id }
+        do_request
+        expect(order_detail.reload.assigned_user).to eq(@staff)
+      end
+    end
+
     describe "resolving dispute" do
       before :each do
         order_detail.change_status!(OrderStatus.complete.first)


### PR DESCRIPTION
The assigned user was not being persisted because the parameter was not
being permitted through.