### PR TITLE
Move FileUpload routes into product resource so they can be reused more easily.

### DIFF
--- a/app/controllers/file_uploads_controller.rb
+++ b/app/controllers/file_uploads_controller.rb
@@ -6,7 +6,7 @@ class FileUploadsController < ApplicationController
   before_action       :init_current_facility
   skip_before_action  :verify_authenticity_token, only: :create
 
-  load_and_authorize_resource class: StoredFile, except: [:download, :uploader_create]
+  load_and_authorize_resource class: StoredFile, except: [:download, :upload_sample_results]
 
   layout "two_column"
 
@@ -15,22 +15,18 @@ class FileUploadsController < ApplicationController
     super
   end
 
-  # GET /facilities/1/services/3/files/upload?type=info
-  # GET /facilities/1/services/3/files/upload?type=template
-  # GET /facilities/1/services/3/files/upload?type=template_result
-  def upload
-    @klass   = params[:product]
-    @product = current_facility.send(@klass).find_by_url_name!(params[:product_id])
-    @file    = @product.stored_files.new(file_type: params[:file_type])
+  # GET /facilities/1/services/3/files?file_type=info
+  # GET /facilities/1/services/3/files?file_type=template
+  # GET /facilities/1/services/3/files?file_type=template_result
+  def index
+    @file = product.stored_files.new(file_type: params[:file_type])
+    @files = @product.stored_files.where(file_type: @file.file_type || params[:file_type])
   end
 
   # GET /facilities/:facility_id/:product/:product_id/files/:file_type/:id
   def download
     redirect_to(
-      current_facility
-        .products
-        .where(type: params[:product].capitalize.singularize)
-        .find_by_url_name!(params[:product_id]) # TODO: update to #find_by for Rails 4
+      product
         .stored_files
         .where(file_type: params[:file_type])
         .find(params[:id])
@@ -40,32 +36,28 @@ class FileUploadsController < ApplicationController
 
   # POST /facilities/1/services/3/files
   def create
-    @klass   = params[:product]
-    @product = current_facility.send(@klass).find_by_url_name!(params[:product_id])
-
-    @file = @product.stored_files.new(params[:stored_file].merge(created_by: session_user.id))
+    @file = product.stored_files.new(params[:stored_file].merge(created_by: session_user.id))
+    @files = @product.stored_files.where(file_type: @file.file_type || params[:file_type])
 
     if @file.save
       flash[:notice] = "File uploaded"
-      redirect_to(upload_product_file_path(current_facility, @product.parameterize, @product, file_type: @file.file_type)) && return
+      redirect_to [current_facility, @product, :file_uploads, file_type: @file.file_type]
+    else
+      render :index
     end
-    render :upload
   end
 
-  # POST /facilities/:facility_id/:product/:product_id/uploader_files
-  def uploader_create
-    @klass    = params[:product]
-    @product  = current_facility.send(@klass).find_by_url_name!(params[:product_id])
-
+  # POST /facilities/:facility_id/:product/:product_id/upload_sample_results
+  def upload_sample_results
     options = { file: params[:qqfile],
                 name: params[:qqfilename].presence || params[:qqfile].original_filename,
                 file_type: params[:file_type],
                 order_detail: OrderDetail.find(params[:order_detail_id]),
-                product: @product,
+                product: product,
                 created_by: current_user.id }
 
-    @upload = @product.stored_files.new(options)
-    authorize! :uploader_create, @upload
+    @upload = product.stored_files.new(options)
+    authorize! :upload_sample_results, @upload
 
     if @upload.save
       ResultsFileNotifier.new(@upload).notify if @upload.sample_result?
@@ -84,8 +76,7 @@ class FileUploadsController < ApplicationController
 
   # GET /facilities/1/services/3/files/survey_upload
   def product_survey
-    @product  = current_facility.services.find_by_url_name!(params[:product_id])
-    @file     = @product.stored_files.new(file_type: "template")
+    @file     = product.stored_files.new(file_type: "template")
     @survey = ExternalServiceManager.survey_service.new
   end
 
@@ -101,9 +92,7 @@ class FileUploadsController < ApplicationController
   end
 
   def destroy
-    @klass   = params[:product]
-    @product = current_facility.send(@klass).find_by_url_name!(params[:product_id])
-    @file    = @product.stored_files.find(params[:id])
+    @file = product.stored_files.find(params[:id])
 
     if @product.stored_files.destroy(@file)
       flash[:notice] = "The file was deleted successfully"
@@ -119,17 +108,26 @@ class FileUploadsController < ApplicationController
     elsif @file.file_type == "template"
       redirect_to(@return_to || product_survey_path(current_facility, @product.parameterize, @product))
     else
-      redirect_to(@return_to || upload_product_file_path(current_facility, @product.parameterize, @product, file_type: @file.file_type))
+      redirect_to(@return_to || [current_facility, @product, :file_uploads, file_type: @file.file_type])
     end
   end
 
-  protected
-
-  def manage_path(_facility, _product)
-    eval("manage_facility_#{@klass.singularize}_path(current_facility, @product)")
-  end
-
   private
+
+  def product
+    if params[:product]
+      # Use the older route behavior
+      # TODO: Remove this once all the necessary routes are removed (see routes.rb:355)
+      klass = params[:product]
+      @product = current_facility.send(klass).find_by!(url_name: params[:product_id])
+    else
+      id_param = params.except(:facility_id).keys.detect { |k| k.end_with?("_id") }
+      clazz = id_param.sub(/_id\z/, "").camelize
+      @product = current_facility
+        .products(clazz)
+        .find_by!(url_name: params[id_param])
+    end
+  end
 
   def create_product_survey_from_file
     @file = @product.stored_files.new(params[:stored_file].merge(created_by: session_user.id, name: "Order Form Template"))

--- a/app/controllers/file_uploads_controller.rb
+++ b/app/controllers/file_uploads_controller.rb
@@ -76,12 +76,12 @@ class FileUploadsController < ApplicationController
 
   # GET /facilities/1/services/3/files/survey_upload
   def product_survey
-    @file     = product.stored_files.new(file_type: "template")
+    @file = product.stored_files.new(file_type: "template")
     @survey = ExternalServiceManager.survey_service.new
   end
 
   def create_product_survey
-    @product = current_facility.services.find_by_url_name!(params[:product_id])
+    @product = current_facility.services.find_by!(url_name: params[:product_id])
 
     if params[:stored_file]
       create_product_survey_from_file
@@ -124,8 +124,8 @@ class FileUploadsController < ApplicationController
       id_param = params.except(:facility_id).keys.detect { |k| k.end_with?("_id") }
       clazz = id_param.sub(/_id\z/, "").camelize
       @product = current_facility
-        .products(clazz)
-        .find_by!(url_name: params[id_param])
+                 .products(clazz)
+                 .find_by!(url_name: params[id_param])
     end
   end
 

--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -28,7 +28,7 @@ module RoutesHelper
       file.product,
       :download_product_file,
       file_type: file.file_type,
-      id: file
+      id: file,
     ]
   end
 

