### PR TITLE
[#132121] Handle more than 1000 accounts receivable

### DIFF
--- a/app/controllers/facility_accounts_controller.rb
+++ b/app/controllers/facility_accounts_controller.rb
@@ -146,7 +146,7 @@ class FacilityAccountsController < ApplicationController
     order_details.each do |od|
       @account_balances[od.account_id] = @account_balances[od.account_id].to_f + od.total.to_f
     end
-    @accounts = Account.find(@account_balances.keys)
+    @accounts = Account.where_ids_in(@account_balances.keys)
   end
 
   # GET /facilities/:facility_id/accounts/:account_id/statements/:statement_id

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -11,6 +11,7 @@ class Account < ActiveRecord::Base
   include Overridable
   include Accounts::AccountNumberSectionable
   include DateHelper
+  include NUCore::Database::WhereIdsIn
 
   has_many :account_users, -> { where(deleted_at: nil) }, inverse_of: :account
   has_many :deleted_account_users, -> { where.not("account_users.deleted_at" => nil) }, class_name: "AccountUser"


### PR DESCRIPTION
On the cross-facility tab, we were hitting 1000+ errors on oracle. This
view is still slow based on the #, but this will stop the errors.