### PR TITLE
[#132371] Returns helpful message on duplicate start date

### DIFF
--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -62,11 +62,15 @@ class PricePoliciesController < ApplicationController
     return flash_remove_active_policy_warning_and_redirect if @start_date <= Date.today
 
     if PricePolicyUpdater.destroy_all_for_product!(@product, @start_date)
-      flash[:notice] = I18n.t("controllers.price_policies.destroy.success")
+      flash[:notice] = text("destroy.success")
     else
-      flash[:error] = I18n.t("controllers.price_policies.destroy.failure")
+      flash[:error] = text("destroy.failure")
     end
     redirect_to facility_product_price_policies_path
+  end
+
+  def translation_scope
+    "controllers.price_policies"
   end
 
   private
@@ -81,7 +85,10 @@ class PricePoliciesController < ApplicationController
 
   def build_price_policies!
     build_price_policies
-    redirect_to facility_product_price_policies_path, alert: I18n.t("controllers.price_policies.errors.same_start_date") if @price_policies.blank?
+    if @price_policies.blank?
+      redirect_to facility_product_price_policies_path,
+        alert: text("errors.same_start_date")
+    end
   end
 
   def build_price_policies_for_edit!
@@ -91,10 +98,10 @@ class PricePoliciesController < ApplicationController
 
   def create_or_update(action)
     if update_policies_from_params!
-      flash[:notice] = I18n.t("controllers.price_policies.#{action}.success")
+      flash[:notice] = text("#{action}.success")
       redirect_to facility_product_price_policies_path
     else
-      flash[:error] = I18n.t("controllers.price_policies.errors.save")
+      flash[:error] = text("errors.save")
       render "price_policies/#{action}"
     end
   end
@@ -127,7 +134,7 @@ class PricePoliciesController < ApplicationController
 
   def flash_remove_active_policy_warning_and_redirect
     flash[:error] =
-      I18n.t("controllers.price_policies.errors.remove_active_policy")
+      text("errors.remove_active_policy")
     redirect_to facility_product_price_policies_path
   end
 

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -8,7 +8,8 @@ class PricePoliciesController < ApplicationController
   before_action :init_current_facility
   before_action :init_product
   before_action :init_price_policy, except: [:index, :new]
-  before_action :build_price_policies!, only: [:create, :edit, :update]
+  before_action :build_price_policies!, only: [:create, :update]
+  before_action :build_price_policies_for_edit!, only: :edit
   before_action :set_expire_date_from_params, only: [:create, :update]
   before_action :set_max_expire_date, only: [:edit, :update]
 
@@ -74,8 +75,17 @@ class PricePoliciesController < ApplicationController
     @product.price_policies.current.any?
   end
 
+  def build_price_policies
+    @price_policies ||= PricePolicyBuilder.get(@product, @start_date)
+  end
+
   def build_price_policies!
-    @price_policies = PricePolicyBuilder.get(@product, @start_date)
+    build_price_policies
+    redirect_to facility_product_price_policies_path, alert: I18n.t("controllers.price_policies.errors.same_start_date") if @price_policies.blank?
+  end
+
+  def build_price_policies_for_edit!
+    build_price_policies
     raise ActiveRecord::RecordNotFound if @price_policies.blank?
   end
 

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -87,7 +87,7 @@ class PricePoliciesController < ApplicationController
     build_price_policies
     if @price_policies.blank?
       redirect_to facility_product_price_policies_path,
-        alert: text("errors.same_start_date")
+                  alert: text("errors.same_start_date")
     end
   end
 

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -144,7 +144,7 @@ en:
       errors:
         remove_active_policy: "Sorry, but you cannot remove an active price policy. If you really want to do so move the start date to the future and try again."
         save: There was an error saving the policy
-        same_start_date: "Sorry, but you cannot start a policy the same date as an active policy that has already been applied to an order"
+        same_start_date: "You have chosen a start date that matches an active policy with existing orders. Please choose another start date."
       new:
         success: Price Rules were successfully created.
 

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -144,6 +144,7 @@ en:
       errors:
         remove_active_policy: "Sorry, but you cannot remove an active price policy. If you really want to do so move the start date to the future and try again."
         save: There was an error saving the policy
+        same_start_date: "Sorry, but you cannot start a policy the same date as an active policy that has already been applied to an order"
       new:
         success: Price Rules were successfully created.
 

--- a/spec/price_policies_controller_shared_examples.rb
+++ b/spec/price_policies_controller_shared_examples.rb
@@ -262,7 +262,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
           @params[:start_date] = @price_policy.start_date
           do_request
           expect(assigns[:price_policies]).to be_empty
-          expect(response).to redirect_to facility_product_price_policies_path(@authable, @product)
+          expect(response).to redirect_to [@authable, @product, PricePolicy]
         end
 
         it "should reject everything if the expiration date spans into the next fiscal year" do

--- a/spec/price_policies_controller_shared_examples.rb
+++ b/spec/price_policies_controller_shared_examples.rb
@@ -49,12 +49,12 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
         maybe_grant_always_sign_in :director
       end
 
-      it "should assign the product" do
+      it "assigns the product" do
         do_request
         expect(assigns[:product]).to eq(@product)
       end
 
-      it "should set the date to today if there are no active policies" do
+      it "sets the date to today if there are no active policies" do
         expect(@price_policy.destroy).to eq(@price_policy)
         do_request
         expect(response.code).to eq("200")
@@ -62,56 +62,64 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
         expect(assigns[:start_date]).not_to be_nil
         expect(assigns[:start_date]).to match_date Date.today
       end
-      it "should set the date to tomorrow if there are active policies" do
+
+      it "sets the date to tomorrow if there are active policies" do
         do_request
         expect(response).to be_success
         expect(assigns[:start_date]).not_to be_nil
         expect(assigns[:start_date]).to match_date(Date.today + 1.day)
       end
-      it "should set the expiration date to when the fiscal year ends" do
+
+      it "sets the expiration date to when the fiscal year ends" do
         do_request
         expect(assigns[:expire_date]).to eq(PricePolicy.generate_expire_date(Date.today))
       end
-      it "should have a new price policy for each group" do
+
+      it "has a new price policy for each group" do
         do_request
         expect(assigns[:price_policies]).to be_is_a Array
         price_groups = assigns[:price_policies].map(&:price_group)
         expect(price_groups).to contain_all PriceGroup.all
       end
-      it "should set the policies in the correct order" do
+      it "sets the policies in the correct order" do
         @price_group.update_attributes(display_order: 2)
         @price_group2.update_attributes(display_order: 1)
         do_request
         expect(assigns[:price_policies].map(&:price_group)).to eq([@price_group2, @price_group])
       end
-      it "should set each price policy to true" do
+
+      it "sets each price policy to true" do
         make_price_policy(@price_group2)
         do_request
         expect(assigns[:price_policies].size).to eq(2)
         expect(assigns[:price_policies].all?(&:can_purchase?)).to be true
       end
-      it "should render the new template" do
+
+      it "renders the new template" do
         do_request
         expect(response).to render_template("price_policies/new")
       end
+
       context "old policies exist" do
         before :each do
           @price_group2_policy = make_price_policy(@price_group2, can_purchase: false, unit_cost: 13)
         end
 
-        it "should set can_purchase based off old policy" do
+        it "sets can_purchase based off old policy" do
           do_request
           expect(assigns[:price_policies].map(&:price_group)).to eq([@price_policy.price_group, @price_group2_policy.price_group])
           expect(assigns[:price_policies][0]).to be_can_purchase
           expect(assigns[:price_policies][1]).not_to be_can_purchase
         end
-        it "should set fields based off the old policy" do
+
+        it "sets fields based off the old policy" do
           do_request
           expect(assigns[:price_policies].map(&:price_group)).to eq([@price_policy.price_group, @price_group2_policy.price_group])
           expect(assigns[:price_policies][0].unit_cost).to eq(@price_policy.unit_cost)
           expect(assigns[:price_policies][1].unit_cost).to eq(@price_group2_policy.unit_cost)
         end
-        it "should leave can_purchase as false if there isn't an existing policy for the group, but there are policies" do
+
+        it "leaves can_purchase as false if there isn't an existing policy for the group, but there are policies" do
           @price_group3 = FactoryGirl.create(:price_group, facility: facility)
 
           do_request
@@ -126,7 +134,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
           price_group3_policy = assigns[:price_policies].find { |pp| pp.price_group_id == @price_group3.id }
           expect(price_group3_policy).to_not be_can_purchase
         end
-        it "should use the policy with the furthest out expiration date" do
+        it "uses the policy with the furthest out expiration date" do
           @price_policy.update_attributes(unit_cost: 16.0)
           @price_policy2 = make_price_policy(@price_group, start_date: 1.year.from_now, expire_date: SettingsHelper.fiscal_year_end(1.year.from_now), unit_cost: 17.0)
           @price_policy3 = make_price_policy(@price_group, start_date: 1.year.ago, expire_date: SettingsHelper.fiscal_year_end(1.year.ago), unit_cost: 18.0)
@@ -157,15 +165,17 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
         maybe_grant_always_sign_in :director
         do_request
       end
-      it "should assign start date" do
+
+      it "assigns start date" do
         expect(assigns[:start_date]).to eq(@price_policy.start_date.to_date)
       end
-      it "should return the existing policies" do
+
+      it "returns the existing policies" do
         expect(assigns[:price_policies]).to be_include @price_policy
         expect(@price_policy).not_to be_new_record
       end
 
-      it "should return a new policy for other groups" do
+      it "returns a new policy for other groups" do
         new_price_policies = assigns[:price_policies].reject { |pp| pp.price_group == @price_group }
         expect(new_price_policies.map(&:price_group)).to contain_all(PriceGroup.all - [@price_group])
         new_price_policies.each do |pp|
@@ -173,12 +183,12 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
         end
       end
 
-      it "should render the edit template" do
+      it "renders the edit template" do
         is_expected.to render_template("price_policies/edit")
       end
     end
 
-    it "should not allow edit of assigned effective price policy" do
+    it "does not allow edit of assigned effective price policy" do
       @account  = FactoryGirl.create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: @director))
       @order    = @director.orders.create(FactoryGirl.attributes_for(:order, created_by: @director.id))
       @order_detail = @order.order_details.create(FactoryGirl.attributes_for(:order_detail).update(product_id: @product.id, account_id: @account.id, price_policy: @price_policy))
