### PR TITLE
[#132371] Adds task for reporting on overlapping price rules

### DIFF
--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -2,7 +2,7 @@ namespace :reports do
   desc "Gives report for concatenated price rules"
   task concatenated_price_rules: :environment do
     policies = {}
-    PricePolicy.current.group_by { |p| [p.product_id, p.price_group_id] }.map { |k, ps| policies[k] = ps if ps.count > 1 }
+    PricePolicy.current.group_by { |p| [p.product_id, p.price_group_id] }.each { |k, ps| policies[k] = ps if ps.count > 1 }
     policies.each do |info, overlapping_policies|
       product = Product.find(info.first)
       price_group = PriceGroup.find(info.last)

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -1,0 +1,15 @@
+namespace :reports do
+  desc "Gives report for concatenated price rules"
+  task concatenated_price_rules: :environment do
+    policies = {}
+    PricePolicy.current.group_by{ |p| [p.product_id, p.price_group_id] }.map{ |k, ps| policies[k] = ps if ps.count > 1 }
+    policies.each do |info, overlapping_policies|
+      product = Product.find(info.first)
+      price_group = PriceGroup.find(info.last)
+      puts "Product: #{product.name} (#{product.facility.name}), Price Group: #{price_group.name}"
+      puts "Policies = #{overlapping_policies.map{ |p| p.id }.join(', ')}"
+      puts "-----------------------------------"
+    end
+    puts "No overlapping policies" if policies.empty?
+  end
+end

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -2,12 +2,12 @@ namespace :reports do
   desc "Gives report for concatenated price rules"
   task concatenated_price_rules: :environment do
     policies = {}
-    PricePolicy.current.group_by{ |p| [p.product_id, p.price_group_id] }.map{ |k, ps| policies[k] = ps if ps.count > 1 }
+    PricePolicy.current.group_by { |p| [p.product_id, p.price_group_id] }.map { |k, ps| policies[k] = ps if ps.count > 1 }
     policies.each do |info, overlapping_policies|
       product = Product.find(info.first)
       price_group = PriceGroup.find(info.last)
       puts "Product: #{product.name} (#{product.facility.name}), Price Group: #{price_group.name}"
-      puts "Policies = #{overlapping_policies.map{ |p| p.id }.join(', ')}"
+      puts "Policies = #{overlapping_policies.map(&:id).join(', ')}"
       puts "-----------------------------------"
     end
     puts "No overlapping policies" if policies.empty?


### PR DESCRIPTION
https://pm.tablexi.com/issues/132371

This adds a task that returns a basic list for which instruments and price groups have overlapping price policies, and the ids of those price policies (in case we want to manually fix them in some way).