### PR TITLE
[#135265] Fix for responsive tables in reservations

### DIFF
--- a/app/assets/javascripts/app/responsive_table.js.coffee
+++ b/app/assets/javascripts/app/responsive_table.js.coffee
@@ -20,6 +20,5 @@ class window.ResponsiveTable
     header = $(@table.find("thead th").eq(index))
     header.data("mobile-header") || header.text()
 
-
 $ ->
   ResponsiveTable.respond()

--- a/app/assets/javascripts/app/responsive_table.js.coffee
+++ b/app/assets/javascripts/app/responsive_table.js.coffee
@@ -5,9 +5,10 @@ class window.ResponsiveTable
     $(".js--responsive_table").each (index, table) ->
       $table = $(table)
       $th = $table.find("thead th")
-      $table.find("tbody tr td").prepend (index) ->
-        $("<div>").addClass("responsive-header")
-                  .text($th.eq(index).text())
+      $table.find("tbody tr").each (index, row) ->
+        $(row).find("td").prepend (index) ->
+          $("<div>").addClass("responsive-header")
+                    .text($th.eq(index).text())
 
 $ ->
   (new ResponsiveTable).respond()

--- a/app/assets/javascripts/app/responsive_table.js.coffee
+++ b/app/assets/javascripts/app/responsive_table.js.coffee
@@ -1,14 +1,24 @@
 class window.ResponsiveTable
 
-  respond: ->
+  @respond: ->
     return unless window.IS_RESPONSIVE
     $(".js--responsive_table").each (index, table) ->
-      $table = $(table)
-      $th = $table.find("thead th")
-      $table.find("tbody tr").each (index, row) ->
-        $(row).find("td").prepend (index) ->
-          $("<div>").addClass("responsive-header")
-                    .text($th.eq(index).text())
+      new ResponsiveTable($(table)).add_responsive_headers()
+
+  constructor: (@table) ->
+
+  add_responsive_headers: ->
+    @table.find("tbody tr").each (index, row) => @add_header_to_row($(row))
+
+  add_header_to_row: ($row) ->
+    $row.find("td").prepend (index) => @responsive_header(index)
+
+  responsive_header: (index) ->
+    $("<div>").addClass("responsive-header").text(@text_for_header(index))
+
+  text_for_header: (index) =>
+    header = $(@table.find("thead th").eq(index))
+    header.data("mobile-header") || header.text()
 
 $ ->
-  (new ResponsiveTable).respond()
+  ResponsiveTable.respond()

--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -79,8 +79,11 @@ $navCollapseColor: #777;
         left: 6px;
         width: 30%;
         padding-right: 10px;
-        white-space: nowrap;
         font-weight: bold;
+      }
+
+      &.order-note.order-note--wide {
+        width: auto;
       }
 
     }
@@ -100,4 +103,3 @@ $navCollapseColor: #777;
     display: none !important;
   }
 }
-

--- a/app/views/reservations/_my_table.html.haml
+++ b/app/views/reservations/_my_table.html.haml
@@ -1,4 +1,4 @@
-%table.table.table-striped.table-hover.old-table
+%table.table.table-striped.table-hover.old-table.js--responsive_table
   %thead
     %tr
       %th.centered= OrderDetail.human_attribute_name(:id)

--- a/app/views/reservations/_my_table.html.haml
+++ b/app/views/reservations/_my_table.html.haml
@@ -16,6 +16,7 @@
         - next unless res
         %td.centered
           = reservation_actions(res)
+          &nbsp;
         %td
           = reservation_view_edit_link(res)
         %td.user-order-detail.order-note.order-note--wide

--- a/app/views/reservations/_my_table.html.haml
+++ b/app/views/reservations/_my_table.html.haml
@@ -3,7 +3,7 @@
     %tr
       %th.centered= OrderDetail.human_attribute_name(:id)
       %th.centered= text("actions")
-      %th= text("reservation")
+      %th{data: {"mobile-header" => text("short_reservation")}}= text("reservation")
       %th.order-note.order-note--wide= OrderDetail.human_attribute_name(:product)
       %th.centered= OrderDetail.human_attribute_name(:status)
       %th.currency= OrderDetail.human_attribute_name(:unassigned_total)

