### PR TITLE
[#144059203] Edit Occupancy Times in Modal

### DIFF
--- a/app/assets/javascripts/app/manage_orders.coffee
+++ b/app/assets/javascripts/app/manage_orders.coffee
@@ -44,7 +44,9 @@ class OrderDetailManagement
 
   initPriceUpdating: ->
     self = this
-    @$element.find('[name^="order_detail[reservation]"]:not([name$=_display]),[name="order_detail[quantity]"],[name="order_detail[account_id]"]').bind "change keyup", (evt) ->
+    # _display is excluded to prevent the displayed input for durations from triggering.
+    # We want only the underlying quantity/mins input to trigger it.
+    @$element.find('.js--pricingUpdate input:not([name$=_display]), .js--pricingUpdate select').bind "change keyup", (evt) ->
       self.updatePricing(evt) if @.value.length > 0
 
   updatePricing: (e) ->

--- a/app/assets/javascripts/app/manage_orders.coffee
+++ b/app/assets/javascripts/app/manage_orders.coffee
@@ -43,11 +43,12 @@ class OrderDetailManagement
     $('[name="order_detail[reservation][actual_duration_mins]_display"]').val(newval).trigger('change')
 
   initPriceUpdating: ->
-    self = this
-    # _display is excluded to prevent the displayed input for durations from triggering.
-    # We want only the underlying quantity/mins input to trigger it.
-    @$element.find('.js--pricingUpdate input:not([name$=_display]), .js--pricingUpdate select').bind "change keyup", (evt) ->
-      self.updatePricing(evt) if @.value.length > 0
+    # _display is excluded to prevent the displayed input for durations from
+    # triggering. We want only the underlying quantity/mins input to trigger it.
+    @$element
+      .find('.js--pricingUpdate input:not([name$=_display]),.js--pricingUpdate select')
+      .bind "change keyup", (evt) =>
+        @updatePricing(evt) if $(evt.target).val().length > 0
 
   updatePricing: (e) ->
     self = this

--- a/app/controllers/journal_cutoff_dates_controller.rb
+++ b/app/controllers/journal_cutoff_dates_controller.rb
@@ -50,10 +50,7 @@ class JournalCutoffDatesController < ApplicationController
   end
 
   def journal_cutoff_date_params
-    params.require(:journal_cutoff_date).permit(:cutoff_date, cutoff_date_time: [:hour, :minute, :ampm]).tap do |params|
-      # If we don't do this, we will interpret 1/10 as October 1.
-      params[:cutoff_date] = parse_usa_date(params[:cutoff_date]) if params[:cutoff_date].is_a?(String)
-    end
+    params.require(:journal_cutoff_date).permit(cutoff_date: [:date, :hour, :minute, :ampm])
   end
 
 end

--- a/app/inputs/time_dropdown_input.rb
+++ b/app/inputs/time_dropdown_input.rb
@@ -36,7 +36,7 @@ class TimeDropdownInput < SimpleForm::Inputs::Base
 
   def minute_options
     step = options[:minute_step] || 1
-    (0..59).step(step).map { |d| ["%02d" % d, d] }
+    (0..59).step(step).map { |d| [format("%02d", d), d] }
   end
 
 end

--- a/app/inputs/time_dropdown_input.rb
+++ b/app/inputs/time_dropdown_input.rb
@@ -1,0 +1,42 @@
+# DateTimeInput
+class TimeDropdownInput < SimpleForm::Inputs::Base
+
+  def input(wrapper_options)
+    merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
+
+    @builder.simple_fields_for attribute_name, object.public_send("#{attribute_name}_date_time_data"), defaults: { include_blank: false, label: false } do |f|
+      template.safe_join(
+        [
+          date_field(f),
+          time_fields(f, merged_input_options),
+        ],
+      )
+    end
+  end
+
+  private
+
+  def date_field(f)
+    f.input :date, input_html: { class: "datepicker" }
+  end
+
+  def time_fields(f, merged_input_options)
+    f.input :time_select do
+      template.content_tag :div, class: "time-select" do
+        template.safe_join(
+          [
+            f.input_field(:hour, merged_input_options.merge(collection: (1..12).to_a)),
+            f.input_field(:minute, merged_input_options.merge(collection: minute_options)),
+            f.input_field(:ampm, merged_input_options.merge(collection: %w(AM PM))),
+          ],
+        )
+      end
+    end
+  end
+
+  def minute_options
+    step = options[:minute_step] || 1
+    (0..59).step(step).map { |d| ["%02d" % d, d] }
+  end
+
+end

--- a/app/models/journal_cutoff_date.rb
+++ b/app/models/journal_cutoff_date.rb
@@ -2,6 +2,9 @@ class JournalCutoffDate < ActiveRecord::Base
 
   include ActiveModel::ForbiddenAttributesProtection
 
+  include DateTimeInput::Model
+  date_time_inputable :cutoff_date
+
   validates :cutoff_date, presence: true
   validate :unique_month_for_cutoff_date, if: :cutoff_date?
 
@@ -18,20 +21,6 @@ class JournalCutoffDate < ActiveRecord::Base
 
   def past?
     cutoff_date < Time.current
-  end
-
-  # TODO: consider turning this into a reusable module
-  def cutoff_date_time=(hash)
-    formatted = "#{cutoff_date.to_date} #{hash[:hour]}:#{hash[:minute]}#{hash[:ampm]}"
-    self.cutoff_date = Time.zone.parse(formatted)
-  end
-
-  def cutoff_date_time
-    {
-      hour: cutoff_date.strftime("%-l"),
-      minute:  "%02d" % cutoff_date.min,
-      ampm: cutoff_date.strftime("%p"),
-    }
   end
 
   private

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -935,7 +935,7 @@ class OrderDetail < ActiveRecord::Base
 
   def update_fulfilled_at_on_resolve
     if problem_changed? && !problem_order?
-      self.fulfilled_at = reservation.reserve_end_at
+      self.fulfilled_at = time_data.actual_end_at
     end
   end
 

--- a/app/views/journal_cutoff_dates/_form.html.haml
+++ b/app/views/journal_cutoff_dates/_form.html.haml
@@ -1,6 +1,7 @@
 = simple_form_for(@journal_cutoff_date) do |f|
-  = f.input :cutoff_date, as: :string, input_html: { class: "datepicker", value: format_usa_date(f.object.cutoff_date) }
-  .time-select= time_select_tag "journal_cutoff_date[cutoff_date_time]", f.object.cutoff_date
+
+  = f.input :cutoff_date, as: :time_dropdown
+
   = f.button :submit, t(".submit"), class: ["btn", "btn-primary"]
   = link_to t(".cancel"), journal_cutoff_dates_path
 

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -9,7 +9,8 @@
         = render "warnings"
 
     .row
-      .span5= account_input(f)
+      .span5.js--pricingUpdate
+        = account_input(f)
 
       .span5
         - if @order_statuses
@@ -41,10 +42,10 @@
     = render_view_hook "after_order_status", f: f, order_detail: @order_detail
 
     .row
-      - if @order_detail.reservation
-        .span5= render "reservation", f: f, reservation: @order_detail.reservation
+      - if @order_detail.time_data.present?
+        .span5= render "order_management/order_details/#{@order_detail.time_data.class.name.underscore}", f: f
       - else
-        .span5
+        .span5.js--pricingUpdate
           = f.input :quantity, as: :order_detail_quantity, hint_html: { class: "help-inline" }
 
       .span5

--- a/app/views/order_management/order_details/_reservation.html.haml
+++ b/app/views/order_management/order_details/_reservation.html.haml
@@ -1,33 +1,30 @@
+- reservation = f.object.reservation
 = f.simple_fields_for reservation do |r|
 
-  .datetime-block
+  .datetime-block.js--pricingUpdate
     - if reservation.admin_editable?
-      = r.input :reserve_start_date, :input_html => { :class => 'datepicker' }
+      = r.input :reserve_start_date, input_html: { class: "datepicker" }
       .control-group
         .controls
           %label &nbsp;
           = time_select r, :reserve_start, minute_step: reservation.product.reserve_interval
-      = r.input :duration_mins, :input_html => { :class => 'timeinput' }
+      = r.input :duration_mins, input_html: { class: "timeinput" }
     - else
       = r.label :reserve_start_date
       = reservation.reserve_to_s
 
-  .datetime-block
+  .datetime-block.js--pricingUpdate
     - if reservation.can_edit_actuals? && !reservation.canceled?
-      = r.input :actual_start_date, :input_html => { :class => 'datepicker' }
+      = r.input :actual_start_date, input_html: { class: "datepicker" }
       .control-group
         .controls
           %label &nbsp;
           = time_select r, :actual_start, :minute_step => 1
-      - options = { :class => 'timeinput' }
-      - options[:value] = '' if r.object.actual_duration_mins == 0
-      = r.input :actual_duration_mins, :input_html => options
-      = render :partial => 'copy_actuals_from_reservation', :locals => { :reservation => reservation }
+      - options = { class: "timeinput" }
+      - options[:value] = "" if r.object.actual_duration_mins == 0
+      = r.input :actual_duration_mins, input_html: options
+      = render "copy_actuals_from_reservation", reservation: reservation
 
     - else
       = r.label :actual_start_date
       = reservation.actuals_string
-
-
-
-

--- a/lib/date_time_input/form_data.rb
+++ b/lib/date_time_input/form_data.rb
@@ -69,6 +69,7 @@ module DateTimeInput
         ampm: ampm,
       }
     end
