### PR TITLE
[#134051] Admin edit users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -142,11 +142,21 @@ class UsersController < ApplicationController
   def email
   end
 
+  # GET /facilities/:facility_id/users/:id/edit
   def edit
     @user = User.find(params[:id])
   end
 
+  # PUT /facilities/:facility_id/users/:id
   def update
+    @user = User.find(params[:id])
+    if @user.update_attributes(params[:user])
+      flash[:notice] = text("update.success")
+      redirect_to facility_user_path(current_facility, @user)
+    else
+      flash[:error] = text("update.error", message: @user.errors.full_messages.to_sentence)
+      render action: "edit"
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -142,6 +142,13 @@ class UsersController < ApplicationController
   def email
   end
 
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def update
+  end
+
   private
 
   def update_access_list_approvals

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,8 @@ class UsersController < ApplicationController
   before_action :authenticate_user!, except: [:password_reset]
   before_action :check_acting_as
 
-  load_and_authorize_resource except: [:password, :password_reset], id_param: :user_id
+  load_and_authorize_resource except: [:password, :password_reset, :edit, :update], id_param: :user_id
+  load_and_authorize_resource only: [:edit, :update], id_param: :id
 
   layout "two_column"
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -151,7 +151,7 @@ class UsersController < ApplicationController
   # PUT /facilities/:facility_id/users/:id
   def update
     @user = User.find(params[:id])
-    if @user.update_attributes(params[:user])
+    if @user.update_attributes(edit_user_params)
       flash[:notice] = text("update.success")
       redirect_to facility_user_path(current_facility, @user)
     else
@@ -161,6 +161,10 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def edit_user_params
+    params.require(:user).permit(:email, :first_name, :last_name)
+  end
 
   def update_access_list_approvals
     if update_approvals.grants_changed?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,6 +77,14 @@ class User < ActiveRecord::Base
     username.casecmp(email.downcase).zero?
   end
 
+  def internal?
+    !external?
+  end
+
+  def admin_editable?
+    external?
+  end
+
   def password_updatable?
     external?
   end

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -1,4 +1,4 @@
-= simple_form_for(@user, url: url) do |f|
+= simple_form_for [current_facility, @user] do |f|
   .form-inputs
     = f.input :first_name
     = f.input :last_name

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -1,0 +1,9 @@
+= simple_form_for(@user, url: url) do |f|
+  .form-inputs
+    = f.input :first_name
+    = f.input :last_name
+    = f.input :email
+    = f.input :username, readonly: true
+    = f.button :submit, button_text, class: ["btn", "btn-primary"]
+    &nbsp;
+    = link_to text("shared.cancel"), facility_users_path

--- a/app/views/users/_form_head.html.haml
+++ b/app/views/users/_form_head.html.haml
@@ -1,0 +1,10 @@
+:javascript
+  $(document).ready(function() {
+    $("input#user_email").keyup(function(e) {
+      $("input#user_username").val(this.value);
+    });
+
+    $("input#user_email").change(function(e) {
+      $("input#user_username").val(this.value);
+    });
+  });

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -9,4 +9,4 @@
 
 %h2= text("head", user: @user.full_name)
 %p= text("subhead")
-= render "form", url: facility_user_path(current_facility, @user), button_text: text("shared.update")
+= render "form", button_text: text("shared.update")

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,29 +1,12 @@
 = content_for :head_content do
-  :javascript
-    $(document).ready(function() {
-      $("input#user_email").keyup(function(e) {
-        $("input#user_username").val(this.value);
-      });
-
-      $("input#user_email").change(function(e) {
-        $("input#user_username").val(this.value);
-      });
-    });
+  = render "form_head"
 
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :sidebar do
   = render "admin/shared/sidenav_users", sidenav_tab: "users"
 
 %h2= text("head", user: @user.full_name)
 %p= text("subhead")
-= simple_form_for(@user, url: facility_user_path(current_facility, @user), method: :put) do |f|
-  .form-inputs
-    = f.input :first_name
-    = f.input :last_name
-    = f.input :email
-    = f.input :username, :readonly => true
-    = f.button :submit, text("update"), class: ["btn", "btn-primary"]
-    &nbsp;
-    = link_to text("shared.cancel"), facility_users_path
+= render "form", url: facility_user_path(current_facility, @user), button_text: text("shared.update")

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,0 +1,29 @@
+= content_for :head_content do
+  :javascript
+    $(document).ready(function() {
+      $("input#user_email").keyup(function(e) {
+        $("input#user_username").val(this.value);
+      });
+
+      $("input#user_email").change(function(e) {
+        $("input#user_username").val(this.value);
+      });
+    });
+
+= content_for :h1 do
+  =h current_facility
+
+= content_for :sidebar do
+  = render "admin/shared/sidenav_users", sidenav_tab: "users"
+
+%h2= text("head", user: @user.full_name)
+%p= text("subhead")
+= simple_form_for(@user, url: facility_user_path(current_facility, @user), method: :put) do |f|
+  .form-inputs
+    = f.input :first_name
+    = f.input :last_name
+    = f.input :email
+    = f.input :username, :readonly => true
+    = f.button :submit, text("update"), class: ["btn", "btn-primary"]
+    &nbsp;
+    = link_to text("shared.cancel"), facility_users_path

--- a/app/views/users/new_external.html.haml
+++ b/app/views/users/new_external.html.haml
@@ -1,29 +1,12 @@
 = content_for :head_content do
-  :javascript
-    $(document).ready(function() {
-      $("input#user_email").keyup(function(e) {
-        $("input#user_username").val(this.value);
-      });
-
-      $("input#user_email").change(function(e) {
-        $("input#user_username").val(this.value);
-      });
-    });
+  = render "form_head"
 
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :sidebar do
   = render "admin/shared/sidenav_users", sidenav_tab: "users"
 
-%h2= t(".head")
+%h2= text("users.new_external.head")
 %p= text("users.new_external.main")
-= simple_form_for(@user, url: facility_users_path, method: :post) do |f|
-  .form-inputs
-    = f.input :first_name
-    = f.input :last_name
-    = f.input :email
-    = f.input :username, :readonly => true
-    = f.button :submit, text("shared.create"), class: ["btn", "btn-primary"]
-    &nbsp;
-    = link_to text("shared.cancel"), facility_users_path
+= render "form", url: facility_users_path, button_text: text("shared.create")

--- a/app/views/users/new_external.html.haml
+++ b/app/views/users/new_external.html.haml
@@ -9,4 +9,4 @@
 
 %h2= text("users.new_external.head")
 %p= text("users.new_external.main")
-= render "form", url: facility_users_path, button_text: text("shared.create")
+= render "form", button_text: text("shared.create")

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -14,3 +14,7 @@
   = f.input :email
   = f.input :last_sign_in_at, :default_value => 'none'
   = f.input :deactivated_at unless f.object.active?
+
+- if can? :edit, @user
+  %ul.inline
+    %li= link_to 'Edit', edit_facility_user_path(current_facility, @user), :class => 'btn'

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -17,4 +17,4 @@
 
 - if can? :edit, @user
   %ul.inline
-    %li= link_to text("shared.edit"), edit_facility_user_path(current_facility, @user), :class => 'btn'
+    %li= link_to text("shared.edit"), edit_facility_user_path(current_facility, @user), class: "btn"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -17,4 +17,4 @@
 
 - if can? :edit, @user
   %ul.inline
-    %li= link_to 'Edit', edit_facility_user_path(current_facility, @user), :class => 'btn'
+    %li= link_to text("shared.edit"), edit_facility_user_path(current_facility, @user), :class => 'btn'

--- a/config/locales/views/admin/en.users.yml
+++ b/config/locales/views/admin/en.users.yml
@@ -7,6 +7,10 @@ en:
           Active users are users which have placed an order or had an order placed
           on their behalf at this !facility_downcase! in the last year.
         no_users: There are no active users for this !facility_downcase!.
+      edit:
+        head: Edit %{user}
+        subhead: You may use this to edit external users. The email address and username must match.
+        update: Update
 
   controllers:
     users:
@@ -15,3 +19,6 @@ en:
         success: The user has been added successfully.
         add_role: |
           You may wish to [add a !facility_downcase! role](%{link}) for this user.
+      update:
+        error: There was an error updating the user. %{message}
+        success: The user has been updated successfully.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,7 +131,7 @@ Nucore::Application.routes.draw do
 
     ### Feature Toggle Create Users ###
     if SettingsHelper.feature_on?(:create_users)
-      resources :users, except: [:edit, :update] do
+      resources :users do
         collection do
           get "new_external"
           post "search"
@@ -148,7 +148,7 @@ Nucore::Application.routes.draw do
         post "access_list/approvals", to: 'users#access_list_approvals'
       end
     else
-      resources :users, except: [:edit, :update, :new, :create], constraints: { id: /\d+/ } do
+      resources :users, except: [:new, :create], constraints: { id: /\d+/ } do
         get "switch_to",    to: 'users#switch_to'
         get "orders",       to: 'users#orders'
         resources :reservations, only: [:index], param: :order_detail_id, controller: "facility_user_reservations" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,7 +148,7 @@ Nucore::Application.routes.draw do
         post "access_list/approvals", to: 'users#access_list_approvals'
       end
     else
-      resources :users, except: [:new, :create], constraints: { id: /\d+/ } do
+      resources :users, except: [:edit, :update, :new, :create], constraints: { id: /\d+/ } do
         get "switch_to",    to: 'users#switch_to'
         get "orders",       to: 'users#orders'
         resources :reservations, only: [:index], param: :order_detail_id, controller: "facility_user_reservations" do

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -131,7 +131,7 @@ class Ability
         end
 
         can [:administer], User
-        can([:edit, :update], User) { |target_user| target_user.external? }
+        can([:edit, :update], User, &:external?)
 
         if controller.is_a?(UsersController) || controller.is_a?(SearchController)
           can :manage, User

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -20,13 +20,13 @@ class Ability
         can :manage, AccountPriceGroupMember
       else
         can :manage, :all
-        cannot([:edit, :update], User) { |target_user| !target_user.external? }
+        cannot([:edit, :update], User) { |target_user| !target_user.admin_editable? }
         unless user.billing_administrator?
           cannot [:manage_accounts, :manage_billing, :manage_users], Facility.cross_facility
         end
         unless user.account_manager?
           cannot :manage, User unless resource.is_a?(Facility) && resource.single_facility?
-          cannot([:edit, :update], User) { |target_user| !target_user.external? }
+          cannot([:edit, :update], User) { |target_user| !target_user.admin_editable? }
         end
       end
 
@@ -131,7 +131,6 @@ class Ability
         end
 
         can [:administer], User
-        can([:edit, :update], User, &:external?)
 
         if controller.is_a?(UsersController) || controller.is_a?(SearchController)
           can :manage, User

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -19,6 +19,7 @@ class Ability
         can :manage, UserPriceGroupMember if resource.admin_editable?
         can :manage, AccountPriceGroupMember
       else
+        can([:edit, :update], User) { |target_user| target_user.external? }
         can :manage, :all
         unless user.billing_administrator?
           cannot [:manage_accounts, :manage_billing, :manage_users], Facility.cross_facility
@@ -130,6 +131,7 @@ class Ability
 
         can [:administer], User
         if controller.is_a?(UsersController) || controller.is_a?(SearchController)
+          can([:edit, :update], User) { |target_user| target_user.external? }
           can :manage, User
           cannot(:switch_to, User) { |target_user| !target_user.active? }
         end

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -134,6 +134,7 @@ class Ability
 
         if controller.is_a?(UsersController) || controller.is_a?(SearchController)
           can :manage, User
+          cannot([:edit, :update], User)
           cannot(:switch_to, User) { |target_user| !target_user.active? }
         end
 
@@ -171,6 +172,7 @@ class Ability
         ]
 
         can :manage, User if controller.is_a?(FacilityUsersController)
