### PR TITLE
[#132794] Get rid of unnecessary error and bang method

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -427,7 +427,7 @@ class OrderDetail < ActiveRecord::Base
     new_state = new_status.state_name
     # don't try to change state if it's not a valid state or it's the same as it was before
     if OrderDetail.aasm.states.map(&:name).include?(new_state) && new_state != state.to_sym
-      raise AASM::InvalidTransition, "Event '#{new_state}' cannot transition from '#{state}'" unless send("to_#{new_state}!")
+      send("to_#{new_state}")
     end
     # don't try to change status if it's the same as before
     unless new_status == order_status

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -727,6 +727,16 @@ RSpec.describe OrderDetail do
       end
 
     end
+
+    describe "invalid quantity" do
+      it "should not transition to complete" do
+        @order_detail.quantity = 0
+        expect {
+          @order_detail.change_status!(OrderStatus.complete_status)
+        }.to raise_error(ActiveRecord::RecordInvalid)
+        expect(@order_detail.reload.state).to eq("new")
+      end
+    end
   end
 
   context "statement" do

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -729,11 +729,10 @@ RSpec.describe OrderDetail do
     end
 
     describe "invalid quantity" do
-      it "should not transition to complete" do
+      it "does not transition to complete" do
         @order_detail.quantity = 0
-        expect {
-          @order_detail.change_status!(OrderStatus.complete_status)
-        }.to raise_error(ActiveRecord::RecordInvalid)
+        expect { @order_detail.change_status!(OrderStatus.complete_status) }
+          .to raise_error(ActiveRecord::RecordInvalid)
         expect(@order_detail.reload.state).to eq("new")
       end
     end


### PR DESCRIPTION
The signature of the `AASM::InvalidTransition` changed in the new
version, but we weren’t hitting this code (because it should be truly
exceptional) so we didn’t know. Then we tried to update a quantity to
zero, and this blew up.

The save! happens shortly after this, so here we only need to do one
save (hence getting rid of the bang).