### PR TITLE
[#132887] Independent instruments

### DIFF
--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -82,7 +82,6 @@ class InstrumentsController < ProductsCommonController
   def schedule
     @admin_reservations =
       @instrument
-      .schedule
       .reservations
       .non_user
       .ends_in_the_future

--- a/app/views/instruments/schedule.html.haml
+++ b/app/views/instruments/schedule.html.haml
@@ -59,7 +59,7 @@
           - if reservation.admin_removable?
             %td
               = link_to t("shared.remove"),
-                facility_instrument_reservation_path(current_facility, reservation.product, reservation),
+                facility_instrument_reservation_path(current_facility, @instrument, reservation),
                 confirm: t("shared.confirm_message"),
                 method: :delete
 
@@ -67,7 +67,7 @@
 
             %td
               = link_to reservation,
-                facility_instrument_reservation_edit_admin_path(current_facility, reservation.product, reservation)
+                facility_instrument_reservation_edit_admin_path(current_facility, @instrument, reservation)
 
             %td= reservation_category_label(reservation)
             %td= reservation.admin_note
@@ -76,10 +76,7 @@
             %td
             %td= reservation.class.model_name.human
             %td
-              - if @instrument == reservation.product
-                = link_to reservation, edit_facility_instrument_offline_reservation_path(current_facility, @instrument, reservation)
-              - else
-                = reservation
+              = link_to reservation, edit_facility_instrument_offline_reservation_path(current_facility, @instrument, reservation)
             %td= reservation_category_label(reservation)
             %td= reservation.admin_note
 

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -512,21 +512,17 @@ RSpec.describe InstrumentsController do
       end
 
       describe "schedule sharing" do
-        let(:instrument2) do
-          FactoryGirl.create(:setup_instrument, facility: @authable,
-                                                schedule: @instrument.schedule)
-        end
         let(:admin_reservation) do
           FactoryGirl.create(
             :admin_reservation,
-            product: instrument2,
+            product: @instrument,
             reserve_start_at: 2.days.from_now,
           )
         end
         let(:admin_reservation2) do
           FactoryGirl.create(
             :admin_reservation,
-            product: instrument2,
+            product: @instrument,
             reserve_start_at: 1.day.from_now,
           )
         end
@@ -535,11 +531,11 @@ RSpec.describe InstrumentsController do
           do_request
         end
 
-        it "should show the primary instrument's admin reservation" do
+        it "should show the primary instrument's reservations" do
           expect(assigns(:admin_reservations)).to include admin_reservation
         end
 
-        it "should show the second instrument's admin reservation" do
+        it "should show the instrument's other admin reservation" do
           expect(assigns(:admin_reservations)).to include admin_reservation2
         end
 

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -532,15 +532,10 @@ RSpec.describe InstrumentsController do
         end
 
         it "should show the primary instrument's reservations" do
-          expect(assigns(:admin_reservations)).to include admin_reservation
-        end
-
-        it "should show the instrument's other admin reservation" do
-          expect(assigns(:admin_reservations)).to include admin_reservation2
+          expect(assigns(:admin_reservations)).to eq([admin_reservation2, admin_reservation])
         end
 
         it "should_allow_operators_only" do
-          expect(assigns(:admin_reservations)).to eq([admin_reservation2, admin_reservation])
           is_expected.to render_template "schedule"
         end
       end


### PR DESCRIPTION
https://pm.tablexi.com/issues/132887

This fixes the instruments schedule to only show the reservations for that instrument in order to simplify the flow of editing reservations. 