--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -22,14 +22,14 @@ module RoutesHelper
     facility_account_statement_path(statement.facility, statement.account_id, statement, format: :pdf)
   end
 
-  def product_file_path(product_info_file)
-    download_product_file_path(
-      product_info_file.product.facility,
-      product_info_file.product.type.pluralize.downcase,
-      product_info_file.product,
-      product_info_file.file_type,
-      product_info_file,
-    )
+  def product_file_path(file)
+    [
+      file.product.facility,
+      file.product,
+      :download_product_file,
+      file_type: file.file_type,
+      id: file
+    ]
   end
 
   def stored_file_path(file)

--- a/app/views/admin/shared/_tabnav_product.html.haml
+++ b/app/views/admin/shared/_tabnav_product.html.haml
@@ -15,7 +15,7 @@
   - if @product.is_a?(Instrument)
     = tab "Restrictions", edit_facility_price_group_product_path(current_facility, @product), (secondary_tab == "restrictions")
     = tab "Reservations", facility_instrument_schedule_path(current_facility, @product), (secondary_tab == "reservations")
-  = tab "Docs", upload_product_file_path(current_facility, @product.parameterize, @product.url_name, :file_type => "info"), (secondary_tab == "documentation")
+  = tab "Docs", [current_facility, @product, :file_uploads, file_type: "info"], (secondary_tab == "documentation")
   - if @product.is_a?(Service)
     = tab "Order Forms", product_survey_path(current_facility, @product.parameterize, @product.url_name), (secondary_tab == "surveys")
   - if @product.respond_to?(:reservations)

--- a/app/views/file_uploads/index.html.haml
+++ b/app/views/file_uploads/index.html.haml
@@ -3,7 +3,7 @@
 
 = content_for :sidebar do
   = render "admin/shared/sidenav_product",
-    sidenav_tab: @product.class.name.pluralize.downcase
+    sidenav_tab: @product.class.name.pluralize.underscore
 
 = content_for :tabnav do
   = render "admin/shared/tabnav_product", secondary_tab: "documentation"
