### PR TITLE
[#144318485] Secure Room PricePolicy calculations

### DIFF
--- a/vendor/engines/secure_rooms/app/models/secure_room_price_policy.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_room_price_policy.rb
@@ -2,4 +2,22 @@ class SecureRoomPricePolicy < PricePolicy
 
   include PricePolicies::Usage
 
+  def estimate_cost_and_subsidy_from_order_detail(order_detail)
+    calculate_cost_and_subsidy_from_order_detail(order_detail)
+  end
+
+  def calculate_cost_and_subsidy_from_order_detail(order_detail)
+    entry_at = order_detail.occupancy.entry_at
+    exit_at = order_detail.occupancy.exit_at
+    return unless entry_at && exit_at
+
+    calculator.calculate(entry_at, exit_at)
+  end
+
+  private
+
+  def calculator
+    PricePolicies::TimeBasedPriceCalculator.new(self)
+  end
+
 end

--- a/vendor/engines/secure_rooms/spec/factories/secure_rooms_price_policies.rb
+++ b/vendor/engines/secure_rooms/spec/factories/secure_rooms_price_policies.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :secure_room_price_policy do
+    usage_rate 60
+    usage_subsidy 10
+    minimum_cost 30
+    can_purchase true
+    start_date { Time.zone.now.beginning_of_day }
+    expire_date { PricePolicy.generate_expire_date(Time.zone.now.beginning_of_day) }
+  end
+end

--- a/vendor/engines/secure_rooms/spec/models/secure_room_price_policy_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/secure_room_price_policy_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe SecureRoomPricePolicy do
+
+  describe "#calculate_cost_and_subsidy_from_order_detail" do
+    let(:product) { build_stubbed(:secure_room, schedule_rules: [schedule_rule]) }
+    let(:schedule_rule) { build_stubbed(:schedule_rule, :all_day) }
+    let(:order_detail) { build_stubbed(:order_detail, product: product, occupancy: occupancy) }
+    let(:price_policy) { build_stubbed(:secure_room_price_policy, product: product, usage_rate: 60, usage_subsidy: 15, minimum_cost: 30) }
+    subject(:costs) { price_policy.calculate_cost_and_subsidy_from_order_detail(order_detail) }
+
+    describe "with an hour of usage" do
+      let(:occupancy) { build_stubbed(:occupancy, entry_at: 1.hour.ago, exit_at: Time.current) }
+      it { is_expected.to eq(cost: 60, subsidy: 15) }
+    end
+
+    describe "with 24 hours of usage" do
+      let(:occupancy) { build_stubbed(:occupancy, entry_at: 24.hours.ago, exit_at: Time.current) }
+      it { is_expected.to eq(cost: 1440, subsidy: 360) }
+    end
+
+    describe "with less than the minimum usage" do
+      let(:occupancy) { build_stubbed(:occupancy, entry_at: 15.minutes.ago, exit_at: Time.current) }
+      it { is_expected.to eq(cost: 30, subsidy: 7.5) }
+    end
+
+    describe "with an orphaned occupancy" do
+      let(:occupancy) { build_stubbed(:occupancy, entry_at: 1.day.ago, exit_at: nil) }
+      it { is_expected.to be_blank }
+    end
+
+    describe "with an exit-only occupancy" do
+      let(:occupancy) { build_stubbed(:occupancy, entry_at: nil, exit_at: 1.day.ago) }
+      it { is_expected.to be_blank }
+    end
+  end
+
+end


### PR DESCRIPTION
I'm putting this into #997 so it's easier to see the diff. It's actually fairly trivial after that refactor.

I'm assuming that we'll test the actual assignment to an order detail as part of the scan out stories.

I'm also assuming that the specs in `PricePolicies::TimeBasedPriceCalculator` handle the majority of the edge and complicated cases, so I just did basic tests to make sure we're wired up properly.