### PR TITLE
[#133731] Increase the size of the delayed_jobs.handler column for MySQL

### DIFF
--- a/db/migrate/20170112204251_increase_delayed_jobs_handler_capacity.rb
+++ b/db/migrate/20170112204251_increase_delayed_jobs_handler_capacity.rb
@@ -1,0 +1,15 @@
+class IncreaseDelayedJobsHandlerCapacity < ActiveRecord::Migration
+
+  def up
+    if NUCore::Database.mysql?
+      change_column :delayed_jobs, :handler, :text, limit: (2**32 - 1)
+    end
+  end
+
+  def down
+    if NUCore::Database.mysql?
+      change_column :delayed_jobs, :handler, :text
+    end
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161024213800) do
+ActiveRecord::Schema.define(version: 20170112204251) do
 
   create_table "account_users", force: :cascade do |t|
     t.integer  "account_id", limit: 4,  null: false
@@ -88,9 +88,9 @@ ActiveRecord::Schema.define(version: 20161024213800) do
   add_index "bundle_products", ["product_id"], name: "fk_bundle_prod_bundle", using: :btree
 
   create_table "delayed_jobs", force: :cascade do |t|
-    t.integer  "priority",   limit: 4,     default: 0, null: false
-    t.integer  "attempts",   limit: 4,     default: 0, null: false
-    t.text     "handler",    limit: 65535,             null: false
+    t.integer  "priority",   limit: 4,          default: 0, null: false
+    t.integer  "attempts",   limit: 4,          default: 0, null: false
+    t.text     "handler",    limit: 4294967295,             null: false
     t.text     "last_error", limit: 65535
     t.datetime "run_at"
     t.datetime "locked_at"


### PR DESCRIPTION
This increases the size limit from 2^8 characters to 2^32 for MySQL.

For Oracle, this column is already a `CLOB`, with a size limit of 2**31 characters, so the migration makes no changes.