### PR TITLE
Remove Reservation#duration_value/unit fields

### DIFF
--- a/app/controllers/facility_reservations_controller.rb
+++ b/app/controllers/facility_reservations_controller.rb
@@ -113,7 +113,7 @@ class FacilityReservationsController < ApplicationController
   def new
     @instrument   = current_facility.instruments.find_by_url_name!(params[:instrument_id])
     @reservation = @instrument.next_available_reservation ||
-                   @instrument.admin_reservations.build(duration_value: @instrument.min_reserve_mins, duration_unit: "minutes")
+                   @instrument.admin_reservations.build(duration_mins: @instrument.min_reserve_mins)
     @reservation = @reservation.becomes(AdminReservation)
     @reservation.round_reservation_times
     set_windows

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -78,8 +78,7 @@ RSpec.describe ReservationsController do
           instrument.reservations.create(
             reserve_start_at: now,
             order_detail: order_detail,
-            duration_value: 60,
-            duration_unit: "minutes",
+            duration_mins: 60,
             split_times: true,
           )
         end
@@ -93,8 +92,7 @@ RSpec.describe ReservationsController do
         let!(:reservation) do
           instrument.reservations.create(reserve_start_at: now - 1.day,
                                          order_detail: order_detail,
-                                         duration_value: 60,
-                                         duration_unit: "minutes",
+                                         duration_mins: 60,
                                          split_times: true)
         end
 
@@ -107,8 +105,7 @@ RSpec.describe ReservationsController do
         let!(:reservation) do
           instrument.reservations.create(reserve_start_at: now + 3.days,
                                          order_detail: order_detail,
-                                         duration_value: 60,
-                                         duration_unit: "minutes",
+                                         duration_mins: 60,
                                          split_times: true)
         end
 
@@ -318,8 +315,7 @@ RSpec.describe ReservationsController do
           reserve_start_hour: "9",
           reserve_start_min: "0",
           reserve_start_meridian: "am",
-          duration_value: "60",
-          duration_unit: "minutes",
+          duration_mins: "60",
         },
       }
     end
@@ -370,8 +366,7 @@ RSpec.describe ReservationsController do
           reserve_start_hour: "9",
           reserve_start_min: "0",
           reserve_start_meridian: "am",
-          duration_value: "60",
-          duration_unit: "minutes",
+          duration_mins: "60",
         },
       )
     end
@@ -513,9 +508,8 @@ RSpec.describe ReservationsController do
         expect(flash[:error]).to be_present
         expect(response).to render_template :new
       end
-      it "should maintain duration value and units" do
-        expect(assigns[:reservation].duration_value).to eq(60)
-        expect(assigns[:reservation].duration_unit).to eq("minutes")
+      it "should maintain duration value" do
+        expect(assigns[:reservation].duration_mins).to eq(60)
       end
       it "should not lose the time" do
         expect(assigns[:reservation].reserve_start_date).to eq(format_usa_date(Time.zone.now.to_date + 1.day))
@@ -815,7 +809,7 @@ RSpec.describe ReservationsController do
       # create reservation for tomorrow @ 9 am for 60 minutes, with order detail reference
       @start        = Time.zone.now.end_of_day + 1.second + 9.hours
       @reservation  = @instrument.reservations.create(reserve_start_at: @start, order_detail: @order_detail,
-                                                      duration_value: 60, duration_unit: "minutes", split_times: true)
+                                                      duration_mins: 60, split_times: true)
       assert @reservation.valid?
     end
 
@@ -898,8 +892,7 @@ RSpec.describe ReservationsController do
             reserve_start_hour: "10",
             reserve_start_min: "0",
             reserve_start_meridian: "am",
-            duration_value: "60",
-            duration_unit: "minutes",
+            duration_mins: "60",
           },
         )
       end
@@ -1009,8 +1002,7 @@ RSpec.describe ReservationsController do
         @reservation = @instrument.reservations.create(
           reserve_start_at: Time.zone.now + 1.day,
           order_detail: @order_detail,
-          duration_value: 60,
-          duration_unit: "minutes",
+          duration_mins: 60,
           split_times: true,
         )
 