+
   end
 
 end

--- a/lib/date_time_input/form_data.rb
+++ b/lib/date_time_input/form_data.rb
@@ -1,0 +1,59 @@
+module DateTimeInput
+
+  class FormData
+
+    def initialize(time)
+      @time = time
+    end
+
+    def self.from_param(param)
+      return new(param) if param.is_a?(Time)
+      param = param.with_indifferent_access
+
+      str = param[:date]
+      format = "%m/%d/%Y"
+
+      if %w(hour minute ampm).all? { |k| param.key? k }
+        str += " #{param[:hour]}:#{param[:minute].to_s.rjust(2, '0')} #{param[:ampm]}"
+        format += " %H:%M %p"
+      end
+
+      parsed_time = Time.strptime(str, format) rescue ArgumentError
+      new(parsed_time)
+    end
+
+    def date
+      return unless @time
+      I18n.l(@time.to_date, format: :usa)
+    end
+
+    def hour
+      return unless @time
+      @time.strftime("%I").to_i
+    end
+
+    def minute
+      return unless @time
+      @time.min
+    end
+
+    def ampm
+      return unless @time
+      @time.strftime("%p")
+    end
+
+    def to_time
+      @time
+    end
+
+    def to_h
+      {
+        date: date,
+        hour: hour,
+        minute: minute,
+        ampm: ampm,
+      }
+    end
+  end
+
+end

