### PR TITLE
[#144058895] Remove translation of problem description

### DIFF
--- a/app/helpers/facility_orders_helper.rb
+++ b/app/helpers/facility_orders_helper.rb
@@ -9,10 +9,7 @@ module FacilityOrdersHelper
     notices << "can_reconcile" if order_detail.can_reconcile_journaled?
     notices << "in_open_journal" if order_detail.in_open_journal?
 
-    # TODO: Share translation key between badges and notices
-    warnings = []
-    warnings << "missing_actuals" if order_detail.complete? && order_detail.reservation.try(:requires_but_missing_actuals?)
-    warnings << "missing_price_policy" if order_detail.missing_price_policy? && !order_detail.reservation.try(:requires_but_missing_actuals?)
+    warnings = Array(order_detail.problem_description_key)
 
     { warnings: warnings, notices: notices }
   end
@@ -20,9 +17,8 @@ module FacilityOrdersHelper
   def order_detail_badges(order_detail)
     notices = order_detail_notices(order_detail)
 
-    # TODO: Share translation key between badges and notices
-    output = build_warning_badges(Array(order_detail.problem_description))
-    output += build_notices(notices[:notices])
+    output = build_badges(notices[:notices], "label-info")
+    output += build_badges(notices[:warnings], "label-important")
 
     safe_join(output)
   end
@@ -48,15 +44,9 @@ module FacilityOrdersHelper
 
   private
 
-  def build_notices(notices)
+  def build_badges(notices, label_class)
     notices.map do |notice|
-      content_tag(:span, t("order_details.notices.#{notice}.badge"), class: ["label", "label-info"])
-    end
-  end
-
-  def build_warning_badges(warnings)
-    warnings.map do |warning|
-      content_tag(:span, warning, class: ["label", "label-important"])
+      content_tag(:span, t("order_details.notices.#{notice}.badge"), class: ["label", label_class])
     end
   end
 

--- a/app/helpers/facility_orders_helper.rb
+++ b/app/helpers/facility_orders_helper.rb
@@ -9,7 +9,10 @@ module FacilityOrdersHelper
     notices << "can_reconcile" if order_detail.can_reconcile_journaled?
     notices << "in_open_journal" if order_detail.in_open_journal?
 
-    warnings = Array(order_detail.problem_description)
+    # TODO: Share translation key between badges and notices
+    warnings = []
+    warnings << "missing_actuals" if order_detail.complete? && order_detail.reservation.try(:requires_but_missing_actuals?)
+    warnings << "missing_price_policy" if order_detail.missing_price_policy? && !order_detail.reservation.try(:requires_but_missing_actuals?)
 
     { warnings: warnings, notices: notices }
   end
@@ -17,7 +20,8 @@ module FacilityOrdersHelper
   def order_detail_badges(order_detail)
     notices = order_detail_notices(order_detail)
 
-    output = build_warnings(notices[:warnings])
+    # TODO: Share translation key between badges and notices
+    output = build_warning_badges(Array(order_detail.problem_description))
     output += build_notices(notices[:notices])
 
     safe_join(output)
@@ -50,7 +54,7 @@ module FacilityOrdersHelper
     end
   end
 
-  def build_warnings(warnings)
+  def build_warning_badges(warnings)
     warnings.map do |warning|
       content_tag(:span, warning, class: ["label", "label-important"])
     end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -859,7 +859,7 @@ class OrderDetail < ActiveRecord::Base
 
   def problem_description
     time_data_problem = time_data.problem_description
-    price_policy_problem = text(:price_policy_missing) if price_policy.blank?
+    price_policy_problem = text(:missing_price_policy) if price_policy.blank?
 
     time_data_problem || price_policy_problem
   end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -31,7 +31,7 @@ class OrderDetail < ActiveRecord::Base
 
   before_save :set_problem_order
   def set_problem_order
-    self.problem = complete? && problem_description.present?
+    self.problem = complete? && problem_description_key.present?
     update_fulfilled_at_on_resolve if time_data.present?
     true # problem might be false; we need the callback chain to continue
   end
@@ -857,11 +857,11 @@ class OrderDetail < ActiveRecord::Base
     "activerecord.models.order_detail"
   end
 
-  def problem_description
-    time_data_problem = time_data.problem_description
-    price_policy_problem = text(:missing_price_policy) if price_policy.blank?
+  def problem_description_key
+    time_data_problem_key = time_data.problem_description_key
+    price_policy_problem_key = :missing_price_policy if price_policy.blank?
 
-    time_data_problem || price_policy_problem
+    time_data_problem_key || price_policy_problem_key
   end
 
   private

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -8,7 +8,6 @@ class Reservation < ActiveRecord::Base
   include Reservations::Rendering
   include Reservations::RelaySupport
   include Reservations::MovingUp
-  include TextHelpers::Translation
 
   # Associations
   #####
@@ -284,10 +283,6 @@ class Reservation < ActiveRecord::Base
 
   def problem_description_key
     :missing_actuals if requires_but_missing_actuals?
-  end
-
-  def translation_scope
-    "activerecord.models.reservation"
   end
 
   def locked?

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -282,8 +282,8 @@ class Reservation < ActiveRecord::Base
     !!(!canceled? && product.control_mechanism != Relay::CONTROL_MECHANISMS[:manual] && !has_actuals?) # TODO: refactor?
   end
 
-  def problem_description
-    text(:missing_actuals) if requires_but_missing_actuals?
+  def problem_description_key
+    :missing_actuals if requires_but_missing_actuals?
   end
 
   def translation_scope

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -283,7 +283,7 @@ class Reservation < ActiveRecord::Base
   end
 
   def problem_description
-    text(:actual_usage_missing) if requires_but_missing_actuals?
+    text(:missing_actuals) if requires_but_missing_actuals?
   end
 
   def translation_scope

--- a/app/models/time_data/null_time_data.rb
+++ b/app/models/time_data/null_time_data.rb
@@ -6,7 +6,7 @@ module TimeData
       true
     end
 
-    def problem_description
+    def problem_description_key
     end
 
     # Gives us both `blank?` and `present?`

--- a/app/models/time_data/required_time_data.rb
+++ b/app/models/time_data/required_time_data.rb
@@ -8,8 +8,8 @@ module TimeData
       false
     end
 
-    def problem_description
-      text(:missing_actuals)
+    def problem_description_key
+      :missing_actuals
     end
 
     def translation_scope

--- a/app/models/time_data/required_time_data.rb
+++ b/app/models/time_data/required_time_data.rb
@@ -2,18 +2,12 @@ module TimeData
 
   class RequiredTimeData
 
-    include TextHelpers::Translation
-
     def order_completable?
       false
     end
 
     def problem_description_key
       :missing_actuals
-    end
-
-    def translation_scope
-      "activerecord.models.time_data.required_time_data"
     end
 
     # Gives us both `blank?` and `present?`

--- a/app/models/time_data/required_time_data.rb
+++ b/app/models/time_data/required_time_data.rb
@@ -9,7 +9,7 @@ module TimeData
     end
 
     def problem_description
-      text(:actual_usage_missing)
+      text(:missing_actuals)
     end
 
     def translation_scope

--- a/app/views/order_management/order_details/_warnings.html.haml
+++ b/app/views/order_management/order_details/_warnings.html.haml
@@ -2,7 +2,7 @@
 - if notices[:warnings].any?
   .alert.alert-error
     - notices[:warnings].each do |warning|
-      = warning
+      = t("order_details.notices.#{warning}.alert")
 
 - if notices[:notices].any?
   .alert.alert-info

--- a/app/views/order_management/order_details/_warnings.html.haml
+++ b/app/views/order_management/order_details/_warnings.html.haml
@@ -2,7 +2,7 @@
 - if notices[:warnings].any?
   .alert.alert-error
     - notices[:warnings].each do |warning|
-      = t("order_details.notices.#{warning}.alert")
+      = warning
 
 - if notices[:notices].any?
   .alert.alert-info

--- a/app/views/shared/_problem_order_details.html.haml
+++ b/app/views/shared/_problem_order_details.html.haml
@@ -29,7 +29,7 @@
         %td= order_detail_description(order_detail)
         %td= order_detail.account
         %td.centered
-          = order_detail.problem_description
+          = t("order_details.notices.#{order_detail.problem_description_key}.badge")
           = link_to text("shared.update"), manage_order_detail_path(order_detail), class: "manage-order-detail"
 
 = will_paginate(@order_details)

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -142,14 +142,14 @@ en:
       reservation:
         one: Reservation
         other: Reservations
-        actual_usage_missing: Actual Usage Missing
+        missing_actuals: Actual Usage Missing
       order:
         one: Order
         other: Orders
       order_detail:
         one: Order Detail
         other: Order Details
-        price_policy_missing: Price Policy Missing
+        missing_price_policy: Price Policy Missing
       order_status:
         one: Current Order Status
         other: Order Statuses
@@ -168,7 +168,7 @@ en:
         other: Statements
       time_data:
         required_time_data:
-          actual_usage_missing: Actual Usage Missing
+          missing_actuals: Actual Usage Missing
       training_request:
         one: Training Request
         other: Training Requests

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -142,14 +142,12 @@ en:
       reservation:
         one: Reservation
         other: Reservations
-        missing_actuals: Actual Usage Missing
       order:
         one: Order
         other: Orders
       order_detail:
         one: Order Detail
         other: Order Details
-        missing_price_policy: Price Policy Missing
       order_status:
         one: Current Order Status
         other: Order Statuses
@@ -166,9 +164,6 @@ en:
       statement:
         one: Statement
         other: Statements
-      time_data:
-        required_time_data:
-          missing_actuals: Actual Usage Missing
       training_request:
         one: Training Request
         other: Training Requests

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1494,7 +1494,7 @@ RSpec.describe Reservation do
     context "requires_but_missing_actuals?" do
       before { expect(reservation).to receive(:requires_but_missing_actuals?).and_return(true) }
 
-      it { is_expected.to eq reservation.text(:actual_usage_missing) }
+      it { is_expected.to eq reservation.text(:missing_actuals) }
     end
 
     context "usage exists" do

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1488,13 +1488,13 @@ RSpec.describe Reservation do
     end
   end
 
-  describe "#problem_description" do
-    subject(:problem_description) { reservation.problem_description }
+  describe "#problem_description_key" do
+    subject(:problem_description_key) { reservation.problem_description_key }
 
     context "requires_but_missing_actuals?" do
       before { expect(reservation).to receive(:requires_but_missing_actuals?).and_return(true) }
 
-      it { is_expected.to eq reservation.text(:missing_actuals) }
+      it { is_expected.to eq :missing_actuals }
     end
 
     context "usage exists" do

--- a/spec/models/time_data/null_time_data_spec.rb
+++ b/spec/models/time_data/null_time_data_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe TimeData::NullTimeData, type: :model do
   let(:null_time_data) { described_class.new }
 
-  describe "#problem_description" do
-    subject(:problem_description) { null_time_data.problem_description }
+  describe "#problem_description_key" do
+    subject(:problem_description_key) { null_time_data.problem_description_key }
 
     it { is_expected.to be_blank }
   end

--- a/spec/models/time_data/required_time_data_spec.rb
+++ b/spec/models/time_data/required_time_data_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe TimeData::RequiredTimeData, type: :model do
   let(:required_time_data) { described_class.new }
 
-  describe "#problem_description" do
-    subject(:problem_description) { required_time_data.problem_description }
+  describe "#problem_description_key" do
+    subject(:problem_description_key) { required_time_data.problem_description_key }
 
-    it { is_expected.to eq required_time_data.text(:missing_actuals) }
+    it { is_expected.to eq :missing_actuals }
   end
 end

--- a/spec/models/time_data/required_time_data_spec.rb
+++ b/spec/models/time_data/required_time_data_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe TimeData::RequiredTimeData, type: :model do
   describe "#problem_description" do
     subject(:problem_description) { required_time_data.problem_description }
 
-    it { is_expected.to eq required_time_data.text(:actual_usage_missing) }
+    it { is_expected.to eq required_time_data.text(:missing_actuals) }
   end
 end

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
@@ -65,11 +65,11 @@ module SecureRooms
       range.duration_mins
     end
 
-    def problem_description
+    def problem_description_key
       if entry_at.blank?
-        text(:missing_entry)
+        :missing_entry
       elsif exit_at.blank?
-        text(:missing_exit)
+        :missing_exit
       end
     end
 

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
@@ -2,8 +2,6 @@ module SecureRooms
 
   class Occupancy < ActiveRecord::Base
 
-    include TextHelpers::Translation
-
     belongs_to :secure_room, foreign_key: :product_id
     belongs_to :user
     belongs_to :account
@@ -71,10 +69,6 @@ module SecureRooms
       elsif exit_at.blank?
         :missing_exit
       end
-    end
-
-    def translation_scope
-      "activerecord.models.secure_rooms/occupancy"
     end
 
     private

--- a/vendor/engines/secure_rooms/spec/models/secure_rooms/occupancy_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/secure_rooms/occupancy_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe SecureRooms::Occupancy do
 
   let(:occupancy) { build :occupancy }
 
-  describe "#problem_description" do
-    subject(:problem_description) { occupancy.problem_description }
+  describe "#problem_description_key" do
+    subject(:problem_description_key) { occupancy.problem_description_key }
 
     context "entry_at.blank?" do
       before { expect(occupancy).to receive(:entry_at).and_return(nil) }
 
-      it { is_expected.to eq occupancy.text(:missing_entry) }
+      it { is_expected.to eq :missing_entry }
     end
 
     context "exit_at.blank?" do
@@ -21,7 +21,7 @@ RSpec.describe SecureRooms::Occupancy do
         expect(occupancy).to receive(:exit_at).and_return(nil)
       end
 
-      it { is_expected.to eq occupancy.text(:missing_exit) }
+      it { is_expected.to eq :missing_exit }
     end
   end
 end


### PR DESCRIPTION
I did a grep for other calls to `order_detail_notices` and it looks like this is the only other spot

This issue was introduced through in #1007