### PR TITLE
Left-align bulk email buttons on the recipient search result screen

### DIFF
--- a/vendor/engines/bulk_email/app/assets/stylesheets/bulk_email/application.scss
+++ b/vendor/engines/bulk_email/app/assets/stylesheets/bulk_email/application.scss
@@ -10,6 +10,10 @@
   margin-top: 15px;
 }
 
+.bulk_email_buttons {
+  direction: rtl;
+}
+
 #bulk_email_create {
   .select_all_none {
     margin-left: 0;

--- a/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_results.html.haml
+++ b/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_results.html.haml
@@ -7,7 +7,7 @@
   .results_header
     .span1.select_all_none= select_all_link(start_none: true)
 
-    .span2.pull-right
+    .bulk_email_buttons.span3.pull-right
       - if current_ability.can?(:deliver, BulkEmail)
         = safe_join(@searcher.search_params_as_hidden_fields)
 


### PR DESCRIPTION
This should fix a button layout issue I didn't see until testing with nucore-nu's skin.

Here's the "before":

<kbd>![screen shot 2016-10-17 at 4 22 24 pm](https://cloud.githubusercontent.com/assets/46662/19456219/03d5fec0-9486-11e6-962c-8c4f6d7f12d4.png)</kbd>

And the "after":

<kbd>![screen shot 2016-10-17 at 4 22 44 pm](https://cloud.githubusercontent.com/assets/46662/19456225/0ad1739e-9486-11e6-93a0-056ef6e936a1.png)</kbd>

Using `direction: rtl` felt weird but it works, and also removes excess right-padding we got when not displaying the "Compose Mail" button (that is all non-global-admins, for now). I picked it up from http://stackoverflow.com/a/26493444.