### PR TITLE
[#120321] Update reservation auto-cancel minutes field messaging

### DIFF
--- a/app/assets/javascripts/app/manage_instruments.coffee
+++ b/app/assets/javascripts/app/manage_instruments.coffee
@@ -10,7 +10,7 @@ $ ->
       else
         $(this).addClass 'interval-error'
 
-  $('#instrument_auto_cancel_mins').change (event)->
+  $('#instrument_auto_cancel_mins').change (event) ->
     $warning_node = $(".js--auto_cancel_mins-zero-warning")
     minutes = $(event.target).val() || 0
 

--- a/app/assets/javascripts/app/manage_instruments.coffee
+++ b/app/assets/javascripts/app/manage_instruments.coffee
@@ -10,3 +10,13 @@ $ ->
       else
         $(this).addClass 'interval-error'
 
+  $('#instrument_auto_cancel_mins').change ->
+    $warning_node = $(".js--auto_cancel_mins-zero-warning")
+    minutes = $(this).val() || 0
+
+    if minutes > 0
+      $warning_node.hide()
+    else
+      $warning_node.show()
+
+  $('#instrument_auto_cancel_mins').change()

--- a/app/assets/javascripts/app/manage_instruments.coffee
+++ b/app/assets/javascripts/app/manage_instruments.coffee
@@ -10,9 +10,9 @@ $ ->
       else
         $(this).addClass 'interval-error'
 
-  $('#instrument_auto_cancel_mins').change ->
+  $('#instrument_auto_cancel_mins').change (event)->
     $warning_node = $(".js--auto_cancel_mins-zero-warning")
-    minutes = $(this).val() || 0
+    minutes = $(event.target).val() || 0
 
     if minutes > 0
       $warning_node.hide()

--- a/app/views/instruments/_instrument_fields.html.haml
+++ b/app/views/instruments/_instrument_fields.html.haml
@@ -1,20 +1,27 @@
 - content_for :head_content do
-  = javascript_include_tag 'power_relay'
+  = javascript_include_tag "power_relay"
 
-= f.input :show_details, :as => :boolean, :label => false, :inline_label => t('instruments.instrument_fields.show_details')
+= f.input :show_details,
+  as: :boolean,
+  label: false,
+  inline_label: text("instruments.instrument_fields.show_details")
 
 - if f.object.new_record?
-  = f.association :schedule, collection: current_facility.schedules.active.ordered, include_blank: t('instruments.instrument_fields.schedule.unshared')
+  = f.association :schedule,
+    collection: current_facility.schedules.active.ordered,
+    include_blank: text("instruments.instrument_fields.schedule.unshared")
 - else
   = f.input :schedule, as: :readonly, value_method: :display_name, hint: false
 
--# - selection = @instrument.control_mechanism || :manual
-= f.input :control_mechanism, collection: options_for_control_mechanism, include_blank: false, selected: @instrument.control_mechanism || :manual
+= f.input :control_mechanism,
+  collection: options_for_control_mechanism,
+  include_blank: false,
+  selected: @instrument.control_mechanism || :manual
 
 - # TODO
 .well#power-relay
-  %h3= t('instruments.instrument_fields.relay.label.relay')
-  %p= t 'instruments.instrument_fields.relay.intro'
+  %h3= text("instruments.instrument_fields.relay.label.relay")
+  %p= text("instruments.instrument_fields.relay.intro")
 
   = f.simple_fields_for :relay, @instrument.relay || @instrument.build_relay do |rf|
     = rf.input :type, collection: options_for_relay, include_blank: false
@@ -24,15 +31,38 @@
     = rf.input :password, as: :string
     = rf.input :auto_logout do
       = rf.check_box :auto_logout
-      = t('instruments.instrument_fields.relay.label.auto_logout_1')
-      = rf.input :auto_logout_minutes, label: false, error: false, wrapper_html: { class: 'input-inline' } , input_html: { style: 'width: 38px' }
-      = t('instruments.instrument_fields.relay.label.auto_logout_2')
+      = text("instruments.instrument_fields.relay.label.auto_logout_1")
+      = rf.input :auto_logout_minutes,
+        label: false,
+        error: false,
+        wrapper_html: { class: "input-inline" },
+        input_html: { style: "width: 38px" }
+      = text("instruments.instrument_fields.relay.label.auto_logout_2")
 
 .well
-  %h3= t('instruments.instrument_fields.reservation.label.restrict')
-  = f.input :reserve_interval, :collection => Instrument::RESERVE_INTERVALS, :label => t('instruments.instrument_fields.reservation.label.reserve_interval'), :hint => t('instruments.instrument_fields.reservation.instruct.reserve_interval')
-  = f.input :min_reserve_mins, :label => t('instruments.instrument_fields.reservation.label.min_reserve'), :hint => t('instruments.instrument_fields.reservation.instruct.min_reserve')
-  = f.input :max_reserve_mins, :label => t('instruments.instrument_fields.reservation.label.max_reserve'), :hint => t('instruments.instrument_fields.reservation.instruct.max_reserve')
-  = f.input :min_cancel_hours, :label => t('instruments.instrument_fields.reservation.label.cancel_hours'), :hint => t('instruments.instrument_fields.reservation.instruct.cancel_hours')
-  = f.input :auto_cancel_mins, :label => t('instruments.instrument_fields.reservation.label.auto_cancel'),  :hint => t('instruments.instrument_fields.reservation.instruct.auto_cancel')
-  = f.input :lock_window, label: t('instruments.instrument_fields.reservation.label.lock_window'), hint: t('instruments.instrument_fields.reservation.instruct.lock_window')
+  %h3= text("instruments.instrument_fields.reservation.label.restrict")
+
+  = f.input :reserve_interval,
+    collection: Instrument::RESERVE_INTERVALS,
+    label: text("instruments.instrument_fields.reservation.label.reserve_interval"),
+    hint: text("instruments.instrument_fields.reservation.instruct.reserve_interval")
+
+  = f.input :min_reserve_mins,
+    label: text("instruments.instrument_fields.reservation.label.min_reserve"),
+    hint: text("instruments.instrument_fields.reservation.instruct.min_reserve")
+
+  = f.input :max_reserve_mins,
+    label: text("instruments.instrument_fields.reservation.label.max_reserve"),
+    hint: text("instruments.instrument_fields.reservation.instruct.max_reserve")
+
+  = f.input :min_cancel_hours,
+    label: text("instruments.instrument_fields.reservation.label.cancel_hours"),
+    hint: text("instruments.instrument_fields.reservation.instruct.cancel_hours")
+
+  = f.input :auto_cancel_mins,
+    label: text("instruments.instrument_fields.reservation.label.auto_cancel"),
+    hint: text("instruments.instrument_fields.reservation.instruct.auto_cancel")
+
+  = f.input :lock_window,
+    label: text("instruments.instrument_fields.reservation.label.lock_window"),
+    hint: text("instruments.instrument_fields.reservation.instruct.lock_window")

--- a/app/views/instruments/_instrument_fields.html.haml
+++ b/app/views/instruments/_instrument_fields.html.haml
@@ -63,6 +63,10 @@
     label: text("instruments.instrument_fields.reservation.label.auto_cancel"),
     hint: text("instruments.instrument_fields.reservation.instruct.auto_cancel")
 
+  %p.js--auto_cancel_mins-zero-warning
+    %i.icon-warning-sign
+    = text("instruments.instrument_fields.reservation.warning.auto_cancel_mins.zero")
+
   = f.input :lock_window,
     label: text("instruments.instrument_fields.reservation.label.lock_window"),
     hint: text("instruments.instrument_fields.reservation.instruct.lock_window")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1087,8 +1087,9 @@ en:
           cancel_hours: "Minimum length of time before a reservation begins that a user may cancel a reservation without invoking the reservation cost"
           auto_cancel: |
             The number of minutes the system will wait before automatically
-            canceling an unstarted reservation. When blank or set to 0, the
-            system will not cancel unstarted reservations.
+            canceling an unstarted reservation.
+            This field should be blank for instruments managed by reservation only.
+            When blank or set to 0, the system will not cancel unstarted reservations.
           lock_window: "Window of time within which a customer may no longer move their reservation. Cancellations are permitted but may invoke a fee."
         label:
           restrict: "Reservation Restrictions"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1085,7 +1085,10 @@ en:
           min_reserve: "Minimum amount of time for a reservation (optional; must be a multiple of the reservation interval)"
           max_reserve: "Maximum amount of time for a reservation (optional)"
           cancel_hours: "Minimum length of time before a reservation begins that a user may cancel a reservation without invoking the reservation cost"
-          auto_cancel: "The duration a due but unactivated reservation can exist before the system cancels it"
+          auto_cancel: |
+            The number of minutes the system will wait before automatically
+            canceling an unstarted reservation. When blank or set to 0, the
+            system will not cancel unstarted reservations.
           lock_window: "Window of time within which a customer may no longer move their reservation. Cancellations are permitted but may invoke a fee."
         label:
           restrict: "Reservation Restrictions"
@@ -1095,6 +1098,9 @@ en:
           cancel_hours: "Cancelation Minimum (hours)"
           auto_cancel: "Automatic Cancelation (minutes)"
           lock_window: "Reservation Lock Window (hours)"
+        warning:
+          auto_cancel_mins:
+            zero: Automatic cancellation will be disabled for this instrument
       schedule:
         unshared: Unshared schedule
         shared: Shared schedule


### PR DESCRIPTION
This updates the field "hint" text and adds a warning message when the field is zero or blank, explaining what that means.

It looks like this:
<img width="871" alt="auto-cancel-warning" src="https://cloud.githubusercontent.com/assets/46662/21157394/bf6ba402-c13e-11e6-8539-7b3f373ab2a2.png">

I fought with `simple_form` for a bit to try to get the warning to appear just to the right of the field instead but did not arrive there.