### PR TITLE
[#132896] Update date ranges without a page refresh

### DIFF
--- a/vendor/engines/bulk_email/app/assets/javascripts/bulk_email/bulk_email.js.coffee
+++ b/vendor/engines/bulk_email/app/assets/javascripts/bulk_email/bulk_email.js.coffee
@@ -1,6 +1,7 @@
 class window.BulkEmailSearchForm
   constructor: (@$form) ->
     @_initUserTypeChangeHandler()
+    @_initDateRangeSelectionHandlers()
 
   authorizedUsersSelectedOnly: ->
     user_types = @selectedUserTypes()
@@ -30,6 +31,13 @@ class window.BulkEmailSearchForm
     @$userTypeCheckboxes()
       .change(=> @toggleNonRestrictedProducts())
       .trigger('change')
+
+  _initDateRangeSelectionHandlers: ->
+    $(".js--bulk-email-date-range-selector").click (event) ->
+      event.preventDefault()
+      $link = $(event.target)
+      $('#bulk_email_start_date').val($link.data('startDate'))
+      $('#bulk_email_end_date').val($link.data('endDate'))
 
 class window.BulkEmailCreateForm
   constructor: (@$form) ->

--- a/vendor/engines/bulk_email/app/helpers/bulk_email/application_helper.rb
+++ b/vendor/engines/bulk_email/app/helpers/bulk_email/application_helper.rb
@@ -16,10 +16,14 @@ module BulkEmail
     end
 
     def date_range_selection_link(translation_key, params, start_date: Date.today, end_date: Date.today)
+      start_date = format_usa_date(start_date)
+      end_date = format_usa_date(end_date)
+
       link_to(
         text(translation_key, scope: "bulk_email.dates.range"),
-        params.merge(start_date: format_usa_date(start_date),
-                     end_date: format_usa_date(end_date)),
+        params.merge(start_date: start_date, end_date: end_date),
+        class: "js--bulk-email-date-range-selector",
+        data: { start_date: start_date, end_date: end_date },
       )
     end
 


### PR DESCRIPTION
This changes the behavior of the "quick links" for selecting date ranges on the bulk email recipient search screen to just update the date fields without a page reload, to preserve other form values.