### PR TITLE
[#128124251] Add links to select date ranges for bulk email recipient search

### DIFF
--- a/vendor/engines/bulk_email/app/assets/stylesheets/bulk_email/application.scss
+++ b/vendor/engines/bulk_email/app/assets/stylesheets/bulk_email/application.scss
@@ -6,6 +6,10 @@
 
 }
 
+.bulk_email_search_actions {
+  margin-top: 15px;
+}
+
 #bulk_email_create {
   .select_all_none {
     margin-left: 0;

--- a/vendor/engines/bulk_email/app/helpers/bulk_email/application_helper.rb
+++ b/vendor/engines/bulk_email/app/helpers/bulk_email/application_helper.rb
@@ -15,6 +15,14 @@ module BulkEmail
       )
     end
 
+    def date_range_selection_link(translation_key, params, start_date: Date.today, end_date: Date.today)
+      link_to(
+        text(translation_key, scope: "bulk_email.dates.range"),
+        params.merge(start_date: format_usa_date(start_date),
+                     end_date: format_usa_date(end_date)),
+      )
+    end
+
   end
 
 end

--- a/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_fields.html.haml
+++ b/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_fields.html.haml
@@ -25,6 +25,17 @@
 
   .row
     .span8
+      = text("bulk_email.dates.select_range")
+      = date_range_selection_link :last_90_days, params, start_date: 90.days.ago
+      ,
+      = date_range_selection_link :in_the_last_year, params, start_date: 1.year.ago
+      ,
+      = date_range_selection_link :next_month, params,
+        start_date: 1.month.from_now.beginning_of_month,
+        end_date: 1.month.from_now.end_of_month
+
+  .row.bulk_email_search_actions
+    .span8
       = f.submit text("shared.search"), class: "btn"
       - if params[:return_path].present?
         = link_to t("shared.cancel"), params[:return_path]

--- a/vendor/engines/bulk_email/config/locales/en.yml
+++ b/vendor/engines/bulk_email/config/locales/en.yml
@@ -9,6 +9,11 @@ en:
       label: Order or Reservation between
       start: Starting
       end: Ending
+      select_range: Select dates
+      range:
+        last_90_days: within the last 90 days
+        in_the_last_year: in the last year
+        next_month: during the next month
     no_results: No users found
     compose_mail: Compose Mail
     export: Export


### PR DESCRIPTION
This includes #782; the feature is in 59046c3.

This adds 3 links that fill in the bulk email recipient search form with some possibly useful date ranges: the last 90 days, the last year, and next month. I expect these to change after client feedback.

These are real links, not JavaScript-driven. I considered JS, but making them standard links updates the recipient list more or less for free.
