### PR TITLE
[#132309] Do not auto-assign pricing when using the popup

### DIFF
--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -53,6 +53,8 @@ class OrderDetails::ParamUpdater
 
     assign_attributes(params)
 
+    @order_detail.manually_priced!
+
     @order_detail.transaction do
       @order_detail.reservation.save_as_user(@editing_user) if @order_detail.reservation
       if order_status_id && order_status_id.to_i != @order_detail.order_status_id

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -498,7 +498,6 @@ RSpec.describe OrderManagement::OrderDetailsController do
       end
 
       it "updates the price while changing accounts" do
-        pending "currently buggy: it uses the new account's price policy, not the params"
         @params[:order_detail] = {
           actual_cost: "20.00",
           actual_subsidy: "4.00",
@@ -543,7 +542,6 @@ RSpec.describe OrderManagement::OrderDetailsController do
       end
 
       it "updates the price while changing quantity" do
-        pending "currently buggy: it uses the price policy's calculation, not the params"
         @params[:order_detail] = {
           actual_cost: "20.00",
           actual_subsidy: "4.00",


### PR DESCRIPTION
We use an ajax call to adjust pricing in the order detail popup, so the
facility staff will see the price changes from an account change, and
they can override that pricing before submitting.