### PR TITLE
[#124051] Add validation for journal reference length

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -47,6 +47,7 @@ class Journal < ActiveRecord::Base
   validates_presence_of   :reference, :updated_by, on: :update
   validates_presence_of   :created_by
   validates_presence_of   :journal_date
+  validates_length_of     :reference, maximum: 50
   validate :journal_date_cannot_be_in_future, if: "journal_date.present?"
   validate :must_have_order_details, on: :create, if: :order_details_for_creation
   validate :must_not_span_fiscal_years, on: :create, if: :has_order_details_for_creation?

--- a/app/views/facility_journals/index.html.haml
+++ b/app/views/facility_journals/index.html.haml
@@ -33,8 +33,8 @@
               %td= human_datetime(pending_journal.created_at)
               - if cross_facility?
                 %td= facility_abbreviations.join("<br>").html_safe
-              %td= f.text_field :reference, class: 'input-medium'
-              %td= f.text_field :description, class: 'input-medium'
+              %td= f.input :reference, label: false, input_html: { class: 'input-medium' }
+              %td= f.input :description, label: false, input_html: { class: 'input-medium' }
               %td
                 = select_tag :journal_status, options_for_select([[' ', nil], ['Succeeded, no errors', 'succeeded'], ['Succeeded, with errors', 'succeeded_errors'], ['Failed', 'failed']], params[:journal_status]), class: 'input-medium'
                 = submit_tag t(".journal.close"),

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Journal do
   let(:order) { create(:purchased_order, product: product) }
   let(:product) { create(:setup_item, facility: facility, facility_account: facility_account) }
 
+  describe "validations" do
+    it { is_expected.to validate_length_of(:reference).is_at_most(50) }
+  end
+
   context "#amount" do
     context "when its order detail quantities change" do
       let(:order_details) { order.order_details }


### PR DESCRIPTION
https://pm.tablexi.com/issues/124051

The journal reference has a database length restriction, but this adds a validation so a reference that is too long for the db can't get past the validation.