### PR TITLE
[#133457] Adds ability to search by statement id

### DIFF
--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -26,10 +26,14 @@ class Statement < ActiveRecord::Base
     "#{account_id}-#{id}"
   end
 
+  def self.find_by_statement_id(query)
+    return nil unless /\A(?<id>\d+)\z/ =~ query
+    find_by(id: id)
+  end
+
   def self.find_by_invoice_number(query)
     return nil unless /\A(?<account_id>\d+)-(?<id>\d+)\z/ =~ query
-    # TODO: Use `find_by(id: id, account_id: account_id)` in Rails 4
-    find_by_id_and_account_id(id, account_id)
+    find_by(id: id, account_id: account_id)
   end
 
   def invoice_date

--- a/app/services/global_search/statement_searcher.rb
+++ b/app/services/global_search/statement_searcher.rb
@@ -10,7 +10,16 @@ module GlobalSearch
 
     def search
       return [] unless Account.config.statements_enabled?
-      Array(Statement.find_by_invoice_number(query.sub(/\A#/, ""))) # Remove leading hash signs to support searching like "#123-456"
+      Array(Statement.send(search_method, parsed_query))
+    end
+
+    # Remove leading hash signs to support searching like "#123-456"
+    def parsed_query
+      query.sub(/\A#/, "")
+    end
+
+    def search_method
+      query.include?("-") ? :find_by_invoice_number : :find_by_statement_id
     end
 
     def restrict(statements)

--- a/spec/controllers/global_search_controller_spec.rb
+++ b/spec/controllers/global_search_controller_spec.rb
@@ -211,6 +211,11 @@ RSpec.describe GlobalSearchController do
           expect(statement_results).to eq([statement])
         end
 
+        it "finds it by the id" do
+          get :index, search: statement.id
+          expect(statement_results).to eq([statement])
+        end
+
         it "does not find it by the wrong invoice number" do
           get :index, search: "0-123"
           expect(statement_results).to be_empty

--- a/spec/services/global_search/statement_searcher_spec.rb
+++ b/spec/services/global_search/statement_searcher_spec.rb
@@ -27,12 +27,17 @@ RSpec.describe GlobalSearch::StatementSearcher do
         it { is_expected.to be_empty }
       end
 
-      describe "with the ID" do
+      describe "with the invoice number" do
         let(:query) { statement.invoice_number }
         it { is_expected.to eq([statement]) }
       end
 
-      describe "with the ID and whitespace" do
+      describe "with the id only" do
+        let(:query) { statement.id }
+        it { is_expected.to eq([statement]) }
+      end
+
+      describe "with the invoice number and whitespace" do
         let(:query) { "   #{statement.invoice_number}  " }
         it { is_expected.to eq([statement]) }
       end
@@ -49,6 +54,11 @@ RSpec.describe GlobalSearch::StatementSearcher do
 
       describe "starting with a pound sign" do
         let(:query) { "##{statement.invoice_number}" }
+        it { is_expected.to eq([statement]) }
+      end
+
+      describe "id only starting with a pound sign" do
+        let(:query) { "##{statement.id}" }
         it { is_expected.to eq([statement]) }
       end
 


### PR DESCRIPTION
https://pm.tablexi.com/issues/133457

This adds the ability to only enter the statement id and use the global search to find statements that way. If the search query does not have a hyphen, it looks by only id.