### PR TITLE
Instructions and scripts on running Oracle with Docker

### DIFF
--- a/config/database.yml.oracle.template
+++ b/config/database.yml.oracle.template
@@ -1,15 +1,15 @@
 defaults: &defaults
   adapter: oracle_enhanced
-  database: 10.114.22.3:1521/xe
-  encoding: utf8
+  username: nucore_open_development
+  password: password
+  database: localhost:1521/xe
 
 development:
   <<: *defaults
   username: nucore_open_development
-  password:
+  password: password
 
 test:
   <<: *defaults
   username: nucore_open_test
-  password:
-
+  password: password

--- a/db/migrate/20120510172358_add_bi_table.rb
+++ b/db/migrate/20120510172358_add_bi_table.rb
@@ -5,7 +5,7 @@ class AddBiTable < ActiveRecord::Migration
       create_table :bi_netids do |t|
         t.string :netid, null: false
         t.references :facility, null: false
-        t.foreign_key :facility
+        t.foreign_key :facilities
       end
 
       add_index :bi_netids, :netid

--- a/db/migrate/20160415231343_clean_duplicate_reservations.rb
+++ b/db/migrate/20160415231343_clean_duplicate_reservations.rb
@@ -13,7 +13,11 @@ class CleanDuplicateReservations < ActiveRecord::Migration
       Reservation.where(order_detail_id: order_detail_id).last.destroy
     end
     if NUCore::Database.oracle?
-      remove_index :reservations, :order_detail_id
+      begin
+        remove_index :reservations, :order_detail_id
+      rescue
+        # this index might not exist; unsure why
+      end
     end
     add_index :reservations, :order_detail_id, unique: true, name: "res_od_uniq_fk"
   end

--- a/doc/HOWTO_docker.md
+++ b/doc/HOWTO_docker.md
@@ -14,17 +14,6 @@ enabled.
 
 - `cp config/database.yml.oracle.template config/database.yml`
 
-Update your database.yml to look like this:
-
-```
-development:
-  adapter: oracle_enhanced
-  database: oracle.local/xe
-  username: nucores_development
-  password: testing
-  encoding: utf8
-```
-
 ```
 docker run -d -p 1521:1521 --name nucore_db wnameless/oracle-xe-11g
 # wait, it sometimes takes a few minutes to come up

--- a/doc/HOWTO_docker.md
+++ b/doc/HOWTO_docker.md
@@ -1,0 +1,29 @@
+# Using Docker for Development
+
+## Install Docker
+
+* Download and install Docker https://docs.docker.com/engine/getstarted/step_one/
+
+## Running Oracle Standalone
+
+If you want to run the Oracle database in Docker, but the app itself in your native
+environment, please follow [the instructions for how to install the Oracle drivers](HOWTO_oracle.txt) first, and then proceed from here.
+
+Make sure you have the `activerecord-oracle_enhanced-adapter` and `ruby-oci8` gems
+enabled.
+
+```
+cp config/database.yml.oracle.template config/database.yml
+docker run -d -p 1521:1521 --name nucore_db wnameless/oracle-xe-11g
+# @ait, it sometimes takes a few minutes to come up
+# "ORA-01033: ORACLE initialization or shutdown in progress" means wait.
+docker/oracle/setup.sh
+# demo:seed is optional
+rake demo:seed
+```
+
+Next time you want to start the server,
+
+```
+docker start nucore_db
+```

--- a/doc/HOWTO_docker.md
+++ b/doc/HOWTO_docker.md
@@ -12,10 +12,22 @@ environment, please follow [the instructions for how to install the Oracle drive
 Make sure you have the `activerecord-oracle_enhanced-adapter` and `ruby-oci8` gems
 enabled.
 
+- `cp config/database.yml.oracle.template config/database.yml`
+
+Update your database.yml to look like this:
+
 ```
-cp config/database.yml.oracle.template config/database.yml
+development:
+  adapter: oracle_enhanced
+  database: oracle.local/xe
+  username: nucores_development
+  password: testing
+  encoding: utf8
+```
+
+```
 docker run -d -p 1521:1521 --name nucore_db wnameless/oracle-xe-11g
-# @ait, it sometimes takes a few minutes to come up
+# wait, it sometimes takes a few minutes to come up
 # "ORA-01033: ORACLE initialization or shutdown in progress" means wait.
 docker/oracle/setup.sh
 # demo:seed is optional

--- a/doc/HOWTO_ldap.md
+++ b/doc/HOWTO_ldap.md
@@ -1,4 +1,4 @@
-# HOWTO Configure LDAP For NUcore
+# HOWTO Configure NUcore for LDAP Authentication
 
 ## Enabling LDAP Authentication On NUcore
 

