### PR TITLE
[#136246] Fix order detail sorting for accessories in oracle

### DIFF
--- a/app/models/order_detail/accessorized.rb
+++ b/app/models/order_detail/accessorized.rb
@@ -17,7 +17,9 @@ module OrderDetail::Accessorized
 
     # Puts parent orders first, followed by their children. Children are ordered by id
     def ordered_by_parents
-      order("COALESCE(order_details.parent_order_detail_id, order_details.id), order_details.parent_order_detail_id, order_details.id")
+      order("COALESCE(order_details.parent_order_detail_id, order_details.id)")
+        .order_by_asc_nulls_first(:parent_order_detail_id)
+        .order(:id)
     end
 
   end

--- a/app/support/accessories/accessorizer.rb
+++ b/app/support/accessories/accessorizer.rb
@@ -110,6 +110,7 @@ class Accessories::Accessorizer
     attrs = @order_detail.attributes.slice("account_id", "created_by")
     attrs.merge(order: @order_detail.order,
                 product: accessory,
+                note: options[:note],
                 quantity: options[:quantity],
                 product_accessory: product_accessory(accessory),
                 state: "new")

--- a/lib/nucore.rb
+++ b/lib/nucore.rb
@@ -106,14 +106,15 @@ module NUCore
       def self.included(base)
         base.extend ClassMethods
       end
+
       module ClassMethods
 
         def order_by_asc_nulls_first(field)
-          NUCore::Database.oracle? ? order("#{field} asc nulls first") : order(field)
+          NUCore::Database.oracle? ? order("#{sanitize_sql(field)} asc nulls first") : order(field)
         end
 
         def order_by_desc_nulls_first(field)
-          NUCore::Database.oracle? ? order("#{field} desc nulls first") : order("-#{field}")
+          NUCore::Database.oracle? ? order("#{sanitize_sql(field)} desc nulls first") : order("-#{sanitize_sql(field)}")
         end
 
       end

--- a/lib/nucore.rb
+++ b/lib/nucore.rb
@@ -108,6 +108,10 @@ module NUCore
       end
       module ClassMethods
 
+        def order_by_asc_nulls_first(field)
+          NUCore::Database.oracle? ? order("#{field} asc nulls first") : order(field)
+        end
+
         def order_by_desc_nulls_first(field)
           NUCore::Database.oracle? ? order("#{field} desc nulls first") : order("-#{field}")
         end

--- a/spec/models/order_details/accessorized_order_detail_spec.rb
+++ b/spec/models/order_details/accessorized_order_detail_spec.rb
@@ -175,12 +175,12 @@ RSpec.describe OrderDetail do
 
     # Ensure
     it "builds the details in the right order" do
-      expect(order_details.order(:id).pluck(:note)).to eq(["original", "interim", "accessory"])
+      expect(order_details.order(:id).pluck(:note)).to eq(%w(original interim accessory))
       expect(order_details.order(:id).pluck(:parent_order_detail_id)).to eq([nil, nil, order_detail.id])
     end
 
     it "puts the parent together with its child with the parent before the child" do
-      expect(order_details.ordered_by_parents.pluck(:note)).to eq(["original", "accessory", "interim"])
+      expect(order_details.ordered_by_parents.pluck(:note)).to eq(%w(original accessory interim))
     end
   end
 end

--- a/spec/models/order_details/accessorized_order_detail_spec.rb
+++ b/spec/models/order_details/accessorized_order_detail_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe OrderDetail do
   let(:instrument) { FactoryGirl.create(:instrument_with_accessory, :timer) }
   let(:accessory) { instrument.accessories.first }
   let(:reservation) { FactoryGirl.create(:completed_reservation, product: instrument) }
-  let(:order_detail) { reservation.order_detail }
+  let(:order_detail) { reservation.order_detail.tap { |od| od.update(note: "original") } }
   let(:accessorizer) { Accessories::Accessorizer.new(order_detail) }
 
   before :each do
@@ -164,6 +164,23 @@ RSpec.describe OrderDetail do
 
     it "makes the order detail a problem order" do
       expect(accessory_order_detail).to be_problem_order
+    end
+  end
+
+  describe "sorting" do
+    let(:order) { order_detail.order }
+    let(:order_details) { order.order_details }
+    let!(:interim_order_detail) { order.add(accessory, 1, note: "interim") }
+    let!(:accessory_order_detail) { accessorizer.add_accessory(accessory, note: "accessory") }
+
+    # Ensure
+    it "builds the details in the right order" do
+      expect(order_details.order(:id).pluck(:note)).to eq(["original", "interim", "accessory"])
+      expect(order_details.order(:id).pluck(:parent_order_detail_id)).to eq([nil, nil, order_detail.id])
+    end
+
+    it "puts the parent together with its child with the parent before the child" do
+      expect(order_details.ordered_by_parents.pluck(:note)).to eq(["original", "accessory", "interim"])
     end
   end
 end


### PR DESCRIPTION
In Oracle, nulls are ordered differently than they are in MySQL. This
was causing accessories to appear before their parent in the order show
view.


| Order | Oracle         | MySQL       |
|------ | ------------ |------------|
| ASC   | NULLs last  | NULLs first |
| DESC | NULLs first | NULLs last |

Reference: http://www.sqlines.com/oracle-to-mysql/null_order_by

If we ever do Postgres support we might need to revisit this.

Problem:
![screen shot 2017-05-03 at 5 57 08 pm](https://cloud.githubusercontent.com/assets/1099111/25684970/06dc375c-302a-11e7-9c01-2b8e377ba178.png)
