### PR TITLE
[#132309] Always use fulfilled at for price calculation

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -309,7 +309,7 @@ class ReservationsController < ApplicationController
 
   def save_reservation_and_order_detail
     @reservation.save_as_user!(session_user)
-    @order_detail.assign_estimated_price(nil, @reservation.reserve_end_at)
+    @order_detail.assign_estimated_price(@reservation.reserve_end_at)
     @order_detail.save_as_user!(session_user)
   end
 

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -144,8 +144,6 @@ class Reservation < ActiveRecord::Base
   def end_reservation!
     self.actual_end_at = Time.zone.now
     save!
-    # reservation is done, now give the best price
-    order_detail.assign_price_policy
     order_detail.complete!
   end
 

--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -83,8 +83,8 @@ class OrderDetails::ParamUpdater
   end
 
   def assign_policy_and_prices
-    @order_detail.assign_price_policy(@order_detail.fulfilled_at) if @order_detail.complete?
-    @order_detail.assign_estimated_price(nil, @order_detail.fulfilled_at || Time.zone.now) unless @order_detail.price_policy && @order_detail.actual_cost
+    @order_detail.assign_price_policy if @order_detail.complete?
+    @order_detail.assign_estimated_price unless @order_detail.price_policy && @order_detail.actual_cost
   end
 
   def change_order_status(order_status_id, apply_cancel_fee)

--- a/app/services/reservation_creator.rb
+++ b/app/services/reservation_creator.rb
@@ -81,7 +81,7 @@ class ReservationCreator
 
   def save_reservation_and_order_detail(session_user)
     reservation.save_as_user!(session_user)
-    order_detail.assign_estimated_price(nil, reservation.reserve_end_at)
+    order_detail.assign_estimated_price(reservation.reserve_end_at)
     order_detail.save_as_user!(session_user)
   end
 

--- a/app/support/accessories/child_updater.rb
+++ b/app/support/accessories/child_updater.rb
@@ -39,7 +39,6 @@ class Accessories::ChildUpdater
     decorated_od = Accessories::Scaling.decorate(od)
     od.account = @order_detail.account
     decorated_od.update_quantity
-    od.assign_actual_price
   end
 
 end

--- a/app/support/end_reservation_only.rb
+++ b/app/support/end_reservation_only.rb
@@ -23,7 +23,6 @@ class EndReservationOnly
   end
 
   def expire_reservation(od)
-    od.assign_actual_price
     od.complete!
 
     # OrderDetail#complete! sets fulfilled_at

--- a/app/support/order_details/price_checker.rb
+++ b/app/support/order_details/price_checker.rb
@@ -9,7 +9,7 @@ class OrderDetails::PriceChecker
   def prices_from_params(params)
     updater = OrderDetails::ParamUpdater.new(@order_detail)
     updater.assign_attributes(params)
-    @order_detail.assign_price_policy(@order_detail.fulfilled_at || Time.zone.now)
+    @order_detail.assign_price_policy
 
     fields = [:estimated_cost, :estimated_subsidy, :estimated_total,
               :actual_cost,    :actual_subsidy,    :actual_total]

--- a/app/support/order_uncanceler.rb
+++ b/app/support/order_uncanceler.rb
@@ -30,7 +30,7 @@ class OrderUncanceler
           state: "complete",
           fulfilled_at: fulfilled_at)
 
-        order_detail.assign_price_policy(fulfilled_at)
+        order_detail.assign_price_policy
         order_detail.save!
         Rails.logger.info "OrderDetail #{order_detail} was uncanceled"
         true

--- a/app/support/price_policy_mass_assigner.rb
+++ b/app/support/price_policy_mass_assigner.rb
@@ -2,7 +2,7 @@ class PricePolicyMassAssigner
 
   def self.assign_price_policies(order_details)
     order_details.select do |order_detail|
-      if order_detail.assign_price_policy(order_detail.fulfilled_at || Time.zone.now)
+      if order_detail.assign_price_policy
         order_detail.save
       else
         false

--- a/lib/tasks/order_details.rake
+++ b/lib/tasks/order_details.rake
@@ -23,7 +23,7 @@ namespace :order_details do
       old_subsidy = od.actual_subsidy
       old_total = od.actual_total
       old_price_group = od.price_policy.try(:price_group)
-      od.assign_price_policy(od.fulfilled_at)
+      od.assign_price_policy
       puts "#{od}|#{od.order_status}|#{od.account}|#{od.user}|#{od.product}|#{od.fulfilled_at}|#{old_price_group}|#{old_cost}|#{old_subsidy}|#{old_total}|#{od.price_policy.try(:price_group)}|#{od.actual_cost}|#{od.actual_subsidy}|#{od.actual_total}|#{od.actual_total == old_total}"
     end
 

--- a/spec/app_support/price_policy_mass_assigner_spec.rb
+++ b/spec/app_support/price_policy_mass_assigner_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe PricePolicyMassAssigner do
     end
 
     context "when no compatible price policies exist" do
+      let(:fulfilled_at) { 10.years.ago }
       it "assigns no price policies" do
         expect(mass_assign_price_policies.size).to eq(0)
         expect(order_detail.price_policy).to be_blank

--- a/spec/app_support/price_policy_mass_assigner_spec.rb
+++ b/spec/app_support/price_policy_mass_assigner_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe PricePolicyMassAssigner do
       facility.facility_accounts.create(facility_account_attributes)
     end
     let(:facility_account_attributes) { attributes_for(:facility_account) }
-    let(:fulfilled_at) { nil }
     let(:item_attributes) do
       attributes_for(:item, facility_account_id: facility_account.id)
     end