--- a/lib/date_time_input/form_data.rb
+++ b/lib/date_time_input/form_data.rb
@@ -7,19 +7,34 @@ module DateTimeInput
     end
 
     def self.from_param(param)
+      from_param!(param)
+    rescue ArgumentError
+      new(nil)
+    end
+
+    def self.from_param!(param)
       return new(param) if param.is_a?(Time)
       param = param.with_indifferent_access
 
       str = param[:date]
       format = "%m/%d/%Y"
 
-      if %w(hour minute ampm).all? { |k| param.key? k }
+      if check_time_param!(param)
         str += " #{param[:hour]}:#{param[:minute].to_s.rjust(2, '0')} #{param[:ampm]}"
         format += " %H:%M %p"
       end
 
-      parsed_time = Time.strptime(str, format) rescue ArgumentError
-      new(parsed_time)
+      new(Time.strptime(str, format))
+    end
+
+    def self.check_time_param!(param)
+      if %w(hour minute ampm).all? { |k| param.key? k }
+        true
+      elsif %w(hour minute ampm).none? { |k| param.key? k }
+        false
+      else
+        raise ArgumentError, "Must have all or none of [:hour, :minute, :ampm] keys"
+      end
     end
 
     def date

--- a/lib/date_time_input/model.rb
+++ b/lib/date_time_input/model.rb
@@ -1,0 +1,27 @@
+module DateTimeInput
+
+  module Model
+
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+
+      def date_time_inputable(attribute)
+        define_method("#{attribute}=") do |input|
+          if input.is_a?(Hash)
+            super(FormData.from_param(input).to_time)
+          else
+            super(input)
+          end
+        end
+
+        define_method("#{attribute}_date_time_data") do
+          FormData.new(public_send(attribute))
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/spec/controllers/journal_cutoff_dates_controller_spec.rb
+++ b/spec/controllers/journal_cutoff_dates_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe JournalCutoffDatesController do
 
     describe "#create" do
       def do_request
