### PR TITLE
[#135112] Setting to configure which roles can create split accounts

### DIFF
--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -74,4 +74,10 @@ class UserRole < ActiveRecord::Base
     !facility_role?
   end
 
+  # Supports a single item or an array of symbols (:account_manager), strings
+  # both underscored ("billing_administrator") and title cased ("Facility Staff).
+  def in?(roles)
+    role.in? Array(roles).map(&:to_s).map(&:titleize)
+  end
+
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -122,6 +122,12 @@ feature:
   send_statement_emails_on: true
   responsive_on: false
 
+split_accounts:
+  # Roles are allowed to create Split Accounts
+  create_roles:
+    - administrator
+    # - account_manager
+
 # This may be overridden in settings.local.yml if your fork is using S3, so
 # be sure to check there for configuration
 paperclip:

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -110,4 +110,28 @@ RSpec.describe UserRole do
       end
     end
   end
+
+  describe "#in?" do
+    subject(:user_role) { described_class.new(role: "Facility Manager") }
+
+    describe "a single symbol" do
+      it { is_expected.to be_in(:facility_manager) }
+      it { is_expected.not_to be_in(:administrator) }
+    end
+
+    describe "a lower case string" do
+      it { is_expected.to be_in("facility_manager") }
+      it { is_expected.not_to be_in("administrator") }
+    end
+
+    describe "upper case strings" do
+      it { is_expected.to be_in(["Administrator", "Facility Manager"]) }
+      it { is_expected.not_to be_in(["Administrator", "Facility Staff"]) }
+    end
+
+    describe "an array of mixed" do
+      it { is_expected.to be_in(["Administrator", :facility_manager]) }
+      it { is_expected.to be_in([:administrator, "Facility Manager"]) }
+    end
+  end
 end

--- a/vendor/engines/split_accounts/app/models/split_accounts/ability_extension.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/ability_extension.rb
@@ -9,7 +9,17 @@ module SplitAccounts
     end
 
     def extend(user, _resource)
-      ability.cannot :create, SplitAccounts::SplitAccount unless user.administrator?
+      ability.cannot :create, SplitAccounts::SplitAccount unless can_create_split_account?(user)
+    end
+
+    private
+
+    def can_create_split_account?(user)
+      user.user_roles.any? { |role| role.in?(valid_roles) }
+    end
+
+    def valid_roles
+      Settings.split_accounts.create_roles
     end
 
   end

--- a/vendor/engines/split_accounts/spec/controllers/facility_accounts_controller_spec.rb
+++ b/vendor/engines/split_accounts/spec/controllers/facility_accounts_controller_spec.rb
@@ -4,6 +4,10 @@ require_relative "../split_accounts_spec_helper"
 RSpec.describe FacilityAccountsController, :enable_split_accounts do
   render_views
 
+  before do
+    allow(Settings).to receive_message_chain(:split_accounts, :create_roles).and_return :administrator
+  end
+
   let(:facility) { FactoryGirl.create(:setup_facility) }
   before { sign_in user }
 


### PR DESCRIPTION
NU wants only global admins, DC wants account managers to be able to as well.

The change for DC will adding `account_manager` to the new setting that lists the roles that are allowed to create split accounts.