### PR TITLE
[#140850873] Restrict secure rooms by schedule rule

### DIFF
--- a/app/models/schedule_rule.rb
+++ b/app/models/schedule_rule.rb
@@ -130,7 +130,7 @@ class ScheduleRule < ActiveRecord::Base
   end
 
   def on_day?(datetime)
-    public_send(%(on_#{datetime.strftime("%a").downcase}?))
+    public_send(%(on_#{datetime.strftime('%a').downcase}?))
   end
 
   def cover?(dt)

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -117,19 +117,7 @@ module Reservations::Validations
               product.available_schedule_rules(order_detail.order.user)
             end
 
-    mins  = (end_at - start_at) / 60
-    (0..mins).each do |n|
-      dt    = start_at.advance(minutes: n)
-      found = false
-      rules.each do |s|
-        if s.includes_datetime(dt)
-          found = true
-          break
-        end
-      end
-      return false unless found
-    end
-    true
+    rules.cover?(start_at, end_at)
   end
 
   # Extended validation methods

--- a/spec/models/schedule_rule_spec.rb
+++ b/spec/models/schedule_rule_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe ScheduleRule do
                                        facility: @facility,
                                        facility_account: @facility_account)
       @rule = @instrument.schedule_rules.build(FactoryGirl.attributes_for(:schedule_rule))
-      expect(@rule.includes_datetime(DateTime.new(1981, 9, 15, 12, 0, 0))).to eq(true)
+      expect(@rule).to be_cover(DateTime.new(1981, 9, 15, 12, 0, 0))
     end
 
     it "should not recognize non-inclusive datetimes" do
@@ -105,7 +105,7 @@ RSpec.describe ScheduleRule do
                                        facility: @facility,
                                        facility_account: @facility_account)
       @rule = @instrument.schedule_rules.build(FactoryGirl.attributes_for(:schedule_rule))
-      expect(@rule.includes_datetime(DateTime.new(1981, 9, 15, 3, 0, 0))).to eq(false)
+      expect(@rule).not_to be_cover(DateTime.new(1981, 9, 15, 3, 0, 0))
     end
   end
 

--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/scans_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/scans_controller.rb
@@ -15,8 +15,8 @@ class SecureRoomsApi::ScansController < ApplicationController
     access_verdict = SecureRooms::CheckAccess.new.authorize(
       @user,
       @card_reader,
-      accounts,
-      selected_account,
+      accounts: accounts,
+      selected_account: selected_account,
     )
 
     render SecureRooms::ScanResponsePresenter.new(@user, @card_reader, access_verdict, accounts).response

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/account_selection_rule.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/account_selection_rule.rb
@@ -5,13 +5,13 @@ module SecureRooms
     class AccountSelectionRule < BaseRule
 
       def evaluate
-        if @accounts.blank?
+        if accounts.blank?
           deny! "User has no valid accounts for this Product"
-        elsif @selected.present?
+        elsif selected_account.present?
           grant!
-        elsif @accounts.present? && @accounts.one?
+        elsif accounts.present? && accounts.one?
           grant!
-        elsif @accounts.present? && @selected.blank?
+        elsif accounts.present? && selected_account.blank?
           pending! "Must select Account"
         end
       end

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/account_selection_rule.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/account_selection_rule.rb
@@ -16,6 +16,16 @@ module SecureRooms
         end
       end
 
+      private
+
+      def accounts
+        params[:accounts]
+      end
+
+      def selected_account
+        params[:selected_account]
+      end
+
     end
 
   end

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/archived_product_rule.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/archived_product_rule.rb
@@ -5,7 +5,7 @@ module SecureRooms
     class ArchivedProductRule < BaseRule
 
       def evaluate
-        deny! "Product is archived" if @card_reader.secure_room.is_archived?
+        deny! "Product is archived" if secure_room.is_archived?
       end
 
     end

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/base_rule.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/base_rule.rb
@@ -4,15 +4,14 @@ module SecureRooms
 
     class BaseRule
 
-      attr_reader :user, :card_reader, :accounts, :selected_account
+      attr_reader :user, :card_reader, :params
 
       delegate :secure_room, to: :card_reader
 
-      def initialize(user, card_reader, accounts = [], selected_account = nil)
+      def initialize(user, card_reader, params = {})
         @user = user
         @card_reader = card_reader
-        @accounts = accounts
-        @selected_account = selected_account
+        @params = params
       end
 
       def call

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/base_rule.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/base_rule.rb
@@ -4,18 +4,22 @@ module SecureRooms
 
     class BaseRule
 
-      def initialize(user, card_reader, accounts, selected)
+      attr_reader :user, :card_reader, :accounts, :selected_account
+
+      delegate :secure_room, to: :card_reader
+
+      def initialize(user, card_reader, accounts = [], selected_account = nil)
         @user = user
         @card_reader = card_reader
         @accounts = accounts
-        @selected = selected
+        @selected_account = selected_account
       end
 
       def call
         evaluate || pass
       end
 
-      def evaluate(_user, _card_reader, _accounts, _selected)
+      def evaluate
         raise NotImplementedError
       end
 

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/operator_rule.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/operator_rule.rb
@@ -5,7 +5,7 @@ module SecureRooms
     class OperatorRule < BaseRule
 
       def evaluate
-        grant! if @user.operator_of?(@card_reader.facility)
+        grant! if user.operator_of?(card_reader.facility)
       end
 
     end

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/requires_approval_rule.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/requires_approval_rule.rb
@@ -5,7 +5,7 @@ module SecureRooms
     class RequiresApprovalRule < BaseRule
 
       def evaluate
-        deny! "User is not on the access list" unless @card_reader.secure_room.can_be_used_by?(@user)
+        deny! "User is not on the access list" unless secure_room.can_be_used_by?(user)
       end
 
     end

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/schedule_rule.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/schedule_rule.rb
@@ -7,6 +7,7 @@ module SecureRooms
       def evaluate
         deny!("No schedule rules configured") if secure_room.schedule_rules.none?
         deny!("Outside of schedule rules") unless secure_room.schedule_rules.cover?(Time.current)
+        deny!("User not in schedule group") unless secure_room.available_schedule_rules(user).cover?(Time.current)
       end
 
     end

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/schedule_rule.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/schedule_rule.rb
@@ -1,0 +1,16 @@
+module SecureRooms
+
+  module AccessRules
+
+    class ScheduleRule < BaseRule
+
+      def evaluate
+        deny!("No schedule rules configured") if secure_room.schedule_rules.none?
+        deny!("Outside of schedule rules") unless secure_room.schedule_rules.cover?(Time.current)
+      end
+
+    end
+
+  end
+
+end

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/verdict.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/verdict.rb
@@ -12,7 +12,15 @@ module SecureRooms
       end
 
       def pass?
-        @result_code == :pass
+        has_result_code?(:pass)
+      end
+
+      def denied?
+        has_result_code?(:deny)
+      end
+
+      def granted?
+        has_result_code?(:grant)
       end
 
       def has_result_code?(code)

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/check_access.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/check_access.rb
@@ -15,9 +15,9 @@ module SecureRooms
       @rules = rules
     end
 
-    def authorize(user, card_reader, accounts = [], selected = nil)
+    def authorize(user, card_reader, params = {})
       answer = @rules.each do |rule|
-        result = rule.new(user, card_reader, accounts, selected).call
+        result = rule.new(user, card_reader, params).call
         break result unless result.pass?
       end
     end

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/check_access.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/check_access.rb
@@ -6,6 +6,7 @@ module SecureRooms
       AccessRules::OperatorRule,
       AccessRules::ArchivedProductRule,
       AccessRules::RequiresApprovalRule,
+      AccessRules::ScheduleRule,
       AccessRules::AccountSelectionRule,
       AccessRules::DenyAllRule,
     ].freeze

--- a/vendor/engines/secure_rooms/spec/controllers/secure_rooms_api/scans_controller_spec.rb
+++ b/vendor/engines/secure_rooms/spec/controllers/secure_rooms_api/scans_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe SecureRoomsApi::ScansController do
 
     subject { response }
 
-    let(:card_reader) { create(:card_reader, tablet_token: "TABLETID") }
+    let(:secure_room) { create(:secure_room, :with_schedule_rule) }
+    let(:card_reader) { create(:card_reader, tablet_token: "TABLETID", secure_room: secure_room) }
     let(:user) { create(:user, card_number: "123456") }
 
     describe "negative responses" do

--- a/vendor/engines/secure_rooms/spec/factories/secure_room.rb
+++ b/vendor/engines/secure_rooms/spec/factories/secure_room.rb
@@ -2,5 +2,11 @@ FactoryGirl.define do
   factory :secure_room, class: SecureRoom, parent: :setup_product do
     sequence(:name) { |n| "Room #{n}" }
     sequence(:url_name) { |n| "Room#{n}" }
+
+    trait :with_schedule_rule do
+      after(:create) do |room, evaluator|
+        room.schedule_rules.create(attributes_for(:schedule_rule))
+      end
+    end
   end
 end

--- a/vendor/engines/secure_rooms/spec/factories/secure_room.rb
+++ b/vendor/engines/secure_rooms/spec/factories/secure_room.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     sequence(:url_name) { |n| "Room#{n}" }
 
     trait :with_schedule_rule do
-      after(:create) do |room, evaluator|
+      after(:create) do |room, _evaluator|
         room.schedule_rules.create(attributes_for(:schedule_rule))
       end
     end

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/account_selection_rule_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/account_selection_rule_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe SecureRooms::AccessRules::AccountSelectionRule, type: :service do
     described_class.new(
       card_user,
       card_reader,
-      accounts,
-      selected_account,
+      accounts: accounts,
+      selected_account: selected_account,
     )
   end
   let(:card_user) { build :user }

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/archived_product_rule_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/archived_product_rule_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe SecureRooms::AccessRules::ArchivedProductRule, type: :service do
     described_class.new(
       card_user,
       card_reader,
-      [],
-      nil,
     )
   end
   let(:card_user) { build :user }

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/operator_rule_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/operator_rule_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe SecureRooms::AccessRules::OperatorRule, type: :service do
     described_class.new(
       card_user,
       card_reader,
-      [],
-      nil,
     )
   end
   let(:card_reader) { build :card_reader }

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/requires_approval_rule_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/requires_approval_rule_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe SecureRooms::AccessRules::RequiresApprovalRule, type: :service do
     described_class.new(
       card_user,
       card_reader,
-      [],
-      nil,
     )
   end
   let(:card_user) { create :user }

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/schedule_rule_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/schedule_rule_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe SecureRooms::AccessRules::ScheduleRule do
+  let(:user) { build(:user) }
+  let(:secure_room) { create(:secure_room) }
+  let(:card_reader) { build(:card_reader, secure_room: secure_room) }
+
+  subject(:result) do
+    described_class.new(
+      user,
+      card_reader,
+    ).call
+  end
+
+  describe "there are no schedule rules" do
+    it { is_expected.to be_denied }
+  end
+
+  describe "there is a schedule rule", :timecop_freeze do
+    # Factory default to 9-5 every day
+    let!(:schedule_rule) { secure_room.schedule_rules.create(attributes_for(:schedule_rule)) }
+
+    describe "and it is inside the rule" do
+      let(:now) { Time.new(2017, 4, 5, 12, 00) }
+
+      it { is_expected.to be_pass }
+    end
+
+    describe "and it is outside the rule" do
+      let(:now) { Time.new(2017, 4, 5, 19, 00) }
+    end
+  end
+end

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/schedule_rule_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/schedule_rule_spec.rb
@@ -22,18 +22,18 @@ RSpec.describe SecureRooms::AccessRules::ScheduleRule do
     let!(:schedule_rule) { secure_room.schedule_rules.create(attributes_for(:schedule_rule)) }
 
     describe "and it is inside the rule" do
-      let(:now) { Time.new(2017, 4, 5, 12, 00) }
+      let(:now) { Time.zone.local(2017, 4, 5, 12, 0) }
 
       it { is_expected.to be_pass }
     end
 
     describe "and it is outside the rule" do
-      let(:now) { Time.new(2017, 4, 5, 19, 00) }
+      let(:now) { Time.zone.local(2017, 4, 5, 19, 0) }
     end
 
     describe "and there are scheduling groups" do
       let!(:schedule_group) { create(:product_access_group, product: secure_room, schedule_rules: [schedule_rule]) }
-      let(:now) { Time.new(2017, 4, 5, 12, 00) }
+      let(:now) { Time.zone.local(2017, 4, 5, 12, 0) }
 
       describe "the user is not part of the group" do
         it { is_expected.to be_denied }


### PR DESCRIPTION
* Users cannot log in outside of available schedule rules
* If schedule groups are enabled, the user needs to be part of a group for the current rule
* I also cleaned up a little bit on the access rules like making the account list and selected account optional.