### PR TITLE
[#133561] Handle attempted reservation creation for deleted cart items

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -95,7 +95,7 @@ class ReservationsController < ApplicationController
     flash.now[:notice] = existing_notices.concat(notices).join("<br />").html_safe unless notices.empty?
   end
 
-  # POST /orders/1/order_details/1/reservations
+  # POST /orders/:order_id/order_details/:order_detail_id/reservations
   def create
     raise ActiveRecord::RecordNotFound unless @reservation.nil?
 
@@ -123,9 +123,10 @@ class ReservationsController < ApplicationController
     end
   end
 
-  # GET /orders/1/order_details/1/reservations/new
+  # GET /orders/:order_id/order_details/:order_detail_id/reservations/new
   def new
     raise ActiveRecord::RecordNotFound unless @reservation.nil?
+
     options = current_user.can_override_restrictions?(@instrument) ? {} : { user: acting_user }
     next_available = @instrument.next_available_reservation(1.minute.from_now, default_reservation_mins.minutes, options)
     @reservation = next_available || default_reservation
@@ -282,9 +283,14 @@ class ReservationsController < ApplicationController
     @order = Order.find(params[:order_id])
     # It's important that the order_detail be the same object as the one in @order.order_details.first
     @order_detail = @order.order_details.find { |od| od.id.to_i == params[:order_detail_id].to_i }
-    @reservation = @order_detail.reservation
-    @instrument = @order_detail.product
-    @facility = @instrument.facility
+    if @order_detail.present?
+      @reservation = @order_detail.reservation
+      @instrument = @order_detail.product
+      @facility = @instrument.facility
+    else
+      flash[:error] = text("order_detail_removed")
+      return redirect_to facility_path(@order.facility)
+    end
     nil
   end
 

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -119,6 +119,9 @@ en:
       create:
         no_selection: "You must select a payment source before reserving"
         success: "The reservation was successfully created."
+      order_detail_removed: |
+        The instrument order has been removed from your cart.
+        Please add it again to make a reservation.
       update:
         failure: The reservation cannot be updated.
 


### PR DESCRIPTION
If the user attempts to create a reservation for an order detail that has been removed from the cart (possible if using multiple tabs or windows), this redirects the user back to the facility landing page with a message to try creating the reservation again from the beginning.