### PR TITLE
[#133594] extending reservations for instruments with cutoff hours

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -128,7 +128,7 @@ class ReservationsController < ApplicationController
     raise ActiveRecord::RecordNotFound unless @reservation.nil?
 
     options = current_user.can_override_restrictions?(@instrument) ? {} : { user: acting_user }
-    next_available = @instrument.next_available_reservation(1.minute.from_now, default_reservation_mins.minutes, options)
+    next_available = @instrument.next_available_reservation(after: 1.minute.from_now, duration: default_reservation_mins.minutes, options: options)
     @reservation = next_available || default_reservation
     @reservation.round_reservation_times
     unless @instrument.can_be_used_by?(@order_detail.user)

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -304,8 +304,14 @@ class ReservationsController < ApplicationController
 
   # TODO: you shouldn't be able to edit reservations that have passed or are outside of the cancellation period (check to make sure order has been placed)
   def invalid_for_update?
-    can_edit = @reservation.admin_editable?
-    can_edit &&= @reservation.can_customer_edit? unless current_user.administrator?
+    if current_user.administrator? && @reservation.admin_editable?
+      can_edit = true
+    elsif @reservation.can_customer_edit?
+      can_edit = true
+    else
+      can_edit = false
+    end
+
     params[:id].to_i != @reservation.id ||
       @reservation.actual_end_at ||
       !can_edit

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -304,17 +304,19 @@ class ReservationsController < ApplicationController
 
   # TODO: you shouldn't be able to edit reservations that have passed or are outside of the cancellation period (check to make sure order has been placed)
   def invalid_for_update?
-    if current_user.administrator? && @reservation.admin_editable?
-      can_edit = true
-    elsif @reservation.can_customer_edit?
-      can_edit = true
-    else
-      can_edit = false
-    end
-
     params[:id].to_i != @reservation.id ||
       @reservation.actual_end_at ||
-      !can_edit
+      !editable_by_current_user?
+  end
+
+  def editable_by_current_user?
+    if current_user.administrator? && @reservation.admin_editable?
+      true
+    elsif @reservation.can_customer_edit?
+      true
+    else
+      false
+    end
   end
 
   def save_reservation_and_order_detail

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -217,10 +217,10 @@ class Reservation < ActiveRecord::Base
   end
 
   def reserve_end_at_editable?
-    outside_lock_window? && Time.zone.now <= reserve_end_at && next_duration_available? && actual_end_at.blank?
+    outside_lock_window? && Time.zone.now <= reserve_end_at && extendable? && actual_end_at.blank?
   end
 
-  def next_duration_available?
+  def extendable?
     next_available = product.next_available_reservation(after: reserve_end_at, options: { ignore_cutoff: true })
 
     return false unless next_available

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -221,7 +221,7 @@ class Reservation < ActiveRecord::Base
   end
 
   def next_duration_available?
-    next_available = product.next_available_reservation(reserve_end_at)
+    next_available = product.next_available_reservation(after: reserve_end_at, options: { ignore_cutoff: true })
 
     return false unless next_available
 

--- a/app/support/products/scheduling_support.rb
+++ b/app/support/products/scheduling_support.rb
@@ -178,7 +178,7 @@ module Products::SchedulingSupport
     def next_reserval_interval_start(time)
       # ensure reservation start times abide by instrument's reserve_interval (i.e. 5 min increments)
       reserve_interval = @rule.instrument.reserve_interval.to_i
-      if time.min % reserve_interval == 0
+      if (time.min % reserve_interval).zero?
         time
       else
         time + (reserve_interval - time.min % reserve_interval).minutes

--- a/app/support/products/scheduling_support.rb
+++ b/app/support/products/scheduling_support.rb
@@ -52,12 +52,12 @@ module Products::SchedulingSupport
 
   def first_available_hour
     return 0 unless schedule_rules.any?
-    schedule_rules.min { |a, b| a.start_hour <=> b.start_hour }.start_hour
+    schedule_rules.min_by(&:start_hour).start_hour
   end
 
   def last_available_hour
     return 23 unless schedule_rules.any?
-    max_rule = schedule_rules.max { |a, b| a.hour_floor <=> b.hour_floor }
+    max_rule = schedule_rules.max_by(&:hour_floor)
     max_rule.end_min == 0 ? max_rule.end_hour - 1 : max_rule.end_hour
   end
 
@@ -151,6 +151,7 @@ module Products::SchedulingSupport
   end
 
   class ReservationFinder
+
     def initialize(time, rule, options = {})
       @time       = time
       @rule       = rule
@@ -202,5 +203,7 @@ module Products::SchedulingSupport
     def day_end
       Time.zone.local(@time.year, @time.month, @time.day, @rule.end_hour, @rule.end_min, 0)
     end
+
   end
+
 end

--- a/app/support/reservations/moving_up.rb
+++ b/app/support/reservations/moving_up.rb
@@ -8,11 +8,12 @@ module Reservations::MovingUp
   # if there is no such time slot. For read-only purposes.
   def earliest_possible
     after = 1.minute.from_now
-    next_res = product.next_available_reservation(after,
-                                                  duration_mins.minutes,
-                                                  exclude: self,
-                                                  user: user,
-                                                  until: reserve_start_at)
+    next_res = product.next_available_reservation(after: after,
+                                                  duration: duration_mins.minutes,
+                                                  options:
+                                                    { exclude: self,
+                                                      user: user,
+                                                      until: reserve_start_at })
     return nil if next_res.nil? || next_res.reserve_start_at >= reserve_start_at
     next_res
   end

--- a/spec/factories/reservations.rb
+++ b/spec/factories/reservations.rb
@@ -98,7 +98,7 @@ FactoryGirl.define do
     transient { user nil }
 
     after(:create) do |reservation, evaluator|
-      reservation.order.update_attribute(user_id: evaluator.user.id) if evaluator.user
+      reservation.order.update_attribute(:user_id, evaluator.user.id) if evaluator.user
       reservation.order.purchase!
     end
 

--- a/spec/factories/reservations.rb
+++ b/spec/factories/reservations.rb
@@ -98,7 +98,7 @@ FactoryGirl.define do
     transient { user nil }
 
     after(:create) do |reservation, evaluator|
-      reservation.order.update_attribute(:user_id, evaluator.user.id) if evaluator.user
+      reservation.order.update_attributes(user_id: evaluator.user.id) if evaluator.user
       reservation.order.purchase!
     end
 

--- a/spec/factories/reservations.rb
+++ b/spec/factories/reservations.rb
@@ -98,7 +98,7 @@ FactoryGirl.define do
     transient { user nil }
 
     after(:create) do |reservation, evaluator|
-      reservation.order.update_attributes(user_id: evaluator.user.id) if evaluator.user
+      reservation.order.update_attribute(user_id: evaluator.user.id) if evaluator.user
       reservation.order.purchase!
     end
 

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -444,16 +444,16 @@ RSpec.describe Instrument do
 
     it "should find next available reservation with 60 minute interval rule, without any pending reservations" do
       # find next reservation after 12 am at 9 am
-      @next_reservation = @instrument.next_available_reservation(after = Time.zone.now.beginning_of_day)
+      @next_reservation = @instrument.next_available_reservation(after: Time.zone.now.beginning_of_day)
       assert_equal Time.zone.now.day, @next_reservation.reserve_start_at.day
       assert_equal 9, @next_reservation.reserve_start_at.hour
       # find next reservation after 9:01 am today at 10 am today
-      @next_reservation = @instrument.next_available_reservation(after = Time.zone.now.beginning_of_day + 9.hours + 1.minute)
+      @next_reservation = @instrument.next_available_reservation(after: Time.zone.now.beginning_of_day + 9.hours + 1.minute)
       assert_equal Time.zone.now.day, @next_reservation.reserve_start_at.day
       assert_equal 10, @next_reservation.reserve_start_at.hour
       assert_equal 0, @next_reservation.reserve_start_at.min
       # find next reservation after 4:01 pm today at 9 am tomorrow
-      @next_reservation = @instrument.next_available_reservation(after = Time.zone.now.beginning_of_day + 16.hours + 1.minute)
+      @next_reservation = @instrument.next_available_reservation(after: Time.zone.now.beginning_of_day + 16.hours + 1.minute)
       assert_equal (Time.zone.now + 1.day).day, @next_reservation.reserve_start_at.day
       assert_equal 9, @next_reservation.reserve_start_at.hour
       assert_equal 0, @next_reservation.reserve_start_at.min
@@ -464,32 +464,32 @@ RSpec.describe Instrument do
       res_end = res_start + 10.days
       reservation = @instrument.reservations.create reserve_start_at: res_start, reserve_end_at: res_end
       expect(reservation).to be_valid
-      next_reservation = @instrument.next_available_reservation res_start
+      next_reservation = @instrument.next_available_reservation(after: res_start)
       expect(next_reservation.reserve_start_at).to be > res_end
-      expect(next_reservation.reserve_start_at).to eq @instrument.next_available_reservation(res_end).reserve_start_at
+      expect(next_reservation.reserve_start_at).to eq @instrument.next_available_reservation(after: res_end).reserve_start_at
     end
 
     it "should find next available reservation with 5 minute interval rule, without any pending reservations" do
       expect(@rule.instrument.update_attribute :reserve_interval, 5).to be true
       # find next reservation after 12 am at 9 am
-      @next_reservation = @instrument.next_available_reservation(after = Time.zone.now.beginning_of_day)
+      @next_reservation = @instrument.next_available_reservation(after: Time.zone.now.beginning_of_day)
       assert_equal Time.zone.now.day, @next_reservation.reserve_start_at.day
       assert_equal 9, @next_reservation.reserve_start_at.hour
       assert_equal 0, @next_reservation.reserve_start_at.min
       # find next reservation after 9:01 am today at 9:05 am today
-      @next_reservation = @instrument.next_available_reservation(after = Time.zone.now.beginning_of_day + 9.hours + 1.minute)
+      @next_reservation = @instrument.next_available_reservation(after: Time.zone.now.beginning_of_day + 9.hours + 1.minute)
       assert_equal Time.zone.now.day, @next_reservation.reserve_start_at.day
       assert_equal 9, @next_reservation.reserve_start_at.hour
       assert_equal 5, @next_reservation.reserve_start_at.min
       # find next reservation after 3:45 pm today at 3:45 pm today
-      @next_reservation = @instrument.next_available_reservation(after = Time.zone.now.beginning_of_day + 15.hours + 45.minutes)
+      @next_reservation = @instrument.next_available_reservation(after: Time.zone.now.beginning_of_day + 15.hours + 45.minutes)
       assert_equal Time.zone.now.day, @next_reservation.reserve_start_at.day
       assert_equal 15, @next_reservation.reserve_start_at.hour
       assert_equal 45, @next_reservation.reserve_start_at.min
     end
 
     context "with cutoff hours" do
-      let(:next_reservation) { @instrument.next_available_reservation(after = Time.zone.now.beginning_of_day) }
+      let(:next_reservation) { @instrument.next_available_reservation(after: Time.zone.now.beginning_of_day) }
 
       before { @rule.instrument.update_attribute :cutoff_hours, 10 }
 
@@ -509,7 +509,7 @@ RSpec.describe Instrument do
                                                       split_times: true)
       assert @reservation1.valid?
       # find next reservation after 12 am tomorrow at 10 am tomorrow
