### PR TITLE
Fix horizontal scroll on transaction search pages

### DIFF
--- a/app/views/shared/transactions/_search.html.haml
+++ b/app/views/shared/transactions/_search.html.haml
@@ -1,19 +1,19 @@
-= modelless_form_for :url => url_for(params), :method => :get, :html => { :class => "search_form" }, :defaults => { :required => false } do |f|
+= modelless_form_for url: url_for(params), method: :get, html: { class: "search_form" }, defaults: { required: false } do |f|
   .row
     %fieldset.span6#search
-      = f.input :facilities, :as => :transaction_chosen
-      = f.input :accounts, :label_method => 'account_list_item', :as => :transaction_chosen unless @account
-      = f.input :products, :as => :transaction_chosen, :data_method => :product_options
-      = f.input :account_owners, :label => Account.human_attribute_name(:owner).pluralize, :label_method => :full_name, :as => :transaction_chosen unless @account
-      = f.input :order_statuses, :data_method => :order_statuses_options, :as => :transaction_chosen
+      = f.input :facilities, as: :transaction_chosen
+      = f.input :accounts, label_method: 'account_list_item', as: :transaction_chosen unless @account
+      = f.input :products, as: :transaction_chosen, data_method: :product_options
+      = f.input :account_owners, label: Account.human_attribute_name(:owner).pluralize, label_method: :full_name, as: :transaction_chosen unless @account
+      = f.input :order_statuses, data_method: :order_statuses_options, as: :transaction_chosen
       = render_view_hook("end_of_first_column", f: f)
     %fieldset.span2#calendar_filter
       %br
-      = f.input "date_range[field]", :collection => @search_options[:date_range], :selected => @date_range_field, :label => false
-      = f.input "date_range[start]", :input_html => { value: @search_fields[:date_range].try(:[], :start).to_s.gsub("-","/"), class: ['datepicker', 'in_past'] }, label: 'Start Date'
-      = f.input "date_range[end]", :input_html => { value: @search_fields[:date_range].try(:[], :end).to_s.gsub("-","/"), :class => ['datepicker', 'in_past'] }, :label => 'End Date'
+      = f.input "date_range[field]", collection: @search_options[:date_range], selected: @date_range_field, label: false
+      = f.input "date_range[start]", input_html: { value: @search_fields[:date_range].try(:[], :start).to_s.gsub("-","/"), class: ['datepicker', 'in_past'] }, label: "Start Date"
+      = f.input "date_range[end]", input_html: { value: @search_fields[:date_range].try(:[], :end).to_s.gsub("-","/"), class: ['datepicker', 'in_past'] }, label: "End Date"
 
       .submit_button
         = f.input :email, as: :hidden, input_html: { value: current_user.email }, disabled: true
         = f.input :format, as: :hidden, input_html: { value: params[:format] }, disabled: true
-        = f.submit "Search", :class => 'btn'
+        = f.submit "Search", class: 'btn'

--- a/app/views/shared/transactions/_search.html.haml
+++ b/app/views/shared/transactions/_search.html.haml
@@ -1,20 +1,19 @@
 = modelless_form_for :url => url_for(params), :method => :get, :html => { :class => "search_form" }, :defaults => { :required => false } do |f|
-  .container
-    .row
-      %fieldset.span6#search
-        = f.input :facilities, :as => :transaction_chosen
-        = f.input :accounts, :label_method => 'account_list_item', :as => :transaction_chosen unless @account
-        = f.input :products, :as => :transaction_chosen, :data_method => :product_options
-        = f.input :account_owners, :label => Account.human_attribute_name(:owner).pluralize, :label_method => :full_name, :as => :transaction_chosen unless @account
-        = f.input :order_statuses, :data_method => :order_statuses_options, :as => :transaction_chosen
-        = render_view_hook("end_of_first_column", f: f)
-      %fieldset.span2#calendar_filter
-        %br
-        = f.input "date_range[field]", :collection => @search_options[:date_range], :selected => @date_range_field, :label => false
-        = f.input "date_range[start]", :input_html => { value: @search_fields[:date_range].try(:[], :start).to_s.gsub("-","/"), class: ['datepicker', 'in_past'] }, label: 'Start Date'
-        = f.input "date_range[end]", :input_html => { value: @search_fields[:date_range].try(:[], :end).to_s.gsub("-","/"), :class => ['datepicker', 'in_past'] }, :label => 'End Date'
+  .row
+    %fieldset.span6#search
+      = f.input :facilities, :as => :transaction_chosen
+      = f.input :accounts, :label_method => 'account_list_item', :as => :transaction_chosen unless @account
+      = f.input :products, :as => :transaction_chosen, :data_method => :product_options
+      = f.input :account_owners, :label => Account.human_attribute_name(:owner).pluralize, :label_method => :full_name, :as => :transaction_chosen unless @account
+      = f.input :order_statuses, :data_method => :order_statuses_options, :as => :transaction_chosen
+      = render_view_hook("end_of_first_column", f: f)
+    %fieldset.span2#calendar_filter
+      %br
+      = f.input "date_range[field]", :collection => @search_options[:date_range], :selected => @date_range_field, :label => false
+      = f.input "date_range[start]", :input_html => { value: @search_fields[:date_range].try(:[], :start).to_s.gsub("-","/"), class: ['datepicker', 'in_past'] }, label: 'Start Date'
+      = f.input "date_range[end]", :input_html => { value: @search_fields[:date_range].try(:[], :end).to_s.gsub("-","/"), :class => ['datepicker', 'in_past'] }, :label => 'End Date'
 
