### PR TITLE
[#140850111] Genericize Product Access Groups and apply to SecureRooms

### DIFF
--- a/app/controllers/concerns/belongs_to_product_controller.rb
+++ b/app/controllers/concerns/belongs_to_product_controller.rb
@@ -1,0 +1,27 @@
+module BelongsToProductController
+
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authenticate_user!
+    before_action :check_acting_as
+    before_action :init_current_facility
+    before_action :init_product
+  end
+
+  private
+
+  def init_product
+    @product = current_facility.products.find_by!(url_name: product_id)
+  end
+
+  def product_id
+    params[product_key]
+  end
+
+  def product_key
+    valid_ids = Product.types.map { |t| "#{t.model_name.param_key}_id" }
+    params.keys.find { |k| k.in?(valid_ids) }
+  end
+
+end

--- a/app/controllers/product_access_groups_controller.rb
+++ b/app/controllers/product_access_groups_controller.rb
@@ -1,14 +1,9 @@
 class ProductAccessGroupsController < ApplicationController
 
-  before_action :authenticate_user!
-  before_action :init_current_facility
-
+  include BelongsToProductController
   admin_tab :all
-  load_and_authorize_resource :facility, find_by: :url_name
-  load_and_authorize_resource :instrument, through: :facility, find_by: :url_name
-  load_and_authorize_resource :product_access_group, through: :instrument
 
-  before_action :init_current_product
+  load_and_authorize_resource :product_access_group, through: :product
 
   layout "two_column"
 
@@ -29,17 +24,17 @@ class ProductAccessGroupsController < ApplicationController
   def update
     if @product_access_group.update_attributes(params[:product_access_group])
       flash[:notice] = "#{ProductAccessGroup.model_name.human} was successfully updated"
-      redirect_to facility_instrument_product_access_groups_path(@facility, @instrument)
+      redirect_to [current_facility, @product, ProductAccessGroup]
     else
       render action: :edit
     end
   end
 
   def create
-    @product_access_group = @instrument.product_access_groups.new(params[:product_access_group])
+    @product_access_group = @product.product_access_groups.new(params[:product_access_group])
     if @product_access_group.save
       flash[:notice] = "#{ProductAccessGroup.model_name.human} was successfully created"
-      redirect_to facility_instrument_product_access_groups_path(@facility, @instrument)
+      redirect_to [current_facility, @product, ProductAccessGroup]
     else
       render action: :new
     end
@@ -48,18 +43,11 @@ class ProductAccessGroupsController < ApplicationController
   def destroy
     if @product_access_group.destroy
       flash[:notice] = "#{ProductAccessGroup.model_name.human} was deleted"
-      redirect_to facility_instrument_product_access_groups_path(@facility, @instrument)
+      redirect_to [current_facility, @product, ProductAccessGroup]
     else
       flash[:error] = "There was an error deleting the #{ProductAccessGroup.model_name.human}"
-      redirect_to edit_facility_instrument_product_access_groups_path(@facility, @instrument, @product_access_group)
+      redirect_to [:edit, current_facility, @product, ProductAccessGroup]
     end
-  end
-
-  private
-
-  def init_current_product
-    # required for tabnav_product
-    @product = @instrument
   end
 
 end

--- a/app/controllers/product_users_controller.rb
+++ b/app/controllers/product_users_controller.rb
@@ -1,16 +1,14 @@
 class ProductUsersController < ApplicationController
 
+  include SearchHelper
+  include BelongsToProductController
+
   admin_tab :index, :new
-  before_action :authenticate_user!
-  before_action :check_acting_as
-  before_action :init_current_facility
-  before_action :init_product
+  before_action :init_product_user
 
   load_and_authorize_resource
 
   layout "two_column"
-
-  include SearchHelper
 
   def initialize
     @active_tab = "admin_products"
@@ -104,15 +102,8 @@ class ProductUsersController < ApplicationController
     @product.class.model_name.human.downcase
   end
 
-  def init_product
-    @product = current_facility.products
-                               .find_by!(url_name: product_id)
+  def init_product_user
     @product_user = @product.product_users.build # for CanCan auth
-  end
-
-  def product_id
-    key = params.except(:facility_id).keys.find { |k| k.end_with?("_id") }
-    params[key]
   end
 
 end

--- a/app/controllers/schedule_rules_controller.rb
+++ b/app/controllers/schedule_rules_controller.rb
@@ -1,14 +1,11 @@
 class ScheduleRulesController < ApplicationController
 
-  admin_tab     :all
-  before_action :authenticate_user!
-  before_action :check_acting_as
-  before_action :init_current_facility
-  before_action :init_product
+  include BelongsToProductController
+
   before_action :init_schedule_rule, only: [:edit, :update, :destroy]
+  authorize_resource
 
-  load_and_authorize_resource
-
+  admin_tab :all
   layout "two_column"
 
   def initialize
@@ -87,21 +84,8 @@ class ScheduleRulesController < ApplicationController
                                           product_access_group_ids: [])
   end
 
