### PR TITLE
[#133153] Project not persisting on reservation creation

### DIFF
--- a/vendor/engines/projects/app/models/projects/order_extension.rb
+++ b/vendor/engines/projects/app/models/projects/order_extension.rb
@@ -5,13 +5,11 @@ module Projects
     extend ActiveSupport::Concern
 
     included do
-      before_save :assign_project_to_order_details
-      attr_accessor :project_id
+      attr_reader :project_id
     end
 
-    private
-
-    def assign_project_to_order_details
+    def project_id=(project_id)
+      @project_id = project_id
       order_details.each { |order_detail| order_detail.project_id = project_id }
     end
 

--- a/vendor/engines/projects/app/views/projects/shared/_select_project.html.haml
+++ b/vendor/engines/projects/app/views/projects/shared/_select_project.html.haml
@@ -2,9 +2,9 @@
   .hide-from-print
     = f.input :project_id, collection: order_detail.selectable_projects, input_html: { class: "js--chosen", data: { placeholder: t(".placeholder") } }, include_blank: true
   .show-for-print
-    - if f.object.project
+    - if order_detail.project
       = f.input :project_id do
-        = f.object.project.name
+        = order_detail.project.name
 
   :javascript
     ChosenActivator.activate();

--- a/vendor/engines/projects/spec/features/placing_an_order_on_a_project_spec.rb
+++ b/vendor/engines/projects/spec/features/placing_an_order_on_a_project_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe "Placing an order with a project" do
+  let!(:product) { FactoryGirl.create(:setup_item) }
+  let!(:account) { FactoryGirl.create(:nufs_account, :with_account_owner, owner: user) }
+  let(:facility) { product.facility }
+  let(:facility_admin) { FactoryGirl.create(:user, :facility_administrator, facility: facility) }
+  let!(:price_policy) do
+    FactoryGirl.create(:item_price_policy,
+                       price_group: PriceGroup.base.first, product: product,
+                       unit_cost: 33.25)
+  end
+  let!(:account_price_group_member) do
+    FactoryGirl.create(:account_price_group_member, account: account, price_group: price_policy.price_group)
+  end
+  let(:user) { FactoryGirl.create(:user) }
+  let!(:project) { FactoryGirl.create(:project, facility: facility) }
+
+  before do
+    login_as facility_admin
+    visit facility_users_path(facility)
+    fill_in "search_term", with: user.full_name
+    click_button "Search"
+    click_link "Order For"
+  end
+
+  describe "adding an item to the cart" do
+    def add_to_cart
+      click_link product.name
+      click_link "Add to cart"
+      choose account.to_s
+      click_button "Continue"
+    end
+
+    it "can place an order", :aggregate_failures do
+      add_to_cart
+      select project.name, from: "Project"
+      click_button "Purchase"
+      expect(OrderDetail.last.project).to eq(project)
+    end
+  end
+end

--- a/vendor/engines/projects/spec/features/reserving_an_instrument_on_a_project_spec.rb
+++ b/vendor/engines/projects/spec/features/reserving_an_instrument_on_a_project_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Reserving an instrument on a project" do
+  let!(:instrument) { FactoryGirl.create(:setup_instrument) }
+  let!(:facility) { instrument.facility }
+  let!(:account) { FactoryGirl.create(:nufs_account, :with_account_owner, owner: user) }
+  let!(:price_policy) { FactoryGirl.create(:instrument_price_policy, price_group: PriceGroup.base.first, product: instrument) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:facility_admin) { FactoryGirl.create(:user, :facility_administrator, facility: facility) }
+  let!(:account_price_group_member) do
+    FactoryGirl.create(:account_price_group_member, account: account, price_group: price_policy.price_group)
+  end
+  let!(:project) { FactoryGirl.create(:project, facility: facility) }
+
+  before do
+    login_as facility_admin
+    visit facility_users_path(facility)
+    fill_in "search_term", with: user.full_name
+    click_button "Search"
+    click_link "Order For"
+  end
+
+  describe "and you create a reservation" do
+    before do
+      click_link instrument.name
+      select user.accounts.first.description, from: "Payment Source"
+      select project.name, from: "Project"
+      click_button "Create"
+    end
+
+    it "returns to My Reservations" do
+      expect(page).to have_content "My Reservations"
+      expect(OrderDetail.last.project).to eq(project)
+    end
+  end
+end

--- a/vendor/engines/projects/spec/models/projects/order_extension_spec.rb
+++ b/vendor/engines/projects/spec/models/projects/order_extension_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Projects::OrderExtension do
     context "when setting it to nil" do
       let(:project_id) { nil }
 
-      it "sets the project_id on its order_details to nil on #save" do
+      it "sets the project_id on its order_details to nil" do
         order.order_details.each do |order_detail|
           expect(order_detail.project_id).to be_blank
         end
@@ -23,7 +23,7 @@ RSpec.describe Projects::OrderExtension do
 
     context "when setting it to a project_id" do
       context "that is valid for the facility" do
-        it "sets this project_id on its order_details on #save" do
+        it "sets this project_id on its order_details" do
           order.order_details.each do |order_detail|
             expect(order_detail.project_id).to eq(project_id)
           end


### PR DESCRIPTION
What was happening is the project_id was being set in the reservation
controller, but then when it redirects to Order#purchase, the
project_id was being reset to NULL.

I discovered this because the newer `.show-for-print` was erring out on
this view.

This also adds feature specs for ordering with a project.