### PR TITLE
user edit link appears only if feature is on

### DIFF
--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -26,7 +26,11 @@ class Ability
         end
         unless user.account_manager?
           cannot :manage, User unless resource.is_a?(Facility) && resource.single_facility?
-          cannot([:edit, :update], User) { |target_user| !target_user.admin_editable? }
+          if SettingsHelper.feature_on?(:create_users)
+            cannot([:edit, :update], User) { |target_user| !target_user.admin_editable? }
+          else
+            cannot([:edit, :update], User)
+          end
         end
       end
 


### PR DESCRIPTION
We saw behavior on UIC where the user edit link was available even though the `:create_users` feature was turned off. The link would then error, since the route did not exist in that context.

This PR corrects that behavior and adds specs verifying that the correct behavior occurs both when the feature is turned on and turned off.