### PR TITLE
[#133346] Include boilerplate and user-entered content when logging bulk email content

### DIFF
--- a/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
+++ b/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
@@ -112,7 +112,7 @@ module BulkEmail
     end
 
     def init_delivery_form
-      @delivery_form = DeliveryForm.new(current_user, current_facility)
+      @delivery_form = DeliveryForm.new(current_user, current_facility, bulk_email_content_generator)
       @delivery_form.assign_attributes(params[:bulk_email_delivery_form])
     end
 

--- a/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
+++ b/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
@@ -73,13 +73,15 @@ module BulkEmail
       end
     end
 
+    def subject_product
+      product_id = params[:product_id].presence ||
+                   params[:bulk_email_delivery_form].try(:[], :product_id)
+      Product.find(product_id) if product_id.present?
+    end
+
     def bulk_email_content_generator
-      @content_generator ||=
-        if params[:product_id].present?
-          ContentGenerator.new(current_facility, Product.find(params[:product_id]))
-        else
-          ContentGenerator.new(current_facility)
-        end
+      @bulk_email_content_generator ||=
+        ContentGenerator.new(current_facility, subject_product)
     end
 
     def bulk_email_recipient_search_params

--- a/vendor/engines/bulk_email/app/mailers/bulk_email/mailer.rb
+++ b/vendor/engines/bulk_email/app/mailers/bulk_email/mailer.rb
@@ -2,23 +2,10 @@ module BulkEmail
 
   class Mailer < BaseMailer
 
-    def send_mail(recipient:, custom_subject:, facility:, custom_message:, product: nil)
+    def send_mail(recipient:, custom_subject:, custom_message:)
       @recipient = recipient
-      @facility = facility
-      @custom_subject = custom_subject
-      @product = product
-      @body = content_generator.wrap_text(custom_message)
-      mail(to: recipient.email, subject: subject)
-    end
-
-    def subject
-      "#{content_generator.subject_prefix} #{@custom_subject}"
-    end
-
-    private
-
-    def content_generator
-      @content_generator ||= ContentGenerator.new(@facility, @product, @recipient)
+      @body = custom_message
+      mail(to: recipient.email, subject: custom_subject)
     end
 
   end

--- a/vendor/engines/bulk_email/app/mailers/bulk_email/mailer.rb
+++ b/vendor/engines/bulk_email/app/mailers/bulk_email/mailer.rb
@@ -2,10 +2,10 @@ module BulkEmail
 
   class Mailer < BaseMailer
 
-    def send_mail(recipient:, custom_subject:, custom_message:)
+    def send_mail(recipient:, subject:, body:)
       @recipient = recipient
-      @body = custom_message
-      mail(to: recipient.email, subject: custom_subject)
+      @body = body
+      mail(to: recipient.email, subject: subject)
     end
 
   end

--- a/vendor/engines/bulk_email/app/models/bulk_email/delivery_form.rb
+++ b/vendor/engines/bulk_email/app/models/bulk_email/delivery_form.rb
@@ -35,12 +35,16 @@ module BulkEmail
 
     private
 
+    def subject
+      "#{content_generator.subject_prefix} #{custom_subject}"
+    end
+
+    def body
+      content_generator.wrap_text(custom_message)
+    end
+
     def deliver(recipient)
-      Mailer.send_mail(
-        recipient: recipient,
-        custom_subject: "#{content_generator.subject_prefix} #{custom_subject}",
-        custom_message: content_generator.wrap_text(custom_message),
-      ).deliver_later
+      Mailer.send_mail(recipient: recipient, subject: subject, body: body).deliver_later
     end
 
     def recipients
@@ -51,8 +55,8 @@ module BulkEmail
       BulkEmail::Job.create!(
         facility: facility,
         user: user,
-        subject: "#{content_generator.subject_prefix} #{custom_subject}",
-        body: content_generator.wrap_text(custom_message),
+        subject: subject,
+        body: body,
         recipients: recipients.map(&:email),
         search_criteria: search_criteria,
       )

--- a/vendor/engines/bulk_email/app/models/bulk_email/delivery_form.rb
+++ b/vendor/engines/bulk_email/app/models/bulk_email/delivery_form.rb
@@ -5,13 +5,14 @@ module BulkEmail
     include ActiveModel::Model
 
     attr_accessor :custom_subject, :custom_message, :recipient_ids, :product_id, :search_criteria
-    attr_reader :facility, :user
+    attr_reader :facility, :user, :content_generator
 
     validates :custom_subject, :custom_message, :recipient_ids, presence: true
 
-    def initialize(user, facility)
+    def initialize(user, facility, content_generator)
       @user = user
       @facility = facility
+      @content_generator = content_generator
     end
 
     def assign_attributes(params)
@@ -52,8 +53,8 @@ module BulkEmail
       BulkEmail::Job.create!(
         facility: facility,
         user: user,
-        subject: custom_subject,
-        body: custom_message,
+        subject: "#{content_generator.subject_prefix} #{custom_subject}",
+        body: content_generator.wrap_text(custom_message),
         recipients: recipients.map(&:email),
         search_criteria: search_criteria,
       )

--- a/vendor/engines/bulk_email/app/models/bulk_email/delivery_form.rb
+++ b/vendor/engines/bulk_email/app/models/bulk_email/delivery_form.rb
@@ -39,12 +39,14 @@ module BulkEmail
       "#{content_generator.subject_prefix} #{custom_subject}"
     end
 
-    def body
-      content_generator.wrap_text(custom_message)
+    def body(recipient_name = nil)
+      content_generator.wrap_text(custom_message, recipient_name)
     end
 
     def deliver(recipient)
-      Mailer.send_mail(recipient: recipient, subject: subject, body: body).deliver_later
+      Mailer
+        .send_mail(recipient: recipient, subject: subject, body: body(recipient.full_name))
+        .deliver_later
     end
 
     def recipients

--- a/vendor/engines/bulk_email/app/models/bulk_email/delivery_form.rb
+++ b/vendor/engines/bulk_email/app/models/bulk_email/delivery_form.rb
@@ -38,10 +38,8 @@ module BulkEmail
     def deliver(recipient)
       Mailer.send_mail(
         recipient: recipient,
-        custom_subject: custom_subject,
-        facility: facility,
-        custom_message: custom_message,
-        product: product,
+        custom_subject: "#{content_generator.subject_prefix} #{custom_subject}",
+        custom_message: content_generator.wrap_text(custom_message),
       ).deliver_later
     end
 

--- a/vendor/engines/bulk_email/app/services/bulk_email/content_generator.rb
+++ b/vendor/engines/bulk_email/app/services/bulk_email/content_generator.rb
@@ -2,25 +2,26 @@ module BulkEmail
 
   class ContentGenerator
 
-    attr_reader :facility, :subject_product, :recipient
+    DEFAULT_RECIPIENT_NAME = "Firstname Lastname".freeze
 
-    def initialize(facility, subject_product = nil, recipient = nil)
+    attr_reader :facility, :subject_product
+
+    def initialize(facility, subject_product = nil)
       @facility = facility
       @subject_product = subject_product
-      @recipient = recipient
     end
 
     def subject_prefix
       "[#{I18n.t('app_name')} #{facility.name}]"
     end
 
-    def wrap_text(text)
-      [greeting, text, signoff].join("\n\n")
+    def wrap_text(text, recipient_name = nil)
+      [greeting(recipient_name), text, signoff].join("\n\n")
     end
 
-    def greeting
+    def greeting(recipient_name = nil)
       [
-        I18n.t("bulk_email.body.greeting", recipient_name: recipient_name),
+        I18n.t("bulk_email.body.greeting", recipient_name: recipient_name || DEFAULT_RECIPIENT_NAME),
         reason_statement,
       ].compact.join("\n\n")
     end
@@ -37,10 +38,6 @@ module BulkEmail
              product_name: subject_product.name,
              scope: "bulk_email.product_unavailable_reason_statements",
              default: :other)
