### PR TITLE
[#135958] Fix error on item and service access list index

### DIFF
--- a/app/views/product_users/_table.html.haml
+++ b/app/views/product_users/_table.html.haml
@@ -1,0 +1,30 @@
+%table.table.table-striped.table-hover
+  %thead
+    %tr
+      %th
+      %th= User.human_attribute_name(:name)
+      %th= User.human_attribute_name(:username)
+      %th= User.human_attribute_name(:email)
+      - if local_assigns[:f]
+        %th= ProductAccessGroup.model_name.human
+  %tbody
+    - @product_users.each do |product_user|
+      - user = product_user.user
+      %tr
+        %td.centered
+          = link_to t("shared.remove"),
+            [current_facility, @product, user],
+            method: :delete,
+            data: { confirm: text("confirm_removal", product_type: @product.model_name.human.downcase) }
+
+        %td
+          = link_to "#{user.last_name}, #{user.first_name}", [current_facility, user]
+
+        %td= user.username
+        %td= user.email
+        - if local_assigns[:f]
+          %td
+            = f.fields_for :product_users, product_user, index: product_user.id do |pu|
+              = pu.select :product_access_group_id,
+                options_from_collection_for_select(@product.product_access_groups, "id", "name", product_user.product_access_group_id),
+                include_blank: true

--- a/app/views/product_users/index.html.haml
+++ b/app/views/product_users/index.html.haml
@@ -9,54 +9,23 @@
   = render "admin/shared/tabnav_product", secondary_tab: "users"
 
 %h2= @product
-%h3= t(".approved_users")
+%h3= text("header")
 
-%p= t(".approval_explanation", product_type: @product.model_name.human.downcase)
+%p= text("explanation", product_type: @product.model_name.human.downcase)
 
-= link_to t(".add_approved_user"),
-  [:new, current_facility, @product, :user],
-  class: "btn-add"
-
-- @show_levels = @product.respond_to?(:product_access_groups) && @product.product_access_groups.any?
+= link_to text("add"), [:new, current_facility, @product, :user], class: "btn-add"
 
 - if @product_users.nil?
 - elsif @product_users.empty?
-  %p.notice= t(".no_users_approved")
+  %p.notice= text("none")
 - else
-  = form_for @product, url: [current_facility, @product, :update_restrictions], method: :put do |f|
-    %table.table.table-striped.table-hover
-      %thead
-        %tr
-          %th
-          %th= t(".th.name")
-          %th= t(".th.user_name")
-          %th= t(".th.email")
-          - if @show_levels
-            %th= ProductAccessGroup.model_name.human
-      %tbody
-        - @product_users.each do |product_user|
-          - user = product_user.user
-          %tr
-            %td.centered
-              = link_to t("shared.remove"),
-                [current_facility, @product, user],
-                method: :delete,
-                data: { confirm: t(".confirm_removal", product_type: @product.model_name.human.downcase) }
-
-            %td
-              = link_to "#{user.last_name}, #{user.first_name}", [current_facility, user]
-
-            %td= user.username
-            %td= user.email
-            - if @show_levels
-              %td
-                = f.fields_for :product_users, product_user, index: product_user.id do |pu|
-                  = pu.select :product_access_group_id,
-                    options_from_collection_for_select(@product.product_access_groups, "id", "name", product_user.product_access_group_id),
-                    include_blank: true
-
-    - if @show_levels
-      = f.submit t(".update", plural_label: ProductAccessGroup.model_name.human.pluralize),
+  - if @product.respond_to?(:product_access_groups) && @product.product_access_groups.any?
+    = form_for @product, url: [current_facility, @product, :update_restrictions], method: :put do |f|
+      = render "table", f: f
+      = f.submit text("update", plural_label: ProductAccessGroup.model_name.human.pluralize),
         class: ["btn", "btn-primary"]
+  - else
+    = render "table"
 
   = will_paginate(@product_users)
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -731,20 +731,6 @@ en:
       quantity: Quantity
 
   product_users:
-    index:
-      add_approved_user: Add Approved User
-      approval_explanation: |
-        This %{product_type} requires a user to be approved before they may
-        purchase the %{product_type}.
-      approved_users: Approved Users
-      confirm_removal: |
-        Are you sure you wish to remove this user from this %{product_type}?
-      no_users_approved: No users are currently approved.
-      th:
-        name: Name
-        user_name: User Name
-        email: Email
-      update: Update %{plural_label}
     new:
       label:
         search_term: "Search by name, NetID, or username"

--- a/config/locales/views/admin/en.product_users.yml
+++ b/config/locales/views/admin/en.product_users.yml
@@ -1,0 +1,15 @@
+en:
+  views:
+    product_users:
+      index:
+        header: Approved Users
+        add: Add Approved User
+        explanation: |
+          This %{product_type} requires a user to be approved before they may
+          purchase the %{product_type}.
+        none: No users are currently approved.
+        update: Update %{plural_label}
+      table:
+        confirm_removal: |
+          Are you sure you wish to remove this user from this %{product_type}?
+


### PR DESCRIPTION
Prior to #937, we were always setting the route for the `form_for` to
`facility_instrument_update_restrictions_path`, which would route, but
would be invalid. But services and items would never have schedule
groups so the submit would never appear, so we never had any problems.

In #937, we made it generic to support secure rooms, which also support
schedule groups.

A test around this would probably be a good idea, but I’d like to get it out there quickly.