### PR TITLE
[#135266] Responsive cart:

### DIFF
--- a/app/assets/stylesheets/app/tables.scss
+++ b/app/assets/stylesheets/app/tables.scss
@@ -17,10 +17,10 @@ table {
 
 table {
   .first-in-bundle {
-    border-top: 3px solid black;
+    border-top: 3px solid $navbarActiveBorderColor;
   }
 }
 
 tfoot.cart {
-  border-top: 3px solid black;
+  border-top: 3px solid $navbarActiveBorderColor;
 }

--- a/app/assets/stylesheets/app/tables.scss
+++ b/app/assets/stylesheets/app/tables.scss
@@ -14,3 +14,13 @@ table {
     }
   }
 }
+
+table {
+  .first-in-bundle {
+    border-top: 3px solid black;
+  }
+}
+
+tfoot.cart {
+  border-top: 3px solid black;
+}

--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -1,6 +1,7 @@
 /* Bootstrap overrides go here. This is included after bootstrap. */
 $navCollapseBackgroundColor: #f7f7f7;
 $navCollapseColor: #777;
+$navbarActiveBorderColor: #aaa;
 
 /* 979px - 980px is where nav-collapse gets triggered */
 @media (max-width: 979px) {
@@ -71,7 +72,7 @@ $navCollapseColor: #777;
     tr { border: 1px solid #ccc; }
 
     .first-in-bundle {
-      border-top: 3px solid black;
+      border-top: 3px solid $navbarActiveBorderColor;
     }
 
     td {

--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -58,6 +58,10 @@ $navCollapseColor: #777;
       display: block;
     }
 
+    td.hide-on-mobile {
+      display: none;
+    }
+
     thead tr {
       position: absolute;
       top: -9999px;
@@ -65,6 +69,10 @@ $navCollapseColor: #777;
     }
 
     tr { border: 1px solid #ccc; }
+
+    .first-in-bundle {
+      border-top: 3px solid black;
+    }
 
     td {
       border: none;
@@ -100,4 +108,3 @@ $navCollapseColor: #777;
     display: none !important;
   }
 }
-

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -1,8 +1,8 @@
 %tr{class: order_detail_iteration.first? ? "first-in-bundle" : ""}
   %td
     - if order_detail_iteration.first?
+      = link_to text("shared.remove"), remove_order_path(@order, order_detail), method: :put
       %strong
-        [#{link_to text("shared.remove"), remove_order_path(@order, order_detail), method: :put}]
         - if order_detail.bundle
           = order_detail.bundle
   %td

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -1,8 +1,8 @@
-%tr
-  - if order_detail_iteration.first?
-    %td.centered{ rowspan: order_details.count }= link_to text("shared.remove"), remove_order_path(@order, order_detail), method: :put
-
+%tr{class: order_detail_iteration.first? ? "first-in-bundle" : ""}
   %td
+    - if order_detail_iteration.first?
+      %strong
+        [#{link_to text("shared.remove"), remove_order_path(@order, order_detail), method: :put}]
     = render "#{order_detail.product.class.name.underscore}_desc", order_detail: order_detail
     - if show_note_input_to_user?(order_detail)
       %label.inline.cart__noteField{ for: "note#{order_detail.id}" }

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -3,6 +3,9 @@
     - if order_detail_iteration.first?
       %strong
         [#{link_to text("shared.remove"), remove_order_path(@order, order_detail), method: :put}]
+        - if order_detail.bundle
+          = order_detail.bundle
+  %td
     = render "#{order_detail.product.class.name.underscore}_desc", order_detail: order_detail
     - if show_note_input_to_user?(order_detail)
       %label.inline.cart__noteField{ for: "note#{order_detail.id}" }

--- a/app/views/orders/_form.html.haml
+++ b/app/views/orders/_form.html.haml
@@ -16,7 +16,7 @@
 
     %tfoot.cart
       %tr
-        %td.currency{colspan: "2"}
+        %td.currency{colspan: "3"}
           %b= t(".td.total")
         %td.currency
           .responsive-header= OrderDetail.human_attribute_name(:estimated_cost)

--- a/app/views/orders/_form.html.haml
+++ b/app/views/orders/_form.html.haml
@@ -2,6 +2,7 @@
   %table.table.table-striped.table-hover.js--cart#cart.js--responsive_table
     %thead
       %tr
+        %th &nbsp;
         %th= OrderDetail.human_attribute_name(:product)
         %th.centered= OrderDetail.human_attribute_name(:quantity)
         %th.currency= OrderDetail.human_attribute_name(:estimated_cost)

--- a/app/views/orders/_form.html.haml
+++ b/app/views/orders/_form.html.haml
@@ -1,8 +1,7 @@
 = simple_form_for order, url: { action: :update_or_purchase } do |f|
-  %table.table.table-striped.table-hover.js--cart#cart
+  %table.table.table-striped.table-hover.js--cart#cart.js--responsive_table
     %thead
       %tr
-        %th
         %th= OrderDetail.human_attribute_name(:product)
         %th.centered= OrderDetail.human_attribute_name(:quantity)
         %th.currency= OrderDetail.human_attribute_name(:estimated_cost)
@@ -14,16 +13,19 @@
       - grouped_order_details.each do |order_details|
         = render partial: "cart_row", collection: order_details, as: :order_detail, locals: { order_details: order_details }
 
-    %tfoot
+    %tfoot.cart
       %tr
-        %td.currency{colspan: "3"}
+        %td.currency{colspan: "2"}
           %b= t(".td.total")
         %td.currency
+          .responsive-header= OrderDetail.human_attribute_name(:estimated_cost)
           %b= number_to_currency order.estimated_cost
         - if order.has_subsidies?
           %td.currency
+            .responsive-header= OrderDetail.human_attribute_name(:estimated_subsidy)
             %b= number_to_currency order.estimated_subsidy
         %td.currency
+          .responsive-header= OrderDetail.human_attribute_name(:estimated_total)
           %b= number_to_currency order.estimated_total
 
   %p.footnote= t(".foot.all")

--- a/app/views/orders/_product_description.html.haml
+++ b/app/views/orders/_product_description.html.haml
@@ -1,8 +1,5 @@
 - unless order_detail.order.validated?
   .label.label-warning= order_detail.validate_for_purchase
 
-- if order_detail.bundle
-  = order_detail.bundle
-  &ndash;
 
 = order_detail.product

--- a/spec/javascripts/fixtures/normal_table.html
+++ b/spec/javascripts/fixtures/normal_table.html
@@ -11,7 +11,7 @@
       <td>Large Hadron Collider</td>
     </tr>
     <tr>
-      <td>24</td>
+      <td></td>
       <td>Small Hadron Collider</td>
     </tr>
   </tbody>


### PR DESCRIPTION
A couple of changes from the existing cart. These changes apply to both the responsive and non-responsive versions. 

* [Remove] is not a separate column, I’ve now put it before the name of the product (and made it bold). Putting it after the name is tricky because the name and upload are part of the same partial, but I could move it to all the different partials if we wanted.

* There’s now a thicker bold line between bundles, but not between products that are part of the same bundle.

Here's the responsive bit:

![cart_-_nucore](https://cloud.githubusercontent.com/assets/5661/25670399/36b23144-2ff2-11e7-9d94-38581301face.png)

![cart_-_nucore](https://cloud.githubusercontent.com/assets/5661/25670422/42e99aec-2ff2-11e7-980b-bd90cc1b70ca.png)

And the non responsive version

![cart_-_nucore](https://cloud.githubusercontent.com/assets/5661/25670452/554819a2-2ff2-11e7-9cf4-45466e2336a4.png)
