### PR TITLE
[#125093] Activate the cross-facilty Users tab for Billing Administrators

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -93,6 +93,7 @@ api:
 # For these settings use SettingsHelper#feature_on?
 feature:
   billing_administrator_on: true
+  billing_administrator_users_tab_on: true
   create_users_on: true
   netids_on: true
   limit_short_description_on: true

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -61,7 +61,8 @@ class Ability
       if resource == Facility.cross_facility
         can [:accounts, :index, :orders, :show], User
       end
-      can [:manage_billing, :manage_users], Facility.cross_facility
+      can :manage_users, Facility.cross_facility if SettingsHelper.feature_on?(:billing_administrator_users_tab)
+      can :manage_billing, Facility.cross_facility
       can [:disputed_orders, :movable_transactions, :transactions], Facility, &:cross_facility?
     end
 

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -61,7 +61,7 @@ class Ability
       if resource == Facility.cross_facility
         can [:accounts, :index, :orders, :show], User
       end
-      can :manage_billing, Facility.cross_facility
+      can [:manage_billing, :manage_users], Facility.cross_facility
       can [:disputed_orders, :movable_transactions, :transactions], Facility, &:cross_facility?
     end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -162,7 +162,15 @@ RSpec.describe Ability do
     context "in cross-facility" do
       let(:facility) { Facility.cross_facility }
 
-      %i(disputed_orders manage_billing manage_users movable_transactions transactions).each do |action|
+      context "with the users tab active", feature_setting: { billing_administrator_users_tab: true } do
+        it { is_expected.to be_allowed_to(:manage_users, facility) }
+      end
+
+      context "with the users tab inactive", feature_setting: { billing_administrator_users_tab: false } do
+        it { is_expected.not_to be_allowed_to(:manage_users, facility) }
+      end
+
+      %i(disputed_orders manage_billing movable_transactions transactions).each do |action|
         it { is_expected.to be_allowed_to(action, facility) }
       end
       it_is_allowed_to([:accounts, :index, :orders, :show], User)
@@ -175,7 +183,15 @@ RSpec.describe Ability do
     context "in no facility" do
       let(:facility) { nil }
 
-      it_is_allowed_to([:manage_billing, :manage_users], Facility.cross_facility)
+      context "with the users tab active", feature_setting: { billing_administrator_users_tab: true } do
+        it { is_expected.to be_allowed_to(:manage_users, Facility.cross_facility) }
+      end
+
+      context "with the users tab inactive", feature_setting: { billing_administrator_users_tab: false } do
+        it { is_expected.not_to be_allowed_to(:manage_users, Facility.cross_facility) }
+      end
+
+      it { is_expected.to be_allowed_to(:manage_billing, Facility.cross_facility) }
       it_is_not_allowed_to([:create, :switch_to], User)
     end
   end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -162,10 +162,9 @@ RSpec.describe Ability do
     context "in cross-facility" do
       let(:facility) { Facility.cross_facility }
 
-      %i(disputed_orders manage_billing movable_transactions transactions).each do |action|
+      %i(disputed_orders manage_billing manage_users movable_transactions transactions).each do |action|
         it { is_expected.to be_allowed_to(action, facility) }
       end
-      it { is_expected.not_to be_allowed_to(:manage_users, facility) }
       it_is_allowed_to([:accounts, :index, :orders, :show], User)
       it_is_not_allowed_to([:create, :switch_to], User)
       it { is_expected.to be_allowed_to(:show, Order) }
@@ -176,8 +175,7 @@ RSpec.describe Ability do
     context "in no facility" do
       let(:facility) { nil }
 
-      it { is_expected.to be_allowed_to(:manage_billing, Facility.cross_facility) }
-      it { is_expected.not_to be_allowed_to(:manage_users, Facility.cross_facility) }
+      it_is_allowed_to([:manage_billing, :manage_users], Facility.cross_facility)
       it_is_not_allowed_to([:create, :switch_to], User)
     end
   end


### PR DESCRIPTION
UIC would like to evaluate this on stage. It shouldn't affect NU (the only BAs currently are staff who do testing). One active DC user is set as a BA. Should it get a feature flag?