### PR TITLE
[#127094] Normal users could place orders in the past

### DIFF
--- a/app/services/reservation_creator.rb
+++ b/app/services/reservation_creator.rb
@@ -1,0 +1,92 @@
+class ReservationCreator
+
+  attr_reader :order, :order_detail, :params, :error
+
+  delegate :merged_order?, :instrument_only_order?, to: :status_q
+
+  def initialize(order, order_detail, params)
+    @order = order
+    @order_detail = order_detail
+    @params = params
+  end
+
+  def save(session_user)
+    if !@order_detail.bundled? && params[:order_account].blank?
+      @error = I18n.t("controllers.reservations.create.no_selection")
+      return false
+    end
+
+    Reservation.transaction do
+      begin
+        update_order_account
+
+        # merge state can change after call to #save! due to OrderDetailObserver#before_save
+        to_be_merged = @order_detail.order.to_be_merged?
+
+        save_reservation_and_order_detail(session_user)
+
+        if to_be_merged
+          # The purchase_order_path or cart_path will handle the backdating, but we need
+          # to do this here for merged reservations.
+          backdate_reservation_if_necessary(session_user)
+          @success = :merged_order
+        elsif @order.order_details.one?
+          @success = :instrument_only_order
+        else
+          @success = :default
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        @error = e.message
+        raise ActiveRecord::Rollback
+      rescue => e
+        @error = I18n.t("orders.purchase.error")
+        @error += " #{e.message}" if e.message
+        raise ActiveRecord::Rollback
+      end
+    end
+  end
+
+  def reservation
+    return @reservation if @reservation
+    @reservation = @order_detail.build_reservation
+    @reservation.assign_attributes(reservation_create_params)
+    @reservation.assign_times_from_params(reservation_create_params)
+    @reservation
+  end
+
+  private
+
+  def reservation_create_params
+    params[:reservation]
+      .except(:reserve_end_date, :reserve_end_hour, :reserve_end_min, :reserve_end_meridian)
+      .merge(product: @order_detail.product)
+  end
+
+  def update_order_account
+    if params[:order_account].present?
+      account = Account.find(params[:order_account].to_i)
+      if account != @order.account
+        @order.invalidate
+        @order.update_attributes!(account: account)
+      end
+    end
+  end
+
+  def backdate_reservation_if_necessary(session_user)
+    facility_ability = Ability.new(session_user, @order.facility, self)
+    if facility_ability.can?(:order_in_past, @order) && @reservation.reserve_end_at < Time.zone.now
+      @order_detail.backdate_to_complete!(@reservation.reserve_end_at)
+    end
+  end
+
+  def save_reservation_and_order_detail(session_user)
+    reservation.save_as_user!(session_user)
+    order_detail.assign_estimated_price(nil, reservation.reserve_end_at)
+    order_detail.save_as_user!(session_user)
+  end
+
+  def status_q
+    ActiveSupport::StringInquirer.new(@success.to_s)
+  end
+
+end

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -541,6 +541,13 @@ RSpec.describe ReservationsController do
       end
     end
 
+    it "handles arbitrary errors" do
+      sign_in @guest
+      @params[:order_account] = 0 # Cause Account not found error
+      expect { do_request }.not_to change(Reservation, :count)
+      expect(response.body).to include(I18n.t("orders.purchase.error"))
+    end
+
     context "with other things in the cart (bundle or multi-add)" do
 
       before :each do

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -452,11 +452,14 @@ RSpec.describe ReservationsController do
       before :each do
         @params.deep_merge!(reservation: { reserve_start_date: Time.zone.now.to_date + (PriceGroupProduct::DEFAULT_RESERVATION_WINDOW + 1).days })
       end
+
       it_should_allow_all facility_operators, "to create a reservation beyond the default reservation window" do
         assert_redirected_to purchase_order_path(@order)
       end
+
       it_should_allow_all [:guest], "to receive an error that they are trying to reserve outside of the window" do
         expect(assigns[:reservation].errors).not_to be_empty
+        expect(flash[:error]).to include("The reservation is too far in advance")
         expect(response).to render_template(:new)
       end
     end

--- a/spec/features/purchasing_a_reservation_spec.rb
+++ b/spec/features/purchasing_a_reservation_spec.rb
@@ -17,12 +17,32 @@ RSpec.describe "Purchasing a reservation" do
     click_link facility.name
     click_link instrument.name
     select user.accounts.first.description, from: "Payment Source"
-    fill_in "Note", with: "A note about my reservation"
-    click_button "Create"
   end
 
-  it "is on the My Reservations page" do
-    expect(page).to have_content "My Reservations"
-    expect(page).to have_content "Note: A note about my reservation"
+  describe "selecting the default time" do
+    before do
+      fill_in "Note", with: "A note about my reservation"
+      click_button "Create"
+    end
+
+    it "is on the My Reservations page" do
+      expect(page).to have_content "My Reservations"
+      expect(page).to have_content "Note: A note about my reservation"
+    end
   end
+
+  describe "attempting to order in the past", :timecop_freeze do
+    let(:now) { Time.zone.local(2016, 8, 20, 11, 0) }
+
+    before do
+      select "10", from: "reservation[reserve_start_hour]"
+      select "10", from: "reservation[reserve_end_hour]"
+      click_button "Create"
+    end
+
+    it "has an error" do
+      expect(page).to have_content "must start at a future time"
+    end
+  end
+
 end


### PR DESCRIPTION
The big problem is that the account assignment on `order_detail` was autosaving the reservation without enforcing the non-admin validations (`save_as_user`).

The first idea I tried was doing `update_column`s so callbacks didn't get triggered, but it turns out we do need validations.

Next idea was flipping `save` and `save_with_extended_validations` so the extended validations (in the future and within 14 day window) are enforced by default, but not when purchasing as an admin. However, too many of our tests rely on those validations not being enforced as part of setup.

This refactor makes sure that `reservation` is not built until the last moment possible.