@@ -1036,8 +1028,7 @@ RSpec.describe ReservationsController do
         @reservation = @instrument.reservations.create!(
           reserve_start_at: Time.zone.now + 1.day,
           order_detail: @order_detail,
-          duration_value: 24,
-          duration_unit: "hours",
+          duration_mins: 24 * 60,
           split_times: true,
         )
 
@@ -1099,7 +1090,7 @@ RSpec.describe ReservationsController do
       # create reservation for tomorrow @ 9 am for 60 minutes, with order detail reference
       @start        = Time.zone.now + 1.second
       @reservation  = @instrument.reservations.create(reserve_start_at: @start, order_detail: @order_detail,
-                                                      duration_value: 60, duration_unit: "minutes", split_times: true)
+                                                      duration_mins: 60, split_times: true)
       assert @reservation.valid?
     end
 

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -363,12 +363,11 @@ RSpec.describe Instrument do
       assert_equal [@reservation2], @instrument.reservations.upcoming(@start + 1.hour)
     end
 
-    it "should allow 1 hour reservations between 9 and 5, using duration_value, duration_unit virtual attribute" do
+    it "should allow 1 hour reservations between 9 and 5, using duration_mins" do
       # 9 am - 10 am
       @start        = Time.zone.now.end_of_day + 1.second + 9.hours
       @reservation1 = @instrument.reservations.create(reserve_start_at: @start,
-                                                      duration_value: 60,
-                                                      duration_unit: "minutes",
+                                                      duration_mins: 60,
                                                       split_times: true)
       assert @reservation1.valid?
       assert_equal 60, @reservation1.reload.duration_mins
@@ -396,8 +395,7 @@ RSpec.describe Instrument do
                                                       reserve_start_hour: "9",
                                                       reserve_start_min: "30",
                                                       reserve_start_meridian: "am",
-                                                      duration_value: "60",
-                                                      duration_unit: "minutes",
+                                                      duration_mins: "60",
                                                       split_times: true)
       expect(@reservation2.errors[:base]).not_to be_empty
       # not allow 9:30 am - 11:30 am
@@ -504,8 +502,7 @@ RSpec.describe Instrument do
       # add reservation for tomorrow morning at 9 am
       @start        = Time.zone.now.end_of_day + 1.second + 9.hours
       @reservation1 = @instrument.reservations.create(reserve_start_at: @start,
-                                                      duration_value: 60,
-                                                      duration_unit: "minutes",
+                                                      duration_mins: 60,
                                                       split_times: true)
       assert @reservation1.valid?
       # find next reservation after 12 am tomorrow at 10 am tomorrow

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -240,8 +240,7 @@ RSpec.describe Order do
                                                      reserve_start_hour: 9,
                                                      reserve_start_min: 00,
                                                      reserve_start_meridian: "am",
-                                                     duration_value: 60,
-                                                     duration_unit: "minutes",
+                                                     duration_mins: 60,
                                                      order_detail: @order_detail,
                                                      split_times: true)
       expect(@order.validate_order!).to be true

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe Reservation do
       reserve_start_hour: 10,
       reserve_start_min: 0,
       reserve_start_meridian: "am",
-      duration_value: 60,
-      duration_unit: "minutes",
+      duration_mins: 60,
       split_times: true,
     )
   end
@@ -281,7 +280,7 @@ RSpec.describe Reservation do
   context "create using virtual attributes" do
     it "should create using date, integer values" do
       assert reservation.valid?
-      expect(reservation.reload.duration_value).to eq(60)
+      expect(reservation.reload.duration_mins).to eq(60)
       expect(reservation.reserve_start_hour).to eq(10)
       expect(reservation.reserve_start_min).to eq(0)
       expect(reservation.reserve_start_meridian).to eq("am")
@@ -295,8 +294,7 @@ RSpec.describe Reservation do
                                                     reserve_start_hour: "10",
                                                     reserve_start_min: "0",
                                                     reserve_start_meridian: "am",
