### PR TITLE
[#132076] Allows admin to add optional category to reservation

### DIFF
--- a/app/controllers/facility_reservations_controller.rb
+++ b/app/controllers/facility_reservations_controller.rb
@@ -80,8 +80,6 @@ class FacilityReservationsController < ApplicationController
       end
     end
 
-    @reservation.assign_category_attribute(session_user, params[:reservation])
-
     Reservation.transaction do
       begin
         @reservation.save_as_user!(session_user)
@@ -157,6 +155,7 @@ class FacilityReservationsController < ApplicationController
     set_windows
 
     @reservation.assign_times_from_params(params[:admin_reservation])
+    @reservation.assign_category_attribute(session_user, params[:reservation])
     @reservation.admin_note = params[:admin_reservation][:admin_note]
 
     if @reservation.save

--- a/app/controllers/facility_reservations_controller.rb
+++ b/app/controllers/facility_reservations_controller.rb
@@ -80,6 +80,8 @@ class FacilityReservationsController < ApplicationController
       end
     end
 
+    @reservation.assign_category_attribute(session_user, params[:reservation])
+
     Reservation.transaction do
       begin
         @reservation.save_as_user!(session_user)

--- a/app/controllers/facility_reservations_controller.rb
+++ b/app/controllers/facility_reservations_controller.rb
@@ -155,8 +155,8 @@ class FacilityReservationsController < ApplicationController
     set_windows
 
     @reservation.assign_times_from_params(params[:admin_reservation])
-    @reservation.assign_category_attribute(session_user, params[:reservation])
     @reservation.admin_note = params[:admin_reservation][:admin_note]
+    @reservation.category = params[:admin_reservation][:category]
 
     if @reservation.save
       flash[:notice] = "The reservation has been updated successfully."

--- a/app/helpers/facility_reservations_helper.rb
+++ b/app/helpers/facility_reservations_helper.rb
@@ -5,12 +5,11 @@ module FacilityReservationsHelper
   end
 
   def admin_category_collection
-    I18n.t("reservations.categories").invert.to_a
+    I18n.t("admin_reservations.categories").invert.to_a
   end
 
   def reservation_category_label(reservation)
-    scope = reservation.is_a?(OfflineReservation) ? "offline_reservations.categories" : "reservations.categories"
-    I18n.t(reservation.category.presence, scope: scope, default: "")
+    I18n.t(reservation.category.presence, scope: "#{reservation.class.name.underscore}s.categories", default: "")
   end
 
   def reservation_links(reservation)

--- a/app/helpers/facility_reservations_helper.rb
+++ b/app/helpers/facility_reservations_helper.rb
@@ -4,8 +4,13 @@ module FacilityReservationsHelper
     I18n.t("offline_reservations.categories").invert.to_a
   end
 
-  def reservation_category_label(category)
-    I18n.t(category.presence, scope: "offline_reservations.categories", default: "")
+  def admin_category_collection
+    I18n.t("reservations.categories").invert.to_a
+  end
+
+  def reservation_category_label(reservation)
+    scope = reservation.is_a?(OfflineReservation) ? "offline_reservations.categories" : "reservations.categories"
+    I18n.t(reservation.category.presence, scope: scope, default: "")
   end
 
   def reservation_links(reservation)

--- a/app/models/admin_reservation.rb
+++ b/app/models/admin_reservation.rb
@@ -2,6 +2,8 @@ class AdminReservation < Reservation
 
   include ActiveModel::ForbiddenAttributesProtection
 
+  validates :category, presence: true
+
   belongs_to :product
 
   # TODO: Move admin parts of Reservation here

--- a/app/models/admin_reservation.rb
+++ b/app/models/admin_reservation.rb
@@ -17,4 +17,8 @@ class AdminReservation < Reservation
 
   # TODO: Move admin parts of Reservation here
 
+  def admin?
+    true
+  end
+
 end

--- a/app/models/admin_reservation.rb
+++ b/app/models/admin_reservation.rb
@@ -2,8 +2,6 @@ class AdminReservation < Reservation
 
   include ActiveModel::ForbiddenAttributesProtection
 
-  validates :category, presence: true
-
   belongs_to :product
 
   # TODO: Move admin parts of Reservation here

--- a/app/models/admin_reservation.rb
+++ b/app/models/admin_reservation.rb
@@ -2,7 +2,18 @@ class AdminReservation < Reservation
 
   include ActiveModel::ForbiddenAttributesProtection
 
+  CATEGORIES = %w(
+    maintenance
+    training
+    reserved_for_staff
+    instrument_unavailable
+    other
+  ).freeze
+
   belongs_to :product
+
+  validates :category,
+            inclusion: { in: CATEGORIES, allow_blank: true }
 
   # TODO: Move admin parts of Reservation here
 

--- a/app/models/offline_reservation.rb
+++ b/app/models/offline_reservation.rb
@@ -6,6 +6,8 @@ class OfflineReservation < Reservation
 
   validates :admin_note, presence: true
   validates :category, presence: true
+  validates :category,
+            inclusion: { in: CATEGORIES, allow_blank: false }
 
   belongs_to :product
 

--- a/app/models/reports/instrument_unavailable_export_raw.rb
+++ b/app/models/reports/instrument_unavailable_export_raw.rb
@@ -42,7 +42,7 @@ module Reports
         end_time: :reserve_end_at,
         total_minutes: -> (reservation) { formatted_total_minutes(reservation) },
         admin_note: :admin_note,
-        category: -> (reservation) { reservation_category_label(reservation.category) },
+        category: -> (reservation) { reservation_category_label(reservation) },
       }
     end
 

