### PR TITLE
[#135084] fix users nav from reservations tab

### DIFF
--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -144,6 +144,8 @@ class Ability
           cannot(:switch_to, User) { |target_user| !target_user.active? }
         end
 
+        can :index, User if controller.is_a?(FacilityUserReservationsController)
+
         can [:list, :show], Facility
         can :act_as, Facility
         can :index, [BundleProduct, PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ScheduleRule, ServicePricePolicy, ProductAccessory, ProductAccessGroup]


### PR DESCRIPTION
- https://pm.tablexi.com/issues/135084

The "Users" link was disappearing from the left nav in the reservations tab on users (`/facilities/:facility_id/users/:user_id/reservations`) due to an ability issue. This PR keeps "Users" in this tab's nav, consistent with the other tabs.