### PR TITLE
[#132895] Remove global admin check from the admin reservation listing

### DIFF
--- a/app/views/instruments/schedule.html.haml
+++ b/app/views/instruments/schedule.html.haml
@@ -73,15 +73,13 @@
             %td= reservation.admin_note
 
           - else
-
-            - if current_user.administrator? # TODO: restrict to global admins until the offline feature is complete
-              %td
-              %td= reservation.class.model_name.human
-              %td
-                = link_to reservation,
-                  edit_facility_instrument_offline_reservation_path(current_facility, @instrument, reservation)
-              %td= reservation_category_label(reservation)
-              %td= reservation.admin_note
+            %td
+            %td= reservation.class.model_name.human
+            %td
+              = link_to reservation,
+                edit_facility_instrument_offline_reservation_path(current_facility, @instrument, reservation)
+            %td= reservation_category_label(reservation)
+            %td= reservation.admin_note
 
 %h3= t(".reservations_calendar")
 


### PR DESCRIPTION
This was a missed `TODO` that should have been done as part of #795. 