### PR TITLE
[#134955] Update paths for file uploads

### DIFF
--- a/app/views/admin/shared/_tabnav_product.html.haml
+++ b/app/views/admin/shared/_tabnav_product.html.haml
@@ -15,7 +15,11 @@
   - if @product.is_a?(Instrument)
     = tab "Restrictions", edit_facility_price_group_product_path(current_facility, @product), (secondary_tab == "restrictions")
     = tab "Reservations", facility_instrument_schedule_path(current_facility, @product), (secondary_tab == "reservations")
-  = tab "Docs", [current_facility, @product, :file_uploads, file_type: "info"], (secondary_tab == "documentation")
+
+  = tab "Docs",
+    [current_facility, @product, :file_uploads, file_type: "info"],
+    (secondary_tab == "documentation")
+
   - if @product.is_a?(Service)
     = tab "Order Forms", product_survey_path(current_facility, @product.parameterize, @product.url_name), (secondary_tab == "surveys")
   - if @product.respond_to?(:reservations)

--- a/app/views/file_uploads/product_survey.html.haml
+++ b/app/views/file_uploads/product_survey.html.haml
@@ -99,7 +99,7 @@
           %tr
             %td
               = link_to text("shared.delete"),
-                [current_facility, @product, :remove_product_file, id: stored_file],
+                [current_facility, @product, stored_file],
                 method: :delete,
                 data: { confirm: t(".download_form.confirm") }
 

--- a/app/views/file_uploads/product_survey.html.haml
+++ b/app/views/file_uploads/product_survey.html.haml
@@ -99,7 +99,7 @@
           %tr
             %td
               = link_to text("shared.delete"),
-                [current_facility, @product, stored_file],
+                [current_facility, @product, :file_upload, id: stored_file],
                 method: :delete,
                 data: { confirm: t(".download_form.confirm") }
 


### PR DESCRIPTION
https://pm.tablexi.com/issues/134955

The "Docs" and "Order Forms" product paths needed changes after the routing cleanup in #894.