+        cannot([:edit, :update], User)
         cannot [:manage_accounts, :manage_billing, :manage_users], Facility.cross_facility
 
         # A facility admin can manage an account if it has no facility (i.e. it's a chart string) or the account

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -19,13 +19,14 @@ class Ability
         can :manage, UserPriceGroupMember if resource.admin_editable?
         can :manage, AccountPriceGroupMember
       else
-        can([:edit, :update], User) { |target_user| target_user.external? }
         can :manage, :all
+        cannot([:edit, :update], User) { |target_user| !target_user.external? }
         unless user.billing_administrator?
           cannot [:manage_accounts, :manage_billing, :manage_users], Facility.cross_facility
         end
         unless user.account_manager?
           cannot :manage, User unless resource.is_a?(Facility) && resource.single_facility?
+          cannot([:edit, :update], User) { |target_user| !target_user.external? }
         end
       end
 
@@ -130,8 +131,9 @@ class Ability
         end
 
         can [:administer], User
+        can([:edit, :update], User) { |target_user| target_user.external? }
+
         if controller.is_a?(UsersController) || controller.is_a?(SearchController)
-          can([:edit, :update], User) { |target_user| target_user.external? }
           can :manage, User
           cannot(:switch_to, User) { |target_user| !target_user.active? }
         end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe UsersController do
       @params[:id] = user.id
     end
 
