### PR TITLE
[#132887] Fix links on shared schedules for admin reservations

### DIFF
--- a/app/views/instruments/schedule.html.haml
+++ b/app/views/instruments/schedule.html.haml
@@ -67,7 +67,7 @@
 
             %td
               = link_to reservation,
-                facility_instrument_reservation_edit_admin_path(current_facility, @instrument, reservation)
+                facility_instrument_reservation_edit_admin_path(current_facility, reservation.product, reservation)
 
             %td= reservation_category_label(reservation)
             %td= reservation.admin_note

--- a/app/views/instruments/schedule.html.haml
+++ b/app/views/instruments/schedule.html.haml
@@ -76,7 +76,10 @@
             %td
             %td= reservation.class.model_name.human
             %td
-              = link_to reservation, edit_facility_instrument_offline_reservation_path(current_facility, @instrument, reservation) if @instrument == reservation.product
+              - if @instrument == reservation.product
+                = link_to reservation, edit_facility_instrument_offline_reservation_path(current_facility, @instrument, reservation)
+              - else
+                = reservation
             %td= reservation_category_label(reservation)
             %td= reservation.admin_note
 

--- a/app/views/instruments/schedule.html.haml
+++ b/app/views/instruments/schedule.html.haml
@@ -59,7 +59,7 @@
           - if reservation.admin_removable?
             %td
               = link_to t("shared.remove"),
-                facility_instrument_reservation_path(current_facility, @instrument, reservation),
+                facility_instrument_reservation_path(current_facility, reservation.product, reservation),
                 confirm: t("shared.confirm_message"),
                 method: :delete
 
@@ -76,8 +76,7 @@
             %td
             %td= reservation.class.model_name.human
             %td
-              = link_to reservation,
-                edit_facility_instrument_offline_reservation_path(current_facility, @instrument, reservation)
+              = link_to reservation, edit_facility_instrument_offline_reservation_path(current_facility, @instrument, reservation) if @instrument == reservation.product
             %td= reservation_category_label(reservation)
             %td= reservation.admin_note
 


### PR DESCRIPTION
https://pm.tablexi.com/issues/132887

This fixes the link for reservations on shared schedules by using the actual instrument the reservation is attached to for the link instead of the instrument page you are on.