### PR TITLE
[#135273] feature flag for responsive site

### DIFF
--- a/app/views/shared/_head.html.haml
+++ b/app/views/shared/_head.html.haml
@@ -1,6 +1,8 @@
 %meta{ "http-equiv" => "content-type", "content" => "text/html; charset=UTF-8" }
 - # use gsub to strip out html tags in the title to prevent html from showing #62643
 = render partial: "/shared/title", locals: { title: yield(:h1).gsub(/<[^>]*>/, " ") }
+- if SettingsHelper.feature_on?(:responsive)
+  %meta{name: "viewport", content: "width=device-width; initial-scale=1.0;"}
 = stylesheet_link_tag "application", media: :all
 = stylesheet_link_tag "print", media: :print
 = javascript_include_tag "application"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -120,6 +120,7 @@ feature:
   results_file_notifications_on: true
   set_statement_search_start_date_on: false
   send_statement_emails_on: true
+  responsive_on: false
 
 # This may be overridden in settings.local.yml if your fork is using S3, so
 # be sure to check there for configuration


### PR DESCRIPTION
[#135273](https://pm.tablexi.com/issues/135273)

add:

```
# For these settings use SettingsHelper#feature_on?
feature:
  responsive_on: true
```

to `settings.local.yml`