### PR TITLE
[#133668] Upgrade the cancancan gem to v1.15.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ end
 gem "devise",           "~> 3.5.10"
 gem "devise-encryptable", "~> 0.2.0"
 gem "devise_ldap_authenticatable", "~> 0.8.5"
-gem "cancancan",        "1.10"
+gem "cancancan", "1.15"
 
 ## models
 gem "aasm", "~> 4.11.1"

--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,10 @@ group :oracle do
 end
 
 ## auth
+gem "cancancan", "1.15"
 gem "devise",           "~> 3.5.10"
 gem "devise-encryptable", "~> 0.2.0"
 gem "devise_ldap_authenticatable", "~> 0.8.5"
-gem "cancancan", "1.15"
 
 ## models
 gem "aasm", "~> 4.11.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
       sass (~> 3.2)
     builder (3.2.2)
     byebug (9.0.6)
-    cancancan (1.10.0)
+    cancancan (1.15.0)
     capistrano (3.5.0)
       airbrussh (>= 1.0.0)
       capistrano-harrow
@@ -507,7 +507,7 @@ DEPENDENCIES
   bootstrap-sass (~> 2.3.2)
   bulk_email!
   c2po (~> 1.0.0)!
-  cancancan (= 1.10)
+  cancancan (= 1.15)
   capistrano
   capistrano-bundler
   capistrano-rails

--- a/app/controllers/global_user_roles_controller.rb
+++ b/app/controllers/global_user_roles_controller.rb
@@ -3,7 +3,7 @@ class GlobalUserRolesController < GlobalSettingsController
   before_action :load_user, only: [:destroy, :edit, :update]
 
   def index
-    @users = UserPresenter.wrap(User.with_global_roles)
+    @users = User.with_global_roles
   end
 
   def destroy
@@ -15,8 +15,6 @@ class GlobalUserRolesController < GlobalSettingsController
     if @user == current_user
       flash[:error] = translate("self_not_allowed", action: "change")
       redirect_to global_user_roles_url
-    else
-      @user = UserPresenter.new(@user)
     end
   end
 

--- a/app/services/user_finder.rb
+++ b/app/services/user_finder.rb
@@ -16,7 +16,7 @@ class UserFinder
   end
 
   def result
-    [UserPresenter.wrap(users), relation.count]
+    [users, relation.count]
   end
 
   private

--- a/app/views/global_user_roles/edit.html.haml
+++ b/app/views/global_user_roles/edit.html.haml
@@ -6,17 +6,18 @@
 
 %h2= t("pages.global_user_roles")
 
-= form_for(:user_role, url: global_user_role_path(@user.id), method: :put) do |form|
+- user = UserPresenter.new(@user)
+= form_for(:user_role, url: global_user_role_path(user.id), method: :put) do |form|
   = form.error_messages
   .form
     = label_tag :username, nil, class: "require"
-    = text_field_tag :username, @user.username, disabled: true
+    = text_field_tag :username, user.username, disabled: true
 
     = label_tag :name, nil, class: "require"
-    = text_field_tag :name, @user.full_name, disabled: true
+    = text_field_tag :name, user.full_name, disabled: true
 
     = label_tag :email, nil, class: "require"
-    = text_field_tag :email, @user.email, disabled: true
+    = text_field_tag :email, user.email, disabled: true
 
     -# Chosen attempts to disable autocomplete, but Chrome still does.
     -# This hidden field tells Chrome to really disable autocomplete:
@@ -24,7 +25,7 @@
 
     = form.label :roles, nil, class: "require"
     = select_tag :roles,
-      @user.global_role_select_options,
+      user.global_role_select_options,
       class: "js--chosen",
       data: { placeholder: t(".select_role_placeholder") },
       multiple: true

--- a/app/views/global_user_roles/index.html.haml
+++ b/app/views/global_user_roles/index.html.haml
@@ -21,7 +21,7 @@
         %th= t(".th.email")
         %th= t(".th.roles")
     %tbody
-      - @users.each do |user|
+      - UserPresenter.wrap(@users).each do |user|
         %tr
           %td.centered
             - if current_user.id != user.id

--- a/app/views/search/_results_table.html.haml
+++ b/app/views/search/_results_table.html.haml
@@ -16,6 +16,6 @@
               = link_to t(".order_for"),
                 facility_user_switch_to_path(current_facility, user)
         %td
-          = render "search/#{@search_type || "manage_user"}_link", user: user
+          = render "search/#{@search_type || "manage_user"}_link", user: UserPresenter.new(user)
         %td= user.username
         %td= user.email

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -24,11 +24,11 @@ class Ability
           cannot [:manage_accounts, :manage_billing, :manage_users], Facility.cross_facility
         end
         unless user.account_manager?
-          cannot :manage, User unless resource.is_a?(Facility) && resource.single_facility?
+          cannot :manage, [User, UserPresenter] unless resource.is_a?(Facility) && resource.single_facility?
         end
       end
 
-      cannot(:switch_to, User) { |target_user| !target_user.active? }
+      cannot(:switch_to, [User, UserPresenter]) { |target_user| !target_user.active? }
       ability_extender.extend(user, resource)
       return
     end
@@ -50,8 +50,8 @@ class Ability
       can [:manage_accounts, :manage_users], Facility.cross_facility
 
       if resource.blank? || resource == Facility.cross_facility
-        can :manage, [Account, AccountUser, User]
-        cannot :switch_to, User
+        can :manage, [Account, AccountUser, User, UserPresenter]
+        cannot :switch_to, [User, UserPresenter]
       end
     end
 
@@ -125,10 +125,10 @@ class Ability
           fileupload.file_type == "sample_result"
         end
 
-        can [:administer], User
+        can [:administer], [User, UserPresenter]
         if controller.is_a?(UsersController) || controller.is_a?(SearchController)
-          can :manage, User
-          cannot(:switch_to, User) { |target_user| !target_user.active? }
+          can :manage, [User, UserPresenter]
+          cannot(:switch_to, [User, UserPresenter]) { |target_user| !target_user.active? }
         end
 
         can [:list, :show], Facility
@@ -164,7 +164,7 @@ class Ability
           TrainingRequest,
         ]
 