@@ -13,7 +13,7 @@
 %p= t(".documentation_note")
 
 - if can? :create, @file
-  = simple_form_for(@file, url: add_product_file_path(current_facility, @product.parameterize, @product), html: { multipart: true, method: :post }) do |f|
+  = simple_form_for(@file, url: [current_facility, @product, :file_uploads, id: @file]) do |f|
     = f.error_messages
     = f.hidden_field :file_type
 
@@ -28,9 +28,7 @@
 
 %br
 
-- files = @product.stored_files.public_send("#{@file.file_type || params[:file_type]}") # TODO: don't allow arbitrary method calls from user params
-
-- if files.empty?
+- if @files.empty?
   %p.notice= t(".no_uploads")
 
 - else
@@ -43,14 +41,14 @@
         %th= t(".th.created_by")
 
     %tbody
-      - files.each do |stored_file|
+      - @files.each do |stored_file|
         %tr
           %td
             - if can?(:delete, stored_file)
               = link_to t("shared.delete"),
-                remove_product_file_path(current_facility, @product.parameterize, @product, stored_file),
+                [current_facility, @product, :file_upload, id: stored_file],
                 method: :delete,
-                confirm: t(".confirm_delete")
+                data: { confirm: t(".confirm_delete") }
 
           %td= link_to stored_file.name, product_file_path(stored_file)
           %td= human_datetime(stored_file.created_at)

--- a/app/views/file_uploads/product_survey.html.haml
+++ b/app/views/file_uploads/product_survey.html.haml
@@ -72,13 +72,11 @@
     = f.error_messages
     = f.hidden_field :file_type
 
-    %ul.form
-      %li
-        = f.label :file, "File", class: "required"
-        = f.file_field :file
+    = f.label :file, "File", class: "required"
+    = f.file_field :file
 
     %ul.inline
-      %li= f.submit "Upload", data: { disable_with: "Uploading..." }, class: "btn"
+      %li= f.submit text("shared.upload"), data: { disable_with: "Uploading..." }, class: "btn"
 
   %br
 
@@ -99,9 +97,9 @@
       %tbody
         - files.each do |stored_file|
           %tr
-            %td.centered
-              = link_to "Delete",
-                remove_product_file_path(current_facility, @product.parameterize, @product, stored_file),
+            %td
+              = link_to text("shared.delete"),
+                [current_facility, @product, :remove_product_file, id: stored_file],
                 method: :delete,
                 data: { confirm: t(".download_form.confirm") }
 

--- a/app/views/order_detail_stored_files/order_file.html.haml
+++ b/app/views/order_detail_stored_files/order_file.html.haml
@@ -13,7 +13,7 @@
 
 %h2=h @order_detail.product
 
-= form_for(@file, :url => order_order_detail_upload_order_file_path, :html => { :multipart => true, :method => :post }) do |f|
+= form_for(@file, url: order_order_detail_upload_order_file_path, html: { multipart: true, method: :post }) do |f|
   = f.error_messages
   %table.table.table-striped.table-hover
     %tbody

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -929,7 +929,7 @@ en:
         main: "Downloadable Order Forms are templates to be filled in by the user and submitted when ordering.  Uploading a new template will replace any existing Downloadable Order Forms."
         notice: "No Downloadable Order Forms have been uploaded."
         confirm: "Are you sure you wish to remove this file?"
-    upload:
+    index:
       confirm_delete: Are you sure you wish to remove this file?
       documentation_note: |
         If provided, documentation will be available for download from the

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,11 +64,14 @@ Nucore::Application.routes.draw do
 
     resources :training_requests, only: [:index, :destroy] if SettingsHelper.feature_on?(:training_requests)
 
-    resources :instruments do
-      member do
-        get "manage"
-      end
+    concern :facility_product do
+      get :manage, on: :member
+      resources :users, controller: "product_users", except: [:show, :edit, :create]
+      resources :file_uploads, path: "files", only: [:index, :create, :destroy]
+      get "/files/:file_type/:id", to: 'file_uploads#download', as: "download_product_file"
+    end
 
+    resources :instruments, concerns: :facility_product do
       get "public_schedule", to: 'instruments#public_schedule'
       get "schedule",        to: 'instruments#schedule'
       get "status",          to: 'instruments#instrument_status'
@@ -86,36 +89,22 @@ Nucore::Application.routes.draw do
       end
 
       resources :reservations, only: [:index]
