### PR TITLE
[#132856] Fixes Current Order Status copy

### DIFF
--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -147,7 +147,7 @@ en:
         one: Order Detail
         other: Order Details
       order_status:
-        one: Order Status
+        one: Current Order Status
         other: Order Statuses
       price_group:
         one: Price Group

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -240,7 +240,7 @@ en:
         journal_date: Journal Date
         journal_or_statement_date: "Journal/Statement Date"
         note: Note
-        order_status: Current Order Status
+        order_status: Order Status
         ordered_at: Ordered Date
         ordered_by: Ordered By
         product: Product

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,7 +254,7 @@ en:
       th:
         amount: Amount
         order_number: "Order #"
-        order_status: Current Order Status
+        order_status: Order Status
         product: Product
         transaction_date: Transaction Date
       unassigned: Unassigned


### PR DESCRIPTION
https://pm.tablexi.com/issues/132856

This changes the locale to return "Current Order Status" for the humanized version of the model name.