### PR TITLE
403 on Sanger Submission controller should 403 instead of error

### DIFF
--- a/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/submissions_controller.rb
+++ b/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/submissions_controller.rb
@@ -60,7 +60,7 @@ module SangerSequencing
       if action_name == "show" && SangerSequencing::Ability.new(acting_user, current_facility).can?(:show, @submission)
         redirect_to facility_sanger_sequencing_admin_submission_path(current_facility, @submission)
       else
-        raise(error)
+        render_403(error)
       end
     end
 


### PR DESCRIPTION
The previous commit was cherry-picked out of NU, which was not running the sanger_sequencing engine specs (which it probably shouldn’t many features have been overridden there). This should fix the failure on master.