### PR TITLE
update eye

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,11 +229,11 @@ GEM
       activesupport (>= 3.0.4)
     excon (0.55.0)
     execjs (2.7.0)
-    eye (0.8.1)
+    eye (0.9.1)
       celluloid (~> 0.17.3)
       celluloid-io (~> 0.17.0)
       sigar (~> 0.7.3)
-      state_machine
+      state_machines
       thor
     eye-patch (0.3.1)
       chronic_duration
@@ -337,7 +337,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
-    nio4r (1.2.1)
+    nio4r (2.0.0)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
     notiffany (0.1.1)
@@ -506,7 +506,7 @@ GEM
     sshkit (1.12.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    state_machine (1.2.0)
+    state_machines (0.4.0)
     sysexits (1.2.0)
     teaspoon (1.1.5)
       railties (>= 3.2.5, < 6)
@@ -528,7 +528,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.5)
-    timers (4.1.1)
+    timers (4.1.2)
       hitimes
     ttfunk (1.0.3)
     tzinfo (1.2.2)


### PR DESCRIPTION
`nucore-open` was using eye 0.8.1, `nucore-nu` is using 0.9.1. This updates open to catch up to NU.