-        post :create, journal_cutoff_date: { cutoff_date: cutoff_date }
+        post :create, journal_cutoff_date: { cutoff_date: { date: cutoff_date, hour: "3", minute: "15", ampm: "PM" } }
       end
 
       describe "success" do
@@ -71,7 +71,7 @@ RSpec.describe JournalCutoffDatesController do
 
           it "interprets month/day correctly" do
             do_request
-            expect(JournalCutoffDate.last.cutoff_date).to eq(Time.zone.parse("2016-06-10"))
+            expect(JournalCutoffDate.last.cutoff_date).to eq(Time.zone.parse("2016-06-10 15:15"))
           end
         end
       end
@@ -91,17 +91,17 @@ RSpec.describe JournalCutoffDatesController do
     end
 
     describe "#update" do
-      let!(:journal_cutoff_date) { JournalCutoffDate.create(cutoff_date: 1.month.from_now) }
+      let!(:journal_cutoff_date) { JournalCutoffDate.create(cutoff_date: Time.zone.parse("2016-06-10 15:15")) }
 
       def do_request
-        put :update, id: journal_cutoff_date.id, journal_cutoff_date: { cutoff_date: new_cutoff_date }
+        put :update, id: journal_cutoff_date.id, journal_cutoff_date: { cutoff_date: { date: new_cutoff_date } }
       end
 
       describe "success" do
-        let(:new_cutoff_date) { 2.months.from_now.change(usec: 0) }
+        let(:new_cutoff_date) { "07/10/2016" }
 
         it "updates the model" do
-          expect { do_request }.to change { journal_cutoff_date.reload.cutoff_date }.to(new_cutoff_date)
+          expect { do_request }.to change { journal_cutoff_date.reload.cutoff_date }.to(Time.zone.parse("2016-07-10"))
         end
       end
 

