### PR TITLE
[#144059203] Fix occupancy modal time zones

### DIFF
--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -13,9 +13,9 @@ module DateHelper
     end
   end
 
-  def parse_usa_date(date, extra_date_info = nil)
+  def parse_usa_date(date, time_string = nil)
     date_string = (date =~ /\d{1,2}\/\d{1,2}\/\d{4}/ ? Date.strptime($&, "%m/%d/%Y") : date).to_s
-    date_string += " #{extra_date_info}" if extra_date_info
+    date_string += " #{time_string}" if time_string
 
     Time.zone.parse(date_string)
   rescue

--- a/lib/date_time_input/form_data.rb
+++ b/lib/date_time_input/form_data.rb
@@ -2,6 +2,8 @@ module DateTimeInput
 
   class FormData
 
+    extend DateHelper
+
     def initialize(time)
       @time = time
     end
@@ -16,15 +18,9 @@ module DateTimeInput
       return new(param) if param.is_a?(Time)
       param = param.with_indifferent_access
 
-      str = param[:date]
-      format = "%m/%d/%Y"
+      time_string = "#{param[:hour]}:#{param[:minute].to_s.rjust(2, '0')} #{param[:ampm]}" if check_time_param!(param)
 
-      if check_time_param!(param)
-        str += " #{param[:hour]}:#{param[:minute].to_s.rjust(2, '0')} #{param[:ampm]}"
-        format += " %H:%M %p"
-      end
-
-      new(Time.strptime(str, format))
+      new(parse_usa_date(param[:date], time_string))
     end
 
     def self.check_time_param!(param)

--- a/lib/date_time_input/form_data.rb
+++ b/lib/date_time_input/form_data.rb
@@ -20,6 +20,7 @@ module DateTimeInput
 
       time_string = "#{param[:hour]}:#{param[:minute].to_s.rjust(2, '0')} #{param[:ampm]}" if check_time_param!(param)
 
+      raise ArgumentError, "Missing date param" unless param[:date].present?
       new(parse_usa_date(param[:date], time_string))
     end
 

--- a/spec/lib/date_time_input/form_data_spec.rb
+++ b/spec/lib/date_time_input/form_data_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe DateTimeInput::FormData do
 
     describe "with all the fields in the AM" do
       let(:hash) { { date: "04/06/2017", hour: 4, minute: 19, ampm: "AM" } }
-      it { is_expected.to eq(Time.zone.parse("2017-04-06 04:19")) }
+      it { is_expected.to eq(Time.zone.parse("2017-04-06 04:19").in_time_zone) }
     end
 
     describe "with all the fields in the PM" do
       let(:hash) { { date: "04/06/2017", hour: 4, minute: 19, ampm: "PM" } }
-      it { is_expected.to eq(Time.zone.parse("2017-04-06 16:19")) }
+      it { is_expected.to eq(Time.zone.parse("2017-04-06 16:19").in_time_zone) }
     end
 
     describe "missing data" do
@@ -43,22 +43,17 @@ RSpec.describe DateTimeInput::FormData do
 
     describe "with all the fields in the AM" do
       let(:hash) { { date: "04/06/2017", hour: 4, minute: 19, ampm: "AM" } }
-      it { is_expected.to eq(Time.zone.parse("2017-04-06 04:19")) }
+      it { is_expected.to eq(Time.zone.parse("2017-04-06 04:19").in_time_zone) }
     end
 
     describe "with all the fields in the PM" do
       let(:hash) { { date: "04/06/2017", hour: 4, minute: 19, ampm: "PM" } }
-      it { is_expected.to eq(Time.zone.parse("2017-04-06 16:19")) }
+      it { is_expected.to eq(Time.zone.parse("2017-04-06 16:19").in_time_zone) }
     end
 
     describe "missing data" do
       let(:hash) { { date: "04/06/2017", hour: 4 } }
       specify { expect { subject }.to raise_error(ArgumentError, /Must have all or none/) }
-    end
-
-    describe "an invalid date" do
-      let(:hash) { { date: "19/06/2017", hour: 4, minute: 19, ampm: "PM" } }
-      specify { expect { subject }.to raise_error(ArgumentError, /time/) }
     end
   end
 


### PR DESCRIPTION
When submitting the order detail modal on stage, the times were being interpreted in UTC, even though the application is running in central time.

This switches the input parser to use `parse_usa_date` which is more lenient than what I had before, but it used pretty much everywhere else we have date parsing, so it seemed like a good thing to use.