### PR TITLE
[#134005] Change column header on My Reservations

### DIFF
--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -267,7 +267,6 @@ linters:
       - "app/views/product_accessories/index.html.haml"
       - "app/views/reservations/edit.html.haml"
       - "app/views/shared/_login_button.html.haml"
-      - "app/views/shared/_reservations_table.html.haml"
       - "app/views/shared/_statements_table.html.haml"
       - "app/views/shared/transactions/_table_inside.html.haml"
       - "app/views/statements/list.html.haml"
@@ -370,7 +369,6 @@ linters:
       - "app/views/price_policies/instrument/_rate_calculation.html.haml"
       - "app/views/price_policies/instrument/_table.html.haml"
       - "app/views/reservations/_reservation_fields.html.haml"
-      - "app/views/reservations/list.html.haml"
       - "app/views/shared/_acting_as.html.haml"
       - "app/views/shared/_header.html.haml"
       - "vendor/engines/projects/app/views/projects/projects/show.html.haml"
@@ -383,7 +381,6 @@ linters:
       - "app/views/facility_orders/show.html.haml"
       - "app/views/price_policies/index.html.haml"
       - "app/views/reports/report.html.haml"
-      - "app/views/reservations/list.html.haml"
       - "app/views/shared/transactions/_in_review.html.haml"
       - "vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_fields.html.haml"
 

--- a/app/views/reservations/_my_table.html.haml
+++ b/app/views/reservations/_my_table.html.haml
@@ -1,18 +1,18 @@
 %table.table.table-striped.table-hover.old-table
   %thead
     %tr
-      %th.centered Order #
-      %th.centered Actions
-      %th Reserved For
-      %th.order-note.order-note--wide Product
-      %th.centered Status
-      %th.currency Total
+      %th.centered= OrderDetail.human_attribute_name(:id)
+      %th.centered= text("actions")
+      %th= text("reservation")
+      %th.order-note.order-note--wide= OrderDetail.human_attribute_name(:product)
+      %th.centered= OrderDetail.human_attribute_name(:status)
+      %th.currency= OrderDetail.human_attribute_name(:unassigned_total)
   %tbody
     - order_details.each do |od|
       - order = od.order
       - res = od.reservation
       %tr
-        %td.centered= link_to od, current_facility ? facility_order_path(current_facility, order) : order_order_detail_path(order, od)
+        %td.centered= link_to od, order_order_detail_path(order, od)
         - next unless res
         %td.centered
           = reservation_actions(res)
@@ -28,16 +28,10 @@
               .order-detail-extra.order-detail-note
                 = render "shared/order_detail_note", order_detail: od
 
-        %td.centered=h od.order_status.name
+        %td.centered= od.order_status.name
         %td.currency
           - od.send(:extend, PriceDisplayment)
           = od.reload.wrapped_total
 
-%p.footnote
-  %span.estimated_cost
-    Orange
-  totals are estimates.
-  %span.actual_cost
-    Green
-  totals are final. Pricing will be assigned to transactions with unassigned totals.
+= render "/price_display_footnote"
 = will_paginate(order_details)

--- a/app/views/reservations/list.html.haml
+++ b/app/views/reservations/list.html.haml
@@ -8,15 +8,14 @@
         reservations_status_path(status: status),
         (@status == status)
 
-- if @order_details.empty?
-  %p.notice
-    = "You have not made any #{Reservation.model_name.human.pluralize.downcase}."
+- if @order_details.any?
+  = render "my_table", order_details: @order_details
 - else
-  = render "shared/reservations_table", order_details: @order_details
+  %p.notice= text("none")
 
 - if session[:reservation_ended]
   - session.delete(:reservation_ended)
-  #logout_modal.modal.hide.fade
+  .modal.hide.fade#logout_modal
     .modal-body= t("reservations.logout.body")
     .modal-footer
       = link_to t("reservations.logout.cancel"), reservations_path, class: "btn"

--- a/config/locales/views/en.reservations.yml
+++ b/config/locales/views/en.reservations.yml
@@ -2,3 +2,10 @@ en:
   controllers:
     reservations:
       acting_as_not_on_approval_list: The user you are ordering for is not on the authorized list for this instrument.
+  views:
+    reservations:
+      list:
+        none: "You have not made any reservations."
+      my_table:
+        actions: Actions
+        reservation: Reservation (Edit/Extend)


### PR DESCRIPTION
NU requested "Reserved For" to be changed to read "Reservation
(Edit/Extend)”.

`reservations_table` is not used anywhere else, so I removed it from
`shared`

I have a question out on if they want it for both Upcoming and All tabs, so that may change based on their feedback.