-                                                    duration_value: "2",
-                                                    duration_unit: "hours",
+                                                    duration_mins: "120",
                                                     split_times: true)
       assert @reservation.valid?
       expect(@reservation.reload.duration_mins).to eq(120)
@@ -315,8 +313,7 @@ RSpec.describe Reservation do
                                      reserve_start_hour: "10",
                                      reserve_start_min: "0",
                                      reserve_start_meridian: "am",
-                                     duration_value: "2",
-                                     duration_unit: "hours",
+                                     duration_mins: "120",
                                      split_times: true)
     end
 
@@ -351,8 +348,7 @@ RSpec.describe Reservation do
                                                      reserve_start_hour: 10,
                                                      reserve_start_min: 0,
                                                      reserve_start_meridian: "am",
-                                                     duration_value: 30,
-                                                     duration_unit: "minutes",
+                                                     duration_mins: 30,
                                                      order_detail: @detail1,
                                                      split_times: true)
     end
@@ -506,7 +502,7 @@ RSpec.describe Reservation do
     it "should not allow two reservations with the same order detail id" do
       reservation2 = @instrument.reservations.new(reserve_start_date: Date.today + 1.day, reserve_start_hour: 10,
                                                   reserve_start_min: 0, reserve_start_meridian: "am",
-                                                  duration_value: 30, duration_unit: "minutes", order_detail: @reservation1.order_detail)
+                                                  duration_mins: 30, order_detail: @reservation1.order_detail)
       assert !reservation2.save
       expect(reservation2.errors[:order_detail]).not_to be_nil
     end
@@ -532,8 +528,7 @@ RSpec.describe Reservation do
                                                      reserve_start_hour: 10,
                                                      reserve_start_min: 0,
                                                      reserve_start_meridian: "am",
-                                                     duration_value: 30,
-                                                     duration_unit: "minutes",
+                                                     duration_mins: 30,
                                                      order_detail: @detail2,
                                                      split_times: true)
       expect(@reservation2).not_to be_valid
@@ -543,8 +538,7 @@ RSpec.describe Reservation do
                                                       reserve_start_hour: 10,
                                                       reserve_start_min: 15,
                                                       reserve_start_meridian: "am",
-                                                      duration_value: 30,
-                                                      duration_unit: "minutes",
+                                                      duration_mins: 30,
                                                       order_detail: @detail2,
                                                       split_times: true)
       expect(@reservation2).not_to be_valid
@@ -554,8 +548,7 @@ RSpec.describe Reservation do
                                                      reserve_start_hour: 9,
                                                      reserve_start_min: 45,
                                                      reserve_start_meridian: "am",
-                                                     duration_value: 30,
-                                                     duration_unit: "minutes",
+                                                     duration_mins: 30,
                                                      order_detail: @detail2,
                                                      split_times: true)
       expect(@reservation2).not_to be_valid
@@ -569,8 +562,7 @@ RSpec.describe Reservation do
                                                      reserve_start_hour: 10,
                                                      reserve_start_min: 0,
                                                      reserve_start_meridian: "am",
-                                                     duration_value: 30,
-                                                     duration_unit: "minutes",
+                                                     duration_mins: 30,
                                                      order_detail: @detail2,
                                                      split_times: true)
 
@@ -778,8 +770,7 @@ RSpec.describe Reservation do
                                       reserve_start_hour: 10,
                                       reserve_start_min: 0,
                                       reserve_start_meridian: "am",
-                                      duration_value: "60",
-                                      duration_unit: "minutes",
+                                      duration_mins: "60",
                                       split_times: true)
     end
 
@@ -788,8 +779,7 @@ RSpec.describe Reservation do
                                           reserve_start_hour: 10,
                                           reserve_start_min: 0,
                                           reserve_start_meridian: "am",
-                                          duration_value: "60",
-                                          duration_unit: "minutes",
+                                          duration_mins: "60",
                                           split_times: true)
       res.valid?
       res
@@ -800,8 +790,7 @@ RSpec.describe Reservation do
                                           reserve_start_hour: 10,
                                           reserve_start_min: 0,
                                           reserve_start_meridian: "am",