--- a/doc/HOWTO_oracle.txt
+++ b/doc/HOWTO_oracle.txt
@@ -38,15 +38,6 @@ export OCI_DIR=$ORACLE_HOME
 
 source ~/.profile
 
-########################################
-If you're using tcsh:
-# Add to (tcsh) ~/.tcshrc
-setenv NLS_LANG "AMERICAN_AMERICA.UTF8"
-setenv ORACLE_HOME /opt/oracle/instantclient
-setenv OCI_DIR=$ORACLE_HOME
-
-source ~/.tcshrc
-
 #########################################
 # sqlplus in path
 sudo ln -s /opt/oracle/instantclient/sqlplus /usr/local/bin/sqlplus
@@ -69,19 +60,4 @@ Enter user-name:
 
 ^D out of that and carry on.
 
-################################################################################
-# ruby-oci8 and activerecord-oracle_enhanced adapter
-################################################################################
-# Instructions sourced from:
-# http://blog.rayapps.com/2009/09/06/how-to-setup-ruby-and-oracle-instant-client-on-snow-leopard/
-
-*** As of Instant client 11.2, you should not need to do anything special ***
-
-# configure database.yml in your rails project
-development:
-  adapter: oracle_enhanced
-  database: oracle.local/xe
-  username: nucores_development
-  password: testing
-  encoding: utf8
-
+`cp config/database.yml.oracle.template config/database.yml`

--- a/doc/HOWTO_oracle.txt
+++ b/doc/HOWTO_oracle.txt
@@ -19,17 +19,18 @@ sudo mkdir -p /opt/oracle/
 cd /opt/oracle
 
 sudo mv ~/Downloads/instantclient-* /opt/oracle
-sudo unzip instantclient-basic-macos.x64-11.2.0.3.0.zip
-sudo unzip instantclient-sdk-macos.x64-11.2.0.3.0.zip
-sudo unzip instantclient-sqlplus-macos.x64-11.2.0.3.0.zip
+sudo unzip instantclient-basic-macos.x64-12.1.0.2.0.zip
+sudo unzip instantclient-sdk-macos.x64-12.1.0.2.0.zip
+sudo unzip instantclient-sqlplus-macos.x64-12.1.0.2.0.zip
 
-sudo ln -s instantclient_11_2 instantclient
+sudo ln -s instantclient_12_1 instantclient
 
 cd instantclient
-sudo ln -s libclntsh.dylib.11.1 libclntsh.dylib
-sudo ln -s libocci.dylib.11.1   libocci.dylib
+sudo ln -s libclntsh.dylib.12.1 libclntsh.dylib
+sudo ln -s libocci.dylib.12.1   libocci.dylib
 
 ########################################
+If you're using bash:
 # Add to (bash) ~/.profile
 export NLS_LANG="AMERICAN_AMERICA.AL32UTF8"
 export ORACLE_HOME=/opt/oracle/instantclient
@@ -38,6 +39,7 @@ export OCI_DIR=$ORACLE_HOME
 source ~/.profile
 
 ########################################
+If you're using tcsh:
 # Add to (tcsh) ~/.tcshrc
 setenv NLS_LANG "AMERICAN_AMERICA.UTF8"
 setenv ORACLE_HOME /opt/oracle/instantclient
@@ -46,25 +48,26 @@ setenv OCI_DIR=$ORACLE_HOME
 source ~/.tcshrc
 
 #########################################
-# El Capitan
-
-In El Capitan, DYLD_* environment variables are unset by default for security reasons.
-
-The scripts here allow instantclient to work without the DYLD_ variables
-https://github.com/kubo/fix_oralib_osx
-
-```
-cd $ORACLE_HOME
-curl -O https://raw.githubusercontent.com/kubo/fix_oralib_osx/master/fix_oralib.rb
-ruby fix_oralib.rb
-```
-
 # sqlplus in path
 sudo ln -s /opt/oracle/instantclient/sqlplus /usr/local/bin/sqlplus
 
 # test it
 # sqlplus myuser/mypassword@//myserver:1521/mydatabase.mydomain.com
 
+You will see an output like this:
+```
+SQL*Plus: Release 12.1.0.2.0 Production on Fri Mar 3 13:48:51 2017
+
+Copyright (c) 1982, 2016, Oracle.  All rights reserved.
+
+ERROR:
+ORA-12154: TNS:could not resolve the connect identifier specified
+
+
+Enter user-name:
+```
+
+^D out of that and carry on.
 
 ################################################################################
 # ruby-oci8 and activerecord-oracle_enhanced adapter
@@ -82,28 +85,3 @@ development:
   password: testing
   encoding: utf8
 
