### PR TITLE
[#144548061] Skip CSRF protection on SecureRooms API

### DIFF
--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/api_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/api_controller.rb
@@ -7,6 +7,8 @@ module SecureRoomsApi
       password: Settings.secure_rooms_api.basic_auth_password,
     )
 
+    skip_before_action :verify_authenticity_token
+
   end
 
 end


### PR DESCRIPTION
Avoids “Can't verify CSRF token authenticity” log messages.