### PR TITLE
Update travel/travel_to to use TimeHelper methods

### DIFF
--- a/spec/controllers/facility_reservations_controller_spec.rb
+++ b/spec/controllers/facility_reservations_controller_spec.rb
@@ -397,7 +397,7 @@ RSpec.describe FacilityReservationsController do
         @instrument_pp.reload.restrict_purchase = false
         @now = @reservation.reserve_start_at + 3.hours
         maybe_grant_always_sign_in :director
-        travel_to(@now) { @order_detail.to_complete! }
+        travel_to_and_return(@now) { @order_detail.to_complete! }
       end
 
       context "update actuals" do
@@ -412,7 +412,7 @@ RSpec.describe FacilityReservationsController do
         end
 
         it "should update the actuals and assign a price policy if there is none" do
-          travel_to(@now) do
+          travel_to_and_return(@now) do
             do_request
             expect(assigns(:order)).to eq(@order)
             expect(assigns(:order_detail)).to eq(@order_detail)
@@ -443,7 +443,7 @@ RSpec.describe FacilityReservationsController do
         end
 
         it "should update the actual cost" do
-          travel_to(@now) do
+          travel_to_and_return(@now) do
             do_request
             expect(assigns(:reservation).actual_start_at).to  eq(@reservation_attrs[:actual_start_at])
             expect(assigns(:reservation).actual_end_at).to    eq(@reservation_attrs[:actual_end_at])

--- a/spec/models/email_event_spec.rb
+++ b/spec/models/email_event_spec.rb
@@ -19,13 +19,17 @@ RSpec.describe EmailEvent do
       end
 
       it "does not yield on second invocation if before the wait time" do
-        travel(1.hour)
-        expect { |b| described_class.notify(user, "key", wait: 2.hours, &b) }.not_to yield_control
+        travel_and_return(1.hour) do
+          expect { |b| described_class.notify(user, "key", wait: 2.hours, &b) }
+            .not_to yield_control
+        end
       end
 
       it "yields on second invocation after the wait time" do
-        travel(3.hours)
-        expect { |b| described_class.notify(user, "key", wait: 2.hours, &b) }.to yield_control
+        travel_and_return(3.hours) do
+          expect { |b| described_class.notify(user, "key", wait: 2.hours, &b) }
+            .to yield_control
+        end
       end
 
       it "yields on an invocation for a different key" do

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -718,7 +718,7 @@ RSpec.describe Instrument do
         context "but it was canceled" do
           let(:user) { FactoryGirl.build :user }
           before :each do
-            travel_to(60.minutes.ago) do
+            travel_to_and_return(60.minutes.ago) do
               reservation.order_detail.update_order_status! user, OrderStatus.canceled.first
               expect(reservation).to be_canceled
             end

--- a/spec/models/price_policy_spec.rb
+++ b/spec/models/price_policy_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe PricePolicy do
     end
     it "should truncate the old policy" do
       @today = Time.zone.local(2011, 06, 06, 12, 0, 0)
-      travel_to(@today) do
+      travel_to_and_return(@today) do
         @pp = FactoryGirl.create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today.beginning_of_day, expire_date: @today + 30.days)
         @pp2 = FactoryGirl.create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today + 2.days, expire_date: @today + 30.days)
         expect(@pp.reload.start_date).to eq(@today.beginning_of_day)
@@ -161,7 +161,7 @@ RSpec.describe PricePolicy do
     it "should not truncate any other policies" do
       @today = Time.zone.local(2011, 06, 06, 12, 0, 0)
 
-      travel_to(@today) do
+      travel_to_and_return(@today) do
         @pp = FactoryGirl.create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today.beginning_of_day, expire_date: @today + 30.days)
         @pp3 = FactoryGirl.create(:item_price_policy, product: @item2, price_group: @price_group, start_date: @today, expire_date: @today + 30.days)
         @pp2 = FactoryGirl.create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today + 2.days, expire_date: @today + 30.days)

--- a/spec/services/auto_canceler_spec.rb
+++ b/spec/services/auto_canceler_spec.rb
@@ -1,10 +1,8 @@
 require "rails_helper"
 
-RSpec.describe AutoCanceler do
-  before :each do
-    # Need to travel later in the day so that previous reservations can be made in the day
-    travel_to(Time.zone.parse("#{Date.today} 12:30:00"))
-  end
+RSpec.describe AutoCanceler, :time_travel do
+  # Need to travel later in the day so that previous reservations can be made in the day
+  let(:now) { Time.zone.parse("#{Date.today} 12:30:00") }
 
   after :each do
     travel_back

--- a/spec/services/results_file_notifier_spec.rb
+++ b/spec/services/results_file_notifier_spec.rb
@@ -21,10 +21,12 @@ RSpec.describe ResultsFileNotifier do
       end
 
       describe "a day later" do
-        before { travel(25.hours) }
-
         it "does send" do
-          expect { notifier.notify }.to change(ActionMailer::Base.deliveries, :count).by(1)
+          travel_and_return(25.hours) do
+            expect { notifier.notify }
+              .to change(ActionMailer::Base.deliveries, :count)
+              .by(1)
+          end
         end
       end
     end


### PR DESCRIPTION
A few more execution-order time issues emerged after merging #841. I searched the code for `/\btravel(_to)?\b/` and believe this takes care of everything that should be using the `travel_to_and_return`/`travel_and_return` helpers instead.