@@ -222,19 +232,20 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
           maybe_grant_always_sign_in :director
         end
 
-        it "should create the new price_groups" do
+        it "creates the new price_groups" do
           do_request
           expect(assigns[:price_policies].map(&:price_group)).to contain_all PriceGroup.all
           assigns[:price_policies].each do |pp|
             expect(pp).not_to be_new_record
           end
         end
-        it "should redirect to show on success" do
+
+        it "redirects to show on success" do
           do_request
           is_expected.to redirect_to price_policy_index_path
         end
 
-        it "should create a new price policy for a group that has no fields, but cant purchase" do
+        it "creates a new price policy for a group that has no fields, but cant purchase" do
           last_price_group = @authable.price_groups.last
           @params.delete :"price_policy_#{last_price_group.id}"
           do_request
@@ -244,7 +255,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
           expect(price_policies_for_empty_group.first).not_to be_can_purchase
         end
 
-        it "should reject everything if expire date is before start date" do
+        it "rejects everything if expire date is before start date" do
           @params[:expire_date] = (@start_date - 2.days).to_s
           do_request
           expect(flash[:error]).not_to be_nil
@@ -254,7 +265,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
           end
         end
 
-        it "should not allow same start date as assigned effective price policy" do
+        it "does not allow same start date as assigned effective price policy" do
           @account  = FactoryGirl.create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: @director))
           @order    = @director.orders.create(FactoryGirl.attributes_for(:order, created_by: @director.id))
           @order_detail = @order.order_details.create(FactoryGirl.attributes_for(:order_detail).update(product_id: @product.id, account_id: @account.id, price_policy: @price_policy))
