### PR TITLE
Update instructions for merging from Open

### DIFF
--- a/bin/merge_describer
+++ b/bin/merge_describer
@@ -1,0 +1,13 @@
+#!/bin/sh
+git log develop.. | egrep '\(#\d+\)$' | while read LINE; do
+  pr=$(echo $LINE | sed -E 's/^.+\(#//' | sed -E 's/\)$//')
+  desc=$(echo $LINE | sed -E 's/ *\(#[0-9]+\)$//')
+  echo "$pr\t$desc"
+done | sort -n |
+
+while read LINE; do
+  pr=$(echo $LINE | cut -d' ' -f1)
+  desc=$(echo $LINE | cut -d' ' -f2-)
+  echo '*' https://github.com/tablexi/nucore-open/pull/$pr
+  echo $desc
+done

--- a/doc/HOWTO_forks.md
+++ b/doc/HOWTO_forks.md
@@ -10,12 +10,16 @@ _While in your fork's directory_
 
 `git remote add upstream git@github.com:tablexi/nucore-open.git` (You should only need to do this once.)
 
+Create a new branch with the name `latest_from_open_YYYYMMDD` (reflecting the current date).
+
 Whenever you want to bring the latest changes from open/master into your branch:
 
 ```
 git fetch upstream
 git merge upstream/master
 ```
+
+Push up your new branch, and run [this shell script](https://gist.github.com/drench/5bec9926fc4c3591ad73f5cb51dc8ec5) which generates a helpful description you can copy/paste into your PR; it contains the commit messages and links to the merged branches since the last merge from open.
 
 # Bringing changes on your fork into Open
 

--- a/doc/HOWTO_forks.md
+++ b/doc/HOWTO_forks.md
@@ -8,7 +8,12 @@ set up remote repositories on each side.
 
 _While in your fork's directory_
 
-`git remote add upstream git@github.com:tablexi/nucore-open.git` (You should only need to do this once.)
+You should only need to do these once:
+
+```
+git remote add upstream git@github.com:tablexi/nucore-open.git
+chmod +x ./bin/merge_describer
+```
 
 Create a new branch with the name `latest_from_open_YYYYMMDD` (reflecting the current date).
 
@@ -19,7 +24,7 @@ git fetch upstream
 git merge upstream/master
 ```
 
-Push up your new branch, and run [this shell script](https://gist.github.com/drench/5bec9926fc4c3591ad73f5cb51dc8ec5) which generates a helpful description you can copy/paste into your PR; it contains the commit messages and links to the merged branches since the last merge from open.
+Push up your new branch, and run ```bin/merge_describer``` which generates a helpful description you can copy/paste into your PR; it contains the commit messages and links to the merged branches since the last merge from open.
 
 # Bringing changes on your fork into Open
 

--- a/doc/HOWTO_forks.md
+++ b/doc/HOWTO_forks.md
@@ -12,7 +12,6 @@ You should only need to do these once:
 
 ```
 git remote add upstream git@github.com:tablexi/nucore-open.git
-chmod +x ./bin/merge_describer
 ```
 
 Create a new branch with the name `latest_from_open_YYYYMMDD` (reflecting the current date).
@@ -24,7 +23,7 @@ git fetch upstream
 git merge upstream/master
 ```
 
-Push up your new branch, and run ```bin/merge_describer``` which generates a helpful description you can copy/paste into your PR; it contains the commit messages and links to the merged branches since the last merge from open.
+Push up your new branch, and run `bin/merge_describer` which generates a helpful description you can copy/paste into your PR; it contains the commit messages and links to the merged branches since the last merge from open.
 
 # Bringing changes on your fork into Open
 


### PR DESCRIPTION
This updates the instructions to be more detailed for merging any changes from open into the other branches; next time someone new does one of these merges, this will walk them through the process a bit more step-by-step. 