### PR TITLE
[#135584] Prevent hard error when trying to purchase an instrument with no reservation

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -285,7 +285,7 @@ class OrdersController < ApplicationController
     if single_reservation?
       # with additional validations (see OrderPurchaser), we discard the existing reservation
       # and redirect to new. otherwise it takes us out of the normal reservation purchase flow
-      @order.order_details.first.reservation.destroy
+      @order.order_details.first.reservation.destroy if @order.order_details.first.reservation
       redirect_to new_order_order_detail_reservation_path(@order, @order.order_details.first)
     else
       redirect_to order_path(@order)


### PR DESCRIPTION
`orders#update_or_purchase (NoMethodError) "undefined method `destroy' for nil:NilClass"`

I'm not 100% how to replicate the error, but it appears that through some multiple
tab situation, there was a "Purchase" button available on the cart, even though
the order did not have a reservation on it. After failing and raising the error,
there was no reservation to destroy.

Looking at Lin's cart, there is one instrument in the cart with no reservation set. But the error did have `"commit"=>"Purchase"` in the params, so somehow the Purchase button was clicked.

![screen shot 2017-04-18 at 6 15 07 pm](https://cloud.githubusercontent.com/assets/1099111/25156886/2cfa686e-2463-11e7-8f0a-b76d09bebccc.png)
