### PR TITLE
[#144058835] Assign account when entry missing

### DIFF
--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/order_handler.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/order_handler.rb
@@ -15,6 +15,8 @@ module SecureRooms
       end
 
       def process
+        return unless user_can_purchase_secure_room?
+
         find_or_create_order
         complete_order
 
@@ -38,14 +40,21 @@ module SecureRooms
 
       def create_order
         ActiveRecord::Base.transaction do
+          assign_account unless occupancy.account_id?
+
           create_order_and_detail
-          # TODO: This avoids an exception but results in un-purchased order on
-          # problem occupancy, which may not appear in the problem-order scope
-          if occupancy.account_id?
-            order.validate_order!
-            order.purchase!
-          end
+          order.validate_order!
+          order.purchase!
         end
+      end
+
+      def assign_account
+        accounts = occupancy.user.accounts_for_product(occupancy.secure_room)
+        occupancy.update(account: accounts.first)
+      end
+
+      def user_can_purchase_secure_room?
+        occupancy.user.accounts_for_product(occupancy.secure_room).present?
       end
 
       def create_order_and_detail

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/order_handler.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/order_handler.rb
@@ -15,6 +15,7 @@ module SecureRooms
       end
 
       def process
+        # TODO: [#145957283] Ensure facility operators with accounts do not create orders on exit
         return unless user_can_purchase_secure_room?
 
         find_or_create_order

--- a/vendor/engines/secure_rooms/config/locales/en.yml
+++ b/vendor/engines/secure_rooms/config/locales/en.yml
@@ -21,7 +21,7 @@ en:
   order_details:
     notices:
       missing_entry:
-        badge: Inferred Account
+        badge: Missing Entry
         alert: This order's account was inferred from the associated user due to its missing entry. Please ensure that the associated account is correct, all times are set and there is a price policy for the date this order was fulfilled.
       missing_exit:
         badge: Missing Exit

--- a/vendor/engines/secure_rooms/config/locales/en.yml
+++ b/vendor/engines/secure_rooms/config/locales/en.yml
@@ -21,8 +21,8 @@ en:
   order_details:
     notices:
       missing_entry:
-        badge: Missing Entry
-        alert: This order's occupancy does not have an entry time. Please ensure that all times are set and there is a price policy for the date this order was fulfilled.
+        badge: Inferred Account
+        alert: This order's account was inferred from the associated user due to its missing entry. Please ensure that the associated account is correct, all times are set and there is a price policy for the date this order was fulfilled.
       missing_exit:
         badge: Missing Exit
         alert: This order's occupancy does not have an exit time. Please ensure that all times are set and there is a price policy for the date this order was fulfilled.

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/access_handlers/occupancy_handler_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/access_handlers/occupancy_handler_spec.rb
@@ -84,7 +84,10 @@ RSpec.describe SecureRooms::AccessHandlers::OccupancyHandler, type: :service do
           let(:card_reader) { create :card_reader, ingress: true }
 
           # orders need to be "purchased" but we don't care about the details
-          before { allow_any_instance_of(OrderDetail).to receive(:valid_for_purchase?).and_return(true) }
+          before do
+            allow_any_instance_of(OrderDetail).to receive(:valid_for_purchase?).and_return(true)
+            allow_any_instance_of(SecureRooms::AccessHandlers::OrderHandler).to receive(:user_can_purchase_secure_room?).and_return(true)
+          end
 
           describe "the new occupancy" do
             subject(:occupancy) { described_class.process(event) }

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/access_manager_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/access_manager_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SecureRooms::AccessManager, type: :service do
     it "calls each AccessHandler" do
       expect(SecureRooms::AccessHandlers::EventHandler).to receive(:process).and_call_original
       expect(SecureRooms::AccessHandlers::OccupancyHandler).to receive(:process).and_call_original
-      expect(SecureRooms::AccessHandlers::OrderHandler).to receive(:process).and_call_original
+      expect(SecureRooms::AccessHandlers::OrderHandler).to receive(:process)
 
       described_class.process(verdict)
     end


### PR DESCRIPTION
* Exits access handling chain if associated user cannot purchase the room, thus facility operators no longer generate orders.
* If user can purchase but order has no associated account, grabs first account from their list of `accounts_for_product`
* Error messaging now begins by stating the account must be double-checked.