### PR TITLE
[#130583] Add padding back to modal for order detail edit

### DIFF
--- a/app/views/order_management/order_details/_shared_details.html.haml
+++ b/app/views/order_management/order_details/_shared_details.html.haml
@@ -1,4 +1,4 @@
-%div.manage_order_detail
+%div.manage_order_detail{class: modal? ? "modal-body" : ""}
   .banner-list
     .row
       = banner_date_label @order_detail, :ordered_at


### PR DESCRIPTION
https://pm.tablexi.com/issues/130583

This fixes the padding on the modal for order detail editing that went away when the print styles were changed.