-      @next_reservation = @instrument.next_available_reservation(after = Time.zone.now.end_of_day + 1.second)
+      @next_reservation = @instrument.next_available_reservation(after: Time.zone.now.end_of_day + 1.second)
       assert_equal (Time.zone.now + 1.day).day, @next_reservation.reserve_start_at.day
       assert_equal 10, @next_reservation.reserve_start_at.hour
     end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1348,7 +1348,7 @@ RSpec.describe Reservation do
         .to contain_all [@today_reservation, @spans_day_reservation]
     end
 
-    it "returns a reservation that spands days when looking up the later date" do
+    it "returns a reservation that spans days when looking up the later date" do
       expect(Reservation.for_date(Time.zone.now + 1.day))
         .to contain_all [@tomorrow_reservation, @spans_day_reservation]
     end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1472,8 +1472,7 @@ RSpec.describe Reservation do
 
           before { reservation.start_reservation! }
 
-          it {
-            expect(reservation.next_duration_available?).to be_truthy }
+          it { expect(reservation.next_duration_available?).to be_truthy }
         end
       end
 
@@ -1488,8 +1487,7 @@ RSpec.describe Reservation do
 
           before { reservation.start_reservation! }
 
-          it {
-            expect(reservation.next_duration_available?).to be_truthy }
+          it { expect(reservation.next_duration_available?).to be_truthy }
         end
       end
     end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1457,6 +1457,20 @@ RSpec.describe Reservation do
         expect(reservation.next_duration_available?).to eq(false)
       end
     end
