### PR TITLE
[#136397] Fix "Create & Start" on new reservations

### DIFF
--- a/app/assets/javascripts/app/logout_after_end_reservation.coffee
+++ b/app/assets/javascripts/app/logout_after_end_reservation.coffee
@@ -1,0 +1,8 @@
+$ ->
+  # The modal is present on the page after ending of a reservation. Auto-log
+  # the user out of their session after 60 seconds.
+  $logoutModal = $("#logout_modal")
+  if $logoutModal.length > 0
+    $logoutModal.modal("show")
+    logoutLink = $logoutModal.find(".logout").attr("href")
+    window.setTimeout((-> window.location.href = logoutLink), 60000)

--- a/app/assets/javascripts/app/reservation_time_checker.coffee
+++ b/app/assets/javascripts/app/reservation_time_checker.coffee
@@ -1,3 +1,5 @@
+# Validates that the selected reservation is valid for max/min durations as well
+# as interval (5, 10, 15, 30 minutes).
 class window.ReservationTimeChecker
   constructor: (@selector, @alertId = 'duration-alert')->
     if @validPage()
@@ -60,3 +62,10 @@ class window.ReservationTimeChecker
         @showError()
       else
         @hideError()
+
+$ ->
+  target = ".js--reservationValidations #reservation_duration_mins, .edit_reservation #reservation_duration_mins"
+
+  if $(target).length
+    new ReservationTimeChecker(target)
+

--- a/app/assets/javascripts/app/reservation_time_checker.coffee
+++ b/app/assets/javascripts/app/reservation_time_checker.coffee
@@ -1,7 +1,7 @@
 # Validates that the selected reservation is valid for max/min durations as well
 # as interval (5, 10, 15, 30 minutes).
 class window.ReservationTimeChecker
-  constructor: (@selector, @alertId = 'duration-alert')->
+  constructor: (@selector, @alertId = 'duration-alert') ->
     if @validPage()
       @initAlert()
       @respondToChange()
@@ -36,7 +36,7 @@ class window.ReservationTimeChecker
   initAlert: -> $(@selector).after "<p id=\"#{@alertId}\" class=\"alert alert-danger hidden\"/>"
 
 
-  setAlert: (msg)-> $("##{@alertId}").text msg
+  setAlert: (msg) -> $("##{@alertId}").text msg
 
 
   currentErrorMessage: ->
@@ -68,4 +68,3 @@ $ ->
 
   if $(target).length
     new ReservationTimeChecker(target)
-

--- a/app/assets/javascripts/app/reservations.coffee
+++ b/app/assets/javascripts/app/reservations.coffee
@@ -1,35 +1,25 @@
 $ ->
-  target = '#new_reservation #reservation_duration_mins, .edit_reservation #reservation_duration_mins'
+  if isBundle? && !isBundle && !ordering_on_behalf
+    $(".js--reservationUpdateCreateAndStart").find("select, input").change ->
 
-  if $(target).length
-    new ReservationTimeChecker(target)
+      return if ctrlMechanism == 'manual'
 
-    if isBundle? && !isBundle && !ordering_on_behalf
-      $('#new_reservation .datetime-block select, #new_reservation #reservation_reserve_start_date').change ->
+      now = new Date()
+      future = now.clone().addMinutes(5)
+      date = $('#reservation_reserve_start_date').val()
+      hour = $('#reservation_reserve_start_hour').val()
+      hour = "0#{hour}" if hour < 10
+      mins = $('#reservation_reserve_start_min').val()
+      mins = "0#{mins}" if mins < 10
+      meridian = $('#reservation_reserve_start_meridian').val()
 
-        return if ctrlMechanism == 'manual'
+      date_string = "#{date} #{hour}:#{mins}:00 #{meridian}"
 
-        now = new Date()
-        future = now.clone().addMinutes(5)
-        date = $('#reservation_reserve_start_date').val()
-        hour = $('#reservation_reserve_start_hour').val()
-        hour = "0#{hour}" if hour < 10
-        mins = $('#reservation_reserve_start_min').val()
-        mins = "0#{mins}" if mins < 10
-        meridian = $('#reservation_reserve_start_meridian').val()
+      picked = new Date(date_string)
 
-        date_string = "#{date} #{hour}:#{mins}:00 #{meridian}"
+      # change reservation creation button based on Reservation
+      text = if instrumentOnline && picked.between(now, future) then 'Create & Start' else 'Create'
+      $('#reservation_submit').attr('value', text)
 
-        picked = new Date(date_string)
+    .trigger('change')
 
-        # change reservation creation button based on Reservation
-        text = if instrumentOnline && picked.between(now, future) then 'Create & Start' else 'Create'
-        $('#reservation_submit').attr('value', text)
-
-      .trigger('change')
-
-  $logoutModal = $("#logout_modal")
-  if $logoutModal.length > 0
-    $logoutModal.modal("show")
-    logoutLink = $logoutModal.find(".logout").attr("href")
-    window.setTimeout((-> window.location.href = logoutLink), 60000)

--- a/app/assets/javascripts/app/reservations.coffee
+++ b/app/assets/javascripts/app/reservations.coffee
@@ -22,4 +22,3 @@ $ ->
       $('#reservation_submit').attr('value', text)
 
     .trigger('change')
-

--- a/app/views/reservations/_reservation_fields.html.haml
+++ b/app/views/reservations/_reservation_fields.html.haml
@@ -1,5 +1,5 @@
 - start_disabled = start_time_disabled?(f.object)
-.well
+.well.js--reservationValidations
   .container
     .row
       .span7

--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -29,7 +29,8 @@
 = simple_form_for([@order, @order_detail, @reservation]) do |f|
   = f.error_messages
   = render "account_field", f: f unless @order_detail.bundled?
-  = render "reservation_fields", f: f
+  .js--reservationUpdateCreateAndStart
+    = render "reservation_fields", f: f
 
   - if acting_as?
     .row


### PR DESCRIPTION
Broken by responsive changes in
https://github.com/tablexi/nucore-open/pull/945 because a class was
removed, probably because it didn’t adhere to the newer best practice
of prefixing with `.js-`.

This also splits some of the js into separate files so each file is
only doing one thing.

We might need to cherry-pick this into NU to get to stage before another release.