### PR TITLE
[#133813] Admins should be able to update user's username

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -163,7 +163,7 @@ class UsersController < ApplicationController
   private
 
   def edit_user_params
-    params.require(:user).permit(:email, :first_name, :last_name)
+    params.require(:user).permit(:email, :first_name, :last_name, :username)
   end
 
   def update_access_list_approvals

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -11,6 +11,7 @@
 
 = readonly_form_for :user do |f|
   = f.input :full_name
+  = f.input :username
   = f.input :email
   = f.input :last_sign_in_at, :default_value => 'none'
   = f.input :deactivated_at unless f.object.active?

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -59,27 +59,31 @@ RSpec.describe UsersController do
   end
 
   describe "PUT #update", feature_setting: { create_users: true } do
-    let(:user) { FactoryGirl.create(:user, :external) }
+    let(:user) { FactoryGirl.create(:user, :external, first_name: "Old") }
 
     before(:each) do
       @method = :put
       @action = :update
       @params[:id] = user.id
-      @params[:user] = { first_name: "New", last_name: "Name" }
+      @params[:user] = { first_name: "New", last_name: "Name", email: "newemail@example.com", username: "newemail@example.com" }
     end
 
     it_should_allow_admin_only(:found) do
       expect(user.reload.first_name).to eq("New")
+      expect(user.last_name).to eq("Name")
+      expect(user.email).to eq("newemail@example.com")
+      expect(user.username).to eq("newemail@example.com")
       expect(response).to redirect_to facility_user_path(facility, user)
     end
 
-    context "with bad params" do
+    context "with not permitted params" do
       before(:each) do
-        @params[:user] = { email: "test@example.com", username: "newusername" }
+        @params[:user] = { uid: "somevalue" }
       end
 
       it_should_allow_admin_only(:found) do
-        expect(user.reload.first_name).to eq(user.first_name)
+        expect(user.reload.first_name).to eq("Old")
+        expect(user.uid).to be_blank
       end
     end
   end


### PR DESCRIPTION
The javascript on the front end will make sure the username and email match for external users.