### PR TITLE
[#130689] Updates grouped options for select

### DIFF
--- a/app/models/bundle.rb
+++ b/app/models/bundle.rb
@@ -5,23 +5,13 @@ class Bundle < Product
 
   def products_for_group_select
     products = facility.products.where.not(type: "Bundle").order(:type, :name)
-    current_group = []
-    current_opts  = []
-    groups = []
+    groups = products.map {|x| x.class.name.pluralize}
+    options = {}
+    groups.map {|x| options[x] = []}
     products.each do |p|
-      if p.class.name != current_group[0]
-        unless current_opts.empty?
-          current_group << current_opts
-          groups << current_group
-          current_group = []
-          current_opts  = []
-        end
-        current_group << p.class.name.pluralize
-      end
-      current_opts << [p.to_s_with_status, p.id]
+      options[p.class.name.pluralize] << [p.to_s_with_status, p.id]
     end
-    groups << (current_group << current_opts) unless current_opts.empty?
-    groups
+    options
   end
 
   def products_active?

--- a/app/models/bundle.rb
+++ b/app/models/bundle.rb
@@ -5,10 +5,9 @@ class Bundle < Product
 
   def products_for_group_select
     products = facility.products.where.not(type: "Bundle").order(:type, :name)
-    options = {}
+    options = Hash.new { |h, k| h[k] = [] }
     products.group_by { |p| p.class.name.pluralize }.each do |cname, products|
-      options[cname] ||= []
-      products.map {|p| options[cname] << [p.to_s_with_status, p.id]}
+      options[cname] = products.map { |p| [p.to_s_with_status, p.id] }
     end
     options
   end

--- a/app/models/bundle.rb
+++ b/app/models/bundle.rb
@@ -5,11 +5,10 @@ class Bundle < Product
 
   def products_for_group_select
     products = facility.products.where.not(type: "Bundle").order(:type, :name)
-    groups = products.map {|x| x.class.name.pluralize}
     options = {}
-    groups.map {|x| options[x] = []}
-    products.each do |p|
-      options[p.class.name.pluralize] << [p.to_s_with_status, p.id]
+    products.group_by { |p| p.class.name.pluralize }.each do |cname, products|
+      options[cname] ||= []
+      products.map {|p| options[cname] << [p.to_s_with_status, p.id]}
     end
     options
   end

--- a/app/models/bundle.rb
+++ b/app/models/bundle.rb
@@ -6,8 +6,8 @@ class Bundle < Product
   def products_for_group_select
     products = facility.products.where.not(type: "Bundle").order(:type, :name)
     options = Hash.new { |h, k| h[k] = [] }
-    products.group_by { |p| p.class.name.pluralize }.each do |cname, products|
-      options[cname] = products.map { |p| [p.to_s_with_status, p.id] }
+    products.group_by { |product| product.class.name.pluralize }.each do |cname, ps|
+      options[cname] = ps.map { |p| [p.to_s_with_status, p.id] }
     end
     options
   end


### PR DESCRIPTION
https://pm.tablexi.com/issues/130689

This updates the grouped options for select for the bundle products to properly group them under a single parent.