### PR TITLE
[#134410] Force Spaces In Responsive Tables

### DIFF
--- a/app/assets/javascripts/app/responsive_table.js.coffee
+++ b/app/assets/javascripts/app/responsive_table.js.coffee
@@ -3,9 +3,18 @@ class window.ResponsiveTable
   @respond: ->
     return unless window.IS_RESPONSIVE
     $(".js--responsive_table").each (index, table) ->
-      new ResponsiveTable($(table)).add_responsive_headers()
+      new ResponsiveTable($(table)).make_responsive()
 
   constructor: (@table) ->
+
+  make_responsive: ->
+    @fill_empty_cells()
+    @add_responsive_headers()
+
+  fill_empty_cells: ->
+    @table.find("td").each (index, cell) =>
+      empty = $(cell).text().trim().length == 0
+      $(cell).append("&nbsp;") if empty
 
   add_responsive_headers: ->
     @table.find("tbody tr").each (index, row) => @add_header_to_row($(row))

--- a/spec/javascripts/fixtures/normal_table.html
+++ b/spec/javascripts/fixtures/normal_table.html
@@ -11,7 +11,7 @@
       <td>Large Hadron Collider</td>
     </tr>
     <tr>
-      <td>24</td>
+      <td></td>
       <td>Small Hadron Collider</td>
     </tr>
   </tbody>

--- a/spec/javascripts/responsive_tables_spec.coffee
+++ b/spec/javascripts/responsive_tables_spec.coffee
@@ -25,3 +25,10 @@ describe "Responsive table support", ->
     $(".table").addClass("js--responsive_table")
     ResponsiveTable.respond()
     expect($(".table")).not.toContainElement(".responsive-header")
+
+  it "inserts a space if the table cell is empty, for spacing", ->
+    $(".table").addClass("js--responsive_table")
+    expected = $("td").eq(2).clone().append("Invoice #&nbsp;").text()
+    ResponsiveTable.respond()
+    expect($("td").eq(2).text()).toEqual(expected)
+    expect($("td").eq(3).text()).toEqual("FacilitySmall Hadron Collider")


### PR DESCRIPTION
A blank cell makes the responsive table look bad, so this fixes it by adding a blank space to empty cells in the responsive JavaScript

This kind of shows it:

![my_files_-_nucore](https://cloud.githubusercontent.com/assets/5661/25709906/4a67e1b6-30b0-11e7-90d8-92ce24d0c84f.png)