### PR TITLE
[#133594] Implemented reservation cutoff time

### DIFF
--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -23,6 +23,7 @@ class Instrument < Product
             :max_reserve_mins,
             :auto_cancel_mins,
             numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_nil: true }
+  validates :cutoff_hours, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   validate :minimum_reservation_is_multiple_of_interval,
            :maximum_reservation_is_multiple_of_interval,

--- a/app/support/products/scheduling_support.rb
+++ b/app/support/products/scheduling_support.rb
@@ -155,7 +155,8 @@ module Products::SchedulingSupport
     attr_accessor :time, :rule, :day_start, :day_end, :options
 
     def initialize(time, rule, options = {})
-      self.time = time
+      first_available_time = Time.zone.now + rule.instrument.cutoff_hours.hours
+      self.time = (time < first_available_time) ? first_available_time : time
       self.rule = rule
       self.day_start = Time.zone.local(time.year, time.month, time.day, rule.start_hour, rule.start_min, 0)
       self.day_end   = Time.zone.local(time.year, time.month, time.day, rule.end_hour, rule.end_min, 0)

--- a/app/support/products/scheduling_support.rb
+++ b/app/support/products/scheduling_support.rb
@@ -155,17 +155,12 @@ module Products::SchedulingSupport
     attr_accessor :time, :rule, :day_start, :day_end, :options
 
     def initialize(time, rule, options = {})
-      self.time = rule.instrument.cutoff_hours > 0 ? time_with_cutoff_hours(time, rule.instrument) : time
+      self.time = rule.instrument.cutoff_hours > 0 ? [time, rule.instrument.cutoff_hours.hours.from_now].max : time
       self.rule = rule
       self.day_start = Time.zone.local(time.year, time.month, time.day, rule.start_hour, rule.start_min, 0)
       self.day_end   = Time.zone.local(time.year, time.month, time.day, rule.end_hour, rule.end_min, 0)
       self.options   = options
       adjust_time
-    end
-
-    def time_with_cutoff_hours(time, instrument)
-      first_available_time = Time.zone.now + instrument.cutoff_hours.hours
-      time < first_available_time ? first_available_time : time
     end
 
     def adjust_time

--- a/app/support/products/scheduling_support.rb
+++ b/app/support/products/scheduling_support.rb
@@ -155,13 +155,17 @@ module Products::SchedulingSupport
     attr_accessor :time, :rule, :day_start, :day_end, :options
 
     def initialize(time, rule, options = {})
-      first_available_time = Time.zone.now + rule.instrument.cutoff_hours.hours
-      self.time = (time < first_available_time) ? first_available_time : time
+      self.time = rule.instrument.cutoff_hours > 0 ? time_with_cutoff_hours(time, rule.instrument) : time
       self.rule = rule
       self.day_start = Time.zone.local(time.year, time.month, time.day, rule.start_hour, rule.start_min, 0)
       self.day_end   = Time.zone.local(time.year, time.month, time.day, rule.end_hour, rule.end_min, 0)
       self.options   = options
       adjust_time
+    end
+
+    def time_with_cutoff_hours(time, instrument)
+      first_available_time = Time.zone.now + instrument.cutoff_hours.hours
+      time < first_available_time ? first_available_time : time
     end
 
     def adjust_time

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -181,7 +181,7 @@ module Reservations::Validations
   private
 
   def admin_or_ordered_by_staff?
-    admin? || order_detail.created_by_user.operable_facilities.include?(facility)
+    admin? || order_detail.try(:created_by_user) && order_detail.created_by_user.operable_facilities.include?(facility)
   end
 
   def requires_cutoff_validation?

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -19,7 +19,7 @@ module Reservations::Validations
       end
     end
 
-    validate :starts_before_cutoff, if: :requires_cutoff_validation?, unless: :admin_or_created_by_admin?, on: [:create, :update]
+    validate :starts_before_cutoff, if: :requires_cutoff_validation?, unless: :admin_or_ordered_by_staff?, on: [:create, :update]
     validate :starts_before_ends
     validate :duration_is_interval
   end
@@ -180,8 +180,8 @@ module Reservations::Validations
 
   private
 
-  def admin_or_created_by_admin?
-    admin? || order_detail.created_by_user.administrator?
+  def admin_or_ordered_by_staff?
+    admin? || order_detail.created_by_user.operable_facilities.include?(facility)
   end
 
   def requires_cutoff_validation?

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -36,7 +36,7 @@ module Reservations::Validations
   end
 
   def starts_before_cutoff