--- a/app/models/reports/instrument_unavailable_report.rb
+++ b/app/models/reports/instrument_unavailable_report.rb
@@ -48,7 +48,7 @@ module Reports
         [
           res.product.name,
           res.type.to_s.sub(/Reservation\z/, ""),
-          reservation_category_label(res.category),
+          reservation_category_label(res),
         ]
       end
     end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -2,7 +2,13 @@ require "date"
 
 class Reservation < ActiveRecord::Base
 
-  # Constants
+  include DateHelper
+  include Reservations::DateSupport
+  include Reservations::Validations
+  include Reservations::Rendering
+  include Reservations::RelaySupport
+  include Reservations::MovingUp
+
   CATEGORIES = %w(
     maintenance
     training
@@ -10,13 +16,6 @@ class Reservation < ActiveRecord::Base
     instrument_unavailable
     other
   ).freeze
-
-  include DateHelper
-  include Reservations::DateSupport
-  include Reservations::Validations
-  include Reservations::Rendering
-  include Reservations::RelaySupport
-  include Reservations::MovingUp
 
   # Associations
   #####
@@ -166,10 +165,6 @@ class Reservation < ActiveRecord::Base
   def assign_actuals_off_reserve
     self.actual_start_at ||= reserve_start_at
     self.actual_end_at   ||= reserve_end_at
-  end
-
-  def assign_category_attribute(user, params)
-    assign_attributes(category: params[:category]) if user.operator_of?(product.facility)
   end
 
   def save_as_user(user)

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -9,14 +9,6 @@ class Reservation < ActiveRecord::Base
   include Reservations::RelaySupport
   include Reservations::MovingUp
 
-  CATEGORIES = %w(
-    maintenance
-    training
-    reserved_for_staff
-    instrument_unavailable
-    other
-  ).freeze
-
   # Associations
   #####
   belongs_to :product

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -2,6 +2,15 @@ require "date"
 
 class Reservation < ActiveRecord::Base
 
+  # Constants
+  CATEGORIES = %w(
+    maintenance
+    training
+    reserved_for_staff
+    instrument_unavailable
+    other
+  ).freeze
+
   include DateHelper
   include Reservations::DateSupport
   include Reservations::Validations
@@ -157,6 +166,10 @@ class Reservation < ActiveRecord::Base
   def assign_actuals_off_reserve
     self.actual_start_at ||= reserve_start_at
     self.actual_end_at   ||= reserve_end_at
+  end
+
+  def assign_category_attribute(user, params)
+    assign_attributes(category: params[:category]) if user.operator_of?(product.facility)
   end
 
   def save_as_user(user)

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -21,14 +21,6 @@ module Reservations::Validations
 
     validate :starts_before_ends
     validate :duration_is_interval
-
-    validates :category,
-              inclusion: { in: -> (r) { r.class::CATEGORIES }, allow_blank: true },
-              if: -> (r) { r.class.const_defined?(:CATEGORIES) }
-
-    validates :category,
-              absence: true,
-              unless: -> (r) { r.class.const_defined?(:CATEGORIES) || r.admin? }
   end
 
   # Validation Methods

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -28,7 +28,7 @@ module Reservations::Validations
 
     validates :category,
               absence: true,
-              unless: -> (r) { r.class.const_defined?(:CATEGORIES) }
+              unless: -> (r) { r.class.const_defined?(:CATEGORIES) || r.admin? }
   end
 
   # Validation Methods

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -23,7 +23,7 @@ module Reservations::Validations
     validate :duration_is_interval
 
     validates :category,
-              inclusion: { in: -> (r) { r.class::CATEGORIES }, allow_blank: false },
+              inclusion: { in: -> (r) { r.class::CATEGORIES }, allow_blank: true },
               if: -> (r) { r.class.const_defined?(:CATEGORIES) }
 
     validates :category,

