### PR TITLE
[#128124193 128124365 128124381] Add instrument down send mail button

### DIFF
--- a/app/views/instruments/schedule.html.haml
+++ b/app/views/instruments/schedule.html.haml
@@ -36,6 +36,8 @@
         method: :put,
         class: "btn-add"
 
+    = render_view_hook "after_offline_toggle"
+
 - if @admin_reservations.empty?
   %p.notice= t(".no_upcoming_admin_reservations")
 

--- a/vendor/engines/bulk_email/app/assets/stylesheets/bulk_email/application.scss
+++ b/vendor/engines/bulk_email/app/assets/stylesheets/bulk_email/application.scss
@@ -1,6 +1,7 @@
 #bulk_email {
   input[type=submit] {
-    float: left !important;
+    float: none;
+    margin-bottom: 0;
   }
 
 }

--- a/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
+++ b/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
@@ -64,14 +64,16 @@ module BulkEmail
     end
 
     def delivery_success_path
+      return_path_from_params || facility_bulk_email_path
+    end
+
+    def return_path_from_params
       return_path = params[:return_path].presence
-      if return_path && Rails.application.routes.recognize_path(return_path)
-        return_path
-      else
-        facility_bulk_email_path
-      end
+      return_path if return_path &&
+                     return_path.starts_with?("/") &&
+                     Rails.application.routes.recognize_path(return_path)
     rescue ActionController::RoutingError
-      facility_bulk_email_path
+      nil
     end
 
     def init_delivery_form

--- a/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
+++ b/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
@@ -68,6 +68,9 @@ module BulkEmail
     end
 
     def return_path_from_params
+      # This controller accepts an optional return_path param to redirect to
+      # after a successful mail queueup. This returns that param value if it is
+      # a valid application path, or nil if not.
       return_path = params[:return_path].presence
       return_path if return_path &&
                      return_path.starts_with?("/") &&

--- a/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
+++ b/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
@@ -64,7 +64,14 @@ module BulkEmail
     end
 
     def delivery_success_path
-      params[:return_path].presence || facility_bulk_email_path
+      return_path = params[:return_path].presence
+      if return_path && Rails.application.routes.recognize_path(return_path)
+        return_path
+      else
+        facility_bulk_email_path
+      end
+    rescue ActionController::RoutingError
+      facility_bulk_email_path
     end
 
     def init_delivery_form

--- a/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
+++ b/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
@@ -41,7 +41,7 @@ module BulkEmail
     def deliver
       if @delivery_form.deliver_all
         flash[:notice] = text("bulk_email.delivery.success", count: @delivery_form.recipient_ids.count)
-        redirect_to facility_bulk_email_path
+        redirect_to delivery_success_path
       else
         flash[:error] = text("bulk_email.delivery.failure")
         @users = User.where_ids_in(@delivery_form.recipient_ids)
@@ -60,7 +60,11 @@ module BulkEmail
     end
 
     def cancel_params
-      @cancel_params ||= params.slice(:start_date, :end_date, :bulk_email, :products)
+      @cancel_params ||= params.slice(:start_date, :end_date, :bulk_email, :products, :return_path)
+    end
+
+    def delivery_success_path
+      params[:return_path].presence || facility_bulk_email_path
     end
 
     def init_delivery_form

--- a/vendor/engines/bulk_email/app/helpers/bulk_email/application_helper.rb
+++ b/vendor/engines/bulk_email/app/helpers/bulk_email/application_helper.rb
@@ -6,6 +6,7 @@ module BulkEmail
 
     def admin_instrument_send_mail_path(instrument)
       facility_bulk_email_path(
+        bulk_email: { user_types: ["customers"] },
         products: [instrument.id],
         start_date: l(Date.today, format: :usa),
         end_date: l(7.days.from_now.to_date, format: :usa),

--- a/vendor/engines/bulk_email/app/helpers/bulk_email/application_helper.rb
+++ b/vendor/engines/bulk_email/app/helpers/bulk_email/application_helper.rb
@@ -9,6 +9,7 @@ module BulkEmail
         products: [instrument.id],
         start_date: l(Date.today, format: :usa),
         end_date: l(7.days.from_now.to_date, format: :usa),
+        return_path: facility_instrument_schedule_path(current_facility, instrument),
       )
     end
 

