### PR TITLE
Spec updates related to UIC

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe UsersController do
 
   end
 
-  describe "GET #edit" do
+  describe "GET #edit", feature_setting: { create_users: true } do
     let(:user) { FactoryGirl.create(:user, :external) }
 
     before(:each) do
@@ -55,12 +55,10 @@ RSpec.describe UsersController do
       @params[:id] = user.id
     end
 
-    context "when create_users is active", feature_setting: { create_users: true } do
-      it_should_allow_admin_only { expect(assigns[:user]).to eq(user) }
-    end
+    it_should_allow_admin_only { expect(assigns[:user]).to eq(user) }
   end
 
-  describe "PUT #update" do
+  describe "PUT #update", feature_setting: { create_users: true } do
     let(:user) { FactoryGirl.create(:user, :external) }
 
     before(:each) do
@@ -70,20 +68,18 @@ RSpec.describe UsersController do
       @params[:user] = { first_name: "New", last_name: "Name" }
     end
 
-    context "when create_users is active", feature_setting: { create_users: true } do
-      it_should_allow_admin_only(:found) do
-        expect(user.reload.first_name).to eq("New")
-        expect(response).to redirect_to facility_user_path(facility, user)
+    it_should_allow_admin_only(:found) do
+      expect(user.reload.first_name).to eq("New")
+      expect(response).to redirect_to facility_user_path(facility, user)
+    end
+
+    context "with bad params" do
+      before(:each) do
+        @params[:user] = { email: "test@example.com", username: "newusername" }
       end
 
-      context "with bad params" do
-        before(:each) do
-          @params[:user] = { email: "test@example.com", username: "newusername" }
-        end
-
-        it_should_allow_admin_only(:found) do
-          expect(user.reload.first_name).to eq(user.first_name)
-        end
+      it_should_allow_admin_only(:found) do
+        expect(user.reload.first_name).to eq(user.first_name)
       end
     end
   end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Product do
         FactoryGirl.create(
           :instrument_price_policy,
           product: product,
-          price_group: order_detail.user.price_groups.first,
+          price_group: product.price_groups.last,
           start_date: Time.zone.now,
           expire_date: Time.zone.now + 1.day,
           usage_rate: 8 / 60.0,

--- a/vendor/engines/bulk_email/spec/services/bulk_email/recipient_searcher_spec.rb
+++ b/vendor/engines/bulk_email/spec/services/bulk_email/recipient_searcher_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe BulkEmail::RecipientSearcher do
       before { params[:products] = [] }
 
       it "returns all authorized users for any instrument" do
-        expect(users).to match(authorized_users)
+        expect(users).to match_array(authorized_users)
       end
     end
 
@@ -364,7 +364,7 @@ RSpec.describe BulkEmail::RecipientSearcher do
       before { params[:products] = [product.id, product2.id] }
 
       it "returns only the users for both products and no more" do
-        expect(users).to match(authorized_users)
+        expect(users).to match_array(authorized_users)
       end
     end
   end


### PR DESCRIPTION
This updates the `UsersController` specs to use the `create_users` flag to determine if `User#edit` and `User#update` are available, and changes the `Product` model specs to not rely on user-based price groups, which are not available in the UIC fork.

This change should resolve the spec failures in https://github.com/tablexi/nucore-uic/pull/113 when merged.