### PR TITLE
[#133148] Accessories not getting pricing and fulfilled_at set

### DIFF
--- a/app/support/accessories/accessorizer.rb
+++ b/app/support/accessories/accessorizer.rb
@@ -76,7 +76,6 @@ class Accessories::Accessorizer
   def assign_attributes_and_save(od, params)
     od.assign_attributes(permitted_attributes(params))
     od.update_quantity # so auto-scaled overrides the parameter
-    od.order_status_id = @order_detail.order_status_id
     od.assign_estimated_price
     od.enabled = true
 
@@ -84,6 +83,9 @@ class Accessories::Accessorizer
       od.save! # do validations before trying to backdate
       od.backdate_to_complete! @order_detail.fulfilled_at
     else
+      # Cannot do this with backdate_to_complete! because then it doesn't think
+      # the status is changing.
+      od.order_status_id = @order_detail.order_status_id
       od.save!
     end
   end

--- a/spec/controllers/accessories_controller_spec.rb
+++ b/spec/controllers/accessories_controller_spec.rb
@@ -145,7 +145,8 @@ RSpec.describe AccessoriesController do
         it "creates the order detail as completed if the original is" do
           order_detail.backdate_to_complete!
           do_request
-          expect(assigns(:order_details).first).to be_complete
+          expect(assigns(:order_details).first.reload).to be_complete
+          expect(assigns(:order_details).first).to be_fulfilled_at
         end
 
         context "adding a disabled accessory" do
@@ -205,7 +206,8 @@ RSpec.describe AccessoriesController do
         it "creates the order detail as completed if the original is" do
           order_detail.backdate_to_complete!
           do_request
-          expect(assigns(:order_details).first).to be_complete
+          expect(assigns(:order_details).first.reload).to be_complete
+          expect(assigns(:order_details).first).to be_fulfilled_at
         end
 
         context "adding a disabled accessory" do


### PR DESCRIPTION
The symptom as described by NU was “there are 5 orders that are marked
as completed but have not moved to Send Notifications. The color of
their pricing is still the orange yellow and not green”.

Here is a way to reproduce:

* Complete a reservation on an instrument that has accessories
* Find the order on "All Transactions"
* Click into the order (not order detail)
* Click the + to "Add Accessories"
* Add an accessory
* The new order detail does not have a fulfilled_at or get its pricing
assigned. It also is in state "new", but it is in the correct
"Complete" order status.