### PR TITLE
Update orders-in-review tests to disregard array ordering

### DIFF
--- a/spec/app_support/notification_sender_spec.rb
+++ b/spec/app_support/notification_sender_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe NotificationSender, :aggregate_failures do
             expect(Notifier)
               .to receive(:review_orders)
               .with(user_id: user.id,
-                    account_ids: AccountUser.where(user_id: user.id).pluck(:account_id))
+                    account_ids: match_array(AccountUser.where(user_id: user.id).pluck(:account_id)))
               .once
               .and_return(delivery)
           end

--- a/spec/controllers/transactions_controller_spec.rb
+++ b/spec/controllers/transactions_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe TransactionsController do
         let(:reviewed_at) { 1.day.from_now }
 
         it "sets order_details to orders in review from all owned accounts", :aggregate_failures do
-          expect(assigns(:order_details)).to match(order_details)
+          expect(assigns(:order_details)).to match_array(order_details)
           expect(assigns(:recently_reviewed)).to be_empty
         end
       end


### PR DESCRIPTION
This is cherry-picked from https://github.com/tablexi/nucore-nu/pull/216. The results coming back from Oracle are correct but not necessarily in the same order as from MySQL.