### PR TITLE
Update AccountPresenter

### DIFF
--- a/vendor/engines/secure_rooms/app/presenters/secure_rooms/account_presenter.rb
+++ b/vendor/engines/secure_rooms/app/presenters/secure_rooms/account_presenter.rb
@@ -1,21 +1,33 @@
 module SecureRooms
 
-  class AccountPresenter < SimpleDelegator
+  class AccountPresenter
+
+    include ActiveModel::Serializers::JSON
+
+    attr_reader :account
 
     def self.wrap(accounts)
       Array(accounts).map { |account| new(account) }
     end
 
-    def to_json
-      {
-        id: id,
-        type: type,
-        description: description,
-        account_number: account_number,
-        expiration_month: expiration_month,
-        expiration_year: expiration_year,
-        owner_name: owner_user_name,
-      }.to_json
+    def initialize(account)
+      @account = account
+    end
+
+    private
+
+    delegate :id, :type, :description, :account_number, :expiration_month, :expiration_year, to: :account
+
+    def attribute_names
+      %w(id type description account_number expiration_month expiration_year owner_name)
+    end
+
+    def attributes
+      @attributes ||= attribute_names.map { |attr| [attr, nil] }.to_h
+    end
+
+    def owner_name
+      account.owner_user_name
     end
 
   end

--- a/vendor/engines/secure_rooms/spec/presenters/secure_rooms/account_presenter_spec.rb
+++ b/vendor/engines/secure_rooms/spec/presenters/secure_rooms/account_presenter_spec.rb
@@ -1,11 +1,31 @@
 require "rails_helper"
 
 RSpec.describe SecureRooms::AccountPresenter do
+  let(:presenter_attributes) do
+    %w(id type description account_number expiration_month expiration_year owner_name)
+  end
+
   describe ".wrap" do
     let(:accounts) { build_stubbed_list :account, 3, :with_account_owner }
     subject(:presenters) { described_class.wrap(accounts) }
 
     it { is_expected.to all(be_a(described_class)) }
+
+    describe "serialized list" do
+      let(:json) { ActiveSupport::JSON.encode presenters }
+
+      subject(:parsed_list) { JSON.parse(json) }
+
+      it "contains correct number of accounts" do
+        expect(parsed_list.length).to eq 3
+      end
+
+      describe "individual account json" do
+        subject(:keys) { parsed_list.first.keys }
+
+        it { is_expected.to eq presenter_attributes }
+      end
+    end
   end
 
   describe "instance methods" do
@@ -18,13 +38,7 @@ RSpec.describe SecureRooms::AccountPresenter do
       describe "keys" do
         subject(:keys) { parsed_json.keys }
 
-        it { is_expected.to include("id") }
-        it { is_expected.to include("type") }
-        it { is_expected.to include("description") }
-        it { is_expected.to include("account_number") }
-        it { is_expected.to include("expiration_month") }
-        it { is_expected.to include("expiration_year") }
-        it { is_expected.to include("owner_name") }
+        it { is_expected.to eq presenter_attributes }
       end
     end
   end


### PR DESCRIPTION
* The previous version ended up lost between `SimpleDelegator` and `ActiveModel::Serialization` and was spitting out the wrong JSON when encoded within an array. It's now a full `ActiveModel::Serializers::JSON` situation, so `ActiveSupport::JSON.encode` will work properly.