### PR TITLE
[#124334] Restrict amount sum to non-cancelled orders

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -126,6 +126,8 @@ class OrderDetail < ActiveRecord::Base
       .where("products.type" => product_type)
   }
 
+  scope :non_cancelled, -> { joins(:order_status).where.not(order_statuses: { name: "Canceled" }) }
+
   def self.for_facility(facility)
     for_facility_id(facility.id)
   end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -126,7 +126,7 @@ class OrderDetail < ActiveRecord::Base
       .where("products.type" => product_type)
   }
 
-  scope :non_cancelled, -> { joins(:order_status).where.not(order_statuses: { name: "Canceled" }) }
+  scope :non_canceled, -> { where.not(state: "canceled") }
 
   def self.for_facility(facility)
     for_facility_id(facility.id)

--- a/app/views/facility_orders/show.html.haml
+++ b/app/views/facility_orders/show.html.haml
@@ -67,11 +67,11 @@
       %td
       %td
       %td.currency
-        %strong= number_to_currency @order_details.inject(0) { |sum,od| sum + od.cost }
+        %strong= number_to_currency @order_details.non_cancelled.inject(0) { |sum,od| sum + od.cost }
       %td.currency
-        %strong= number_to_currency @order_details.inject(0) { |sum,od| sum + od.subsidy }
+        %strong= number_to_currency @order_details.non_cancelled.inject(0) { |sum,od| sum + od.subsidy }
       %td.currency
-        %strong= number_to_currency @order_details.inject(0) { |sum,od| sum + od.total }
+        %strong= number_to_currency @order_details.non_cancelled.inject(0) { |sum,od| sum + od.total }
       %td
 
 = render :partial => 'merge_order_form'

--- a/app/views/facility_orders/show.html.haml
+++ b/app/views/facility_orders/show.html.haml
@@ -67,11 +67,11 @@
       %td
       %td
       %td.currency
-        %strong= number_to_currency @order_details.non_cancelled.inject(0) { |sum,od| sum + od.cost }
+        %strong= number_to_currency @order_details.non_canceled.inject(0) { |sum,od| sum + od.cost }
       %td.currency
-        %strong= number_to_currency @order_details.non_cancelled.inject(0) { |sum,od| sum + od.subsidy }
+        %strong= number_to_currency @order_details.non_canceled.inject(0) { |sum,od| sum + od.subsidy }
       %td.currency
-        %strong= number_to_currency @order_details.non_cancelled.inject(0) { |sum,od| sum + od.total }
+        %strong= number_to_currency @order_details.non_canceled.inject(0) { |sum,od| sum + od.total }
       %td
 
 = render :partial => 'merge_order_form'

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -968,13 +968,13 @@ RSpec.describe OrderDetail do
       end
     end
 
-    describe "non_cancelled" do
-      let!(:order_detail) { create(:order_detail, order_status: OrderStatus.canceled.first, order: Order.last, product: Product.last) }
+    describe "non_canceled" do
+      let!(:order_detail) { create(:order_detail, order_status: OrderStatus.canceled.first, state: "canceled", order: Order.last, product: Product.last) }
       let!(:active_order_detail) { create(:order_detail, order_status: OrderStatus.complete.first, order: Order.last, product: Product.last) }
 
       it "should return only order details with non-cancelled status" do
-        expect(OrderDetail.non_cancelled).to include(active_order_detail)
-        expect(OrderDetail.non_cancelled).to_not include(order_detail)
+        expect(OrderDetail.non_canceled).to include(active_order_detail)
+        expect(OrderDetail.non_canceled).to_not include(order_detail)
       end
     end
   end

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -967,6 +967,16 @@ RSpec.describe OrderDetail do
         end
       end
     end
+
+    describe "non_cancelled" do
+      let!(:order_detail) { create(:order_detail, order_status: OrderStatus.canceled.first, order: Order.last, product: Product.last) }
+      let!(:active_order_detail) { create(:order_detail, order_status: OrderStatus.complete.first, order: Order.last, product: Product.last) }
+
+      it "should return only order details with non-cancelled status" do
+        expect(OrderDetail.non_cancelled).to include(active_order_detail)
+        expect(OrderDetail.non_cancelled).to_not include(order_detail)
+      end
+    end
   end
 
   context "ordered_on_behalf_of?" do


### PR DESCRIPTION
https://pm.tablexi.com/issues/124334

This restricts the price sum on the orders page based on whether the order status is cancelled.