### PR TITLE
[#125724] Track ordered_by on the order detail level

### DIFF
--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -102,7 +102,7 @@ class FacilityOrdersController < ApplicationController
     @order = build_merge_order if merge?(product)
 
     begin
-      details = @order.add product, quantity
+      details = @order.add product, quantity, created_by: current_user.id
       notifications = false
       details.each do |d|
         d.set_default_status!

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -193,6 +193,7 @@ RSpec.describe FacilityOrdersController do
 
       it_should_allow :director, "to add an item to existing order directly" do
         assert_no_merge_order @order, @product
+        expect(@order.order_details.last.created_by_user).to eq(@director)
       end
 
       context "with instrument" do


### PR DESCRIPTION
https://pm.tablexi.com/issues/125724

This sets the order detail ordered_by accurately for orders that are added to, using the current user instead of just defaulting to the user who placed the original order.