### PR TITLE
[#125660] Make reservation cancellation idempotent

### DIFF
--- a/app/controllers/facility_user_reservations_controller.rb
+++ b/app/controllers/facility_user_reservations_controller.rb
@@ -24,7 +24,7 @@ class FacilityUserReservationsController < ApplicationController
     reservation = @order_detail.reservation
     raise ActiveRecord::RecordNotFound if reservation.blank?
 
-    unless reservation.canceled_at?
+    unless reservation.canceled?
       raise ActiveRecord::RecordNotFound unless reservation.can_cancel?
 
       @order_detail.transaction do

--- a/app/controllers/facility_user_reservations_controller.rb
+++ b/app/controllers/facility_user_reservations_controller.rb
@@ -18,9 +18,9 @@ class FacilityUserReservationsController < ApplicationController
                      .paginate(page: params[:page])
   end
 
-  # PUT /facilities/:facility_id/users/:user_id/reservations/:id/cancel
+  # PUT /facilities/:facility_id/users/:user_id/reservations/:order_detail_id/cancel
   def cancel
-    order_detail = user_order_details.find(params[:id])
+    order_detail = user_order_details.find(params[:order_detail_id])
     raise ActiveRecord::RecordNotFound if not_customer_cancelable?(order_detail.reservation)
     order_detail.transaction do
       if order_detail.reservation.canceled_at? || cancel_with_fee(order_detail)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,7 +138,7 @@ Nucore::Application.routes.draw do
         end
         get "switch_to",    to: 'users#switch_to'
         get "orders",       to: 'users#orders'
-        resources :reservations, only: [:index], controller: "facility_user_reservations" do
+        resources :reservations, only: [:index], param: :order_detail_id, controller: "facility_user_reservations" do
           member do
             put "cancel"
           end
@@ -151,7 +151,7 @@ Nucore::Application.routes.draw do
       resources :users, except: [:edit, :update, :new, :create], constraints: { id: /\d+/ } do
         get "switch_to",    to: 'users#switch_to'
         get "orders",       to: 'users#orders'
-        resources :reservations, only: [:index], controller: "facility_user_reservations" do
+        resources :reservations, only: [:index], param: :order_detail_id, controller: "facility_user_reservations" do
           member do
             put "cancel"
           end

--- a/spec/controllers/facility_user_reservations_controller_spec.rb
+++ b/spec/controllers/facility_user_reservations_controller_spec.rb
@@ -40,22 +40,41 @@ RSpec.describe FacilityUserReservationsController do
     end
 
     shared_examples_for "it can cancel the reservation" do
-      context "when a cancellation fee applies" do
-        before(:each) do
-          sign_in(operator)
-          price_policies.update_all(cancellation_cost: 12)
+      def execute_cancel_request
+        sign_in(operator)
+        put :cancel,
+            facility_id: facility.url_name,
+            user_id: user.id,
+            order_detail_id: order_detail.id
+      end
 
-          put :cancel,
-              facility_id: facility.url_name,
-              user_id: user.id,
-              order_detail_id: order_detail.id
+      context "when a cancellation fee applies" do
+        before do
+          price_policies.update_all(cancellation_cost: 12)
+          execute_cancel_request
         end
 
         it "cancels the reservation with fee, considering the order 'complete'", :aggregate_failures do
           expect(response)
             .to redirect_to(facility_user_reservations_path(facility, user))
+          expect(flash[:error]).to be_blank
+          expect(flash[:notice]).to include("canceled successfully")
           expect(order_detail.reload).to be_complete
           expect(order_detail.actual_cost).to eq(12)
+        end
+      end
+
+      context "when the reservation has already been canceled" do
+        before do
+          reservation.update_attribute(:canceled_at, 1.second.ago)
+          execute_cancel_request
+        end
+
+        it "behaves as it does when initially canceled", :aggregate_failures do
+          expect(response)
+            .to redirect_to(facility_user_reservations_path(facility, user))
+          expect(flash[:error]).to be_blank
+          expect(flash[:notice]).to include("canceled successfully")
         end
       end
     end

--- a/spec/controllers/facility_user_reservations_controller_spec.rb
+++ b/spec/controllers/facility_user_reservations_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe FacilityUserReservationsController do
           put :cancel,
               facility_id: facility.url_name,
               user_id: user.id,
-              id: order_detail.id
+              order_detail_id: order_detail.id
         end
 
         it "cancels the reservation with fee, considering the order 'complete'", :aggregate_failures do


### PR DESCRIPTION
When canceling an already-canceled reservation, the controller should behave to a client the same as it did when cancelling initially.