### PR TITLE
[#134671] force responsive nav background color

### DIFF
--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -10,11 +10,11 @@ $navCollapseColor: #777;
   .visible-with-nav {
     display: none !important;
   }
-
   .nav-collapse {
     background-color: $navCollapseBackgroundColor;
+    position: relative;
+    top: 10px;
   }
-
   .nav-collapse .nav {
     margin: 0;
     border-top: 1px solid #ddd;
@@ -25,7 +25,16 @@ $navCollapseColor: #777;
   header .navbar .nav > li > a, .nav-collapse .dropdown-menu a {
     padding: 10px;
     border-radius: 0;
+  }
+  /* this selector has to override specificity of bootstrap-responsive's
+      `header .navbar .nav > li > a` and `!important` as well as target
+      only the .nav-collapse links
+  */
+  header .navbar .nav-collapse .nav > li > a, .nav-collapse .dropdown-menu a {
     color: $navCollapseColor !important;
+    &:hover {
+      color: $navCollapseColor !important;
+    }
   }
   header .navbar .nav > li.navbar-text {
     padding: 10px;

--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -1,4 +1,6 @@
 /* Bootstrap overrides go here. This is included after bootstrap. */
+$navCollapseBackgroundColor: #f7f7f7;
+$navCollapseColor: #777;
 
 /* 979px - 980px is where nav-collapse gets triggered */
 @media (max-width: 979px) {
@@ -7,6 +9,10 @@
   }
   .visible-with-nav {
     display: none !important;
+  }
+
+  .nav-collapse {
+    background-color: $navCollapseBackgroundColor;
   }
 
   .nav-collapse .nav {
@@ -19,14 +25,16 @@
   header .navbar .nav > li > a, .nav-collapse .dropdown-menu a {
     padding: 10px;
     border-radius: 0;
+    color: $navCollapseColor !important;
   }
   header .navbar .nav > li.navbar-text {
     padding: 10px;
     line-height: 20px;
+    color: $navCollapseColor !important;
   }
   .nav-collapse .navbar-form, .nav-collapse .navbar-search {
     margin: 0;
-    padding: 10px 10px 0 10px;
+    padding: 10px;
     border-bottom: 0;
   }
 


### PR DESCRIPTION
[#134671](https://pm.tablexi.com/issues/134671)

This PR is being submitted with the awareness that the green header background color gets split in two when the hamburger menu opens. To prevent this would require a *lot* of messy overrides on the way Bootstrap styles the header / menu, in both the small and desktop versions. It may also serve as a subtle indicator as to where the hamburger menu ends when it opens.

![screen shot 2017-04-26 at 10 57 24 am](https://cloud.githubusercontent.com/assets/14095/25444020/590395cc-2a6f-11e7-9bc1-6b95a28cbcc0.png)