--- a/spec/lib/date_time_input/form_data_spec.rb
+++ b/spec/lib/date_time_input/form_data_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.describe DateTimeInput::FormData do
+
+  describe ".from_param" do
+    let(:form_data) { described_class.from_param(hash) }
+    subject(:output_time) { form_data.to_time }
+
+    describe "with only a date" do
+      let(:hash) { { date: "04/06/2017" } }
+      it { is_expected.to eq(Time.zone.parse("2017-04-06")) }
+    end
+
+    describe "with all the fields in the AM" do
+      let(:hash) { { date: "04/06/2017", hour: 4, minute: 19, ampm: "AM" } }
+      it { is_expected.to eq(Time.zone.parse("2017-04-06 04:19")) }
+    end
+
+    describe "with all the fields in the PM" do
+      let(:hash) { { date: "04/06/2017", hour: 4, minute: 19, ampm: "PM" } }
+      it { is_expected.to eq(Time.zone.parse("2017-04-06 16:19")) }
+    end
+
+    describe "missing data" do
+      let(:hash) { { date: "04/06/2017", hour: 4 } }
+      it { is_expected.to be_nil }
+    end
+
+    describe "an invalid date" do
+      let(:hash) { { date: "19/06/2017", hour: 4, minute: 19, ampm: "PM" } }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe ".from_param!" do
+    let(:form_data) { described_class.from_param!(hash) }
+    subject(:output_time) { form_data.to_time }
+
+    describe "with only a date" do
+      let(:hash) { { date: "04/06/2017" } }
+      it { is_expected.to eq(Time.zone.parse("2017-04-06")) }
+    end
+
+    describe "with all the fields in the AM" do
+      let(:hash) { { date: "04/06/2017", hour: 4, minute: 19, ampm: "AM" } }
+      it { is_expected.to eq(Time.zone.parse("2017-04-06 04:19")) }
+    end
+
+    describe "with all the fields in the PM" do
+      let(:hash) { { date: "04/06/2017", hour: 4, minute: 19, ampm: "PM" } }
+      it { is_expected.to eq(Time.zone.parse("2017-04-06 16:19")) }
+    end
+
+    describe "missing data" do
+      let(:hash) { { date: "04/06/2017", hour: 4 } }
+      specify { expect { subject }.to raise_error(ArgumentError, /Must have all or none/) }
+    end
+
+    describe "an invalid date" do
+      let(:hash) { { date: "19/06/2017", hour: 4, minute: 19, ampm: "PM" } }
+      specify { expect { subject }.to raise_error(ArgumentError, /time/) }
+    end
+  end
+
+  describe "with a datetime" do
+    let(:time) { Time.zone.parse("2017-04-11 17:34") }
+    subject(:form_data) { described_class.new(time) }
+
+    describe "fields" do
+      specify { expect(form_data.date).to eq("04/11/2017") }
+      specify { expect(form_data.hour).to eq(5) }
+      specify { expect(form_data.minute).to eq(34) }
+      specify { expect(form_data.ampm).to eq("PM") }
+      specify { expect(form_data.to_time).to eq(time) }
+    end
+
+    describe "to_h" do
+      it "outputs the expected hash" do
+        expect(form_data.to_h).to eq(
+          date: "04/11/2017",
+          hour: 5,
+          minute: 34,
+          ampm: "PM",
+        )
+      end
+    end
+  end
+
+  describe "with a null value" do
+    subject(:form_data) { described_class.new(nil) }
+
+    describe "fields" do
+      specify { expect(form_data.date).to be_nil }
+      specify { expect(form_data.hour).to be_nil }
+      specify { expect(form_data.minute).to be_nil }
+      specify { expect(form_data.ampm).to be_nil }
+    end
+
+    describe "to_h" do
+      it "renders null values" do
+        expect(form_data.to_h).to eq(
+          date: nil,
+          hour: nil,
+          minute: nil,
+          ampm: nil,
+        )
+      end
+    end
+  end
+
+end

--- a/spec/lib/date_time_input/model_spec.rb
+++ b/spec/lib/date_time_input/model_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe DateTimeInput::Model do
+
+  # Super won't work within the same class, so create a basic superclass.
+  let(:ar_faker_clazz) do
+    Class.new do
+      attr_accessor :datetime
+    end
+  end
+
+  let(:clazz) do
+    Class.new(ar_faker_clazz) do
+      include DateTimeInput::Model
+      date_time_inputable :datetime
+    end
+  end
+
+  subject(:instance) { clazz.new }
+
+  describe "setter" do
+    it "can set a datetime directly" do
+      date = Time.current
+      instance.datetime = date
+      expect(instance.datetime).to eq(date)
+    end
+
+    it "can set from a valid set of fields" do
+      params = { date: "06/09/2017", hour: "6", minute: "07", ampm: "PM" }
+      instance.datetime = params
+      expect(instance.datetime).to eq(Time.zone.parse("2017-06-09 18:07"))
+    end
+
+    it "sets to nil on invalid fields" do
+      params = { date: "06/09/2017", hour: "6" }
+      instance.datetime = params
+      expect(instance.datetime).to be_nil
+    end
+  end
+
+  describe "getter" do
+    describe "with a time value" do
+      let(:time) { Time.zone.parse("2017-08-03 14:23:45") }
+      subject(:data) { instance.tap { |i| i.datetime = time }.datetime_date_time_data }
+
+      specify { expect(data.date).to eq("08/03/2017") }
+      specify { expect(data.hour).to eq(2) }
+      specify { expect(data.minute).to eq(23) }
+      specify { expect(data.ampm).to eq("PM") }
+    end
+
+    describe "with an empty time value" do
+      subject(:data) { instance.datetime_date_time_data }
+
+      specify { expect(data.date).to be_nil }
+      specify { expect(data.hour).to be_nil }
+      specify { expect(data.minute).to be_nil }
+      specify { expect(data.ampm).to be_nil }
+    end
+  end
+end

