### PR TITLE
[#135129] Re-enable Accounts tab within users for UIC

### DIFF
--- a/app/views/admin/shared/_tabnav_users.html.haml
+++ b/app/views/admin/shared/_tabnav_users.html.haml
@@ -13,7 +13,7 @@
       facility_user_reservations_path(current_facility, @user),
       secondary_tab == "reservations"
 
-  - if SettingsHelper.feature_on?(:manage_payment_sources_with_users) && current_ability.can?(:manage, Account)
+  - if current_ability.can?(:manage, Account)
     = tab t(".accounts"),
       facility_user_accounts_path(current_facility, @user),
       secondary_tab == "accounts"


### PR DESCRIPTION
UIC has manage_payment_sources_with_users: false. Their managers should still be able
to see this tab. When a manager clicks on the payment source, they get kicked over
to the Billing tab, which should be fine.

This was changed in #862.