### PR TITLE
Oracle-related query updates and refactoring

### DIFF
--- a/app/support/auto_canceler.rb
+++ b/app/support/auto_canceler.rb
@@ -13,7 +13,10 @@ class AutoCanceler
   def cancelable_reservations
     @cancelable_reservations ||= Reservation
                                  .joins(:product, order_detail: :order)
-                                 .where(build_sql, now: Time.zone.now)
+                                 .where(actual_start_at: nil, actual_end_at: nil, canceled_at: nil)
+                                 .where("auto_cancel_mins IS NOT NULL AND auto_cancel_mins > 0")
+                                 .where(order_details: { state: %w(new inprocess) })
+                                 .where(time_condition, now: Time.current)
                                  .merge(Order.purchased)
                                  .readonly(false)
   end
@@ -29,28 +32,10 @@ class AutoCanceler
 
   def time_condition
     if NUCore::Database.oracle?
-      "(:now - reserve_start_At) >= NumToDSInterval(auto_cancel_mins, 'MINUTE')"
+      "(:now - reserve_start_at) >= NumToDSInterval(auto_cancel_mins, 'MINUTE')"
     else
       "TIMESTAMPDIFF(MINUTE, reserve_start_at, :now) >= auto_cancel_mins"
     end
-  end
-
-  def build_sql
-    <<-SQL
-        actual_start_at IS NULL
-      AND
-        actual_end_at IS NULL
-      AND
-        canceled_at IS NULL
-      AND
-        auto_cancel_mins IS NOT NULL
-      AND
-        auto_cancel_mins > 0
-      AND
-        (order_details.state = 'new' OR order_details.state = 'inprocess')
-      AND
-        #{time_condition}
-    SQL
   end
 
   def admin

--- a/app/support/auto_canceler.rb
+++ b/app/support/auto_canceler.rb
@@ -29,13 +29,9 @@ class AutoCanceler
 
   def time_condition
     if NUCore::Database.oracle?
-      <<-CONDITION
-        (EXTRACT(MINUTE FROM (:now - reserve_start_at)) +
-         EXTRACT(HOUR FROM (:now - reserve_start_at))*60 +
-         EXTRACT(DAY FROM (:now - reserve_start_at))*24*60) >= auto_cancel_mins
-      CONDITION
+      "(:now - reserve_start_At) >= NumToDSInterval(auto_cancel_mins, 'MINUTE')"
     else
-      " TIMESTAMPDIFF(MINUTE, reserve_start_at, :now) >= auto_cancel_mins"
+      "TIMESTAMPDIFF(MINUTE, reserve_start_at, :now) >= auto_cancel_mins"
     end
   end
 

--- a/app/support/auto_canceler.rb
+++ b/app/support/auto_canceler.rb
@@ -13,7 +13,9 @@ class AutoCanceler
   def cancelable_reservations
     @cancelable_reservations ||= Reservation
                                  .joins(:product, order_detail: :order)
-                                 .where(actual_start_at: nil, actual_end_at: nil, canceled_at: nil)
+                                 .not_started
+                                 .not_ended
+                                 .not_canceled
                                  .where("auto_cancel_mins IS NOT NULL AND auto_cancel_mins > 0")
                                  .where(order_details: { state: %w(new inprocess) })
                                  .where(time_condition, now: Time.current)

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,21 @@
 # Load the rails application
 require File.expand_path("../application", __FILE__)
 