-                                          duration_value: "60",
-                                          duration_unit: "minutes",
+                                          duration_mins: "60",
                                           split_times: true)
       res.valid?
       allow(res).to receive(:admin?).and_return(true)
@@ -854,8 +843,7 @@ RSpec.describe Reservation do
                                                        reserve_start_hour: 6,
                                                        reserve_start_min: 0,
                                                        reserve_start_meridian: "pm",
-                                                       duration_value: "60",
-                                                       duration_unit: "minutes",
+                                                       duration_mins: "60",
                                                        split_times: true)
         end
 
@@ -876,8 +864,7 @@ RSpec.describe Reservation do
                                                        reserve_start_hour: 5,
                                                        reserve_start_min: 30,
                                                        reserve_start_meridian: "pm",
-                                                       duration_value: "60",
-                                                       duration_unit: "minutes",
+                                                       duration_mins: "60",
                                                        split_times: true)
         end
 
@@ -902,8 +889,7 @@ RSpec.describe Reservation do
                                                     reserve_start_hour: 10,
                                                     reserve_start_min: 0,
                                                     reserve_start_meridian: "am",
-                                                    duration_value: 61,
-                                                    duration_unit: "minutes",
+                                                    duration_mins: 61,
                                                     split_times: true)
       expect(@reservation).not_to be_valid
       expect(@reservation.errors[:base]).to include "The reservation is too long"
@@ -915,8 +901,7 @@ RSpec.describe Reservation do
                                        reserve_start_hour: 10,
                                        reserve_start_min: 0,
                                        reserve_start_meridian: "am",
-                                       duration_value: 60,
-                                       duration_unit: "minutes",
+                                       duration_mins: 60,
                                        split_times: true)
       end
 
@@ -928,8 +913,7 @@ RSpec.describe Reservation do
                                                     reserve_start_hour: 10,
                                                     reserve_start_min: 0,
                                                     reserve_start_meridian: "am",
-                                                    duration_value: 75,
-                                                    duration_unit: "minutes",
+                                                    duration_mins: 75,
                                                     split_times: true)
       allow(@reservation).to receive(:admin?).and_return(true)
       expect(@reservation).to be_valid
@@ -944,8 +928,7 @@ RSpec.describe Reservation do
                                                     reserve_start_hour: 10,
                                                     reserve_start_min: 0,
                                                     reserve_start_meridian: "am",
-                                                    duration_value: 29,
-                                                    duration_unit: "minutes",
+                                                    duration_mins: 29,
                                                     split_times: true)
       expect(@reservation).not_to be_valid
       expect(@reservation.errors[:base]).to include "The reservation is too short"
@@ -956,8 +939,7 @@ RSpec.describe Reservation do
                                                     reserve_start_hour: 10,
                                                     reserve_start_min: 0,
                                                     reserve_start_meridian: "am",
-                                                    duration_value: 30,
-                                                    duration_unit: "minutes",
+                                                    duration_mins: 30,
                                                     split_times: true)
       expect(@reservation).to be_valid
     end
@@ -967,8 +949,7 @@ RSpec.describe Reservation do
                                                     reserve_start_hour: 10,
                                                     reserve_start_min: 0,
                                                     reserve_start_meridian: "am",
-                                                    duration_value: 15,
-                                                    duration_unit: "minutes",
+                                                    duration_mins: 15,
                                                     split_times: true)
       allow(@reservation).to receive(:admin?).and_return(true)
       expect(@reservation).to be_valid
@@ -986,8 +967,7 @@ RSpec.describe Reservation do
                                                   reserve_start_hour: 10,
                                                   reserve_start_min: 0,
                                                   reserve_start_meridian: "pm",
-                                                  duration_value: 4,
-                                                  duration_unit: "hours",
+                                                  duration_mins: 240,
                                                   split_times: true)
     assert @reservation.invalid?
     # create rule2 that is adjacent to rule (10 pm to 12 am), allowing multi-day reservations
@@ -997,8 +977,7 @@ RSpec.describe Reservation do
                                                   reserve_start_hour: 10,
                                                   reserve_start_min: 0,
                                                   reserve_start_meridian: "pm",
