### PR TITLE
[#140895375] Add tablet token to card readers

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170405172045) do
+ActiveRecord::Schema.define(version: 20170405182534) do
 
   create_table "account_users", force: :cascade do |t|
     t.integer  "account_id", limit: 4,  null: false
@@ -614,6 +614,7 @@ ActiveRecord::Schema.define(version: 20170405172045) do
     t.datetime "updated_at",                                       null: false
     t.string   "description",           limit: 255
     t.boolean  "direction_in",                      default: true, null: false
+    t.string   "tablet_token",          limit: 255
   end
 
   add_index "secure_rooms_card_readers", ["card_reader_number", "control_device_number"], name: "i_secure_room_reader_ids", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -619,6 +619,7 @@ ActiveRecord::Schema.define(version: 20170405182534) do
 
   add_index "secure_rooms_card_readers", ["card_reader_number", "control_device_number"], name: "i_secure_room_reader_ids", unique: true, using: :btree
   add_index "secure_rooms_card_readers", ["product_id"], name: "index_secure_rooms_card_readers_on_product_id", using: :btree
+  add_index "secure_rooms_card_readers", ["tablet_token"], name: "index_secure_rooms_card_readers_on_tablet_token", unique: true, using: :btree
 
   create_table "splits", force: :cascade do |t|
     t.integer "parent_split_account_id", limit: 4,                         null: false

--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/scans_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/scans_controller.rb
@@ -19,7 +19,7 @@ class SecureRoomsApi::ScansController < ApplicationController
       selected_account,
     )
 
-    render SecureRooms::ScanResponsePresenter.new(@user, access_verdict, accounts).response
+    render SecureRooms::ScanResponsePresenter.new(@user, @card_reader, access_verdict, accounts).response
   end
 
   private

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/card_reader.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/card_reader.rb
@@ -4,12 +4,14 @@ module SecureRooms
 
     belongs_to :secure_room, foreign_key: :product_id
 
-    validates :product_id, :card_reader_number, :control_device_number, presence: true
-    validates :card_reader_number, uniqueness: { scope: :control_device_number }
-
     delegate :facility, to: :secure_room
 
     alias_attribute :ingress, :direction_in
+
+    validates :product_id, :card_reader_number, :control_device_number, presence: true
+    validates :card_reader_number, uniqueness: { scope: :control_device_number }
+
+    before_create :set_tablet_token
 
     def egress?
       !ingress?
@@ -27,6 +29,10 @@ module SecureRooms
 
     def attribute_translation_scope
       "#{self.class.i18n_scope}.attributes.#{model_name.i18n_key}"
+    end
+
+    def set_tablet_token
+      self.tablet_token ||= ("A".."Z").to_a.sample(12).join
     end
 
   end

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/card_reader.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/card_reader.rb
@@ -10,6 +10,7 @@ module SecureRooms
 
     validates :product_id, :card_reader_number, :control_device_number, presence: true
     validates :card_reader_number, uniqueness: { scope: :control_device_number }
+    validates :tablet_token, uniqueness: true
 
     before_create :set_tablet_token
 
@@ -32,7 +33,13 @@ module SecureRooms
     end
 
     def set_tablet_token
-      self.tablet_token ||= ("A".."Z").to_a.sample(12).join
+      return if tablet_token.present?
+
+      # Generate random tokens until it finds one that doesn't already exist
+      self.tablet_token = loop do
+        token = ("A".."Z").to_a.sample(12).join
+        break token if self.class.find_by(tablet_token: token).blank?
+      end
     end
 
   end

--- a/vendor/engines/secure_rooms/app/presenters/secure_rooms/scan_response_presenter.rb
+++ b/vendor/engines/secure_rooms/app/presenters/secure_rooms/scan_response_presenter.rb
@@ -2,8 +2,9 @@ module SecureRooms
 
   class ScanResponsePresenter
 
-    def initialize(user, access_verdict, accounts)
+    def initialize(user, card_reader, access_verdict, accounts)
       @user = user
+      @card_reader = card_reader
       @access_verdict = access_verdict
       @accounts = accounts
     end
