### PR TITLE
[#125701] External user statements view

### DIFF
--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -34,7 +34,7 @@ class StatementsController < ApplicationController
 
   def init_account
     # CanCan will make sure that we're authorizing the account
-    @account = Account.find(params[:id] || params[:account_id])
+    @account = Account.find(params[:account_id])
   end
 
   #

--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -15,7 +15,7 @@ class StatementsController < ApplicationController
 
   # GET /accounts/:id/statements
   def index
-    @statements = @account.statements.paginate(page: params[:page])
+    @statements = @account.statements.uniq.paginate(page: params[:page])
   end
 
   # GET /accounts/:account_id/statements/:id
@@ -42,10 +42,8 @@ class StatementsController < ApplicationController
     @account = Account.find(params[:account_id])
   end
 
-  #
-  # Override CanCan's find -- it won't properly search by 'recent'
   def init_statement
-    @statement = Statement.find_by(id: params[:id], account_id: @account.id)
+    @statement = Statement.find_by!(id: params[:id], account_id: @account.id)
     @facility = @statement.facility
   end
 

--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -4,7 +4,7 @@ class StatementsController < ApplicationController
   before_action :authenticate_user!
   before_action :check_acting_as
   before_action :init_account
-  before_action :init_statement
+  before_action :init_statement, only: [:show]
 
   load_and_authorize_resource
 
@@ -13,22 +13,12 @@ class StatementsController < ApplicationController
     super
   end
 
-  # GET /accounts/:account_id/facilities/:facility_id/statements/:id
+  # GET /accounts/:account_id/statements/:id
   def show
     action = "show"
     @active_tab = "accounts"
 
-    case params[:id]
-    when "recent"
-      @order_details = @account.order_details.for_facility_with_price_policy(@facility)
-      @order_details = @order_details.paginate(page: params[:page])
-    when "list"
-      action = "list"
-      @statements = @statements.paginate(page: params[:page])
-    end
-
     respond_to do |format|
-      format.html { render action: action }
       format.pdf do
         @statement_pdf = StatementPdfFactory.instance(@statement, params[:show].blank?)
         render action: "show"
@@ -44,21 +34,14 @@ class StatementsController < ApplicationController
 
   def init_account
     # CanCan will make sure that we're authorizing the account
-    @account = Account.find(params[:account_id])
+    @account = Account.find(params[:id] || params[:account_id])
   end
 
   #
   # Override CanCan's find -- it won't properly search by 'recent'
   def init_statement
-    @facility = Facility.find_by_url_name!(params[:facility_id])
-    @statements = @account.statements.where(facility_id: @facility.id)
-
-    @statement = if params[:id] =~ /\w+/i
-                   @statements.blank? ? Statement.find_by_facility_id(@facility.id) : @statements.first
-                 else
-                   @account.statements.find(params[:id])
-                 end
-    @statement = Statement.new if @statement.nil?
+    @statement = Statement.find(params[:id])
+    @facility = @statement.facility
   end
 
 end

--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -13,6 +13,12 @@ class StatementsController < ApplicationController
     super
   end
 
+  # GET /accounts/:id/statements
+  def index
+    @order_details = @account.order_details.has_statement.by_statemented_at
+    @date_range_field = "journal_or_statement_date"
+  end
+
   # GET /accounts/:account_id/statements/:id
   def show
     action = "show"
@@ -40,7 +46,7 @@ class StatementsController < ApplicationController
   #
   # Override CanCan's find -- it won't properly search by 'recent'
   def init_statement
-    @statement = Statement.find(params[:id])
+    @statement = @account.statements.find(params[:id])
     @facility = @statement.facility
   end
 

--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -46,7 +46,7 @@ class StatementsController < ApplicationController
   #
   # Override CanCan's find -- it won't properly search by 'recent'
   def init_statement
-    @statement = @account.statements.find(params[:id])
+    @statement = Statement.find_by(id: params[:id], account_id: @account.id)
     @facility = @statement.facility
   end
 

--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -15,8 +15,7 @@ class StatementsController < ApplicationController
 
   # GET /accounts/:id/statements
   def index
-    @order_details = @account.order_details.has_statement.by_statemented_at
-    @date_range_field = "journal_or_statement_date"
+    @statements = @account.statements.paginate(page: params[:page])
   end
 
   # GET /accounts/:account_id/statements/:id

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -96,7 +96,6 @@ class OrderDetail < ActiveRecord::Base
   ## TODO validate which fields can be edited for which states
 
   scope :by_ordered_at, -> { joins(:order).order("orders.ordered_at DESC") }
-  scope :by_statemented_at, -> { joins(:statement).order("statements.created_at DESC") }
   scope :batch_updatable, -> { where(dispute_at: nil, state: %w(new inprocess)) }
   scope :new_or_inprocess, lambda {
     where(state: %w(new inprocess))
@@ -283,7 +282,6 @@ class OrderDetail < ActiveRecord::Base
       .where(orders: { facility_id: facility.id })
       .where.not(statement_id: nil)
   }
-  scope :has_statement, -> { where.not(statement_id: nil) }
 
   scope :non_reservations, -> { joins(:product).where("products.type <> 'Instrument'") }
   scope :reservations, -> { joins(:product).where("products.type = 'Instrument'") }

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -96,6 +96,7 @@ class OrderDetail < ActiveRecord::Base
   ## TODO validate which fields can be edited for which states
 
   scope :by_ordered_at, -> { joins(:order).order("orders.ordered_at DESC") }
+  scope :by_statemented_at, -> { joins(:statement).order("statements.created_at DESC") }
   scope :batch_updatable, -> { where(dispute_at: nil, state: %w(new inprocess)) }
   scope :new_or_inprocess, lambda {
     where(state: %w(new inprocess))
@@ -282,6 +283,7 @@ class OrderDetail < ActiveRecord::Base
       .where(orders: { facility_id: facility.id })
       .where.not(statement_id: nil)
   }
+  scope :has_statement, -> { where.not(statement_id: nil) }
 
   scope :non_reservations, -> { joins(:product).where("products.type <> 'Instrument'") }
   scope :reservations, -> { joins(:product).where("products.type = 'Instrument'") }

--- a/app/views/accounts/transactions.html.haml
+++ b/app/views/accounts/transactions.html.haml
@@ -10,4 +10,4 @@
 #header_billing.grid_9
   = render :partial => 'shared/transactions/search'
 .clearfix
-= render :partial => 'shared/transactions/table'
+= render :partial => 'shared/transactions/table', locals: { show_statements: true }

--- a/app/views/facility_statements/index.html.haml
+++ b/app/views/facility_statements/index.html.haml
@@ -6,30 +6,4 @@
 
 %h2= t(".head")
 
-- if @statements.empty?
-  %p.notice= t(".no_statements")
-- else
-  %table.table.table-striped.table-hover
-    %thead
-      %tr
-        %th= Statement.human_attribute_name(:invoice_number)
-        %th= Statement.human_attribute_name(:created_at)
-        %th= Statement.human_attribute_name(:sent_to)
-        %th= Account.model_name.human
-        %th.currency # of #{Order.model_name.human.pluralize}
-        %th.currency= Statement.human_attribute_name(:total_cost)
-        %th= Statement.human_attribute_name(:status)
-    %tbody
-      - @statements.each do |s|
-        %tr
-          %td.centered
-            = "##{s.invoice_number}"
-            %br
-            = link_to t("statements.pdf.download"), statement_path(s)
-          %td= human_datetime(s.created_at)
-          %td= s.account.notify_users.map(&:full_name).join(', ')
-          %td= link_to s.account, facility_account_path(current_facility, s.account)
-          %td.currency=h s.order_details.count
-          %td.currency= number_to_currency(s.total_cost)
-          %td= t("statements.reconciled.#{s.reconciled?}")
-  = will_paginate(@statements)
+= render partial: 'shared/statements_table', locals: { admin_view: true }

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -1,0 +1,48 @@
+- if @statements.empty?
+  %p.notice= t(".no_statements")
+- else
+  %table.table.table-striped.table-hover
+    %thead
+      %tr
+        %th= Statement.human_attribute_name(:invoice_number)
+        %th= Statement.human_attribute_name(:created_at)
+        %th= Statement.human_attribute_name(:sent_to)
+        - if local_assigns[:admin_view]
+          %th= Account.model_name.human
+        - else
+          %th= Facility.model_name.human
+          %th= OrderDetail.human_attribute_name("description")
+        %th.currency # of #{Order.model_name.human.pluralize}
+        %th.currency= Statement.human_attribute_name(:total_cost)
+        %th= Statement.human_attribute_name(:status)
+        %th= Statement.model_name.human
+    %tbody
+      - @statements.each do |s|
+        %tr
+          %td.centered
+            = "##{s.invoice_number}"
+            %br
+            = link_to t("statements.pdf.download"), statement_path(s)
+          %td= human_datetime(s.created_at)
+          %td= s.account.notify_users.map(&:full_name).join(', ')
+          - if local_assigns[:admin_view]
+            %td= link_to s.account, facility_account_path(current_facility, s.account)
+          - else
+            %td= s.facility.name
+            %td.user-order-detail
+              - order_detail = s.order_details.first
+              .order-detail-description
+                = order_detail_description(order_detail)
+                - order_detail.extend PriceDisplayment
+                = "(#{order_detail.wrapped_quantity})".html_safe unless order_detail.problem?
+                - if order_detail.reservation
+                  %br
+                  %em= order_detail.reservation
+              - if order_detail.note.present?
+                .order-detail-extra.order-detail-note= "Note: #{order_detail.note}"
+          %td.currency=h s.order_details.count
+          %td.currency= number_to_currency(s.total_cost)
+          %td= t("statements.reconciled.#{s.reconciled?}")
+          %td
+            = link_to "Download", account_statement_path(s.account, s, format: :pdf)
+  = will_paginate(@statements)

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -11,11 +11,9 @@
           %th= Account.model_name.human
         - else
           %th= Facility.model_name.human
-          %th= OrderDetail.human_attribute_name("description")
         %th.currency # of #{Order.model_name.human.pluralize}
         %th.currency= Statement.human_attribute_name(:total_cost)
         %th= Statement.human_attribute_name(:status)
-        %th= Statement.model_name.human
     %tbody
       - @statements.each do |s|
         %tr
@@ -29,20 +27,8 @@
             %td= link_to s.account, facility_account_path(current_facility, s.account)
           - else
             %td= s.facility.name
-            %td.user-order-detail
-              - order_detail = s.order_details.first
-              .order-detail-description
-                = order_detail_description(order_detail)
-                - order_detail.extend PriceDisplayment
-                = "(#{order_detail.wrapped_quantity})".html_safe unless order_detail.problem?
-                - if order_detail.reservation
-                  %br
-                  %em= order_detail.reservation
-              - if order_detail.note.present?
-                .order-detail-extra.order-detail-note= "Note: #{order_detail.note}"
           %td.currency=h s.order_details.count
           %td.currency= number_to_currency(s.total_cost)
           %td= t("statements.reconciled.#{s.reconciled?}")
-          %td
-            = link_to "Download", account_statement_path(s.account, s, format: :pdf)
+
   = will_paginate(@statements)

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -20,7 +20,8 @@
           %td.centered
             = "##{s.invoice_number}"
             %br
-            = link_to t("statements.pdf.download"), statement_path(s)
+            - path = local_assigns[:admin_view] ? statement_path(s) : account_statement_path(s.account, s, format: :pdf)
+            = link_to t("statements.pdf.download"), path
           %td= human_datetime(s.created_at)
           %td= s.account.notify_users.map(&:full_name).join(', ')
           - if local_assigns[:admin_view]

--- a/app/views/shared/_tabnav_account.html.haml
+++ b/app/views/shared/_tabnav_account.html.haml
@@ -1,7 +1,6 @@
 %ul.nav.nav-tabs
   = tab t('shared.tabnav_account.details'), account_path(@account), (secondary_tab == 'details')
   = tab t('shared.tabnav_account.transact'), transactions_account_path(@account), (secondary_tab == 'transactions')
-  - if @facility && @account.class.using_statements?
-    = tab t('shared.tabnav_account.statement'), account_facility_statement_path(@account, @facility, 'list'), (secondary_tab == 'statements')
-  = tab t('shared.tabnav_account.statement'), account_statements_path(@account), (secondary_tab == 'statements')
+  - if @account.class.using_statements?
+    = tab t('shared.tabnav_account.statement'), account_statements_path(@account), (secondary_tab == 'statements')
   = tab t('shared.tabnav_account.members'), account_account_users_path(@account), (secondary_tab == 'members')

--- a/app/views/shared/_tabnav_account.html.haml
+++ b/app/views/shared/_tabnav_account.html.haml
@@ -3,4 +3,5 @@
   = tab t('shared.tabnav_account.transact'), transactions_account_path(@account), (secondary_tab == 'transactions')
   - if @facility && @account.class.using_statements?
     = tab t('shared.tabnav_account.statement'), account_facility_statement_path(@account, @facility, 'list'), (secondary_tab == 'statements')
+  = tab t('shared.tabnav_account.statement'), account_statements_path(@account), (secondary_tab == 'statements')
   = tab t('shared.tabnav_account.members'), account_account_users_path(@account), (secondary_tab == 'members')

--- a/app/views/shared/transactions/_table.html.haml
+++ b/app/views/shared/transactions/_table.html.haml
@@ -27,6 +27,6 @@
     .row
       .span12= yield :action_instructions
     .row
-      .span12= render :partial => 'shared/transactions/table_inside', :locals => { :order_details => order_details, :show_statements => local_assigns[:show_statements] }
+      .span12= render partial: 'shared/transactions/table_inside', locals: { order_details: order_details, show_statements: local_assigns[:show_statements] }
 
 

--- a/app/views/shared/transactions/_table.html.haml
+++ b/app/views/shared/transactions/_table.html.haml
@@ -27,6 +27,6 @@
     .row
       .span12= yield :action_instructions
     .row
-      .span12= render :partial => 'shared/transactions/table_inside', :locals => { :order_details => order_details }
+      .span12= render :partial => 'shared/transactions/table_inside', :locals => { :order_details => order_details, :show_statements => local_assigns[:show_statements] }
 
 

--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -18,6 +18,8 @@
         %th= Account.human_attribute_name("owner")
       %th.currency= OrderDetail.human_attribute_name("cost")
       %th= OrderDetail.human_attribute_name("order_status")
+      - if local_assigns[:show_statements]
+        %th= Statement.model_name.human
   %tbody
     - order_details.each do |order_detail|
       %tr{ class: row_class(order_detail) }
@@ -58,4 +60,6 @@
           - order_detail.send(:extend, PriceDisplayment)
           = order_detail.wrapped_total
         %td.nowrap= order_detail.order_status
+        - if local_assigns[:show_statements]
+          %td= link_to "Download", account_statement_path(@account, order_detail.statement, format: :pdf) if order_detail.statement
 = will_paginate(order_details) if order_details.respond_to? :total_pages

--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -61,5 +61,5 @@
           = order_detail.wrapped_total
         %td.nowrap= order_detail.order_status
         - if local_assigns[:show_statements]
-          %td= link_to "Download", account_statement_path(@account, order_detail.statement, format: :pdf) if order_detail.statement
+          %td= link_to "Download", account_statement_path(@account, order_detail.statement_id, format: :pdf) if order_detail.statement
 = will_paginate(order_details) if order_details.respond_to? :total_pages

--- a/app/views/statements/index.html.haml
+++ b/app/views/statements/index.html.haml
@@ -1,18 +1,42 @@
 = content_for :tabnav do
-  = render :partial => 'shared/tabnav_account', :locals => {:secondary_tab => 'transactions'}
-= content_for :h1 do
-  = t('.h1')
+  = render :partial => 'shared/tabnav_account', :locals => {:secondary_tab => 'statements'}
+  = content_for :h1 do
+    = t_my(Statement)
 
-- if @facilities.empty?
-  %p.notice= t('.notice')
-- else
-  %table.table.table-striped.table-hover
-    %thead
-      %tr
-        %th= Facility.model_name.human
-        %th.centered= t('.th.total')
-    %tbody
-      - @facilities.each do |facility|
+  - if @order_details.empty?
+    %p.notice= "You do not have any #{Statement.model_name.human.pluralize.downcase}."
+  - else
+    = will_paginate(@order_details) if @order_details.respond_to? :total_pages
+    %table.table.table-striped.table-hover.dense.old-table
+      %thead
         %tr
-          %td= facility
-          %td.currency= link_to number_to_currency(@account.unreconciled_total(facility)), account_facility_statement_path(@account, facility, 'recent')
+          %th= Order.model_name.human
+          %th= OrderDetail.model_name.human
+          %th.nowrap= OrderDetail.human_attribute_name(@date_range_field)
+          %th= OrderDetail.human_attribute_name("description")
+          %th= OrderDetail.human_attribute_name("user")
+          %th.currency= OrderDetail.human_attribute_name("cost")
+          %th= Statement.model_name.human
+      %tbody
+        - @order_details.each do |order_detail|
+          %tr{ class: row_class(order_detail) }
+            %td.nowrap= link_to order_detail.order.id, order_path(order_detail.order)
+            %td.nowrap= link_to order_detail.id, order_order_detail_path(order_detail.order, order_detail)
+            %td= order_detail.send(:"#{@date_range_field}").try(:strftime, "%m/%d/%Y")
+            %td.user-order-detail
+              .order-detail-description
+                = order_detail_description(order_detail)
+                - order_detail.extend PriceDisplayment
+                = "(#{order_detail.wrapped_quantity})".html_safe unless order_detail.problem?
+                - if order_detail.reservation
+                  %br
+                  %em= order_detail.reservation
+              - if order_detail.note.present?
+                .order-detail-extra.order-detail-note= "Note: #{order_detail.note}"
+            %td= order_detail.order.user.full_name
+            %td.currency
+              - order_detail.send(:extend, PriceDisplayment)
+              = order_detail.wrapped_total
+            %td
+              = link_to "Download", account_statement_path(@account, order_detail.statement, format: :pdf)
+    = will_paginate(@order_details) if @order_details.respond_to? :total_pages

--- a/app/views/statements/index.html.haml
+++ b/app/views/statements/index.html.haml
@@ -3,40 +3,4 @@
   = content_for :h1 do
     = t_my(Statement)
 
-  - if @order_details.empty?
-    %p.notice= "You do not have any #{Statement.model_name.human.pluralize.downcase}."
-  - else
-    = will_paginate(@order_details) if @order_details.respond_to? :total_pages
-    %table.table.table-striped.table-hover.dense.old-table
-      %thead
-        %tr
-          %th= Order.model_name.human
-          %th= OrderDetail.model_name.human
-          %th.nowrap= OrderDetail.human_attribute_name(@date_range_field)
-          %th= OrderDetail.human_attribute_name("description")
-          %th= OrderDetail.human_attribute_name("user")
-          %th.currency= OrderDetail.human_attribute_name("cost")
-          %th= Statement.model_name.human
-      %tbody
-        - @order_details.each do |order_detail|
-          %tr{ class: row_class(order_detail) }
-            %td.nowrap= link_to order_detail.order.id, order_path(order_detail.order)
-            %td.nowrap= link_to order_detail.id, order_order_detail_path(order_detail.order, order_detail)
-            %td= order_detail.send(:"#{@date_range_field}").try(:strftime, "%m/%d/%Y")
-            %td.user-order-detail
-              .order-detail-description
-                = order_detail_description(order_detail)
-                - order_detail.extend PriceDisplayment
-                = "(#{order_detail.wrapped_quantity})".html_safe unless order_detail.problem?
-                - if order_detail.reservation
-                  %br
-                  %em= order_detail.reservation
-              - if order_detail.note.present?
-                .order-detail-extra.order-detail-note= "Note: #{order_detail.note}"
-            %td= order_detail.order.user.full_name
-            %td.currency
-              - order_detail.send(:extend, PriceDisplayment)
-              = order_detail.wrapped_total
-            %td
-              = link_to "Download", account_statement_path(@account, order_detail.statement, format: :pdf)
-    = will_paginate(@order_details) if @order_details.respond_to? :total_pages
+  = render partial: 'shared/statements_table'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Nucore::Application.routes.draw do
 
   # front-end accounts
   resources :accounts, only: [:index, :show] do
+    resources :statements, only: [:show]
     member do
       get "user_search"
       get "transactions"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Nucore::Application.routes.draw do
 
   # front-end accounts
   resources :accounts, only: [:index, :show] do
-    resources :statements, only: [:show]
+    resources :statements, only: [:show, :index]
     member do
       get "user_search"
       get "transactions"

--- a/spec/controllers/statements_controller_spec.rb
+++ b/spec/controllers/statements_controller_spec.rb
@@ -11,5 +11,23 @@ RSpec.describe StatementsController do
     @authable = create_nufs_account_with_owner
   end
 
-  # TODO: add specs for #show
+  describe "GET show" do
+    let(:user) { User.find_by(username: "owner") }
+    let(:admin) { User.find_by(username: "admin") }
+    let(:statement) { create(:statement, account_id: user.accounts.first.id, created_by: admin.id) }
+    let(:order) { create(:order, user: user, created_by: user.id) }
+    let(:product) { create(:setup_item) }
+    let(:order_detail) { create(:order_detail, statement: statement, product: product, order: order) }
+
+    before do
+      sign_in user
+      get :show, account_id: user.accounts.first.id, id: statement.id, format: :pdf
+    end
+
+    it "renders a PDF" do
+      puts response.to_a
+      expect(response.code).to eq("200")
+      expect(response.headers["Content-Type"]).to eq("application/pdf; charset=utf-8")
+    end
+  end
 end

--- a/spec/controllers/statements_controller_spec.rb
+++ b/spec/controllers/statements_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe StatementsController do
     let(:user) { User.find_by(username: "owner") }
     let(:admin) { User.find_by(username: "admin") }
     let(:statement) { create(:statement, account_id: user.accounts.first.id, created_by: admin.id) }
-    let(:order) { create(:order, user: user, created_by: user.id) }
+    let(:order) { create(:order, user: user, created_by: user.id, account_id: user.accounts.first.id) }
     let(:product) { create(:setup_item) }
     let(:order_detail) { create(:order_detail, statement: statement, product: product, order: order) }
 
@@ -25,7 +25,6 @@ RSpec.describe StatementsController do
     end
 
     it "renders a PDF" do
-      puts response.to_a
       expect(response.code).to eq("200")
       expect(response.headers["Content-Type"]).to eq("application/pdf; charset=utf-8")
     end


### PR DESCRIPTION
https://pm.tablexi.com/issues/125701

This gives users a column to download their statements for transactions if available. I made this part of the transactions table, so the users still had the benefits of search to find their statements. The link only shows if they have a statement to view. 