### PR TITLE
[#144059389] Add task marking occupancies orphaned

### DIFF
--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -9,6 +9,16 @@ module Admin
       render nothing: true
     end
 
+    def process_five_minute_tasks
+      workers = [AutoExpireReservation, EndReservationOnly, AutoLogout]
+
+      workers.each do |worker|
+        worker.new.perform
+      end
+
+      render nothing: true
+    end
+
   end
 
 end

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -2,7 +2,7 @@ module Admin
 
   class ServicesController < ApplicationController
 
-    skip_before_action :verify_authenticity_token, only: :cancel_reservations_for_offline_instruments
+    skip_before_action :verify_authenticity_token
 
     def cancel_reservations_for_offline_instruments
       InstrumentOfflineReservationCanceler.new.cancel!
@@ -10,13 +10,14 @@ module Admin
     end
 
     def process_five_minute_tasks
-      workers = [AutoExpireReservation, EndReservationOnly, AutoLogout]
-
-      workers.each do |worker|
+      self.class.five_minute_tasks.each do |worker|
         worker.new.perform
       end
-
       render nothing: true
+    end
+
+    def self.five_minute_tasks
+      @five_minute_tasks ||= [AutoExpireReservation, EndReservationOnly, AutoLogout]
     end
 
   end

--- a/app/support/auto_logout.rb
+++ b/app/support/auto_logout.rb
@@ -43,7 +43,8 @@ class AutoLogout
     reservation.product.relay.deactivate unless reservation.other_reservation_using_relay?
     reservation.order_detail.complete!
   rescue => e
-    STDERR.puts "Error on Order # #{od} - #{e}"
+    ActiveSupport::Notifications.instrument("background_error",
+                                            exception: e, information: "Error on Order # #{od} - #{e}")
     raise ActiveRecord::Rollback
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -365,6 +365,7 @@ Nucore::Application.routes.draw do
   namespace :admin do
     namespace :services do
       post "cancel_reservations_for_offline_instruments"
+      post "process_five_minute_tasks"
     end
   end
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,11 +9,7 @@ require File.expand_path(File.dirname(__FILE__) + "/environment")
 job_type :rake, "cd :path && :environment_variable=:environment bundle exec rake :task :output"
 
 every 5.minutes, roles: [:db] do
-  rake "order_details:expire_reservations"
-end
-
-every 5.minutes, roles: [:db] do
-  rake "order_details:auto_logout"
+  command "curl --silent -X POST #{Rails.application.routes.url_helpers.admin_services_process_five_minute_tasks_url}"
 end
 
 every 1.minute, roles: [:db] do

--- a/spec/controllers/admin/services_controller_spec.rb
+++ b/spec/controllers/admin/services_controller_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Admin::ServicesController do
+  it "routes", :aggregate_failures do
+    expect(post: "/admin/services/cancel_reservations_for_offline_instruments").to route_to(controller: "admin/services", action: "cancel_reservations_for_offline_instruments")
+    expect(post: "/admin/services/process_five_minute_tasks").to route_to(controller: "admin/services", action: "process_five_minute_tasks")
+  end
+
+  context "cancel_reservations_for_offline_instruments" do
+    it "calls #cancel! on an InstrumentOfflineReservationCanceler" do
+      expect_any_instance_of(InstrumentOfflineReservationCanceler).to receive(:cancel!)
+      post :cancel_reservations_for_offline_instruments
+    end
+  end
+
+  context "process_five_minute_tasks" do
+    it "calls #perform on each object" do
+      Admin::ServicesController.five_minute_tasks.each do |task|
+        expect_any_instance_of(task).to receive(:perform)
+      end
+      post :process_five_minute_tasks
+    end
+  end
+
+end

--- a/vendor/engines/secure_rooms/app/support/secure_rooms/auto_orphan_occupancy.rb
+++ b/vendor/engines/secure_rooms/app/support/secure_rooms/auto_orphan_occupancy.rb
@@ -13,7 +13,13 @@ module SecureRooms
     private
 
     def occupancy_order_details
-      OrderDetail.joins(:occupancy).merge(SecureRooms::Occupancy.current)
+      OrderDetail.joins(:occupancy).merge(long_running_occupancies)
+    end
+
+    def long_running_occupancies
+      SecureRooms::Occupancy.current.where(
+        SecureRooms::Occupancy.arel_table[:entry_at].lt(Time.current - 12.hours),
+      )
     end
 
     def orphan_occupancy(od)

--- a/vendor/engines/secure_rooms/app/support/secure_rooms/auto_orphan_occupancy.rb
+++ b/vendor/engines/secure_rooms/app/support/secure_rooms/auto_orphan_occupancy.rb
@@ -17,9 +17,7 @@ module SecureRooms
     end
 
     def long_running_occupancies
-      SecureRooms::Occupancy.current.where(
-        SecureRooms::Occupancy.arel_table[:entry_at].lt(Time.current - 12.hours),
-      )
+      SecureRooms::Occupancy.current.where("entry_at < ?", 12.hours.ago)
     end
 
     def orphan_occupancy(od)

--- a/vendor/engines/secure_rooms/app/support/secure_rooms/auto_orphan_occupancy.rb
+++ b/vendor/engines/secure_rooms/app/support/secure_rooms/auto_orphan_occupancy.rb
@@ -1,0 +1,30 @@
+module SecureRooms
+
+  class AutoOrphanOccupancy
+
+    def perform
+      occupancy_order_details.each do |od|
+        od.transaction do
+          orphan_occupancy(od)
+        end
+      end
+    end
+
+    private
+
+    def occupancy_order_details
+      OrderDetail.joins(:occupancy).merge(SecureRooms::Occupancy.current)
+    end
+
+    def orphan_occupancy(od)
+      od.occupancy.mark_orphaned!
+      SecureRooms::AccessHandlers::OrderHandler.process(od.occupancy)
+    rescue => e
+      ActiveSupport::Notifications.instrument("background_error",
+                                              exception: e, information: "Failed orphan occupancy order detail with id: #{od.id}")
+      raise ActiveRecord::Rollback
+    end
+
+  end
+
+end

--- a/vendor/engines/secure_rooms/lib/secure_rooms/engine.rb
+++ b/vendor/engines/secure_rooms/lib/secure_rooms/engine.rb
@@ -14,6 +14,8 @@ module SecureRooms
       bundle_index = Product.types.index(Bundle) || -1
       Product.types.insert(bundle_index, SecureRoom)
 
+      Admin::ServicesController.five_minute_tasks << SecureRooms::AutoOrphanOccupancy
+
       ViewHook.add_hook "users.show",
                         "additional_user_fields",
                         "secure_rooms/shared/card_number_form_field"

--- a/vendor/engines/secure_rooms/lib/tasks/restricted_rooms_tasks.rake
+++ b/vendor/engines/secure_rooms/lib/tasks/restricted_rooms_tasks.rake
@@ -1,4 +1,8 @@
-# desc "Explaining what the task does"
-# task :secure_rooms do
-#   # Task goes here
-# end
+namespace :secure_rooms do
+  namespace :order_details do
+    desc "mark order_details with long-running occupancies as orphaned"
+    task orphan_occupancies: :environment do
+      SecureRooms::AutoOrphanOccupancy.new.perform
+    end
+  end
+end

--- a/vendor/engines/secure_rooms/spec/support/auto_orphan_occupancy_spec.rb
+++ b/vendor/engines/secure_rooms/spec/support/auto_orphan_occupancy_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe SecureRooms::AutoOrphanOccupancy, :time_travel do
+  let(:action) { described_class.new }
+
+  let(:facility) { create(:setup_facility) }
+  let(:secure_room) { create(:secure_room, facility: facility) }
+  let!(:policy) { create(:secure_room_price_policy, product: secure_room, usage_rate: 60, price_group: order_detail.account.price_groups.first) }
+  let(:order) { create(:purchased_order, product: secure_room) }
+  let!(:order_detail) { order.order_details.first }
+
+  describe '#perform' do
+    context "an active occupancy" do
+      let!(:occupancy) do
+        create(
+          :occupancy,
+          :active,
+          user: order_detail.user,
+          secure_room: secure_room,
+          order_detail: order_detail,
+          account: order_detail.account,
+        )
+      end
+
+      it "orphans the occupancy" do
+        expect { action.perform }.to change { occupancy.reload.orphan? }.from(false).to(true)
+      end
+
+      it "sends the occupancy through the order handler" do
+        expect(SecureRooms::AccessHandlers::OrderHandler).to receive(:process).with(occupancy)
+        action.perform
+      end
+
+      it "sets the order_detail problem status" do
+        expect { action.perform }.to change { order_detail.reload.problem }.to(true)
+      end
+
+      it "does not assign pricing" do
+        action.perform
+        expect(order_detail.reload.price_policy).to be_nil
+      end
+
+      it "sets the occupancy fulfilled at time" do
+        action.perform
+        expect(order_detail.reload.fulfilled_at).to eq occupancy.reload.orphaned_at
+      end
+    end
+
+    context "a completed occupancy" do
+      let!(:occupancy) do
+        create(
+          :occupancy,
+          :complete,
+          user: order_detail.user,
+          secure_room: secure_room,
+          order_detail: order_detail,
+          account: order_detail.account,
+        )
+      end
+
+      it "does not orphan the occupancy" do
+        expect { action.perform }.not_to change { occupancy.reload.orphan? }
+      end
+
+      it "does not involve the order handler" do
+        expect(SecureRooms::AccessHandlers::OrderHandler).not_to receive(:process)
+        action.perform
+      end
+    end
+  end
+end


### PR DESCRIPTION
Notes:
* `AutoExpireReservation` uses `Time.zone.now - 12.hours` for the window, but I feel like I remember saying we might just run this job overnight since rooms would typically be closed? If not and we do want the 12 hour window, should that be moved into a real constant and/or setting then?
* I'm not sure how whenever/`schedule.rb` work within the engine, and figured it's easier to chat about it if we're already familiar with that.