--- a/spec/models/journal_cutoff_date_spec.rb
+++ b/spec/models/journal_cutoff_date_spec.rb
@@ -4,54 +4,52 @@ RSpec.describe JournalCutoffDate do
   it { is_expected.to validate_presence_of(:cutoff_date) }
 
   describe "cutoff_date" do
-    subject(:hash) { described_class.new(cutoff_date: cutoff_date).cutoff_date_time }
+    subject(:hash) { described_class.new(cutoff_date: cutoff_date).cutoff_date_date_time_data.to_h }
     describe "am" do
       let(:cutoff_date) { Time.zone.parse("2016-01-01 08:45") }
-      it { is_expected.to eq(hour: "8", minute: "45", ampm: "AM") }
+      it { is_expected.to eq(date: "01/01/2016", hour: 8, minute: 45, ampm: "AM") }
     end
 
     describe "pm" do
       let(:cutoff_date) { Time.zone.parse("2016-01-01 16:37") }
-      it { is_expected.to eq(hour: "4", minute: "37", ampm: "PM") }
+      it { is_expected.to eq(date: "01/01/2016", hour: 4, minute: 37, ampm: "PM") }
     end
 
     describe "midnight" do
-      let(:cutoff_date) { Time.zone.parse("2016-01-01 00:10") }
-      it { is_expected.to eq(hour: "12", minute: "10", ampm: "AM") }
+      let(:cutoff_date) { Time.zone.parse("2016-04-01 00:10") }
+      it { is_expected.to eq(date: "04/01/2016", hour: 12, minute: 10, ampm: "AM") }
     end
 
     describe "noon" do
       let(:cutoff_date) { Time.zone.parse("2016-01-01 12:00") }
-      it { is_expected.to eq(hour: "12", minute: "00", ampm: "PM") }
+      it { is_expected.to eq(date: "01/01/2016", hour: 12, minute: 0, ampm: "PM") }
     end
   end
 
   describe "cutoff_date=" do
     let(:model) do
-      described_class.new(cutoff_date: Time.zone.parse("2016-02-01")).tap do |model|
-        model.cutoff_date_time = cutoff_date_hash
-      end
+      described_class.new(cutoff_date: cutoff_date_hash)
     end
 
     subject(:cutoff_date) { model.cutoff_date }
 
     describe "am" do
-      let(:cutoff_date_hash) { { hour: "8", minute: "45", ampm: "AM" } }
+      let(:cutoff_date_hash) { { date: "02/01/2016", hour: "8", minute: "45", ampm: "AM" } }
       it { is_expected.to eq(Time.zone.parse("2016-02-01 08:45")) }
     end
 
     describe "pm" do
-      let(:cutoff_date_hash) { { hour: "4", minute: "37", ampm: "PM" } }
+      let(:cutoff_date_hash) { { date: "02/01/2016", hour: "4", minute: "37", ampm: "PM" } }
       it { is_expected.to eq(Time.zone.parse("2016-02-01 16:37")) }
     end
 
     describe "midnight" do
-      let(:cutoff_date_hash) { { hour: "12", minute: "10", ampm: "AM" } }
+      let(:cutoff_date_hash) { { date: "02/01/2016", hour: "12", minute: "10", ampm: "AM" } }
       it { is_expected.to eq(Time.zone.parse("2016-02-01 00:10")) }
     end
 
     describe "noon" do
-      let(:cutoff_date_hash) { { hour: "12", minute: "00", ampm: "PM" } }
+      let(:cutoff_date_hash) { { date: "02/01/2016", hour: "12", minute: "00", ampm: "PM" } }
       it { is_expected.to eq(Time.zone.parse("2016-02-01 12:00")) }
     end
   end

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
@@ -2,7 +2,6 @@ module SecureRooms
 
   class Occupancy < ActiveRecord::Base
 
