### PR TITLE
[#135268] Responsive order page and order detail page

### DIFF
--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -83,6 +83,10 @@ $navCollapseColor: #777;
         font-weight: bold;
       }
 
+      &.order-note.order-note--wide {
+        width: auto;
+      }
+
     }
 
     th.currency, td.currency {
@@ -100,4 +104,3 @@ $navCollapseColor: #777;
     display: none !important;
   }
 }
-

--- a/app/views/order_details/show.html.haml
+++ b/app/views/order_details/show.html.haml
@@ -59,11 +59,12 @@
 
 .row
   .span12
-    %table.table.table-striped.table-hover.old-table.old-table
+    %table.table.table-striped.table-hover.old-table.old-table.js--responsive_table
       %thead
         %tr
           %th.centered= t('.th.action')
-          %th{:colspan => 2}= t('.th.quantity')
+          %th= t('.th.quantity')
+          %th= t('.th.product')
           %th= t('.th.status')
           %th.currency= t('.th.cost')
           - if @order_detail.has_subsidies?
@@ -79,6 +80,8 @@
                 = link_to t('reservations.switch.end'), order_order_detail_reservation_switch_instrument_path(@order, @order_detail, res, :switch => 'off'), :class => end_reservation_class(res)
               - elsif res.can_cancel?
                 = link_to t('.link.reservation.cancel'), "#"
+            - else
+              &nbsp;
           %td.centered=h @order_detail.wrapped_quantity
           %td.user-order-detail
             .order-detail-description= order_detail_description(@order_detail)

--- a/app/views/shared/_order_details_table.html.haml
+++ b/app/views/shared/_order_details_table.html.haml
@@ -1,4 +1,4 @@
-%table.table.table-striped.table-hover.old-table
+%table.table.table-striped.table-hover.old-table.js--responsive_table
   %thead
     %tr
       %th.centered= OrderDetail.human_attribute_name(:id)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -680,7 +680,8 @@ en:
         dispute: "Dispute Purchase"
       th:
         action: "Action"
-        quantity: "Quantity/Product"
+        quantity: "Quantity"
+        product: "Product"
         status: "Status"
         cost: "Cost"
         adjust: "Adjustment"


### PR DESCRIPTION
https://pm.tablexi.com/issues/135268

This makes the order and order detail page responsive. Notes:

![my_orders_-_nucore](https://cloud.githubusercontent.com/assets/5661/25622635/a07ec16a-2f1a-11e7-80c3-c5701d9a4d12.png)

![order__38-56_-_nucore](https://cloud.githubusercontent.com/assets/5661/25584927/ad4b577c-2e5d-11e7-9e09-5b08961b2349.png)

The detail page had Quantity/Product as a two-column header, which I split because the colspan header was confusing the JavaScript creating the headers.