### PR TITLE
Update developer documentation and guidelines

### DIFF
--- a/doc/FACTORIES.md
+++ b/doc/FACTORIES.md
@@ -1,7 +1,6 @@
 # How to use the factories
 
-NUcore has been upgraded Factory Girl 2.6. Until support for 1.8 is able to be dropped, that is
-the highest version we can use.
+NUcore has been upgraded to Factory Girl 3.X.
 
 Since the upgrade from Factory Girl 1, we've set up a new series of factories for use.
 
@@ -19,8 +18,8 @@ Creates a facility and all the necessary accounts and price groups to begin usin
 For putting multiple products on a facility, use:
 
     facility = FactoryGirl.create :facility
-    item1 = FactoryGirl.create :setup_item, :facility => facility
-    item2 = FactoryGirl.create :setup_item, :facility => facility
+    item1 = FactoryGirl.create :setup_item, facility: facility
+    item2 = FactoryGirl.create :setup_item, facility: facility
 
 ### Instruments
 
@@ -29,15 +28,15 @@ For putting multiple products on a facility, use:
 #### Shared schedules
 
     schedule = FactoryGirl.create :schedule # Will create the facility if not specified
-    instrument1 = FactoryGirl.create :setup_instrument, :schedule => schedule
-    instrument2 = FactoryGirl.create :setup_instrument, :schedule => schedule
+    instrument1 = FactoryGirl.create :setup_instrument, schedule: schedule
+    instrument2 = FactoryGirl.create :setup_instrument, schedule: schedule
 
 ## Orders
 
 `FactoryGirl.create :setup_order` will setup an order including accounts and users if not specified. It will also create an order detail if you specify a product.
 
     item1 = FactoryGirl.create :setup_item
-    order = FactoryGirl.create :setup_order, :product => item1 # Facility is taken from the product
+    order = FactoryGirl.create :setup_order, product: item1 # Facility is taken from the product
     order.order_details.first # Contains an order detail of item1 with quantity 1
 
 ## Reservations
@@ -49,8 +48,8 @@ This will create a reservation, a new instrument on a new facility, with a new o
 This will allow you to place a reservation on an already existing order detail:
 
     instrument = FactoryGirl.create :setup_instrument
-    order = FactoryGirl.create :setup_order, :product => instrument
-    reservation = FactoryGirl.create :setup_reservation, :order_detail => order.order_details.first
+    order = FactoryGirl.create :setup_order, product: instrument
+    reservation = FactoryGirl.create :setup_reservation, order_detail: order.order_details.first
 
 For the ultimate in setup, you can create a purchased reservation. This alone will create all the dependencies you need.
 
@@ -59,9 +58,9 @@ For the ultimate in setup, you can create a purchased reservation. This alone wi
 If you want to specify the dependencies, you'll need to create them first and pass them in.
 
     instrument = FactoryGirl.create :setup_instrument
-    reservation1 = FactoryGirl.create :purchased_reservation, :product => instrument
+    reservation1 = FactoryGirl.create :purchased_reservation, product: instrument
 	# Need to specify :reserve_start_at and :reserve_end_at so as not to
 	# conflict with reservation1
-    reservation2 = FactoryGirl.create :purchased_reservation, :product => instrument, :reserve_start_at => reservation1.reserve_end_at, :reserve_end_at => reservation1.reserve_end_at + 1.hour
+    reservation2 = FactoryGirl.create :purchased_reservation, product: instrument, reserve_start_at: reservation1.reserve_end_at, reserve_end_at: reservation1.reserve_end_at + 1.hour
 
 

--- a/doc/coding_standards.md
+++ b/doc/coding_standards.md
@@ -53,7 +53,7 @@ It's difficult to see a salient change amidst a lot of stylistic updates, so if 
 run rubocop or do another large stylistic update, give it a separate commit, or even
 its own PR if the changes are significant enough.
 
-Views are not rubocoped, nor are Rails-specific cops inside of engines, so try to
+Views are not Rubocopped, nor are Rails-specific cops inside of engines, so try to
 follow the same style guidelines.
 
 * Use Ruby 1.9 hash syntax
@@ -78,7 +78,7 @@ changes upstream.
 
 The best method is to isolate your feature inside of an engine in `vendor/engines`. When
 necessary, create a hook point where you need it within the open-source branch and hook
