### PR TITLE
[#144059265] More generic handling on importing unsupported product types

### DIFF
--- a/app/support/order_row_importer.rb
+++ b/app/support/order_row_importer.rb
@@ -24,6 +24,8 @@ class OrderRowImporter
     :fulfillment_date,
   ].map { |k| HEADERS[k] }
 
+  cattr_accessor(:importable_product_types) { [Item, Service] }
+
   def self.order_key_for_row(row)
     new(row, nil).order_key
   end
@@ -214,14 +216,13 @@ class OrderRowImporter
   end
 
   def validate_product_is_importable
-    case
-    when product.is_a?(Service)
+    unless product.class.in?(importable_product_types)
+      add_error("import of #{product.class.model_name.human} orders not allowed at this time")
+    end
+
+    if product.is_a?(Service)
       add_error("Service requires survey") if product.active_survey?
       add_error("Service requires template") if product.active_template?
-    when product.is_a?(Instrument)
-      add_error("import of Instrument orders not allowed at this time")
-    when product.is_a?(Bundle)
-      add_error("import of Bundle orders not allowed at this time")
     end
   end
 

--- a/spec/app_support/order_row_importer_spec.rb
+++ b/spec/app_support/order_row_importer_spec.rb
@@ -266,6 +266,29 @@ RSpec.describe OrderRowImporter do
       end
     end
 
+    describe "when the product is an instrument" do
+      let(:chart_string) { account.account_number }
+      let(:price_group) { create(:price_group, facility: facility) }
+      let(:product) do
+        create(:setup_instrument,
+               facility: facility,
+               facility_account: facility_account,
+              )
+      end
+      let(:product_name) { product.name }
+      let(:username) { user.username }
+
+      before(:each) do
+        create(:user_price_group_member, user: user, price_group: price_group)
+        product.instrument_price_policies.create(
+          attributes_for(:instrument_price_policy, price_group: price_group),
+        )
+      end
+
+      it_behaves_like "an order was not created"
+      it_behaves_like "it has an error message", "Instrument orders not allowed"
+    end
+
     context "when the user has an account for the product's facility" do
       let(:chart_string) { account.account_number }
       let(:fulfillment_date) { "1/1/1999" }

--- a/vendor/engines/secure_rooms/spec/services/order_row_importer_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/order_row_importer_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe OrderRowImporter do
+  subject { OrderRowImporter.new(row, order_import) }
+
+  let(:secure_room) { create(:secure_room) }
+  let(:facility) { secure_room.facility }
+  let(:user) { create(:user) }
+  let(:order_import) { build(:order_import, creator: user, facility: facility) }
+  let(:account) { create(:nufs_account, :with_account_owner, owner: user) }
+
+  let(:row) do
+    ref = {
+      "Netid / Email" => user.username,
+      "Chart String" => account.account_number,
+      "Product Name" => secure_room.name,
+      "Quantity" => "1",
+      "Order Date" => "12/16/2016",
+      "Fulfillment Date" => "12/16/2016",
+      "Errors" => "",
+      "Note" => "",
+    }
+    CSV::Row.new(ref.keys, ref.values)
+  end
+
+  it "does not allow importing secure rooms" do
+    expect { subject.import }.not_to change(OrderDetail, :count)
+
+    # Errors is an array, so find one item matching the substring
+    expect(subject.errors).to include(include("Secure Room orders not allowed"))
+  end
+end


### PR DESCRIPTION
Only allow import of Items and Services by default. This will give a
useful message when trying to import SecureRooms or instruments telling
you the particular product type is not supported for imports.

There are plenty of opportunities to refactor here, but I this was originally considered a "chore", so I opted to just make a minimal change.