### PR TITLE
[#126780] Change scope for AvailableAccountFinder

### DIFF
--- a/app/views/order_details/edit.html.haml
+++ b/app/views/order_details/edit.html.haml
@@ -10,7 +10,7 @@
 = simple_form_for([@order, @order_detail]) do |f|
   %p.alert.alert-warning= text(".warning")
 
-  = f.input :account_id, collection: AvailableAccountsFinder.new(@order_detail.order.user, @order_detail.facility, current: @order_detail.account), include_blank: false, label: Account.model_name.human
+  = f.input :account_id, collection: AvailableAccountsFinder.new(@order_detail.user, @order_detail.facility, current: @order_detail.account), include_blank: false, label: Account.model_name.human
 
   %ul.inline
     %li= f.submit t("shared.save"), class: ["btn", "btn-primary"]

--- a/app/views/order_details/edit.html.haml
+++ b/app/views/order_details/edit.html.haml
@@ -10,7 +10,7 @@
 = simple_form_for([@order, @order_detail]) do |f|
   %p.alert.alert-warning= text(".warning")
 
-  = f.input :account_id, collection: AvailableAccountsFinder.new(acting_user, @order_detail.facility, current: @order_detail.account), include_blank: false, label: Account.model_name.human
+  = f.input :account_id, collection: AvailableAccountsFinder.new(@order_detail.order.user, @order_detail.facility, current: @order_detail.account), include_blank: false, label: Account.model_name.human
 
   %ul.inline
     %li= f.submit t("shared.save"), class: ["btn", "btn-primary"]


### PR DESCRIPTION
https://pm.tablexi.com/issues/126780

This uses the user that the order was placed for instead of the acting user to scope payment sources for the order detail editing.