### PR TITLE
[#136233] Exclude problem orders from Send Notifications

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -161,6 +161,7 @@ class OrderDetail < ActiveRecord::Base
       .where(reviewed_at: nil)
       .with_price_policy
       .not_disputed
+      .where(problem: false)
   }
 
   def self.all_movable

--- a/spec/controllers/facility_notifications_controller_spec.rb
+++ b/spec/controllers/facility_notifications_controller_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe FacilityNotificationsController do
   end
 
   describe "GET #index" do
+    let!(:problem_order) do
+      place_and_complete_item_order(@user, @authable, @account2).tap do |od|
+        od.update!(price_policy: nil)
+      end
+    end
+
     before :each do
       @method = :get
       @action = :index
@@ -43,7 +49,7 @@ RSpec.describe FacilityNotificationsController do
       it_should_deny_all [:staff, :senior_staff]
 
       it_should_allow_managers_only do
-        expect(assigns(:order_details) - [@order_detail1, @order_detail2, @order_detail3]).to be_empty
+        expect(assigns(:order_details)).to contain_exactly(@order_detail1, @order_detail2, @order_detail3)
         expect(assigns(:order_detail_action)).to eq(:send_notifications)
         is_expected.not_to set_flash
       end


### PR DESCRIPTION
Orders with $0 usage rates or instruments configured with a timer but priced on reservation would get a price policy assigned when they were auto-expired. This was causing them to appear in the "Send Notifications" tab, and thus could be reviewed, journaled, and reconciled, even though they were problem orders.

This will now exclude them from the Send Notifications tab so they must first be dealt with in the Problem Reservations tab.