@@ -87,9 +86,10 @@ RSpec.describe PricePolicyMassAssigner do
       end
 
       context "when order details are unfulfilled" do
-        it "assigns the current price policy" do
-          expect(mass_assign_price_policies).to eq [order_detail]
-          expect(order_detail.price_policy).to eq current_price_policy
+        let(:fulfilled_at) { nil }
+
+        it "does not get a price policy" do
+          expect(order_detail.price_policy).to be_blank
         end
       end
     end

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -516,12 +516,12 @@ RSpec.describe OrderManagement::OrderDetailsController do
     end
 
     describe "when the price policy would change" do
-      let!(:previous_price_policy) { FactoryGirl.create(:item_price_policy, product: item, price_group: price_group, unit_cost: 19, start_date: 30.days.ago, expire_date: 28.day.ago) }
+      let!(:previous_price_policy) { FactoryGirl.create(:item_price_policy, product: item, price_group: price_group, unit_cost: 19, start_date: 30.days.ago, expire_date: 28.days.ago) }
       before { order_detail.backdate_to_complete!(29.days.ago) }
 
       it "uses the fulfillment price policy rather than now's" do
         @params[:order_detail] = {
-          account_id: new_account.id
+          account_id: new_account.id,
         }
         do_request
         expect(order_detail.reload.price_policy).to eq(previous_price_policy)

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -495,7 +495,7 @@ RSpec.describe OrderManagement::OrderDetailsController do
         expect(order_detail.reload.actual_total).to eq(16.00)
       end
 
-      it "updates the price while changing accounts" do
+      xit "updates the price while changing accounts" do
         @params[:order_detail] = {
           actual_cost: "20.00",
           actual_subsidy: "4.00",
@@ -538,7 +538,7 @@ RSpec.describe OrderManagement::OrderDetailsController do
         expect { do_request }.to change { order_detail.reload.quantity }.to(2)
       end
 
-      it "updates the price while changing quantity" do
+      xit "updates the price while changing quantity" do
         @params[:order_detail] = {
           actual_cost: "20.00",
           actual_subsidy: "4.00",

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -495,7 +495,8 @@ RSpec.describe OrderManagement::OrderDetailsController do
         expect(order_detail.reload.actual_total).to eq(16.00)
       end
 
-      xit "updates the price while changing accounts" do
+      it "updates the price while changing accounts" do
+        pending "currently buggy: it uses the new account's price policy, not the params"
         @params[:order_detail] = {
           actual_cost: "20.00",
           actual_subsidy: "4.00",
@@ -531,6 +532,7 @@ RSpec.describe OrderManagement::OrderDetailsController do
 
     describe "changing quantity" do
       before do
+        order_detail.backdate_to_complete!(Time.current)
         @params[:order_detail] = { quantity: 2 }
       end
 
@@ -538,7 +540,8 @@ RSpec.describe OrderManagement::OrderDetailsController do
         expect { do_request }.to change { order_detail.reload.quantity }.to(2)
       end
 
-      xit "updates the price while changing quantity" do
+      it "updates the price while changing quantity" do
+        pending "currently buggy: it uses the price policy's calculation, not the params"
         @params[:order_detail] = {
           actual_cost: "20.00",
           actual_subsidy: "4.00",

--- a/spec/services/accessories_child_updater_spec.rb
+++ b/spec/services/accessories_child_updater_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Accessories::ChildUpdater do
     before { allow(order_detail).to receive(:child_order_details).and_return [child_order_detail] }
 
     it "updates the child" do
-      expect(child_order_detail).to receive(:assign_actual_price)
+      expect(child_order_detail).to receive(:account=)
       expect(child_order_detail).to receive(:save)
       expect(order_detail.update_children).to eq([child_order_detail])
     end

--- a/vendor/engines/c2po/spec/models/order_detail_spec.rb
+++ b/vendor/engines/c2po/spec/models/order_detail_spec.rb
@@ -127,8 +127,8 @@ RSpec.describe OrderDetail do
 
       context "with actual costs" do
         before :each do
-          order_detail.update_attributes(actual_cost: 20, actual_subsidy: 10)
-          order_detail.save!
+          order_detail.backdate_to_complete!
+          order_detail.update_attributes!(actual_cost: 20, actual_subsidy: 10)
           original_statement.add_order_detail(order_detail)
           original_statement.save!
 

--- a/vendor/engines/split_accounts/spec/models/reports/export_raw_spec.rb
+++ b/vendor/engines/split_accounts/spec/models/reports/export_raw_spec.rb
@@ -18,9 +18,6 @@ RSpec.describe Reports::ExportRaw, :enable_split_accounts do
   let(:order_detail) do
     order_detail = base_order_detail
 
-    # prevent the order_detail from assigning different actual_cost and actual_subsidy
-    allow(order_detail).to receive(:assign_actual_price).and_return(nil)
-
     order_detail.quantity = 1
     order_detail.actual_subsidy = BigDecimal("9.99")
     order_detail.actual_cost = BigDecimal("19.99")


### PR DESCRIPTION
If you change the account of an order, we were calculating the price policy based on the current time, not the fulfilled_at date. This removes the parameter from the `assigns_price_policy` method to make sure we don't run into this again.

The one time we do want to use current time is when canceling a reservation with fee, because we don't really have a fulfilled_at, so we should use the current time.

This also cleans up an unused argument in `assign_estimated_price`.

I have two pending tests for another issue: if you change the account of an order in the popup, and also modify the cost, we're recalculating the pricing in the before_save hook and overwriting whatever the user put in. That fix will likely come as a separate PR.