### PR TITLE
[#134079] Make jQuery-ui theme an ERB so it uses rails `image_tag` helper

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,11 +35,8 @@ $baseFontSize: 12px;
 @import "calendar/fullcalendar.extensions";
 @import "clockpunch";
 
-// Must import each individually because the jquery-ui-rails gem is in CSS, not SASS
-@import "jquery-ui/core";
-@import "jquery-ui/datepicker";
-@import "jquery-ui/dialog";
-@import "jquery-ui/draggable";
-@import "jquery-ui/tabs";
-@import "jquery-ui/theme";
+
+// This uses a theme in vendor/engines because it looks better in the context
+// of NUcore than the default theme.
+// See vendor/engines/stylesheets/jquery-ui.theme.md for instructions on updating the theme.
 @import "jquery-ui-smoothness";

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,6 +35,8 @@ Nucore::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = true
 
+  config.assets.raise_runtime_errors = true
+
   # Raise exceptions when missing I18n translations
   config.action_view.raise_on_missing_translations = true
 end

--- a/vendor/assets/stylesheets/jquery-ui-smoothness.css.erb
+++ b/vendor/assets/stylesheets/jquery-ui-smoothness.css.erb
@@ -910,7 +910,7 @@ body .ui-tooltip {
 }
 .ui-widget-header {
   border: 1px solid #aaaaaa;
-  background: #cccccc url("jquery-ui-smoothness/ui-bg_highlight-soft_75_cccccc_1x100.png") 50% 50% repeat-x;
+  background: #cccccc url(<%= image_path("jquery-ui-smoothness/ui-bg_highlight-soft_75_cccccc_1x100.png") %>) 50% 50% repeat-x;
   color: #222222;
   font-weight: bold;
 }
@@ -930,7 +930,7 @@ works properly when clicked or hovered */
 html .ui-button.ui-state-disabled:hover,
 html .ui-button.ui-state-disabled:active {
   border: 1px solid #d3d3d3;
-  background: #e6e6e6 url("jquery-ui-smoothness/ui-bg_glass_75_e6e6e6_1x400.png") 50% 50% repeat-x;
+  background: #e6e6e6 url(<%= image_path("jquery-ui-smoothness/ui-bg_glass_75_e6e6e6_1x400.png") %>) 50% 50% repeat-x;
   font-weight: normal;
   color: #555555;
 }
@@ -953,7 +953,7 @@ a:visited.ui-button,
 .ui-button:hover,
 .ui-button:focus {
   border: 1px solid #999999;
-  background: #dadada url("jquery-ui-smoothness/ui-bg_glass_75_dadada_1x400.png") 50% 50% repeat-x;
+  background: #dadada url(<%= image_path("jquery-ui-smoothness/ui-bg_glass_75_dadada_1x400.png") %>) 50% 50% repeat-x;
   font-weight: normal;
   color: #212121;
 }
@@ -981,7 +981,7 @@ a.ui-button:active,
 .ui-button:active,
 .ui-button.ui-state-active:hover {
   border: 1px solid #aaaaaa;
-  background: #ffffff url("jquery-ui-smoothness/ui-bg_glass_65_ffffff_1x400.png") 50% 50% repeat-x;
+  background: #ffffff url(<%= image_path("jquery-ui-smoothness/ui-bg_glass_65_ffffff_1x400.png") %>) 50% 50% repeat-x;
   font-weight: normal;
   color: #212121;
 }
@@ -1003,7 +1003,7 @@ a.ui-button:active,
 .ui-widget-content .ui-state-highlight,
 .ui-widget-header .ui-state-highlight {
   border: 1px solid #fcefa1;
-  background: #fbf9ee url("jquery-ui-smoothness/ui-bg_glass_55_fbf9ee_1x400.png") 50% 50% repeat-x;
+  background: #fbf9ee url(<%= image_path("jquery-ui-smoothness/ui-bg_glass_55_fbf9ee_1x400.png") %>) 50% 50% repeat-x;
   color: #363636;
 }
 .ui-state-checked {
@@ -1019,7 +1019,7 @@ a.ui-button:active,
 .ui-widget-content .ui-state-error,
 .ui-widget-header .ui-state-error {
   border: 1px solid #cd0a0a;
-  background: #fef1ec url("jquery-ui-smoothness/ui-bg_glass_95_fef1ec_1x400.png") 50% 50% repeat-x;
+  background: #fef1ec url(<%= image_path("jquery-ui-smoothness/ui-bg_glass_95_fef1ec_1x400.png") %>) 50% 50% repeat-x;
   color: #cd0a0a;
 }
 .ui-state-error a,
@@ -1065,31 +1065,31 @@ a.ui-button:active,
 }
 .ui-icon,
 .ui-widget-content .ui-icon {
-  background-image: url("jquery-ui-smoothness/ui-icons_222222_256x240.png");
+  background-image: url(<%= image_path("jquery-ui-smoothness/ui-icons_222222_256x240.png") %>);
 }
 .ui-widget-header .ui-icon {
-  background-image: url("jquery-ui-smoothness/ui-icons_222222_256x240.png");
+  background-image: url(<%= image_path("jquery-ui-smoothness/ui-icons_222222_256x240.png") %>);
 }
 .ui-state-hover .ui-icon,
 .ui-state-focus .ui-icon,
 .ui-button:hover .ui-icon,
 .ui-button:focus .ui-icon {
-  background-image: url("jquery-ui-smoothness/ui-icons_454545_256x240.png");
+  background-image: url(<%= image_path("jquery-ui-smoothness/ui-icons_454545_256x240.png") %>);
 }
 .ui-state-active .ui-icon,
 .ui-button:active .ui-icon {
-  background-image: url("jquery-ui-smoothness/ui-icons_454545_256x240.png");
+  background-image: url(<%= image_path("jquery-ui-smoothness/ui-icons_454545_256x240.png") %>);
 }
 .ui-state-highlight .ui-icon,
 .ui-button .ui-state-highlight.ui-icon {
-  background-image: url("jquery-ui-smoothness/ui-icons_2e83ff_256x240.png");
+  background-image: url(<%= image_path("jquery-ui-smoothness/ui-icons_2e83ff_256x240.png") %>);
 }
 .ui-state-error .ui-icon,
 .ui-state-error-text .ui-icon {
-  background-image: url("jquery-ui-smoothness/ui-icons_cd0a0a_256x240.png");
+  background-image: url(<%= image_path("jquery-ui-smoothness/ui-icons_cd0a0a_256x240.png") %>);
 }
 .ui-button .ui-icon {
-  background-image: url("jquery-ui-smoothness/ui-icons_888888_256x240.png");
+  background-image: url(<%= image_path("jquery-ui-smoothness/ui-icons_888888_256x240.png") %>);
 }
 
 /* positioning */

--- a/vendor/assets/stylesheets/jquery-ui.theme.md
+++ b/vendor/assets/stylesheets/jquery-ui.theme.md
@@ -1,0 +1,19 @@
+# Using a custom jquery-ui theme
+
+As of jquery-ui 1.12/jquery-ui-rails 6, the default theme changed. The jquery-ui-rails
+gem only includes the default (now "Base") theme. The old theme ("Smoothness")
+looks better within the context of NUcore, so we keep a copy of the css in
+vendor/engines.
+
+* Download the Smoothness theme from https://jqueryui.com/themeroller
+
+* Copy the `jquery-ui.css` file into vendor/assets/stylesheets
+
+* Replace the hard-coded image paths with Rails asset paths and convert the file
+to ERB:
+
+```
+cat vendor/assets/stylesheets/jquery-ui.css | perl -pe 's/url\("images\/([\w.-]+)"\)/url(<%= image_path("jquery-ui-smoothness\/\1") %>)/g' > vendor/assets/stylesheets/jquery-ui-smoothness.css.erb
+```
+
+* Delete the jquery-ui.css


### PR DESCRIPTION
We had problems on deployment because the image assets weren't in the hard-coded
paths we expected (including digest) when we updated to revert to the Smoothness
theme of previous jquery-ui versions. The noticeable was the previous/next month arrows on the date-picker widget.

Inspired by:
https://github.com/jquery-ui-rails/jquery-ui-rails/blob/master/app/assets/stylesheets/jquery-ui/theme.css.erb

The jquery-ui-rails repo has a complicated Rakefile that does similar building
from the "base" theme, but simpler instructions have been provided in
`vendor/assets/stylesheets/jquery-ui.theme.md`.

See #960 for the previous attempt to fix.