+
+    context "when the instrument has cutoff_hours set to 1" do
+      before { instrument.update_attributes(cutoff_hours: 1) }
+
+      context "when the reservation is started", :time_travel do
+        let(:now) { reservation.reserve_start_at }
+
+        before { reservation.start_reservation! }
+
+        it {
+          binding.pry
+          expect(reservation.next_duration_available?).to be_truthy }
+      end
+    end
   end
 
   describe "#duration_mins" do

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1427,8 +1427,8 @@ RSpec.describe Reservation do
   describe "#extendable?" do
     subject(:reservation) do
       FactoryGirl.build(:purchased_reservation,
-                         :running,
-                         product: instrument)
+                        :running,
+                        product: instrument)
     end
 
     before do
@@ -1443,9 +1443,9 @@ RSpec.describe Reservation do
     context "with another reservation following" do
       let(:other_reservation) do
         FactoryGirl.build(:purchased_reservation,
-                           reserve_start_at: reservation.reserve_end_at,
-                           reserve_end_at: reservation.reserve_end_at + 1.hour,
-                           product: reservation.product)
+                          reserve_start_at: reservation.reserve_end_at,
+                          reserve_end_at: reservation.reserve_end_at + 1.hour,
+                          product: reservation.product)
       end
 
       before do
@@ -1497,9 +1497,9 @@ RSpec.describe Reservation do
       context "with another reservation following" do
         let(:other_reservation) do
           FactoryGirl.build(:purchased_reservation,
-                             reserve_start_at: reservation.reserve_end_at,
-                             reserve_end_at: reservation.reserve_end_at + 1.hour,
-                             product: reservation.product)
+                            reserve_start_at: reservation.reserve_end_at,
+                            reserve_end_at: reservation.reserve_end_at + 1.hour,
+                            product: reservation.product)
         end
 
         before do


### PR DESCRIPTION
- https://pm.tablexi.com/issues/133594 (Dartmouth)
- https://pm.tablexi.com/issues/28901 (NU)
- https://pm.tablexi.com/issues/121867 (UIC)

Extending reservations behaves appropriately in conjunction with mandated advance reservations (cutoff hours).