-    it_should_allow_operators_only do
+    it_should_allow_admin_only do
       expect(assigns[:user]).to eq(user)
     end
   end
@@ -70,7 +70,7 @@ RSpec.describe UsersController do
       @params[:user] = { first_name: "New", last_name: "Name" }
     end
 
-    it_should_allow_operators_only(:found) do
+    it_should_allow_admin_only(:found) do
       expect(user.reload.first_name).to eq("New")
       expect(response).to redirect_to facility_user_path(facility, user)
     end
@@ -80,7 +80,7 @@ RSpec.describe UsersController do
         @params[:user] = { email: "test@example.com", username: "newusername" }
       end
 
-      it_should_allow_operators_only(:found) do
+      it_should_allow_admin_only(:found) do
         expect(user.reload.first_name).to eq(user.first_name)
       end
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -46,6 +46,46 @@ RSpec.describe UsersController do
 
   end
 
+  describe "GET #edit" do
+    let(:user) { FactoryGirl.create(:user) }
+
+    before(:each) do
+      @method = :get
+      @action = :edit
+      @params[:id] = user.id
+    end
+
+    it_should_allow_operators_only do
+      expect(assigns[:user]).to eq(user)
+    end
+  end
+
+  describe "PUT #update" do
+    let(:user) { FactoryGirl.create(:user) }
+
+    before(:each) do
+      @method = :put
+      @action = :update
+      @params[:id] = user.id
+      @params[:user] = { first_name: "New", last_name: "Name" }
+    end
+
+    it_should_allow_operators_only(:found) do
+      expect(user.reload.first_name).to eq("New")
+      expect(response).to redirect_to facility_user_path(facility, user)
+    end
+
+    context "with bad params" do
+      before(:each) do
+        @params[:user] = { email: "test@example.com", username: "newusername" }
+      end
+
+      it_should_allow_operators_only(:found) do
+        expect(user.reload.first_name).to eq(user.first_name)
+      end
+    end
+  end
+
   describe "GET #access_list" do
     let(:facility) { FactoryGirl.create(:setup_facility) }
     let(:user) { FactoryGirl.create(:user) }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe UsersController do
   end
 
   describe "GET #edit" do