-    errors.add(:reserve_start_at, :after_cutoff) if reserve_start_at < product.cutoff_hours.hours.from_now
+    errors.add(:reserve_start_at, :after_cutoff, hours: product.cutoff_hours) if reserve_start_at < product.cutoff_hours.hours.from_now
   end
 
   def duration_is_interval

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -19,7 +19,7 @@ module Reservations::Validations
       end
     end
 
-    validate :starts_before_cutoff, if: :requires_cutoff_validation?, unless: :admin?, on: [:create, :update]
+    validate :starts_before_cutoff, if: :requires_cutoff_validation?, unless: :admin_or_created_by_admin?, on: [:create, :update]
     validate :starts_before_ends
     validate :duration_is_interval
   end
@@ -179,6 +179,10 @@ module Reservations::Validations
   end
 
   private
+
+  def admin_or_created_by_admin?
+    admin? || order_detail.created_by_user.administrator?
+  end
 
   def requires_cutoff_validation?
     product.cutoff_hours && reserve_start_at && in_the_future? && reserve_start_at_changed?

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -19,6 +19,7 @@ module Reservations::Validations
       end
     end
 
+    validate :starts_before_cutoff, unless: :admin?, on: [:create, :update]
     validate :starts_before_ends
     validate :duration_is_interval
   end
@@ -31,6 +32,12 @@ module Reservations::Validations
     end
     if actual_start_at && actual_end_at
       errors.add("actual_end_date", "must be after the actual start time") if actual_end_at <= actual_start_at
+    end
+  end
+
+  def starts_before_cutoff
+    if product.cutoff_time && reserve_start_at && in_the_future? && reserve_start_at_changed?
+      errors.add("reserve_start_at", "must be before the cutoff time for this instrument") if reserve_start_at < Time.now + product.cutoff_time.hours
     end
   end
 

--- a/app/views/instruments/_instrument_fields.html.haml
+++ b/app/views/instruments/_instrument_fields.html.haml
@@ -70,3 +70,6 @@
   = f.input :lock_window,
     label: text("instruments.instrument_fields.reservation.label.lock_window"),
     hint: text("instruments.instrument_fields.reservation.instruct.lock_window")
+  = f.input :cutoff_time,
+    label: t("instruments.instrument_fields.reservation.label.cutoff_time"),
+    hint: t("instruments.instrument_fields.reservation.instruct.cutoff_time")

--- a/app/views/instruments/_instrument_fields.html.haml
+++ b/app/views/instruments/_instrument_fields.html.haml
@@ -70,6 +70,6 @@
   = f.input :lock_window,
     label: text("instruments.instrument_fields.reservation.label.lock_window"),
     hint: text("instruments.instrument_fields.reservation.instruct.lock_window")
-  = f.input :cutoff_time,
-    label: t("instruments.instrument_fields.reservation.label.cutoff_time"),
-    hint: t("instruments.instrument_fields.reservation.instruct.cutoff_time")
+  = f.input :cutoff_hours,
+    label: text("instruments.instrument_fields.reservation.label.cutoff_hours"),
+    hint: text("instruments.instrument_fields.reservation.instruct.cutoff_hours")

--- a/app/views/instruments/manage.html.haml
+++ b/app/views/instruments/manage.html.haml
@@ -21,7 +21,7 @@
   = f.input :min_cancel_hours, :value_method => :to_i
   = f.input :auto_cancel_mins, :value_method => :to_i
   = f.input :lock_window, value_method: :to_i, default_value: 0
-  = f.input :cutoff_time, value_method: :to_i, default_value: 0
+  = f.input :cutoff_hours, value_method: :to_i, default_value: 0
 
 - if can? :edit, Product
   %ul.inline

--- a/app/views/instruments/manage.html.haml
+++ b/app/views/instruments/manage.html.haml
@@ -21,6 +21,7 @@
   = f.input :min_cancel_hours, :value_method => :to_i
   = f.input :auto_cancel_mins, :value_method => :to_i
   = f.input :lock_window, value_method: :to_i, default_value: 0
