### PR TITLE
[#125093] Allow Business Admins to use a cross-facility "Users" tab

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -124,7 +124,7 @@ class UsersController < ApplicationController
   # GET /facilities/:facility_id/users/:user_id/access_list
   def access_list
     @facility = current_facility
-    @products_by_type = @facility.products_requiring_approval_by_type
+    @products_by_type = Product.for_facility(@facility).requiring_approval_by_type
     @training_requested_product_ids = @user.training_requests.pluck(:product_id)
   end
 
@@ -158,7 +158,7 @@ class UsersController < ApplicationController
 
   def update_approvals
     @update_approvals ||= ProductApprover.new(
-      current_facility.products_requiring_approval,
+      Product.for_facility(current_facility).requiring_approval,
       @user,
       session_user,
     ).update_approvals(approved_products_from_params, params[:product_access_group])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,8 +10,7 @@ module ApplicationHelper
   end
 
   def can_create_users?
-    SettingsHelper.feature_on?(:create_users) &&
-      current_ability.can?(:manage_users, current_facility || Facility.cross_facility)
+    SettingsHelper.feature_on?(:create_users) && current_ability.can?(:create, User)
   end
 
   def html_title(title = nil)

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -50,7 +50,6 @@ class Facility < ActiveRecord::Base
             if: -> { SettingsHelper.feature_on?(:limit_short_description) }
 
   delegate :in_dispute, to: :order_details, prefix: true
-  delegate :requiring_approval, :requiring_approval_by_type, to: :products, prefix: true
 
   scope :active, -> { where(is_active: true) }
   scope :sorted, -> { order(:name) }

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -52,7 +52,7 @@ class Product < ActiveRecord::Base
     where("products.id NOT IN (?)", exclusion_list)
   end
 
-  scope :for_facility, lambda {|facility|
+  scope :for_facility, lambda { |facility|
     return self.class.none if facility.blank?
     return where(facility_id: facility.id) if facility.single_facility?
     return all if facility.cross_facility?

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -53,10 +53,13 @@ class Product < ActiveRecord::Base
   end
 
   scope :for_facility, lambda { |facility|
-    return self.class.none if facility.blank?
-    return where(facility_id: facility.id) if facility.single_facility?
-    return all if facility.cross_facility?
-    self.class.none
+    if facility.blank?
+      self.class.none
+    elsif facility.single_facility?
+      where(facility_id: facility.id)
+    else # cross-facility
+      all
+    end
   }
 
   def self.requiring_approval

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -54,7 +54,7 @@ class Product < ActiveRecord::Base
 
   scope :for_facility, lambda { |facility|
     if facility.blank?
-      self.class.none
+      none
     elsif facility.single_facility?
       where(facility_id: facility.id)
     else # cross-facility

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -52,6 +52,13 @@ class Product < ActiveRecord::Base
     where("products.id NOT IN (?)", exclusion_list)
   end
 
+  scope :for_facility, lambda {|facility|
+    return self.class.none if facility.blank?
+    return where(facility_id: facility.id) if facility.single_facility?
+    return all if facility.cross_facility?
+    self.class.none
+  }
+
   def self.requiring_approval
     where(requires_approval: true)
   end

--- a/app/presenters/order_detail_presenter.rb
+++ b/app/presenters/order_detail_presenter.rb
@@ -49,10 +49,6 @@ class OrderDetailPresenter < SimpleDelegator
     facility_order_path(facility, order)
   end
 
-  def show_reservation_path
-    facility_order_order_detail_reservation_path(facility, order, id, reservation)
-  end
-
   def survey_url
     survey_completed? ? external_service_receiver.show_url : ""
   end

--- a/app/presenters/order_detail_presenter.rb
+++ b/app/presenters/order_detail_presenter.rb
@@ -41,6 +41,10 @@ class OrderDetailPresenter < SimpleDelegator
     reconcile_warning? ? "reconcile-warning" : ""
   end
 
+  def show_order_detail_path
+    order_order_detail_path(order, self)
+  end
+
   def show_order_path
     facility_order_path(facility, order)
   end

--- a/app/views/admin/shared/_sidenav_users.html.haml
+++ b/app/views/admin/shared/_sidenav_users.html.haml
@@ -1,5 +1,5 @@
 %ul.sidebar-nav
-  - if current_ability.can?(:administer, User)
+  - if current_ability.can?(:index, User)
     = tab t("activerecord.models.user", count: 2), facility_users_path, (sidenav_tab == "users")
 
   = render_view_hook "after_facility_users", sidenav_tab: sidenav_tab

--- a/app/views/admin/shared/_tabnav_users.html.haml
+++ b/app/views/admin/shared/_tabnav_users.html.haml
@@ -13,7 +13,7 @@
       facility_user_reservations_path(current_facility, @user),
       secondary_tab == "reservations"
 
-  - if current_ability.can?(:manage, Account)
+  - if SettingsHelper.feature_on?(:manage_payment_sources_with_users) && current_ability.can?(:manage, Account)
     = tab t(".accounts"),
       facility_user_accounts_path(current_facility, @user),
       secondary_tab == "accounts"

--- a/app/views/admin/shared/_tabnav_users.html.haml
+++ b/app/views/admin/shared/_tabnav_users.html.haml
@@ -3,7 +3,7 @@
     facility_user_path(current_facility, @user),
     secondary_tab == "details"
 
-  - if current_ability.can?(:administer, Order)
+  - if current_ability.can?(:show, Order)
     = tab t(".orders"),
       facility_user_orders_path(current_facility, @user),
       secondary_tab == "orders"

--- a/app/views/admin/shared/_tabnav_users.html.haml
+++ b/app/views/admin/shared/_tabnav_users.html.haml
@@ -8,7 +8,7 @@
       facility_user_orders_path(current_facility, @user),
       secondary_tab == "orders"
 
-  - if current_ability.can?(:administer, Reservation)
+  - if current_ability.can?(:index, OrderDetail) # The controller authorizes against OrderDetail, not Reservation
     = tab t(".reservations"),
       facility_user_reservations_path(current_facility, @user),
       secondary_tab == "reservations"

--- a/app/views/facility_account_orders/index.html.haml
+++ b/app/views/facility_account_orders/index.html.haml
@@ -32,16 +32,14 @@
           %td= order_detail.ordered_at
           %td
             %ul
+              - reservation = order_detail.reservation
               %li= order_detail.description_as_html
-              - if order_detail.reservation.present?
-                - if order_detail.reservation_admin_editable?
-                  %li.indented
-                    = link_to order_detail.reservation,
-                      order_detail.edit_reservation_path
-                - else
-                  %li.indented
-                    = link_to order_detail.reservation,
-                      order_detail.show_reservation_path
+              - if reservation.present?
+                %li.indented
+                  - if order_detail.reservation_admin_editable? && current_ability.can?(:edit, reservation)
+                    = link_to reservation, order_detail.edit_reservation_path
+                  - else
+                    = reservation
 
               - if order_detail.survey_completed?
                 %li.indented

--- a/app/views/facility_account_orders/index.html.haml
+++ b/app/views/facility_account_orders/index.html.haml
@@ -24,25 +24,29 @@
         %th.currency= t(".th.amount")
 
     %tbody
-      - OrderDetailPresenter.wrap(@order_details).each do |order_detail|
-        %tr{class: order_detail.row_class}
+      - @order_details.each do |order_detail|
+        - od = OrderDetailPresenter.new(order_detail)
+        %tr{class: od.row_class}
           %td
-            = link_to order_detail.description, order_detail.show_order_path
+            - if current_ability.can?(:show, order_detail)
+              = link_to od.description, od.show_order_path
+            - else
+              = od.description
 
-          %td= order_detail.ordered_at
+          %td= od.ordered_at
 
           = render "shared/order_detail_cell",
-            od: order_detail,
-            show_reservation: order_detail.reservation.present?
+            od: od,
+            show_reservation: od.reservation.present?
 
-          %td= order_detail.order_status
+          %td= od.order_status
           %td.currency
-            - if order_detail.cost_estimated?
-              %span.estimated_cost= order_detail.estimated_total
-            - elsif order_detail.price_policy.blank?
+            - if od.cost_estimated?
+              %span.estimated_cost= od.estimated_total
+            - elsif od.price_policy.blank?
               = t(".unassigned")
             - else
-              %span.actual_cost= order_detail.actual_total
+              %span.actual_cost= od.actual_total
       %tr
         %td.centered{colspan: 5}= will_paginate(@order_details)
 

--- a/app/views/facility_account_orders/index.html.haml
+++ b/app/views/facility_account_orders/index.html.haml
@@ -30,30 +30,10 @@
             = link_to order_detail.description, order_detail.show_order_path
 
           %td= order_detail.ordered_at
-          %td
-            %ul
-              - reservation = order_detail.reservation
-              %li= order_detail.description_as_html
-              - if reservation.present?
-                %li.indented
-                  - if order_detail.reservation_admin_editable? && current_ability.can?(:edit, reservation)
-                    = link_to reservation, order_detail.edit_reservation_path
-                  - else
-                    = reservation
 
-              - if order_detail.survey_completed?
-                %li.indented
-                  = link_to t(".label.view_order.form"),
-                    order_detail.survey_url, target: "_blank"
-
-              - if order_detail.stored_files_template_result.present?
-                - order_detail.stored_files_template_result.each do |stored_file|
-                  %li.indented
-                    = link_to t(".label.view_order.file"), stored_file.download_url
-
-              - if order_detail.note.present?
-                %li
-                  %i= t(".note", text: order_detail.note)
+          = render "shared/order_detail_cell",
+            od: order_detail,
+            show_reservation: order_detail.reservation.present?
 
           %td= order_detail.order_status
           %td.currency

--- a/app/views/facility_orders/show.html.haml
+++ b/app/views/facility_orders/show.html.haml
@@ -8,7 +8,7 @@
     = banner_date_label @order, :ordered_at
     = banner_label @order, :user
     = banner_label @order, :created_by_user
-    - if @merge_orders.blank?
+    - if @merge_orders.blank? && current_ability.can?(:send_receipt, @order)
       .pull-right= render "send_receipt"
 
 = render "merge_order"

--- a/app/views/facility_orders/show.html.haml
+++ b/app/views/facility_orders/show.html.haml
@@ -81,6 +81,7 @@
           = number_to_currency @order_details.non_canceled.inject(0) { |sum,od| sum + od.total }
       %td
 
-= render "merge_order_form"
+- if current_ability.can?(:update, Order)
+  = render "merge_order_form"
 
 #order-detail-modal.modal.hide.fade{ data: { backdrop: "static" } }

--- a/app/views/facility_user_reservations/index.html.haml
+++ b/app/views/facility_user_reservations/index.html.haml
@@ -43,7 +43,7 @@
           %td.user-order-detail.order-detail-description
             - if current_facility.try(:single_facility?)
               = link_to order_detail.description_as_html_with_facility_prefix,
-                facility_instrument_path(order_detail.facility, order_detail.product)
+                facility_instrument_schedule_path(order_detail.facility, order_detail.product)
             - else
               = order_detail.description_as_html_with_facility_prefix
 

--- a/app/views/facility_user_reservations/index.html.haml
+++ b/app/views/facility_user_reservations/index.html.haml
@@ -41,8 +41,11 @@
           %td= order_detail.reservation
 
           %td.user-order-detail.order-detail-description
-            = link_to order_detail.description_as_html_with_facility_prefix,
-              facility_instrument_path(order_detail.facility, order_detail.product)
+            - if current_facility.try(:single_facility?)
+              = link_to order_detail.description_as_html_with_facility_prefix,
+                facility_instrument_path(order_detail.facility, order_detail.product)
+            - else
+              = order_detail.description_as_html_with_facility_prefix
 
             - if order_detail.product.offline?
               = tooltip_icon "icon-warning-sign icon-large",

--- a/app/views/search/_results_table.html.haml
+++ b/app/views/search/_results_table.html.haml
@@ -1,8 +1,11 @@
-- order_for = local_assigns[:order_for]
+- search_type = @search_type.presence || "manage_user"
+- can_switch_any = users.any? { |user| current_ability.can?(:switch_to, user) }
+- show_order_for_links = search_type == "manage_user" && can_switch_any
+
 %table.table.table-striped.table-hover
   %thead
     %tr
-      - if order_for
+      - if show_order_for_links
         %th
       %th= t(".name")
       %th= t(".username")
@@ -10,12 +13,12 @@
   %tbody
     - users.each do |user|
       %tr
-        - if order_for
+        - if show_order_for_links
           %td.centered
             - if current_ability.can?(:switch_to, user)
               = link_to t(".order_for"),
                 facility_user_switch_to_path(current_facility, user)
         %td
-          = render "search/#{@search_type || "manage_user"}_link", user: UserPresenter.new(user)
+          = render "search/#{search_type}_link", user: UserPresenter.new(user)
         %td= user.username
         %td= user.email

--- a/app/views/search/user_search_results.html.haml
+++ b/app/views/search/user_search_results.html.haml
@@ -6,10 +6,7 @@
     %p.alert.alert-info= t(".no_users_found")
   - else
     %h3= t(".select_existing_user")
-    - if @search_type == "manage_user"
-      = render "results_table", order_for: true, users: @users
-    - else
-      = render "results_table", users: @users
+    = render "results_table", users: @users
 
     - if @count > @limit
       %p.notice= t(".more_users_alert", count: @count - @limit)

--- a/app/views/shared/_order_details_table.html.haml
+++ b/app/views/shared/_order_details_table.html.haml
@@ -13,7 +13,7 @@
       %tr
         %td.centered
           = link_to order_detail,
-            current_facility ? order_detail.show_order_path : order_order_detail_path(order_detail.order, order_detail)
+            current_facility ? order_detail.show_order_path : order_detail.show_order_detail_path
         %td= order_detail.ordered_at
         %td.centered= order_detail.quantity
         %td

--- a/app/views/shared/_order_details_table.html.haml
+++ b/app/views/shared/_order_details_table.html.haml
@@ -1,37 +1,34 @@
 %table.table.table-striped.table-hover.old-table
   %thead
     %tr
-      %th.centered Order #
-      %th Ordered On
-      %th Quantity
-      %th Product
-      %th.centered Status
-      %th.currency Total
+      %th.centered= OrderDetail.human_attribute_name(:id)
+      %th= OrderDetail.human_attribute_name(:ordered_at)
+      %th= OrderDetail.human_attribute_name(:quantity)
+      %th= OrderDetail.human_attribute_name(:product)
+      %th.centered= OrderDetail.human_attribute_name(:status)
+      %th.currency= OrderDetail.human_attribute_name(:actual_total)
   %tbody
     - @order_details.each do |od|
-      - order = od.order
+      - order_detail = OrderDetailPresenter.new(od)
       %tr
-        %td.centered= link_to od, current_facility ? facility_order_path(current_facility, order) : order_order_detail_path(order, od)
-        %td=h human_datetime(order.ordered_at)
-        %td.centered=h od.quantity
+        %td.centered
+          = link_to order_detail,
+            current_facility ? order_detail.show_order_path : order_order_detail_path(order_detail.order, order_detail)
+        %td= order_detail.ordered_at
+        %td.centered= order_detail.quantity
         %td
           %ul.unstyled
-            %li
-              - product_name = order_detail_description(od)
-              = "#{h od.product.facility.abbreviation} / #{product_name}".html_safe
-            - unless od.note.blank?
+            %li= order_detail.description_as_html_with_facility_prefix
+            - if order_detail.note.present?
               %li
-                %i=h "Note: #{od.note}"
-        %td.centered=h od.order_status.try(:name)
-        %td.currency
-          - od.send(:extend, PriceDisplayment)
-          = od.wrapped_total
+                %i= "Note: #{order_detail.note}"
+        %td.centered= order_detail.order_status.try(:name)
+        %td.currency= order_detail.wrapped_total
 
 %p.footnote
-  %span.estimated_cost
-    Orange
-  totals are estimates.
-  %span.actual_cost
-    Green
-  totals are final. Pricing will be assigned to transactions with unassigned totals.
+  %span.estimated_cost= text("users.reservations.estimated_cost.color")
+  = text("users.reservations.estimated_cost.note")
+  %span.actual_cost= text("users.reservations.actual_cost.color")
+  = text("users.reservations.actual_cost.note")
+
 = will_paginate(@order_details)

--- a/app/views/users/access_list.html.haml
+++ b/app/views/users/access_list.html.haml
@@ -1,18 +1,19 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :sidebar do
-  = render partial: 'admin/shared/sidenav_users', locals: { sidenav_tab: 'users' }
+  = render "admin/shared/sidenav_users", sidenav_tab: "users"
 
 = content_for :tabnav do
-  = render partial: 'admin/shared/tabnav_users', locals: { secondary_tab: 'access_list' }
+  = render "admin/shared/tabnav_users", secondary_tab: "access_list"
 
 %h1
-  = t(:head, scope: 'users.access_list', name: @user.full_name)
+  = t(".head", name: @user.full_name)
   %small= mail_to @user.email
 
 - if @products_by_type.blank?
-  %p.notice= t('.no_products', name: @user.full_name)
+  %p.notice= t(".no_products", name: @user.full_name)
+
 - else
   = form_for :user, url: facility_user_access_list_approvals_path(@facility, @user) do |form|
     - @products_by_type.each_pair do |product_type, products|
@@ -21,17 +22,23 @@
       %table.table.table-striped.table-hover
         %thead
           %tr
-            %th.approval-column= t('.th.approval_received')
+            %th.approval-column= Product.human_attribute_name(:can_be_used_by?)
             %th.product-column= Product.model_name.human
             %th.scheduling-group-column= ProductAccessGroup.model_name.human
+
         %tbody
           - products.each do |product|
             %tr.js--access-list-row
               %td.approval-column.approval-checkbox
-                = check_box_tag "approved_products[]", product.id, product.can_be_used_by?(@user)
+                = check_box_tag "approved_products[]",
+                  product.id,
+                  product.can_be_used_by?(@user)
               %td.product-column
                 - if training_requested_for?(product)
-                  %span.label.label-important= t(:training_requested, scope: 'users.access_list')
+                  %span.label.label-important= t(".training_requested")
                 = link_to product, [product.facility, product, :users]
-              %td.scheduling-group-column= scheduling_group_select(product, @user) if product.has_access_list?
-    = submit_tag t('.update_approvals.submit'), class: ['btn', 'btn-primary']
+              %td.scheduling-group-column
+                - if product.has_access_list?
+                  = scheduling_group_select(product, @user)
+
+    = submit_tag t(".update_approvals.submit"), class: ["btn", "btn-primary"]

--- a/app/views/users/access_list.html.haml
+++ b/app/views/users/access_list.html.haml
@@ -8,11 +8,11 @@
   = render "admin/shared/tabnav_users", secondary_tab: "access_list"
 
 %h1
-  = t(".head", name: @user.full_name)
+  = text("users.access_list.head", name: @user.full_name)
   %small= mail_to @user.email
 
 - if @products_by_type.blank?
-  %p.notice= t(".no_products", name: @user.full_name)
+  %p.notice= text("users.access_list.no_products", name: @user.full_name)
 
 - else
   = form_for :user, url: facility_user_access_list_approvals_path(@facility, @user) do |form|
@@ -35,10 +35,12 @@
                   product.can_be_used_by?(@user)
               %td.product-column
                 - if training_requested_for?(product)
-                  %span.label.label-important= t(".training_requested")
+                  %span.label.label-important
+                    = text("users.access_list.training_requested")
                 = link_to product, [product.facility, product, :users]
               %td.scheduling-group-column
                 - if product.has_access_list?
                   = scheduling_group_select(product, @user)
 
-    = submit_tag t(".update_approvals.submit"), class: ["btn", "btn-primary"]
+    = submit_tag text("users.access_list.update_approvals.submit"),
+      class: ["btn", "btn-primary"]

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,5 +1,6 @@
 = content_for :h1 do
   = current_facility
+
 = content_for :sidebar do
   = render "admin/shared/sidenav_users", sidenav_tab: "users"
 
@@ -10,10 +11,13 @@
 #result
   %h3= text(".head")
   %p= text(".instruct")
+
   - if @users.any?
-    = render "search/results_table", order_for: true, users: @users
+    = render "search/results_table",
+      order_for: current_facility.try(:single_facility?),
+      users: @users
+
     = will_paginate(@users)
 
   - else
     %p.notice= text(".no_users")
-

--- a/app/views/users/orders.html.haml
+++ b/app/views/users/orders.html.haml
@@ -1,14 +1,16 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :sidebar do
-  = render :partial => 'admin/shared/sidenav_users', :locals => { :sidenav_tab => 'users' }
+  = render "admin/shared/sidenav_users", sidenav_tab: "users"
   
 = content_for :tabnav do
-  = render :partial => 'admin/shared/tabnav_users', :locals => {:secondary_tab => 'orders'}
+  = render "admin/shared/tabnav_users", secondary_tab: "orders"
  
-%h1 #{@user.full_name} Orders 
+%h1 #{@user.full_name} #{Order.model_name.human(count: @order_details.count)}
+
 - if @order_details.empty?
-  %p.notice #{@user.full_name} has not placed any orders.
+  %p.notice= text("users.orders.none", name: @user.full_name)
+
 - else
-  =render :partial => 'shared/order_details_table', :locals => { :order_details => @order_details }
+  = render "shared/order_details_table", order_details: @order_details

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -197,6 +197,7 @@ en:
         revenue_account: Revenue Account
         is_active: "Is Active?"
       product:
+        can_be_used_by?: Approved?
         url: URL
         url_name: URL Name
         requires_approval: Requires Approval?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -993,8 +993,6 @@ en:
     access_list:
       head: "%{name} Access List"
       no_products: "%{name} does not have any available products."
-      th:
-        approval_received: "Approved?"
       training_requested: Training Requested
       update_approvals:
         submit: "Update Access List"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,12 +245,7 @@ en:
   facility_account_orders:
     index:
       h3: Purchased Orders
-      label:
-        view_order:
-          file: View Order File
-          form: View Order Form
       no_orders: No transactions exist for this period.
-      note: "Note: %{text}"
       th:
         amount: Amount
         order_number: "Order #"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1014,6 +1014,8 @@ en:
       label:
         id: "NetID"
         have_id: "Does the new user have a NetID?"
+    orders:
+      none: "%{name} has not placed any orders."
     reservations:
       actions: Actions
       actual_cost:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170112204251) do
+ActiveRecord::Schema.define(version: 20170130213649) do
 
   create_table "account_users", force: :cascade do |t|
     t.integer  "account_id", limit: 4,  null: false
@@ -65,7 +65,7 @@ ActiveRecord::Schema.define(version: 20170112204251) do
   end
 
   create_table "bulk_email_jobs", force: :cascade do |t|
-    t.integer  "facility_id",     limit: 4,     null: false
+    t.integer  "facility_id",     limit: 4
     t.integer  "user_id",         limit: 4,     null: false
     t.string   "subject",         limit: 255,   null: false
     t.text     "body",            limit: 65535, null: false

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -57,8 +57,7 @@ class Ability
 
     if user.billing_administrator?
       can :manage, [Account, Journal, Order, OrderDetail, Reservation]
-      can :manage, User if resource == Facility.cross_facility
-      cannot :administer, [Order, OrderDetail, Reservation]
+      can :manage, [Reservation, User] if resource == Facility.cross_facility
       can [:manage_billing, :manage_users], Facility.cross_facility
       can [:disputed_orders, :movable_transactions, :transactions], Facility, &:cross_facility?
     end

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -60,7 +60,7 @@ class Ability
       can [:send_receipt, :show], Order
       if resource == Facility.cross_facility
         can :manage, [Reservation, User]
-        cannot :switch_to, User
+        cannot [:create, :switch_to], User
       end
       can [:manage_billing, :manage_users], Facility.cross_facility
       can [:disputed_orders, :movable_transactions, :transactions], Facility, &:cross_facility?

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -56,7 +56,8 @@ class Ability
     end
 
     if user.billing_administrator?
-      can :manage, [Account, Journal, Order, OrderDetail, Reservation]
+      can :manage, [Account, Journal, OrderDetail]
+      can :show, Order
       can :manage, [Reservation, User] if resource == Facility.cross_facility
       can [:manage_billing, :manage_users], Facility.cross_facility
       can [:disputed_orders, :movable_transactions, :transactions], Facility, &:cross_facility?

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -57,7 +57,7 @@ class Ability
 
     if user.billing_administrator?
       can :manage, [Account, Journal, OrderDetail]
-      can :show, Order
+      can [:send_receipt, :show], Order
       can :manage, [Reservation, User] if resource == Facility.cross_facility
       can [:manage_billing, :manage_users], Facility.cross_facility
       can [:disputed_orders, :movable_transactions, :transactions], Facility, &:cross_facility?

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -58,7 +58,10 @@ class Ability
     if user.billing_administrator?
       can :manage, [Account, Journal, OrderDetail]
       can [:send_receipt, :show], Order
-      can :manage, [Reservation, User] if resource == Facility.cross_facility
+      if resource == Facility.cross_facility
+        can :manage, [Reservation, User]
+        cannot :switch_to, User
+      end
       can [:manage_billing, :manage_users], Facility.cross_facility
       can [:disputed_orders, :movable_transactions, :transactions], Facility, &:cross_facility?
     end

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -57,7 +57,7 @@ class Ability
 
     if user.billing_administrator?
       can :manage, [Account, Journal, Order, OrderDetail, Reservation]
-      can :manage, [Product, Reservation, User] if resource == Facility.cross_facility
+      can :manage, [Reservation, User] if resource == Facility.cross_facility
       can [:manage_billing, :manage_users], Facility.cross_facility
       can [:disputed_orders, :movable_transactions, :transactions], Facility, &:cross_facility?
     end

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -60,6 +60,7 @@ class Ability
       can [:send_receipt, :show], Order
       if resource == Facility.cross_facility
         can :manage, [Reservation, User]
+        cannot [:edit, :update], Reservation
         cannot [:create, :switch_to], User
       end
       can :manage_billing, Facility.cross_facility

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -57,8 +57,9 @@ class Ability
 
     if user.billing_administrator?
       can :manage, [Account, Journal, Order, OrderDetail, Reservation]
+      can :manage, User if resource == Facility.cross_facility
       cannot :administer, [Order, OrderDetail, Reservation]
-      can :manage_billing, Facility.cross_facility
+      can [:manage_billing, :manage_users], Facility.cross_facility
       can [:disputed_orders, :movable_transactions, :transactions], Facility, &:cross_facility?
     end
 

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -59,9 +59,7 @@ class Ability
       can :manage, [Account, Journal, OrderDetail]
       can [:send_receipt, :show], Order
       if resource == Facility.cross_facility
-        can :manage, [Reservation, User]
-        cannot [:edit, :update], Reservation
-        cannot [:create, :switch_to], User
+        can [:accounts, :index, :orders, :show], User
       end
       can :manage_billing, Facility.cross_facility
       can [:disputed_orders, :movable_transactions, :transactions], Facility, &:cross_facility?

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -57,7 +57,7 @@ class Ability
 
     if user.billing_administrator?
       can :manage, [Account, Journal, Order, OrderDetail, Reservation]
-      can :manage, [Reservation, User] if resource == Facility.cross_facility
+      can :manage, [Product, Reservation, User] if resource == Facility.cross_facility
       can [:manage_billing, :manage_users], Facility.cross_facility
       can [:disputed_orders, :movable_transactions, :transactions], Facility, &:cross_facility?
     end

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -62,7 +62,7 @@ class Ability
         can :manage, [Reservation, User]
         cannot [:create, :switch_to], User
       end
-      can [:manage_billing, :manage_users], Facility.cross_facility
+      can :manage_billing, Facility.cross_facility
       can [:disputed_orders, :movable_transactions, :transactions], Facility, &:cross_facility?
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe ApplicationHelper do
     before(:each) do
       allow(current_ability)
         .to receive(:can?)
-          .with(:manage_users, current_facility) { can_manage_users? }
+        .with(:create, User)
+        .and_return(can_manage_users?)
     end
 
     context "when the user can :manage_users for the current facility" do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -171,6 +171,7 @@ RSpec.describe Ability do
       it_is_not_allowed_to([:create, :switch_to], User)
       it { is_expected.to be_allowed_to(:show, Order) }
       it { is_expected.to be_allowed_to(:administer, Reservation) }
+      it_is_not_allowed_to([:edit, :update], Reservation)
       it { is_expected.not_to be_allowed_to(:administer, Product) }
     end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Ability do
     context "in a single facility" do
       it { is_expected.to be_allowed_to(:manage_billing, Facility.cross_facility) }
       it { is_expected.to be_allowed_to(:manage_users, Facility.cross_facility) }
-      it { is_expected.to be_allowed_to(:show, Order) }
+      it_is_allowed_to([:send_receipt, :show], Order)
       it { is_expected.not_to be_allowed_to(:manage_billing, facility) }
       it { is_expected.not_to be_allowed_to(:transactions, facility) }
       it { is_expected.not_to be_allowed_to(:manage, Reservation) }

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Ability do
         it { is_expected.to be_allowed_to(action, facility) }
       end
       it { is_expected.to be_allowed_to(:manage, User) }
-      it_is_not_allowed_to([:switch_to], User)
+      it_is_not_allowed_to([:create, :switch_to], User)
       it { is_expected.to be_allowed_to(:show, Order) }
       it { is_expected.to be_allowed_to(:administer, Reservation) }
       it { is_expected.not_to be_allowed_to(:administer, Product) }
@@ -176,7 +176,7 @@ RSpec.describe Ability do
       let(:facility) { nil }
 
       it_is_allowed_to([:manage_billing, :manage_users], Facility.cross_facility)
-      it_is_not_allowed_to([:switch_to], User)
+      it_is_not_allowed_to([:create, :switch_to], User)
     end
   end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -152,8 +152,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:manage, OrderDetail) }
 
     context "in a single facility" do
-      it { is_expected.to be_allowed_to(:manage_billing, Facility.cross_facility) }
-      it { is_expected.not_to be_allowed_to(:manage_users, Facility.cross_facility) }
+      it { is_expected.not_to be_allowed_to(:manage_users, facility) }
       it_is_allowed_to([:send_receipt, :show], Order)
       it { is_expected.not_to be_allowed_to(:manage_billing, facility) }
       it { is_expected.not_to be_allowed_to(:transactions, facility) }
@@ -167,10 +166,9 @@ RSpec.describe Ability do
         it { is_expected.to be_allowed_to(action, facility) }
       end
       it { is_expected.not_to be_allowed_to(:manage_users, facility) }
-      it { is_expected.to be_allowed_to(:manage, User) }
+      it_is_allowed_to([:accounts, :index, :orders, :show], User)
       it_is_not_allowed_to([:create, :switch_to], User)
       it { is_expected.to be_allowed_to(:show, Order) }
-      it { is_expected.to be_allowed_to(:administer, Reservation) }
       it_is_not_allowed_to([:edit, :update], Reservation)
       it { is_expected.not_to be_allowed_to(:administer, Product) }
     end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -167,6 +167,7 @@ RSpec.describe Ability do
         it { is_expected.to be_allowed_to(action, facility) }
       end
       it { is_expected.to be_allowed_to(:manage, User) }
+      it { is_expected.not_to be_allowed_to(:switch_to, User) }
       it { is_expected.to be_allowed_to(:show, Order) }
       it { is_expected.to be_allowed_to(:administer, Reservation) }
       it { is_expected.not_to be_allowed_to(:administer, Product) }
@@ -177,6 +178,7 @@ RSpec.describe Ability do
 
       it { is_expected.to be_allowed_to(:manage_billing, Facility.cross_facility) }
       it { is_expected.to be_allowed_to(:manage_users, Facility.cross_facility) }
+      it { is_expected.not_to be_allowed_to(:switch_to, User) }
     end
   end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -158,11 +158,11 @@ RSpec.describe Ability do
       is_expected.not_to be_allowed_to(:administer, Order)
       is_expected.not_to be_allowed_to(:administer, OrderDetail)
       is_expected.not_to be_allowed_to(:administer, Reservation)
-      is_expected.not_to be_allowed_to(:manage_users, Facility.cross_facility)
     end
 
     context "in a single facility" do
       it { is_expected.to be_allowed_to(:manage_billing, Facility.cross_facility) }
+      it { is_expected.to be_allowed_to(:manage_users, Facility.cross_facility) }
       it { is_expected.not_to be_allowed_to(:manage_billing, facility) }
       it { is_expected.not_to be_allowed_to(:transactions, facility) }
     end
@@ -170,15 +170,17 @@ RSpec.describe Ability do
     context "in cross-facility" do
       let(:facility) { Facility.cross_facility }
 
-      %i(disputed_orders manage_billing movable_transactions transactions).each do |action|
+      %i(disputed_orders manage_billing manage_users movable_transactions transactions).each do |action|
         it { is_expected.to be_allowed_to(action, facility) }
       end
+      it { is_expected.to be_allowed_to(:manage, User) }
     end
 
     context "in no facility" do
       let(:facility) { nil }
 
       it { is_expected.to be_allowed_to(:manage_billing, Facility.cross_facility) }
+      it { is_expected.to be_allowed_to(:manage_users, Facility.cross_facility) }
     end
   end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -151,14 +151,14 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:manage, Account) }
     it { is_expected.to be_allowed_to(:manage, Journal) }
     it { is_expected.to be_allowed_to(:manage, OrderDetail) }
