### PR TITLE
[#133417] Grant Account Managers un/suspend Account in cross-facility context

### DIFF
--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -52,8 +52,6 @@ class Ability
         can :manage, [Account, AccountUser, User]
         cannot :switch_to, User
       end
-
-      cannot [:suspend, :unsuspend], Account
     end
 
     if user.billing_administrator?

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -29,6 +29,7 @@ class Ability
       end
 
       cannot(:switch_to, User) { |target_user| !target_user.active? }
+      ability_extender.extend(user, resource)
       return
     end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -52,13 +52,12 @@ RSpec.describe Ability do
     it { is_expected.not_to be_allowed_to(:disputed, Order) }
     it { is_expected.not_to be_allowed_to(:manage_billing, facility) }
     it { is_expected.not_to be_allowed_to(:administer, User) }
-    it { is_expected.not_to be_allowed_to(:suspend, Account) }
-    it { is_expected.not_to be_allowed_to(:unsuspend, Account) }
     it { is_expected.not_to be_allowed_to(:batch_update, Order) }
     it { is_expected.not_to be_allowed_to(:batch_update, Reservation) }
 
     context "in a single facility" do
       it { is_expected.not_to be_allowed_to(:manage_accounts, facility) }
+      it { is_expected.not_to be_allowed_to(:manage, Account) }
       it { is_expected.not_to be_allowed_to(:manage, AccountUser) }
       it { is_expected.not_to be_allowed_to(:manage, User) }
       it { is_expected.not_to be_allowed_to(:switch_to, other_user) }
@@ -68,6 +67,7 @@ RSpec.describe Ability do
       let(:facility) { Facility.cross_facility }
 
       it { is_expected.to be_allowed_to(:manage_accounts, facility) }
+      it { is_expected.to be_allowed_to(:manage, Account) }
       it { is_expected.to be_allowed_to(:manage, AccountUser) }
       it { is_expected.to be_allowed_to(:manage, User) }
       it { is_expected.not_to be_allowed_to(:switch_to, other_user) }

--- a/vendor/engines/split_accounts/app/models/split_accounts/ability_extension.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/ability_extension.rb
@@ -8,12 +8,8 @@ module SplitAccounts
       @ability = ability
     end
 
-    def extend(user, resource)
+    def extend(user, _resource)
       ability.cannot :create, SplitAccounts::SplitAccount unless user.administrator?
-
-      if user.account_manager? && resource == Facility.cross_facility
-        ability.can [:suspend, :unsuspend], SplitAccounts::SplitAccount
-      end
     end
 
   end

--- a/vendor/engines/split_accounts/app/models/split_accounts/ability_extension.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/ability_extension.rb
@@ -8,8 +8,12 @@ module SplitAccounts
       @ability = ability
     end
 
-    def extend(user, _resource)
+    def extend(user, resource)
       ability.cannot :create, SplitAccounts::SplitAccount unless user.administrator?
+
+      if user.account_manager? && resource == Facility.cross_facility
+        ability.can [:suspend, :unsuspend], SplitAccounts::SplitAccount
+      end
     end
 
   end

--- a/vendor/engines/split_accounts/spec/controllers/facility_accounts_controller_spec.rb
+++ b/vendor/engines/split_accounts/spec/controllers/facility_accounts_controller_spec.rb
@@ -138,16 +138,7 @@ RSpec.describe FacilityAccountsController, :enable_split_accounts do
     let(:user) { FactoryGirl.create(:user, :account_manager) }
     let(:facility) { Facility.cross_facility }
     include_examples "allows editing"
-
-    describe "show" do
-      let(:split_account) { FactoryGirl.create(:split_account) }
-
-      before { get :show, facility_id: facility.url_name, id: split_account.id }
-
-      it "does not show the suspend buttons" do
-        expect(response.body).not_to include("Suspend")
-      end
-    end
+    include_examples "allows suspending"
   end
 
   describe "as a staff member" do


### PR DESCRIPTION
Account Managers previously had `:manage` rights to `Account` (covering all actions) with exceptions for `:suspend` and `:unsuspend`. This removes those exceptions.