+  = f.input :cutoff_time, value_method: :to_i, default_value: 0
 
 - if can? :edit, Product
   %ul.inline

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -77,7 +77,7 @@ en:
               conflict: The reservation conflicts with another reservation.
               conflict_in_cart: The reservation conflicts with another reservation in your cart. Please purchase or remove it then continue.
             reserve_start_at:
-              after_cutoff: must be before the cutoff time for this instrument
+              after_cutoff: must be at least %{hours} hours in the future.
         stored_file:
           attributes:
             name:

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -76,6 +76,8 @@ en:
             base:
               conflict: The reservation conflicts with another reservation.
               conflict_in_cart: The reservation conflicts with another reservation in your cart. Please purchase or remove it then continue.
+            reserve_start_at:
+              after_cutoff: must be before the cutoff time for this instrument
         stored_file:
           attributes:
             name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1102,6 +1102,7 @@ en:
             This field should be blank for instruments managed by reservation only.
             When blank or set to 0, the system will not cancel unstarted reservations.
           lock_window: "Window of time within which a customer may no longer move their reservation. Cancellations are permitted but may invoke a fee."
+          cutoff_time: "Minimum amount of hours before reservation instrument can be reserved."
         label:
           restrict: "Reservation Restrictions"
           reserve_interval: "Interval (minutes)"
@@ -1110,6 +1111,7 @@ en:
           cancel_hours: "Cancelation Minimum (hours)"
           auto_cancel: "Automatic Cancelation (minutes)"
           lock_window: "Reservation Lock Window (hours)"
+          cutoff_time: "Cutoff Time (hours)"
         warning:
           auto_cancel_mins:
             zero: Automatic cancellation will be disabled for this instrument

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1102,7 +1102,7 @@ en:
             This field should be blank for instruments managed by reservation only.
             When blank or set to 0, the system will not cancel unstarted reservations.
           lock_window: "Window of time within which a customer may no longer move their reservation. Cancellations are permitted but may invoke a fee."
-          cutoff_time: "Minimum amount of hours before reservation instrument can be reserved."
+          cutoff_hours: "Minimum number of hours before instrument can be reserved."
         label:
           restrict: "Reservation Restrictions"
           reserve_interval: "Interval (minutes)"
@@ -1111,7 +1111,7 @@ en:
           cancel_hours: "Cancelation Minimum (hours)"
           auto_cancel: "Automatic Cancelation (minutes)"
           lock_window: "Reservation Lock Window (hours)"
-          cutoff_time: "Cutoff Time (hours)"
+          cutoff_hours: "Cutoff Time (hours)"
         warning:
           auto_cancel_mins:
             zero: Automatic cancellation will be disabled for this instrument

--- a/db/migrate/20161213173410_add_cutoff_time_to_products.rb
+++ b/db/migrate/20161213173410_add_cutoff_time_to_products.rb
@@ -1,0 +1,7 @@
+class AddCutoffTimeToProducts < ActiveRecord::Migration
+
+  def change
+    add_column :products, :cutoff_time, :integer, null: false, default: 0
+  end
+
+end

--- a/db/migrate/20161213173410_add_cutoff_time_to_products.rb
+++ b/db/migrate/20161213173410_add_cutoff_time_to_products.rb
@@ -1,7 +1,7 @@
 class AddCutoffTimeToProducts < ActiveRecord::Migration
 
   def change
-    add_column :products, :cutoff_time, :integer, null: false, default: 0
+    add_column :products, :cutoff_hours, :integer, null: false, default: 0
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -480,6 +480,7 @@ ActiveRecord::Schema.define(version: 20170112204251) do
     t.integer  "lock_window",               limit: 4,     default: 0,     null: false
     t.text     "training_request_contacts", limit: 65535
     t.boolean  "note_available_to_users",                 default: false, null: false
+    t.integer  "cutoff_time",               limit: 4,     default: 0,     null: false
   end
 
   add_index "products", ["facility_account_id"], name: "fk_facility_accounts", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -480,7 +480,7 @@ ActiveRecord::Schema.define(version: 20170112204251) do
     t.integer  "lock_window",               limit: 4,     default: 0,     null: false
     t.text     "training_request_contacts", limit: 65535
     t.boolean  "note_available_to_users",                 default: false, null: false
-    t.integer  "cutoff_time",               limit: 4,     default: 0,     null: false
+    t.integer  "cutoff_hours",              limit: 4,     default: 0,     null: false
   end
 
   add_index "products", ["facility_account_id"], name: "fk_facility_accounts", using: :btree

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -488,6 +488,15 @@ RSpec.describe Instrument do
       assert_equal 45, @next_reservation.reserve_start_at.min
     end
 