--- a/app/views/facility_reservations/_reservation_fields.html.haml
+++ b/app/views/facility_reservations/_reservation_fields.html.haml
@@ -1,4 +1,7 @@
 - if @reservation.admin_editable?
+  .control-group
+    = f.input :category do
+      = f.select :category, options_for_select(Reservation::CATEGORIES.map {|c| [t("reservations.categories.#{c}"), c]}, f.object.category), include_blank: "Select a Category"
   .datetime-block
     = f.input :reserve_start_date, input_html: { class: "datepicker" }
     .control-group

--- a/app/views/facility_reservations/_reservation_fields.html.haml
+++ b/app/views/facility_reservations/_reservation_fields.html.haml
@@ -1,7 +1,8 @@
 - if @reservation.admin_editable?
-  .control-group
-    = f.input :category do
-      = f.select :category, options_for_select(Reservation::CATEGORIES.map {|c| [t("reservations.categories.#{c}"), c]}, f.object.category), include_blank: "Select a Category"
+  - if @reservation.admin?
+    .control-group
+      = f.input :category do
+        = f.select :category, options_for_select(Reservation::CATEGORIES.map {|c| [t("reservations.categories.#{c}"), c]}, f.object.category), include_blank: "Select a Category"
   .datetime-block
     = f.input :reserve_start_date, input_html: { class: "datepicker" }
     .control-group

--- a/app/views/facility_reservations/_reservation_fields.html.haml
+++ b/app/views/facility_reservations/_reservation_fields.html.haml
@@ -2,7 +2,7 @@
   - if @reservation.admin?
     .control-group
       = f.input :category do
-        = f.select :category, options_for_select(Reservation::CATEGORIES.map {|c| [t("reservations.categories.#{c}"), c]}, f.object.category), include_blank: "Select a Category"
+        = f.select :category, options_for_select(admin_category_collection, f.object.category), include_blank: "Select a Category"
   .datetime-block
     = f.input :reserve_start_date, input_html: { class: "datepicker" }
     .control-group

--- a/app/views/instruments/schedule.html.haml
+++ b/app/views/instruments/schedule.html.haml
@@ -69,7 +69,7 @@
               = link_to reservation,
                 facility_instrument_reservation_edit_admin_path(current_facility, @instrument, reservation)
 
-            %td= reservation_category_label(reservation.category)
+            %td= reservation_category_label(reservation)
             %td= reservation.admin_note
 
           - else
@@ -80,7 +80,7 @@
               %td
                 = link_to reservation,
                   edit_facility_instrument_offline_reservation_path(current_facility, @instrument, reservation)
-              %td= reservation_category_label(reservation.category)
+              %td= reservation_category_label(reservation)
               %td= reservation.admin_note
 
 %h3= t(".reservations_calendar")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -528,6 +528,14 @@ en:
     new:
       mark_offline: Take instrument offline
 
+  admin_reservations:
+    categories:
+      maintenance: Maintenance
+      training: Training
+      reserved_for_staff: Reserved For Staff
+      instrument_unavailable: Instrument Unavailable
+      other: Other
+
   order_management:
     order_details:
       edit:
@@ -538,12 +546,6 @@ en:
       add_button: Add %{group}
 
   reservations:
-    categories:
-      maintenance: Maintenance
-      training: Training
-      reserved_for_staff: Reserved For Staff
-      instrument_unavailable: Instrument Unavailable
-      other: Other
     logout:
       body: "You will be logged out automatically in 60 seconds. Would you like to remain logged in?"
       cancel: "Stay logged in"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -538,6 +538,12 @@ en:
       add_button: Add %{group}
 
   reservations:
+    categories:
+      maintenance: Maintenance
+      training: Training
+      reserved_for_staff: Reserved For Staff
+      instrument_unavailable: Instrument Unavailable
+      other: Other
     logout:
       body: "You will be logged out automatically in 60 seconds. Would you like to remain logged in?"
       cancel: "Stay logged in"

--- a/spec/controllers/reports/instrument_unavailable_reports_controller_spec.rb
+++ b/spec/controllers/reports/instrument_unavailable_reports_controller_spec.rb
@@ -54,11 +54,13 @@ RSpec.describe Reports::InstrumentUnavailableReportsController do
             FactoryGirl.create(:admin_reservation,
                                product: instruments.first,
                                reserve_start_at: (date_start + 2.days).beginning_of_day,
-                               duration: 1.day)
+                               duration: 1.day,
+                               category: nil)
             FactoryGirl.create(:admin_reservation,
                                product: instruments.third,
                                reserve_start_at: (date_start + 1.day).beginning_of_day,
-                               duration: 3.days)
+                               duration: 3.days,
+                               category: nil)
             xhr(:get, :index, params)
           end
 

