### PR TITLE
Update I18n load_path

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,10 +46,10 @@ module Nucore
 
     # The default locale is :en and all translations under config/locales/ are auto-loaded
     # But we want to make sure anything in the override folder happens at the very end
-    config.i18n.load_path += FileList[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
-      .exclude(Rails.root.join("config", "locales", "override", "**"))
-
-    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "override", "*.{rb,yml}").to_s]
+    initializer "nucore.i18n.move_overrides_to_end", after: "text_helpers.i18n.add_load_paths" do
+      config.i18n.load_path -= Dir[Rails.root.join("config", "locales", "override", "*.{rb,yml}").to_s]
+      config.i18n.load_path += Dir[Rails.root.join("config", "locales", "override", "*.{rb,yml}").to_s]
+    end
     # config.i18n.default_locale = :de
 
     # JavaScript files you want as :defaults (application.js is always included).


### PR DESCRIPTION
The UIC load path was not in the correct order, but only in production. I could not figure out what was happening differently between there and stage, and why it has not been a problem for NU or DC.

I did figure out that `text_helpers` adds the subdirectories `**/*.{rb,yml}`. That happens after this initialization, and appeared to be loading everything again, so we would have `/en.yml` multiple times, which could be after the `override/en.yml`.

This now waits until after that initialization and forces the `override/` directory to happen at higher priority in the load path.

This is already in UIC, and I'm testing it on DC.