+# TODO: RAILS5
+# Versions of the Oracle adapter before 1.7 make an assumption that a Time value
+# without fractional seconds is actually a Date. This causes failures most
+# consistently in tests, because time helpers always sets usec to zero, but
+# could also happen in the wild 1 out of 1000 times.
+#
+# Remove this require and patch file after upgrading the gem to 1.7 or above,
+# which only supports Rails 5.0 and up.
+if Rails.version < "5.0"
+  if defined?(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
+    require File.expand_path("../../lib/patches/oracle_enhanced_adapter", __FILE__)
+  end
+else
+  raise "Remove the reference to the oracle_enhanced_adapter patch in #{__FILE__} for Rails 5+"
+end
+
 # Initialize the rails application
 Nucore::Application.initialize!

--- a/lib/patches/oracle_enhanced_adapter.rb
+++ b/lib/patches/oracle_enhanced_adapter.rb
@@ -1,0 +1,70 @@
+# rubocop:disable Style/BarePercentLiterals
+# rubocop:disable Style/RescueModifier
+# rubocop:disable Style/SpaceInsideStringInterpolation
+# rubocop:disable Style/UnneededPercentQ
+
+module ActiveRecord
+
+  module ConnectionAdapters
+
+    class OracleEnhancedAdapter
+
+      # This method is near-verbatim from https://github.com/rsim/oracle-enhanced/tree/v1.6.7
+      # The only difference is under the value.acts_like?(:time) condition to
+      # patch a bug where it assumed that no fractional seconds meant the value
+      # was a Date, not a Time.
+      #
+      # Without the patch:
+      #
+      # [1] pry(main)> ActiveRecord::Base.connection.quote(Time.current.change(usec: 0))
+      # => "TO_DATE('2017-01-04 19:40:56','YYYY-MM-DD HH24:MI:SS')"
+      # [2] pry(main)> ActiveRecord::Base.connection.quote(Time.current.change(usec: 1))
+      # => "TO_TIMESTAMP('2017-01-04 19:40:58:000001','YYYY-MM-DD HH24:MI:SS:FF6')"
+      #
+      # With the patch:
+      #
+      # [1] pry(main)> ActiveRecord::Base.connection.quote(Time.current.change(usec: 0))
+      # => "TO_TIMESTAMP('2017-01-04 19:41:51:000000','YYYY-MM-DD HH24:MI:SS:FF6')"
+      # [2] pry(main)> ActiveRecord::Base.connection.quote(Time.current.change(usec: 1))
+      # => "TO_TIMESTAMP('2017-01-04 19:41:53:000001','YYYY-MM-DD HH24:MI:SS:FF6')"
+      #
+      # This patch should be disabled in config/environment.rb and removed after
+      # upgrading activerecord-oracle_enhanced-adapter to 1.7, which should
+      # coincide with an upgrade to Rails 5.
+
+      def quote(value, column = nil) #:nodoc:
+        if value && column
+          case column.type
+          when :text, :binary
+            %Q{empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'blob' }()}
+          # NLS_DATE_FORMAT independent TIMESTAMP support
+          when :timestamp
+            quote_timestamp_with_to_timestamp(value)
+          # NLS_DATE_FORMAT independent DATE support
+          when :date, :time, :datetime
+            quote_date_with_to_date(value)
+          when :raw
+            quote_raw(value)
+          when :string
+            # NCHAR and NVARCHAR2 literals should be quoted with N'...'.
+            # Read directly instance variable as otherwise migrations with table column default values are failing
+            # as migrations pass ColumnDefinition object to this method.
+            # Check if instance variable is defined to avoid warnings about accessing undefined instance variable.
+            column.instance_variable_defined?('@nchar') && column.instance_variable_get('@nchar') ? 'N' << super : super
+          else
+            super
+          end
+        elsif value.acts_like?(:date)
+          quote_date_with_to_date(value)
+        elsif value.acts_like?(:time)
+          quote_timestamp_with_to_timestamp(value)
+        else
+          super
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/spec/support/matchers/sql_matchers.rb
+++ b/spec/support/matchers/sql_matchers.rb
@@ -1,16 +1,30 @@
 if NUCore::Database.oracle?
+
+  def timestamp_pattern(field, operator, time)
+    timestamp = time.utc.strftime("%Y-%m-%d\\s%H:%M:%S")
+
+    /
+      \b
+      #{field}
+      \s
+      #{operator}
+      \s
+      TO_TIMESTAMP\('#{timestamp}:\d{6}','YYYY-MM-DD\sHH24:MI:SS:FF6'\)
+    /x
+  end
+
   RSpec::Matchers.define :contain_beginning_of_day do |field, datetime|
-    expected = "#{field} >= TO_DATE('#{datetime.beginning_of_day.utc.strftime('%Y-%m-%d %H:%M:%S')}','YYYY-MM-DD HH24:MI:SS')"
     match do |actual|
-      actual.where_values.include? expected
+      actual.to_sql =~ timestamp_pattern(field, ">=", datetime.beginning_of_day)
     end
   end
+
   RSpec::Matchers.define :contain_end_of_day do |field, datetime|
-    expected = /#{field.to_s} <= TO_TIMESTAMP\('#{datetime.end_of_day.utc.strftime('%Y-%m-%d %H:%M:%S')}:\d{6}','YYYY-MM-DD HH24:MI:SS:FF6'\)/
     match do |actual|
-      actual.to_sql =~ expected
+      actual.to_sql =~ timestamp_pattern(field, "<=", datetime.end_of_day)
     end
   end
+
   RSpec::Matchers.define :contain_string_in_sql do |expected|
     expected = expected.tr("\`", "\"").upcase
     match do |actual|
@@ -24,7 +38,9 @@ if NUCore::Database.oracle?
       "expected that #{actual.to_sql.upcase} would not include #{expected}"
     end
   end
+
 else
+
   RSpec::Matchers.define :contain_end_of_day do |field, datetime|
     expected = /\A#{field} <= '#{datetime.end_of_day.utc.strftime('%Y-%m-%d %H:%M:%S')}(\.9+)?'\z/
     match do |actual|


### PR DESCRIPTION
Issues in Oracle queries emerged after switching from TimeCop to Rails' built-in Time Helpers (because `travel`/`travel_to` always round to the nearest second).

These changes came out of https://github.com/tablexi/nucore-nu/pull/217.