### PR TITLE
[#133375] Fix access to statements for facility admin/director

### DIFF
--- a/app/controllers/facility_accounts_controller.rb
+++ b/app/controllers/facility_accounts_controller.rb
@@ -12,7 +12,7 @@ class FacilityAccountsController < ApplicationController
 
   authorize_resource :account
 
-  before_action :check_billing_access, only: [:accounts_receivable, :show_statement]
+  before_action :check_billing_access, only: [:accounts_receivable]
 
   layout "two_column"
 

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -20,7 +20,7 @@
           %td.centered
             = "##{s.invoice_number}"
             %br
-            - path = local_assigns[:admin_view] ? statement_path(s) : account_statement_path(s.account, s, format: :pdf)
+            - path = current_facility ? statement_path(s) : account_statement_path(s.account, s, format: :pdf)
             = link_to t("statements.pdf.download"), path
           %td= human_datetime(s.created_at)
           %td= s.account.notify_users.map(&:full_name).join(', ')

--- a/spec/controllers/facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_accounts_controller_spec.rb
@@ -325,19 +325,37 @@ RSpec.describe FacilityAccountsController, feature_setting: { edit_accounts: tru
       is_expected.to render_template "show_statement_list"
     end
 
-    it "should show statement PDF" do
-      @params[:statement_id] = @statement.id
-      @params[:format] = "pdf"
-      maybe_grant_always_sign_in :director
-      do_request
-      expect(assigns(:account)).to eq(@account)
-      expect(assigns(:facility)).to eq(@authable)
-      expect(assigns(:statement)).to eq(@statement)
-      expect(response.content_type).to eq("application/pdf")
-      expect(response.body).to match(/%PDF-1.\d/)
-      is_expected.to render_template "statements/show"
-    end
+    describe "show" do
+      before do
+        @params[:statement_id] = @statement.id
+        @params[:format] = "pdf"
+      end
 
+      it "shows the statement PDF for a director" do
+        maybe_grant_always_sign_in :director
+        do_request
+        expect(assigns(:account)).to eq(@account)
+        expect(assigns(:facility)).to eq(@authable)
+        expect(assigns(:statement)).to eq(@statement)
+        expect(response.content_type).to eq("application/pdf")
+        expect(response.body).to match(/%PDF-1.\d/)
+        is_expected.to render_template "statements/show"
+      end
+
+      it "does not allow an account admin" do
+        user = create(:user, :business_administrator, account: @account)
+        sign_in user
+        do_request
+        expect(response.code).to eq("403")
+      end
+
+      it "allows billing administrator to access the statement" do
+        user = create(:user, :billing_administrator)
+        sign_in user
+        do_request
+        expect(response).to be_success
+      end
+    end
   end
 
   context "suspension", if: SettingsHelper.feature_on?(:suspend_accounts) do

--- a/spec/controllers/facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_accounts_controller_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe FacilityAccountsController, feature_setting: { edit_accounts: tru
         expect(assigns(:facility)).to eq(@authable)
         expect(assigns(:statement)).to eq(@statement)
         expect(response.content_type).to eq("application/pdf")
-        expect(response.body).to match(/%PDF-1.\d/)
+        expect(response.body).to match(/\A%PDF-1.\d+\b/)
         is_expected.to render_template "statements/show"
       end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -41,7 +41,7 @@ FactoryGirl.define do
         user,
         AccountUser::ACCOUNT_ADMINISTRATOR,
         evaluator.account,
-        evaluator.administrator,
+        evaluator.administrator || user,
       )
     end
   end


### PR DESCRIPTION
Related to #784 and #787, facility staff were getting 403s when trying
to download statements. `statement_path` is a alias to
`facility_account_statement_path`.

When testing, we should make sure all of these views have access to
their statements:
* as a PI looking through “My Payment Sources” (this should be the one
place we use `account_statement_path`.
* as a facility admin, director
* Under “Statement History”
* Under “Payment Sources”…”Statements”
* as a billing admin looking under the cross facility tab under
“Statement History”