### PR TITLE
[#133966] Join orders to transactions in-review search queries

### DIFF
--- a/app/controllers/facility_notifications_controller.rb
+++ b/app/controllers/facility_notifications_controller.rb
@@ -24,7 +24,7 @@ class FacilityNotificationsController < ApplicationController
 
   # GET /facilities/notifications
   def index_with_search
-    @order_details = @order_details.all_need_notification
+    @order_details = @order_details.need_notification
     @order_detail_action = :send_notifications
   end
 

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -197,11 +197,12 @@ class OrderDetail < ActiveRecord::Base
       .where("dispute_at IS NULL OR dispute_resolved_at IS NOT NULL")
   }
 
-  def self.all_in_review
-    where(state: "complete")
-      .where("order_details.reviewed_at > ?", Time.zone.now)
+  scope :all_in_review, lambda {
+    joins(:order)
+      .where(state: "complete")
+      .where("order_details.reviewed_at > ?", Time.current)
       .where("dispute_at IS NULL OR dispute_resolved_at IS NOT NULL")
-  end
+  }
 
   def self.recently_reviewed
     where(state: %w(complete reconciled))

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -162,26 +162,32 @@ class OrderDetail < ActiveRecord::Base
     pending.joins(:reservation).merge(Reservation.not_canceled)
   end
 
+  scope :with_price_policy, -> { where.not(price_policy_id: nil) }
+
   scope :for_facility_with_price_policy, lambda { |facility|
     joins(:order)
       .order(fulfilled_at: :desc)
-      .where("orders.facility_id" => facility.id)
-      .where.not(price_policy_id: nil)
+      .where(orders: { facility_id: facility.id })
+      .with_price_policy
+  }
+
+  scope :not_disputed, lambda {
+    where("dispute_at IS NULL OR dispute_resolved_at IS NOT NULL")
   }
 
   scope :need_notification, lambda {
     joins(:product)
       .where(state: "complete")
       .where(reviewed_at: nil)
-      .where.not(price_policy_id: nil)
-      .where("dispute_at IS NULL OR dispute_resolved_at IS NOT NULL")
+      .with_price_policy
+      .not_disputed
   }
 
   def self.all_need_notification # TODO: is use need_notification instead?
     where(state: "complete")
       .where(reviewed_at: nil)
-      .where("price_policy_id IS NOT NULL")
-      .where("dispute_at IS NULL OR dispute_resolved_at IS NOT NULL")
+      .with_price_policy
+      .not_disputed
   end
 
   def self.all_movable
@@ -194,20 +200,20 @@ class OrderDetail < ActiveRecord::Base
       .where(products: { facility_id: facility.id })
       .where(state: "complete")
       .where("order_details.reviewed_at > ?", Time.zone.now)
-      .where("dispute_at IS NULL OR dispute_resolved_at IS NOT NULL")
+      .not_disputed
   }
 
   scope :all_in_review, lambda {
     joins(:order)
       .where(state: "complete")
       .where("order_details.reviewed_at > ?", Time.current)
-      .where("dispute_at IS NULL OR dispute_resolved_at IS NOT NULL")
+      .not_disputed
   }
 
   def self.recently_reviewed
     where(state: %w(complete reconciled))
       .where("order_details.reviewed_at < ?", Time.zone.now)
-      .where("dispute_at IS NULL OR dispute_resolved_at IS NOT NULL")
+      .not_disputed
       .order(:reviewed_at).reverse_order
   end
 
@@ -262,9 +268,9 @@ class OrderDetail < ActiveRecord::Base
       .where(problem: false)
       .where("reviewed_at <= ?", Time.current)
       .where(statement_id: nil)
-      .where.not(price_policy_id: nil)
+      .with_price_policy
       .where("accounts.type" => Account.config.statement_account_types)
-      .where("dispute_at IS NULL OR dispute_resolved_at IS NOT NULL")
+      .not_disputed
   }
 
   scope :need_journal, lambda { # TODO: share common pieces with :need_statement scope
@@ -274,8 +280,8 @@ class OrderDetail < ActiveRecord::Base
       .where("reviewed_at <= ?", Time.current)
       .where("accounts.type" => Account.config.journal_account_types)
       .where(journal_id: nil)
-      .where.not(price_policy_id: nil)
-      .where("dispute_at IS NULL OR dispute_resolved_at IS NOT NULL")
+      .with_price_policy
+      .not_disputed
   }
 
   scope :statemented, lambda { |facility|

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -183,13 +183,6 @@ class OrderDetail < ActiveRecord::Base
       .not_disputed
   }
 
-  def self.all_need_notification # TODO: is use need_notification instead?
-    where(state: "complete")
-      .where(reviewed_at: nil)
-      .with_price_policy
-      .not_disputed
-  end
-
   def self.all_movable
     where(journal_id: nil)
       .where("order_details.state NOT IN('canceled', 'reconciled')")


### PR DESCRIPTION
The `OrderDetail.all_in_review` scope needs to `JOIN` the orders table to for references to `ordered_at` in transaction searches to work.

This also includes some scope refactoring and cleanup.