### PR TITLE
Add a warning when the Sanger sequencing is printed

### DIFF
--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/print_warning.js.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/print_warning.js.coffee
@@ -17,8 +17,12 @@ class @PrintWarning
   mediaQuery: -> window.matchMedia("print")
 
   onPrintAction: ->
-    $(".js--print-warning").text("Even if you have printed the order, this order is not submitted. Please click Save Submission and move to the next step.")
-    alert "This order is not submitted. Please click Save Submission and move to the next step before printing your sample sheet."
+    $(".js--print-warning").text(
+      "Even if you have printed the order, this order is not submitted.
+      Please click Save Submission and move to the next step.")
+    alert("This order is not submitted.
+      Please click Save Submission and move to the next step before
+      printing your sample sheet.")
 
 $ ->
   new PrintWarning().initListener()

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/print_warning.js.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/print_warning.js.coffee
@@ -17,9 +17,6 @@ class @PrintWarning
   mediaQuery: -> window.matchMedia("print")
 
   onPrintAction: ->
-    $(".js--print-warning").text(
-      "Even if you have printed the order, this order is not submitted.
-      Please click Save Submission and move to the next step.")
     alert("This order is not submitted.
       Please click Save Submission and move to the next step before
       printing your sample sheet.")

--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/print_warning.js.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/print_warning.js.coffee
@@ -1,0 +1,24 @@
+# Per https://www.tjvantoll.com/2012/06/15/detecting-print-requests-with-javascript/
+
+class @PrintWarning
+
+  initListener: ->
+    return unless @shouldWarn()
+    @listen()
+    window.onbeforeprint = @onPrintAction
+
+  shouldWarn: -> $(".js--print-warning").length
+
+  listen: ->
+    @mediaQuery().addListener (query) =>
+      return unless query.matches
+      @onPrintAction()
+
+  mediaQuery: -> window.matchMedia("print")
+
+  onPrintAction: ->
+    $(".js--print-warning").text("Even if you have printed the order, this order is not submitted. Please click Save Submission and move to the next step.")
+    alert "This order is not submitted. Please click Save Submission and move to the next step before printing your sample sheet."
+
+$ ->
+  new PrintWarning().initListener()

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/submissions/_form.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/submissions/_form.html.haml
@@ -18,6 +18,9 @@
             = sf.input :_destroy, as: :hidden
     - if @submission.quantity_editable?
       %tfoot
-        %td{colspan: 3}= f.add_nested_fields_link :samples, text("add"), class: "btn btn-success"
+        %tr
+          %td{colspan: 3}= f.add_nested_fields_link :samples, text("add"), class: "btn btn-success"
+
+  %h4.js--print-warning= text("warning")
 
   = f.submit text("submit"), class: "btn btn-primary"

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/submissions/edit.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/submissions/edit.html.haml
@@ -3,6 +3,7 @@
 
 = content_for :head_content do
   = javascript_include_tag "sanger_sequencing/submission"
+  = javascript_include_tag "sanger_sequencing/print_warning"
 
 = content_for :breadcrumb do
   %ul.breadcrumb

--- a/vendor/engines/sanger_sequencing/config/locales/en.yml
+++ b/vendor/engines/sanger_sequencing/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
       submissions:
         form:
           submit: "Save Submission"
+          warning: "This order is not submitted. Please click Save Submission and move to the next step before printing your sample sheet."
           add: Add
           remove: Remove
       orders:

--- a/vendor/engines/sanger_sequencing/spec/javascripts/sanger_sequencing/print_warning_spec.js.coffee
+++ b/vendor/engines/sanger_sequencing/spec/javascripts/sanger_sequencing/print_warning_spec.js.coffee
@@ -1,0 +1,19 @@
+#= require sanger_sequencing/print_warning
+#= require helpers/jasmine-jquery
+
+describe "Print Warning", ->
+
+  it "does nothing without the right thing in place", ->
+    warning = new PrintWarning
+    spyOn(warning, "listen")
+    expect(warning.shouldWarn()).toBeFalsy()
+    warning.initListener()
+    expect(warning.listen).not.toHaveBeenCalled()
+
+  it "warns when the right elements are in place", ->
+    warning = new PrintWarning
+    spyOn(warning, "listen")
+    setFixtures($("<h2>").addClass("js--print-warning"))
+    expect(warning.shouldWarn()).toBeTruthy()
+    warning.initListener()
+    expect(warning.listen).toHaveBeenCalled()


### PR DESCRIPTION
Per https://www.tjvantoll.com/2012/06/15/detecting-print-requests-with-javascript/ adds a warning to the Sanger order form page, requesting that users continue their submission if they print.

If the user does print, they get an alert warning them to continue, and the message on the page changes.