### PR TITLE
[#134410] Added viewport meta tag

### DIFF
--- a/app/views/shared/_head.html.haml
+++ b/app/views/shared/_head.html.haml
@@ -1,4 +1,5 @@
 %meta{ "http-equiv" => "content-type", "content" => "text/html; charset=UTF-8" }
+%meta{ "name" => "viewport", "content" => "width=device-width, initial-scale=1, maximum-scale=1" }
 - # use gsub to strip out html tags in the title to prevent html from showing #62643
 = render partial: "/shared/title", locals: { title: yield(:h1).gsub(/<[^>]*>/, " ") }
 = stylesheet_link_tag "application", media: :all


### PR DESCRIPTION
https://pm.tablexi.com/issues/134410

This adds the viewport meta tag to the head so the bootstrap elements are properly responsive, and we can look into what needs to be changed in the order flow. Tested this with ngrok, it does now show the bootstrap elements as responsive now in mobile browsers.  