### PR TITLE
[#132887] Fix the schedule links so they still stay with instrument

### DIFF
--- a/app/controllers/facility_reservations_controller.rb
+++ b/app/controllers/facility_reservations_controller.rb
@@ -141,7 +141,7 @@ class FacilityReservationsController < ApplicationController
   # GET /facilities/:facility_id/instruments/:instrument_id/reservations/:id/edit_admin
   def edit_admin
     @instrument  = current_facility.instruments.find_by_url_name!(params[:instrument_id])
-    @reservation = @instrument.reservations.find(params[:reservation_id])
+    @reservation = Reservation.where(product_id: @instrument.schedule.products.map(&:id)).find(params[:reservation_id])
     raise ActiveRecord::RecordNotFound unless @reservation.order_detail_id.nil?
     set_windows
     render layout: "two_column"
@@ -150,7 +150,7 @@ class FacilityReservationsController < ApplicationController
   # PUT /facilities/:facility_id/instruments/:instrument_id/reservations/:id
   def update_admin
     @instrument  = current_facility.instruments.find_by_url_name!(params[:instrument_id])
-    @reservation = @instrument.reservations.find(params[:reservation_id])
+    @reservation = Reservation.where(product_id: @instrument.schedule.products.map(&:id)).find(params[:reservation_id])
     raise ActiveRecord::RecordNotFound unless @reservation.order_detail_id.nil?
     set_windows
 
@@ -185,7 +185,7 @@ class FacilityReservationsController < ApplicationController
   # DELETE  /facilities/:facility_id/instruments/:instrument_id/reservations/:id
   def destroy
     @instrument  = current_facility.instruments.find_by_url_name!(params[:instrument_id])
-    @reservation = @instrument.reservations.find(params[:id])
+    @reservation = Reservation.where(product_id: @instrument.schedule.products.map(&:id)).find(params[:reservation_id])
     raise ActiveRecord::RecordNotFound unless @reservation.order_detail_id.nil?
 
     @reservation.destroy

--- a/app/views/facility_reservations/edit_admin.html.haml
+++ b/app/views/facility_reservations/edit_admin.html.haml
@@ -18,7 +18,7 @@
 = content_for :tabnav do
   = render :partial => 'admin/shared/tabnav_product', :locals => {:secondary_tab => 'reservations'}
 
-%h2= @instrument
+%h2= @reservation.product
 
 = simple_form_for([@instrument, @reservation], :url => facility_instrument_reservation_update_admin_path) do |f|
   = f.error_messages

--- a/app/views/instruments/schedule.html.haml
+++ b/app/views/instruments/schedule.html.haml
@@ -59,7 +59,7 @@
           - if reservation.admin_removable?
             %td
               = link_to t("shared.remove"),
-                facility_instrument_reservation_path(current_facility, reservation.product, reservation),
+                facility_instrument_reservation_path(current_facility, @instrument, reservation),
                 confirm: t("shared.confirm_message"),
                 method: :delete
 
@@ -67,7 +67,7 @@
 
             %td
               = link_to reservation,
-                facility_instrument_reservation_edit_admin_path(current_facility, reservation.product, reservation)
+                facility_instrument_reservation_edit_admin_path(current_facility, @instrument, reservation)
 
             %td= reservation_category_label(reservation)
             %td= reservation.admin_note


### PR DESCRIPTION
https://pm.tablexi.com/issues/132856

This links the edit reservation to still have the path of the instrument you are looking at if it is a shared schedule, and then returns to the path you were at if you edit or cancel instead of the base instrument for the reservation.

This is a little non-rails-y but the behavior they want is a bit weird to me, so this was the best way in my opinion. 