-    it { is_expected.to be_allowed_to(:manage, Order) }
-    it { is_expected.to be_allowed_to(:manage, Reservation) }
 
     context "in a single facility" do
       it { is_expected.to be_allowed_to(:manage_billing, Facility.cross_facility) }
       it { is_expected.to be_allowed_to(:manage_users, Facility.cross_facility) }
+      it { is_expected.to be_allowed_to(:show, Order) }
       it { is_expected.not_to be_allowed_to(:manage_billing, facility) }
       it { is_expected.not_to be_allowed_to(:transactions, facility) }
+      it { is_expected.not_to be_allowed_to(:manage, Reservation) }
     end
 
     context "in cross-facility" do
@@ -168,7 +168,7 @@ RSpec.describe Ability do
         it { is_expected.to be_allowed_to(action, facility) }
       end
       it { is_expected.to be_allowed_to(:manage, User) }
-      it { is_expected.to be_allowed_to(:administer, Order) }
+      it { is_expected.to be_allowed_to(:show, Order) }
       it { is_expected.to be_allowed_to(:administer, Reservation) }
       it { is_expected.not_to be_allowed_to(:administer, Product) }
     end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -154,12 +154,6 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:manage, Order) }
     it { is_expected.to be_allowed_to(:manage, Reservation) }
 
