### PR TITLE
[#126780] Fixes scope to return overlap of accounts

### DIFF
--- a/app/services/available_accounts_finder.rb
+++ b/app/services/available_accounts_finder.rb
@@ -1,18 +1,27 @@
 class AvailableAccountsFinder
 
-  def initialize(user, facility, current: nil)
+  def initialize(user, facility, current: nil, current_user: nil)
     @user = user
+    @current_user = current_user
     @facility = facility
     @current_account = current
   end
 
   def accounts
-    accounts = @user.accounts.for_facility(@facility).active
+    accounts = available_accounts
     if @current_account && !accounts.include?(@current_account)
       accounts += [@current_account]
     end
     accounts
   end
   alias to_a accounts
+
+  private
+
+  def available_accounts
+    available_accounts = @user.accounts.for_facility(@facility).active
+    available_accounts = available_accounts & @current_user.accounts.for_facility(@facility).active if @current_user
+    available_accounts
+  end
 
 end

--- a/app/services/available_accounts_finder.rb
+++ b/app/services/available_accounts_finder.rb
@@ -8,20 +8,11 @@ class AvailableAccountsFinder
   end
 
   def accounts
-    accounts = available_accounts
-    if @current_account && !accounts.include?(@current_account)
-      accounts += [@current_account]
-    end
+    accounts = @user.accounts.for_facility(@facility).active
+    accounts &= @current_user.accounts.for_facility(@facility).active if @current_user
+    accounts += [@current_account] if @current_account && !accounts.include?(@current_account)
     accounts
   end
   alias to_a accounts
-
-  private
-
-  def available_accounts
-    available_accounts = @user.accounts.for_facility(@facility).active
-    available_accounts &= @current_user.accounts.for_facility(@facility).active if @current_user
-    available_accounts
-  end
 
 end

--- a/app/services/available_accounts_finder.rb
+++ b/app/services/available_accounts_finder.rb
@@ -20,7 +20,7 @@ class AvailableAccountsFinder
 
   def available_accounts
     available_accounts = @user.accounts.for_facility(@facility).active
-    available_accounts = available_accounts & @current_user.accounts.for_facility(@facility).active if @current_user
+    available_accounts &= @current_user.accounts.for_facility(@facility).active if @current_user
     available_accounts
   end
 

--- a/app/views/order_details/edit.html.haml
+++ b/app/views/order_details/edit.html.haml
@@ -10,7 +10,7 @@
 = simple_form_for([@order, @order_detail]) do |f|
   %p.alert.alert-warning= text(".warning")
 
-  = f.input :account_id, collection: AvailableAccountsFinder.new(@order_detail.user, @order_detail.facility, current: @order_detail.account), include_blank: false, label: Account.model_name.human
+  = f.input :account_id, collection: AvailableAccountsFinder.new(@order_detail.user, @order_detail.facility, current: @order_detail.account, current_user: acting_user), include_blank: false, label: Account.model_name.human
 
   %ul.inline
     %li= f.submit t("shared.save"), class: ["btn", "btn-primary"]

--- a/spec/services/available_accounts_finder_spec.rb
+++ b/spec/services/available_accounts_finder_spec.rb
@@ -30,6 +30,19 @@ RSpec.describe AvailableAccountsFinder do
         is_expected.to eq([chartstring])
       end
     end
+
+    context "with a different current user" do
+      subject(:accounts) { described_class.new(user, facility, current: current, current_user: current_user).accounts }
+
+      let(:current_user) { FactoryGirl.create(:user) }
+      let!(:other_chartstring) { FactoryGirl.create(:nufs_account, :with_account_owner, owner: current_user) }
+
+      before { FactoryGirl.create(:account_user, :business_administrator, user: user, account: other_chartstring) }
+
+      describe "for any facility" do
+        it { is_expected.to match_array([chartstring, other_chartstring]) }
+      end
+    end
   end
 
   describe "with an expired account" do

--- a/spec/services/available_accounts_finder_spec.rb
+++ b/spec/services/available_accounts_finder_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe AvailableAccountsFinder do
       before { FactoryGirl.create(:account_user, :business_administrator, user: user, account: other_chartstring) }
 
       describe "for any facility" do
-        it { is_expected.to match_array([chartstring, other_chartstring]) }
+        it { is_expected.to contain_exactly(chartstring, other_chartstring) }
       end
     end
   end


### PR DESCRIPTION
https://pm.tablexi.com/issues/126780

This changes the scope so it only returns accounts that both the acting as user and the order detail user have access to.