### PR TITLE
update rubocop to reflect in-use style conventions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,4 +14,6 @@ inherit_from:
 #
 
 Style/EmptyMethod:
-  Enabled: false
+  EnforcedStyle: expanded
+Style/HashSyntax:
+  EnforcedStyle: ruby19

--- a/app/controllers/concerns/price_group_members_controller.rb
+++ b/app/controllers/concerns/price_group_members_controller.rb
@@ -14,7 +14,8 @@ module PriceGroupMembersController
     load_and_authorize_resource
   end
 
-  def new; end
+  def new
+  end
 
   def initialize
     @active_tab = "admin_facility"

--- a/app/controllers/price_groups_controller.rb
+++ b/app/controllers/price_groups_controller.rb
@@ -61,7 +61,8 @@ class PriceGroupsController < ApplicationController
   end
 
   # GET /price_groups/:id/edit
-  def edit; end
+  def edit
+  end
 
   # POST /price_groups
   def create

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe OrdersController do
 
   class DummyNotifier
 
-    def deliver; end
+    def deliver
+    end
 
   end
 

--- a/spec/models/order_detail_observer_spec.rb
+++ b/spec/models/order_detail_observer_spec.rb
@@ -5,12 +5,15 @@ RSpec.describe OrderDetailObserver do
     class DummyHook1
 
       attr_accessor :settings
-      def on_status_change(order_detail, old_status, new_status); end
+      def on_status_change(order_detail, old_status, new_status)
+      end
 
     end
+
     class DummyHook2
 
-      def on_status_change(order_detail, old_status, new_status); end
+      def on_status_change(order_detail, old_status, new_status)
+      end
 
     end
     class DummyHook3; end

--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms/card_numbers_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms/card_numbers_controller.rb
@@ -19,7 +19,8 @@ module SecureRooms
       super
     end
 
-    def edit; end
+    def edit
+    end
 
     def update
       if @user.update_attributes(update_user_params)


### PR DESCRIPTION
- enforce 1.9 hash syntax for symbol keys
- enforce expanded style for empty methods (i.e. no `def method; end`)