### PR TITLE
[#131810] Prevent duplicate users in staff lists

### DIFF
--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -33,7 +33,7 @@ class Facility < ActiveRecord::Base
   has_many :facility_accounts
   has_many :training_requests, through: :products
   has_many :user_roles, dependent: :destroy
-  has_many :users, through: :user_roles
+  has_many :users, -> { distinct }, through: :user_roles
 
   validates_presence_of :name, :short_description, :abbreviation
   validate_url_name :url_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,7 +113,6 @@ class User < ActiveRecord::Base
     facility
       .users
       .order("LOWER(user_roles.role), LOWER(users.last_name), LOWER(users.first_name)")
-      .distinct
   end
 
   #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,15 +109,11 @@ class User < ActiveRecord::Base
   end
 
   # Find the users for a facility
-  # TODO: move this to facility?
   def self.find_users_by_facility(facility)
-    find_by_sql(<<-SQL)
-      SELECT u.*
-      FROM #{User.table_name} u
-      LEFT JOIN #{UserRole.table_name} ur ON u.id=ur.user_id
-      WHERE ur.facility_id = #{facility.id}
-      ORDER BY LOWER(ur.role), LOWER(u.last_name), LOWER(u.first_name)
-    SQL
+    facility
+      .users
+      .order("LOWER(user_roles.role), LOWER(users.last_name), LOWER(users.first_name)")
+      .distinct
   end
 
   #

--- a/spec/controllers/facility_users_controller_spec.rb
+++ b/spec/controllers/facility_users_controller_spec.rb
@@ -20,10 +20,9 @@ RSpec.describe FacilityUsersController do
     end
 
     it_should_allow_managers_only do |user|
-      expect(assigns(:users)).to be_kind_of Array
       expect(assigns(:users).size).to be >= 1
-      expect(assigns(:users)).to be_include @staff
-      expect(assigns(:users)).to be_include user unless user == @admin
+      expect(assigns(:users)).to include @staff
+      expect(assigns(:users)).to include user unless user == @admin
     end
 
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -278,9 +278,7 @@ RSpec.describe User do
     let!(:normal_user) { create(:user) }
     let!(:other_facilitly_director) { create(:user, :facility_director, facility: build_stubbed(:facility)) }
     let!(:facility_admin_and_director) do
-      create(:user, :facility_director, facility: facility) do |u|
-        UserRole.create!(user: u, facility: facility, role: UserRole::FACILITY_ADMINISTRATOR)
-      end
+      create(:user, :facility_director, :facility_administrator, facility: facility)
     end
 
     it "finds just the users for that facility" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -271,4 +271,20 @@ RSpec.describe User do
       end
     end
   end
+
+  describe ".find_users_by_facility" do
+    let!(:facility_director) { create(:user, :facility_director, facility: facility) }
+    let!(:staff) { create(:user, :staff, facility: facility) }
+    let!(:normal_user) { create(:user) }
+    let!(:other_facilitly_director) { create(:user, :facility_director, facility: build_stubbed(:facility)) }
+    let!(:facility_admin_and_director) do
+      create(:user, :facility_director, facility: facility) do |u|
+        UserRole.create!(user: u, facility: facility, role: UserRole::FACILITY_ADMINISTRATOR)
+      end
+    end
+
+    it "finds just the users for that facility" do
+      expect(described_class.find_users_by_facility(facility)).to contain_exactly(facility_director, staff, facility_admin_and_director)
+    end
+  end
 end


### PR DESCRIPTION
* Order detail popup assigned user dropdown
* New/In Process Orders assigned user dropdown
* Admin Facility Staff index - Mentioned in NU #126595, but there are a
couple other issues still left around duplicate behavior.