-    end
-
-    def recipient_name
-      recipient.try(:full_name) || "Firstname Lastname"
     end
 
   end

--- a/vendor/engines/bulk_email/spec/mailers/bulk_email/mailer_spec.rb
+++ b/vendor/engines/bulk_email/spec/mailers/bulk_email/mailer_spec.rb
@@ -5,21 +5,17 @@ RSpec.describe BulkEmail::Mailer do
     let(:email) { ActionMailer::Base.deliveries.last }
     let(:recipient) { FactoryGirl.build_stubbed(:user) }
     let(:custom_subject) { "Custom subject" }
-    let(:custom_message) { "Custom message" }
+    let(:body) { "Custom message" }
 
     before(:each) do
       described_class
-        .send_mail(
-          custom_message: custom_message,
-          custom_subject: custom_subject,
-          recipient: recipient,
-        )
+        .send_mail(body: body, subject: custom_subject, recipient: recipient)
         .deliver_now
     end
 
     it { expect(email.to).to eq [recipient.email] }
     it { expect(email.subject).to eq(custom_subject) }
-    it { expect(email.html_part.to_s).to include(custom_message) }
-    it { expect(email.text_part.to_s).to include(custom_message) }
+    it { expect(email.html_part.to_s).to include(body) }
+    it { expect(email.text_part.to_s).to include(body) }
   end
 end

--- a/vendor/engines/bulk_email/spec/mailers/bulk_email/mailer_spec.rb
+++ b/vendor/engines/bulk_email/spec/mailers/bulk_email/mailer_spec.rb
@@ -6,22 +6,19 @@ RSpec.describe BulkEmail::Mailer do
     let(:recipient) { FactoryGirl.build_stubbed(:user) }
     let(:custom_subject) { "Custom subject" }
     let(:custom_message) { "Custom message" }
