### PR TITLE
[#145490555] Rename Control Device Number to MAC address

### DIFF
--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/scans_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/scans_controller.rb
@@ -22,9 +22,10 @@ module SecureRoomsApi
 
     def load_user_and_reader
       @user = User.find_by!(card_number: params[:card_number])
+
       @card_reader = SecureRooms::CardReader.find_by!(
         card_reader_number: params[:reader_identifier],
-        control_device_number: params[:controller_identifier],
+        control_device_number: params[:controller_identifier].upcase,
       )
     end
 

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/card_reader.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/card_reader.rb
@@ -2,7 +2,7 @@ module SecureRooms
 
   class CardReader < ActiveRecord::Base
 
-    MAC_ADDRESS_FORMAT = /\A([0-9A-F]{2}:){5}([0-9A-F]{2})\z/.freeze
+    MAC_ADDRESS_FORMAT = /\A([0-9A-F]{2}:){5}([0-9A-F]{2})\z/
 
     belongs_to :secure_room, foreign_key: :product_id
 
@@ -11,7 +11,7 @@ module SecureRooms
     alias_attribute :ingress, :direction_in
 
     validates :product_id, presence: true
-    validates :control_device_number, presence: true, format: { with: MAC_ADDRESS_FORMAT, allow_blank: false }
+    validates :control_device_number, presence: true, format: { with: MAC_ADDRESS_FORMAT }
     validates :card_reader_number, presence: true, uniqueness: { scope: :control_device_number }
     validates :tablet_token, uniqueness: true
 
@@ -51,7 +51,7 @@ module SecureRooms
     end
 
     def clean_mac_address
-      self.control_device_number = control_device_number.to_s.upcase.gsub("-", ":")
+      self.control_device_number = control_device_number.to_s.upcase.tr("-", ":")
     end
 
   end

--- a/vendor/engines/secure_rooms/config/locales/en.yml
+++ b/vendor/engines/secure_rooms/config/locales/en.yml
@@ -61,7 +61,7 @@ en:
       secure_rooms/card_reader:
         description: Description
         card_reader_number: Card Reader Number
-        control_device_number: Control Device Number
+        control_device_number: MAC Address
         direction: Direction
         direction_in: Direction
         human_direction:

--- a/vendor/engines/secure_rooms/config/locales/en.yml
+++ b/vendor/engines/secure_rooms/config/locales/en.yml
@@ -78,6 +78,13 @@ en:
         orphaned_at: Time Marked as Orphaned
         actual_duration_mins: Duration
 
+    errors:
+      models:
+        secure_rooms/card_reader:
+          attributes:
+            control_device_number:
+              invalid: must be in "00:00:00:00:00:00" format
+
   controllers:
     secure_rooms/card_readers:
       create:
@@ -128,3 +135,8 @@ en:
           occupancies_title: Occupancies
         tabnav_users:
           title: Secure Room Access
+
+  simple_form:
+    placeholders:
+      card_reader:
+        control_device_number: "00:00:00:00:00:00"

--- a/vendor/engines/secure_rooms/spec/controllers/secure_rooms_api/scans_controller_spec.rb
+++ b/vendor/engines/secure_rooms/spec/controllers/secure_rooms_api/scans_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SecureRoomsApi::ScansController do
     subject { response }
 
     let(:secure_room) { create(:secure_room, :with_schedule_rule) }
-    let(:card_reader) { create(:card_reader, tablet_token: "TABLETID", secure_room: secure_room) }
+    let(:card_reader) { create(:card_reader, tablet_token: "TABLETID", secure_room: secure_room, control_device_number: "FF:FF:FF:FF:FF:FF") }
     let(:user) { create(:user, card_number: "123456") }
 
     describe "negative responses" do
@@ -85,6 +85,17 @@ RSpec.describe SecureRoomsApi::ScansController do
             expect(JSON.parse(response.body)["tablet_identifier"]).to eq("TABLETID")
           end
         end
+      end
+
+      describe "with a mis-cased controller ID" do
+        before do
+          post :scan,
+               card_number: user.card_number,
+               reader_identifier: card_reader.card_reader_number,
+               controller_identifier: card_reader.control_device_number.downcase
+        end
+
+        it { is_expected.not_to have_http_status(:not_found) }
       end
     end
   end

--- a/vendor/engines/secure_rooms/spec/factories/card_reader.rb
+++ b/vendor/engines/secure_rooms/spec/factories/card_reader.rb
@@ -2,7 +2,8 @@ FactoryGirl.define do
   factory :card_reader, class: SecureRooms::CardReader do
     secure_room
     sequence(:card_reader_number) { |n| "card_reader_#{n}" }
-    sequence(:control_device_number) { |n| "control_device_#{n}" }
+    # Generate a sequential MAC address
+    sequence(:control_device_number) { |n| format("%012X", n).scan(/.{2}/).join(":") }
     ingress true
 
     trait :exit do

--- a/vendor/engines/secure_rooms/spec/features/manage_card_reader_spec.rb
+++ b/vendor/engines/secure_rooms/spec/features/manage_card_reader_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe "Managing CardReaders" do
   it "can create a card reader" do
     visit facility_secure_room_card_readers_path(facility, secure_room)
     click_link "Add Card Reader"
-    fill_in "card_reader[description]", with: "New Reader Description"
-    fill_in "card_reader[card_reader_number]", with: "New Reader Number"
-    fill_in "card_reader[control_device_number]", with: "New Device Number"
+    fill_in "Description", with: "New Reader Description"
+    fill_in "Card Reader Number", with: "New Reader Number"
+    fill_in "MAC Address", with: "New Device Number"
     click_button "Create Card Reader"
 
     new_reader = secure_room.card_readers.find_by(
@@ -34,9 +34,9 @@ RSpec.describe "Managing CardReaders" do
     it "can edit a card reader" do
       visit facility_secure_room_card_readers_path(facility, secure_room)
       within(".product_list") { click_link "Edit" }
-      fill_in "card_reader[description]", with: "Edited Reader Description"
-      fill_in "card_reader[card_reader_number]", with: "Edited Reader Number"
-      fill_in "card_reader[control_device_number]", with: "Edited Device Number"
+      fill_in "Description", with: "Edited Reader Description"
+      fill_in "Card Reader Number", with: "Edited Reader Number"
+      fill_in "MAC Address", with: "Edited Device Number"
       select "Out", from: "Direction"
       click_button "Update Card Reader"
 

--- a/vendor/engines/secure_rooms/spec/features/manage_card_reader_spec.rb
+++ b/vendor/engines/secure_rooms/spec/features/manage_card_reader_spec.rb
@@ -11,19 +11,14 @@ RSpec.describe "Managing CardReaders" do
     click_link "Add Card Reader"
     fill_in "Description", with: "New Reader Description"
     fill_in "Card Reader Number", with: "New Reader Number"
-    fill_in "MAC Address", with: "New Device Number"
+    fill_in "MAC Address", with: "00:00:00:00:00:00"
     click_button "Create Card Reader"
-
-    new_reader = secure_room.card_readers.find_by(
-      card_reader_number: "New Reader Number",
-      control_device_number: "New Device Number",
-    )
 
     expect(current_path).to eq(facility_secure_room_card_readers_path(facility, secure_room))
     within(".secure_rooms_card_reader") do
       expect(page).to have_content("New Reader Description")
       expect(page).to have_content("New Reader Number")
-      expect(page).to have_content("New Device Number")
+      expect(page).to have_content("00:00:00:00:00:00")
       expect(page).to have_content("In")
     end
   end
@@ -36,7 +31,7 @@ RSpec.describe "Managing CardReaders" do
       within(".product_list") { click_link "Edit" }
       fill_in "Description", with: "Edited Reader Description"
       fill_in "Card Reader Number", with: "Edited Reader Number"
-      fill_in "MAC Address", with: "Edited Device Number"
+      fill_in "MAC Address", with: "FF:FF:FF:FF:FF:FF"
       select "Out", from: "Direction"
       click_button "Update Card Reader"
 
@@ -44,7 +39,7 @@ RSpec.describe "Managing CardReaders" do
       within(".secure_rooms_card_reader") do
         expect(page).to have_content("Edited Reader Description")
         expect(page).to have_content("Edited Reader Number")
-        expect(page).to have_content("Edited Device Number")
+        expect(page).to have_content("FF:FF:FF:FF:FF:FF")
         expect(page).to have_content("Out")
       end
     end

--- a/vendor/engines/secure_rooms/spec/models/secure_rooms/card_reader_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/secure_rooms/card_reader_spec.rb
@@ -3,11 +3,39 @@ require "rails_helper"
 RSpec.describe SecureRooms::CardReader do
   it { is_expected.to validate_presence_of :product_id }
   it { is_expected.to validate_presence_of :card_reader_number }
-  it { is_expected.to validate_presence_of :control_device_number }
+
+  describe "card_reader_number" do
+    it { is_expected.to validate_presence_of :control_device_number }
+
+    it { is_expected.to allow_value("00:00:00:00:00:00").for(:control_device_number) }
+    it { is_expected.to allow_value("FF:FF:FF:FF:FF:FF").for(:control_device_number) }
+
+    describe "valid after transformations" do
+      it { is_expected.to allow_value("ff:ff:ff:ff:ff:ff").for(:control_device_number) }
+      it { is_expected.to allow_value("00-00-00-00-00-00").for(:control_device_number) }
+    end
+
+    it { is_expected.not_to allow_value("12345").for(:control_device_number) }
+    it { is_expected.not_to allow_value("GG:GG:GG:GG:GG:GG").for(:control_device_number) }
+    it { is_expected.not_to allow_value("F:F:F:F:F:F").for(:control_device_number) }
+    it { is_expected.not_to allow_value("0:0:0:0:0:0").for(:control_device_number) }
+
+    it "upcases" do
+      subject.control_device_number = "ff:ff:ff:ff:ff:ff"
+      subject.valid?
+      expect(subject.control_device_number).to eq("FF:FF:FF:FF:FF:FF")
+    end
+
+    it "replaces dashes with colons" do
+      subject.control_device_number = "00-00-00-00-00-00"
+      subject.valid?
+      expect(subject.control_device_number).to eq("00:00:00:00:00:00")
+    end
+  end
 
   describe "with a product" do
     let(:product) { create(:secure_room) }
-    subject { described_class.new(secure_room: product) }
+    subject { described_class.new(secure_room: product, control_device_number: "00:00:00:00:00:00") }
 
     it { is_expected.to validate_uniqueness_of(:card_reader_number).scoped_to(:control_device_number) }
     it { is_expected.to validate_uniqueness_of(:tablet_token) }


### PR DESCRIPTION
I considered actually renaming the column, but eventually decided against it. I also considered adding an `alias_attribute :control_device_number, :mac_address`. It seemed to make things clearer and more obvious when looking at very specific places (e.g. inside the factory or validations), but got confusing when you stepped back and saw both in the same picture.