### PR TITLE
Bug fix for responsive tables

### DIFF
--- a/app/assets/javascripts/app/responsive_table.js.coffee
+++ b/app/assets/javascripts/app/responsive_table.js.coffee
@@ -5,9 +5,10 @@ class window.ResponsiveTable
     $(".js--responsive_table").each (index, table) ->
       $table = $(table)
       $th = $table.find("thead th")
-      $table.find("tbody tr td").prepend (index) ->
-        $("<div>").addClass("responsive-header")
-                  .text($th.eq(index).text())
+      $table.find("tbody tr").each (index, row) ->
+        $(row).find("td").prepend (index) ->
+          $("<div>").addClass("responsive-header")
+                    .text($th.eq(index).text())
 
 $ ->
   (new ResponsiveTable).respond()

--- a/spec/javascripts/fixtures/normal_table.html
+++ b/spec/javascripts/fixtures/normal_table.html
@@ -10,5 +10,9 @@
       <td>12</td>
       <td>Large Hadron Collider</td>
     </tr>
+    <tr>
+      <td>24</td>
+      <td>Small Hadron Collider</td>
+    </tr>
   </tbody>
 </table>

--- a/spec/javascripts/responsive_tables_spec.coffee
+++ b/spec/javascripts/responsive_tables_spec.coffee
@@ -16,9 +16,11 @@ describe "Responsive table support", ->
     $(".table").addClass("js--responsive_table")
     responsiveTable = new ResponsiveTable
     responsiveTable.respond()
-    expect($("td .responsive-header").size()).toEqual(2)
+    expect($("td .responsive-header").size()).toEqual(4)
     expect($("td .responsive-header").eq(0).text()).toEqual("Invoice Number")
     expect($("td .responsive-header").eq(1).text()).toEqual("Facility")
+    expect($("td .responsive-header").eq(2).text()).toEqual("Invoice Number")
+    expect($("td .responsive-header").eq(3).text()).toEqual("Facility")
 
   it "ignores a table if the global variable is false", ->
     window.IS_RESPONSIVE = false


### PR DESCRIPTION

![search_results_-_nucore](https://cloud.githubusercontent.com/assets/5661/25588697/012fc114-2e6f-11e7-8975-25625145067d.png)

The first round of the JS only set the headers for the first row of the table, this should fix.