-        can :manage, User if controller.is_a?(FacilityUsersController)
+        can :manage, [User, UserPresenter] if controller.is_a?(FacilityUsersController)
         cannot [:manage_accounts, :manage_billing, :manage_users], Facility.cross_facility
 
         # A facility admin can manage an account if it has no facility (i.e. it's a chart string) or the account

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -24,11 +24,11 @@ class Ability
           cannot [:manage_accounts, :manage_billing, :manage_users], Facility.cross_facility
         end
         unless user.account_manager?
-          cannot :manage, [User, UserPresenter] unless resource.is_a?(Facility) && resource.single_facility?
+          cannot :manage, User unless resource.is_a?(Facility) && resource.single_facility?
         end
       end
 
-      cannot(:switch_to, [User, UserPresenter]) { |target_user| !target_user.active? }
+      cannot(:switch_to, User) { |target_user| !target_user.active? }
       ability_extender.extend(user, resource)
       return
     end
@@ -50,8 +50,8 @@ class Ability
       can [:manage_accounts, :manage_users], Facility.cross_facility
 
       if resource.blank? || resource == Facility.cross_facility
-        can :manage, [Account, AccountUser, User, UserPresenter]
-        cannot :switch_to, [User, UserPresenter]
+        can :manage, [Account, AccountUser, User]
+        cannot :switch_to, User
       end
     end
 
@@ -125,10 +125,10 @@ class Ability
           fileupload.file_type == "sample_result"
         end
 
-        can [:administer], [User, UserPresenter]
+        can [:administer], User
         if controller.is_a?(UsersController) || controller.is_a?(SearchController)
-          can :manage, [User, UserPresenter]
-          cannot(:switch_to, [User, UserPresenter]) { |target_user| !target_user.active? }
+          can :manage, User
+          cannot(:switch_to, User) { |target_user| !target_user.active? }
         end
 
         can [:list, :show], Facility
@@ -164,7 +164,7 @@ class Ability
           TrainingRequest,
         ]
 
-        can :manage, [User, UserPresenter] if controller.is_a?(FacilityUsersController)
+        can :manage, User if controller.is_a?(FacilityUsersController)
         cannot [:manage_accounts, :manage_billing, :manage_users], Facility.cross_facility
 
         # A facility admin can manage an account if it has no facility (i.e. it's a chart string) or the account

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe Ability do
 
     it { is_expected.to be_allowed_to(:switch_to, active_user) }
     it { is_expected.not_to be_allowed_to(:switch_to, deactivated_user) }
-    it { is_expected.not_to be_allowed_to(:switch_to, UserPresenter.new(deactivated_user)) }
   end
 
   describe "account manager" do


### PR DESCRIPTION
There's a change in how cancancan handles objects decorated with `SimpleDelegator`, in that it no longer does. This adds `UserPresenter` to `lib/ability.rb` along side the `User` `can`/`cannot` calls for this reason.

More discussion here: https://github.com/CanCanCommunity/cancancan/issues/255