### PR TITLE
[#130583] Match safari and chrome print styles

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -48,4 +48,14 @@
       display: none;
     }
   }
+
+  .max-width {
+    max-width: 38% !important;
+    display: inline-block !important;
+    float: left !important;
+
+    &--wide {
+      max-width: 50% !important
+    }
+  }
 }

--- a/app/views/order_management/order_details/edit.html.haml
+++ b/app/views/order_management/order_details/edit.html.haml
@@ -37,7 +37,7 @@
               method: :post
 
     .row
-      .span5= account_input(f)
+      .span5.max-width= account_input(f)
 
       .span3
         - if @order_statuses
@@ -60,16 +60,16 @@
 
     .row
       - if @order_detail.reservation
-        .span5= render "reservation", f: f, reservation: @order_detail.reservation
+        .span5.max-width= render "reservation", f: f, reservation: @order_detail.reservation
       - else
-        .span5
+        .span5.max-width
           = f.input :quantity, as: :order_detail_quantity, hint_html: { class: "help-inline" }
 
-      .span5
+      .span5.max-width.max-width--wide
         = render "costs", f: f
 
     .row
-      .span5
+      .span5.max-width
         = f.input :note, input_html: { class: "note" }
         = render "reconcile_note", f: f
 


### PR DESCRIPTION
https://pm.tablexi.com/issues/130583

This is a dumb hack that keeps the safari and chrome print styles consistent. Needs to be tested on Windows. 

If this does not work, I recommend we just use a separate print view, because using form fields as display fields in print view is not really ideal, nor are any of the column span stylings. 