--- a/spec/factories/reservations.rb
+++ b/spec/factories/reservations.rb
@@ -59,7 +59,7 @@ FactoryGirl.define do
 
   factory :admin_reservation, class: AdminReservation, parent: :reservation do
     order_detail nil
-    category { Reservation::CATEGORIES.sample }
+    category { AdminReservation::CATEGORIES.sample }
   end
 
   factory :offline_reservation, class: OfflineReservation, parent: :reservation do

--- a/spec/factories/reservations.rb
+++ b/spec/factories/reservations.rb
@@ -59,6 +59,7 @@ FactoryGirl.define do
 
   factory :admin_reservation, class: AdminReservation, parent: :reservation do
     order_detail nil
+    category { Reservation::CATEGORIES.sample }
   end
 
   factory :offline_reservation, class: OfflineReservation, parent: :reservation do

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Reservation do
   end
 
   describe "validations" do
-    it { is_expected.to validate_absence_of :category }
+    it { is_expected.to validate_inclusion_of(:category).in_array(Reservation::CATEGORIES) }
   end
 
   describe ".upcoming_offline", :timecop_freeze do
@@ -1085,6 +1085,28 @@ RSpec.describe Reservation do
   end
 
   context "basic reservation rules" do
+    context "category" do
+      before do
+        reservation.assign_category_attribute(user, { category: "maintenance" })
+      end
+
+      context "when facility operator" do
+        let(:user) { create(:user, :administrator) }
+
+        it "should assign category attribute" do
+          expect(reservation.category).to eq("maintenance")
+        end
+      end
+
+      context "when not facility operator" do
+        let(:user) { create(:user) }
+
+        it "should not assign category attribute" do
+          expect(reservation.category).to be_nil
+        end
+      end
+    end
+
     it "should not allow reservations starting before now" do
       @earlier = Date.today - 1
       @reservation = @instrument.reservations.create(reserve_start_date: @earlier, reserve_start_hour: 10,

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -29,7 +29,13 @@ RSpec.describe Reservation do
   end
 
   describe "validations" do
-    it { is_expected.to validate_inclusion_of(:category).in_array(AdminReservation::CATEGORIES) }
+    it { is_expected.to validate_absence_of :category }
+
+    context "when admin reservation" do
+      before { allow(reservation).to receive(:admin?).and_return(true) }
+
+      it { is_expected.not_to validate_absence_of :category }
+    end
   end
 
   describe ".upcoming_offline", :timecop_freeze do

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Reservation do
   end
 
   describe "validations" do
-    it { is_expected.to validate_inclusion_of(:category).in_array(Reservation::CATEGORIES) }
+    it { is_expected.to validate_inclusion_of(:category).in_array(AdminReservation::CATEGORIES) }
   end
 
   describe ".upcoming_offline", :timecop_freeze do

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -28,16 +28,6 @@ RSpec.describe Reservation do
     allow_any_instance_of(Reservation).to receive(:admin?).and_return(false)
   end
 
-  describe "validations" do
-    it { is_expected.to validate_absence_of :category }
-
-    context "when admin reservation" do
-      before { allow(reservation).to receive(:admin?).and_return(true) }
-
-      it { is_expected.not_to validate_absence_of :category }
-    end
-  end
-
   describe ".upcoming_offline", :timecop_freeze do
     subject { described_class.upcoming_offline(1.year.from_now) }
     let(:now) { Time.current }

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1087,7 +1087,7 @@ RSpec.describe Reservation do
   context "basic reservation rules" do
     context "category" do
       before do
-        reservation.assign_category_attribute(user, { category: "maintenance" })
+        reservation.assign_category_attribute(user, category: "maintenance")
       end
 
       context "when facility operator" do

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1085,27 +1085,6 @@ RSpec.describe Reservation do
   end
 
   context "basic reservation rules" do
-    context "category" do
-      before do
-        reservation.assign_category_attribute(user, category: "maintenance")
-      end
-
-      context "when facility operator" do
-        let(:user) { create(:user, :administrator) }
-
-        it "should assign category attribute" do
-          expect(reservation.category).to eq("maintenance")
-        end
-      end
-
-      context "when not facility operator" do
-        let(:user) { create(:user) }
-
-        it "should not assign category attribute" do
-          expect(reservation.category).to be_nil
-        end
-      end
-    end
 
     it "should not allow reservations starting before now" do
       @earlier = Date.today - 1


### PR DESCRIPTION
https://pm.tablexi.com/issues/132076

This allows adding a category on the admin side to a reservation, to indicate blocking off an instrument for a certain period of time.