### PR TITLE
[#133007] Unpurchased orders were appearing on user view

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -104,7 +104,8 @@ class UsersController < ApplicationController
     # order details for this facility
     @order_details = @user.order_details
                           .non_reservations
-                          .where("orders.facility_id = ? AND orders.ordered_at IS NOT NULL", current_facility.id)
+                          .for_facility(current_facility)
+                          .purchased
                           .order("orders.ordered_at DESC")
                           .paginate(page: params[:page])
   end


### PR DESCRIPTION
This was ultimately fixed by PR #780, where ordered_at was being set on
unpurchased orders. There were a few leftover orders still in that
state. I manually set their ordered_at to nil on prod.

This PR cleans up the scopes to use more standardized ones.