### PR TITLE
fix outdated PriceGroup.base ref

### DIFF
--- a/vendor/engines/secure_rooms/spec/factories/secure_room.rb
+++ b/vendor/engines/secure_rooms/spec/factories/secure_room.rb
@@ -11,7 +11,7 @@ FactoryGirl.define do
 
     trait :with_base_price do
       after(:create) do |room, _evaluator|
-        create(:secure_room_price_policy, price_group: PriceGroup.base.first, product: room)
+        create(:secure_room_price_policy, price_group: PriceGroup.base, product: room)
       end
     end
   end


### PR DESCRIPTION
Changed in: https://github.com/tablexi/nucore-open/pull/962/files#diff-0b65ec7aecf9ba902e4573184a39becdR23

Broken ref in: https://github.com/tablexi/nucore-open/pull/1024/files#diff-63c250c022dff5ce3447c43f93437a27R14

Unlucky merge timing.