-    it "cannot administer resources" do
-      is_expected.not_to be_allowed_to(:administer, Order)
-      is_expected.not_to be_allowed_to(:administer, OrderDetail)
-      is_expected.not_to be_allowed_to(:administer, Reservation)
-    end
-
     context "in a single facility" do
       it { is_expected.to be_allowed_to(:manage_billing, Facility.cross_facility) }
       it { is_expected.to be_allowed_to(:manage_users, Facility.cross_facility) }
@@ -174,6 +168,8 @@ RSpec.describe Ability do
         it { is_expected.to be_allowed_to(action, facility) }
       end
       it { is_expected.to be_allowed_to(:manage, User) }
+      it { is_expected.to be_allowed_to(:administer, Order) }
+      it { is_expected.to be_allowed_to(:administer, Reservation) }
     end
 
     context "in no facility" do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -152,8 +152,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:manage, OrderDetail) }
 
     context "in a single facility" do
-      it { is_expected.to be_allowed_to(:manage_billing, Facility.cross_facility) }
-      it { is_expected.to be_allowed_to(:manage_users, Facility.cross_facility) }
+      it_is_allowed_to([:manage_billing, :manage_users], Facility.cross_facility)
       it_is_allowed_to([:send_receipt, :show], Order)
       it { is_expected.not_to be_allowed_to(:manage_billing, facility) }
       it { is_expected.not_to be_allowed_to(:transactions, facility) }
