### PR TITLE
[#132462] Fix pagination count issue

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,7 +34,6 @@ class UsersController < ApplicationController
       User
       .with_recent_orders(current_facility)
       .order(:last_name, :first_name)
-      .to_a
       .paginate(page: params[:page])
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,6 +34,7 @@ class UsersController < ApplicationController
       User
       .with_recent_orders(current_facility)
       .order(:last_name, :first_name)
+      .to_a
       .paginate(page: params[:page])
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,10 +50,9 @@ class User < ActiveRecord::Base
   end
 
   def self.with_recent_orders(facility)
-    order_query = Order.recent.for_facility(facility)
-    select("DISTINCT users.*")
+    distinct
       .joins(:orders)
-      .merge(order_query)
+      .merge(Order.recent.for_facility(facility))
   end
 
   def self.sort_last_first


### PR DESCRIPTION
https://pm.tablexi.com/issues/132462

I am guessing that this is occurring because of an ActiveRecord Relation size/count problem, due to the complex query that returns the users being counted. This seems to be an issue within the will_paginate gem (see: https://github.com/mislav/will_paginate/issues), so I don't know how much I want to do beyond this, unless we want to swap the gem out with kaminari. 

This is a hack that should fix the pagination page count issue, by turning the ActiveRecord relation into an array. 