-  def init_product
-    @product = current_facility.products.find_by!(url_name: product_id)
-  end
-
   def init_schedule_rule
     @schedule_rule = @product.schedule_rules.find(params[:id])
-  end
-
-  def product_id
-    params[product_key]
-  end
-
-  def product_key
-    valid_ids = Product.types.map { |t| "#{t.model_name.param_key}_id" }
-    params.keys.find { |k| k.in?(valid_ids) }
   end
 
 end

--- a/app/models/concerns/products/schedule_rule_support.rb
+++ b/app/models/concerns/products/schedule_rule_support.rb
@@ -4,6 +4,7 @@ module Products::ScheduleRuleSupport
 
   included do
     has_many :schedule_rules, foreign_key: :product_id, inverse_of: :product
+    has_many :product_access_groups, foreign_key: :product_id, inverse_of: :product
   end
 
   def can_purchase?(group_ids = nil)

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -10,7 +10,6 @@ class Instrument < Product
   # -------
 
   has_many :instrument_price_policies, foreign_key: "product_id"
-  has_many :product_access_groups, foreign_key: "product_id"
   has_many :admin_reservations, foreign_key: "product_id"
   has_many :offline_reservations, foreign_key: "product_id"
 

--- a/app/views/admin/shared/_tabnav_product.html.haml
+++ b/app/views/admin/shared/_tabnav_product.html.haml
@@ -5,7 +5,7 @@
     = tab "Scheduling", [current_facility, @product, ScheduleRule], (secondary_tab == "schedule_rules")
   - if @product.requires_approval?
     = tab "Access List", [current_facility, @product, :users], (secondary_tab == "users")
-  - if @product.requires_approval? && @product.is_a?(Instrument)
+  - if @product.requires_approval? && @product.respond_to?(:product_access_groups)
     = tab ProductAccessGroup.model_name.human.pluralize, facility_instrument_product_access_groups_path(current_facility, @product), (secondary_tab == "restriction_levels")
   - if @product.is_a?(Bundle)
     = tab "Bundled Products", facility_bundle_bundle_products_path(current_facility, @product), (secondary_tab == "products")

--- a/app/views/product_access_groups/_fields.html.haml
+++ b/app/views/product_access_groups/_fields.html.haml
@@ -2,4 +2,4 @@
 
 %ul.inline
   %li= f.submit :class => ['btn', 'btn-primary']
-  %li= link_to 'Cancel', facility_instrument_product_access_groups_path(@facility, @instrument)
+  %li= link_to 'Cancel', [current_facility, @product, ProductAccessGroup]

--- a/app/views/product_access_groups/_headers.html.haml
+++ b/app/views/product_access_groups/_headers.html.haml
@@ -1,7 +1,7 @@
 = content_for :h1 do
-  =h @facility
+  = current_facility
 = content_for :sidebar do
-  = render :partial => 'admin/shared/sidenav_product', :locals => { :sidenav_tab => 'instruments' }
+  = render "admin/shared/sidenav_product", sidenav_tab: @product.product_type
 = content_for :tabnav do
-  = render :partial => 'admin/shared/tabnav_product', :locals => {:secondary_tab => 'restriction_levels'}
-%h2= @instrument
+  = render "admin/shared/tabnav_product", secondary_tab: "restriction_levels"
+%h2= @product

