### PR TITLE
[#128124251] Add space between the greeting and body in bulk emails

### DIFF
--- a/vendor/engines/bulk_email/app/services/bulk_email/content_generator.rb
+++ b/vendor/engines/bulk_email/app/services/bulk_email/content_generator.rb
@@ -22,7 +22,7 @@ module BulkEmail
       [
         I18n.t("bulk_email.body.greeting", recipient_name: recipient_name),
         reason_statement,
-      ].compact.join("\n")
+      ].compact.join("\n\n")
     end
 
     def signoff


### PR DESCRIPTION
Looking at some test email, I think it looks better and is more readable with a blank line between the greeting and body.