### PR TITLE
[#98768] Hiding cancelled orders with cost

### DIFF
--- a/app/helpers/timeline_helper.rb
+++ b/app/helpers/timeline_helper.rb
@@ -12,7 +12,7 @@ module TimelineHelper
     classes << "admin" if reservation.admin?
     classes << "behalf_of" if reservation.ordered_on_behalf_of?
     classes << "in_progress" if reservation.can_switch_instrument?
-    classes << "status_#{status(reservation)}" if reservation.order_detail
+    classes << "status_#{display_status_class(reservation)}" if reservation.order_detail
     classes.concat spans_midnight_class(reservation.reserve_start_at, reservation.reserve_end_at)
     classes.join(" ")
   end
@@ -67,7 +67,7 @@ module TimelineHelper
     @public_timeline ||= false
   end
 
-  def status(reservation)
+  def display_status_class(reservation)
     reservation.canceled_at ? "canceled" : reservation.order_detail.order_status.to_s.downcase
   end
 

--- a/app/helpers/timeline_helper.rb
+++ b/app/helpers/timeline_helper.rb
@@ -12,7 +12,7 @@ module TimelineHelper
     classes << "admin" if reservation.admin?
     classes << "behalf_of" if reservation.ordered_on_behalf_of?
     classes << "in_progress" if reservation.can_switch_instrument?
-    classes << "status_#{reservation.order_detail.order_status.to_s.downcase}" if reservation.order_detail
+    classes << "status_#{status(reservation)}" if reservation.order_detail
     classes.concat spans_midnight_class(reservation.reserve_start_at, reservation.reserve_end_at)
     classes.join(" ")
   end
@@ -65,6 +65,10 @@ module TimelineHelper
 
   def public_timeline?
     @public_timeline ||= false
+  end
+
+  def status(reservation)
+    reservation.canceled_at ? "canceled" : reservation.order_detail.order_status.to_s.downcase
   end
 
 end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -875,7 +875,7 @@ class OrderDetail < ActiveRecord::Base
     fee = cancellation_fee
     self.actual_cost = fee
     self.actual_subsidy = 0
-    change_status!(fee > 0 ? OrderStatus.canceled.first : order_status)
+    change_status!(fee > 0 ? OrderStatus.complete.first : order_status)
     save! if changed? # If the cancel goes from complete => complete, change status doesn't save
     true
   end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -875,7 +875,7 @@ class OrderDetail < ActiveRecord::Base
     fee = cancellation_fee
     self.actual_cost = fee
     self.actual_subsidy = 0
-    change_status!(fee > 0 ? OrderStatus.complete.first : order_status)
+    change_status!(fee > 0 ? OrderStatus.canceled.first : order_status)
     save! if changed? # If the cancel goes from complete => complete, change status doesn't save
     true
   end


### PR DESCRIPTION
https://pm.tablexi.com/issues/98768

We want cancelled orders with cost to have a canceled status, not complete, and this fixes that; then they no longer show in the daily view schedule. 