--- a/app/views/product_access_groups/edit.html.haml
+++ b/app/views/product_access_groups/edit.html.haml
@@ -1,5 +1,5 @@
 = render :partial => "headers"
 %h3 Edit #{ProductAccessGroup.model_name.human}
-= simple_form_for([current_facility, @instrument, @product_access_group]) do |f|
+= simple_form_for([current_facility, @product, @product_access_group]) do |f|
   = f.error_messages
   = render :partial => "fields", :locals => {:f => f}

--- a/app/views/product_access_groups/index.html.haml
+++ b/app/views/product_access_groups/index.html.haml
@@ -2,9 +2,9 @@
 
 %h3= ProductAccessGroup.model_name.human
 
-- if can? :add, ProductAccessGroup
+- if can? :create, ProductAccessGroup
   %p= link_to t(".add_button", group: ProductAccessGroup.model_name.human),
-    new_facility_instrument_product_access_group_path(@facility, @instrument),
+    [:new, current_facility, @product, :product_access_group],
     class: ["btn", "btn-add"]
 
 %table.table.table-striped.table-hover
@@ -20,14 +20,14 @@
         %td
           - if can?(:delete, level)
             = link_to t("shared.remove"),
-              facility_instrument_product_access_group_path(@facility, @instrument, level),
+              [current_facility, @product, level],
               method: :delete,
               data: { confirm: t("shared.confirm_message") }
 
         - if can?(:edit, level)
           %td
             = link_to level.name,
-              edit_facility_instrument_product_access_group_path(@facility, @instrument, level)
+              [:edit, current_facility, @product, level]
         - else
           %td= level.name
 

--- a/app/views/product_access_groups/new.html.haml
+++ b/app/views/product_access_groups/new.html.haml
@@ -1,5 +1,5 @@
 = render :partial => "headers"
 %h3 New #{ProductAccessGroup.model_name.human}
-= simple_form_for([current_facility, @instrument, @product_access_group]) do |f|
+= simple_form_for([current_facility, @product, @product_access_group]) do |f|
   = f.error_messages
   = render :partial => "fields", :locals => {:f => f}

--- a/app/views/product_users/index.html.haml
+++ b/app/views/product_users/index.html.haml
@@ -23,7 +23,7 @@
 - elsif @product_users.empty?
   %p.notice= t(".no_users_approved")
 - else
-  = form_for @product, url: facility_instrument_update_restrictions_path(current_facility, @product), method: :put do |f|
+  = form_for @product, url: [current_facility, @product, :update_restrictions], method: :put do |f|
     %table.table.table-striped.table-hover
       %thead
         %tr

--- a/spec/controllers/product_access_groups_controller_spec.rb
+++ b/spec/controllers/product_access_groups_controller_spec.rb
@@ -29,8 +29,7 @@ RSpec.describe ProductAccessGroupsController do
       @method = :get
     end
     it_should_allow_operators_only :success, "see index" do
-      expect(assigns[:facility]).to eq(@authable)
-      expect(assigns[:instrument]).to eq(@instrument)
+      expect(assigns[:product]).to eq(@instrument)
       expect(assigns[:product_access_groups]).to eq([@level, @level2])
     end
   end
@@ -41,8 +40,7 @@ RSpec.describe ProductAccessGroupsController do
       @method = :get
     end
     it_should_allow_managers_and_senior_staff_only :success, "do new" do
-      expect(assigns[:facility]).to eq(@authable)
-      expect(assigns[:instrument]).to eq(@instrument)
+      expect(assigns[:product]).to eq(@instrument)
       expect(assigns[:product_access_group]).to be_new_record
       expect(response).to render_template :new
     end
@@ -58,8 +56,8 @@ RSpec.describe ProductAccessGroupsController do
         @params.merge!(product_access_group: FactoryGirl.attributes_for(:product_access_group))
       end
       it_should_allow_managers_and_senior_staff_only :redirect, "do create" do
-        expect(assigns[:facility]).to eq(@authable)
-        expect(assigns[:instrument]).to eq(@instrument)
+
+        expect(assigns[:product]).to eq(@instrument)
         expect(assigns[:product_access_group]).not_to be_new_record
         expect(flash[:notice]).not_to be_nil
         expect(response).to redirect_to(facility_instrument_product_access_groups_path(@authable, @instrument))
