### PR TITLE
[#134059] More space in notes

### DIFF
--- a/app/assets/javascripts/app/detail_notes.coffee
+++ b/app/assets/javascripts/app/detail_notes.coffee
@@ -1,10 +1,12 @@
 $ ->
-  hiddenText = "See Note"
-  openText = "Hide Note"
+  hiddenText = "More"
+  openText = "Less"
 
   $('.js--toggleNote').on 'click', (e) ->
     e.preventDefault()
-    $(this).next(".js--note").toggle()
+    $parent = $(this).parent()
     text = $(this).text()
+    $parent.find(".js--note").toggle()
+    $parent.find(".js--truncatedNote").toggle()
     $(this).text if text == hiddenText then openText else hiddenText
     return

--- a/app/assets/javascripts/app/detail_notes.coffee
+++ b/app/assets/javascripts/app/detail_notes.coffee
@@ -4,9 +4,9 @@ $ ->
 
   $('.js--toggleNote').on 'click', (e) ->
     e.preventDefault()
-    $parent = $(this).parent()
-    text = $(this).text()
+    $parent = $(@).parent()
+    text = $(@).text()
     $parent.find(".js--note").toggle()
     $parent.find(".js--truncatedNote").toggle()
-    $(this).text if text == hiddenText then openText else hiddenText
+    $(@).text if text == hiddenText then openText else hiddenText
     return

--- a/app/assets/javascripts/app/detail_notes.coffee
+++ b/app/assets/javascripts/app/detail_notes.coffee
@@ -1,0 +1,10 @@
+$ ->
+  hiddenText = "See Note"
+  openText = "Hide Note"
+
+  $('.js--toggleNote').on 'click', (e) ->
+    e.preventDefault()
+    $(this).next(".js--note").toggle()
+    text = $(this).text()
+    $(this).text if text == hiddenText then openText else hiddenText
+    return

--- a/app/assets/stylesheets/app/cart.scss
+++ b/app/assets/stylesheets/app/cart.scss
@@ -4,7 +4,7 @@
 
 .cart__noteField {
   margin-top: 1em;
-  input {
+  textarea {
     margin-bottom: 0;
     width: 80%;
   }

--- a/app/assets/stylesheets/app/order_details.scss
+++ b/app/assets/stylesheets/app/order_details.scss
@@ -1,7 +1,10 @@
 .user-order-detail {
+  width: 30%;
+
   .order-detail-extra {
     margin-left: 1em;
   }
+
   .order-detail-note {
     font-style: italic;
   }

--- a/app/assets/stylesheets/app/order_details.scss
+++ b/app/assets/stylesheets/app/order_details.scss
@@ -1,6 +1,4 @@
 .user-order-detail {
-  // width: 25%;
-
   .order-detail-extra {
     margin-left: 1em;
   }

--- a/app/assets/stylesheets/app/order_details.scss
+++ b/app/assets/stylesheets/app/order_details.scss
@@ -1,5 +1,5 @@
 .user-order-detail {
-  width: 30%;
+  // width: 25%;
 
   .order-detail-extra {
     margin-left: 1em;

--- a/app/assets/stylesheets/app/order_management.scss
+++ b/app/assets/stylesheets/app/order_management.scss
@@ -57,6 +57,10 @@
   }
 }
 
+.modal.fade.in {
+  top: 5%;
+}
+
 /* Specific Form Overrides */
 .manage_order_detail {
   .order_detail_order_status {

--- a/app/assets/stylesheets/app/order_management.scss
+++ b/app/assets/stylesheets/app/order_management.scss
@@ -57,7 +57,7 @@
   }
 }
 
-.modal.fade.in {
+#order-detail-modal {
   top: 5%;
 }
 

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -212,6 +212,10 @@ form.compact { margin: 0 }
 td.order-note,
 th.order-note {
   width: 20%;
+
+  &.order-note--wide {
+    width: 40%;
+  }
 }
 
 .js--note {

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -209,6 +209,15 @@ form.compact { margin: 0 }
   }
 }
 
+td.order-note,
+th.order-note {
+  width: 20%;
+}
+
+.js--note {
+  display: none;
+}
+
 td.currency,
 th.currency {
   text-align: right;

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -89,7 +89,7 @@ class OrderDetail < ActiveRecord::Base
   # only do this validation if it hasn't been ordered yet. Update errors caused by notification sending
   # were being triggered on orders where the orderer had been removed from the account.
   validate :account_usable_by_order_owner?, if: ->(o) { o.account_id_changed? || o.order.nil? || o.order.ordered_at.nil? }
-  validates_length_of :note, maximum: 255, allow_blank: true, allow_nil: true
+  validates_length_of :note, maximum: 1000, allow_blank: true, allow_nil: true
 
   ## TODO validate assigned_user is a member of the product's facility
   ## TODO validate order status is global or a member of the product's facility

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -89,7 +89,7 @@ class OrderDetail < ActiveRecord::Base
   # only do this validation if it hasn't been ordered yet. Update errors caused by notification sending
   # were being triggered on orders where the orderer had been removed from the account.
   validate :account_usable_by_order_owner?, if: ->(o) { o.account_id_changed? || o.order.nil? || o.order.ordered_at.nil? }
-  validates_length_of :note, maximum: 100, allow_blank: true, allow_nil: true
+  validates_length_of :note, maximum: 255, allow_blank: true, allow_nil: true
 
   ## TODO validate assigned_user is a member of the product's facility
   ## TODO validate order status is global or a member of the product's facility

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -18,9 +18,8 @@
         class: "datepicker__data string optional"
 
       = label_tag :note, OrderDetail.human_attribute_name(:note)
-      = text_field_tag :note,
+      = text_area_tag :note,
         nil,
-        maxlength: 100,
         class: "string optional wide"
 
       %br

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -20,6 +20,7 @@
       = label_tag :note, OrderDetail.human_attribute_name(:note)
       = text_area_tag :note,
         nil,
+        maxlength: 1000,
         class: "string optional wide"
 
       %br

--- a/app/views/facility_orders/index.html.haml
+++ b/app/views/facility_orders/index.html.haml
@@ -19,7 +19,8 @@
           %th.order_num_width.centered= 'Order Detail'
           %th.ordered_on_width= sortable 'date', 'Ordered On'
           %th User Name
-          %th{ :colspan => 2 }== Quantity / #{sortable 'product'}
+          %th Quantity
+          %th.order-note= sortable 'product'
           %th= sortable 'assigned_to'
           %th= sortable 'status'
           %th.currency Price

--- a/app/views/facility_reservations/index.html.haml
+++ b/app/views/facility_reservations/index.html.haml
@@ -19,7 +19,7 @@
           %th= sortable 'reserved_by'
           %th{:colspan => 2}= sortable 'date', 'Reserved On'
           %th{:colspan => 2}= sortable "reserve_range", 'Reserved For'
-          %th= sortable 'product_name', 'Product'
+          %th{ colspan: 2 }= sortable 'product_name', 'Product'
           %th= sortable 'assigned_to', 'Assigned To'
           %th= sortable 'status', 'Status'
           %th.currency Price

--- a/app/views/facility_reservations/index.html.haml
+++ b/app/views/facility_reservations/index.html.haml
@@ -19,7 +19,7 @@
           %th= sortable 'reserved_by'
           %th{:colspan => 2}= sortable 'date', 'Reserved On'
           %th{:colspan => 2}= sortable "reserve_range", 'Reserved For'
-          %th{ colspan: 2 }= sortable 'product_name', 'Product'
+          %th.order-note= sortable 'product_name', 'Product'
           %th= sortable 'assigned_to', 'Assigned To'
           %th= sortable 'status', 'Status'
           %th.currency Price

--- a/app/views/facility_user_reservations/index.html.haml
+++ b/app/views/facility_user_reservations/index.html.haml
@@ -53,7 +53,7 @@
 
             - if order_detail.note.present?
               .order-detail-extra.order-detail-note
-                = text("order_details.note", note: order_detail.note)
+                = render partial: "shared/order_detail_note", locals: { order_detail: order_detail }
 
           %td.centered= order_detail.order_status.name
           %td.currency= order_detail.wrapped_total

--- a/app/views/facility_user_reservations/index.html.haml
+++ b/app/views/facility_user_reservations/index.html.haml
@@ -53,7 +53,7 @@
 
             - if order_detail.note.present?
               .order-detail-extra.order-detail-note
-                = render partial: "shared/order_detail_note", locals: { order_detail: order_detail }
+                = render "shared/order_detail_note", order_detail: order_detail
 
           %td.centered= order_detail.order_status.name
           %td.currency= order_detail.wrapped_total

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -43,7 +43,7 @@
 
     .row
       .span5
-        = f.input :note, as: :text, input_html: { class: "note", rows: 3 }
+        = f.input :note, input_html: { class: "note", rows: 3 }
         = render "reconcile_note", f: f
 
       .span4

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -43,7 +43,7 @@
 
     .row
       .span5
-        = f.input :note, input_html: { class: "note" }
+        = f.input :note, as: :text, input_html: { class: "note", rows: 3 }
         = render "reconcile_note", f: f
 
       .span4

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -7,7 +7,8 @@
     - if show_note_input_to_user?(order_detail)
       %label.inline.cart__noteField{ for: "note#{order_detail.id}" }
         Note:
-        = text_field_tag("note#{order_detail.id}", order_detail.note, maxlength: 100, size: 100 )
+        %br
+        = text_area_tag("note#{order_detail.id}", order_detail.note, rows: 3 )
 
     - if order_detail.product.is_a?(Instrument)
       %td

--- a/app/views/shared/_order_detail_cell.html.haml
+++ b/app/views/shared/_order_detail_cell.html.haml
@@ -17,4 +17,4 @@
       = link_to t("order_details.show.link.view.order_file"), facility_template_result_path(stored_file)
   - if od.note.present?
     .order-detail-extra.order-detail-note
-      = render partial: "shared/order_detail_note", locals: { order_detail: od }
+      = render "shared/order_detail_note", order_detail: od

--- a/app/views/shared/_order_detail_cell.html.haml
+++ b/app/views/shared/_order_detail_cell.html.haml
@@ -1,6 +1,6 @@
 - unless defined?(show_reservation)
   - show_reservation = true
-%td.user-order-detail{ colspan: 2 }
+%td.user-order-detail.order-note
   .order-detail-description
     = order_detail_description(od)
     - if show_reservation && od.reservation
@@ -16,4 +16,6 @@
     .order-detail-extra
       = link_to t("order_details.show.link.view.order_file"), facility_template_result_path(stored_file)
   - if od.note.present?
-    .order-detail-extra.order-detail-note= "Note: #{truncate(od.note, length: 100, separator: ' ')}"
+    .order-detail-extra.order-detail-note
+      = link_to "See Note", "#", class: "js--toggleNote"
+      .js--note= od.note

--- a/app/views/shared/_order_detail_cell.html.haml
+++ b/app/views/shared/_order_detail_cell.html.haml
@@ -1,6 +1,6 @@
 - unless defined?(show_reservation)
   - show_reservation = true
-%td.user-order-detail
+%td.user-order-detail{ colspan: 2 }
   .order-detail-description
     = order_detail_description(od)
     - if show_reservation && od.reservation
@@ -16,4 +16,4 @@
     .order-detail-extra
       = link_to t("order_details.show.link.view.order_file"), facility_template_result_path(stored_file)
   - if od.note.present?
-    .order-detail-extra.order-detail-note= "Note: #{od.note}"
+    .order-detail-extra.order-detail-note= "Note: #{truncate(od.note, length: 100, separator: ' ')}"

--- a/app/views/shared/_order_detail_cell.html.haml
+++ b/app/views/shared/_order_detail_cell.html.haml
@@ -17,6 +17,4 @@
       = link_to t("order_details.show.link.view.order_file"), facility_template_result_path(stored_file)
   - if od.note.present?
     .order-detail-extra.order-detail-note
-      .js--note= od.note
-      .js--truncatedNote= truncate(od.note, length: 100, separator: " ", omission: "... ")
-      = link_to text("note.more"), "#", class: "js--toggleNote" if od.note.size > 100
+      = render partial: "shared/order_detail_note", locals: { order_detail: od }

--- a/app/views/shared/_order_detail_cell.html.haml
+++ b/app/views/shared/_order_detail_cell.html.haml
@@ -19,4 +19,4 @@
     .order-detail-extra.order-detail-note
       .js--note= od.note
       .js--truncatedNote= truncate(od.note, length: 100, separator: " ", omission: "... ")
-      = link_to "More", "#", class: "js--toggleNote" if od.note.size > 100
+      = link_to text("note.more"), "#", class: "js--toggleNote" if od.note.size > 100

--- a/app/views/shared/_order_detail_cell.html.haml
+++ b/app/views/shared/_order_detail_cell.html.haml
@@ -17,5 +17,6 @@
       = link_to t("order_details.show.link.view.order_file"), facility_template_result_path(stored_file)
   - if od.note.present?
     .order-detail-extra.order-detail-note
-      = link_to "See Note", "#", class: "js--toggleNote"
       .js--note= od.note
+      .js--truncatedNote= truncate(od.note, length: 100, separator: " ", omission: "... ")
+      = link_to "More", "#", class: "js--toggleNote" if od.note.size > 100

--- a/app/views/shared/_order_detail_note.html.haml
+++ b/app/views/shared/_order_detail_note.html.haml
@@ -1,3 +1,3 @@
-.js--note= "Note: #{order_detail.note}"
-.js--truncatedNote= truncate("Note: #{order_detail.note}", length: 100, separator: " ", omission: "... ")
+%i.js--note= "Note: #{order_detail.note}"
+%i.js--truncatedNote= truncate("Note: #{order_detail.note}", length: 100, separator: " ", omission: "... ")
 = link_to text("note.more"), "#", class: "js--toggleNote" if order_detail.note.size > 100

--- a/app/views/shared/_order_detail_note.html.haml
+++ b/app/views/shared/_order_detail_note.html.haml
@@ -1,3 +1,3 @@
-%i.js--note= "Note: #{order_detail.note}"
+%i.js--note= text("note.full", note: order_detail.note)
 %i.js--truncatedNote= truncate("Note: #{order_detail.note}", length: 100, separator: " ", omission: "... ")
 = link_to text("note.more"), "#", class: "js--toggleNote" if order_detail.note.size > 100

--- a/app/views/shared/_order_detail_note.html.haml
+++ b/app/views/shared/_order_detail_note.html.haml
@@ -1,3 +1,3 @@
-.js--note= order_detail.note
-.js--truncatedNote= truncate(order_detail.note, length: 100, separator: " ", omission: "... ")
+.js--note= "Note: #{order_detail.note}"
+.js--truncatedNote= truncate("Note: #{order_detail.note}", length: 100, separator: " ", omission: "... ")
 = link_to text("note.more"), "#", class: "js--toggleNote" if order_detail.note.size > 100

--- a/app/views/shared/_order_detail_note.html.haml
+++ b/app/views/shared/_order_detail_note.html.haml
@@ -1,0 +1,3 @@
+.js--note= order_detail.note
+.js--truncatedNote= truncate(order_detail.note, length: 100, separator: " ", omission: "... ")
+= link_to text("note.more"), "#", class: "js--toggleNote" if order_detail.note.size > 100

--- a/app/views/shared/_order_details_table.html.haml
+++ b/app/views/shared/_order_details_table.html.haml
@@ -21,7 +21,7 @@
             %li= order_detail.description_as_html_with_facility_prefix
             - if order_detail.note.present?
               %li
-                = render partial: "shared/order_detail_note", locals: { order_detail: order_detail }
+                = render "shared/order_detail_note", order_detail: order_detail
         %td.centered= order_detail.order_status.try(:name)
         %td.currency= order_detail.wrapped_total
 

--- a/app/views/shared/_order_details_table.html.haml
+++ b/app/views/shared/_order_details_table.html.haml
@@ -16,12 +16,12 @@
             current_facility ? order_detail.show_order_path : order_detail.show_order_detail_path
         %td= order_detail.ordered_at
         %td.centered= order_detail.quantity
-        %td
+        %td.order-note.order-note--wide
           %ul.unstyled
             %li= order_detail.description_as_html_with_facility_prefix
             - if order_detail.note.present?
               %li
-                %i= "Note: #{order_detail.note}"
+                = render partial: "shared/order_detail_note", locals: { order_detail: order_detail }
         %td.centered= order_detail.order_status.try(:name)
         %td.currency= order_detail.wrapped_total
 

--- a/app/views/shared/_reservations_table.html.haml
+++ b/app/views/shared/_reservations_table.html.haml
@@ -26,7 +26,7 @@
               = tooltip_icon "icon-warning-sign icon-large", t("instruments.offline.note")
             - if od.note.present?
               .order-detail-extra.order-detail-note
-                = render partial: "shared/order_detail_note", locals: { order_detail: od }
+                = render "shared/order_detail_note", order_detail: od
 
         %td.centered=h od.order_status.name
         %td.currency

--- a/app/views/shared/_reservations_table.html.haml
+++ b/app/views/shared/_reservations_table.html.haml
@@ -25,7 +25,8 @@
             - if od.product.offline?
               = tooltip_icon "icon-warning-sign icon-large", t("instruments.offline.note")
             - if od.note.present?
-              .order-detail-extra.order-detail-note= "Note: #{od.note}"
+              .order-detail-extra.order-detail-note
+                = render partial: "shared/order_detail_note", locals: { order_detail: od }
 
         %td.centered=h od.order_status.name
         %td.currency

--- a/app/views/shared/_reservations_table.html.haml
+++ b/app/views/shared/_reservations_table.html.haml
@@ -4,7 +4,7 @@
       %th.centered Order #
       %th.centered Actions
       %th Reserved For
-      %th Product
+      %th.order-note.order-note--wide Product
       %th.centered Status
       %th.currency Total
   %tbody
@@ -18,7 +18,7 @@
           = reservation_actions(res)
         %td
           = reservation_view_edit_link(res)
-        %td.user-order-detail
+        %td.user-order-detail.order-note.order-note--wide
           .order-detail-description
             - product_name = order_detail_description(od)
             = link_to "#{od.product.facility.abbreviation} / #{product_name}".html_safe, facility_instrument_path(od.product.facility, od.product)

--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -49,8 +49,9 @@
               %em= order_detail.reservation
           - if order_detail.note.present?
             .order-detail-extra.order-detail-note
-              = link_to "See Note", "#", class: "js--toggleNote"
               .js--note= order_detail.note
+              .js--truncatedNote= truncate(order_detail.note, length: 100, separator: " ", omission: "... ")
+              = link_to text("note.more"), "#", class: "js--toggleNote" if order_detail.note.size > 100
 
 
         %td= order_detail.order.user.full_name

--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -49,7 +49,7 @@
               %em= order_detail.reservation
           - if order_detail.note.present?
             .order-detail-extra.order-detail-note
-              = render partial: "shared/order_detail_note", locals: { order_detail: order_detail }
+              = render "shared/order_detail_note", order_detail: order_detail
 
 
         %td= order_detail.order.user.full_name

--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -49,9 +49,7 @@
               %em= order_detail.reservation
           - if order_detail.note.present?
             .order-detail-extra.order-detail-note
-              .js--note= order_detail.note
-              .js--truncatedNote= truncate(order_detail.note, length: 100, separator: " ", omission: "... ")
-              = link_to text("note.more"), "#", class: "js--toggleNote" if order_detail.note.size > 100
+              = render partial: "shared/order_detail_note", locals: { order_detail: order_detail }
 
 
         %td= order_detail.order.user.full_name

--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -11,7 +11,7 @@
         %th.nowrap= OrderDetail.human_attribute_name(@extra_date_column_header || @extra_date_column)
       - if current_facility.blank? || cross_facility?
         %th= Facility.model_name.human
-      %th= OrderDetail.human_attribute_name("description")
+      %th.order-note= OrderDetail.human_attribute_name("description")
       %th.nowrap= OrderDetail.human_attribute_name("user")
       - unless @account
         %th= Account.model_name.human
@@ -39,7 +39,7 @@
         - if current_facility.blank? || cross_facility?
 
           %td= order_detail.order.facility
-        %td.user-order-detail
+        %td.user-order-detail.order-note
           .order-detail-description
             = order_detail_description(order_detail)
             - order_detail.extend PriceDisplayment
@@ -48,7 +48,9 @@
               %br
               %em= order_detail.reservation
           - if order_detail.note.present?
-            .order-detail-extra.order-detail-note= "Note: #{order_detail.note}"
+            .order-detail-extra.order-detail-note
+              = link_to "See Note", "#", class: "js--toggleNote"
+              .js--note= order_detail.note
 
 
         %td= order_detail.order.user.full_name

--- a/config/locales/views/en.order_details.yml
+++ b/config/locales/views/en.order_details.yml
@@ -5,3 +5,11 @@ en:
         warning: |
           Changing the Payment Source could result in adjusted pricing. If you are
           concerned about this or receive incorrect pricing, please contact the !facility_downcase!.
+    shared:
+      order_detail_cell:
+        note:
+          more: More
+      transactions:
+        table_inside:
+          note:
+            more: More

--- a/config/locales/views/en.order_details.yml
+++ b/config/locales/views/en.order_details.yml
@@ -9,3 +9,4 @@ en:
       order_detail_note:
         note:
           more: More
+          full: "Note: %{note}"

--- a/config/locales/views/en.order_details.yml
+++ b/config/locales/views/en.order_details.yml
@@ -6,10 +6,6 @@ en:
           Changing the Payment Source could result in adjusted pricing. If you are
           concerned about this or receive incorrect pricing, please contact the !facility_downcase!.
     shared:
-      order_detail_cell:
+      order_detail_note:
         note:
           more: More
-      transactions:
-        table_inside:
-          note:
-            more: More

--- a/db/migrate/20170123183841_change_note_limit_for_order_details.rb
+++ b/db/migrate/20170123183841_change_note_limit_for_order_details.rb
@@ -1,7 +1,14 @@
 class ChangeNoteLimitForOrderDetails < ActiveRecord::Migration
 
-  def change
-    change_column :order_details, :note, :string, limit: nil
+  def up
+    add_column :order_details, :temp_note, :text
+    OrderDetail.all.each { |od| od.update_attribute(:temp_note, od.note) }
+    remove_column :order_details, :note
+    rename_column :order_details, :temp_note, :note
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
   end
 
 end

--- a/db/migrate/20170123183841_change_note_limit_for_order_details.rb
+++ b/db/migrate/20170123183841_change_note_limit_for_order_details.rb
@@ -1,0 +1,7 @@
+class ChangeNoteLimitForOrderDetails < ActiveRecord::Migration
+
+  def change
+    change_column :order_details, :note, :string, limit: nil
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -243,16 +243,16 @@ ActiveRecord::Schema.define(version: 20170130213649) do
   add_index "notifications", ["user_id"], name: "index_notifications_on_user_id", using: :btree
 
   create_table "order_details", force: :cascade do |t|
-    t.integer  "order_id",                limit: 4,                                            null: false
+    t.integer  "order_id",                limit: 4,                                              null: false
     t.integer  "parent_order_detail_id",  limit: 4
-    t.integer  "product_id",              limit: 4,                                            null: false
-    t.integer  "quantity",                limit: 4,                                            null: false
+    t.integer  "product_id",              limit: 4,                                              null: false
+    t.integer  "quantity",                limit: 4,                                              null: false
     t.integer  "price_policy_id",         limit: 4
-    t.decimal  "actual_cost",                         precision: 10, scale: 2
-    t.decimal  "actual_subsidy",                      precision: 10, scale: 2
+    t.decimal  "actual_cost",                           precision: 10, scale: 2
+    t.decimal  "actual_subsidy",                        precision: 10, scale: 2
     t.integer  "assigned_user_id",        limit: 4
-    t.decimal  "estimated_cost",                      precision: 10, scale: 2
-    t.decimal  "estimated_subsidy",                   precision: 10, scale: 2
+    t.decimal  "estimated_cost",                        precision: 10, scale: 2
+    t.decimal  "estimated_subsidy",                     precision: 10, scale: 2
     t.integer  "response_set_id",         limit: 4
     t.integer  "account_id",              limit: 4
     t.datetime "dispute_at"
@@ -266,17 +266,17 @@ ActiveRecord::Schema.define(version: 20170130213649) do
     t.string   "state",                   limit: 50
     t.integer  "group_id",                limit: 4
     t.integer  "bundle_product_id",       limit: 4
-    t.string   "note",                    limit: 255
     t.datetime "fulfilled_at"
     t.datetime "reviewed_at"
     t.integer  "statement_id",            limit: 4
     t.integer  "journal_id",              limit: 4
     t.string   "reconciled_note",         limit: 255
-    t.integer  "created_by",              limit: 4,                                            null: false
+    t.integer  "created_by",              limit: 4,                                              null: false
     t.integer  "product_accessory_id",    limit: 4
-    t.boolean  "problem",                                                      default: false, null: false
+    t.boolean  "problem",                                                        default: false, null: false
     t.datetime "reconciled_at"
     t.integer  "project_id",              limit: 4
+    t.text     "note",                    limit: 65535
   end
 
   add_index "order_details", ["account_id"], name: "fk_od_accounts", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,8 +97,8 @@ ActiveRecord::Schema.define(version: 20170130213649) do
     t.datetime "failed_at"
     t.string   "locked_by",  limit: 255
     t.string   "queue",      limit: 255
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+    t.datetime "created_at",                                null: false
+    t.datetime "updated_at",                                null: false
   end
 
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
@@ -266,7 +266,7 @@ ActiveRecord::Schema.define(version: 20170130213649) do
     t.string   "state",                   limit: 50
     t.integer  "group_id",                limit: 4
     t.integer  "bundle_product_id",       limit: 4
-    t.string   "note",                    limit: 100
+    t.string   "note",                    limit: 255
     t.datetime "fulfilled_at"
     t.datetime "reviewed_at"
     t.integer  "statement_id",            limit: 4

--- a/spec/app_support/order_row_importer_spec.rb
+++ b/spec/app_support/order_row_importer_spec.rb
@@ -386,7 +386,7 @@ RSpec.describe OrderRowImporter do
       include_context "valid row values"
 
       context "it is too long" do
-        let(:notes) { "a" * 101 }
+        let(:notes) { "a" * 256 }
 
         it_behaves_like "an order was not created"
         it_behaves_like "it has an error message", "Note is too long"

--- a/spec/app_support/order_row_importer_spec.rb
+++ b/spec/app_support/order_row_importer_spec.rb
@@ -386,7 +386,7 @@ RSpec.describe OrderRowImporter do
       include_context "valid row values"
 
       context "it is too long" do
-        let(:notes) { "a" * 256 }
+        let(:notes) { "a" * 1001 }
 
         it_behaves_like "an order was not created"
         it_behaves_like "it has an error message", "Note is too long"


### PR DESCRIPTION
https://pm.tablexi.com/issues/134059

This allows more space for order detail notes (no longer restricted to 100 characters, now up to string length of 255). I believe I fixed all views for longer notes, but it's possible I missed some, so if you see anything, just let me know. 