### PR TITLE
[#133446] Reply to bulk email

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -36,7 +36,7 @@ class Notifier < ActionMailer::Base
 
   def order_notification(order, recipient)
     @order = order
-    send_nucore_mail recipient, text("views.notifier.order_notification.subject"), template_name: "order_receipt", reply_to: reply_to_email(@order, @order.facility)
+    send_nucore_mail recipient, text("views.notifier.order_notification.subject"), "order_receipt"
   end
 
   # Custom order forms send out a confirmation email when filled out by a
@@ -45,7 +45,7 @@ class Notifier < ActionMailer::Base
     @user = args[:user]
     @order = args[:order]
     @greeting = text("views.notifier.order_receipt.intro")
-    send_nucore_mail args[:user].email, text("views.notifier.order_receipt.subject"), reply_to: reply_to_email(@order, @order.facility)
+    send_nucore_mail args[:user].email, text("views.notifier.order_receipt.subject")
   end
 
   def review_orders(args)
@@ -63,7 +63,7 @@ class Notifier < ActionMailer::Base
     @account = args[:account]
     @statement = args[:statement]
     attach_statement_pdf
-    send_nucore_mail args[:user].email, text("views.notifier.statement.subject", facility: @facility), reply_to: reply_to_email(@statement.order_details.first.order, @facility)
+    send_nucore_mail args[:user].email, text("views.notifier.statement.subject", facility: @facility)
   end
 
   def order_detail_status_change(order_detail, old_status, new_status, to)
@@ -71,7 +71,7 @@ class Notifier < ActionMailer::Base
     @old_status = old_status
     @new_status = new_status
     template = "order_status_changed_to_#{new_status.downcase_name}"
-    send_nucore_mail to, t("views.notifier.#{template}.subject", order_detail: order_detail, user: order_detail.order.user, product: order_detail.product), template_name: template, reply_to: reply_to_email(order_detail.order, order_detail.facility)
+    send_nucore_mail to, t("views.notifier.#{template}.subject", order_detail: order_detail, user: order_detail.order.user, product: order_detail.product), template
   end
 
   private
@@ -87,14 +87,8 @@ class Notifier < ActionMailer::Base
     @statement_pdf ||= StatementPdfFactory.instance(@statement)
   end
 
-  def send_nucore_mail(to, subject, template_name: nil, reply_to: nil)
-    options = { subject: subject, to: to, template_name: template_name }
-    options[:reply_to] = reply_to if reply_to
-    mail(options)
-  end
-
-  def reply_to_email(order, facility)
-    order.order_details.first.product.contact_email || facility.email
+  def send_nucore_mail(to, subject, template_name = nil)
+    mail(subject: subject, to: to, template_name: template_name)
   end
 
 end

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -12,17 +12,8 @@ RSpec.describe Notifier do
 
     let(:recipient) { "orders@example.net" }
 
-    context "when product has a contact email" do
-      let(:product) { create(:setup_instrument, facility: facility, contact_email: "test@example.com") }
-
-      it "generates and order notification with product reply to" do
-        expect(email.reply_to).to eq [product.contact_email]
-      end
-    end
-
     it "generates an order notification", :aggregate_failures do
       expect(email.to).to eq [recipient]
-      expect(email.reply_to).to eq [facility.email]
       expect(email.subject).to include("Order Notification")
       expect(email.html_part.to_s).to match(/Ordered By.+#{user.full_name}/m)
       expect(email.text_part.to_s).to include("Ordered By: #{user.full_name}")
@@ -43,7 +34,6 @@ RSpec.describe Notifier do
 
     it "generates a receipt", :aggregate_failures do
       expect(email.to).to eq [user.email]
-      expect(email.reply_to).to eq [facility.email]
       expect(email.subject).to include("Order Receipt")
       expect(email.html_part.to_s).to match(/Ordered By.+#{user.full_name}/m)
       expect(email.text_part.to_s).to include("Ordered By: #{user.full_name}")

--- a/vendor/engines/bulk_email/app/mailers/bulk_email/mailer.rb
+++ b/vendor/engines/bulk_email/app/mailers/bulk_email/mailer.rb
@@ -2,10 +2,12 @@ module BulkEmail
 
   class Mailer < BaseMailer
 
-    def send_mail(recipient:, subject:, body:)
+    def send_mail(recipient:, subject:, body:, reply_to: nil)
       @recipient = recipient
       @body = body
-      mail(to: recipient.email, subject: subject)
+      options = { to: recipient.email, subject: subject }
+      options[:reply_to] = reply_to if reply_to.present?
+      mail(options)
     end
 
   end

--- a/vendor/engines/bulk_email/app/models/bulk_email/delivery_form.rb
+++ b/vendor/engines/bulk_email/app/models/bulk_email/delivery_form.rb
@@ -43,9 +43,13 @@ module BulkEmail
       content_generator.wrap_text(custom_message, recipient_name)
     end
 
+    def reply_to
+      facility.email
+    end
+
     def deliver(recipient)
       Mailer
-        .send_mail(recipient: recipient, subject: subject, body: body(recipient.full_name))
+        .send_mail(recipient: recipient, subject: subject, body: body(recipient.full_name), reply_to: reply_to)
         .deliver_later
     end
 

--- a/vendor/engines/bulk_email/app/models/bulk_email/delivery_form.rb
+++ b/vendor/engines/bulk_email/app/models/bulk_email/delivery_form.rb
@@ -44,7 +44,7 @@ module BulkEmail
     end
 
     def reply_to
-      facility.email
+      product.try(:contact_email).presence || facility.email
     end
 
     def deliver(recipient)

--- a/vendor/engines/bulk_email/spec/mailers/bulk_email/mailer_spec.rb
+++ b/vendor/engines/bulk_email/spec/mailers/bulk_email/mailer_spec.rb
@@ -6,16 +6,30 @@ RSpec.describe BulkEmail::Mailer do
     let(:recipient) { FactoryGirl.build_stubbed(:user) }
     let(:custom_subject) { "Custom subject" }
     let(:body) { "Custom message" }
+    let(:reply_to) { "reply@example.com" }
 
-    before(:each) do
-      described_class
-        .send_mail(body: body, subject: custom_subject, recipient: recipient)
-        .deliver_now
+    context "with reply_to set" do
+      before(:each) do
+        described_class
+          .send_mail(body: body, subject: custom_subject, recipient: recipient, reply_to: reply_to)
+          .deliver_now
+      end
+
+      it { expect(email.to).to eq [recipient.email] }
+      it { expect(email.subject).to eq(custom_subject) }
+      it { expect(email.reply_to).to eq [reply_to] }
+      it { expect(email.html_part.to_s).to include(body) }
+      it { expect(email.text_part.to_s).to include(body) }
     end
 
-    it { expect(email.to).to eq [recipient.email] }
-    it { expect(email.subject).to eq(custom_subject) }
-    it { expect(email.html_part.to_s).to include(body) }
-    it { expect(email.text_part.to_s).to include(body) }
+    context "without reply_to set" do
+      before(:each) do
+        described_class
+          .send_mail(body: body, subject: custom_subject, recipient: recipient)
+          .deliver_now
+      end
+
+      it { expect(email.reply_to).to be_nil }
+    end
   end
 end


### PR DESCRIPTION
https://pm.tablexi.com/issues/133446

This adds the reply_to field to the bulk email and removes it from the emails where I mistakenly added it. 

We don't actually have the product id here unless we parse it from the search criteria, so I'm using the facility email. Another option I came across would be adding it to the bulk email form, so it's always customizable (totally doable), would love to hear if anyone has a preference.  