### PR TITLE
[#125661] Handle case of account owner in statement

### DIFF
--- a/app/support/statement_pdf.rb
+++ b/app/support/statement_pdf.rb
@@ -74,6 +74,9 @@ class StatementPdf
 
     pdf.text @facility.to_s, size: 20, font_style: :bold
     pdf.text "Invoice ##{@statement.invoice_number}"
+    pdf.text "Account: #{@account}"
+    pdf.text "Owner: #{@account.owner.user}"
+    pdf.move_down(10)
   end
 
   def generate_order_detail_rows(pdf)

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Notifier do
 
   if EngineManager.engine_loaded?(:c2po)
     describe ".statement" do
-      let(:account) { FactoryGirl.build_stubbed(:purchase_order_account) }
+      let(:account) { FactoryGirl.create(:purchase_order_account, :with_account_owner) }
       let(:statement) { FactoryGirl.build_stubbed(:statement, facility: facility, account: account) }
       let(:email_html) { email.html_part.to_s.gsub(/&nbsp;/, " ") } # Markdown changes some whitespace to &nbsp;
       let(:email_text) { email.text_part.to_s }


### PR DESCRIPTION
NU’s statement includes the account owner. The new test from #872 did
not set up an owner so it was crashing when running under NU.

I added the owner to the statement to reproduce the failure I was
seeing in NU, then adjusted the test.