-
-# Other untested techniques...
-# Choose one of the methods at the bottom of this page: http://wiki.github.com/rsim/oracle-enhanced/troubleshooting
-
-# ------------------------------------------------------------------------------
-# Configuring environment variables for GUI launched Eclipse/RadRails, etc.
-# ------------------------------------------------------------------------------
-# Sourced from:
-# http://developer.apple.com/mac/library/documentation/MacOSX/Conceptual/BPRuntimeConfig/Articles/EnvironmentVars.html#//apple_ref/doc/uid/20002093-BCIJIJBH
-# http://developer.apple.com/mac/library/qa/qa2001/qa1255.html
-# http://developer.apple.com/mac/library/qa/qa2001/qa1067.html
-
-# emacs ~/.MacOSX/environment.plist, then login again
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>ORACLE_HOME</key>
-  <string>/opt/oracle/instantclient</string>
-  <key>OCI_DIR</key>
-  <string>/opt/oracle/instantclient</string>
-  <key>NLS_LANG</key>
-  <string>AMERICAN_AMERICA.AL32UTF8</string>
-</dict>
-</plist>

--- a/docker/oracle/create_databases.rb
+++ b/docker/oracle/create_databases.rb
@@ -1,0 +1,19 @@
+require 'yaml'
+require 'erb'
+
+puts "Loading database config"
+config_file_path = File.expand_path('../../../config/database.yml', __FILE__)
+erb = ERB.new(File.read(config_file_path)).result
+config = YAML.load( erb )
+
+sql_file = File.expand_path("../setup.sql", __FILE__)
+
+begin
+  puts "Creating database users"
+  connection_string = "system/oracle@#{config["development"]["database"]}"
+  output = `sqlplus #{connection_string} < #{sql_file}`
+  puts output
+# On a fresh create, it may take a few seconds for oracle server to come up,
+# so rety this block until we create the user
+end until output.include?("User created.")
+

--- a/docker/oracle/create_databases.rb
+++ b/docker/oracle/create_databases.rb
@@ -4,16 +4,16 @@ require 'erb'
 puts "Loading database config"
 config_file_path = File.expand_path('../../../config/database.yml', __FILE__)
 erb = ERB.new(File.read(config_file_path)).result
-config = YAML.load( erb )
+config = YAML.safe_load(erb)
 
 sql_file = File.expand_path("../setup.sql", __FILE__)
 
-begin
+loop do
   puts "Creating database users"
-  connection_string = "system/oracle@#{config["development"]["database"]}"
+  connection_string = "system/oracle@#{config['development']['database']}"
   output = `sqlplus #{connection_string} < #{sql_file}`
   puts output
-# On a fresh create, it may take a few seconds for oracle server to come up,
-# so rety this block until we create the user
-end until output.include?("User created.")
-
+  break if output.include?("User created.")
+  # On a fresh create, it may take a few seconds for oracle server to come up,
+  # so rety this block until we create the user
+end

--- a/docker/oracle/setup.sh
+++ b/docker/oracle/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+echo "Creating Databases"
+ruby docker/oracle/create_databases.rb
+
+echo "Loading development schema"
+bundle exec rake db:oracle_drop_severe
+bundle exec rake db:migrate
+
+echo "Loading test schema"
+export RAILS_ENV=test
+bundle exec rake db:oracle_drop_severe
+bundle exec rake db:schema:load
+
+echo "Done!"

--- a/docker/oracle/setup.sql
+++ b/docker/oracle/setup.sql
@@ -1,0 +1,20 @@
+alter profile default limit password_life_time unlimited;
+
+CREATE USER nucore_open_development
+    IDENTIFIED BY password
+    DEFAULT TABLESPACE users
+    TEMPORARY TABLESPACE temp;
+
+GRANT connect, resource TO nucore_open_development;
+
+CREATE USER nucore_open_test
+    IDENTIFIED BY password
+    DEFAULT TABLESPACE users
+    TEMPORARY TABLESPACE temp;
+
+GRANT connect, resource TO nucore_open_test;
+
+-- create tablespace BC_NUCORE
+--     DATAFILE 'bc_nucore.dat'
+--     SIZE 100M
+--     AUTOEXTEND ON;

--- a/lib/tasks/demo_seed.rake
+++ b/lib/tasks/demo_seed.rake
@@ -53,7 +53,7 @@ namespace :demo do
     pgnu = pgex = nil
 
     Settings.price_group.name.to_hash.each do |k, v|
-      price_group = PriceGroup.find_or_create_by!(name: v) do |pg|
+      price_group = PriceGroup.find_or_initialize_by(name: v) do |pg|
         pg.is_internal = (k == :base || k == :cancer_center)
         pg.display_order = order
       end


### PR DESCRIPTION
This is a pared down version of #436 from way back when. That branch sought to do a full environment with Docker. This only has instructions for getting the database set up and the necessary scripts. It assumes you'll be running the app in your native environment.

It also includes some updates for running `rake db:migrate` from scratch. It does not include the resulting Oracle-based `schema.rb`.

Meara and I can use this as a base for getting her NU environment up and running.