### PR TITLE
CLOB safe distinct

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -41,7 +41,9 @@ class Journal < ActiveRecord::Base
 
   has_many                :journal_rows
   belongs_to              :facility
-  has_many :order_details, -> { uniq }, through: :journal_rows
+  # The distinct is necessary for SplitAccount orders where one order detail might
+  # be split across multiple journal rows
+  has_many :order_details, -> { clob_safe_distinct }, through: :journal_rows
   belongs_to              :created_by_user, class_name: "User", foreign_key: :created_by
 
   validates_presence_of   :reference, :updated_by, on: :update

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -7,6 +7,7 @@ class OrderDetail < ActiveRecord::Base
   include NotificationSubject
   include OrderDetail::Accessorized
   include NUCore::Database::WhereIdsIn
+  include NUCore::Database::ClobSafeDistinct
 
   versioned
 

--- a/lib/nucore.rb
+++ b/lib/nucore.rb
@@ -34,6 +34,29 @@ module NUCore
       end
     end
 
+    # Oracle has problems with doing `DISTINCT *` on a table that contains
+    # a CLOB (i.e. text) column.
+    # See https://github.com/rsim/oracle-enhanced/issues/112
+    module ClobSafeDistinct
+
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+
+        def clob_safe_distinct
+          if NUCore::Database.oracle?
+            # `select` instead of `pluck` results in a subquery rather than
+            # two queries.
+            where(id: distinct.select(:id))
+          else
+            distinct
+          end
+        end
+
+      end
+
+    end
+
     module WhereIdsIn
 
       extend ActiveSupport::Concern


### PR DESCRIPTION
Oracle has problems when doing `DISTINCT *` on a table containing CLOBs, which
we now do after changing `order_details.note` to a text field.