-                                                  duration_value: 4,
-                                                  duration_unit: "hours",
+                                                  duration_mins: 240,
                                                   split_times: true)
     assert @reservation.valid?
   end
@@ -1101,7 +1080,7 @@ RSpec.describe Reservation do
       @earlier = Date.today - 1
       @reservation = @instrument.reservations.create(reserve_start_date: @earlier, reserve_start_hour: 10,
                                                      reserve_start_min: 0, reserve_start_meridian: "pm",
-                                                     duration_value: 4, duration_unit: "hours")
+                                                     duration_mins: 240)
       assert @reservation.invalid?
     end
 
@@ -1123,8 +1102,7 @@ RSpec.describe Reservation do
                                                    reserve_start_hour: 6,
                                                    reserve_start_min: 0,
                                                    reserve_start_meridian: "pm",
-                                                   duration_value: 1,
-                                                   duration_unit: "hours",
+                                                   duration_mins: 60,
                                                    split_times: true)
         expect(@reservation).to be_valid
 
@@ -1132,18 +1110,17 @@ RSpec.describe Reservation do
                                                     reserve_start_hour: 10,
                                                     reserve_start_min: 0,
                                                     reserve_start_meridian: "am",
-                                                    duration_value: 1,
-                                                    duration_unit: "hours",
+                                                    duration_mins: 60,
                                                     split_times: true)
         expect(@reservation2).to be_valid
       end
 
       it "should not let reservations occur after times defined by schedule rules" do
-        @reservation = @instrument.reservations.new(reserve_start_date: Date.today + 1, reserve_start_hour: 8, reserve_start_min: 0, reserve_start_meridian: "pm", duration_value: 1, duration_unit: "hours")
+        @reservation = @instrument.reservations.new(reserve_start_date: Date.today + 1, reserve_start_hour: 8, reserve_start_min: 0, reserve_start_meridian: "pm", duration_mins: 6)
         expect(@reservation).to be_invalid
       end
       it "should not let reservations occur before times define by schedule rules" do
-        @reservation = @instrument.reservations.new(reserve_start_date: Date.today + 1, reserve_start_hour: 5, reserve_start_min: 0, reserve_start_meridian: "am", duration_value: 1, duration_unit: "hours")
+        @reservation = @instrument.reservations.new(reserve_start_date: Date.today + 1, reserve_start_hour: 5, reserve_start_min: 0, reserve_start_meridian: "am", duration_mins: 60)
         expect(@reservation).to be_invalid
       end
 
@@ -1164,8 +1141,7 @@ RSpec.describe Reservation do
                                          reserve_start_hour: 6,
                                          reserve_start_min: 0,
                                          reserve_start_meridian: "pm",
-                                         duration_value: 1,
-                                         duration_unit: "hours",
+                                         duration_mins: 60,
                                          order_detail: @order_detail,
                                          product: @instrument,
                                          split_times: true)
@@ -1270,8 +1246,7 @@ RSpec.describe Reservation do
   context "as_calendar_obj" do
     before :each do
       @reservation = instrument.reservations.create!(reserve_start_at: 1.hour.ago,
-                                                     duration_value: 60,
-                                                     duration_unit: "minutes",
+                                                     duration_mins: 60,
                                                      split_times: true)
 
       @reserve_start_at_timestamp = @reservation.reserve_start_at.strftime("%a, %d %b %Y %H:%M:%S")
@@ -1318,23 +1293,19 @@ RSpec.describe Reservation do
       @rule = @instrument.schedule_rules.create(FactoryGirl.attributes_for(:schedule_rule).merge(start_hour: 0, end_hour: 24))
 
       @spans_day_reservation = instrument.reservations.create!(reserve_start_at: Time.current.end_of_day - 1.hour,
-                                                               duration_value: 120,
-                                                               duration_unit: "minutes",
+                                                               duration_mins: 120,
                                                                split_times: true)
 
       @today_reservation = instrument.reservations.create!(reserve_start_at: Time.current.beginning_of_day + 8.hours,
-                                                           duration_value: 120,
-                                                           duration_unit: "minutes",
+                                                           duration_mins: 120,
                                                            split_times: true)
 
       @yeserday_reservation = instrument.reservations.create!(reserve_start_at: Time.current.beginning_of_day - 16.hours,
-                                                              duration_value: 120,
-                                                              duration_unit: "minutes",
+                                                              duration_mins: 120,
                                                               split_times: true)
 
       @tomorrow_reservation = instrument.reservations.create!(reserve_start_at: Time.current.end_of_day + 8.hours,
-                                                              duration_value: 120,
-                                                              duration_unit: "minutes",
+                                                              duration_mins: 120,
                                                               split_times: true)
     end
 
