### PR TITLE
Facility account view updates

### DIFF
--- a/app/views/facility_facility_accounts/index.html.haml
+++ b/app/views/facility_facility_accounts/index.html.haml
@@ -12,7 +12,7 @@
   %li= link_to t("admin.shared.add", model: FacilityAccount.model_name.human), new_facility_facility_account_path, :class => "btn-add"
 
 - if @accounts.empty?
-  %p.notice= t(".notice")
+  %p.notice= text(".notice")
 - else
   %table.table.table-striped.table-hover
     %thead

--- a/app/views/facility_facility_accounts/index.html.haml
+++ b/app/views/facility_facility_accounts/index.html.haml
@@ -6,7 +6,7 @@
 
 %h2= FacilityAccount.model_name.human(count: 2)
 
-%p= text(".main")
+%p= text("main")
 
 %ul.inline
   %li
@@ -14,7 +14,7 @@
       new_facility_facility_account_path, class: "btn-add"
 
 - if @accounts.empty?
-  %p.notice= text(".notice")
+  %p.notice= text("notice")
 
 - else
   %table.table.table-striped.table-hover
@@ -31,4 +31,4 @@
           %td
             = account
             - unless account.is_active?
-              = text(".inactive")
+              = text("inactive")

--- a/app/views/facility_facility_accounts/index.html.haml
+++ b/app/views/facility_facility_accounts/index.html.haml
@@ -9,10 +9,13 @@
 %p= text(".main")
 
 %ul.inline
-  %li= link_to t("admin.shared.add", model: FacilityAccount.model_name.human), new_facility_facility_account_path, :class => "btn-add"
+  %li
+    = link_to text("admin.shared.add", model: FacilityAccount.model_name.human),
+      new_facility_facility_account_path, class: "btn-add"
 
 - if @accounts.empty?
   %p.notice= text(".notice")
+
 - else
   %table.table.table-striped.table-hover
     %thead
@@ -20,7 +23,12 @@
         %th
         %th= FacilityAccount.human_attribute_name(:account_number)
     %tbody
-      - @accounts.each do |a|
+      - @accounts.each do |account|
         %tr
-          %td= link_to t("shared.edit"), edit_facility_facility_account_path(current_facility, a)
-          %td=h a.to_s + (a.is_active? ? "" : text(".inactive"))
+          %td
+            = link_to t("shared.edit"),
+              edit_facility_facility_account_path(current_facility, account)
+          %td
+            = account
+            - unless account.is_active?
+              = text(".inactive")

--- a/config/locales/views/admin/en.facility_facility_accounts.yml
+++ b/config/locales/views/admin/en.facility_facility_accounts.yml
@@ -18,4 +18,3 @@ en:
         success: "%{model} was successfully created"
       update:
         success: "%{model} was successfully updated."
-


### PR DESCRIPTION
This should fix a missing translation on `.notice` I found in testing, and also adds whitespace between the account number and "(inactive)" when the recharge chart string is not active.