### PR TITLE
Fix Statment flash spec for when it is not using a CC account

### DIFF
--- a/spec/controllers/facility_statements_controller_spec.rb
+++ b/spec/controllers/facility_statements_controller_spec.rb
@@ -171,7 +171,7 @@ if Account.config.statements_enabled?
         it "displays properly formatted flash message" do
           sign_in(@user)
           do_request
-          expect(flash[:notice]).to match(%r{Notifications sent successfully to:<br/>.*account description<br/.*})
+          expect(flash[:notice]).to start_with("Notifications sent successfully to:<br/>#{@account.account_list_item}<br/")
         end
       end
 


### PR DESCRIPTION
UIC allows their RRC accounts (NufsAccount) to be statemented. This spec was
failing when merged into their fork.