### PR TITLE
[#126819] Standardize on a general bulk email instrument offline message

### DIFF
--- a/vendor/engines/bulk_email/config/locales/en.yml
+++ b/vendor/engines/bulk_email/config/locales/en.yml
@@ -30,11 +30,13 @@ en:
     sending: Sending...
 
     product_unavailable_reason_statements:
-      out_of_order: "%{product_name} is out of order."
-      maintenance: "%{product_name} is undergoing maintenance."
-      operator_not_available: "There is no operator available for %{product_name}."
-      instrument_not_available: "%{product_name} is not available."
-      other: "%{product_name} is not available."
+      other: &standard_statement |
+        %{product_name} has been taken offline.
+        You may receive additional messages regarding the status of this instrument.
+      out_of_order: *standard_statement
+      maintenance: *standard_statement
+      operator_not_available: *standard_statement
+      instrument_not_available: *standard_statement
 
   activemodel:
     attributes:

--- a/vendor/engines/bulk_email/config/locales/en.yml
+++ b/vendor/engines/bulk_email/config/locales/en.yml
@@ -30,13 +30,9 @@ en:
     sending: Sending...
 
     product_unavailable_reason_statements:
-      other: &standard_statement |
+      other: |
         %{product_name} has been taken offline.
         You may receive additional messages regarding the status of this instrument.
-      out_of_order: *standard_statement
-      maintenance: *standard_statement
-      operator_not_available: *standard_statement
-      instrument_not_available: *standard_statement
 
   activemodel:
     attributes:

--- a/vendor/engines/bulk_email/spec/services/bulk_email/content_generator_spec.rb
+++ b/vendor/engines/bulk_email/spec/services/bulk_email/content_generator_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe BulkEmail::ContentGenerator do
 
       it "includes the instrument name with a downtime reason" do
         expect(subject.greeting)
-          .to include("#{instrument.name} is out of order")
+          .to include("#{instrument.name} has been taken offline")
       end
     end
   end


### PR DESCRIPTION
This change updates the canned text to be the same for all instrument down categories, but leaves the door open for different messages based on category if needed.