--- a/config/locales/views/en.reservations.yml
+++ b/config/locales/views/en.reservations.yml
@@ -9,3 +9,4 @@ en:
       my_table:
         actions: Actions
         reservation: "Reservation (Edit/Extend)"
+        short_reservation: "Reservation"

--- a/config/locales/views/en.reservations.yml
+++ b/config/locales/views/en.reservations.yml
@@ -8,4 +8,4 @@ en:
         none: "You have not made any reservations."
       my_table:
         actions: Actions
-        reservation: Reservation (Edit/Extend)
+        reservation: "Reservation (Edit/Extend)"

--- a/spec/javascripts/fixtures/normal_table.html
+++ b/spec/javascripts/fixtures/normal_table.html
@@ -1,7 +1,7 @@
 <table class="table">
   <thead>
     <tr>
-      <th>Invoice Number</th>
+      <th data-mobile-header="Invoice #">Invoice Number</th>
       <th>Facility</th>
     </tr>
   </thead>

--- a/spec/javascripts/fixtures/normal_table.html
+++ b/spec/javascripts/fixtures/normal_table.html
@@ -10,5 +10,9 @@
       <td>12</td>
       <td>Large Hadron Collider</td>
     </tr>
+    <tr>
+      <td>24</td>
+      <td>Small Hadron Collider</td>
+    </tr>
   </tbody>
 </table>

--- a/spec/javascripts/responsive_tables_spec.coffee
+++ b/spec/javascripts/responsive_tables_spec.coffee
@@ -16,9 +16,11 @@ describe "Responsive table support", ->
     $(".table").addClass("js--responsive_table")
     responsiveTable = new ResponsiveTable
     responsiveTable.respond()
-    expect($("td .responsive-header").size()).toEqual(2)
+    expect($("td .responsive-header").size()).toEqual(4)
     expect($("td .responsive-header").eq(0).text()).toEqual("Invoice Number")
     expect($("td .responsive-header").eq(1).text()).toEqual("Facility")
+    expect($("td .responsive-header").eq(2).text()).toEqual("Invoice Number")
+    expect($("td .responsive-header").eq(3).text()).toEqual("Facility")
 
   it "ignores a table if the global variable is false", ->
     window.IS_RESPONSIVE = false

--- a/spec/javascripts/responsive_tables_spec.coffee
+++ b/spec/javascripts/responsive_tables_spec.coffee
@@ -8,23 +8,20 @@ describe "Responsive table support", ->
     loadFixtures("normal_table.html")
 
   it "ignores a normal table", ->
-    responsiveTable = new ResponsiveTable
-    responsiveTable.respond()
+    ResponsiveTable.respond()
     expect($(".table")).not.toContainElement(".responsive-header")
 
   it "responds to a responsive table if reponsive", ->
     $(".table").addClass("js--responsive_table")
-    responsiveTable = new ResponsiveTable
-    responsiveTable.respond()
+    ResponsiveTable.respond()
     expect($("td .responsive-header").size()).toEqual(4)
-    expect($("td .responsive-header").eq(0).text()).toEqual("Invoice Number")
+    expect($("td .responsive-header").eq(0).text()).toEqual("Invoice #")
     expect($("td .responsive-header").eq(1).text()).toEqual("Facility")
-    expect($("td .responsive-header").eq(2).text()).toEqual("Invoice Number")
+    expect($("td .responsive-header").eq(2).text()).toEqual("Invoice #")
     expect($("td .responsive-header").eq(3).text()).toEqual("Facility")
 
   it "ignores a table if the global variable is false", ->
     window.IS_RESPONSIVE = false
     $(".table").addClass("js--responsive_table")
-    responsiveTable = new ResponsiveTable
-    responsiveTable.respond()
+    ResponsiveTable.respond()
     expect($(".table")).not.toContainElement(".responsive-header")


### PR DESCRIPTION
![my_reservations_-_nucore](https://cloud.githubusercontent.com/assets/5661/25624217/595038a6-2f1e-11e7-8ce1-674fe632f443.png)

The obvious problem here is the overflow of the caption "Reservation (Edit/Extend)". There's no particularly easy way to get that to wrap (because of how the responsive div is set up). Is shortening the header to "Reservation" an option?