### PR TITLE
[#135761] Disable cart purchase button on submit

### DIFF
--- a/app/views/orders/_form.html.haml
+++ b/app/views/orders/_form.html.haml
@@ -43,4 +43,4 @@
         %li
           = f.submit t("shared.purchase"),
             class: %w(btn btn-primary),
-            data: { confirm: t(".confirm") }
+            data: { disable_with: t("shared.purchase") }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -617,7 +617,6 @@ en:
         account: "Payment Source"
         owner: "Owner"
     form:
-      confirm: "Are you sure you wish to place this order?"
       foot:
         all: "All prices are estimates. Actual cost is assigned when the order is complete."
         instrument: "* Instrument pricing is estimated; the final price may vary based on actual time used."


### PR DESCRIPTION
Also, remove the confirmation popup as it was deemed unnecessary and
added friction.