### PR TITLE
 [#126394] Update public schedule calendar icon tooltips

### DIFF
--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -58,12 +58,15 @@ module ProductsHelper
   end
 
   def public_calendar_availability_options(product)
-    if product.available? && product.online?
+    if product.offline?
+      { class: ["icon-calendar", "in-use"],
+        title: text("instruments.offline.note") }
+    elsif product.available?
       { class: ["icon-calendar", "available"],
         title: text("instruments.public_schedule.available") }
     else
       { class: ["icon-calendar", "in-use"],
-        title: text("instruments.public_schedule.in-use") }
+        title: text("instruments.public_schedule.unavailable") }
     end
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,6 +34,9 @@ Nucore::Application.configure do
 
   # Expands the lines which load the assets
   config.assets.debug = true
+
+  # Raise exceptions when missing I18n translations
+  config.action_view.raise_on_missing_translations = true
 end
 
 # What's this for?

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,6 +45,9 @@ Nucore::Application.configure do
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   Delayed::Worker.delay_jobs = false
+
+  # Raise exceptions when missing I18n translations
+  config.action_view.raise_on_missing_translations = true
 end
 
 GOOGLE_ANALYTICS_KEY = nil

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,9 +45,6 @@ Nucore::Application.configure do
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   Delayed::Worker.delay_jobs = false
-
-  # Raise exceptions when missing I18n translations
-  config.action_view.raise_on_missing_translations = true
 end
 
 GOOGLE_ANALYTICS_KEY = nil

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1055,7 +1055,7 @@ en:
       place_reservation: Place Reservation
       icon: Public Schedule
       available: Available
-      in-use: In Use
+      unavailable: Unavailable
     schedule:
       administrative_reservations: Administrative Reservations
       add_admin_reservation: Add Admin Reservation


### PR DESCRIPTION
This came about because text_helpers was not translating the "-" in "in-use" but "in use" was not accurate given an instrument might be unavailable because it's offline.

With this change:
* If an instrument is available and online, the tooltip should be "Available"
* If an instrument is offline, the tooltip should be "Instrument is down"
* If an instrument is otherwise unavailable, the tooltip should be "Unavailable"

Though it may not have caught this "in-use" missing translation, this change also configures the ~~`test` and~~ `development` environment~~s~~ to raise exceptions on missing translations.