--- a/vendor/engines/bulk_email/app/helpers/bulk_email/application_helper.rb
+++ b/vendor/engines/bulk_email/app/helpers/bulk_email/application_helper.rb
@@ -1,0 +1,17 @@
+module BulkEmail
+
+  module ApplicationHelper
+
+    include Rails.application.routes.url_helpers
+
+    def admin_instrument_send_mail_path(instrument)
+      facility_bulk_email_path(
+        products: [instrument.id],
+        start_date: l(Date.today, format: :usa),
+        end_date: l(7.days.from_now.to_date, format: :usa),
+      )
+    end
+
+  end
+
+end

--- a/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_fields.html.haml
+++ b/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_fields.html.haml
@@ -3,7 +3,7 @@
   .row
     .span3
       - @user_types.each do |user_type, label_text|
-        = label_tag(user_type, class: "checkbox") do
+        = label_tag(nil, class: "checkbox") do
           = check_box_tag "bulk_email[user_types][]",
             user_type,
             user_type_selected?(user_type),

--- a/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_fields.html.haml
+++ b/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_fields.html.haml
@@ -26,3 +26,6 @@
   .row
     .span8
       = f.submit text("shared.search"), class: "btn"
+      - if params[:return_path].present?
+        = link_to t("shared.cancel"), params[:return_path]
+        = hidden_field_tag "return_path", params[:return_path]

--- a/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_results.html.haml
+++ b/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_results.html.haml
@@ -1,6 +1,9 @@
 = form_tag facility_bulk_email_path, method: :post, id: "bulk_email_create" do
   = hidden_field_tag :format, :csv
 
+  - if params[:return_path].present?
+    = hidden_field_tag :return_path, params[:return_path]
+
   .results_header
     .span1.select_all_none= select_all_link(start_none: true)
 

--- a/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_results.html.haml
+++ b/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_results.html.haml
@@ -7,15 +7,14 @@
   .results_header
     .span1.select_all_none= select_all_link(start_none: true)
 
-    - if current_ability.can?(:deliver, BulkEmail)
-      = safe_join(@searcher.search_params_as_hidden_fields)
+    .span2.pull-right
+      - if current_ability.can?(:deliver, BulkEmail)
+        = safe_join(@searcher.search_params_as_hidden_fields)
 
-      .span1.pull-right
         = submit_tag t("bulk_email.compose_mail"),
           data: { format: :html },
           class: "btn btn-primary js--bulk-email-submit-button js--bulk-email-compose-button"
 
-    .span1.pull-right
       = submit_tag t("bulk_email.export"),
         data: { format: :csv },
         class: "btn btn-primary js--bulk-email-submit-button js--bulk-email-download-csv-button"

--- a/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/create.html.haml
+++ b/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/create.html.haml
@@ -13,6 +13,9 @@
   - @users.each do |user|
     = hidden_field_tag "bulk_email_delivery_form[recipient_ids][]", user.id, id: nil
 
+  - if params[:return_path].present?
+    = hidden_field_tag :return_path, params[:return_path]
+
   .span8
     = label_tag text("bulk_email.recipients")
     .well= @users.map(&:email).join(", ")

--- a/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/create.html.haml
+++ b/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/create.html.haml
@@ -7,7 +7,7 @@
 %h2= t("bulk_email.title")
 
 = content_for :sidebar do
-  = render "admin/shared/sidenav_users", sidenav_tab: "email"
+  = render "admin/shared/sidenav_users", sidenav_tab: "bulk_email"
 
 = simple_form_for @delivery_form, method: :post, url: facility_bulk_email_deliver_path do |f|
   - @users.each do |user|

--- a/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/search.html.haml
+++ b/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/search.html.haml
@@ -8,7 +8,7 @@
 %h2= t("bulk_email.title")
 
 = content_for :sidebar do
-  = render "admin/shared/sidenav_users", sidenav_tab: "email"
+  = render "admin/shared/sidenav_users", sidenav_tab: "bulk_email"
 
 = render "fields"
 

