### PR TITLE
[#130782] Adds feature tag for setting default start date

### DIFF
--- a/app/controllers/facility_statements_controller.rb
+++ b/app/controllers/facility_statements_controller.rb
@@ -29,6 +29,7 @@ class FacilityStatementsController < ApplicationController
   def new_with_search
     @order_details = @order_details.need_statement(@facility)
     @order_detail_action = :send_statements
+    set_default_start_date if SettingsHelper.feature_on?(:set_start_date)
     @layout = "two_column_head"
   end
 

--- a/app/controllers/facility_statements_controller.rb
+++ b/app/controllers/facility_statements_controller.rb
@@ -29,7 +29,7 @@ class FacilityStatementsController < ApplicationController
   def new_with_search
     @order_details = @order_details.need_statement(@facility)
     @order_detail_action = :send_statements
-    set_default_start_date if SettingsHelper.feature_on?(:set_start_date)
+    set_default_start_date if SettingsHelper.feature_on?(:set_statement_search_start_date)
     @layout = "two_column_head"
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -111,6 +111,7 @@ feature:
   my_files_on: true
   # results file notifications requires that my_files be on as well
   results_file_notifications_on: true
+  set_start_date_on: false
 
 # This may be overridden in settings.local.yml if your fork is using S3, so
 # be sure to check there for configuration

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -111,7 +111,7 @@ feature:
   my_files_on: true
   # results file notifications requires that my_files be on as well
   results_file_notifications_on: true
-  set_start_date_on: false
+  set_statement_search_start_date_on: false
 
 # This may be overridden in settings.local.yml if your fork is using S3, so
 # be sure to check there for configuration

--- a/spec/controllers/facility_statements_controller_spec.rb
+++ b/spec/controllers/facility_statements_controller_spec.rb
@@ -67,14 +67,30 @@ if Account.config.statements_enabled?
 
       it_should_deny_all [:staff, :senior_staff]
 
-      it "should return the right order details" do
-        grant_and_sign_in(@user)
-        do_request
-        expect(response).to be_success
-        expect(assigns[:search_options][:accounts]).to contain_all [@account, @account2]
-        expect(assigns(:facility)).to eq(@authable)
-        expect(assigns(:order_detail_action)).to eq(:send_statements)
-        expect(assigns(:order_details)).to contain_all [@order_detail1, @order_detail3]
+      context "if set start date feature is enabled", feature_setting: { set_start_date: false } do
+        it "should return the right order details without start date" do
+          grant_and_sign_in(@user)
+          do_request
+          expect(response).to be_success
+          expect(controller.params[:date_range]).not_to be_present
+          expect(assigns[:search_options][:accounts]).to contain_all [@account, @account2]
+          expect(assigns(:facility)).to eq(@authable)
+          expect(assigns(:order_detail_action)).to eq(:send_statements)
+          expect(assigns(:order_details)).to contain_all [@order_detail1, @order_detail3]
+        end
+      end
+
+      context "if set start date feature is enabled", feature_setting: { set_start_date: true } do
+        it "should return the right order details with start date" do
+          grant_and_sign_in(@user)
+          do_request
+          expect(response).to be_success
+          expect(controller.params[:date_range][:start]).to be_present
+          expect(assigns[:search_options][:accounts]).to contain_all [@account, @account2]
+          expect(assigns(:facility)).to eq(@authable)
+          expect(assigns(:order_detail_action)).to eq(:send_statements)
+          expect(assigns(:order_details)).to contain_all [@order_detail1, @order_detail3]
+        end
       end
 
       it_should_support_searching

--- a/spec/controllers/facility_statements_controller_spec.rb
+++ b/spec/controllers/facility_statements_controller_spec.rb
@@ -67,7 +67,7 @@ if Account.config.statements_enabled?
 
       it_should_deny_all [:staff, :senior_staff]
 
-      context "if set start date feature is enabled", feature_setting: { set_start_date: false } do
+      context "if set statement search start date feature is enabled", feature_setting: { set_statement_search_start_date: false } do
         it "should return the right order details without start date" do
           grant_and_sign_in(@user)
           do_request
@@ -80,7 +80,7 @@ if Account.config.statements_enabled?
         end
       end
 
-      context "if set start date feature is enabled", feature_setting: { set_start_date: true } do
+      context "if set statement search start date feature is enabled", feature_setting: { set_statement_search_start_date: true } do
         it "should return the right order details with start date" do
           grant_and_sign_in(@user)
           do_request


### PR DESCRIPTION
https://pm.tablexi.com/issues/130782

This adds the ability to turn on setting a default start date under the create statements tab in billing.