### PR TITLE
[#145286873] Fix: Update duration field when exit_at changes

### DIFF
--- a/app/assets/javascripts/app/reservation_time_field_adjustor.js.coffee
+++ b/app/assets/javascripts/app/reservation_time_field_adjustor.js.coffee
@@ -68,6 +68,7 @@ class window.ReservationTimeFieldAdjustor
   _reserveEndChangeCallback: =>
     if @calculateDuration() >= 0
       @durationField().val(@calculateDuration())
+      @durationField().trigger("change")
       @_changed()
     else
       # If the duration ends up negative, i.e. end is before start,


### PR DESCRIPTION
When changing the exit at on occupancies, the hidden field for duration
was getting updated, but it wasn’t updating the displayed field was not
being updated.