@@ -70,8 +68,8 @@ RSpec.describe ProductAccessGroupsController do
         @params.merge!(product_access_group: FactoryGirl.attributes_for(:product_access_group, name: ""))
       end
       it_should_allow_managers_and_senior_staff_only :success, "do create" do
-        expect(assigns[:facility]).to eq(@authable)
-        expect(assigns[:instrument]).to eq(@instrument)
+
+        expect(assigns[:product]).to eq(@instrument)
         expect(assigns[:product_access_group]).to be_new_record
         expect(assigns[:product_access_group].errors).not_to be_empty
         expect(response).to render_template :new
@@ -87,8 +85,7 @@ RSpec.describe ProductAccessGroupsController do
       @params.merge!(id: @product_access_group.id)
     end
     it_should_allow_managers_and_senior_staff_only :success, "do edit" do
-      expect(assigns[:facility]).to eq(@authable)
-      expect(assigns[:instrument]).to eq(@instrument)
+      expect(assigns[:product]).to eq(@instrument)
       expect(assigns[:product_access_group]).to eq(@product_access_group)
       expect(response).to render_template :edit
     end
@@ -105,8 +102,8 @@ RSpec.describe ProductAccessGroupsController do
         @params.merge!(product_access_group: { name: "new name" })
       end
       it_should_allow_managers_and_senior_staff_only :redirect, "do update" do
-        expect(assigns[:facility]).to eq(@authable)
-        expect(assigns[:instrument]).to eq(@instrument)
+
+        expect(assigns[:product]).to eq(@instrument)
         expect(assigns[:product_access_group]).to eq(@product_access_group)
         expect(assigns[:product_access_group].name).to eq("new name")
         expect(flash[:notice]).not_to be_nil
@@ -118,8 +115,8 @@ RSpec.describe ProductAccessGroupsController do
         @params.merge!(product_access_group: { name: "" })
       end
       it_should_allow_managers_and_senior_staff_only :success, "do update" do
-        expect(assigns[:facility]).to eq(@authable)
-        expect(assigns[:instrument]).to eq(@instrument)
+
+        expect(assigns[:product]).to eq(@instrument)
         expect(assigns[:product_access_group]).to eq(@product_access_group)
         expect(assigns[:product_access_group].errors).not_to be_empty
         expect(response).to render_template :edit

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -238,6 +238,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:administer, User) }
     it { is_expected.to be_allowed_to(:manage, PriceGroup) }
     it { is_expected.to be_allowed_to(:manage, ScheduleRule) }
+    it { is_expected.to be_allowed_to(:manage, ProductAccessGroup) }
     it_is_not_allowed_to([:edit, :update]) { FactoryGirl.create(:user) }
 
     it_behaves_like "it can destroy admistrative reservations"
@@ -277,6 +278,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:manage, PriceGroup) }
     it_is_allowed_to([:batch_update, :cancel, :index], Reservation)
     it { is_expected.to be_allowed_to(:manage, ScheduleRule) }
+    it { is_expected.to be_allowed_to(:manage, ProductAccessGroup) }
     it { is_expected.to be_allowed_to(:administer, User) }
     it { is_expected.not_to be_allowed_to(:manage_accounts, Facility.cross_facility) }
     it { is_expected.not_to be_allowed_to(:manage_billing, Facility.cross_facility) }
@@ -296,6 +298,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:read, UserPriceGroupMember) }
     it { is_expected.not_to be_allowed_to(:manage, PriceGroup) }
     it { is_expected.to be_allowed_to(:index, ScheduleRule) }
+    it { is_expected.to be_allowed_to(:index, ProductAccessGroup) }
 
     it_behaves_like "it can destroy admistrative reservations"
     it_behaves_like "it allows switch_to on active, but not deactivated users"
@@ -308,6 +311,7 @@ RSpec.describe Ability do
     it_is_allowed_to([:bring_online, :create, :edit, :new, :update], OfflineReservation)
     it { is_expected.to be_allowed_to(:manage, TrainingRequest) }
     it { is_expected.to be_allowed_to(:manage, ScheduleRule) }
+    it { is_expected.to be_allowed_to(:manage, ProductAccessGroup) }
   end
 
   describe "staff" do