-    let(:facility) { FactoryGirl.build_stubbed(:facility) }
-    let(:subject_prefix) { "[#{I18n.t('app_name')} #{facility.name}]" }
 
     before(:each) do
       described_class
         .send_mail(
           custom_message: custom_message,
           custom_subject: custom_subject,
-          facility: facility,
           recipient: recipient,
         )
         .deliver_now
     end
 
     it { expect(email.to).to eq [recipient.email] }
-    it { expect(email.subject).to eq "#{subject_prefix} #{custom_subject}" }
+    it { expect(email.subject).to eq(custom_subject) }
     it { expect(email.html_part.to_s).to include(custom_message) }
     it { expect(email.text_part.to_s).to include(custom_message) }
   end

--- a/vendor/engines/bulk_email/spec/models/bulk_email/delivery_form_spec.rb
+++ b/vendor/engines/bulk_email/spec/models/bulk_email/delivery_form_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.describe BulkEmail::DeliveryForm do
-  subject(:form) { described_class.new(user, facility) }
+  subject(:form) { described_class.new(user, facility, content_generator) }
+  let(:content_generator) { BulkEmail::ContentGenerator.new(facility) }
   let(:facility) { FactoryGirl.create(:facility) }
   let(:recipients) { FactoryGirl.create_list(:user, 3) }
   let(:user) { FactoryGirl.create(:user) }
@@ -22,14 +23,18 @@ RSpec.describe BulkEmail::DeliveryForm do
       form.custom_subject = "Subject line"
       form.custom_message = "Custom message"
       form.search_criteria = { this: "is", a: "test" }
+
+      allow(content_generator).to receive(:greeting).and_return("Greeting")
+      allow(content_generator).to receive(:signoff).and_return("Signoff")
+      allow(content_generator).to receive(:subject_prefix).and_return("Prefix")
     end
 
     let(:bulk_email_job) { BulkEmail::Job.last }
 
-    it "queues mail to all recipients" do
+    it "queues mail to all recipients", :aggregate_failures do
       expect { form.deliver_all }.to change(BulkEmail::Job, :count).by(1)
-      expect(bulk_email_job.subject).to eq(form.custom_subject)
-      expect(bulk_email_job.body).to eq(form.custom_message)
+      expect(bulk_email_job.subject).to eq("Prefix #{form.custom_subject}")
+      expect(bulk_email_job.body).to eq("Greeting\n\n#{form.custom_message}\n\nSignoff")
       expect(bulk_email_job.recipients).to match_array(recipients.map(&:email))
       expect(bulk_email_job.search_criteria).to match(this: "is", a: "test")
     end

--- a/vendor/engines/bulk_email/spec/services/bulk_email/content_generator_spec.rb
+++ b/vendor/engines/bulk_email/spec/services/bulk_email/content_generator_spec.rb
@@ -1,24 +1,23 @@
 require "rails_helper"
 
 RSpec.describe BulkEmail::ContentGenerator do
+  subject { described_class.new(facility) }
+
   let(:facility) { instrument.facility }
   let(:instrument) { FactoryGirl.create(:setup_instrument, :offline) }
   let(:recipient) { FactoryGirl.build(:user) }
 
   describe "#greeting" do
-    context "without a recipient" do
-      subject { described_class.new(facility) }
-
+    context "without a recipient name" do
       it "generates a greeting with a placeholder name" do
         expect(subject.greeting).to include("Firstname Lastname")
       end
     end
 
-    context "with a recipient" do
-      subject { described_class.new(facility, nil, recipient) }
-
+    context "with a recipient name" do
       it "generates a greeting with a placeholder name" do
-        expect(subject.greeting).to include(recipient.full_name)
+        expect(subject.greeting(recipient.full_name))
+          .to include(recipient.full_name)
       end
     end
 
@@ -33,14 +32,10 @@ RSpec.describe BulkEmail::ContentGenerator do
   end
 
   describe "#signoff" do
-    subject { described_class.new(facility) }
-
     it { expect(subject.signoff).to be_present }
   end
 
   describe "#subject_prefix" do
-    subject { described_class.new(facility) }
-
     it "includes the app and facility names" do
       expect(subject.subject_prefix)
         .to eq("[#{I18n.t('app_name')} #{facility.name}]")
@@ -48,7 +43,7 @@ RSpec.describe BulkEmail::ContentGenerator do
   end
 
   describe "#wrap_text" do
-    subject { described_class.new(facility, instrument, recipient) }
+    subject { described_class.new(facility, instrument) }
 
     it "wraps content with the greeting and signoff" do
       expect(subject.wrap_text("This is some text"))


### PR DESCRIPTION
This changes bulk email logging so that it includes the unalterable "canned" parts of the subject and body along with user-entered text.

As a side-effect it ended up simplifying `BulkEmail::Mailer` quite a bit.