### PR TITLE
[#132384] Show reconciled date on order popup

### DIFF
--- a/app/views/order_management/order_details/edit.html.haml
+++ b/app/views/order_management/order_details/edit.html.haml
@@ -45,6 +45,7 @@
         - else
           = f.label :order_status
           = @order_detail.order_status
+          = l(@order_detail.reconciled_at.to_date, format: :usa) if @order_detail.reconciled_at
 
       - if @order_detail.reservation
         .cancel-fee-option.span2


### PR DESCRIPTION
Useful after #793 which adds a `reconciled_at` filter.

Couple notes:
* Some older reconciled orders do not have `reconciled_at` because we didn't really
know when they were reconciled.
* I'm only showing the date part because most orders are reconciled via journals
which only have a date part, not a time part.