-        .submit_button
-          = f.input :email, as: :hidden, input_html: { value: current_user.email }, disabled: true
-          = f.input :format, as: :hidden, input_html: { value: params[:format] }, disabled: true
-          = f.submit "Search", :class => 'btn'
+      .submit_button
+        = f.input :email, as: :hidden, input_html: { value: current_user.email }, disabled: true
+        = f.input :format, as: :hidden, input_html: { value: params[:format] }, disabled: true
+        = f.submit "Search", :class => 'btn'

--- a/app/views/shared/transactions/_search.html.haml
+++ b/app/views/shared/transactions/_search.html.haml
@@ -10,8 +10,8 @@
     %fieldset.span2#calendar_filter
       %br
       = f.input "date_range[field]", collection: @search_options[:date_range], selected: @date_range_field, label: false
-      = f.input "date_range[start]", input_html: { value: @search_fields[:date_range].try(:[], :start).to_s.gsub("-","/"), class: ["datepicker", "in_past"] }, label: "Start Date"
-      = f.input "date_range[end]", input_html: { value: @search_fields[:date_range].try(:[], :end).to_s.gsub("-","/"), class: ["datepicker", "in_past"] }, label: "End Date"
+      = f.input "date_range[start]", input_html: { value: @search_fields[:date_range].try(:[], :start).to_s.gsub("-","/"), class: ["datepicker", "in_past"] }, label: t("reports.fields.date_start")
+      = f.input "date_range[end]", input_html: { value: @search_fields[:date_range].try(:[], :end).to_s.gsub("-","/"), class: ["datepicker", "in_past"] }, label: t("reports.fields.date_end")
 
       .submit_button
         = f.input :email, as: :hidden, input_html: { value: current_user.email }, disabled: true

--- a/app/views/shared/transactions/_search.html.haml
+++ b/app/views/shared/transactions/_search.html.haml
@@ -2,7 +2,7 @@
   .row
     %fieldset.span6#search
       = f.input :facilities, as: :transaction_chosen
-      = f.input :accounts, label_method: 'account_list_item', as: :transaction_chosen unless @account
+      = f.input :accounts, label_method: "account_list_item", as: :transaction_chosen unless @account
       = f.input :products, as: :transaction_chosen, data_method: :product_options
       = f.input :account_owners, label: Account.human_attribute_name(:owner).pluralize, label_method: :full_name, as: :transaction_chosen unless @account
       = f.input :order_statuses, data_method: :order_statuses_options, as: :transaction_chosen
@@ -10,10 +10,10 @@
     %fieldset.span2#calendar_filter
       %br
       = f.input "date_range[field]", collection: @search_options[:date_range], selected: @date_range_field, label: false
-      = f.input "date_range[start]", input_html: { value: @search_fields[:date_range].try(:[], :start).to_s.gsub("-","/"), class: ['datepicker', 'in_past'] }, label: "Start Date"
-      = f.input "date_range[end]", input_html: { value: @search_fields[:date_range].try(:[], :end).to_s.gsub("-","/"), class: ['datepicker', 'in_past'] }, label: "End Date"
+      = f.input "date_range[start]", input_html: { value: @search_fields[:date_range].try(:[], :start).to_s.gsub("-","/"), class: ["datepicker", "in_past"] }, label: "Start Date"
+      = f.input "date_range[end]", input_html: { value: @search_fields[:date_range].try(:[], :end).to_s.gsub("-","/"), class: ["datepicker", "in_past"] }, label: "End Date"
 
       .submit_button
         = f.input :email, as: :hidden, input_html: { value: current_user.email }, disabled: true
         = f.input :format, as: :hidden, input_html: { value: params[:format] }, disabled: true
-        = f.submit "Search", class: 'btn'
+        = f.submit "Search", class: "btn"


### PR DESCRIPTION
The search had an extra `.container` that it didn’t need causing the
transaction search pages to have a horizontal scroll.

Lint cleanup coming in a second commit shortly.