-    include TextHelpers::Translation
     include DateTimeInput::Model
 
     date_time_inputable :entry_at

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
@@ -2,6 +2,12 @@ module SecureRooms
 
   class Occupancy < ActiveRecord::Base
 
+    include TextHelpers::Translation
+    include DateTimeInput::Model
+
+    date_time_inputable :entry_at
+    date_time_inputable :exit_at
+
     belongs_to :secure_room, foreign_key: :product_id
     belongs_to :user
     belongs_to :account

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
@@ -20,6 +20,9 @@ module SecureRooms
     delegate :facility, to: :secure_room
     delegate :to_s, to: :range
 
+    alias_attribute :actual_start_at, :entry_at
+    alias_attribute :actual_end_at, :exit_at
+
     def self.valid
       where(orphaned_at: nil)
     end

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/order_detail_extension.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/order_detail_extension.rb
@@ -7,6 +7,8 @@ module SecureRooms
     included do
       has_one :occupancy, dependent: :destroy, inverse_of: :order_detail, class_name: SecureRooms::Occupancy
 
+      accepts_nested_attributes_for :occupancy, update_only: true
+
       scope :occupancies, -> { joins(:product).where(products: { type: SecureRoom }) }
     end
 

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/order_details/param_updater_extension.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/order_details/param_updater_extension.rb
@@ -1,0 +1,22 @@
+module SecureRooms
+
+  module OrderDetails
+
+    module ParamUpdaterExtension
+
+      extend ActiveSupport::Concern
+
+      included do
+        permitted_attributes.append(
+          occupancy_attributes: [
+            entry_at: [:date, :hour, :minute, :ampm],
+            exit_at: [:date, :hour, :minute, :ampm],
+          ],
+        )
+      end
+
+    end
+
+  end
+
+end

--- a/vendor/engines/secure_rooms/app/views/order_management/order_details/secure_rooms/_occupancy.html.haml
+++ b/vendor/engines/secure_rooms/app/views/order_management/order_details/secure_rooms/_occupancy.html.haml
@@ -1,0 +1,4 @@
+.datetime-block.js--pricingUpdate
+  = f.simple_fields_for :occupancy_attributes, f.object.time_data do |of|
+    = of.input :entry_at, as: :time_dropdown
+    = of.input :exit_at, as: :time_dropdown

--- a/vendor/engines/secure_rooms/config/locales/en.yml
+++ b/vendor/engines/secure_rooms/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
         entry_at: Time of Entry
         exit_at: Time of Exit
         orphaned_at: Time Marked as Orphaned
+        actual_duration_mins: Duration
 
   controllers:
     secure_rooms/card_readers:

--- a/vendor/engines/secure_rooms/lib/secure_rooms/engine.rb
+++ b/vendor/engines/secure_rooms/lib/secure_rooms/engine.rb
@@ -9,6 +9,7 @@ module SecureRooms
 
       NavTab::LinkCollection.send :include, SecureRooms::LinkCollectionExtension
       OrderDetail.send :include, SecureRooms::OrderDetailExtension
+      ::OrderDetails::ParamUpdater.send :include, SecureRooms::OrderDetails::ParamUpdaterExtension
 
       bundle_index = Product.types.index(Bundle) || -1
       Product.types.insert(bundle_index, SecureRoom)