-    let(:user) { FactoryGirl.create(:user) }
+    let(:user) { FactoryGirl.create(:user, :external) }
 
     before(:each) do
       @method = :get
@@ -61,7 +61,7 @@ RSpec.describe UsersController do
   end
 
   describe "PUT #update" do
-    let(:user) { FactoryGirl.create(:user) }
+    let(:user) { FactoryGirl.create(:user, :external) }
 
     before(:each) do
       @method = :put

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -165,13 +165,6 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:manage, OrderDetail) }
     it_is_not_allowed_to([:edit, :update], FactoryGirl.create(:user))
 
-    it "cannot administer resources" do
-      is_expected.not_to be_allowed_to(:administer, Order)
-      is_expected.not_to be_allowed_to(:administer, OrderDetail)
-      is_expected.not_to be_allowed_to(:administer, Reservation)
-      is_expected.not_to be_allowed_to(:manage_users, Facility.cross_facility)
-    end
-
     context "in a single facility" do
       it { is_expected.not_to be_allowed_to(:manage_users, facility) }
       it_is_allowed_to([:send_receipt, :show], Order)

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -17,19 +17,11 @@ RSpec.describe Ability do
 
   shared_examples_for "it can edit users" do
     context "when user is external" do
-      let(:facility_user) { create(:user, :external) }
-
-      %i(edit update).each do |action|
-        it { is_expected.to be_allowed_to(action, facility_user) }
-      end
+      it_is_allowed_to([:edit, :update], FactoryGirl.create(:user, :external))
     end
 
     context "when user is internal" do
-      let(:facility_user) { create(:user) }
-
-      %i(edit update).each do |action|
-        it { is_expected.not_to be_allowed_to(action, facility_user) }
-      end
+      it_is_not_allowed_to([:edit, :update], FactoryGirl.create(:user))
     end
   end
 
