### PR TITLE
[#132637] Cart should not include merge orders

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -21,7 +21,7 @@ class Order < ActiveRecord::Base
   end
 
   def self.carts
-    where(ordered_at: nil)
+    where(ordered_at: nil, merge_with_order_id: nil)
   end
 
   def self.for_facility(facility)

--- a/app/views/facility_orders/_merge_order.html.haml
+++ b/app/views/facility_orders/_merge_order.html.haml
@@ -5,12 +5,12 @@
       %thead
         %tr
           %th
-          %th= t('orders.show.th.product')
-          %th.centered= t('orders.show.th.quantity')
-          %th.currency= t('orders.show.th.cost')
+          %th= OrderDetail.human_attribute_name(:product)
+          %th.centered= OrderDetail.human_attribute_name(:quantity)
+          %th.currency= OrderDetail.human_attribute_name(:estimated_cost)
           - if @order.has_subsidies?
-            %th.currency= t('orders.show.th.adjust')
-          %th.currency= t('orders.show.th.extend')
+            %th.currency= OrderDetail.human_attribute_name(:estimated_subsidy)
+          %th.currency= OrderDetail.human_attribute_name(:estimated_total)
 
       %tbody
         - @merge_orders.each do |order|

--- a/app/views/orders/_form.html.haml
+++ b/app/views/orders/_form.html.haml
@@ -3,12 +3,12 @@
     %thead
       %tr
         %th
-        %th= t(".th.product")
-        %th.centered= t(".th.quantity")
-        %th.currency= t(".th.cost")
-        - if order.has_subsidies?
-          %th.currency= t(".th.adjust")
-        %th.currency= t(".th.extend")
+        %th= OrderDetail.human_attribute_name(:product)
+        %th.centered= OrderDetail.human_attribute_name(:quantity)
+        %th.currency= OrderDetail.human_attribute_name(:estimated_cost)
+        - if @order.has_subsidies?
+          %th.currency= OrderDetail.human_attribute_name(:estimated_subsidy)
+        %th.currency= OrderDetail.human_attribute_name(:estimated_total)
 
     %tbody
       - grouped_order_details.each do |order_details|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -635,12 +635,6 @@ en:
         instrument: "* Instrument pricing is estimated; the final price may vary based on actual time used."
       td:
         total: Estimated Totals
-      th:
-        product: Product
-        quantity: Quantity
-        cost: Estimated Price
-        adjust: Estimated Adjustment
-        extend: Estimated Total
     receipt:
       crumbs:
         orders: "My Orders"


### PR DESCRIPTION
* As a facility staff/admin, add a service requiring an order form or a
reservation to an existing order
* You will now have a “The following order details need your
attention.“ listing
* Go to your cart
* The attention-needed order appears as your cart
* Remove the order detail
* Get `orders#remove (RuntimeError) "Can't modify frozen hash”` error

What was happening:
* The Order is destroyed by OrderDetailObserver#after_destroy
* In OrdersController#remove, we trying to set `order.account_id = nil`
on an already destroyed order.

The solution is to make sure the merge order is not considered when
pulling up your cart.

This also fixes some translation missing errors.