### PR TITLE
Update migration to support mariadb 5.5

### DIFF
--- a/db/migrate/20170308030632_change_schedule_rule_to_belong_to_product.rb
+++ b/db/migrate/20170308030632_change_schedule_rule_to_belong_to_product.rb
@@ -1,5 +1,17 @@
 class ChangeScheduleRuleToBelongToProduct < ActiveRecord::Migration
-  def change
+
+  def up
+    # MySQL 5.6+ will rename the foreign key with the column, but Mariadb 5.5
+    # (which Dartmouth uses) triggers contraint validation errors.
+    remove_foreign_key :schedule_rules, :instruments
     rename_column :schedule_rules, :instrument_id, :product_id
+    add_foreign_key :schedule_rules, :products
   end
+
+  def down
+    remove_foreign_key :schedule_rules, :products
+    rename_column :schedule_rules, :product_id, :instrument_id
+    add_foreign_key :schedule_rules, :products, column: :instrument_id
+  end
+
 end


### PR DESCRIPTION
MySQL 5.6+ will rename the foreign key when renaming a column, but Mariadb 5.5
(which Dartmouth uses) triggers constraint validation errors.