@@ -265,7 +276,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
           expect(response).to redirect_to [@authable, @product, PricePolicy]
         end
 
-        it "should reject everything if the expiration date spans into the next fiscal year" do
+        it "rejects everything if the expiration date spans into the next fiscal year" do
           @params[:expire_date] = (PricePolicy.generate_expire_date(@start_date) + 1.day).to_s
           do_request
           expect(response).to be

--- a/spec/price_policies_controller_shared_examples.rb
+++ b/spec/price_policies_controller_shared_examples.rb
@@ -245,7 +245,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
           is_expected.to redirect_to price_policy_index_path
         end
 
-        it "creates a new price policy for a group that has no fields, but cant purchase" do
+        it "creates a new price policy for a group that has no fields, but cannot purchase" do
           last_price_group = @authable.price_groups.last
           @params.delete :"price_policy_#{last_price_group.id}"
           do_request

--- a/spec/price_policies_controller_shared_examples.rb
+++ b/spec/price_policies_controller_shared_examples.rb
@@ -254,6 +254,17 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
           end
         end
 
+        it "should not allow same start date as assigned effective price policy" do
+          @account  = FactoryGirl.create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: @director))
+          @order    = @director.orders.create(FactoryGirl.attributes_for(:order, created_by: @director.id))
+          @order_detail = @order.order_details.create(FactoryGirl.attributes_for(:order_detail).update(product_id: @product.id, account_id: @account.id, price_policy: @price_policy))
+
+          @params[:start_date] = @price_policy.start_date
+          do_request
+          expect(assigns[:price_policies]).to be_empty
+          expect(response).to redirect_to facility_product_price_policies_path(@authable, @product)
+        end
+
         it "should reject everything if the expiration date spans into the next fiscal year" do
           @params[:expire_date] = (PricePolicy.generate_expire_date(@start_date) + 1.day).to_s
           do_request


### PR DESCRIPTION
https://pm.tablexi.com/issues/132371

This adds a helpful error message if you try to make a price policy for a product with an active applied price policy with the same start date.