### PR TITLE
[#140895293] Basic SecureRooms events API endpoint

### DIFF
--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/api_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/api_controller.rb
@@ -1,0 +1,12 @@
+module SecureRoomsApi
+
+  class ApiController < ApplicationController
+
+    http_basic_authenticate_with(
+      name: Settings.secure_rooms_api.basic_auth_name,
+      password: Settings.secure_rooms_api.basic_auth_password,
+    )
+
+  end
+
+end

--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/events_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/events_controller.rb
@@ -1,0 +1,12 @@
+module SecureRoomsApi
+
+  class EventsController < SecureRoomsApi::ApiController
+
+    def create
+      Rails.logger.info "SecureRoomsApi Event: #{params}"
+      render nothing: true
+    end
+
+  end
+
+end

--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/scans_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/scans_controller.rb
@@ -1,32 +1,31 @@
-class SecureRoomsApi::ScansController < ApplicationController
+module SecureRoomsApi
 
-  http_basic_authenticate_with(
-    name: Settings.secure_rooms_api.basic_auth_name,
-    password: Settings.secure_rooms_api.basic_auth_password,
-  )
+  class ScansController < SecureRoomsApi::ApiController
 
-  before_action :load_user_and_reader
+    before_action :load_user_and_reader
 
-  def scan
-    verdict = SecureRooms::CheckAccess.new.authorize(
-      @user,
-      @card_reader,
-      requested_account_id: params[:account_identifier],
-    )
+    def scan
+      verdict = SecureRooms::CheckAccess.new.authorize(
+        @user,
+        @card_reader,
+        requested_account_id: params[:account_identifier],
+      )
 
-    SecureRooms::AccessManager.process(verdict)
+      SecureRooms::AccessManager.process(verdict)
 
-    render SecureRooms::ScanResponsePresenter.present(verdict)
-  end
+      render SecureRooms::ScanResponsePresenter.present(verdict)
+    end
 
-  private
+    private
 
-  def load_user_and_reader
-    @user = User.find_by!(card_number: params[:card_number])
-    @card_reader = SecureRooms::CardReader.find_by!(
-      card_reader_number: params[:reader_identifier],
-      control_device_number: params[:controller_identifier],
-    )
+    def load_user_and_reader
+      @user = User.find_by!(card_number: params[:card_number])
+      @card_reader = SecureRooms::CardReader.find_by!(
+        card_reader_number: params[:reader_identifier],
+        control_device_number: params[:controller_identifier],
+      )
+    end
+
   end
 
 end

--- a/vendor/engines/secure_rooms/config/routes.rb
+++ b/vendor/engines/secure_rooms/config/routes.rb
@@ -18,5 +18,6 @@ Rails.application.routes.draw do
 
   namespace :secure_rooms_api do
     post '/scan', to: 'scans#scan'
+    resources :events, only: :create
   end
 end

--- a/vendor/engines/secure_rooms/spec/controllers/secure_rooms_api/events_controller_spec.rb
+++ b/vendor/engines/secure_rooms/spec/controllers/secure_rooms_api/events_controller_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe SecureRoomsApi::EventsController do
-
   before do
     name = Settings.secure_rooms_api.basic_auth_name
     password = Settings.secure_rooms_api.basic_auth_password
@@ -41,6 +40,5 @@ RSpec.describe SecureRoomsApi::EventsController do
 
       it { is_expected.to have_http_status(:unauthorized) }
     end
-
   end
 end

--- a/vendor/engines/secure_rooms/spec/controllers/secure_rooms_api/events_controller_spec.rb
+++ b/vendor/engines/secure_rooms/spec/controllers/secure_rooms_api/events_controller_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe SecureRoomsApi::EventsController do
+
+  before do
+    name = Settings.secure_rooms_api.basic_auth_name
+    password = Settings.secure_rooms_api.basic_auth_password
+    encoded_auth_credentials = ActionController::HttpAuthentication::Basic.encode_credentials(name, password)
+    request.env['HTTP_AUTHORIZATION'] = encoded_auth_credentials
+  end
+
+  describe "create" do
+    subject { response }
+
+    describe "some data" do
+      let(:params) do
+        {
+          message_id: "000009",
+          message_type: "10",
+          class_code: "5",
+          task_code: "5",
+          event_code: "1",
+          priority: "100",
+          task_description: "eventlogger task",
+          event_description: "start task",
+        }
+      end
+
+      before do
+        post :create, params
+      end
+
+      it { is_expected.to be_success }
+    end
+
+    describe "invalid credentials" do
+      before do
+        request.env.delete("HTTP_AUTHORIZATION")
+        post :create
+      end
+
+      it { is_expected.to have_http_status(:unauthorized) }
+    end
+
+  end
+end

--- a/vendor/engines/secure_rooms/spec/controllers/secure_rooms_api/scans_controller_spec.rb
+++ b/vendor/engines/secure_rooms/spec/controllers/secure_rooms_api/scans_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SecureRoomsApi::ScansController do
       name = Settings.secure_rooms_api.basic_auth_name
       password = Settings.secure_rooms_api.basic_auth_password
       encoded_auth_credentials = ActionController::HttpAuthentication::Basic.encode_credentials(name, password)
-      request.env['HTTP_AUTHORIZATION'] = encoded_auth_credentials
+      request.env["HTTP_AUTHORIZATION"] = encoded_auth_credentials
     end
 
     subject { response }


### PR DESCRIPTION
This is intentionally basic, only setting up the endpoint and logging,
in order to unblock other work. Future changes in implement the storage
of these events.