### PR TITLE
[#133079] Hide grey background when archived/hidden instruments

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -32,6 +32,14 @@ class Schedule < ActiveRecord::Base
   # Instance methods
   # --------
 
+  def publicly_visible_products
+    products.active
+  end
+
+  def facility_visible_products
+    products.not_archived
+  end
+
   def shared?
     products.count > 1
   end

--- a/app/support/products/scheduling_support.rb
+++ b/app/support/products/scheduling_support.rb
@@ -50,10 +50,6 @@ module Products::SchedulingSupport
     end
   end
 
-  def schedule_sharing?
-    schedule.shared?
-  end
-
   def first_available_hour
     return 0 unless schedule_rules.any?
     schedule_rules.min { |a, b| a.start_hour <=> b.start_hour }.start_hour

--- a/app/views/shared/timeline/_instrument.html.haml
+++ b/app/views/shared/timeline/_instrument.html.haml
@@ -1,26 +1,25 @@
-- unless instrument.is_archived? || (instrument.is_hidden? && public_timeline?)
-  .timeline_instrument
-    %h4
-      - if public_timeline?
-        = link_to instrument,
-          facility_instrument_path(current_facility, instrument)
-      - else
-        = link_to instrument,
-          facility_instrument_schedule_path(current_facility, instrument)
+.timeline_instrument
+  %h4
+    - if public_timeline?
+      = link_to instrument,
+        facility_instrument_path(current_facility, instrument)
+    - else
+      = link_to instrument,
+        facility_instrument_schedule_path(current_facility, instrument)
 
-      - if instrument.offline?
-        = tooltip_icon "icon-warning-sign icon-large", t("instruments.offline.note")
+    - if instrument.offline?
+      = tooltip_icon "icon-warning-sign icon-large", t("instruments.offline.note")
 
-    -# Add .reschedulable to enable drag/drop
-    .timeline
-      .unit_container
-        = render partial: "shared/timeline/reservation",
-          collection: (instrument.visible_reservations(@display_datetime) + ScheduleRule.unavailable_for_date(instrument, @display_datetime)),
-          as: :reservation,
-          locals: { product: instrument }
+  -# Add .reschedulable to enable drag/drop
+  .timeline
+    .unit_container
+      = render partial: "shared/timeline/reservation",
+        collection: (instrument.visible_reservations(@display_datetime) + ScheduleRule.unavailable_for_date(instrument, @display_datetime)),
+        as: :reservation,
+        locals: { product: instrument }
 
-        - if @display_datetime.beginning_of_day == Time.zone.now.beginning_of_day
-          .current_time{style: "left: #{datetime_left_position(@display_datetime, Time.zone.now)}"}
+      - if @display_datetime.beginning_of_day == Time.zone.now.beginning_of_day
+        .current_time{style: "left: #{datetime_left_position(@display_datetime, Time.zone.now)}"}
 
-      - if !public_timeline? && instrument.has_real_relay?
-        = render "shared/timeline/relay_switch", instrument: instrument
+    - if !public_timeline? && instrument.has_real_relay?
+      = render "shared/timeline/relay_switch", instrument: instrument

--- a/app/views/shared/timeline/_instrument.html.haml
+++ b/app/views/shared/timeline/_instrument.html.haml
@@ -18,8 +18,8 @@
         as: :reservation,
         locals: { product: instrument }
 
-      - if @display_datetime.beginning_of_day == Time.zone.now.beginning_of_day
-        .current_time{style: "left: #{datetime_left_position(@display_datetime, Time.zone.now)}"}
+      - if @display_datetime.beginning_of_day == Time.current.beginning_of_day
+        .current_time{style: "left: #{datetime_left_position(@display_datetime, Time.current)}"}
 
     - if !public_timeline? && instrument.has_real_relay?
       = render "shared/timeline/relay_switch", instrument: instrument

--- a/app/views/shared/timeline/_schedule.html.haml
+++ b/app/views/shared/timeline/_schedule.html.haml
@@ -1,6 +1,7 @@
-- if schedule.shared?
+- products = public_timeline? ? schedule.publicly_visible_products : schedule.facility_visible_products
+- if products.count > 1
   .timeline-schedule
     %h3= schedule.name
-    = render :partial => 'shared/timeline/instrument', :collection => schedule.products, :as => :instrument
+    = render partial: "shared/timeline/instrument", collection: products, as: :instrument
 - else
-  = render :partial => 'shared/timeline/instrument', :locals => { :instrument => schedule.products.first }
+  = render partial: "shared/timeline/instrument", collection: products, as: :instrument

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -127,31 +127,6 @@ RSpec.describe Instrument do
       end
     end
 
-    describe "#schedule_sharing?" do
-      let!(:instrument1) { FactoryGirl.create(:setup_instrument) }
-      let!(:instrument2) { FactoryGirl.create(:setup_instrument, facility: facility, schedule: schedule2) }
-
-      context "when the instruments use different schedules" do
-        let(:schedule2) { nil }
-
-        it "does not consider the instruments to be sharing", :aggregate_failures do
-          expect(instrument1).not_to be_schedule_sharing
-          expect(instrument2).not_to be_schedule_sharing
-          expect(instrument1.schedule).not_to eq(instrument2.schedule)
-        end
-      end
-
-      context "when the instruments use the same schedule" do
-        let(:schedule2) { instrument1.schedule }
-
-        it "considers the instruments to be sharing", :aggregate_failures do
-          expect(instrument1).to be_schedule_sharing
-          expect(instrument2).to be_schedule_sharing
-          expect(instrument1.schedule).to eq(instrument2.schedule)
-        end
-      end
-    end
-
     describe "name updating" do
       before :each do
         @instrument = setup_instrument(schedule: nil)


### PR DESCRIPTION
On the public timeline, if there were archived or hidden instruments,
the grey background was appearing even if there was only one visible
instrument. On the facility timeline view, archived instruments were
causing the same problem.

This also removes an unused method on Instrument.