### PR TITLE
Change note field in merge order to regular text field

### DIFF
--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -17,12 +17,13 @@
         data: { min_date: SettingsHelper.fiscal_year_beginning.iso8601, max_date: Date.today.iso8601 },
         class: "datepicker__data string optional"
 
-      %br
-
       = label_tag :note, OrderDetail.human_attribute_name(:note)
-      = text_area_tag :note,
+      = text_field_tag :note,
         nil,
+        maxlength: 100,
         class: "string optional wide"
+
+      %br
 
       = submit_tag text("admin.shared.add_to", model: @order.class),
         class: "btn btn-primary",


### PR DESCRIPTION
The note expansion PR (https://github.com/tablexi/nucore-open/pull/861) hasn't
gone in yet, and we need to do a release. This should get undone as part of that
PR.