@@ -167,7 +166,7 @@ RSpec.describe Ability do
         it { is_expected.to be_allowed_to(action, facility) }
       end
       it { is_expected.to be_allowed_to(:manage, User) }
-      it { is_expected.not_to be_allowed_to(:switch_to, User) }
+      it_is_not_allowed_to([:switch_to], User)
       it { is_expected.to be_allowed_to(:show, Order) }
       it { is_expected.to be_allowed_to(:administer, Reservation) }
       it { is_expected.not_to be_allowed_to(:administer, Product) }
@@ -176,9 +175,8 @@ RSpec.describe Ability do
     context "in no facility" do
       let(:facility) { nil }
 
-      it { is_expected.to be_allowed_to(:manage_billing, Facility.cross_facility) }
-      it { is_expected.to be_allowed_to(:manage_users, Facility.cross_facility) }
-      it { is_expected.not_to be_allowed_to(:switch_to, User) }
+      it_is_allowed_to([:manage_billing, :manage_users], Facility.cross_facility)
+      it_is_not_allowed_to([:switch_to], User)
     end
   end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -169,6 +169,7 @@ RSpec.describe Ability do
       end
       it { is_expected.to be_allowed_to(:manage, User) }
       it { is_expected.to be_allowed_to(:administer, Order) }
