### PR TITLE
[DNM] [WIP] [#145788259] Add new order/cart related scope thing

### DIFF
--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -22,6 +22,7 @@ class FacilityOrdersController < ApplicationController
 
   # GET /facility/1/orders
   def index
+    # TODO: what about occupancies~?
     @order_details = new_or_in_process_orders.paginate(page: params[:page])
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -307,6 +307,7 @@ class OrdersController < ApplicationController
   # all my orders
   def index
     # new or in process
+    # TODO: what about occupancies~?
     @order_details = session_user.order_details.non_reservations
     @available_statuses = %w(pending all)
     case params[:status]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -103,6 +103,7 @@ class UsersController < ApplicationController
   # GET /facilities/:facility_id/users/:user_id/orders
   def orders
     # order details for this facility
+    # TODO: what about occupancies~?
     @order_details = @user.order_details
                           .non_reservations
                           .for_facility(current_facility)

--- a/app/helpers/facility_order_status_helper.rb
+++ b/app/helpers/facility_order_status_helper.rb
@@ -2,6 +2,7 @@ module FacilityOrderStatusHelper
 
   def new_or_in_process_orders
     # will never include instrument order details
+    # TODO: what about occupancies~?
     facility_ods = current_facility.order_details.non_reservations
     facility_ods = facility_ods.joins(:order).where("(order_details.state = ? OR order_details.state = ?) AND orders.state = ?", "new", "inprocess", "purchased")
 
@@ -25,6 +26,7 @@ module FacilityOrderStatusHelper
   end
 
   def disputed_orders
+    # TODO: what about occupancies~?
     current_facility.order_details
                     .non_reservations
                     .in_dispute

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -44,6 +44,7 @@ class Cart
 
   # Will find the first cart that either has a non-instrument,
   # has multiple items, or is empty
+  # TODO: what about occupancies~?
   def non_reservation_only_cart
     all_carts.find { |order| order.order_details.non_reservations.any? || order.order_details.size != 1 }
   end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -122,6 +122,7 @@ class Facility < ActiveRecord::Base
   end
 
   def problem_non_reservation_order_details
+    # TODO: what about occupancies~?
     complete_problem_order_details.non_reservations
   end
 

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -256,7 +256,7 @@ class OrderDetail < ActiveRecord::Base
       .where.not(statement_id: nil)
   }
 
-  scope :non_reservations, -> { joins(:product).where("products.type <> 'Instrument'") }
+  scope :non_reservations, -> { joins(:product).merge(Product.orderable_through_cart) }
   scope :reservations, -> { joins(:product).where("products.type = 'Instrument'") }
 
   scope :purchased, -> { joins(:order).merge(Order.purchased) }

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -55,9 +55,14 @@ class Product < ActiveRecord::Base
   scope :archived, -> { where(is_archived: true) }
   scope :not_archived, -> { where(is_archived: false) }
   scope :mergeable_into_order, -> { not_archived.where(type: mergeable_types) }
+  scope :orderable_through_cart, -> { not_archived.where(type: cart_types) }
 
   def self.types
     @product_types ||= [Instrument, Item, Service, Bundle]
+  end
+
+  def self.cart_types
+    @cart_types ||= [Item, Service, Bundle]
   end
 
   def self.mergeable_types

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -510,6 +510,7 @@ RSpec.describe FacilityOrdersController do
       @action = :tab_counts
       @order_detail2 = FactoryGirl.create(:order_detail, order: @order, product: @product)
 
+      # TODO: what about occupancies~?
       expect(@authable.order_details.non_reservations.new_or_inprocess.size).to eq(2)
 
       @problem_order_details = (1..3).map do |_i|
@@ -537,6 +538,7 @@ RSpec.describe FacilityOrdersController do
         maybe_grant_always_sign_in :director
       end
       it "should get only new if thats all you ask for" do
+        # TODO: what about occupancies~?
         @authable.order_details.non_reservations.new_or_inprocess.to_sql
         @params[:tabs] = ["new_or_in_process_orders"]
         do_request


### PR DESCRIPTION
#### Note I'm just tossing this together for context of discussing this change, it's not a real PR

* What is currently `non_reservations` is in theory conceptually changing since occupancies are now a similar concept. This adds a scope that in theory could filter to "cart items" (which totally might be the wrong concept, let's discuss)
* each place we use `non_reservations` is highlighted with a `TODO` so we can scan through 'em all