--- a/vendor/engines/secure_rooms/spec/features/admin_edit_occupancy_spec.rb
+++ b/vendor/engines/secure_rooms/spec/features/admin_edit_occupancy_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe "Editing an occupancy" do
+  let(:facility) { create(:setup_facility) }
+  let(:secure_room) { create(:secure_room, facility: facility) }
+  let!(:policy) { create(:secure_room_price_policy, product: secure_room, usage_rate: 60, price_group: order_detail.account.price_groups.first) }
+  let(:order) { create(:purchased_order, product: secure_room) }
+  let!(:order_detail) { order.order_details.first }
+
+  let(:director) { create(:user, :facility_director, facility: facility) }
+  let!(:occupancy) do
+    create(
+      :occupancy,
+      *traits,
+      secure_room: secure_room,
+      order_detail: order_detail,
+      account: order_detail.account,
+      entry_at: entry_at,
+      exit_at: exit_at,
+    )
+  end
+
+  before do
+    order_detail.complete!
+    login_as director
+    visit facility_transactions_path(facility)
+    click_link order_detail.id
+  end
+
+  describe "with a complete occupancy", :aggregate_failures do
+    let(:traits) { :complete }
+    let(:entry_at) { Time.zone.parse("2017-09-12 08:30") }
+    let(:exit_at) { Time.zone.parse("2017-09-12 09:30") }
+
+    it "can change the times" do
+      fill_in "order_detail_occupancy_attributes_entry_at_date", with: "04/12/2017"
+      select "7", from: "order_detail_occupancy_attributes_entry_at_hour"
+      select "10", from: "order_detail_occupancy_attributes_entry_at_minute"
+      select "PM", from: "order_detail_occupancy_attributes_entry_at_ampm"
+
+      fill_in "order_detail_occupancy_attributes_exit_at_date", with: "4/12/2017"
+      select "8", from: "order_detail_occupancy_attributes_exit_at_hour"
+      select "00", from: "order_detail_occupancy_attributes_exit_at_minute"
+      select "PM", from: "order_detail_occupancy_attributes_exit_at_ampm"
+
+      fill_in "Price", with: "45.37"
+
+      click_button "Save"
+
+      expect(occupancy.reload.entry_at).to eq(Time.zone.parse("2017-04-12 19:10"))
+      expect(occupancy.exit_at).to eq(Time.zone.parse("2017-04-12 20:00"))
+
+      expect(order_detail.reload.actual_cost).to eq(45.37)
+    end
+  end
+
+  describe "with an orphaned swipe in" do
+    let(:traits) { :orphan }
+    let(:entry_at) { Time.zone.parse("2017-09-12 08:30") }
+    let(:exit_at) { nil }
+
+    it "can set the end time" do
+      fill_in "order_detail_occupancy_attributes_exit_at_date", with: "9/12/2017"
+      select "9", from: "order_detail_occupancy_attributes_exit_at_hour"
+      select "45", from: "order_detail_occupancy_attributes_exit_at_minute"
+      select "AM", from: "order_detail_occupancy_attributes_exit_at_ampm"
+
+      click_button "Save"
+
+      expect(occupancy.reload.entry_at).to eq(Time.zone.parse("2017-09-12 08:30"))
+      expect(occupancy.exit_at).to eq(Time.zone.parse("2017-09-12 09:45"))
+      expect(order_detail.reload.fulfilled_at).to eq(occupancy.exit_at)
+    end
+  end
+
+  describe "with an orphaned swipe out" do
+    let(:traits) { :orphan }
+    let(:entry_at) { nil }
+    let(:exit_at) { Time.zone.parse("2017-09-12 10:30") }
+
+    it "can set the start time" do
+      fill_in "order_detail_occupancy_attributes_entry_at_date", with: "9/12/2017"
+      select "9", from: "order_detail_occupancy_attributes_entry_at_hour"
+      select "45", from: "order_detail_occupancy_attributes_entry_at_minute"
+      select "AM", from: "order_detail_occupancy_attributes_entry_at_ampm"
+
+      click_button "Save"
+
+      expect(occupancy.reload.entry_at).to eq(Time.zone.parse("2017-09-12 09:45"))
+      expect(occupancy.exit_at).to eq(Time.zone.parse("2017-09-12 10:30"))
+      expect(order_detail.reload.fulfilled_at).to eq(occupancy.exit_at)
+    end
+  end
+end


### PR DESCRIPTION
This adds support for modifying an occupancies entry and exit time. I used what was there for JournalCutoffDates as my jumping off point (after a few bad initial attempts) since that was my favorite method we've come up with so far for handling date inputs from forms, so that's why there are changes in that section (I tried to isolate that to the first commit)

Will come in future PRs:
* Implement support for duration
* Better handling against problem occupancies
* Refactor Reservations to use this (this might not happen just yet because it's a significant chunk of work, but I _really_ want to kill off Reservations::DateSupport)