### PR TITLE
[#133080] Fix translations on user create failures

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -77,7 +77,7 @@ class UsersController < ApplicationController
   def create_internal
     @user = username_lookup(params[:username])
     if @user.nil?
-      flash[:error] = I18n.t("users.search.notice1")
+      flash[:error] = text("users.search.netid_not_found")
       redirect_to facility_users_path
     elsif @user.persisted?
       flash[:error] = text("users.search.user_already_exists", username: @user.username)
@@ -85,7 +85,7 @@ class UsersController < ApplicationController
     elsif @user.save
       save_user_success
     else
-      flash[:error] = I18n.t("users.create.error")
+      flash[:error] = text("create.error", message: @user.errors.full_messages.to_sentence)
       redirect_to facility_users_path
     end
   end

--- a/config/locales/views/admin/en.users.yml
+++ b/config/locales/views/admin/en.users.yml
@@ -11,7 +11,7 @@ en:
   controllers:
     users:
       create:
-        error: There was an error creating the user.
+        error: There was an error creating the user. %{message}
         success: The user has been added successfully.
         add_role: |
           You may wish to [add a !facility_downcase! role](%{link}) for this user.

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -179,9 +179,35 @@ RSpec.describe UsersController do
           end
 
           context "user already exists" do
+            let!(:user) { FactoryGirl.create(:user) }
             before :each do
-              @user = FactoryGirl.create(:user)
-              @params[:username] = @user.username
+              @params[:username] = user.username
+              do_request
+            end
+
+            it "flashes an error" do
+              is_expected.to set_flash
+              expect(response).to redirect_to facility_users_path
+            end
+          end
+
+          describe "user not found" do
+            before do
+              @params[:username] = "doesnotexist"
+              do_request
+            end
+
+            it "flashes an error" do
+              is_expected.to set_flash
+              expect(response).to redirect_to facility_users_path
+            end
+          end
+
+          describe "user is invalid" do
+            let(:user) { build(:user, first_name: "") }
+            before do
+              allow(controller).to receive(:username_lookup).and_return user
+              @params[:username] = user.username
               do_request
             end
 


### PR DESCRIPTION
This came about because we found a couple NetIDs that share the same
email, which was causing a translation not found error. The message
will now also include any validation messages.