+      it { is_expected.to be_allowed_to(:administer, Product) }
       it { is_expected.to be_allowed_to(:administer, Reservation) }
     end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -169,8 +169,8 @@ RSpec.describe Ability do
       end
       it { is_expected.to be_allowed_to(:manage, User) }
       it { is_expected.to be_allowed_to(:administer, Order) }
-      it { is_expected.to be_allowed_to(:administer, Product) }
       it { is_expected.to be_allowed_to(:administer, Reservation) }
+      it { is_expected.not_to be_allowed_to(:administer, Product) }
     end
 
     context "in no facility" do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -152,7 +152,8 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:manage, OrderDetail) }
 
     context "in a single facility" do
-      it_is_allowed_to([:manage_billing, :manage_users], Facility.cross_facility)
+      it { is_expected.to be_allowed_to(:manage_billing, Facility.cross_facility) }
+      it { is_expected.not_to be_allowed_to(:manage_users, Facility.cross_facility) }
       it_is_allowed_to([:send_receipt, :show], Order)
       it { is_expected.not_to be_allowed_to(:manage_billing, facility) }
       it { is_expected.not_to be_allowed_to(:transactions, facility) }
@@ -162,9 +163,10 @@ RSpec.describe Ability do
     context "in cross-facility" do
       let(:facility) { Facility.cross_facility }
 
-      %i(disputed_orders manage_billing manage_users movable_transactions transactions).each do |action|
+      %i(disputed_orders manage_billing movable_transactions transactions).each do |action|
         it { is_expected.to be_allowed_to(action, facility) }
       end
