### PR TITLE
Homogenize product new/edit views

### DIFF
--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -41,9 +41,11 @@ module ProductsHelper
   def product_url_hint(product)
     product_url_name = product.try(:url_name).presence || "url-name"
 
-    url_name_hint = send("facility_#{product.class.name.downcase}_url",
-                         current_facility.url_name,
-                         product_url_name)
+    send(
+      "facility_#{product.class.name.underscore}_url",
+      current_facility.url_name,
+      product_url_name,
+    )
   end
 
   private

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -41,7 +41,7 @@ module ProductsHelper
   def product_url_hint(product)
     product_url_name = product.try(:url_name).presence || "url-name"
 
-    send(
+    public_send(
       "facility_#{product.class.name.underscore}_url",
       current_facility.url_name,
       product_url_name,

--- a/app/views/admin/shared/_product_manage.haml
+++ b/app/views/admin/shared/_product_manage.haml
@@ -1,14 +1,15 @@
-- product = @instrument || @service || @item || @bundle
-= f.input :url_name, :input_html => { :value => link_to(send("facility_#{product.class.name.downcase}_url", current_facility, product), send("facility_#{product.class.name.downcase}_url", current_facility, product))}
+= f.input :url_name, input_html: { value: link_to(url_for([current_facility, @product, only_path: false]), [current_facility, @product]) }
 
 - if SettingsHelper::feature_on? :product_specific_contacts
   = f.input :email
 
-= f.input :description, :input_html => { :class => 'wysiwyg' }
+= f.input :description, input_html: { class: "wysiwyg" }
 
-- unless product.is_a?(Bundle)
+- unless @product.is_a?(Bundle)
   - if SettingsHelper.feature_on? :recharge_accounts
-    = f.input :facility_account, :label => t('shared.product_manage.label.deposit'), :input_html => { :value => product.facility_account.account_number + (product.facility_account.is_active? ? '' : ' (inactive)') }
+    = f.input :facility_account,
+      label: t("shared.product_manage.label.deposit"),
+      input_html: { value: @product.facility_account.account_number + (@product.facility_account.is_active? ? "" : " (inactive)") }
 
   = f.input :initial_order_status
   = f.input :requires_approval

--- a/app/views/admin/shared/_tabnav_product.html.haml
+++ b/app/views/admin/shared/_tabnav_product.html.haml
@@ -1,23 +1,22 @@
-- product = @instrument || @service || @item || @bundle || @product
-- return nil if product.nil? || product.id.nil?
+- return nil if @product.nil? || @product.id.nil?
 %ul.nav.nav-tabs
-  = tab "Details", send("manage_facility_#{product.class.name.downcase}_path", current_facility, product), (secondary_tab == 'details')
-  - if product.is_a?(Instrument)
-    = tab 'Scheduling', facility_instrument_schedule_rules_path(current_facility, product), (secondary_tab == 'schedule_rules')
-  - if product.requires_approval?
-    = tab 'Access List', [current_facility, product, :users], (secondary_tab == 'users')
-  - if product.requires_approval? && product.is_a?(Instrument)
-    = tab ProductAccessGroup.model_name.human.pluralize, facility_instrument_product_access_groups_path(current_facility, product), (secondary_tab == 'restriction_levels')
-  - if product.is_a?(Bundle)
-    = tab 'Bundled Products', facility_bundle_bundle_products_path(current_facility, product), (secondary_tab == 'products')
+  = tab "Details", [:manage, current_facility, @product], (secondary_tab == "details")
+  - if @product.is_a?(Instrument)
+    = tab "Scheduling", facility_instrument_schedule_rules_path(current_facility, @product), (secondary_tab == "schedule_rules")
+  - if @product.requires_approval?
+    = tab "Access List", [current_facility, @product, :users], (secondary_tab == "users")
+  - if @product.requires_approval? && @product.is_a?(Instrument)
+    = tab ProductAccessGroup.model_name.human.pluralize, facility_instrument_product_access_groups_path(current_facility, @product), (secondary_tab == "restriction_levels")
+  - if @product.is_a?(Bundle)
+    = tab "Bundled Products", facility_bundle_bundle_products_path(current_facility, @product), (secondary_tab == "products")
   - else
     - if can? :index, PricePolicy
-      = tab 'Pricing', send("facility_#{product.class.name.downcase}_price_policies_path", current_facility, product), (secondary_tab == 'pricing_rules')
-  - if product.is_a?(Instrument)
-    = tab 'Restrictions', send("edit_facility_price_group_product_path", current_facility, product), (secondary_tab == 'restrictions')
-    = tab 'Reservations', facility_instrument_schedule_path(current_facility, product), (secondary_tab == 'reservations')
-  = tab 'Docs', upload_product_file_path(current_facility, product.parameterize, product.url_name, :file_type => 'info'), (secondary_tab == 'documentation')
-  - if product.is_a?(Service)
-    = tab 'Order Forms', product_survey_path(current_facility, product.parameterize, product.url_name), (secondary_tab == 'surveys')
-  - if product.respond_to?(:reservations)
-    = tab 'Accessories', facility_product_product_accessories_path(current_facility, product), (secondary_tab == 'accessories')
+      = tab "Pricing", [current_facility, @product, PricePolicy], (secondary_tab == "pricing_rules")
+  - if @product.is_a?(Instrument)
+    = tab "Restrictions", edit_facility_price_group_product_path(current_facility, @product), (secondary_tab == "restrictions")
+    = tab "Reservations", facility_instrument_schedule_path(current_facility, @product), (secondary_tab == "reservations")
+  = tab "Docs", upload_product_file_path(current_facility, @product.parameterize, @product.url_name, :file_type => "info"), (secondary_tab == "documentation")
+  - if @product.is_a?(Service)
+    = tab "Order Forms", product_survey_path(current_facility, @product.parameterize, @product.url_name), (secondary_tab == "surveys")
+  - if @product.respond_to?(:reservations)
+    = tab "Accessories", facility_product_product_accessories_path(current_facility, @product), (secondary_tab == "accessories")

--- a/app/views/instruments/edit.html.haml
+++ b/app/views/instruments/edit.html.haml
@@ -4,18 +4,18 @@
   = current_facility
 
 = content_for :sidebar do
-  = render "admin/shared/sidenav_product", sidenav_tab: "instruments"
+  = render "admin/shared/sidenav_product", sidenav_tab: @product.class.name.pluralize.underscore
 
 = content_for :tabnav do
   = render "admin/shared/tabnav_product", secondary_tab: "details"
 
-%h2= @instrument
+%h2= @product
 
-= simple_form_for([current_facility, @instrument]) do |f|
-  = f.error_notification
+= simple_form_for([current_facility, @product]) do |f|
+  = f.error_messages
   .form-inputs
     = render "admin/products/details_fields", f: f
     = render "instrument_fields", f: f
   %ul.inline
-    %li= f.button :submit, text("shared.save"), class: ["btn", "btn-primary"]
-    %li= link_to text("shared.cancel"), manage_facility_instrument_path(current_facility, @instrument)
+    %li= f.submit text("shared.save"), class: ["btn", "btn-primary"]
+    %li= link_to text("shared.cancel"), [:manage, current_facility, @product]

--- a/app/views/instruments/new.html.haml
+++ b/app/views/instruments/new.html.haml
@@ -4,14 +4,15 @@
   = current_facility
 
 = content_for :sidebar do
-  = render "admin/shared/sidenav_product", sidenav_tab: "instruments"
+  = render "admin/shared/sidenav_product", sidenav_tab: @product.class.name.pluralize.underscore
 
-%h2= text("admin.shared.add", model: Instrument.model_name.human)
-= simple_form_for([current_facility, @instrument]) do |f|
-  = f.error_notification
+%h2= text("admin.shared.add", model: @product.class.model_name.human)
+
+= simple_form_for([current_facility, @product]) do |f|
+  = f.error_messages
   .form-inputs
     = render "admin/products/details_fields", f: f
     = render "instrument_fields", f: f
   %ul.inline
-    %li= f.submit text("shared.save"), class: "btn"
-    %li= link_to text("shared.cancel"), facility_instruments_path
+    %li= f.submit text("shared.save"), class: ["btn", "btn-primary"]
+    %li= link_to text("shared.cancel"), [current_facility, @product]

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,18 +1,20 @@
 = render "shared/headers/ckeditor"
 
 = content_for :h1 do
-  =h current_facility
+  = current_facility
+
 = content_for :sidebar do
-  = render "admin/shared/sidenav_product", sidenav_tab: "items"
+  = render "admin/shared/sidenav_product", sidenav_tab: @product.class.name.pluralize.underscore
+
 = content_for :tabnav do
   = render "admin/shared/tabnav_product", secondary_tab: "details"
 
-%h2= @item
+%h2= @product
 
-= simple_form_for([current_facility, @item]) do |f|
+= simple_form_for([current_facility, @product]) do |f|
   = f.error_messages
-  %ul.form
-    %li= render "admin/products/details_fields", f: f
+  .form-inputs
+    = render "admin/products/details_fields", f: f
   %ul.inline
-    %li= f.submit text("shared.save"), class: "btn"
-    %li= link_to text("shared.cancel"), manage_facility_item_path(current_facility, @item)
+    %li= f.submit text("shared.save"), class: ["btn", "btn-primary"]
+    %li= link_to text("shared.cancel"), [:manage, current_facility, @product]

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -10,7 +10,7 @@
 
 = simple_form_for([current_facility, @product]) do |f|
   = f.error_messages
-  .form-imputs
+  .form-inputs
     = render "admin/products/details_fields", f: f
   %ul.inline
     %li= f.submit text("shared.create"), class: ["btn", "btn-primary"]

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -2,15 +2,16 @@
 
 = content_for :h1 do
   = current_facility
+
 = content_for :sidebar do
-  = render "admin/shared/sidenav_product", sidenav_tab: "items"
+  = render "admin/shared/sidenav_product", sidenav_tab: @product.class.name.pluralize.underscore
 
-%h2= text("admin.shared.add", model: Item.model_name.human)
+%h2= text("admin.shared.add", model: @product.class.model_name.human)
 
-= simple_form_for([current_facility, @item]) do |f|
+= simple_form_for([current_facility, @product]) do |f|
   = f.error_messages
-  %ul.form
+  .form-imputs
     = render "admin/products/details_fields", f: f
   %ul.inline
-    %li= f.submit text("shared.create"), :class => "btn"
-    %li= link_to text("shared.cancel"), facility_items_path
+    %li= f.submit text("shared.create"), class: ["btn", "btn-primary"]
+    %li= link_to text("shared.cancel"), [current_facility, @product]

--- a/app/views/services/edit.html.haml
+++ b/app/views/services/edit.html.haml
@@ -1,18 +1,20 @@
 = render "shared/headers/ckeditor"
 
 = content_for :h1 do
-  =h current_facility
+  = current_facility
+
 = content_for :sidebar do
-  = render "admin/shared/sidenav_product", sidenav_tab: "services"
+  = render "admin/shared/sidenav_product", sidenav_tab: @product.class.name.pluralize.underscore
+
 = content_for :tabnav do
   = render "admin/shared/tabnav_product", secondary_tab: "details"
 
-%h2= @service
+%h2= @product
 
-= simple_form_for([current_facility, @service]) do |f|
+= simple_form_for([current_facility, @product]) do |f|
   = f.error_messages
-  %ul.form
+  .form-inputs
     = render "admin/products/details_fields", f: f
   %ul.inline
-    %li= f.submit text("shared.save"), class: "btn"
-    %li= link_to text("shared.cancel"), manage_facility_service_path(current_facility, @service)
+    %li= f.submit text("shared.save"), class: ["btn", "btn-primary"]
+    %li= link_to text("shared.cancel"), [:manage, current_facility, @product]

--- a/app/views/services/new.html.haml
+++ b/app/views/services/new.html.haml
@@ -2,14 +2,16 @@
 
 = content_for :h1 do
   = current_facility
-= content_for :sidebar do
-  = render "admin/shared/sidenav_product", sidenav_tab: "services"
 
-%h2= text("admin.shared.add", model: Service.model_name.human)
-= simple_form_for([current_facility, @service]) do |f|
+= content_for :sidebar do
+  = render "admin/shared/sidenav_product", sidenav_tab: @product.class.name.pluralize.underscore
+
+%h2= text("admin.shared.add", model: @product.class.model_name.human)
+
+= simple_form_for([current_facility, @product]) do |f|
   = f.error_messages
-  %ul.form
+  .form-inputs
     = render "admin/products/details_fields", f: f
   %ul.inline
-    %li= f.submit text("shared.create"), class: "btn"
-    %li= link_to text("shared.cancel"), facility_services_path
+    %li= f.submit text("shared.create"), class: ["btn", "btn-primary"]
+    %li= link_to text("shared.cancel"), [current_facility, @product]


### PR DESCRIPTION
As I was working on spiking adding a new product type, I found several
discrepancies between the item/service/instrument new/edit views. This
brings them closer together. There is obviously further DRY to do as
item/new and service/new are identical as well as their edit views. and
their show/edit views are now very similar.

ProductsCommonController sets a `@product` variable, so it was trivial
to switch to that. There were also some discrepancies is what was one
level up from the details_field partial which led some views to have
some additional padding that shouldn’t have been there.

The longer-term goal would be to further clean these up as we add new product
types, but this seemed like a good first step.