### PR TITLE
[#132371] Fix view to only show newest price policies

### DIFF
--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -23,7 +23,7 @@ class PricePoliciesController < ApplicationController
 
   # GET /facilities/:facility_id/{product_type}/:product_id/price_policies
   def index
-    @current_price_policies = @product.price_policies.current
+    @current_price_policies = @product.price_policies.current_and_newest
     @current_start_date = @current_price_policies.first.try(:start_date)
     @past_price_policies_by_date = @product.past_price_policies_grouped_by_start_date
     @next_price_policies_by_date = @product.upcoming_price_policies_grouped_by_start_date

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -33,13 +33,13 @@ class PricePolicy < ActiveRecord::Base
   end
 
   def self.current_and_newest
-    # TODO: Fix bug that causes this to be neccessary (in truncate_existing_policies)
+    # TODO: Fix bug that allows overlapping price policies (in truncate_existing_policies)
     # This method returns the newest price policy for when price policies accidentally overlap.
     current.newest
   end
 
   def self.newest
-    ids = group(:price_group_id).maximum(:id).collect(&:last)
+    ids = group(:price_group_id).maximum(:id).values
     where(id: ids)
   end
 

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -35,7 +35,12 @@ class PricePolicy < ActiveRecord::Base
   def self.current_and_newest
     # TODO: Fix bug that causes this to be neccessary (in truncate_existing_policies)
     # This method returns the newest price policy for when price policies accidentally overlap.
-    current.group_by(&:price_group_id).map { |_, policies| policies.sort { |x, y| y.id <=> x.id }.first }
+    current.newest
+  end
+
+  def self.newest
+    ids = group(:price_group_id).maximum(:id).collect(&:last)
+    where(id: ids)
   end
 
   def self.current_for_date(date)

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -35,7 +35,7 @@ class PricePolicy < ActiveRecord::Base
   def self.current_and_newest
     # TODO: Fix bug that causes this to be neccessary (in truncate_existing_policies)
     # This method returns the newest price policy for when price policies accidentally overlap.
-    current.group_by(&:price_group_id).map { |_, policies| policies.sort { |x,y| y.id <=> x.id }.first }
+    current.group_by(&:price_group_id).map { |_, policies| policies.sort { |x, y| y.id <=> x.id }.first }
   end
 
   def self.current_for_date(date)

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -32,6 +32,12 @@ class PricePolicy < ActiveRecord::Base
     current_for_date(Time.zone.now)
   end
 
+  def self.current_and_newest
+    # TODO: Fix bug that causes this to be neccessary (in truncate_existing_policies)
+    # This method returns the newest price policy for when price policies accidentally overlap.
+    current.group_by(&:price_group_id).map { |_, policies| policies.sort { |x,y| y.id <=> x.id }.first }
+  end
+
   def self.current_for_date(date)
     where("start_date <= :now AND expire_date > :now", now: date)
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -184,7 +184,7 @@ class Product < ActiveRecord::Base
   def cheapest_price_policy(order_detail, date = Time.zone.now)
     groups = order_detail.price_groups
     return nil if groups.empty?
-    price_policies = current_price_policies(date).to_a.delete_if { |pp| pp.restrict_purchase? || groups.exclude?(pp.price_group) }
+    price_policies = current_price_policies(date).newest.to_a.delete_if { |pp| pp.restrict_purchase? || groups.exclude?(pp.price_group) }
 
     # provide a predictable ordering of price groups so that equal unit costs
     # are always handled the same way. Put the base group at the front of the

--- a/spec/models/price_policy_spec.rb
+++ b/spec/models/price_policy_spec.rb
@@ -35,20 +35,20 @@ RSpec.describe PricePolicy do
   end
 
   context "current and newest" do
-    let(:price_policy) { FactoryGirl.create(:instrument_price_policy) }
-    let(:overlapping_price_policy) do
+    let!(:price_policy) do
       FactoryGirl.create(
         :instrument_price_policy,
-        start_date: (price_policy.start_date + 1.day).beginning_of_day,
+        start_date: Time.zone.now,
+        expire_date: Time.zone.now + 1.day
+      )
+    end
+    let!(:overlapping_price_policy) do
+      FactoryGirl.create(
+        :instrument_price_policy,
+        start_date: 1.day.ago.beginning_of_day,
         product: price_policy.product,
         price_group: price_policy.price_group,
       )
-    end
-
-    before { overlapping_price_policy.update_attributes(start_date: 1.day.ago.beginning_of_day) }
-
-    it "saves updated price policy" do
-      expect(overlapping_price_policy).to be_valid
     end
 
     it "has two overlapping policies" do

--- a/spec/models/price_policy_spec.rb
+++ b/spec/models/price_policy_spec.rb
@@ -34,6 +34,29 @@ RSpec.describe PricePolicy do
     end
   end
 
+  context "current and newest" do
+    let(:price_policy) { FactoryGirl.create(:instrument_price_policy) }
+    let(:overlapping_price_policy) do
+      FactoryGirl.create(
+        :instrument_price_policy,
+        start_date: (price_policy.start_date + 1.day).beginning_of_day,
+        product: price_policy.product,
+        price_group: price_policy.price_group
+      )
+    end
+
+    before { overlapping_price_policy.update_attributes(start_date: 1.day.ago.beginning_of_day) }
+
+    it "saves updated price policy" do
+      expect(overlapping_price_policy).to be_valid
+    end
+
+    it "has two overlapping policies" do
+      policies = price_policy.product.price_policies
+      expect(policies.current.count).to be > policies.current_and_newest.count
+    end
+  end
+
   context "expire date" do
     before :each do
       @start_date = Time.zone.parse("2020-5-5")

--- a/spec/models/price_policy_spec.rb
+++ b/spec/models/price_policy_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe PricePolicy do
       FactoryGirl.create(
         :instrument_price_policy,
         start_date: Time.zone.now,
-        expire_date: Time.zone.now + 1.day
+        expire_date: Time.zone.now + 1.day,
       )
     end
     let!(:overlapping_price_policy) do

--- a/spec/models/price_policy_spec.rb
+++ b/spec/models/price_policy_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe PricePolicy do
         :instrument_price_policy,
         start_date: (price_policy.start_date + 1.day).beginning_of_day,
         product: price_policy.product,
-        price_group: price_policy.price_group
+        price_group: price_policy.price_group,
       )
     end
 


### PR DESCRIPTION
https://pm.tablexi.com/issues/132371

This fixes the view to only show newest price policies instead of the mistakenly overlapping ones together.