### PR TITLE
[#133442] Redirect to order assignment when not logged in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -144,12 +144,6 @@ class ApplicationController < ActionController::Base
     render "/acting_error", status: 403, layout: "application"
   end
 
-  #
-  # Customize Devise redirect after login
-  def after_sign_in_path_for(resource)
-    session[:requested_params] || super
-  end
-
   def after_sign_out_path_for(_)
     if current_facility.present?
       facility_path(current_facility)
@@ -176,7 +170,7 @@ class ApplicationController < ActionController::Base
   end
 
   def store_fullpath_in_session
-    session[:requested_params] = request.fullpath
+    store_location_for(:user, request.fullpath) unless current_user
   end
 
   def current_ability

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -83,6 +83,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
   end
 
   def authorize_order_detail
+    session[:requested_params] = request.path if request.get? && !request.xhr? && !user_signed_in?
     authorize! :update, @order_detail
   end
 

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -2,6 +2,8 @@ class OrderManagement::OrderDetailsController < ApplicationController
 
   include OrderDetailFileDownload
 
+  before_action :authenticate_user!
+
   load_resource :facility, find_by: :url_name
   load_resource :order, through: :facility
   load_resource :order_detail, through: :order
@@ -83,7 +85,6 @@ class OrderManagement::OrderDetailsController < ApplicationController
   end
 
   def authorize_order_detail
-    session[:requested_params] = request.path if request.get? && !request.xhr?
     authorize! :update, @order_detail
   end
 

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -83,7 +83,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
   end
 
   def authorize_order_detail
-    session[:requested_params] = request.path if request.get? && !request.xhr? && !user_signed_in?
+    session[:requested_params] = request.path if request.get? && !request.xhr?
     authorize! :update, @order_detail
   end
 

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -131,7 +131,6 @@ RSpec.describe InstrumentsController do
       it "requires sign in" do
         do_request
         expect(assigns(:product)).to eq(instrument)
-        expect(session[:requested_params]).to be_present
         assert_redirected_to new_user_session_path
       end
 


### PR DESCRIPTION
https://pm.tablexi.com/issues/133442

As a non-logged in user, the staff member is redirected appropriately when clicking an order link from an assigned staff email.