@@ -317,7 +321,8 @@ RSpec.describe Ability do
     it_is_not_allowed_to([:bring_online, :create, :edit, :new, :update], OfflineReservation)
     it { is_expected.to be_allowed_to(:create, TrainingRequest) }
     it_behaves_like "it can not manage training requests"
-    it_is_not_allowed_to([:new, :create, :edit, :update, :destroy], ScheduleRule)
+    it_is_not_allowed_to([:create, :update, :destroy], ScheduleRule)
+    it_is_not_allowed_to([:create, :update, :destroy], ProductAccessGroup)
   end
 
   describe "unprivileged user" do

--- a/spec/support/shared_examples/product_access_groups_controller_shared_examples.rb
+++ b/spec/support/shared_examples/product_access_groups_controller_shared_examples.rb
@@ -1,0 +1,157 @@
+RSpec.shared_examples_for "A product supporting ProductAccessGroupsController" do |product_sym|
+  render_views
+
+  let(:facility) { FactoryGirl.create(:facility) }
+  let(:facility_account) { facility.facility_accounts.create(FactoryGirl.attributes_for(:facility_account)) }
+  let(:product) { FactoryGirl.create(product_sym, facility: facility, facility_account: facility_account)}
+  let(:senior_staff) { FactoryGirl.create(:user, :senior_staff, facility: facility) }
+  let(:params) { { facility_id: facility.url_name, :"#{product_sym}_id" => product.url_name } }
+
+  context "index" do
+    let(:staff) { FactoryGirl.create(:user, :staff, facility: facility) }
+
+    let(:product2) { FactoryGirl.create(product_sym, facility: facility, facility_account: facility_account) }
+    let!(:product_groups) { FactoryGirl.create_list(:product_access_group, 2, product: product) }
+    let!(:other_product_group) { FactoryGirl.create(:product_access_group, product: product2) }
+
+    before :each do
+      sign_in staff
+      get :index, params
+    end
+
+    it "succeeds and renders" do
+      expect(response).to be_success
+      expect(response).to render_template(:index)
+    end
+
+    it "assigns the product and access groups" do
+      expect(assigns[:product]).to eq(product)
+      expect(assigns[:product_access_groups]).to eq(product_groups)
+    end
+  end
+
+  context "new" do
+    before :each do
+      sign_in senior_staff
+      get :new, params
+    end
+
+    it "succeeds and renders" do
+      expect(response).to be_success
+      expect(response).to render_template(:new)
+    end
+
+    it "assigns the product and group" do
+      expect(assigns[:product]).to eq(product)
+      expect(assigns[:product_access_group]).to be_new_record
+    end
+  end
+
+  context "create" do
+    before do
+      sign_in senior_staff
+    end
+
+    context "correct info" do
+      before do
+        post :create, params.merge(product_access_group: FactoryGirl.attributes_for(:product_access_group))
+      end
+
+      it "creates and assigns the new record" do
+        expect(assigns[:product]).to eq(product)
+        expect(assigns[:product_access_group]).to be_persisted
+      end
+
+      it "redirects with a flash" do
+        expect(flash[:notice]).to be_present
+        expect(response).to redirect_to([facility, product, ProductAccessGroup])
+      end
+    end
+
+    context "missing data" do
+      before do
+        post :create, params.merge(product_access_group: FactoryGirl.attributes_for(:product_access_group, name: ""))
+      end
+
+      it "should assign, but not persist the record" do
+        expect(assigns[:product]).to eq(product)
+        expect(assigns[:product_access_group]).to be_new_record
+        expect(assigns[:product_access_group].errors).to be_present
+      end
+
+      it "renders the new template" do
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  context "edit" do
+    let!(:product_access_group) { FactoryGirl.create(:product_access_group, product: product) }
+
+    before do
+      sign_in senior_staff
+      get :edit, params.merge(id: product_access_group.id)
+    end
+
+    it "assigns the variables and renders the edit template" do
+      expect(assigns[:product]).to eq(product)
+      expect(assigns[:product_access_group]).to eq(product_access_group)
+      expect(response).to render_template :edit
+    end
+  end
+
+  context "update" do
+    let(:product_access_group) { FactoryGirl.create(:product_access_group, product: product) }
+
+    before :each do
+      sign_in senior_staff
+    end
+
+    context "correct info" do
+      before do
+        post :update, params.merge(id: product_access_group.id, product_access_group: { name: "new name" })
+      end
+
+      it "assigns and updates the access group" do
+        expect(assigns[:product]).to eq(product)
+        expect(assigns[:product_access_group]).to eq(product_access_group)
+        expect(product_access_group.reload.name).to eq("new name")
+      end
+
+      it "sets the flash and redirects" do
+        expect(flash[:notice]).to be_present
+        expect(response).to redirect_to([facility, product, ProductAccessGroup])
+      end
+    end
+
+    context "missing data" do
+      before do
+        post :update, params.merge(id: product_access_group.id, product_access_group: { name: "" })
+      end
+
+      it "assigns, but does not update the access group" do
+        expect(assigns[:product]).to eq(product)
+        expect(assigns[:product_access_group]).to eq(product_access_group)
+        expect(assigns[:product_access_group].errors).to be_present
+        expect(response).to render_template :edit
+      end
+    end
+  end
+
+  context "destroy" do
+    let(:product_access_group) { FactoryGirl.create(:product_access_group, product: product) }
+    before :each do
+      sign_in senior_staff
+      delete :destroy, params.merge(id: product_access_group.id)
+    end
+
+    it "destroys the record" do
+      expect(assigns[:product_access_group]).to be_destroyed
+    end
+
+    it "sets the flash and redirects" do
+      expect(flash[:notice]).to be_present
+      expect(response).to redirect_to([facility, product, ProductAccessGroup])
+    end
+  end
+end