+    it "should find next available reservation with cutoff hours" do
+      expect(@rule.instrument.update_attribute :cutoff_hours, 10).to be true
+
+      @next_reservation = @instrument.next_available_reservation(after = Time.zone.now.beginning_of_day)
+      assert_equal (Time.zone.now + 1.day).day, @next_reservation.reserve_start_at.day
+      assert_equal 9, @next_reservation.reserve_start_at.hour
+      assert_equal 0, @next_reservation.reserve_start_at.min
+    end
+
     it "should find next available reservation with pending reservations" do
       # add reservation for tomorrow morning at 9 am
       @start        = Time.zone.now.end_of_day + 1.second + 9.hours

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -488,13 +488,16 @@ RSpec.describe Instrument do
       assert_equal 45, @next_reservation.reserve_start_at.min
     end
 
-    it "should find next available reservation with cutoff hours" do
-      expect(@rule.instrument.update_attribute :cutoff_hours, 10).to be true
+    context "with cutoff hours" do
+      let(:next_reservation) { @instrument.next_available_reservation(after = Time.zone.now.beginning_of_day) }
 
-      @next_reservation = @instrument.next_available_reservation(after = Time.zone.now.beginning_of_day)
-      assert_equal (Time.zone.now + 1.day).day, @next_reservation.reserve_start_at.day
-      assert_equal 9, @next_reservation.reserve_start_at.hour
-      assert_equal 0, @next_reservation.reserve_start_at.min
+      before { @rule.instrument.update_attribute :cutoff_hours, 10 }
+
+      it "finds the next available reservation with cutoff hours" do
+        assert_equal (Time.zone.now + 1.day).day, next_reservation.reserve_start_at.day
+        assert_equal 9, next_reservation.reserve_start_at.hour
+        assert_equal 0, next_reservation.reserve_start_at.min
+      end
     end
 
     it "should find next available reservation with pending reservations" do

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1,4 +1,4 @@
- require "rails_helper"
+require "rails_helper"
 
 RSpec.describe Reservation do
   include DateHelper

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+ require "rails_helper"
 
 RSpec.describe Reservation do
   include DateHelper

--- a/spec/models/reservations_validations_spec.rb
+++ b/spec/models/reservations_validations_spec.rb
@@ -46,6 +46,16 @@ RSpec.describe Reservations::Validations do
           reservation.valid?
           expect(reservation.errors).to be_added(:reserve_start_at, :after_cutoff)
         end
+
+        context "when an admin made the reservation" do
+          let(:admin_user) { create(:user, :administrator) }
+
+          before do
+            reservation.order_detail.update_attribute(:created_by_user, admin_user)
+          end
+
+          it { is_expected.to be_valid }
+        end
       end
     end
   end

--- a/spec/models/reservations_validations_spec.rb
+++ b/spec/models/reservations_validations_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Reservations::Validations do
 
         it "returns the right errors" do
           reservation.valid?
-          expect(reservation.errors).to be_added(:reserve_start_at, :after_cutoff)
+          expect(reservation.errors).to be_added(:reserve_start_at, :after_cutoff, hours: 2)
         end
 
         context "when an admin made the reservation" do

--- a/spec/models/reservations_validations_spec.rb
+++ b/spec/models/reservations_validations_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Reservations::Validations do
       end
 
       context "when reservation is after the cutoff" do
-        let(:reservation) { build :setup_reservation, reserve_start_at: Time.zone.now + 3.hours }
+        let(:reservation) { build :setup_reservation, reserve_start_at: 3.hours.from_now }
         let(:user) { reservation.order_detail.created_by_user }
 
         it "saves the reservation" do

--- a/spec/models/reservations_validations_spec.rb
+++ b/spec/models/reservations_validations_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Reservations::Validations do
         end
 
         context "when an admin made the reservation" do
-          let(:admin_user) { create(:user, :administrator) }
+          let(:admin_user) { create(:user, :facility_administrator, facility: reservation.product.facility) }
 
           before do
             reservation.order_detail.update_attribute(:created_by_user, admin_user)

--- a/spec/models/reservations_validations_spec.rb
+++ b/spec/models/reservations_validations_spec.rb
@@ -28,19 +28,24 @@ RSpec.describe Reservations::Validations do
   describe "starts_before_cutoff" do
     context "when there is a cutoff" do
       before :each do
