### PR TITLE
[WIP] [#140077839] Update operator access restrict admin

### DIFF
--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/operator_rule.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/operator_rule.rb
@@ -5,7 +5,7 @@ module SecureRooms
     class OperatorRule < BaseRule
 
       def evaluate
-        grant! if user.operator_of?(card_reader.facility)
+        grant! if user.operator_of?(card_reader.facility) && !user.administrator?
       end
 
     end

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/operator_rule_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/operator_rule_spec.rb
@@ -17,8 +17,14 @@ RSpec.describe SecureRooms::AccessRules::OperatorRule, type: :service do
     it { is_expected.to have_result_code(:grant) }
   end
 
+  context "user is a global admin" do
+    let(:card_user) { create :user, :administrator }
+
+    it { is_expected.to have_result_code(:pass) }
+  end
+
   context "user is not an operator" do
-    let(:card_user) { build :user }
+    let(:card_user) { create :user }
 
     it { is_expected.to have_result_code(:pass) }
   end


### PR DESCRIPTION
I had a small chunk of time so I took a peek at this since it seemed small--if this requires too much additional discussion beyond just a quick chat about roles, we can drop it since it's not above the priority line

* On first add of a spec for `create :user, :administrator` it was immediately green, so I switched the `build` for a `create` to avoid the false positive
* `Role#operator_of?`, which we currently use, includes the check `administrator`? but is otherwise helpful, so I added a check against that role specifically. I'm not sure business-wise why we use a special case in our situation, so I'm not quite sure if this is the correct fix.
