### PR TITLE
[#121328] Allow editing of started reservation in the grace period

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -236,7 +236,7 @@ class Reservation < ActiveRecord::Base
   end
 
   def outside_lock_window?
-    before_lock_window? || Time.zone.now >= reserve_start_at
+    before_lock_window? || Time.zone.now >= reserve_start_at || in_grace_period?
   end
 
   def admin_editable?

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -415,15 +415,16 @@ RSpec.describe Reservation do
             end
 
             context "the instrument has a reservation lock window" do
+              let(:current_time) { Time.zone.now }
+
               before :each do
-                @current_time = Time.zone.now
                 instrument.update_attribute(:lock_window, 12)
                 reservation.reload
               end
 
               context "within the grace period" do
                 before do
-                  reservation.assign_attributes(reserve_start_at: @current_time + 5.minutes, actual_start_at: @current_time)
+                  reservation.assign_attributes(reserve_start_at: current_time + 5.minutes, actual_start_at: current_time)
                   reservation.save(validate: false)
                 end
 

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -413,6 +413,23 @@ RSpec.describe Reservation do
             context "there is no following reservation" do
               it_behaves_like "a customer is allowed to edit"
             end
+
+            context "the instrument has a reservation lock window" do
+              before :each do
+                @current_time = Time.zone.now
+                instrument.update_attribute(:lock_window, 12)
+                reservation.reload
+              end
+
+              context "within the grace period" do
+                before do
+                  reservation.assign_attributes(reserve_start_at: @current_time + 5.minutes, actual_start_at: @current_time)
+                  reservation.save(validate: false)
+                end
+
+                it_behaves_like "a customer is allowed to edit"
+              end
+            end
           end
 
           context "the reservation has not yet begun" do

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -395,8 +395,7 @@ RSpec.describe Reservation do
 
           context "the reservation has begun" do
             before :each do
-              reservation.assign_attributes(reserve_start_at: 3.hours.ago, actual_start_at: 3.hours.ago)
-              reservation.save(validate: false)
+              reservation.update_columns(reserve_start_at: 3.hours.ago, actual_start_at: 3.hours.ago)
             end
 
             context "there is a following reservation" do
@@ -424,8 +423,7 @@ RSpec.describe Reservation do
 
               context "within the grace period" do
                 before do
-                  reservation.assign_attributes(reserve_start_at: current_time + 5.minutes, actual_start_at: current_time)
-                  reservation.save(validate: false)
+                  reservation.update_columns(reserve_start_at: current_time + 5.minutes, actual_start_at: current_time)
                 end
 
                 it_behaves_like "a customer is allowed to edit"


### PR DESCRIPTION
https://pm.tablexi.com/issues/121328

This allows you to edit the duration of a started reservation while you are within the grade period (which is automatically added to the reserve_start_at when you Create & Start a reservation right away.