+      it { is_expected.not_to be_allowed_to(:manage_users, facility) }
       it { is_expected.to be_allowed_to(:manage, User) }
       it_is_not_allowed_to([:create, :switch_to], User)
       it { is_expected.to be_allowed_to(:show, Order) }
@@ -175,7 +177,8 @@ RSpec.describe Ability do
     context "in no facility" do
       let(:facility) { nil }
 
-      it_is_allowed_to([:manage_billing, :manage_users], Facility.cross_facility)
+      it { is_expected.to be_allowed_to(:manage_billing, Facility.cross_facility) }
+      it { is_expected.not_to be_allowed_to(:manage_users, Facility.cross_facility) }
       it_is_not_allowed_to([:create, :switch_to], User)
     end
   end

--- a/spec/presenters/order_detail_presenter_spec.rb
+++ b/spec/presenters/order_detail_presenter_spec.rb
@@ -162,19 +162,6 @@ RSpec.describe OrderDetailPresenter do
     it { is_expected.to eq("/orders/#{order.id}/order_details/#{order_detail.id}") }
   end
 
-  describe "#show_reservation_path" do
-    subject { presented.show_reservation_path }
-
-    include_context "order with a reservation"
-
-    let(:expected_path) do
-      "/#{facilities_route}/#{facility.url_name}/orders/#{order.id}/order_details/"\
-      "#{order_detail.id}/reservations/#{reservation.id}"
-    end
-
-    it { is_expected.to eq(expected_path) }
-  end
-
   describe "#survey_url" do
     subject { presented.survey_url }
 

--- a/spec/presenters/order_detail_presenter_spec.rb
+++ b/spec/presenters/order_detail_presenter_spec.rb
@@ -154,6 +154,14 @@ RSpec.describe OrderDetailPresenter do
     it { is_expected.to eq("/#{facilities_route}/#{facility.url_name}/orders/#{order.id}") }
   end
 
+  describe "#show_order_detail_path" do
+    subject { presented.show_order_detail_path }
+
+    include_context "order with a reservation"
+
+    it { is_expected.to eq("/orders/#{order.id}/order_details/#{order_detail.id}") }
+  end
+
   describe "#show_reservation_path" do
     subject { presented.show_reservation_path }
 

--- a/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
+++ b/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
@@ -104,7 +104,7 @@ module BulkEmail
     end
 
     def init_search_options
-      @products = current_facility.products.active_plus_hidden.order("products.name").includes(:facility)
+      @products = Product.for_facility(current_facility).active_plus_hidden.order("products.name").includes(:facility)
       @search_options = { products: @products }
       @search_fields = params.merge(facility_id: current_facility.id)
       @user_types = user_types

--- a/vendor/engines/bulk_email/app/inputs/bulk_email/body_input.rb
+++ b/vendor/engines/bulk_email/app/inputs/bulk_email/body_input.rb
@@ -13,6 +13,7 @@ module BulkEmail
     private
 
     def readonly_text(content)
+      return if content.blank?
       rows = content.count("\n") + 1
       template.content_tag(:textarea, content, input_html_options.merge(disabled: true, rows: rows))
     end

--- a/vendor/engines/bulk_email/app/models/bulk_email/ability_extension.rb
+++ b/vendor/engines/bulk_email/app/models/bulk_email/ability_extension.rb
@@ -12,10 +12,6 @@ module BulkEmail
       if user.manager_of?(resource) || user.facility_senior_staff_of?(resource)
         ability.can(:send_bulk_emails, resource)
       end
-
-      if resource == Facility.cross_facility && user.billing_administrator?
-        ability.can(:send_bulk_emails, resource)
-      end
     end
 
   end

--- a/vendor/engines/bulk_email/app/models/bulk_email/ability_extension.rb
+++ b/vendor/engines/bulk_email/app/models/bulk_email/ability_extension.rb
@@ -12,6 +12,10 @@ module BulkEmail
       if user.manager_of?(resource) || user.facility_senior_staff_of?(resource)
         ability.can(:send_bulk_emails, resource)
       end
+
+      if resource == Facility.cross_facility && user.billing_administrator?
+        ability.can(:send_bulk_emails, resource)
+      end
     end
 
   end

--- a/vendor/engines/bulk_email/app/models/bulk_email/job.rb
+++ b/vendor/engines/bulk_email/app/models/bulk_email/job.rb
@@ -10,8 +10,7 @@ module BulkEmail
     serialize :recipients, Array
     serialize :search_criteria, Hash
 
-    validates :facility_id,
-              :user_id,
+    validates :user_id,
               :subject,
               :body,
               :recipients,

--- a/vendor/engines/bulk_email/app/services/bulk_email/content_generator.rb
+++ b/vendor/engines/bulk_email/app/services/bulk_email/content_generator.rb
@@ -20,7 +20,7 @@ module BulkEmail
     end
 
     def wrap_text(text, recipient_name = nil)
-      [greeting(recipient_name), text, signoff].join("\n\n")
+      [greeting(recipient_name), text, signoff].compact.join("\n\n")
     end
 
     def greeting(recipient_name = nil)
@@ -31,7 +31,9 @@ module BulkEmail
     end
 
     def signoff
-      I18n.t("bulk_email.body.signoff", facility_name: facility.name)
+      if facility.single_facility?
+        I18n.t("bulk_email.body.signoff", facility_name: facility.name)
+      end
     end
 
     private

--- a/vendor/engines/bulk_email/app/services/bulk_email/content_generator.rb
+++ b/vendor/engines/bulk_email/app/services/bulk_email/content_generator.rb
@@ -12,7 +12,11 @@ module BulkEmail
     end
 
     def subject_prefix
-      "[#{I18n.t('app_name')} #{facility.name}]"
+      if facility.single_facility?
+        "[#{I18n.t('app_name')} #{facility.name}]"
+      else
+        "[#{I18n.t('app_name')}]"
+      end
     end
 
     def wrap_text(text, recipient_name = nil)

--- a/vendor/engines/bulk_email/app/services/bulk_email/recipient_searcher.rb
+++ b/vendor/engines/bulk_email/app/services/bulk_email/recipient_searcher.rb
@@ -71,7 +71,7 @@ module BulkEmail
     def product_ids_from_params
       # if we don't have any products, get all for the facility
       search_fields[:products].presence ||
-        Facility.find(search_fields[:facility_id]).products.map(&:id)
+        Facility.find(search_fields[:facility_id]).products.pluck(:id)
     end
 
     def selected_user_types

--- a/vendor/engines/bulk_email/app/services/bulk_email/recipient_searcher.rb
+++ b/vendor/engines/bulk_email/app/services/bulk_email/recipient_searcher.rb
@@ -55,16 +55,23 @@ module BulkEmail
     end
 
     def search_authorized_users
-      result = users.joins(:product_users).uniq
-      # if we don't have any products, listed get them all for the current facility
-      product_ids = search_fields[:products].presence || Facility.find(search_fields[:facility_id]).products.map(&:id)
-      result.where(product_users: { product_id: product_ids }).reorder(*self.class::DEFAULT_SORT)
+      users
+        .joins(:product_users)
+        .uniq
+        .where(product_users: { product_id: product_ids_from_params })
+        .reorder(*self.class::DEFAULT_SORT)
     end
 
     private
 
     def hidden_tags_for(key, values)
       Array(values).map { |value| hidden_field_tag(key, value, id: nil) }
+    end
+
+    def product_ids_from_params
+      # if we don't have any products, get all for the facility
+      search_fields[:products].presence ||
+        Facility.find(search_fields[:facility_id]).products.map(&:id)
     end
 
     def selected_user_types
@@ -79,8 +86,7 @@ module BulkEmail
     def find_order_details
       OrderDetail
         .for_products(search_fields[:products])
-        .joins(:order)
-        .where(orders: { facility_id: search_fields[:facility_id] })
+        .for_facility_id(search_fields[:facility_id].presence)
         .ordered_or_reserved_in_range(start_date, end_date)
     end
 

