### PR TITLE
Fix Oracle error on loading facility staff (#191)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,7 @@ class User < ActiveRecord::Base
   end
 
   def self.sort_last_first
-    order(:last_name, :first_name)
+    order("LOWER(users.last_name), LOWER(users.first_name)")
   end
 
   # finds all user role mappings for a this user in a facility
@@ -112,7 +112,7 @@ class User < ActiveRecord::Base
   def self.find_users_by_facility(facility)
     facility
       .users
-      .order("LOWER(user_roles.role), LOWER(users.last_name), LOWER(users.first_name)")
+      .sort_last_first
   end
 
   #


### PR DESCRIPTION
`ORA-01791: not a SELECTed expression` because we're not SELECTing the
user_roles table. There's no real reason we're sorting by the role first.

Pulled up from https://github.com/tablexi/nucore-nu/pull/191