### PR TITLE
[#133446] Adds reply to for facility email

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -36,7 +36,7 @@ class Notifier < ActionMailer::Base
 
   def order_notification(order, recipient)
     @order = order
-    send_nucore_mail recipient, text("views.notifier.order_notification.subject"), template_name: "order_receipt", reply: @order.facility.email
+    send_nucore_mail recipient, text("views.notifier.order_notification.subject"), "order_receipt", reply_to_email(@order, @order.facility)
   end
 
   # Custom order forms send out a confirmation email when filled out by a
@@ -45,7 +45,7 @@ class Notifier < ActionMailer::Base
     @user = args[:user]
     @order = args[:order]
     @greeting = text("views.notifier.order_receipt.intro")
-    send_nucore_mail args[:user].email, text("views.notifier.order_receipt.subject"), reply: @order.facility.email
+    send_nucore_mail args[:user].email, text("views.notifier.order_receipt.subject"), nil, reply_to_email(@order, @order.facility)
   end
 
   def review_orders(args)
@@ -63,7 +63,7 @@ class Notifier < ActionMailer::Base
     @account = args[:account]
     @statement = args[:statement]
     attach_statement_pdf
-    send_nucore_mail args[:user].email, text("views.notifier.statement.subject", facility: @facility), reply: @facility.email
+    send_nucore_mail args[:user].email, text("views.notifier.statement.subject", facility: @facility), nil, reply_to_email(@statement.order_details.first.order, @facility)
   end
 
   def order_detail_status_change(order_detail, old_status, new_status, to)
@@ -71,7 +71,7 @@ class Notifier < ActionMailer::Base
     @old_status = old_status
     @new_status = new_status
     template = "order_status_changed_to_#{new_status.downcase_name}"
-    send_nucore_mail to, t("views.notifier.#{template}.subject", order_detail: order_detail, user: order_detail.order.user, product: order_detail.product), template_name: template, reply: order_detail.facility.email
+    send_nucore_mail to, t("views.notifier.#{template}.subject", order_detail: order_detail, user: order_detail.order.user, product: order_detail.product), template, reply_to_email(order_detail.order, order_detail.facility)
   end
 
   private
@@ -87,8 +87,12 @@ class Notifier < ActionMailer::Base
     @statement_pdf ||= StatementPdfFactory.instance(@statement)
   end
 
-  def send_nucore_mail(to, subject, options = {})
-    mail(subject: subject, to: to, template_name: options[:template_name], reply_to: options[:reply])
+  def send_nucore_mail(to, subject, template_name = nil, reply_to = nil)
+    mail(subject: subject, to: to, template_name: template_name, reply_to: reply_to)
+  end
+
+  def reply_to_email(order, facility)
+    order.order_details.first.product.contact_email || facility.email
   end
 
 end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -36,7 +36,7 @@ class Notifier < ActionMailer::Base
 
   def order_notification(order, recipient)
     @order = order
-    send_nucore_mail recipient, text("views.notifier.order_notification.subject"), "order_receipt"
+    send_nucore_mail recipient, text("views.notifier.order_notification.subject"), template_name: "order_receipt", reply: @order.facility.email
   end
 
   # Custom order forms send out a confirmation email when filled out by a
@@ -45,7 +45,7 @@ class Notifier < ActionMailer::Base
     @user = args[:user]
     @order = args[:order]
     @greeting = text("views.notifier.order_receipt.intro")
-    send_nucore_mail args[:user].email, text("views.notifier.order_receipt.subject")
+    send_nucore_mail args[:user].email, text("views.notifier.order_receipt.subject"), reply: @order.facility.email
   end
 
   def review_orders(args)
@@ -63,7 +63,7 @@ class Notifier < ActionMailer::Base
     @account = args[:account]
     @statement = args[:statement]
     attach_statement_pdf
-    send_nucore_mail args[:user].email, text("views.notifier.statement.subject", facility: @facility)
+    send_nucore_mail args[:user].email, text("views.notifier.statement.subject", facility: @facility), reply: @facility.email
   end
 
   def order_detail_status_change(order_detail, old_status, new_status, to)
@@ -71,7 +71,7 @@ class Notifier < ActionMailer::Base
     @old_status = old_status
     @new_status = new_status
     template = "order_status_changed_to_#{new_status.downcase_name}"
-    send_nucore_mail to, t("views.notifier.#{template}.subject", order_detail: order_detail, user: order_detail.order.user, product: order_detail.product), template
+    send_nucore_mail to, t("views.notifier.#{template}.subject", order_detail: order_detail, user: order_detail.order.user, product: order_detail.product), template_name: template, reply: order_detail.facility.email
   end
 
   private
@@ -87,8 +87,8 @@ class Notifier < ActionMailer::Base
     @statement_pdf ||= StatementPdfFactory.instance(@statement)
   end
 
-  def send_nucore_mail(to, subject, template_name = nil)
-    mail(subject: subject, to: to, template_name: template_name)
+  def send_nucore_mail(to, subject, options = {})
+    mail(subject: subject, to: to, template_name: options[:template_name], reply_to: options[:reply])
   end
 
 end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -36,7 +36,7 @@ class Notifier < ActionMailer::Base
 
   def order_notification(order, recipient)
     @order = order
-    send_nucore_mail recipient, text("views.notifier.order_notification.subject"), "order_receipt", reply_to_email(@order, @order.facility)
+    send_nucore_mail recipient, text("views.notifier.order_notification.subject"), template_name: "order_receipt", reply_to: reply_to_email(@order, @order.facility)
   end
 
   # Custom order forms send out a confirmation email when filled out by a
@@ -45,7 +45,7 @@ class Notifier < ActionMailer::Base
     @user = args[:user]
     @order = args[:order]
     @greeting = text("views.notifier.order_receipt.intro")
-    send_nucore_mail args[:user].email, text("views.notifier.order_receipt.subject"), nil, reply_to_email(@order, @order.facility)
+    send_nucore_mail args[:user].email, text("views.notifier.order_receipt.subject"), reply_to: reply_to_email(@order, @order.facility)
   end
 
   def review_orders(args)
@@ -63,7 +63,7 @@ class Notifier < ActionMailer::Base
     @account = args[:account]
     @statement = args[:statement]
     attach_statement_pdf
-    send_nucore_mail args[:user].email, text("views.notifier.statement.subject", facility: @facility), nil, reply_to_email(@statement.order_details.first.order, @facility)
+    send_nucore_mail args[:user].email, text("views.notifier.statement.subject", facility: @facility), reply_to: reply_to_email(@statement.order_details.first.order, @facility)
   end
 
   def order_detail_status_change(order_detail, old_status, new_status, to)
@@ -71,7 +71,7 @@ class Notifier < ActionMailer::Base
     @old_status = old_status
     @new_status = new_status
     template = "order_status_changed_to_#{new_status.downcase_name}"
-    send_nucore_mail to, t("views.notifier.#{template}.subject", order_detail: order_detail, user: order_detail.order.user, product: order_detail.product), template, reply_to_email(order_detail.order, order_detail.facility)
+    send_nucore_mail to, t("views.notifier.#{template}.subject", order_detail: order_detail, user: order_detail.order.user, product: order_detail.product), template_name: template, reply_to: reply_to_email(order_detail.order, order_detail.facility)
   end
 
   private
@@ -87,8 +87,10 @@ class Notifier < ActionMailer::Base
     @statement_pdf ||= StatementPdfFactory.instance(@statement)
   end
 
-  def send_nucore_mail(to, subject, template_name = nil, reply_to = nil)
-    mail(subject: subject, to: to, template_name: template_name, reply_to: reply_to)
+  def send_nucore_mail(to, subject, template_name: nil, reply_to: nil)
+    options = { subject: subject, to: to, template_name: template_name }
+    options[:reply_to] = reply_to if reply_to
+    mail(options)
   end
 
   def reply_to_email(order, facility)

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe Notifier do
 
     let(:recipient) { "orders@example.net" }
 
+    context "when product has a contact email" do
+      let(:product) { create(:setup_instrument, facility: facility, contact_email: "test@example.com") }
+
+      it "generates and order notification with product reply to" do
+        expect(email.reply_to).to eq [product.contact_email]
+      end
+    end
+
     it "generates an order notification", :aggregate_failures do
       expect(email.to).to eq [recipient]
       expect(email.reply_to).to eq [facility.email]

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Notifier do
 
     it "generates an order notification", :aggregate_failures do
       expect(email.to).to eq [recipient]
+      expect(email.reply_to).to eq [facility.email]
       expect(email.subject).to include("Order Notification")
       expect(email.html_part.to_s).to match(/Ordered By.+#{user.full_name}/m)
       expect(email.text_part.to_s).to include("Ordered By: #{user.full_name}")
@@ -34,6 +35,7 @@ RSpec.describe Notifier do
 
     it "generates a receipt", :aggregate_failures do
       expect(email.to).to eq [user.email]
+      expect(email.reply_to).to eq [facility.email]
       expect(email.subject).to include("Order Receipt")
       expect(email.html_part.to_s).to match(/Ordered By.+#{user.full_name}/m)
       expect(email.text_part.to_s).to include("Ordered By: #{user.full_name}")


### PR DESCRIPTION
https://pm.tablexi.com/issues/133446

This adds the reply_to option to all facility related emails so they can communicate with the facility in a reply email. 

I *believe* this is all the spots that need it, but I can add it to any other they'd like the reply_to to direct to the facility. 