--- a/vendor/engines/bulk_email/db/migrate/20170130213649_make_bulk_email_job_facility_nullable.rb
+++ b/vendor/engines/bulk_email/db/migrate/20170130213649_make_bulk_email_job_facility_nullable.rb
@@ -1,0 +1,11 @@
+class MakeBulkEmailJobFacilityNullable < ActiveRecord::Migration
+
+  def up
+    change_column :bulk_email_jobs, :facility_id, :integer, null: true
+  end
+
+  def down
+    change_column :bulk_email_jobs, :facility_id, :integer, null: false
+  end
+
+end

--- a/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
+++ b/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe BulkEmail::BulkEmailController do
 
         context "in a cross-facility context" do
           let(:facility) { Facility.cross_facility }
-          it_behaves_like "it can search for recipients"
+          it { is_expected.to render_template("403") }
         end
       end
     end

--- a/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
+++ b/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
@@ -7,65 +7,39 @@ RSpec.describe BulkEmail::BulkEmailController do
   let(:facility_account) { FactoryGirl.create(:facility_account) }
   let!(:instrument) { FactoryGirl.create(:instrument, facility_account: facility_account) }
   let!(:item) { FactoryGirl.create(:item, facility_account: facility_account) }
+  let(:params) { { facility_id: facility.url_name } }
   let!(:restricted_item) { FactoryGirl.create(:item, facility_account: facility_account, requires_approval: true) }
   let!(:service) { FactoryGirl.create(:service, facility_account: facility_account) }
 
-  before(:each) do
-    @params = { facility_id: facility.url_name }
-  end
-
-  def do_request
-    method(@method).call(@action, @params)
-  end
-
   describe "POST #search" do
-    before :each do
-      @action = "search"
-      @method = :post
-      @params.merge!(bulk_email: { user_types: user_types })
-    end
-
     context "when not logged in" do
-      let(:user_types) { [] }
-
-      before { do_request }
-
+      before { post "search", params }
       it { is_expected.to redirect_to(new_user_session_url) }
-
     end
 
     context "when logged in" do
+      let(:params) { super().merge(bulk_email: { user_types: user_types }) }
+      let!(:hidden_product) { nil }
       let(:user_types) { [] }
 
       before do
         sign_in user
-        do_request
+        post "search", params
       end
 
       shared_examples_for "it can search for recipients" do
         context "when at least one user_type is set" do
           let(:user_types) { %i(customers) }
-
-          before { do_request }
-
           it { expect(assigns[:users]).not_to be_nil }
         end
 
         context "when no user_types are set" do
           let(:user_types) { [] }
-
-          before { do_request }
-
           it { expect(assigns[:users]).to be_blank }
         end
 
         context "parameter settings" do
           let(:user_types) { %i(customers) }
-
-          before(:each) do
-            do_request
-            expect(response).to be_success
-          end
 
           it "sets products, in order" do
             expect(assigns[:products])
@@ -82,10 +56,9 @@ RSpec.describe BulkEmail::BulkEmailController do
           end
 
           context "when where are no restricted instruments" do
-            before { restricted_item.destroy }
+            let!(:restricted_item) { nil }
 
             it "does not include authorized_users as a user_type" do
-              do_request
               expect(assigns[:user_types]).not_to include(:authorized_users)
             end
           end
@@ -93,16 +66,11 @@ RSpec.describe BulkEmail::BulkEmailController do
 
         context "when there is a hidden product" do
           let(:user_types) { %i(customers) }
-
           let!(:hidden_product) do
             FactoryGirl.create(:item, :hidden, facility_account: facility_account)
           end
 
-          it "includes the hidden product" do
-            do_request
-            expect(response).to be_success
-            expect(assigns[:products]).to include(hidden_product)
-          end
+          it { expect(assigns[:products]).to include(hidden_product) }
         end
 
         context "when there is an archived product" do
@@ -112,11 +80,7 @@ RSpec.describe BulkEmail::BulkEmailController do
             FactoryGirl.create(:item, :archived, facility_account: facility_account)
           end
 
-          it "does not load the archived product" do
-            do_request
-            expect(response).to be_success
-            expect(assigns[:products]).not_to include(archived_product)
-          end
+          it { expect(assigns[:products]).not_to include(archived_product) }
         end
       end
 
@@ -138,6 +102,10 @@ RSpec.describe BulkEmail::BulkEmailController do
   end
 
   describe "POST #create" do
+    let(:params) do
+      super().merge(format: :csv, recipient_ids: recipients.map(&:id))
+    end
+
     let(:recipients) { FactoryGirl.create_list(:user, 3) }
     let(:expected_csv_content) { csv_header + "\n" + expected_csv_body + "\n" }
     let(:csv_header) { "Name,Username,Email" }
@@ -148,14 +116,9 @@ RSpec.describe BulkEmail::BulkEmailController do
     end
     let(:user) { FactoryGirl.create(:user, :senior_staff, facility: facility) }
 
-    before(:each) do
-      @action = "create"
-      @method = :post
-      @params[:format] = :csv
-      @params[:recipient_ids] = recipients.map(&:id)
-
+    before do
       sign_in user
-      do_request
+      post "create", params
     end
 
     it "generates the expected CSV" do
@@ -168,13 +131,10 @@ RSpec.describe BulkEmail::BulkEmailController do
   describe "POST #deliver" do
     let(:recipients) { FactoryGirl.create_list(:user, 3) }
     let(:custom_message) { "Custom message" }
-    let(:return_path) { nil }
     let(:user) { FactoryGirl.create(:user, :senior_staff, facility: facility) }
 
-    before(:each) do
-      @action = "deliver"
-      @method = :post
-      @params[:bulk_email_delivery_form] = {
+    let(:params) do
+      super().merge(bulk_email_delivery_form: {
         custom_subject: custom_subject,
         custom_message: custom_message,
         recipient_ids: recipients.map(&:id),
@@ -183,44 +143,41 @@ RSpec.describe BulkEmail::BulkEmailController do
           end_date: "1/1/2016",
           bulk_email: { user_types: ["customers"], products: [1] },
         }.to_json,
-      }
-      @params[:return_path] = return_path if return_path.present?
+      })
+    end
 
+    before do
       sign_in user
-      do_request
+      post "deliver", params
     end
 
     context "when the form is valid" do
       let(:custom_subject) { "Custom subject" }
+      let(:default_return_path) { facility_bulk_email_path }
 
       context "when no return_path param specified" do
         it "submits successfully" do
-          is_expected.to redirect_to(facility_bulk_email_path)
+          is_expected.to redirect_to(default_return_path)
           expect(flash[:notice]).to include("3 email messages queued")
         end
       end
 
-      context "with a routable return_path param" do
-        let(:return_path) { facility_instruments_path(facility) }
+      context "when specifying a return_path param" do
+        let(:params) { super().merge(return_path: return_path) }
 
-        it "redirects to the path specified in the param" do
-          is_expected.to redirect_to(return_path)
+        context "that is routable" do
+          let(:return_path) { facility_instruments_path(facility) }
+          it { is_expected.to redirect_to(return_path) }
         end
-      end
 
-      context "with a return_path param set to a full URL" do
-        let(:return_path) { "http://example.net/" }
-
-        it "falls back to redirecting to the bulk email path" do
-          is_expected.to redirect_to(facility_bulk_email_path)
+        context "that is a full URL" do
+          let(:return_path) { "http://example.net/" }
+          it { is_expected.to redirect_to(default_return_path) }
         end
-      end
 
-      context "with a non-routable return_path param" do
-        let(:return_path) { "a bad return path value" }
-
-        it "falls back to redirecting to the bulk email path" do
-          is_expected.to redirect_to(facility_bulk_email_path)
+        context "that is not routable" do
+          let(:return_path) { "a bad return path value" }
+          it { is_expected.to redirect_to(default_return_path) }
         end
       end
     end

