### PR TITLE
[#133383] Add optional note, fulfilled_at, and status fields to the facility order screen

### DIFF
--- a/app/assets/javascripts/app/merge_order_form.js.coffee
+++ b/app/assets/javascripts/app/merge_order_form.js.coffee
@@ -1,0 +1,16 @@
+class window.MergeOrderForm
+  constructor: (@$form) ->
+    @$fulfilled_at = @$form.find("#fulfilled_at")
+    @$order_status_id = @$form.find("#order_status_id")
+    @initializeListener()
+    @$order_status_id.change()
+
+  initializeListener: ->
+    @$order_status_id.change (event) =>
+      if $(event.target).find("option:selected").text() == "Complete"
+        @$fulfilled_at.show()
+      else
+        @$fulfilled_at.hide()
+
+$ ->
+  new MergeOrderForm($("form.edit_order"))

--- a/app/assets/javascripts/app/merge_order_form.js.coffee
+++ b/app/assets/javascripts/app/merge_order_form.js.coffee
@@ -13,4 +13,4 @@ class window.MergeOrderForm
         @$fulfilled_at.hide()
 
 $ ->
-  $(".js--edit-order").each -> new MergeOrderForm($(this))
+  $(".js--edit-order").each (_, form) -> new MergeOrderForm($(form))

--- a/app/assets/javascripts/app/merge_order_form.js.coffee
+++ b/app/assets/javascripts/app/merge_order_form.js.coffee
@@ -13,4 +13,4 @@ class window.MergeOrderForm
         @$fulfilled_at.hide()
 
 $ ->
-  new MergeOrderForm($("form.edit_order"))
+  $(".js--edit-order").each -> new MergeOrderForm($(this))

--- a/app/assets/stylesheets/app/chosen-override.scss
+++ b/app/assets/stylesheets/app/chosen-override.scss
@@ -1,5 +1,6 @@
 .chosen-container {
   font-size: 90%;
+  margin-bottom: 10px;
 
   .chosen-results {
     li {

--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -69,10 +69,16 @@ class FacilityOrdersController < ApplicationController
     if quantity <= 0
       flash[:notice] = I18n.t "controllers.facility_orders.update.zero_quantity"
     else
-      if OrderAppender.new(product, quantity, original_order, current_user).add!
-        flash[:error] = I18n.t "controllers.facility_orders.update.notices", product: product.name
-      else
-        flash[:notice] = I18n.t "controllers.facility_orders.update.success", product: product.name
+      order_appender = OrderAppender.new(product, quantity, original_order, current_user)
+      begin
+        if order_appender.add!
+          flash[:error] = I18n.t "controllers.facility_orders.update.notices", product: product.name
+        else
+          flash[:notice] = I18n.t "controllers.facility_orders.update.success", product: product.name
+        end
+      rescue => e
+        Rails.logger.error "#{e.message}\n#{e.backtrace.join("\n")}"
+        flash[:error] = I18n.t "controllers.facility_orders.update.error", product: product.name
       end
     end
 

--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -60,8 +60,9 @@ class FacilityOrdersController < ApplicationController
     end
   end
 
+  # PUT/PATCH /facilities/:facility_id/orders/:id
   def update
-    product = Product.find(params[:product_add].to_i)
+    product = current_facility.products.find(params[:product_add])
     original_order = @order
     quantity = params[:product_add_quantity].to_i
 

--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -63,13 +63,15 @@ class FacilityOrdersController < ApplicationController
   # PUT/PATCH /facilities/:facility_id/orders/:id
   def update
     product = current_facility.products.find(params[:product_add])
-    original_order = @order
     quantity = params[:product_add_quantity].to_i
 
     if quantity <= 0
       flash[:notice] = I18n.t "controllers.facility_orders.update.zero_quantity"
     else
-      order_appender = OrderAppender.new(product, quantity, original_order, current_user)
+      order_appender = OrderAppender.new(product: product,
+                                         quantity: quantity,
+                                         original_order: @order,
+                                         user: current_user)
       begin
         if order_appender.add!
           flash[:error] = I18n.t "controllers.facility_orders.update.notices", product: product.name
@@ -82,7 +84,7 @@ class FacilityOrdersController < ApplicationController
       end
     end
 
-    redirect_to facility_order_path(current_facility, original_order)
+    redirect_to facility_order_path(current_facility, @order)
   end
 
   protected

--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -71,7 +71,10 @@ class FacilityOrdersController < ApplicationController
       order_appender = OrderAppender.new(product: product,
                                          quantity: quantity,
                                          original_order: @order,
-                                         user: current_user)
+                                         user: current_user,
+                                         note: params[:note].presence,
+                                         fulfilled_at: parse_usa_date(params[:fulfilled_at]),
+                                         order_status_id: params[:order_status_id].presence)
       begin
         if order_appender.add!
           flash[:error] = I18n.t "controllers.facility_orders.update.notices", product: product.name

--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -68,15 +68,8 @@ class FacilityOrdersController < ApplicationController
     if quantity <= 0
       flash[:notice] = text("update.zero_quantity")
     else
-      order_appender = OrderAppender.new(product: product,
-                                         quantity: quantity,
-                                         original_order: @order,
-                                         user: current_user,
-                                         note: params[:note].presence,
-                                         fulfilled_at: parse_usa_date(params[:fulfilled_at]),
-                                         order_status_id: params[:order_status_id].presence)
       begin
-        if order_appender.add!
+        if order_appender.add!(product, quantity, params)
           flash[:error] = text("update.notices", product: product.name)
         else
           flash[:notice] = text("update.success", product: product.name)
@@ -112,6 +105,10 @@ class FacilityOrdersController < ApplicationController
 
   def load_merge_orders
     @merge_orders = Order.where(merge_with_order_id: @order.id, created_by: current_user.id)
+  end
+
+  def order_appender
+    @order_appender ||= OrderAppender.new(@order, current_user)
   end
 
 end

--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -66,7 +66,7 @@ class FacilityOrdersController < ApplicationController
     quantity = params[:product_add_quantity].to_i
 
     if quantity <= 0
-      flash[:notice] = I18n.t "controllers.facility_orders.update.zero_quantity"
+      flash[:notice] = text("update.zero_quantity")
     else
       order_appender = OrderAppender.new(product: product,
                                          quantity: quantity,
@@ -77,13 +77,13 @@ class FacilityOrdersController < ApplicationController
                                          order_status_id: params[:order_status_id].presence)
       begin
         if order_appender.add!
-          flash[:error] = I18n.t "controllers.facility_orders.update.notices", product: product.name
+          flash[:error] = text("update.notices", product: product.name)
         else
-          flash[:notice] = I18n.t "controllers.facility_orders.update.success", product: product.name
+          flash[:notice] = text("update.success", product: product.name)
         end
       rescue => e
         Rails.logger.error "#{e.message}\n#{e.backtrace.join("\n")}"
-        flash[:error] = I18n.t "controllers.facility_orders.update.error", product: product.name
+        flash[:error] = text("update.error", product: product.name)
       end
     end
 

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -53,6 +53,10 @@ class Instrument < Product
     days = price_group_products.collect(&:reservation_window).max.to_i
   end
 
+  def mergeable?
+    true
+  end
+
   def restriction_levels_for(user)
     product_access_groups.joins(:product_users).where(product_users: { user_id: user.id })
   end

--- a/app/models/order_status.rb
+++ b/app/models/order_status.rb
@@ -42,6 +42,10 @@ class OrderStatus < ActiveRecord::Base
     reconciled.first
   end
 
+  def self.add_to_order_statuses(facility)
+    non_protected_statuses(facility) - canceled
+  end
+
   def editable?
     !!facility
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -222,6 +222,10 @@ class Product < ActiveRecord::Base
     product_users.find_by_user_id(user.id)
   end
 
+  def mergeable?
+    false
+  end
+
   def offline?
     false
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -25,4 +25,8 @@ class Service < Product
     stored_files.template.count > 0
   end
 
+  def mergeable?
+    active_survey? || active_template?
+  end
+
 end

--- a/app/services/order_appender.rb
+++ b/app/services/order_appender.rb
@@ -1,18 +1,25 @@
 class OrderAppender
 
-  attr_reader :product, :quantity, :original_order, :user
+  attr_reader :fulfilled_at, :note, :order_status_id, :original_order, :product,
+              :quantity, :user
 
-  def initialize(product:, quantity:, original_order:, user:)
+  def initialize(product:, quantity:, original_order:, user:, note: nil, fulfilled_at: nil, order_status_id: nil)
     @product = product
     @quantity = quantity
     @original_order = original_order
     @user = user
+    @note = note
+    @fulfilled_at = fulfilled_at
+    @order_status_id = order_status_id
   end
 
   def add!
     notifications = false
     order_details.each do |order_detail|
+      order_detail.note = note if note.present?
+      order_detail.fulfilled_at = fulfilled_at if fulfilled_at.present?
       order_detail.set_default_status!
+      order_detail.change_status!(order_status) if order_status_id.present?
       if order.to_be_merged? && !order_detail.valid_for_purchase?
         notifications = true
         MergeNotification.create_for!(user, order_detail)
@@ -50,6 +57,11 @@ class OrderAppender
       product.is_a?(Instrument) ||
         (product.is_a?(Service) && (product.active_survey? || product.active_template?))
     end
+  end
+
+  def order_status
+    @order_status ||=
+      OrderStatus.for_facility(product.facility).find(order_status_id)
   end
 
   def products

--- a/app/services/order_appender.rb
+++ b/app/services/order_appender.rb
@@ -2,7 +2,7 @@ class OrderAppender
 
   attr_reader :product, :quantity, :original_order, :user
 
-  def initialize(product, quantity, original_order, user)
+  def initialize(product:, quantity:, original_order:, user:)
     @product = product
     @quantity = quantity
     @original_order = original_order

--- a/app/services/order_appender.rb
+++ b/app/services/order_appender.rb
@@ -1,0 +1,52 @@
+class OrderAppender
+
+  attr_reader :product, :quantity, :original_order, :user
+
+  def initialize(product, quantity, original_order, user)
+    @product = product
+    @quantity = quantity
+    @order = @original_order = original_order
+    @user = user
+  end
+
+  def merge?
+    products = product.is_a?(Bundle) ? product.products : [product]
+
+    products.any? do |p|
+      p.is_a?(Instrument) || (p.is_a?(Service) && (p.active_survey? || p.active_template?))
+    end
+  end
+
+  def add!
+    @order = build_merge_order(@order) if merge?
+
+    begin
+      order_details = @order.add(product, quantity, created_by: user.id)
+      notifications = false
+      order_details.each do |order_detail|
+        order_detail.set_default_status!
+        if @order.to_be_merged? && !order_detail.valid_for_purchase?
+          notifications = true
+          MergeNotification.create_for!(user, order_detail)
+        end
+      end
+
+      notifications
+    rescue => e
+      Rails.logger.error "#{e.message}\n#{e.backtrace.join("\n")}"
+      @order.destroy if @order != original_order
+      flash[:error] = I18n.t "controllers.facility_orders.update.error", product: product.name
+    end
+  end
+
+  def build_merge_order(order)
+    Order.create!(
+      merge_with_order_id: order.id,
+      facility_id: order.facility_id,
+      account_id: order.account_id,
+      user_id: order.user_id,
+      created_by: user.id,
+    )
+  end
+
+end

--- a/app/services/order_appender.rb
+++ b/app/services/order_appender.rb
@@ -21,9 +21,11 @@ class OrderAppender
     notifications = false
     order_details.each do |order_detail|
       order_detail.note = note if note.present?
-      order_detail.fulfilled_at = fulfilled_at if fulfilled_at.present?
       order_detail.set_default_status!
       order_detail.change_status!(order_status) if order_status.present?
+      if fulfilled_at.present? && order_status == OrderStatus.complete_status
+        order_detail.update_attribute(:fulfilled_at, fulfilled_at)
+      end
       if order.to_be_merged? && !order_detail.valid_for_purchase?
         notifications = true
         MergeNotification.create_for!(user, order_detail)

--- a/app/services/order_appender.rb
+++ b/app/services/order_appender.rb
@@ -1,7 +1,7 @@
 class OrderAppender
 
-  attr_reader :fulfilled_at, :note, :order_status_id, :original_order, :product,
-              :quantity, :user
+  attr_reader :fulfilled_at, :note, :order_details, :order_status_id,
+              :original_order, :product, :quantity, :user
 
   def initialize(product:, quantity:, original_order:, user:, note: nil, fulfilled_at: nil, order_status_id: nil)
     @product = product
@@ -11,6 +11,7 @@ class OrderAppender
     @note = note
     @fulfilled_at = fulfilled_at
     @order_status_id = order_status_id
+    @order_details = add_order_details
   end
 
   def add!
@@ -34,12 +35,8 @@ class OrderAppender
 
   private
 
-  def order
-    @order ||= merge? ? build_merge_order : original_order
-  end
-
-  def order_details
-    @order_details ||= order.add(product, quantity, created_by: user.id)
+  def add_order_details
+    order.add(product, quantity, created_by: user.id)
   end
 
   def build_merge_order
@@ -57,6 +54,10 @@ class OrderAppender
       product.is_a?(Instrument) ||
         (product.is_a?(Service) && (product.active_survey? || product.active_template?))
     end
+  end
+
+  def order
+    @order ||= merge? ? build_merge_order : original_order
   end
 
   def order_status

--- a/app/services/order_appender.rb
+++ b/app/services/order_appender.rb
@@ -5,48 +5,55 @@ class OrderAppender
   def initialize(product, quantity, original_order, user)
     @product = product
     @quantity = quantity
-    @order = @original_order = original_order
+    @original_order = original_order
     @user = user
   end
 
-  def merge?
-    products = product.is_a?(Bundle) ? product.products : [product]
-
-    products.any? do |p|
-      p.is_a?(Instrument) || (p.is_a?(Service) && (p.active_survey? || p.active_template?))
-    end
-  end
-
   def add!
-    @order = build_merge_order(@order) if merge?
-
-    begin
-      order_details = @order.add(product, quantity, created_by: user.id)
-      notifications = false
-      order_details.each do |order_detail|
-        order_detail.set_default_status!
-        if @order.to_be_merged? && !order_detail.valid_for_purchase?
-          notifications = true
-          MergeNotification.create_for!(user, order_detail)
-        end
+    notifications = false
+    order_details.each do |order_detail|
+      order_detail.set_default_status!
+      if order.to_be_merged? && !order_detail.valid_for_purchase?
+        notifications = true
+        MergeNotification.create_for!(user, order_detail)
       end
-
-      notifications
-    rescue => e
-      Rails.logger.error "#{e.message}\n#{e.backtrace.join("\n")}"
-      @order.destroy if @order != original_order
-      flash[:error] = I18n.t "controllers.facility_orders.update.error", product: product.name
     end
+
+    notifications
+  rescue => e
+    order.destroy if order != original_order
+    raise e
   end
 
-  def build_merge_order(order)
+  private
+
+  def order
+    @order ||= merge? ? build_merge_order : original_order
+  end
+
+  def order_details
+    @order_details ||= order.add(product, quantity, created_by: user.id)
+  end
+
+  def build_merge_order
     Order.create!(
-      merge_with_order_id: order.id,
-      facility_id: order.facility_id,
-      account_id: order.account_id,
-      user_id: order.user_id,
+      merge_with_order_id: original_order.id,
+      facility_id: original_order.facility_id,
+      account_id: original_order.account_id,
+      user_id: original_order.user_id,
       created_by: user.id,
     )
+  end
+
+  def merge?
+    products.any? do |product|
+      product.is_a?(Instrument) ||
+        (product.is_a?(Service) && (product.active_survey? || product.active_template?))
+    end
+  end
+
+  def products
+    @products ||= product.is_a?(Bundle) ? product.products : [product]
   end
 
 end

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -14,7 +14,7 @@
       = text_field_tag :fulfilled_at,
         nil,
         placeholder: OrderDetail.human_attribute_name(:fulfilled_at),
-        data: { "min-date": SettingsHelper.fiscal_year_beginning.iso8601, "max-date": Date.today.iso8601 },
+        data: { min_date: SettingsHelper.fiscal_year_beginning.iso8601, max_date: Date.today.iso8601 },
         class: "datepicker__data string optional"
 
       %br

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -6,21 +6,24 @@
       = select_tag :product_add,
         options_for_select(current_facility.products.active_plus_hidden.pluck(:name, :id))
 
-      = text_field_tag :note,
-        nil,
-        placeholder: OrderDetail.human_attribute_name(:note),
-        class: "string optional"
+      = label_tag :order_status_id, OrderDetail.human_attribute_name(:order_status)
+      = select_tag :order_status_id,
+        options_for_select(OrderStatus.add_to_order_statuses(current_facility).map { |s| [s.name_with_level, s.id] }),
+        class: "js--chosen optional"
 
       = text_field_tag :fulfilled_at,
         nil,
         placeholder: OrderDetail.human_attribute_name(:fulfilled_at),
+        data: { "min-date": SettingsHelper.fiscal_year_beginning.iso8601, "max-date": Date.today.iso8601 },
         class: "datepicker__data string optional"
 
-      = select_tag :order_status_id,
-        options_for_select(OrderStatus.for_facility(current_facility).pluck(:name, :id)),
-        include_blank: true,
-        class: "js--chosen optional",
-        data: { placeholder: OrderDetail.human_attribute_name(:order_status) }
-
       %br
+
+      = label_tag :note, OrderDetail.human_attribute_name(:note)
+      = text_field_tag :note,
+        nil,
+        maxlength: 100,
+        size: 100,
+        class: "string optional"
+
       = submit_tag "Add To Order", class: "btn btn-primary", id: :product_add_btn

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -20,10 +20,8 @@
       %br
 
       = label_tag :note, OrderDetail.human_attribute_name(:note)
-      = text_field_tag :note,
+      = text_area_tag :note,
         nil,
-        maxlength: 100,
-        size: 100,
-        class: "string optional"
+        class: "string optional wide"
 
       = submit_tag "Add To Order", class: "btn btn-primary", id: :product_add_btn

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -1,7 +1,8 @@
 - if @merge_orders.blank?
   .well
-    = form_for [current_facility, @order], :method => :put do |f|
+    = form_for [current_facility, @order], method: :put do |f|
       = text_field_tag :product_add_quantity, 1
-      = select_tag :product_add, options_for_select(current_facility.products.active_plus_hidden.collect{|p| [ p.name, p.id ]})
+      = select_tag :product_add,
+        options_for_select(current_facility.products.active_plus_hidden.pluck(:name, :id))
       %br
-      = submit_tag 'Add To Order', :class => 'btn btn-primary', :id => :product_add_btn
+      = submit_tag "Add To Order", class: "btn btn-primary", id: :product_add_btn

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -8,15 +8,19 @@
 
       = text_field_tag :note,
         nil,
-        placeholder: OrderDetail.human_attribute_name(:note)
+        placeholder: OrderDetail.human_attribute_name(:note),
+        class: "string optional"
 
       = text_field_tag :fulfilled_at,
         nil,
-        placeholder: OrderDetail.human_attribute_name(:fulfilled_at)
+        placeholder: OrderDetail.human_attribute_name(:fulfilled_at),
+        class: "datepicker__data string optional"
 
       = select_tag :order_status_id,
         options_for_select(OrderStatus.for_facility(current_facility).pluck(:name, :id)),
-        prompt: OrderDetail.human_attribute_name(:order_status)
+        include_blank: true,
+        class: "js--chosen optional",
+        data: { placeholder: OrderDetail.human_attribute_name(:order_status) }
 
       %br
       = submit_tag "Add To Order", class: "btn btn-primary", id: :product_add_btn

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -1,6 +1,6 @@
 - if @merge_orders.blank?
   .well
-    = form_for [current_facility, @order], method: :put do |f|
+    = simple_form_for [current_facility, @order], method: :put, html: { class: "js--edit-order" } do |f|
       = text_field_tag :product_add_quantity, 1
 
       = select_tag :product_add,

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -2,7 +2,21 @@
   .well
     = form_for [current_facility, @order], method: :put do |f|
       = text_field_tag :product_add_quantity, 1
+
       = select_tag :product_add,
         options_for_select(current_facility.products.active_plus_hidden.pluck(:name, :id))
+
+      = text_field_tag :note,
+        nil,
+        placeholder: OrderDetail.human_attribute_name(:note)
+
+      = text_field_tag :fulfilled_at,
+        nil,
+        placeholder: OrderDetail.human_attribute_name(:fulfilled_at)
+
+      = select_tag :order_status_id,
+        options_for_select(OrderStatus.for_facility(current_facility).pluck(:name, :id)),
+        prompt: OrderDetail.human_attribute_name(:order_status)
+
       %br
       = submit_tag "Add To Order", class: "btn btn-primary", id: :product_add_btn

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -24,4 +24,6 @@
         nil,
         class: "string optional wide"
 
-      = submit_tag "Add To Order", class: "btn btn-primary", id: :product_add_btn
+      = submit_tag text("admin.shared.add_to", model: @order.class),
+        class: "btn btn-primary",
+        id: :product_add_btn

--- a/app/views/facility_orders/show.html.haml
+++ b/app/views/facility_orders/show.html.haml
@@ -1,6 +1,7 @@
 - content_for :h1 do
   = current_facility
-%h2= "Order ##{@order.id}"
+
+%h2= "#{Order.model_name.human} ##{@order.id}"
 
 .container.banner-list
   .row
@@ -8,16 +9,16 @@
     = banner_label @order, :user
     = banner_label @order, :created_by_user
     - if @merge_orders.blank?
-      .pull-right= render :partial => 'send_receipt'
+      .pull-right= render "send_receipt"
 
-= render :partial => 'merge_order'
+= render "merge_order"
 
 %table.order-list.table.table-striped.table-hover#order-management
   %thead
     %tr
-      %th{:colspan => 4}
-      %th{:colspan => 2}= OrderDetail.human_attribute_name(:quantity)
-      %th{:colspan => 3} Pricing
+      %th{colspan: 4}
+      %th{colspan: 2}= OrderDetail.human_attribute_name(:quantity)
+      %th{colspan: 3} Pricing
     %tr
       %th.order-id= OrderDetail.human_attribute_name(:id)
       %th.badges Status
@@ -29,12 +30,15 @@
       %th.currency Subsidy
       %th.currency Total
       %th.badges
+
   %tbody
     - @order_details.each do |od|
       - od.send(:extend, PriceDisplayment)
-      %tr{:class => [od.parent_order_detail_id ? 'child' : 'parent', "status-#{od.order_status.root.name.underscore}", flash[:updated_order_details].try(:include?, od.id) ? 'updated-order-detail' : ''] }
+      %tr{class: [od.parent_order_detail_id ? "child" : "parent", "status-#{od.order_status.root.name.underscore}", flash[:updated_order_details].try(:include?, od.id) ? "updated-order-detail" : ""] }
         %td.order-id
-          = link_to od, manage_order_detail_path(od), :class => 'manage-order-detail'
+          = link_to od,
+            manage_order_detail_path(od),
+            class: "manage-order-detail"
         %td.badges
           = status_badge(od)
         %td.product
@@ -42,10 +46,10 @@
           = "<br/>#{od.reservation}".html_safe if od.reservation
         %td.action
           - if od.add_accessories?
-            = link_to new_facility_order_order_detail_accessory_path(current_facility, @order, od), :class => ['has_accessories', 'persistent'] do
-              = tooltip_icon 'icon-plus-sign-alt', t('product_accessories.pick_accessories.title')
-          = render :partial => 'order_file_icon', :locals => { :od => od }
-          = render :partial => 'result_file_icon', :locals => { :od => od }
+            = link_to new_facility_order_order_detail_accessory_path(current_facility, @order, od), class: ["has_accessories", "persistent"] do
+              = tooltip_icon "icon-plus-sign-alt", t("product_accessories.pick_accessories.title")
+          = render "order_file_icon", od: od
+          = render "result_file_icon", od: od
 
         %td.currency.timeinput= od.reservation.try(:duration_mins)
         - if od.reservation.try(:actual_duration_mins)
@@ -67,15 +71,16 @@
       %td
       %td
       %td.currency
-        %strong= number_to_currency @order_details.non_canceled.inject(0) { |sum,od| sum + od.cost }
+        %strong
+          = number_to_currency @order_details.non_canceled.inject(0) { |sum,od| sum + od.cost }
       %td.currency
-        %strong= number_to_currency @order_details.non_canceled.inject(0) { |sum,od| sum + od.subsidy }
+        %strong
+          = number_to_currency @order_details.non_canceled.inject(0) { |sum,od| sum + od.subsidy }
       %td.currency
-        %strong= number_to_currency @order_details.non_canceled.inject(0) { |sum,od| sum + od.total }
+        %strong
+          = number_to_currency @order_details.non_canceled.inject(0) { |sum,od| sum + od.total }
       %td
 
-= render :partial => 'merge_order_form'
+= render "merge_order_form"
 
-#order-detail-modal.modal.hide.fade{ :data => { :backdrop => 'static' } }
-
-
+#order-detail-modal.modal.hide.fade{ data: { backdrop: "static" } }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
   admin:
     shared:
       add: "Add %{model}"
+      add_to: "Add To %{model}"
       edit: "Edit %{model}"
       tabnav_users:
         details: "Details"

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe FacilityOrdersController do
     end
 
     it_should_allow_operators_only :redirect, "to send a receipt" do
-      expect(flash[:notice]).to be_present
+      expect(flash[:notice]).to include("sent successfully")
       expect(ActionMailer::Base.deliveries.size).to eq(1)
       mail = ActionMailer::Base.deliveries.first
       expect(mail.subject).to include("Order Receipt")
@@ -354,9 +354,9 @@ RSpec.describe FacilityOrdersController do
       end
 
       if order.to_be_merged?
-        expect(flash[:error]).to be_present
+        expect(flash[:error]).to include("needs your attention")
       else
-        expect(flash[:notice]).to be_present
+        expect(flash[:notice]).to include("successfully added to this order")
       end
 
       assert_redirected_to facility_order_path(@authable, order.to_be_merged? ? order.merge_order : order)

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -203,11 +203,38 @@ RSpec.describe FacilityOrdersController do
 
       context "when adding an instrument" do
         let(:instrument) { FactoryGirl.create(:instrument, facility_account: facility_account) }
+        let(:merge_order) { Order.find_by(merge_with_order_id: order.id) }
+        let(:order_detail) { merge_order.order_details.last }
 
         before { @params[:product_add] = instrument.id }
 
         it_should_allow :director, "to add an instrument to existing order via merge" do
-          assert_merge_order order, instrument
+          assert_merge_order(order, instrument)
+        end
+
+        context "when setting a note" do
+          before { @params[:note] = "This is a note" }
+
+          it_should_allow :director, "to add an instrument to existing order via merge" do
+            expect(order_detail.note).to eq("This is a note")
+          end
+        end
+
+        context "when setting fulfilled_at" do
+          before { @params[:fulfilled_at] = "10/11/2016" }
+
+          it_should_allow :director, "to add an instrument to existing order via merge" do
+            expect(order_detail.fulfilled_at.to_date)
+              .to match_date(Date.new(2016, 10, 11))
+          end
+        end
+
+        context "when setting an order status" do
+          before { @params[:order_status_id] = OrderStatus.in_process_status.id }
+
+          it_should_allow :director, "to add an instrument to existing order via merge" do
+            expect(order_detail.order_status).to eq(OrderStatus.in_process_status)
+          end
         end
       end
 

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe FacilityOrdersController do
 
     context "when no compatible price policies exist" do
       before :each do
-        ItemPricePolicy.all.each(&:destroy)
+        ItemPricePolicy.destroy_all
         do_request
       end
 
@@ -193,7 +193,7 @@ RSpec.describe FacilityOrdersController do
     context "with a product_add_quantity of 1" do
       before do
         @params[:product_add_quantity] = 1
-        order.order_details.each(&:destroy)
+        order.order_details.destroy_all
       end
 
       it_should_allow :director, "to add an item to existing order directly" do

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -40,9 +40,19 @@ FactoryGirl.define do
     end
 
     factory :bundle, class: Bundle do
+      transient do
+        bundle_products []
+      end
+
       account nil # bundles don't have accounts
       sequence(:name) { |n| "Bundle #{n}" }
       sequence(:url_name) { |n| "bundle-#{n}" }
+
+      after(:create) do |bundle, evaluator|
+        evaluator.bundle_products.each do |product|
+          BundleProduct.create!(bundle: bundle, product: product, quantity: 1)
+        end
+      end
     end
 
     trait :archived do

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -518,6 +518,62 @@ RSpec.describe Product do
     end
   end
 
+  describe "#mergeable?" do
+    context "when it's a Bundle" do
+      subject { FactoryGirl.build(:bundle) }
+
+      it { is_expected.not_to be_mergeable }
+    end
+
+    context "when it's an Item" do
+      subject { FactoryGirl.build(:item) }
+
+      it { is_expected.not_to be_mergeable }
+    end
+
+    context "when it's an Instrument" do
+      subject { FactoryGirl.build(:instrument) }
+
+      it { is_expected.to be_mergeable }
+    end
+
+    context "when it's a Service" do
+      subject { FactoryGirl.build(:service) }
+
+      context "with an active survey" do
+        before { allow(subject).to receive(:active_survey?).and_return(true) }
+
+        context "with an active template" do
+          before { allow(subject).to receive(:active_template?).and_return(true) }
+
+          it { is_expected.to be_mergeable }
+        end
+
+        context "without an active template" do
+          before { allow(subject).to receive(:active_template?).and_return(false) }
+
+          it { is_expected.to be_mergeable }
+        end
+      end
+
+      context "without an active survey" do
+        before { allow(subject).to receive(:active_survey?).and_return(false) }
+
+        context "with an active template" do
+          before { allow(subject).to receive(:active_template?).and_return(true) }
+
+          it { is_expected.to be_mergeable }
+        end
+
+        context "without an active template" do
+          before { allow(subject).to receive(:active_template?).and_return(false) }
+
+          it { is_expected.not_to be_mergeable }
+        end
+      end
+    end
+  end
+
   describe "#offline?" do
     it { is_expected.not_to be_offline }
   end


### PR DESCRIPTION
This includes general updates to the related controller, views and specs. Enough was happening in private controller methods when adding-to-order that it seemed appropriate to extract it to a service object. I think Code Climate might say it hasn't gone far enough.

A few other notes:

* The addition of a bottom margin on `chosen-container` was specifically to better align the fields on this form, but looking across the app I thought this tweak would make sense elsewhere, like in the report filters.

Without the margin:
![report filter without margin](https://cloud.githubusercontent.com/assets/46662/22115129/899d7b6a-de31-11e6-89c5-2fa3c987ccf4.png)

With the margin:
![report filter with margin](https://cloud.githubusercontent.com/assets/46662/22115146/9701d8e6-de31-11e6-9332-5917c5d836dc.png)

* `fulfilled_at` is a date in the form, but a timestamp in the database, set to midnight local (app) time. Would something like noon be more reasonable?

* The order status select offers all available status values, but the state machine won't necessarily allow them all to be set. This is facility-facing so I went with presuming an operator would know what the appropriate state should be.