### PR TITLE
[#126724] Prevent order_at from getting set on cart quantity change

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -250,7 +250,9 @@ class OrdersController < ApplicationController
   # PUT /orders/:id/purchase
   def purchase
     @order.being_purchased_by_admin = facility_ability.can?(:act_as, @order.facility)
-    @order.ordered_at = build_order_date if ordering_on_behalf_with_date_params?
+
+    order_purchaser.backdate_to = build_order_date if ordering_on_behalf_with_date_params?
+
     @order.transaction do
       @order.assign_attributes(order_params)
       order_purchaser.purchase!

--- a/app/services/order_purchaser.rb
+++ b/app/services/order_purchaser.rb
@@ -1,6 +1,8 @@
 class OrderPurchaser
 
   attr_reader :acting_as, :order, :order_in_past, :params, :user
+  attr_accessor :backdate_to
+
   alias acting_as? acting_as
   alias order_in_past? order_in_past
 
@@ -17,6 +19,8 @@ class OrderPurchaser
 
   def purchase!
     return if order_detail_updater.update! && quantities_changed?
+
+    order.ordered_at = backdate_to if backdate_to
 
     validate_and_purchase!
     order_in_the_past! if order_in_past?

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -558,6 +558,22 @@ RSpec.describe OrdersController do
         expect(assigns[:order].reload.ordered_at).to match_date Time.zone.now
       end
 
+      it "does not ordered_at when quantities change" do
+        @order.validate_order!
+        maybe_grant_always_sign_in :director
+        switch_to @staff
+
+        @params.merge!(
+          "quantity#{@order_detail.id}" => 5,
+          "order_date" => "09/30/2016",
+          "order_time" => { "hour" =>"4", "minute" => "0", "ampm" =>"PM" }
+        )
+        do_request
+
+        expect(@order.reload.state).not_to eq("purchased")
+        expect(@order.ordered_at).to be_blank
+      end
+
       context "setting status of order details" do
         before :each do
           maybe_grant_always_sign_in :director

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -558,7 +558,7 @@ RSpec.describe OrdersController do
         expect(assigns[:order].reload.ordered_at).to match_date Time.zone.now
       end
 
-      it "does not ordered_at when quantities change" do
+      it "does not set ordered_at when quantities change" do
         @order.validate_order!
         maybe_grant_always_sign_in :director
         switch_to @staff

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -566,7 +566,7 @@ RSpec.describe OrdersController do
         @params.merge!(
           "quantity#{@order_detail.id}" => 5,
           "order_date" => "09/30/2016",
-          "order_time" => { "hour" =>"4", "minute" => "0", "ampm" =>"PM" }
+          "order_time" => { "hour" => "4", "minute" => "0", "ampm" => "PM" },
         )
         do_request
 


### PR DESCRIPTION
Here's how to replicate:

* Order as another user
* Open the "More options" so you can see the order date fields
* Change the quantity
* Click "Purchase"
* You'll see "Quantities have changed. Please review updated prices then click "Purchase".", however the date set in "More options" will be stored as the ordered_at date, even though the order has not been purchased.

Also, UIC #121346

This is some pretty gnarly code (I’m pretty sure I wrote it :frowning:), and it didn’t seem worth more time than I had already spent on tracking down the issue.