--- a/vendor/engines/bulk_email/app/views/bulk_email/instruments/_send_mail_button.html.haml
+++ b/vendor/engines/bulk_email/app/views/bulk_email/instruments/_send_mail_button.html.haml
@@ -1,0 +1,4 @@
+= link_to t("bulk_email.send_mail"),
+  admin_instrument_send_mail_path(@instrument),
+  method: :get,
+  class: "btn-add"

--- a/vendor/engines/bulk_email/config/locales/en.yml
+++ b/vendor/engines/bulk_email/config/locales/en.yml
@@ -4,7 +4,6 @@ en:
     user_type:
       customers: Customers
       account_owners: Account Owners
-      customers_and_account_owners: Customers and Account Owners
       authorized_users: Authorized Users
     dates:
       label: Order or Reservation between

--- a/vendor/engines/bulk_email/lib/bulk_email/engine.rb
+++ b/vendor/engines/bulk_email/lib/bulk_email/engine.rb
@@ -5,6 +5,7 @@ module BulkEmail
     config.to_prepare do
       ::AbilityExtensionManager.extensions << "BulkEmail::AbilityExtension"
       ViewHook.add_hook "admin.shared.sidenav_users", "after_facility_users", "bulk_email/admin/bulk_email_tab"
+      ViewHook.add_hook "instruments.schedule", "after_offline_toggle", "bulk_email/instruments/send_mail_button"
     end
 
   end

--- a/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
+++ b/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
@@ -143,6 +143,7 @@ RSpec.describe BulkEmail::BulkEmailController do
   describe "POST #deliver" do
     let(:recipients) { FactoryGirl.create_list(:user, 3) }
     let(:custom_message) { "Custom message" }
+    let(:return_path) { nil }
 
     before(:each) do
       @action = "deliver"
@@ -152,6 +153,7 @@ RSpec.describe BulkEmail::BulkEmailController do
         custom_message: custom_message,
         recipient_ids: recipients.map(&:id),
       }
+      @params[:return_path] = return_path if return_path.present?
 
       sign_in @admin
       do_request
@@ -160,9 +162,27 @@ RSpec.describe BulkEmail::BulkEmailController do
     context "when the form is valid" do
       let(:custom_subject) { "Custom subject" }
 
-      it "submits successfully" do
-        is_expected.to redirect_to(facility_bulk_email_path)
-        expect(flash[:notice]).to include("3 email messages queued")
+      context "when no return_path param specified" do
+        it "submits successfully" do
+          is_expected.to redirect_to(facility_bulk_email_path)
+          expect(flash[:notice]).to include("3 email messages queued")
+        end
+      end
+
+      context "with a routable return_path param" do
+        let(:return_path) { facility_instruments_path(facility) }
+
+        it "redirects to the path specified in the param" do
+          is_expected.to redirect_to(return_path)
+        end
+      end
+
+      context "with a non-routable return_path param" do
+        let(:return_path) { "a bad return path value" }
+
+        it "falls back to redirecting to the bulk email path" do
+          is_expected.to redirect_to(facility_bulk_email_path)
+        end
       end
     end
 

--- a/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
+++ b/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
@@ -177,6 +177,14 @@ RSpec.describe BulkEmail::BulkEmailController do
         end
       end
 
+      context "with a return_path param set to a full URL" do
+        let(:return_path) { "http://example.net/" }
+
+        it "falls back to redirecting to the bulk email path" do
+          is_expected.to redirect_to(facility_bulk_email_path)
+        end
+      end
+
       context "with a non-routable return_path param" do
         let(:return_path) { "a bad return path value" }
 


### PR DESCRIPTION
This adds a "send mail" button to the instrument admin screen to the right of the online/offline toggle button. When clicked, it sends the user into the bulk email flow with the current instrument selected and a range of the next seven days filled-in as start and end dates.

If canceled from the recipient search screen, the user should be sent back to instrument admin.
After a successful send action, the user should be sent back to instrument admin.
If canceled on the mail composition screen, the user is sent back to the recipient search screen as before, and canceling from there should bring the user back to instrument admin.

As before, the user does not get redirected on CSV export though we may want to rethink that.