### PR TITLE
Use newer metadata-based feature-flags in testing

### DIFF
--- a/spec/controller_spec_helper.rb
+++ b/spec/controller_spec_helper.rb
@@ -1,27 +1,3 @@
-RSpec.shared_context "feature enabled" do |feature|
-  before(:all) do
-    SettingsHelper.enable_feature(feature)
-    Nucore::Application.reload_routes!
-  end
-
-  after(:all) do
-    Settings.reload!
-    Nucore::Application.reload_routes!
-  end
-end
-
-RSpec.shared_context "feature disabled" do |feature|
-  before(:all) do
-    SettingsHelper.enable_feature(feature, false)
-    Nucore::Application.reload_routes!
-  end
-
-  after(:all) do
-    Settings.reload!
-    Nucore::Application.reload_routes!
-  end
-end
-
 #
 # Call this method in a before(:all) block at the top of your +describe+
 def create_users

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -114,8 +114,7 @@ RSpec.describe UsersController do
   end
 
   context "creating users" do
-    context "enabled" do
-      include_context "feature enabled", :create_users
+    context "enabled", feature_setting: { create_users: true } do
 
       it "routes", :aggregate_failures do
         expect(get: "/#{facilities_route}/url_name/users/new").to route_to(controller: "users", action: "new", facility_id: "url_name")
@@ -301,8 +300,7 @@ RSpec.describe UsersController do
       end
     end
 
-    context "disabled" do
-      include_context "feature disabled", :create_users
+    context "disabled", feature_setting: { create_users: false } do
       it "doesn't route route", :aggregate_failures do
         expect(get: "/#{facilities_route}/url_name/users/new").not_to be_routable
         expect(get: "/#{facilities_route}/url_name/users/edit").not_to be_routable


### PR DESCRIPTION
Remove older shared context way of doing things, so it's no longer confusing
which style to use.