### PR TITLE
[#133351] Send one notification per account admin

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -50,7 +50,6 @@ class Notifier < ActionMailer::Base
 
   def review_orders(args)
     @user = User.find(args[:user_id])
-    @facility = Facility.find(args[:facility_id])
     @accounts = Account.where(id: args[:account_ids]).pluck(:description).map { |s| %("#{s}") }.to_sentence
     send_nucore_mail @user.email, text("views.notifier.review_orders.subject")
   end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -51,7 +51,7 @@ class Notifier < ActionMailer::Base
   def review_orders(args)
     @user = User.find(args[:user_id])
     @facility = Facility.find(args[:facility_id])
-    @account = Account.find(args[:account_id])
+    @accounts = Account.where(id: args[:account_ids]).pluck(:description).map { |s| %("#{s}") }.to_sentence
     send_nucore_mail @user.email, text("views.notifier.review_orders.subject")
   end
 

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -50,7 +50,7 @@ class Notifier < ActionMailer::Base
 
   def review_orders(args)
     @user = User.find(args[:user_id])
-    @accounts = Account.where(id: args[:account_ids]).pluck(:description).map { |s| %("#{s}") }.to_sentence
+    @accounts = Account.find(args[:account_ids]).map(&:account_list_item).to_sentence
     send_nucore_mail @user.email, text("views.notifier.review_orders.subject")
   end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -46,6 +46,8 @@ class Account < ActiveRecord::Base
     end
   end
 
+  delegate :administrators, to: :account_users
+
   # The @@config class variable stores account configuration details via a
   # seperate `AccountConfig` class. This way downstream repositories can use
   # customized account configurations. Also the `Account` model stays as thin

--- a/app/models/account_user.rb
+++ b/app/models/account_user.rb
@@ -7,6 +7,10 @@ class AccountUser < ActiveRecord::Base
   ACCOUNT_OWNER = "Owner".freeze
   ACCOUNT_ADMINISTRATOR = "Business Administrator".freeze
 
+  scope :administrators, lambda {
+    User.where(id: where(user_role: admin_user_roles).select(:user_id))
+  }
+
   def self.read_only_user_roles
     [ACCOUNT_PURCHASER]
   end

--- a/app/models/account_user.rb
+++ b/app/models/account_user.rb
@@ -7,16 +7,16 @@ class AccountUser < ActiveRecord::Base
   ACCOUNT_OWNER = "Owner".freeze
   ACCOUNT_ADMINISTRATOR = "Business Administrator".freeze
 
-  scope :administrators, lambda {
-    User.where(id: where(user_role: admin_user_roles).select(:user_id))
-  }
-
   def self.read_only_user_roles
     [ACCOUNT_PURCHASER]
   end
 
   def self.admin_user_roles
     [ACCOUNT_OWNER, ACCOUNT_ADMINISTRATOR]
+  end
+
+  def self.administrators
+    User.where(id: where(user_role: admin_user_roles).select(:user_id))
   end
 
   def self.user_roles

--- a/app/support/notification_sender.rb
+++ b/app/support/notification_sender.rb
@@ -76,6 +76,9 @@ class NotificationSender
 
     private
 
+    # This builds a Hash of account_id Arrays, keyed by user_id.
+    # The user_ids are the administrators (owners and business administrators)
+    # of the given accounts.
     def notifications_hash(account_ids_to_notify)
       account_ids_to_notify.each_with_object({}) do |account_id, notifications|
         Account.find(account_id).administrators.each do |administrator|

--- a/app/support/notification_sender.rb
+++ b/app/support/notification_sender.rb
@@ -48,10 +48,8 @@ class NotificationSender
   end
 
   def find_accounts_to_notify
-    # TODO: Poor man's multi-item `pluck`. Fix in Rails 4
-    ActiveRecord::Base.connection.select_all(order_details.select(["order_details.account_id", "products.facility_id"])).each do |od|
-      @account_ids_to_notify << [od["account_id"], od["facility_id"]]
-    end
+    @account_ids_to_notify =
+      order_details.pluck("order_details.account_id", "products.facility_id").to_set
   end
 
   def mark_order_details_as_reviewed

--- a/app/support/notification_sender.rb
+++ b/app/support/notification_sender.rb
@@ -8,7 +8,7 @@ class NotificationSender
   end
 
   def perform
-    @account_ids_to_notify = Set.new
+    @account_ids_to_notify = []
     @orders_notified = []
     @errors = []
 
@@ -49,7 +49,7 @@ class NotificationSender
 
   def find_accounts_to_notify
     @account_ids_to_notify =
-      order_details.pluck("order_details.account_id", "products.facility_id").to_set
+      order_details.distinct.pluck("order_details.account_id", "products.facility_id")
   end
 
   def mark_order_details_as_reviewed

--- a/app/support/notification_sender.rb
+++ b/app/support/notification_sender.rb
@@ -38,7 +38,7 @@ class NotificationSender
   end
 
   def accounts_notified
-    Account.where(id: account_ids_to_notify)
+    Account.where_ids_in(account_ids_to_notify)
   end
 
   private

--- a/app/views/notifier/review_orders.html.haml
+++ b/app/views/notifier/review_orders.html.haml
@@ -1,1 +1,4 @@
-= html("body_html", facility: @facility.to_s, account: @account.to_s, login_url: transactions_in_review_account_url(@account, facilities: [@facility.id]))
+= html "body_html",
+  facility: @facility.to_s,
+  accounts: @accounts,
+  login_url: transactions_in_review_url

--- a/app/views/notifier/review_orders.html.haml
+++ b/app/views/notifier/review_orders.html.haml
@@ -1,4 +1,1 @@
-= html "body_html",
-  facility: @facility.to_s,
-  accounts: @accounts,
-  login_url: transactions_in_review_url
+= html "body_html", accounts: @accounts, login_url: transactions_in_review_url

--- a/app/views/notifier/review_orders.text.erb
+++ b/app/views/notifier/review_orders.text.erb
@@ -1,3 +1,3 @@
-<%= t("views.notifier.review_orders.body", accounts: @accounts) %>
+<%= text("views.notifier.review_orders.body", accounts: raw(@accounts), smart: false) %>
 
 <%= transactions_in_review_url %>

--- a/app/views/notifier/review_orders.text.erb
+++ b/app/views/notifier/review_orders.text.erb
@@ -1,3 +1,3 @@
-<%= text(".body", facility: @facility.to_s, account: @account.to_s) %>
+<%= text(".body", facility: @facility.to_s, accounts: @accounts.html_safe) %>
 
-<%= transactions_in_review_account_url(@account, facilities: [@facility.id]) %>
+<%= transactions_in_review_url %>

--- a/app/views/notifier/review_orders.text.erb
+++ b/app/views/notifier/review_orders.text.erb
@@ -1,3 +1,3 @@
-<%= text(".body", facility: @facility.to_s, accounts: @accounts.html_safe) %>
+<%= t("views.notifier.review_orders.body", facility: @facility, accounts: @accounts) %>
 
 <%= transactions_in_review_url %>

--- a/app/views/notifier/review_orders.text.erb
+++ b/app/views/notifier/review_orders.text.erb
@@ -1,3 +1,3 @@
-<%= t("views.notifier.review_orders.body", facility: @facility, accounts: @accounts) %>
+<%= t("views.notifier.review_orders.body", accounts: @accounts) %>
 
 <%= transactions_in_review_url %>

--- a/config/locales/en.notifier.yml
+++ b/config/locales/en.notifier.yml
@@ -24,7 +24,7 @@ en:
         body: |
           New transactions for %{facility} have been posted to %{accounts}.
 
-          Please log in to !app_name! and review these charges.
+          Please log in to review these charges.
         body_html: |
           New transactions for %{facility} have been posted to %{accounts}.
 

--- a/config/locales/en.notifier.yml
+++ b/config/locales/en.notifier.yml
@@ -22,11 +22,11 @@ en:
       review_orders:
         subject: "!app_name! Orders For Review"
         body: |
-          New transactions for %{facility} have been posted to %{accounts}.
+          New transactions have been posted to %{accounts}.
 
           Please log in to review these charges.
         body_html: |
-          New transactions for %{facility} have been posted to %{accounts}.
+          New transactions have been posted to %{accounts}.
 
           Please log in to [!app_name!](%{login_url}) and review these charges.
       statement:

--- a/config/locales/en.notifier.yml
+++ b/config/locales/en.notifier.yml
@@ -21,9 +21,12 @@ en:
         subject: "%{user} has made a reservation for %{product}. Please approve."
       review_orders:
         subject: "!app_name! Orders For Review"
-        body: "New transactions for %{facility} have been posted to \"%{account}\". Please log in to !app_name! and review these charges."
+        body: |
+          New transactions for %{facility} have been posted to %{accounts}.
+
+          Please log in to !app_name! and review these charges.
         body_html: |
-          New transactions for %{facility} have been posted to "%{account}".
+          New transactions for %{facility} have been posted to %{accounts}.
 
           Please log in to [!app_name!](%{login_url}) and review these charges.
       statement:

--- a/spec/app_support/notification_sender_spec.rb
+++ b/spec/app_support/notification_sender_spec.rb
@@ -1,45 +1,64 @@
 require "rails_helper"
 
 RSpec.describe NotificationSender, :aggregate_failures do
-  let(:user) { create(:user) }
+  subject(:notification_sender) { described_class.new(facility, order_detail_ids) }
 
-  let(:facility) { create(:facility) }
+  let(:accounts) do
+    account_owners.map do |user|
+      FactoryGirl.create_list(:setup_account, 2, owner: user, facility_id: facility.id)
+    end.flatten
+  end
+  let(:account_ids) { accounts.map(&:id) }
+  let(:delivery) { OpenStruct.new(deliver_now: true) }
+  let(:facility) { item.facility }
+  let(:item) { FactoryGirl.create(:setup_item, :with_facility_account) }
+  let!(:order_details) do
+    accounts.map do |account|
+      FactoryGirl.create(:account_user, :purchaser, user_id: purchaser.id, account_id: account.id)
+      Array.new(3) { place_product_order(purchaser, facility, item, account) }
+    end.flatten
+  end
+  let(:order_detail_ids) { order_details.map(&:id) }
+  let(:price_policy) { item.price_policies.first }
+  let(:account_owners) { FactoryGirl.create_list(:user, 2) }
+  let(:purchaser) { FactoryGirl.create(:user) }
 
-  let(:facility_account) do
-    facility.facility_accounts.create(attributes_for(:facility_account))
+  before(:each) do
+    # This feature only gets used when there is a review period, so go ahead and enable it.
+    allow(SettingsHelper).to receive(:has_review_period?).and_return true
+
+    OrderDetail.update_all(state: "complete", price_policy_id: price_policy.id)
   end
 
-  let(:item) do
-    facility
-      .items
-      .create(attributes_for(:item, facility_account_id: facility_account.id))
-  end
+  describe "#perform" do
+    context "when multiple users administer multiple accounts" do
+      context "and multiple accounts have complete orders" do
+        it "notifies each user once while setting order_details to reviewed" do
+          account_owners.each do |user|
+            expect(Notifier)
+              .to receive(:review_orders)
+              .with(user_id: user.id,
+                    facility_id: facility.id,
+                    account_ids: AccountUser.where(user_id: user.id).pluck(:account_id))
+              .once
+              .and_return(delivery)
+          end
 
-  let(:account) { create(:setup_account, owner: user, facility_id: facility.id) }
-  let(:ids) { order_details.map(&:id) }
-  let(:action) { described_class.new(facility, ids) }
+          expect(notification_sender.perform).to be_truthy
+          expect(notification_sender.account_ids_notified).to match(account_ids)
+          expect(order_details.map(&:reload)).to be_all(&:reviewed_at?)
+        end
 
-  # This feature only gets used when there is a review period, so go ahead and enable it.
-  before { allow(SettingsHelper).to receive(:has_review_period?).and_return true }
+      end
 
-  describe "with a reasonable sized group" do
-    let!(:order_details) { Array.new(5) { place_product_order(user, facility, item, account) } }
+      context "when an order_detail ID is invalid" do
+        let(:order_detail_ids) { [-1, order_details.first.id] }
 
-    before { OrderDetail.update_all(state: "complete", price_policy_id: item.price_policies.first.id) }
-
-    it "notifies the appropriate accounts and sets the order details to reviewed" do
-      expect(action.perform).to be_truthy
-      expect(action.account_ids_notified).to eq([account.id])
-      expect(order_details).to be_all { |od| od.reload.reviewed_at? }
-    end
-
-    describe "with an id that does not exist" do
-      let(:ids) { [-1, order_details.first.id] }
-
-      it "has an error for the id" do
-        expect(action.perform).to be_falsey
-        expect(action.errors.first).to include("-1")
-        expect(order_details.first.reload).not_to be_reviewed
+        it "errors while not setting the valid ID as reviewed" do
+          expect(notification_sender.perform).to be_falsey
+          expect(notification_sender.errors.first).to include("-1")
+          expect(order_details.first.reload).not_to be_reviewed
+        end
       end
     end
   end

--- a/spec/app_support/notification_sender_spec.rb
+++ b/spec/app_support/notification_sender_spec.rb
@@ -38,14 +38,13 @@ RSpec.describe NotificationSender, :aggregate_failures do
             expect(Notifier)
               .to receive(:review_orders)
               .with(user_id: user.id,
-                    facility_id: facility.id,
                     account_ids: AccountUser.where(user_id: user.id).pluck(:account_id))
               .once
               .and_return(delivery)
           end
 
           expect(notification_sender.perform).to be_truthy
-          expect(notification_sender.account_ids_notified).to match(account_ids)
+          expect(notification_sender.account_ids_to_notify).to match_array(account_ids)
           expect(order_details.map(&:reload)).to be_all(&:reviewed_at?)
         end
 

--- a/spec/controllers/facility_notifications_controller_spec.rb
+++ b/spec/controllers/facility_notifications_controller_spec.rb
@@ -93,8 +93,8 @@ RSpec.describe FacilityNotificationsController do
           maybe_grant_always_sign_in(:admin)
         end
 
-        it "sends emails to the two accounts" do
-          expect { do_request }.to change { Notifier.deliveries.count }.by(2)
+        it "sends one email for the two accounts" do
+          expect { do_request }.to change { Notifier.deliveries.count }.by(1)
         end
 
         it "should display the account list if less than 10 accounts" do

--- a/spec/controllers/facility_notifications_controller_spec.rb
+++ b/spec/controllers/facility_notifications_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe FacilityNotificationsController do
 
     it_should_allow_managers_only :redirect do
       expect(assigns(:errors)).to be_empty
-      expect(assigns(:accounts_to_notify).to_a).to eq([[@account.id, @authable.id]])
+      expect(assigns(:accounts_to_notify)).to contain_exactly(@account.id)
       expect([@order_detail1, @order_detail2]).to be_all { |od| od.reload.reviewed_at > 6.days.from_now }
 
       expect(Notifier.deliveries.count).to eq(1)
@@ -85,7 +85,7 @@ RSpec.describe FacilityNotificationsController do
       it_should_allow_managers_only :redirect do
         expect(assigns(:errors)).to be_empty
         expect([@order_detail1, @order_detail2, @order_detail3]).to be_all { |od| od.reload.reviewed_at? }
-        expect(assigns(:accounts_to_notify).to_a).to eq([[@account.id, @authable.id], [@account2.id, @authable.id]])
+        expect(assigns(:accounts_to_notify)).to contain_exactly(@account.id, @account2.id)
       end
 
       context "while signed in" do

--- a/spec/mailers/previews/notifier_preview.rb
+++ b/spec/mailers/previews/notifier_preview.rb
@@ -1,0 +1,11 @@
+class NotifierPreview < ActionMailer::Preview
+
+  def review_orders
+    Notifier.review_orders(
+      account_ids: Account.limit(3).pluck(:id),
+      facility_id: Facility.first.id,
+      user_id: User.first.id,
+    )
+  end
+
+end


### PR DESCRIPTION
~~~This includes #827; I'll rebase once that's merged.~~~

Rather than sending one notification per account, this sends one notification per user, noting which accounts the notification is about, and links the user to `/transactions/in_review`.

The notification sender spec got a bit of an overhaul and this adds a new mailer preview for `Notifier.review_orders`.