@@ -1372,8 +1343,7 @@ RSpec.describe Reservation do
     let!(:weekend_res) do
       @instrument.reservations.create!(
         reserve_start_at: Time.zone.parse("2013-02-22 17:00:00"),
-        duration_value: 4080,
-        duration_unit: "minutes",
+        duration_mins: 4080,
         split_times: true,
       )
     end
@@ -1381,8 +1351,7 @@ RSpec.describe Reservation do
     let!(:monday_res) do
       @instrument.reservations.create!(
         reserve_start_at: Time.zone.parse("2013-02-25 13:00:00"),
-        duration_value: 180,
-        duration_unit: "minutes",
+        duration_mins: 180,
         split_times: true,
       )
     end
@@ -1390,8 +1359,7 @@ RSpec.describe Reservation do
     let!(:next_weekend_res) do
       @instrument.reservations.create!(
         reserve_start_at: next_sunday - 7.hours,
-        duration_value: 600,
-        duration_unit: "minutes",
+        duration_mins: 600,
         split_times: true,
       )
     end
@@ -1399,8 +1367,7 @@ RSpec.describe Reservation do
     let!(:next_monday_res) do
       @instrument.reservations.create!(
         reserve_start_at: next_sunday + 7.hours,
-        duration_value: 180,
-        duration_unit: "minutes",
+        duration_mins: 180,
         split_times: true,
       )
     end
@@ -1408,8 +1375,7 @@ RSpec.describe Reservation do
     let!(:prior_friday_res) do
       @instrument.reservations.create!(
         reserve_start_at: weekend_res.reserve_start_at - 7.hours,
-        duration_value: 180,
-        duration_unit: "minutes",
+        duration_mins: 180,
         split_times: true,
       )
     end

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -133,8 +133,7 @@ def place_reservation_for_instrument(ordered_by, instrument, account, reserve_st
   res_attrs = {
     reserve_start_at: reserve_start,
     order_detail: order_detail,
-    duration_value: 60,
-    duration_unit: "minutes",
+    duration_mins: 60,
     split_times: true,
   }
 
@@ -171,8 +170,7 @@ def place_reservation(facility, order_detail, reserve_start, extra_reservation_a
   res_attrs = {
     reserve_start_at: reserve_start,
     order_detail: order_detail,
-    duration_value: 60,
-    duration_unit: "minutes",
+    duration_mins: 60,
     split_times: true,
   }
   order_detail.update_attributes!(product: @instrument)
@@ -182,7 +180,7 @@ def place_reservation(facility, order_detail, reserve_start, extra_reservation_a
 
   # If reserve_end_at is unset, derive it from reserve_start_at + duration:
   res_attrs[:reserve_end_at] ||=
-    reserve_start + res_attrs[:duration_value].public_send(res_attrs[:duration_unit])
+    reserve_start + res_attrs[:duration_mins].minutes
 
   @reservation = @instrument.reservations.build(res_attrs)
   @reservation.save(validate: false)


### PR DESCRIPTION
These fields are no longer used: we only ever work with minutes. The
larger goal is to remove the Reservations::DateSupport module entirely
with something more sane and more generic.

The UI fields always submit a minutes value for the duration.

It’s not entirely clear why the unit field existed (it came from the
pre “Initial Fork” commit, so git blame is useless here. Possibly,
there was a dropdown allowing you to set the duration as “X hours”.
Since that no longer exists, there is no reason for the added
complexity of supporting multiple units.