### PR TITLE
[#132384] Adds reconciled filter to date range field

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -345,7 +345,7 @@ class OrderDetail < ActiveRecord::Base
     search = search.joins(:journal) if action.to_sym == :journal_date
 
     # If we're searching on fulfilled_at, ignore any order details that don't have a fulfilled date
-    search = search.where("fulfilled_at IS NOT NULL") if action.to_sym == :fulfilled_at
+    search = search.where("#{action} IS NOT NULL") if action.to_sym == :fulfilled_at || :reconciled_at
 
     if start_date
       search = search.where("#{action} >= ?", start_date.beginning_of_day)

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -345,7 +345,7 @@ class OrderDetail < ActiveRecord::Base
     search = search.joins(:journal) if action.to_sym == :journal_date
 
     # If we're searching on fulfilled_at, ignore any order details that don't have a fulfilled date
-    search = search.where("#{action} IS NOT NULL") if action.to_sym == :fulfilled_at || :reconciled_at
+    search = search.where("#{action} IS NOT NULL") if [:reconciled_at, :fulfilled_at].include?(action.to_sym)
 
     if start_date
       search = search.where("#{action} >= ?", start_date.beginning_of_day)

--- a/app/services/transaction_search/date_range_searcher.rb
+++ b/app/services/transaction_search/date_range_searcher.rb
@@ -3,7 +3,7 @@ module TransactionSearch
   class DateRangeSearcher < BaseSearcher
 
     include DateHelper
-    FIELDS = %w(ordered_at fulfilled_at journal_or_statement_date).freeze
+    FIELDS = %w(ordered_at fulfilled_at reconciled_at journal_or_statement_date).freeze
 
     attr_reader :date_range_field
 

--- a/app/services/transaction_search/date_range_searcher.rb
+++ b/app/services/transaction_search/date_range_searcher.rb
@@ -3,7 +3,7 @@ module TransactionSearch
   class DateRangeSearcher < BaseSearcher
 
     include DateHelper
-    FIELDS = %w(ordered_at fulfilled_at reconciled_at journal_or_statement_date).freeze
+    FIELDS = %w(ordered_at fulfilled_at journal_or_statement_date reconciled_at).freeze
 
     attr_reader :date_range_field
 

--- a/config/locales/views/admin/en.transaction_search.yml
+++ b/config/locales/views/admin/en.transaction_search.yml
@@ -5,3 +5,4 @@ en:
         ordered_at: Ordered
         fulfilled_at: Fulfilled
         journal_or_statement_date: "Journaled/Statement"
+        reconciled_at: Reconciled


### PR DESCRIPTION
https://pm.tablexi.com/issues/132384

This allows you to use `reconciled_at` for an option on the date range search for order details.