-      resources :users, controller: "product_users", except: [:show, :edit, :create]
-      get "/users/user_search_results", to: "product_users#user_search_results"
       put "update_restrictions", to: "product_users#update_restrictions"
     end
 
-    resources :services do
-      member do
-        get "manage"
-      end
+    resources :services, concerns: :facility_product do
       resources :price_policies, controller: "service_price_policies", except: [:show]
-      resources :users, controller: "product_users", except: [:show, :edit, :create]
-      get "/users/user_search_results", to: 'product_users#user_search_results'
     end
 
-    resources :items do
-      member do
-        get "manage"
-      end
+    resources :items, concerns: :facility_product do
       resources :price_policies, controller: "item_price_policies", except: [:show]
-      resources :users, controller: "product_users", except: [:show, :edit, :create]
-      get "/users/user_search_results", to: 'product_users#user_search_results'
     end
 
     resources :bundles do
-      member do
-        get "manage"
-      end
-      resources :users, controller: "product_users", except: [:show, :edit, :create]
-      get "/users/user_search_results", to: 'product_users#user_search_results'
+      get :manage, on: :member
       resources :bundle_products, controller: "bundle_products", except: [:show]
+      resources :file_uploads, path: "files", only: [:new, :create, :destroy]
+      get "/files/:file_type/:id", to: 'file_uploads#download', as: "download_product_file"
     end
 
     resources :price_group_products, only: [:edit, :update]
@@ -365,13 +354,10 @@ Nucore::Application.routes.draw do
   resources :my_files, only: [:index] if SettingsHelper.feature_on?(:my_files)
 
   # file upload routes
-  get   "/#{I18n.t("facilities_downcase")}/:facility_id/:product/:product_id/files/upload",                                   to: 'file_uploads#upload',                as: "upload_product_file"
-  post  "/#{I18n.t("facilities_downcase")}/:facility_id/:product/:product_id/files",                                          to: 'file_uploads#create',                as: "add_product_file"
-  post  "/#{I18n.t("facilities_downcase")}/:facility_id/:product/:product_id/uploader_files",                                 to: 'file_uploads#uploader_create',       as: "add_uploader_file"
-  delete "/#{I18n.t("facilities_downcase")}/:facility_id/:product/:product_id/files/:id",                                      to: 'file_uploads#destroy',               as: "remove_product_file"
-  get   "/#{I18n.t("facilities_downcase")}/:facility_id/:product/:product_id/files/:file_type/:id",                           to: 'file_uploads#download',              as: "download_product_file"
-  get   "/#{I18n.t("facilities_downcase")}/:facility_id/:product/:product_id/files/product_survey",                           to: 'file_uploads#product_survey',        as: "product_survey"
-  post  "/#{I18n.t("facilities_downcase")}/:facility_id/:product/:product_id/files/create_product_survey",                    to: 'file_uploads#create_product_survey', as: "create_product_survey"
+  post  "/#{I18n.t("facilities_downcase")}/:facility_id/:product/:product_id/sample_results", to: 'file_uploads#upload_sample_results', as: "add_uploader_file"
+  get   "/#{I18n.t("facilities_downcase")}/:facility_id/:product/:product_id/files/product_survey", to: 'file_uploads#product_survey', as: "product_survey"
+  post  "/#{I18n.t("facilities_downcase")}/:facility_id/:product/:product_id/files/create_product_survey", to: 'file_uploads#create_product_survey', as: "create_product_survey"
+
   put   "/#{I18n.t("facilities_downcase")}/:facility_id/services/:service_id/surveys/:external_service_passer_id/activate",   to: 'surveys#activate',                 as: "activate_survey"
   put   "/#{I18n.t("facilities_downcase")}/:facility_id/services/:service_id/surveys/:external_service_passer_id/deactivate", to: 'surveys#deactivate',               as: "deactivate_survey"
   get "/#{I18n.t("facilities_downcase")}/:facility_id/services/:service_id/surveys/:external_service_id/complete", to: "surveys#complete", as: "complete_survey"

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -127,7 +127,8 @@ class Ability
 
         can [:administer, :index, :view_details, :schedule, :show], Product
 
-        can [:upload, :uploader_create, :destroy], StoredFile do |fileupload|
+        can [:index], StoredFile
+        can [:upload_sample_results, :destroy], StoredFile do |fileupload|
           fileupload.file_type == "sample_result"
         end
 


### PR DESCRIPTION
* Change "upload" to "index"
* Rename "uploader_create" to "upload_sample_results" to better reflect how its used.

There are still more routes to deal with, but this should cover the main Docs tab.