-into that with your engine. Try to avoid overriding entire views (like happens in
+into that with your engine. Try to avoid overriding entire views (as happens in
 the `c2po` engine). Then a change to the default view might need to happen in
 multiple places. See the following section for more information.
 
@@ -126,7 +126,7 @@ _We should consider `optional` groups in Bundler 1.10 to see if this helps_
 ## Commits
 
 Good commit messages vastly improve the history of the project. Tools like `git log`,
-`git blame`, and `git bisect` are much easier to use when each commit is a discreet
+`git blame`, and `git bisect` are much easier to use when each commit is a discrete
 piece of work. Each commit to master should result in a green build.
 
 When merging Pull Requests, we prefer to use Github's "Squash and Merge" green button.

--- a/doc/coding_standards.md
+++ b/doc/coding_standards.md
@@ -22,6 +22,26 @@ All changes should go through a Pull Request and be reviewed prior to merging.
 
 If you're tracking down a bug, write a test for it. Even if you fix the bug first, undo your change, write a failing test, and then re-do your change to make it pass.
 
+## Use locales
+
+Views should use locales/I18n whenever possible. This facilitates easy overriding
+in downstream forks. We've begun moving locales into separate files, in general
+one per controller/view set. This is still a work in progress, but see `config/locales` for examples.
+
+Fork-specific overrides should be put in `config/locales/override/en.yml`. We've
+made sure this is the last file to be loaded, so it always takes precedence. Nothing
+should be in that file in nucore-open except the locales that we use to verify this
+behavior in specs.
+
+We use the [text-helpers](https://github.com/ahorner/text-helpers) gem for view
+and controller locales. Use the standard [Rails I18n](http://guides.rubyonrails.org/i18n.html) for model names, attributes, and error messages.
+
+* Prefer `Model.model_name.human` and `Model.human_attribute_name` over view-specific locales
+* Prefer text-helper's `text` method over `I18n.t`
+* When including references to "facility" and "facilities", within a longer string,
+  use text-helper's interpolation features with `facility_downcase`/`facilities_downcase`
+  e.g. `text("in this !facility_downcase!"). _We haven't found a better way to do this yet_
+
 ## Rubocop
 
 We have rubocop set up with a set of style guidelines. When you're working in a file,
@@ -32,6 +52,20 @@ on the files you're touching.
 It's difficult to see a salient change amidst a lot of stylistic updates, so if you
 run rubocop or do another large stylistic update, give it a separate commit, or even
 its own PR if the changes are significant enough.
+
+Views are not rubocoped, nor are Rails-specific cops inside of engines, so try to
+follow the same style guidelines.
+
+* Use Ruby 1.9 hash syntax
+
+  ```ruby
+  :key => value # Bad
+  key: value # Good
+  ```
+
+* Prefer double-quotes to single-quotes
+* Prefer `before_action` to `before_filter`
+* Prefer `find_by(key: value)` over dynamic finders (`find_by_key(value)`)
 
 ## Fork-specific changes
 
@@ -44,13 +78,38 @@ changes upstream.
 
 The best method is to isolate your feature inside of an engine in `vendor/engines`. When
 necessary, create a hook point where you need it within the open-source branch and hook
-into that with your engine. Try to avoid overriding entire views (like happens in the `c2po` engine). Then a change to the default view might need to happen in multiple places.
-
-_We have yet to find a perfect mechanism for this, but some options include:_
+into that with your engine. Try to avoid overriding entire views (like happens in
+the `c2po` engine). Then a change to the default view might need to happen in
+multiple places. See the following section for more information.
 
 * A factory configured in settings (e.g. `ValidatorFactory`, `StatementPdfFactory`
 * Adding a module onto an existing class in the engine initializer (see `vendor/engines/c2po/lib/c2po.rb`)
 * Other things we haven't thought of
+
+## Extending views within engines
+
+When necessary, you can add to a view from your engine with minimal change to the
+main application's view.
+
+`render_view_hook("useful_identifier", local_variables)`
+
+`"useful_identifier"` should be relevant to where it exists in the view. E.g.
+`after_end_of_form`.
+
+To insert a partial into this hook, within your engine's `to_prepare` block, add
+
+```ruby
+config.to_prepare do
+  Viewhook.add_hook "partial_name", "useful_identifier", "your_engine/partial"
+end
+```
+
+`partial_name` - The name of the partial where `render_view_hook` lives. It should use dots, and will be the same as the locale scope for the view. E.g. `reservations.account_field`
+
+`your_engine/partial` - The name of the partial you wish to include, located within your engine.
+
+[`vendor/engines/projects/lib/projects/engine.rb`](vendor/engines/projects/lib/projects/engine.rb) has plenty of examples, as well
+as examples of other ways to hook into the app from an engine.
 
 ## Gemfiles
 
@@ -66,40 +125,45 @@ _We should consider `optional` groups in Bundler 1.10 to see if this helps_
 
 ## Commits
 
-Prefix your commits and pull requests with the ticket number. `[#12345] Fix critical issue`
+Good commit messages vastly improve the history of the project. Tools like `git log`,
+`git blame`, and `git bisect` are much easier to use when each commit is a discreet
+piece of work. Each commit to master should result in a green build.
 
-[TODO]
+When merging Pull Requests, we prefer to use Github's "Squash and Merge" green button.
+This allows the history of `master` to be one commit per feature or bug fix. It
+also keeps commits from long-running PRs to be included in the history in chronological
+order of when they were merged, not when they were written.
+
+Use [Chris Beam's guidelines](https://chris.beams.io/posts/git-commit/) as a template
+for your commits.
+
+Prefix your pull requests with the ticket number. `[#12345] Fix critical issue`.
+This is an open source project, so many people will not have access to the discussion
+of the ticket, so include an explanation of the feature or bug fix in the pull
+request body.
 
 ## Other
-
-### Refactor Scopes
-There are plenty of old-style scopes and finders (`find(:all, conditions: ...)`, `scope :xxxx, conditions: ...`, etc) lying around from when NUcore was young. Always use the newer style, and fix up scopes as you have the opportunity.
-
-### Prepare for Rails Upgrades
-Since this is still a Rails 3.2 project, you may find yourself needing to use
-outmoded idioms like a dynamic finders. Tag these with `TODO:` comments so we
-can more easily find them with `rake notes`.
 
 ### Put application code where it belongs
 There is quite a bit of code inside of `/lib` that is actually application code. Many of the
 classes/modules are actually service objects or model concerns. Move them to the appropriate
 place inside of `/app`.
 
-We have an `app/support` directory that probably would be more at home in `app/services` or `app/models/concerns`. Move them to where they belong.
+We have an `app/support` directory that probably would be more at home in `app/services` or `app/models/concerns`. Move them to where they belong. This has led to an odd `spec` folder structure where `spec/support` is for testing support, and `spec/app_support` holds the tests for `app/support`.
 
 Don't worry too much about moving code you're not actively working with. But when you do work on
 something that seems to be in the wrong place, please fix it!
 
 ### Don't use DCI
-There are a few places where we are using (DCI)[http://www.sitepoint.com/dci-the-evolution-of-the-object-oriented-paradigm/] such as `PriceDisplayment`. Do not use this technique going forward. Prefer decorators/presenters. Prefer `SimpleDelegator` for your decorators; we have
-chosen not to use something more magical like Draper.
+There are a few places where we are using [DCI](http://www.sitepoint.com/dci-the-evolution-of-the-object-oriented-paradigm) such as `PriceDisplayment`. Do not use this technique going forward. Prefer decorators/presenters. Consider [`SimpleDelegator`](http://ruby-doc.org/stdlib/libdoc/delegate/rdoc/SimpleDelegator.html) or [`DelegateClass`](http://ruby-doc.org/stdlib/libdoc/delegate/rdoc/Object.html); we have chosen not to use something
+more magical like Draper.
 
 ### Documentation
 If a class is not immediately obvious what its purpose is, add comments to the top of the
 class explaining its purpose and its use.
 
 ### Skinny Models, Controllers, and Views
-You'll see lots of long controller methods or complex logic in the views. Don't contribute to the problem. If you need to touch one of these, start by refactoring out a service object or presenter. Additionally, try to avoid adding additional business logic onto the models. `OrderDetail` is already large enough!
+You'll see lots of long controller methods or complex logic in the views. Don't contribute to the problem. If you need to touch one of these, start by refactoring out a service object or presenter. Additionally, try to avoid adding additional business logic onto the models. `OrderDetail` is already [large enough](https://en.wikipedia.org/wiki/God_object)!
 
 ### Roles
 Prefer `Ability` checks (`can? :read, @order_detail)` over Role checks in views and controllers (e.g. `User#manager_of?(facility)`).


### PR DESCRIPTION
I found these changes from about 6 months ago while I was cleaning up old branches. I think they still hold.

* Using locales
* View/engine notes about being excluded from rubocop
* Using view hooks
* Remove note about Rails 3.2 TODOs
* Update factories doc for version and hash syntax
* Remove "Refactor Scopes" section now that we're on 4.2
* Add links to decorator preferences
* Improve guidelines on commits and pull requests