### PR TITLE
[#145957283] Skip order for exempt users

### DIFF
--- a/vendor/engines/secure_rooms/app/models/secure_rooms/card_reader.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/card_reader.rb
@@ -14,6 +14,10 @@ module SecureRooms
 
     before_create :set_tablet_token
 
+    def self.ingress
+      where(ingress: true)
+    end
+
     def self.egress
       where(ingress: false)
     end

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/order_handler.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/order_handler.rb
@@ -53,6 +53,11 @@ module SecureRooms
         occupancy.update(account: accounts.first)
       end
 
+      # Whether or not an occupant must pay for their time is determined by
+      # CheckAccess at scan-in time. In the event we don't have access to
+      # scan-in information, we check the user's access with a room's in-reader
+      # to find what the verdict would have been. A verdict returning accounts
+      # signifies the user would have needed to select one to enter.
       def user_exempt_from_purchase?
         in_reader = occupancy.secure_room.card_readers.ingress.first
         SecureRooms::CheckAccess.new.authorize(occupancy.user, in_reader).accounts.blank?

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/order_handler.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/order_handler.rb
@@ -15,8 +15,7 @@ module SecureRooms
       end
 
       def process
-        # TODO: [#145957283] Ensure facility operators with accounts do not create orders on exit
-        return unless user_can_purchase_secure_room?
+        return if user_exempt_from_purchase?
 
         find_or_create_order
         complete_order
@@ -54,8 +53,9 @@ module SecureRooms
         occupancy.update(account: accounts.first)
       end
 
-      def user_can_purchase_secure_room?
-        occupancy.user.accounts_for_product(occupancy.secure_room).present?
+      def user_exempt_from_purchase?
+        in_reader = occupancy.secure_room.card_readers.ingress.first
+        SecureRooms::CheckAccess.new.authorize(occupancy.user, in_reader).accounts.blank?
       end
 
       def create_order_and_detail

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/access_handlers/occupancy_handler_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/access_handlers/occupancy_handler_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe SecureRooms::AccessHandlers::OccupancyHandler, type: :service do
           # orders need to be "purchased" but we don't care about the details
           before do
             allow_any_instance_of(OrderDetail).to receive(:valid_for_purchase?).and_return(true)
-            allow_any_instance_of(SecureRooms::AccessHandlers::OrderHandler).to receive(:user_can_purchase_secure_room?).and_return(true)
+            allow_any_instance_of(SecureRooms::AccessHandlers::OrderHandler).to receive(:user_exempt_from_purchase?).and_return(false)
           end
 
           describe "the new occupancy" do


### PR DESCRIPTION
* runs `CheckAccess` again, since that will leave `accounts` blank if the user was granted from an earlier rule--then, if `accounts` is populated, the user would have had to select a valid account
* cleans up the `OrderHandler` specs with better fixtures available