### PR TITLE
[#133461] Prevent bundles as accessories 

### DIFF
--- a/app/controllers/product_accessories_controller.rb
+++ b/app/controllers/product_accessories_controller.rb
@@ -39,9 +39,8 @@ class ProductAccessoriesController < ApplicationController
 
   def set_available_accessories
     # Already set as an accessory, or is this instrument
-    non_available_accessories = [@product.id]
-    non_available_accessories += @product_accessories.map(&:accessory_id) if @product_accessories.present?
-    @available_accessories = current_facility.products.non_instruments.exclude(non_available_accessories).order(:name)
+    non_available_accessories = [@product.id] + Array(@product_accessories).map(&:accessory_id)
+    @available_accessories = current_facility.products.accessorizable.exclude(non_available_accessories).order(:name)
   end
 
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -59,12 +59,13 @@ class Product < ActiveRecord::Base
     @product_types ||= [Instrument, Item, Service, Bundle]
   end
 
-  def self.non_instruments
-    where("products.type <> 'Instrument'")
+  # Products that can be used as accessories
+  def self.accessorizable
+    where(type: [Item, Service])
   end
 
-  def self.exclude(exclusion_list)
-    where("products.id NOT IN (?)", exclusion_list)
+  def self.exclude(products)
+    where.not(id: products)
   end
 
   scope :for_facility, lambda { |facility|

--- a/app/views/product_accessories/index.html.haml
+++ b/app/views/product_accessories/index.html.haml
@@ -1,39 +1,37 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :sidebar do
-  = render :partial => 'admin/shared/sidenav_product', :locals => {:sidenav_tab => @product.class.name.downcase.pluralize}
+  = render "admin/shared/sidenav_product", sidenav_tab: @product.class.name.downcase.pluralize
 
 = content_for :tabnav do
-  = render :partial => 'admin/shared/tabnav_product', :locals => {:secondary_tab => 'accessories'}
+  = render "admin/shared/tabnav_product", secondary_tab: "accessories"
 
-%h2=h @product
+%h2= @product
 
-%p= t('product_accessories.index.description')
+%p= t("product_accessories.index.description")
 
 - if can? :edit, ProductAccessory
   - if @available_accessories.count > 0
-    = simple_form_for @product_accessory, :url => facility_product_product_accessories_path(current_facility, @product, @product_accessory), :defaults => { :required => false } do |f|
+    = simple_form_for @product_accessory, url: facility_product_product_accessories_path(current_facility, @product, @product_accessory), defaults: { required: false } do |f|
       %ul.inline
-        %li= f.association :accessory, :collection => @available_accessories, :include_blank => false
-        %li= f.input :scaling_type, :collection => ProductAccessory.scaling_types, :label_method => Proc.new { |t| t("product_accessories.type.#{t}") }, :include_blank => false
-        %li= f.submit t('.add'), :class => ['btn', 'btn-primary', 'btn-inline']
+        %li= f.association :accessory, collection: @available_accessories, include_blank: false, label: ProductAccessory.model_name.human
+        %li= f.input :scaling_type, collection: ProductAccessory.scaling_types, label_method: ->(type) { t(type, scope: "product_accessories.type.") }, include_blank: false
+        %li= f.submit t(".add"), class: ["btn", "btn-primary", "btn-inline"]
 
-
-- if @product_accessories.empty?
-  %p.notice= t('.no_accessories')
-- else
+- if @product_accessories.any?
   %table.table.table-striped.table-hover
     %thead
       %tr
         %th.actions
-        %th Accessory
-        %th Scaling Type
+        %th= ProductAccessory.model_name.human
+        %th= ProductAccessory.human_attribute_name(:scaling_type)
     %tbody
       - @product_accessories.each do |pa|
         - accessory = pa.accessory
         %tr
-          %td.centered= link_to 'Remove', facility_product_product_accessory_path(current_facility, @product, pa), :method => :delete if can? :delete, pa
-          %td= link_to accessory.to_s_with_status, send("manage_facility_#{accessory.class.name.downcase}_path", current_facility, accessory)
-          %td.centered= t("product_accessories.type.#{pa.scaling_type}")
-
+          %td.centered= link_to text("shared.remove"), facility_product_product_accessory_path(current_facility, @product, pa), method: :delete if can? :delete, pa
+          %td= link_to accessory.to_s_with_status, [:manage, current_facility, accessory]
+          %td.centered= t(pa.scaling_type, scope: "product_accessories.type")
+- else
+  %p.notice= t(".no_accessories")

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -158,6 +158,9 @@ en:
         one: Product
         other: Products
       product_access_group: Scheduling Group
+      product_accessory:
+        one: Accessory
+        other: Accessories
       service:
         one: Service
         other: Services
@@ -210,6 +213,8 @@ en:
         is_hidden: Is Hidden?
         facility_account: Recharge Chart String
         training_request_contacts: Training Request Contacts
+      product_accessory:
+        scaling_type: Scaling Type
       instrument:
         min_reserve_mins: Minimum Reservation Minutes
         max_reserve_mins: Maximum Reservation Minutes

--- a/spec/controllers/product_accessories_controller_spec.rb
+++ b/spec/controllers/product_accessories_controller_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe ProductAccessoriesController do
   let(:instrument) { FactoryGirl.create(:setup_instrument) }
   let(:facility) { instrument.facility }
   let(:accessory) { FactoryGirl.create(:setup_item, facility: facility) }
-  let(:unchosen_accessory) { FactoryGirl.create(:setup_item, facility: facility) }
 
   before :each do
     @authable = facility
@@ -17,6 +16,11 @@ RSpec.describe ProductAccessoriesController do
   end
 
   describe "index" do
+    let!(:unchosen_accessory) { FactoryGirl.create(:setup_item, facility: facility) }
+    let!(:bundle) do
+      FactoryGirl.create(:bundle, facility: facility)
+    end
+
     before :each do
       @method = :get
       @action = :index
@@ -30,7 +34,6 @@ RSpec.describe ProductAccessoriesController do
       before :each do
         maybe_grant_always_sign_in :admin
         instrument.accessories << accessory
-        unchosen_accessory # load
         do_request
       end
 
@@ -39,11 +42,15 @@ RSpec.describe ProductAccessoriesController do
       end
 
       it "excludes the already created accessory in the list" do
-        expect(assigns(:available_accessories)).to_not include(accessory)
+        expect(assigns(:available_accessories)).not_to include(accessory)
       end
 
       it "does not include itself" do
-        expect(assigns(:available_accessories)).to_not include(instrument)
+        expect(assigns(:available_accessories)).not_to include(instrument)
+      end
+
+      it "does not include the bundle" do
+        expect(assigns(:available_accessories)).not_to include(bundle)
       end
     end
 
@@ -53,7 +60,7 @@ RSpec.describe ProductAccessoriesController do
       ProductAccessory.first.soft_delete
       instrument.accessories << unchosen_accessory
       do_request
-      expect(assigns(:product_accessories)).to_not include accessory
+      expect(assigns(:product_accessories)).not_to include(accessory)
     end
   end
 


### PR DESCRIPTION
Bundles should not be able to be used as accessories.

They do not have their own price policies, and when they were getting set up as accessories, they would cause problems with reconciliation because they don’t have price policies.