### PR TITLE
[#130772] Keep bulk email state on compose form errors

### DIFF
--- a/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
+++ b/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
@@ -61,15 +61,12 @@ module BulkEmail
     def populate_flow_state_params
       return if params[:bulk_email_delivery_form].blank?
       search_criteria = JSON.parse(params[:bulk_email_delivery_form][:search_criteria])
-      params[:product_id] ||= params[:bulk_email_delivery_form][:product_id]
-      params[:start_date] ||= search_criteria["start_date"]
-      params[:end_date] ||= search_criteria["end_date"]
-      params[:bulk_email] ||= {}
-      params[:bulk_email][:user_types] ||=
-        search_criteria["bulk_email"]["user_types"]
-      params[:products] ||= search_criteria["products"]
-      params[:recipient_ids] ||=
-        params[:bulk_email_delivery_form][:recipient_ids]
+      params[:product_id] = params[:bulk_email_delivery_form][:product_id]
+      params[:start_date] = search_criteria["start_date"]
+      params[:end_date] = search_criteria["end_date"]
+      params[:bulk_email] = { user_types: search_criteria["bulk_email"]["user_types"] }
+      params[:products] = search_criteria["products"]
+      params[:recipient_ids] = params[:bulk_email_delivery_form][:recipient_ids]
     end
 
     def bulk_email_cancel_path

--- a/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
+++ b/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
@@ -61,12 +61,8 @@ module BulkEmail
     def populate_flow_state_params
       return if params[:bulk_email_delivery_form].blank?
       search_criteria = JSON.parse(params[:bulk_email_delivery_form][:search_criteria])
-      params[:product_id] = params[:bulk_email_delivery_form][:product_id]
-      params[:start_date] = search_criteria["start_date"]
-      params[:end_date] = search_criteria["end_date"]
-      params[:bulk_email] = { user_types: search_criteria["bulk_email"]["user_types"] }
-      params[:products] = search_criteria["products"]
-      params[:recipient_ids] = params[:bulk_email_delivery_form][:recipient_ids]
+      params.merge!(search_criteria.slice("bulk_email", "start_date", "end_date", "products"))
+      params.merge!(params[:bulk_email_delivery_form].slice(:product_id, :recipient_ids))
     end
 
     def bulk_email_cancel_path

--- a/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
+++ b/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
@@ -45,7 +45,7 @@ module BulkEmail
         flash[:notice] = text("bulk_email.delivery.success", count: @delivery_form.recipient_ids.count)
         redirect_to delivery_success_path
       else
-        flash[:error] = text("bulk_email.delivery.failure")
+        flash.now[:error] = text("bulk_email.delivery.failure")
         @users = User.where_ids_in(@delivery_form.recipient_ids)
         render :create
       end

--- a/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
+++ b/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
@@ -152,7 +152,11 @@ RSpec.describe BulkEmail::BulkEmailController do
         custom_subject: custom_subject,
         custom_message: custom_message,
         recipient_ids: recipients.map(&:id),
-        search_criteria: { this: "is", a: "test" }.to_json,
+        search_criteria: {
+          start_date: "12/31/1999",
+          end_date: "1/1/2016",
+          bulk_email: { user_types: ["customers"], products: [1] },
+        }.to_json,
       }
       @params[:return_path] = return_path if return_path.present?
 


### PR DESCRIPTION
This should solve the problem of losing bulk email "state" when running into a form error on the mail compose screen. It should also clean up the issue where a flash error message generated in that case was lingering beyond where it made sense to display.

I'm not super-pleased about `#populate_flow_state_params`. I added doc, but does it deserve an extraction?