-        reservation.product.update_attribute(:cutoff_time, 2)
+        reservation.product.update_attribute(:cutoff_hours, 2)
       end
 
       context "when reservation is after the cutoff" do
-        before { reservation.assign_attributes(reserve_start_at: Time.now + 3.hours, reserve_end_at: Time.now + 4.hours) }
+        let(:reservation) { build :setup_reservation, reserve_start_at: Time.now + 3.hours }
 
         it { is_expected.to be_valid }
       end
 
       context "when reservation is before the cutoff" do
-        before { reservation.assign_attributes(reserve_start_at: Time.now + 1.hour, reserve_end_at: Time.now + 2.hours) }
+        let(:reservation) { build :setup_reservation, reserve_start_at: Time.now + 1.hour }
 
         it { is_expected.not_to be_valid }
+
+        it "returns the right errors" do
+          reservation.valid?
+          expect(reservation.errors).to be_added(:reserve_start_at, :after_cutoff)
+        end
       end
     end
   end

--- a/spec/models/reservations_validations_spec.rb
+++ b/spec/models/reservations_validations_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Reservations::Validations do
         let(:user) { reservation.order_detail.created_by_user }
 
         it "saves the reservation" do
-          expect(reservation.save_as_user(user)).to eq(true)
+          expect(reservation.save_as_user(user)).to be(true)
         end
       end
 
@@ -44,8 +44,8 @@ RSpec.describe Reservations::Validations do
         let(:reservation) { build :setup_reservation, reserve_start_at: Time.zone.now + 1.hour }
         let(:user) { reservation.order_detail.created_by_user }
 
-        it "returns the right errors" do
-          reservation.save_as_user(user)
+        it "does not save reservation" do
+          expect(reservation.save_as_user(user)).to be(false)
           expect(reservation.persisted?).to eq(false)
           expect(reservation.errors).to be_added(:reserve_start_at, :after_cutoff, hours: 2)
         end
@@ -54,7 +54,7 @@ RSpec.describe Reservations::Validations do
           let(:user) { create(:user, :facility_administrator, facility: reservation.product.facility) }
 
           it "saves the reservation" do
-            expect(reservation.save_as_user(user)).to eq(true)
+            expect(reservation.save_as_user(user)).to be(true)
           end
         end
       end

--- a/spec/models/reservations_validations_spec.rb
+++ b/spec/models/reservations_validations_spec.rb
@@ -24,4 +24,24 @@ RSpec.describe Reservations::Validations do
     reservation.update_attributes reserve_start_at: now, reserve_end_at: now + 1.hour + 5.minutes
     expect(reservation.errors[:base]).to be_present
   end
+
+  describe "starts_before_cutoff" do
+    context "when there is a cutoff" do
+      before :each do
+        reservation.product.update_attribute(:cutoff_time, 2)
+      end
+
+      context "when reservation is after the cutoff" do
+        before { reservation.assign_attributes(reserve_start_at: Time.now + 3.hours, reserve_end_at: Time.now + 4.hours) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when reservation is before the cutoff" do
+        before { reservation.assign_attributes(reserve_start_at: Time.now + 1.hour, reserve_end_at: Time.now + 2.hours) }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+  end
 end

--- a/spec/models/reservations_validations_spec.rb
+++ b/spec/models/reservations_validations_spec.rb
@@ -32,13 +32,13 @@ RSpec.describe Reservations::Validations do
       end
 
       context "when reservation is after the cutoff" do
-        let(:reservation) { build :setup_reservation, reserve_start_at: Time.now + 3.hours }
+        let(:reservation) { build :setup_reservation, reserve_start_at: Time.zone.now + 3.hours }
 
         it { is_expected.to be_valid }
       end
 
       context "when reservation is before the cutoff" do
-        let(:reservation) { build :setup_reservation, reserve_start_at: Time.now + 1.hour }
+        let(:reservation) { build :setup_reservation, reserve_start_at: Time.zone.now + 1.hour }
 
         it { is_expected.not_to be_valid }
 


### PR DESCRIPTION
https://pm.tablexi.com/issues/133594

This allows users to set a cutoff time on an instrument that prevents users from making reservations that are less than that number of hours before the reservation (so the staff has time to prepare). You can still cancel the reservation. 