### PR TITLE
[#132878] Fix default Sanger batch download

### DIFF
--- a/vendor/engines/sanger_sequencing/app/presenters/sanger_sequencing/well_plate_presenter.rb
+++ b/vendor/engines/sanger_sequencing/app/presenters/sanger_sequencing/well_plate_presenter.rb
@@ -7,9 +7,9 @@ module SangerSequencing
     attr_reader :well_plate, :plate_mode
     delegate :samples, to: :well_plate
 
-    def initialize(well_plate, plate_mode = :default)
+    def initialize(well_plate, plate_mode)
       @well_plate = well_plate
-      @plate_mode = plate_mode
+      @plate_mode = plate_mode.presence || :default
     end
 
     def to_csv

--- a/vendor/engines/sanger_sequencing/spec/presenters/sanger_sequencing/well_plate_presenter_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/presenters/sanger_sequencing/well_plate_presenter_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SangerSequencing::WellPlatePresenter do
     let(:sample_rows) { presenter.sample_rows }
 
     describe "for a default sanger plate" do
-      let(:presenter) { described_class.new(well_plate) }
+      let(:presenter) { described_class.new(well_plate, "") }
       let(:expected_results_group) { a_kind_of(String) }
       let(:expected_instrument_protocol) { a_kind_of(String) }
       let(:expected_analysis_protocol) { a_kind_of(String) }


### PR DESCRIPTION
The plate_mode argument is coming in as either nil or a blank string
because it’s coming from the `group` field on batches. That was causing
`NoMethodError: undefined method `keys' for #<String:0x00000009d8b6f8>`
on production, and a missing translation in development.