### PR TITLE
Remove dead JS that was relying on draggable/droppable

### DIFF
--- a/app/assets/javascripts/timeline.js
+++ b/app/assets/javascripts/timeline.js
@@ -1,30 +1,4 @@
 $(function() {
-  //Set Draggable Unit, grid and axis
-  $( ".reschedulable .unit:not(.blackout)" ).draggable({
-    axis: "x",
-    containment: "parent",
-    grid: [ 2, 0],
-    opacity: 0.7,
-    revert: 'invalid',
-      stop: function(){
-          $(this).draggable('option','revert','invalid');
-      }
-  });
-  //The unit container will fit the units.
-  $('.reschedulable .unit_container').droppable({
-      tolerance: 'fit'
-  });
-  //Do not allow the overlap, yell at me if I try to drop a reservation on a reservation
-  $('.reschedulable .unit').droppable({
-    greedy: true,
-    tolerance: 'touch',
-    hoverClass: "invalid",
-    drop: function(event,ui){
-       $(this).off('invalid');
-        ui.draggable.draggable('option','revert',true);
-        alert("These Times Over Lap - You Can't Do that.");
-    }
-  })
   //Tool Tip
   tooltipContent = function($el, $tip) {
     var match = $el.attr("id").match(/block_(\w+_)?reservation_(\d+)/);

--- a/app/views/shared/timeline/_instrument.html.haml
+++ b/app/views/shared/timeline/_instrument.html.haml
@@ -10,7 +10,6 @@
     - if instrument.offline?
       = tooltip_icon "icon-warning-sign icon-large", t("instruments.offline.note")
 
-  -# Add .reschedulable to enable drag/drop
   .timeline
     .unit_container
       = render partial: "shared/timeline/reservation",


### PR DESCRIPTION
This was causing JS errors on the timeline view. I only noticed it because the relay switches weren’t appearing.

Related to #910.