@@ -12,8 +13,7 @@ module SecureRooms
       {
         status: status_for_code(@access_verdict.result_code),
         json: {
-          # TODO: (#140895375) return actual tablet_identifier
-          tablet_identifier: "abc123",
+          tablet_identifier: @card_reader.tablet_token,
           name: @user.full_name,
           response: @access_verdict.result_code,
           reason: @access_verdict.reason,

--- a/vendor/engines/secure_rooms/app/views/secure_rooms/card_readers/index.html.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_rooms/card_readers/index.html.haml
@@ -18,17 +18,19 @@
     %thead
       %tr
         %th= SecureRooms::CardReader.human_attribute_name(:description)
-        %th= SecureRooms::CardReader.human_attribute_name(:card_reader_number)
         %th= SecureRooms::CardReader.human_attribute_name(:control_device_number)
+        %th= SecureRooms::CardReader.human_attribute_name(:card_reader_number)
         %th= SecureRooms::CardReader.human_attribute_name(:direction)
+        %th= SecureRooms::CardReader.human_attribute_name(:tablet_token)
         %th
         %th
     %tbody
       - @card_readers.each do |card_reader|
         %tr[card_reader]
           %td= card_reader.description
-          %td= card_reader.card_reader_number
           %td= card_reader.control_device_number
+          %td= card_reader.card_reader_number
           %td= card_reader.direction
+          %td= card_reader.tablet_token if card_reader.ingress?
           %td= link_to text("shared.edit"), edit_facility_secure_room_card_reader_path(current_facility, @product, card_reader)
           %td= link_to text("shared.remove"), facility_secure_room_card_reader_path(current_facility, @product, card_reader), data: { confirm: text("shared.confirm_message") }, method: :delete

--- a/vendor/engines/secure_rooms/config/locales/en.yml
+++ b/vendor/engines/secure_rooms/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
         human_direction:
           "true": In
           "false": Out
+        tablet_token: Tablet Token
 
   controllers:
     secure_rooms/card_readers:

--- a/vendor/engines/secure_rooms/db/migrate/20170405182534_add_table_token_to_card_readers.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170405182534_add_table_token_to_card_readers.rb
@@ -1,0 +1,12 @@
+class AddTableTokenToCardReaders < ActiveRecord::Migration
+
+  class SecureRooms::CardReader < ActiveRecord::Base
+  end
+
+  def change
+    add_column :secure_rooms_card_readers, :tablet_token, :string
+    SecureRooms::CardReader.reset_column_information
+    SecureRooms::CardReader.find_each { |cr| cr.update_column(:tablet_token, ("A".."Z").to_a.sample(12).join) }
+  end
+
+end

--- a/vendor/engines/secure_rooms/db/migrate/20170405182534_add_tablet_token_to_card_readers.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170405182534_add_tablet_token_to_card_readers.rb
@@ -1,10 +1,12 @@
-class AddTableTokenToCardReaders < ActiveRecord::Migration
+class AddTabletTokenToCardReaders < ActiveRecord::Migration
 
   class SecureRooms::CardReader < ActiveRecord::Base
   end
 
   def change
     add_column :secure_rooms_card_readers, :tablet_token, :string
+    add_index :secure_rooms_card_readers, :tablet_token, unique: true
+
     SecureRooms::CardReader.reset_column_information
     SecureRooms::CardReader.find_each { |cr| cr.update_column(:tablet_token, ("A".."Z").to_a.sample(12).join) }
   end

--- a/vendor/engines/secure_rooms/spec/models/secure_rooms/card_reader_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/secure_rooms/card_reader_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe SecureRooms::CardReader do
     subject { described_class.new(secure_room: product) }
 
     it { is_expected.to validate_uniqueness_of(:card_reader_number).scoped_to(:control_device_number) }
+    it { is_expected.to validate_uniqueness_of(:tablet_token) }
   end
 
   describe "direction_in" do

--- a/vendor/engines/secure_rooms/spec/models/secure_rooms/card_reader_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/secure_rooms/card_reader_spec.rb
@@ -31,4 +31,18 @@ RSpec.describe SecureRooms::CardReader do
       end
     end
   end
+
+  describe "tablet_token" do
+    it "sets a token on create" do
+      reader = build(:card_reader)
+      expect(reader.tablet_token).to be_blank
+      reader.save
+      expect(reader.tablet_token).to match(/\A[A-Z]{12}\z/)
+    end
+
+    it "does not change the token later" do
+      reader = create(:card_reader)
+      expect { reader.save }.not_to change(reader, :tablet_token)
+    end
+  end
 end


### PR DESCRIPTION
I went with `tablet_token` since that feels closer to what it is rather than an identifier. I left the API key the same since the doors service looks for that.