### PR TITLE
[#144058951] Use Event#occurred for occupancy times

### DIFF
--- a/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
@@ -49,7 +49,7 @@ module SecureRooms
     def associate_entry!(event)
       update!(
         entry_event: event,
-        entry_at: Time.current,
+        entry_at: event.occurred_at,
       )
       self
     end
@@ -57,7 +57,7 @@ module SecureRooms
     def associate_exit!(event)
       update!(
         exit_event: event,
-        exit_at: Time.current,
+        exit_at: event.occurred_at,
       )
       self
     end


### PR DESCRIPTION
When associating both an entry_at and exit_at for an entry-only
scanner, the timing of the two `associate_` calls mattered because if
`associate_exit` happens first, then `entry_at > exit_at`, which causes
the price policy to fail. This instead uses the event’s `occured_at`
time to set both, so the times will be equal.

Unfortunately, I couldn’t find a good way to make the tests catch this. Because we’re using Rails’s time helpers, time gets frozen and doesn’t move forward.