### PR TITLE
[#132927] Prevent double click on Reconcile Orders

### DIFF
--- a/app/views/facility_accounts_reconciliation/_action_row.html.haml
+++ b/app/views/facility_accounts_reconciliation/_action_row.html.haml
@@ -7,4 +7,4 @@
       .controls
         = text_field_tag :reconciled_at, format_usa_date(Time.current), class: :datepicker__data, data: { min_date: unreconciled_order_details.map(&:journal_or_statement_date).min.iso8601, max_date: Time.current.iso8601 }
 
-  .span1.pull-right= submit_tag t("facility_journals.show.submit"), class: ["btn", "btn-primary"]
+  .span1.pull-right= submit_tag t("facility_journals.show.submit"), class: ["btn", "btn-primary"], data: { disable_with: "Reconciling..." }

--- a/app/views/facility_accounts_reconciliation/_action_row.html.haml
+++ b/app/views/facility_accounts_reconciliation/_action_row.html.haml
@@ -7,4 +7,4 @@
       .controls
         = text_field_tag :reconciled_at, format_usa_date(Time.current), class: :datepicker__data, data: { min_date: unreconciled_order_details.map(&:journal_or_statement_date).min.iso8601, max_date: Time.current.iso8601 }
 
-  .span1.pull-right= submit_tag t("facility_journals.show.submit"), class: ["btn", "btn-primary"], data: { disable_with: "Reconciling..." }
+  .span1.pull-right= submit_tag t("facility_journals.show.submit"), class: ["btn", "btn-primary"], data: { disable_with: t("facility_journals.show.submit") }


### PR DESCRIPTION
Pulled up from https://github.com/tablexi/nucore-nu/pull/206