--- a/spec/support/shared_examples/product_access_groups_controller_shared_examples.rb
+++ b/spec/support/shared_examples/product_access_groups_controller_shared_examples.rb
@@ -3,7 +3,7 @@ RSpec.shared_examples_for "A product supporting ProductAccessGroupsController" d
 
   let(:facility) { FactoryGirl.create(:facility) }
   let(:facility_account) { facility.facility_accounts.create(FactoryGirl.attributes_for(:facility_account)) }
-  let(:product) { FactoryGirl.create(product_sym, facility: facility, facility_account: facility_account)}
+  let(:product) { FactoryGirl.create(product_sym, facility: facility, facility_account: facility_account) }
   let(:senior_staff) { FactoryGirl.create(:user, :senior_staff, facility: facility) }
   let(:params) { { facility_id: facility.url_name, :"#{product_sym}_id" => product.url_name } }
 

--- a/vendor/engines/secure_rooms/config/routes.rb
+++ b/vendor/engines/secure_rooms/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
       facility_product_routing_concern
       resources :price_policies, controller: "secure_room_price_policies", except: :show
       resources :schedule_rules, except: [:show]
+      resources :product_access_groups
+      put "update_restrictions", to: "product_users#update_restrictions"
     end
 
     resources :users, only: [] do

--- a/vendor/engines/secure_rooms/spec/controllers/product_access_groups_controller_spec.rb
+++ b/vendor/engines/secure_rooms/spec/controllers/product_access_groups_controller_spec.rb
@@ -1,7 +1,5 @@
 require "rails_helper"
 
 RSpec.describe ProductAccessGroupsController, :aggregate_failures do
-
   it_behaves_like "A product supporting ProductAccessGroupsController", :secure_room
-
 end

--- a/vendor/engines/secure_rooms/spec/controllers/product_access_groups_controller_spec.rb
+++ b/vendor/engines/secure_rooms/spec/controllers/product_access_groups_controller_spec.rb
@@ -2,6 +2,6 @@ require "rails_helper"
 
 RSpec.describe ProductAccessGroupsController, :aggregate_failures do
 
-  it_behaves_like "A product supporting ProductAccessGroupsController", :instrument
+  it_behaves_like "A product supporting ProductAccessGroupsController", :secure_room
 
 end


### PR DESCRIPTION
This pulls the product_access_group features (aka scheduling groups) out of instruments and into the ScheduleRule support module so the feature can be shared with SecureRooms. This PR also makes necessary changes so the controller can support multiple types of products by making a `BelongsToProductController` module that will load the product by service_id, item_id, etc.