### PR TITLE
Fix canceled_at/by migration for Admin and Offline reservations

### DIFF
--- a/db/migrate/20170501201633_add_canceled_to_order_detail.rb
+++ b/db/migrate/20170501201633_add_canceled_to_order_detail.rb
@@ -4,7 +4,7 @@ class AddCanceledToOrderDetail < ActiveRecord::Migration
     add_column :order_details, :canceled_by, :integer
     add_column :order_details, :canceled_reason, :string
 
-    Reservation.find_each do |reservation|
+    Reservation.where.not(order_detail_id: nil).find_each do |reservation|
       reservation.order_detail.update_attributes(canceled_at: reservation.canceled_at,
                                                  canceled_by: reservation.canceled_by,
                                                  canceled_reason: reservation.canceled_reason)


### PR DESCRIPTION
Admin reservations and Offline reservations do not have an associated order_detail.

Update to https://github.com/tablexi/nucore-open/pull/1008