### PR TITLE
Fix ability matcher

### DIFF
--- a/spec/support/matchers/ability_matchers.rb
+++ b/spec/support/matchers/ability_matchers.rb
@@ -19,7 +19,7 @@ def it_is_allowed_to(actions, object = nil)
   Array(actions).each do |action|
     it "is allowed to #{action}" do
       target = object || yield
-      expect(subject).to be_allowed_to(action, object)
+      expect(subject).to be_allowed_to(action, target)
     end
   end
 end


### PR DESCRIPTION
Introduced in #931, this is intended to test on a block if it's given, otherwise
use the object. We don't actually use the block version of the positive assertion,
but we do use the negative. This was meant to be parallel to the negative version, but looks like I messed
it up.