### PR TITLE
Upgrade shoulda-matchers to 3.1.X

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,9 +96,6 @@ group :development, :test do
   gem "quiet_assets"
   gem "rspec-rails", "~> 3.5.2"
   gem "rspec-activejob"
-  gem "shoulda-matchers",  "~> 2.8.0", require: false
-  gem "rspec-collection_matchers"
-  gem "single_test", "0.4.0"
   gem "spring"
   gem "spring-commands-rspec"
   gem "teaspoon-jasmine"
@@ -113,6 +110,9 @@ group :test do
   gem "capybara"
   gem "capybara-email"
   gem "poltergeist"
+  gem "rspec-collection_matchers"
+  gem "shoulda-matchers",  "~> 3.1.0"
+  gem "single_test", "0.4.0"
 end
 
 group :stage, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,7 +325,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.10.1)
+    minitest (5.10.2)
     multi_json (1.12.1)
     mysql2 (0.3.21)
     nenv (0.3.0)
@@ -477,8 +477,8 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     shellany (0.0.1)
-    shoulda-matchers (2.8.0)
-      activesupport (>= 3.0.0)
+    shoulda-matchers (3.1.1)
+      activesupport (>= 4.0.0)
     sigar (0.7.3)
     simple_form (3.3.1)
       actionpack (> 4, < 5.1)
@@ -531,7 +531,7 @@ GEM
     timers (4.1.2)
       hitimes
     ttfunk (1.0.3)
-    tzinfo (1.2.2)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
       execjs (>= 0.3.0)
@@ -631,7 +631,7 @@ DEPENDENCIES
   sanger_sequencing (~> 0.0.1)!
   sass-rails (~> 5.0.6)
   secure_rooms!
-  shoulda-matchers (~> 2.8.0)
+  shoulda-matchers (~> 3.1.0)
   simple_form (~> 3.3.1)
   single_test (= 0.4.0)
   split_accounts (~> 0.0.1)!

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe User do
 
   it "validates uniquess of username" do
     # we need at least 1 user to test validations
-    is_expected.to validate_uniqueness_of(:username)
+    is_expected.to validate_uniqueness_of(:username).case_insensitive
   end
 
   context "when the created username is mixed-case" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -130,3 +130,10 @@ end
 FactoryGirl::SyntaxRunner.class_eval do
   include RSpec::Mocks::ExampleMethods
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
I thought I was going to want a new feature (ignoring case sensitivity in uniqueness), but turns out that doesn't do what I wanted when the case-insensitivity is on the `scoped_to` side. But I figured we might as well have this upgraded.