### PR TITLE
[#132637] Fix behavior of cancel on merge order reservation

### DIFF
--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -55,7 +55,9 @@
 
     - url_after_action = facility_path(@instrument.facility)
     %li
-    - if @order_detail.bundled?
+    - if @order.to_be_merged?
+      = link_to t("shared.cancel"), facility_order_path(@instrument.facility, @order.merge_order)
+    - elsif @order_detail.bundled?
       = link_to t("shared.cancel"), url_after_action
     - else
       = link_to t("shared.cancel"),


### PR DESCRIPTION
When adding a reservation to an existing order (i.e. by facility
staff), the “Cancel” button was not returning you to the expected
location and was instead causing an error.

`orders#remove (RuntimeError) "Can't modify frozen hash”`