### PR TITLE
[#140077839] Prevent global admins from scanning in to SecureRooms

### DIFF
--- a/app/models/concerns/users/roles.rb
+++ b/app/models/concerns/users/roles.rb
@@ -40,14 +40,23 @@ module Users
       end
     end
 
-    def operator_of?(facility)
+    def operator_of?(facility, allow_global: true)
       return false if facility.blank?
-      manager_of?(facility) || facility_staff_of?(facility) || facility_senior_staff_of?(facility)
+      [
+        facility_staff_of?(facility),
+        facility_senior_staff_of?(facility),
+        manager_of?(facility, allow_global: allow_global),
+      ].any?
     end
 
-    def manager_of?(facility)
+    def manager_of?(facility, allow_global: true)
       return false if facility.blank?
-      facility_director_of?(facility) || facility_administrator_of?(facility) || administrator?
+      manager_of = [
+        facility_director_of?(facility),
+        facility_administrator_of?(facility),
+      ].any?
+
+      manager_of || (allow_global && administrator?)
     end
 
     def can_override_restrictions?(product)

--- a/app/models/concerns/users/roles.rb
+++ b/app/models/concerns/users/roles.rb
@@ -40,23 +40,14 @@ module Users
       end
     end
 
-    def operator_of?(facility, allow_global: true)
+    def operator_of?(facility)
       return false if facility.blank?
-      [
-        facility_staff_of?(facility),
-        facility_senior_staff_of?(facility),
-        manager_of?(facility, allow_global: allow_global),
-      ].any?
+      user_roles.operator?(facility) || administrator?
     end
 
-    def manager_of?(facility, allow_global: true)
+    def manager_of?(facility)
       return false if facility.blank?
-      manager_of = [
-        facility_director_of?(facility),
-        facility_administrator_of?(facility),
-      ].any?
-
-      manager_of || (allow_global && administrator?)
+      user_roles.manager?(facility) || administrator?
     end
 
     def can_override_restrictions?(product)

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -47,6 +47,14 @@ class UserRole < ActiveRecord::Base
     where(role: global_roles)
   end
 
+  def self.operator?(facility)
+    any? { |ur| ur.facility == facility && ur.in?(facility_roles) }
+  end
+
+  def self.manager?(facility)
+    any? { |ur| ur.facility == facility && ur.in?(facility_management_roles) }
+  end
+
   #
   # Assigns +role+ to +user+ for +facility+
   # [_user_]

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/operator_rule.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/operator_rule.rb
@@ -5,7 +5,7 @@ module SecureRooms
     class OperatorRule < BaseRule
 
       def evaluate
-        grant!(:operator) if user.operator_of?(card_reader.facility, allow_global: false)
+        grant!(:operator) if user.user_roles.operator?(card_reader.facility)
       end
 
     end

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/operator_rule.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/operator_rule.rb
@@ -5,7 +5,7 @@ module SecureRooms
     class OperatorRule < BaseRule
 
       def evaluate
-        grant!(:operator) if user.operator_of?(card_reader.facility)
+        grant!(:operator) if user.operator_of?(card_reader.facility, allow_global: false)
       end
 
     end

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/operator_rule_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/operator_rule_spec.rb
@@ -7,19 +7,45 @@ RSpec.describe SecureRooms::AccessRules::OperatorRule, type: :service do
       card_reader,
     )
   end
-  let(:card_reader) { build :card_reader }
+  let(:card_reader) { build(:card_reader) }
+  let(:secure_room) { card_reader.secure_room }
+  let(:facility) { secure_room.facility }
 
   subject(:response) { rule.call }
 
   context "user is facility operator" do
-    let(:card_user) { create :user, :facility_administrator, facility: card_reader.secure_room.facility }
+    let(:card_user) { create(:user, :facility_administrator, facility: facility) }
 
     it { is_expected.to have_result_code(:grant) }
   end
 
   context "user is not an operator" do
-    let(:card_user) { build :user }
+    let(:card_user) { create(:user) }
 
     it { is_expected.to have_result_code(:pass) }
+  end
+
+  describe "a global admin" do
+    let(:card_user) { create(:user, :administrator) }
+
+    it { is_expected.to have_result_code(:pass) }
+
+    describe "and also an operator of the facility" do
+      before { card_user.user_roles.create!(role: UserRole::FACILITY_DIRECTOR, facility: facility) }
+
+      it { is_expected.to have_result_code(:grant) }
+    end
+  end
+
+  describe "an account administrator" do
+    let(:card_user) { create(:user, :account_manager) }
+
+    it { is_expected.to have_result_code(:pass) }
+
+    describe "and also an operator of the facility" do
+      before { card_user.user_roles.create!(role: UserRole::FACILITY_DIRECTOR, facility: facility) }
+
+      it { is_expected.to have_result_code(:grant) }
+    end
   end
 end


### PR DESCRIPTION
unless they also have a facility-specific role.

This last change makes me wonder if we can get rid of some of the `facility_staff_of?`/`facility_senior_staff_of?` methods that are generated by meta-programming. Seemed out of scope for this, though.