--- a/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
+++ b/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
@@ -144,15 +144,15 @@ RSpec.describe BulkEmail::BulkEmailController do
 
     let(:params) do
       super().merge(bulk_email_delivery_form: {
-        custom_subject: custom_subject,
-        custom_message: custom_message,
-        recipient_ids: recipients.map(&:id),
-        search_criteria: {
-          start_date: "12/31/1999",
-          end_date: "1/1/2016",
-          bulk_email: { user_types: ["customers"], products: [1] },
-        }.to_json,
-      })
+                      custom_subject: custom_subject,
+                      custom_message: custom_message,
+                      recipient_ids: recipients.map(&:id),
+                      search_criteria: {
+                        start_date: "12/31/1999",
+                        end_date: "1/1/2016",
+                        bulk_email: { user_types: ["customers"], products: [1] },
+                      }.to_json,
+                    })
     end
 
     before do

--- a/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
+++ b/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
@@ -98,6 +98,15 @@ RSpec.describe BulkEmail::BulkEmailController do
         let(:user) { FactoryGirl.create(:user, :senior_staff, facility: facility) }
         it_behaves_like "it can search for recipients"
       end
+
+      context "when logged in as a billing administrator" do
+        let(:user) { FactoryGirl.create(:user, :billing_administrator) }
+
+        context "in a cross-facility context" do
+          let(:facility) { Facility.cross_facility }
+          it_behaves_like "it can search for recipients"
+        end
+      end
     end
   end
 

--- a/vendor/engines/bulk_email/spec/models/bulk_email/ability_extension_spec.rb
+++ b/vendor/engines/bulk_email/spec/models/bulk_email/ability_extension_spec.rb
@@ -25,7 +25,15 @@ RSpec.describe BulkEmail::AbilityExtension do
 
   describe "billing administrator", feature_setting: { billing_administrator: true } do
     let(:user) { FactoryGirl.create(:user, :billing_administrator) }
-    it_behaves_like "it may not send bulk email"
+
+    context "when in a single-facility context" do
+      it_behaves_like "it may not send bulk email"
+    end
+
+    context "when in a cross-facility context" do
+      let(:facility) { Facility.cross_facility }
+      it_behaves_like "it may send bulk email"
+    end
   end
 
   describe "facility administrator" do

--- a/vendor/engines/bulk_email/spec/models/bulk_email/ability_extension_spec.rb
+++ b/vendor/engines/bulk_email/spec/models/bulk_email/ability_extension_spec.rb
@@ -26,13 +26,9 @@ RSpec.describe BulkEmail::AbilityExtension do
   describe "billing administrator", feature_setting: { billing_administrator: true } do
     let(:user) { FactoryGirl.create(:user, :billing_administrator) }
 
-    context "when in a single-facility context" do
-      it_behaves_like "it may not send bulk email"
-    end
-
     context "when in a cross-facility context" do
       let(:facility) { Facility.cross_facility }
-      it_behaves_like "it may send bulk email"
+      it_behaves_like "it may not send bulk email"
     end
   end
 

--- a/vendor/engines/bulk_email/spec/models/bulk_email/delivery_form_spec.rb
+++ b/vendor/engines/bulk_email/spec/models/bulk_email/delivery_form_spec.rb
@@ -59,6 +59,5 @@ RSpec.describe BulkEmail::DeliveryForm do
 
       it_behaves_like "it delivers mail"
     end
-
   end
 end

--- a/vendor/engines/bulk_email/spec/models/bulk_email/delivery_form_spec.rb
+++ b/vendor/engines/bulk_email/spec/models/bulk_email/delivery_form_spec.rb
@@ -25,18 +25,40 @@ RSpec.describe BulkEmail::DeliveryForm do
       form.search_criteria = { this: "is", a: "test" }
 
       allow(content_generator).to receive(:greeting).and_return("Greeting")
-      allow(content_generator).to receive(:signoff).and_return("Signoff")
+      allow(content_generator).to receive(:signoff).and_return(signoff)
       allow(content_generator).to receive(:subject_prefix).and_return("Prefix")
     end
 
     let(:bulk_email_job) { BulkEmail::Job.last }
 
-    it "queues mail to all recipients", :aggregate_failures do
-      expect { form.deliver_all }.to change(BulkEmail::Job, :count).by(1)
-      expect(bulk_email_job.subject).to eq("Prefix #{form.custom_subject}")
-      expect(bulk_email_job.body).to eq("Greeting\n\n#{form.custom_message}\n\nSignoff")
-      expect(bulk_email_job.recipients).to match_array(recipients.map(&:email))
-      expect(bulk_email_job.search_criteria).to match(this: "is", a: "test")
+    shared_examples_for "it delivers mail" do
+      it "queues mail to all recipients", :aggregate_failures do
+        expect { form.deliver_all }.to change(BulkEmail::Job, :count).by(1)
+        expect(bulk_email_job.subject).to eq("Prefix #{form.custom_subject}")
+        expect(bulk_email_job.body).to eq(expected_body)
+        expect(bulk_email_job.recipients).to match_array(recipients.map(&:email))
+        expect(bulk_email_job.search_criteria).to match(this: "is", a: "test")
+      end
     end
+
+    context "when in a single-facility context" do
+      let(:expected_body) { "Greeting\n\nCustom message\n\n#{signoff}" }
+      let(:signoff) { "If you have any questions, etc." }
+
+      it_behaves_like "it delivers mail"
+    end
+
+    context "when in a cross-facility context" do
+      let(:expected_body) { "Greeting\n\nCustom message" }
+      let(:facility) { Facility.cross_facility }
+      let(:signoff) { nil }
+
+      before do
+        allow(content_generator).to receive(:signoff).and_return(nil)
+      end
+
+      it_behaves_like "it delivers mail"
+    end
+
   end
 end

--- a/vendor/engines/bulk_email/spec/services/bulk_email/content_generator_spec.rb
+++ b/vendor/engines/bulk_email/spec/services/bulk_email/content_generator_spec.rb
@@ -32,7 +32,15 @@ RSpec.describe BulkEmail::ContentGenerator do
   end
 
   describe "#signoff" do
-    it { expect(subject.signoff).to be_present }
+    context "when in a single-facility context" do
+      it { expect(subject.signoff).to be_present }
+    end
+
+    context "when in a cross-facility context" do
+      let(:facility) { Facility.cross_facility }
+
+      it { expect(subject.signoff).to be_blank }
+    end
   end
 
   describe "#subject_prefix" do

--- a/vendor/engines/bulk_email/spec/services/bulk_email/content_generator_spec.rb
+++ b/vendor/engines/bulk_email/spec/services/bulk_email/content_generator_spec.rb
@@ -36,9 +36,19 @@ RSpec.describe BulkEmail::ContentGenerator do
   end
 
   describe "#subject_prefix" do
-    it "includes the app and facility names" do
-      expect(subject.subject_prefix)
-        .to eq("[#{I18n.t('app_name')} #{facility.name}]")
+    context "when in a single-facility context" do
+      it "includes the app and facility names" do
+        expect(subject.subject_prefix)
+          .to eq("[#{I18n.t('app_name')} #{facility.name}]")
+      end
+    end
+
+    context "when in a cross-facility context" do
+      let(:facility) { Facility.cross_facility }
+
+      it "includes only the app name" do
+        expect(subject.subject_prefix).to eq("[#{I18n.t('app_name')}]")
+      end
     end
   end
 


### PR DESCRIPTION
https://pm.tablexi.com/issues/125093

This opens the cross-facility "Users" tab to Billing Administrators. It already exists for Account Managers, but opening it to BAs revealed queries that expected a single facility, and partials that weren't checking certain abilities and settings flags. For example, we probably should have been checking the `manage_payment_sources_with_users` setting on the "User" side from the start.

The bulk email feature probably had the most significant changes: it no longer requires a bulk email job to have a facility, and omits the canned "signoff" when in a cross-facility context (since the message normally mentions contacting the facility).

Its controller tests also needed to move away from `controller_spec_helper`; it would have been complicated to make it work with certain products and user roles were associated with a particular facility, while making the requests against the "ALL" facility.