### PR TITLE
[#133125] Prevent creation of usernames with extra whitespace

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -183,7 +183,7 @@ class UsersController < ApplicationController
 
   def username_lookup(username)
     return nil unless username.present?
-    username_database_lookup(username) || service_username_lookup(username)
+    username_database_lookup(username.strip) || service_username_lookup(username.strip)
   end
 
   def username_database_lookup(username)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -42,6 +42,7 @@ Devise.setup do |config|
   config.authentication_keys = [:username]
 
   config.case_insensitive_keys = [:username]
+  config.strip_whitespace_keys = [:username]
 
   # The realm used in Http Basic Authentication
   # config.http_authentication_realm = "Application"


### PR DESCRIPTION
When creating a new external user, any surrounding whitespace should be
ignored when looking up the user as well as when it creates the user.

This had caused a problem for DC where one of their users was unable to
log in, and also because email and username did not match, were unable
to use the forgot password feature.