### PR TITLE
[#146173013] Configure res/occ timeout in settings

### DIFF
--- a/app/support/auto_expire_reservation.rb
+++ b/app/support/auto_expire_reservation.rb
@@ -15,7 +15,7 @@ class AutoExpireReservation
   end
 
   def earliest_allowed_time
-    Time.zone.now - Settings.reservations.timeout_period
+    Settings.reservations.timeout_period.seconds.ago
   end
 
   def purchased_active_order_details

--- a/app/support/auto_expire_reservation.rb
+++ b/app/support/auto_expire_reservation.rb
@@ -14,11 +14,15 @@ class AutoExpireReservation
     purchased_active_order_details
   end
 
+  def earliest_allowed_time
+    Time.zone.now - Settings.reservations.timeout_period
+  end
+
   def purchased_active_order_details
     OrderDetail.purchased_active_reservations
                .joins(:product)
                .joins_relay
-               .where("reservations.reserve_end_at < ?", Time.zone.now - 12.hours)
+               .where("reservations.reserve_end_at < ?", earliest_allowed_time)
                .readonly(false)
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -61,6 +61,10 @@ order_details:
 
 reservations:
   grace_period: <%= 5.minutes %>
+  timeout_period: <%= 12.hours %>
+
+occupancies:
+  timeout_period: <%= 12.hours %>
 
 billing:
   review_period: <%= 7.days %>

--- a/vendor/engines/secure_rooms/app/support/secure_rooms/auto_orphan_occupancy.rb
+++ b/vendor/engines/secure_rooms/app/support/secure_rooms/auto_orphan_occupancy.rb
@@ -12,8 +12,12 @@ module SecureRooms
 
     private
 
+    def earliest_allowed_time
+      Time.zone.now - Settings.occupancies.timeout_period
+    end
+
     def long_running_occupancies
-      SecureRooms::Occupancy.current.where("entry_at < ?", 12.hours.ago)
+      SecureRooms::Occupancy.current.where("entry_at < ?", earliest_allowed_time)
     end
 
     def orphan_occupancy(occupancy)

--- a/vendor/engines/secure_rooms/app/support/secure_rooms/auto_orphan_occupancy.rb
+++ b/vendor/engines/secure_rooms/app/support/secure_rooms/auto_orphan_occupancy.rb
@@ -13,7 +13,7 @@ module SecureRooms
     private
 
     def earliest_allowed_time
-      Time.zone.now - Settings.occupancies.timeout_period
+      Settings.occupancies.timeout_period.seconds.ago
     end
 
     def long_running_occupancies


### PR DESCRIPTION
Since the setting is now required.. should we add a default directly into the code? Like:
```
Settings.reservations.timeout_period || 12.hours
```