### PR TITLE
[#136734] Drop reservation canceled_* columns

### DIFF
--- a/db/migrate/20170515214930_drop_canceled_from_reservations.rb
+++ b/db/migrate/20170515214930_drop_canceled_from_reservations.rb
@@ -1,7 +1,7 @@
 class DropCanceledFromReservations < ActiveRecord::Migration
   def change
-    remove_column :reservations, :canceled_at
-    remove_column :reservations, :canceled_by
-    remove_column :reservations, :canceled_reason
+    remove_column :reservations, :canceled_at, :datetime
+    remove_column :reservations, :canceled_by, :integer
+    remove_column :reservations, :canceled_reason, :string
   end
 end

--- a/db/migrate/20170515214930_drop_canceled_from_reservations.rb
+++ b/db/migrate/20170515214930_drop_canceled_from_reservations.rb
@@ -1,0 +1,7 @@
+class DropCanceledFromReservations < ActiveRecord::Migration
+  def change
+    remove_column :reservations, :canceled_at
+    remove_column :reservations, :canceled_by
+    remove_column :reservations, :canceled_reason
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -530,9 +530,6 @@ ActiveRecord::Schema.define(version: 20170609131421) do
     t.datetime "reserve_end_at"
     t.datetime "actual_start_at"
     t.datetime "actual_end_at"
-    t.datetime "canceled_at"
-    t.integer  "canceled_by",      limit: 4
-    t.string   "canceled_reason",  limit: 50
     t.string   "admin_note",       limit: 255
     t.string   "type",             limit: 255
     t.string   "category",         limit: 255


### PR DESCRIPTION
Depends on #1008, DO NOT MERGE until that has been deployed/verified on stage.

Will need to be rebased on current master after #1008 is merged in, which should resolve the current test failures.