@@ -218,7 +210,6 @@ RSpec.describe Ability do
 
     it_behaves_like "it can destroy admistrative reservations"
     it_behaves_like "it allows switch_to on active, but not deactivated users"
-    it_behaves_like "it can edit users"
   end
 
   describe "facility director" do
@@ -259,7 +250,6 @@ RSpec.describe Ability do
     it { is_expected.not_to be_allowed_to(:manage_users, Facility.cross_facility) }
     it_behaves_like "it can destroy admistrative reservations"
     it_behaves_like "it allows switch_to on active, but not deactivated users"
-    it_behaves_like "it can edit users"
   end
 
   shared_examples_for "it has common staff abilities" do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -15,6 +15,24 @@ RSpec.describe Ability do
     end
   end
 
+  shared_examples_for "it can edit users" do
+    context "when user is external" do
+      let(:facility_user) { create(:user, :external) }
+
+      %i(edit update).each do |action|
+        it { is_expected.to be_allowed_to(action, facility_user) }
+      end
+    end
+
+    context "when user is internal" do
+      let(:facility_user) { create(:user) }
+
+      %i(edit update).each do |action|
+        it { is_expected.not_to be_allowed_to(action, facility_user) }
+      end
+    end
+  end
+
   shared_examples_for "it can destroy admistrative reservations" do
     let(:order) { build_stubbed(:order) }
     let(:order_detail) { build_stubbed(:order_detail, order: order) }
@@ -127,6 +145,8 @@ RSpec.describe Ability do
       it { is_expected.to be_allowed_to(:manage_billing, facility) }
       it { is_expected.to be_allowed_to(:batch_update, Order) }
       it { is_expected.to be_allowed_to(:batch_update, Reservation) }
+
+      it_behaves_like "it can edit users"
     end
 
     context "in cross-facility" do
@@ -198,6 +218,7 @@ RSpec.describe Ability do
 
     it_behaves_like "it can destroy admistrative reservations"
     it_behaves_like "it allows switch_to on active, but not deactivated users"
+    it_behaves_like "it can edit users"
   end
 
   describe "facility director" do
@@ -238,6 +259,7 @@ RSpec.describe Ability do
     it { is_expected.not_to be_allowed_to(:manage_users, Facility.cross_facility) }
     it_behaves_like "it can destroy admistrative reservations"
     it_behaves_like "it allows switch_to on active, but not deactivated users"
+    it_behaves_like "it can edit users"
   end
 
   shared_examples_for "it has common staff abilities" do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe Ability do
     it { is_expected.not_to be_allowed_to(:administer, User) }
     it { is_expected.not_to be_allowed_to(:batch_update, Order) }
     it_is_not_allowed_to([:batch_update, :cancel, :index], Reservation)
+    it_is_not_allowed_to([:edit, :update], FactoryGirl.create(:user))
 
     context "in a single facility" do
       it { is_expected.not_to be_allowed_to(:manage_accounts, facility) }
@@ -162,6 +163,14 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:manage, Account) }
     it { is_expected.to be_allowed_to(:manage, Journal) }
     it { is_expected.to be_allowed_to(:manage, OrderDetail) }
+    it_is_not_allowed_to([:edit, :update], FactoryGirl.create(:user))
+
+    it "cannot administer resources" do
+      is_expected.not_to be_allowed_to(:administer, Order)
+      is_expected.not_to be_allowed_to(:administer, OrderDetail)
+      is_expected.not_to be_allowed_to(:administer, Reservation)
+      is_expected.not_to be_allowed_to(:manage_users, Facility.cross_facility)
+    end
 
     context "in a single facility" do
       it { is_expected.not_to be_allowed_to(:manage_users, facility) }
@@ -207,6 +216,7 @@ RSpec.describe Ability do
     it_is_allowed_to([:batch_update, :cancel, :index], Reservation)
     it { is_expected.to be_allowed_to(:administer, User) }
     it { is_expected.to be_allowed_to(:manage, PriceGroup) }
+    it_is_not_allowed_to([:edit, :update], FactoryGirl.create(:user))
 
     it_behaves_like "it can destroy admistrative reservations"
     it_behaves_like "it allows switch_to on active, but not deactivated users"


### PR DESCRIPTION
https://pm.tablexi.com/issues/134051

This adds functionality for facility operators updating users' email (same as username), first name, and last name, and non-admin users cannot access it.  They can only edit external users. 