### PR TITLE
[#136429] Prevent duplicate details in Journal#order_details

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -46,7 +46,7 @@ class Journal < ActiveRecord::Base
 
   # _order_details is used for building associations, and may contain duplicates.
   # Consider this private. Use order_details instead.
-  has_many :_order_details, class_name: "OrderDetail", through: :journal_rows
+  has_many :_order_details, class_name: "OrderDetail", through: :journal_rows, source: :order_detail
 
   validates_presence_of   :reference, :updated_by, on: :update
   validates_presence_of   :created_by

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -104,9 +104,9 @@ class Journal < ActiveRecord::Base
       [facility_id]
     else
       _order_details.joins(:order)
-                   .select("orders.facility_id")
-                   .collect(&:facility_id)
-                   .uniq
+                    .select("orders.facility_id")
+                    .collect(&:facility_id)
+                    .uniq
     end
   end
 

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -39,12 +39,13 @@ class Journal < ActiveRecord::Base
 
   attr_accessor :order_details_for_creation
 
-  has_many                :journal_rows
-  belongs_to              :facility
-  # The distinct is necessary for SplitAccount orders where one order detail might
-  # be split across multiple journal rows
-  has_many :order_details, -> { clob_safe_distinct }, through: :journal_rows
-  belongs_to              :created_by_user, class_name: "User", foreign_key: :created_by
+  belongs_to :facility
+  belongs_to :created_by_user, class_name: "User", foreign_key: :created_by
+
+  has_many :journal_rows
+  # `has_many :order_details, -> { distrinct }, through: :journal_rows` does not
+  # work because Oracle has a problem with `DISTINCT *` and CLOB fields.
+  has_many :order_details
 
   validates_presence_of   :reference, :updated_by, on: :update
   validates_presence_of   :created_by

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -7,8 +7,6 @@ class OrderDetail < ActiveRecord::Base
   include NotificationSubject
   include OrderDetail::Accessorized
   include NUCore::Database::WhereIdsIn
-  include NUCore::Database::ClobSafeDistinct
-  include TextHelpers::Translation
 
   versioned
 

--- a/app/support/journals/closer.rb
+++ b/app/support/journals/closer.rb
@@ -45,7 +45,12 @@ class Journals::Closer
 
   def mark_as_succeeded
     if journal.update_attributes(params.merge(is_successful: true))
-      journal.order_details.update_all(state: "reconciled", order_status_id: OrderStatus.reconciled_status.id, reconciled_at: reconciled_at)
+      journal.order_details.update_all(
+        state: "reconciled",
+        order_status_id: OrderStatus.reconciled_status.id,
+        reconciled_at: reconciled_at,
+        updated_at: Time.current
+      )
     else
       false
     end

--- a/app/support/journals/closer.rb
+++ b/app/support/journals/closer.rb
@@ -49,7 +49,7 @@ class Journals::Closer
         state: "reconciled",
         order_status_id: OrderStatus.reconciled_status.id,
         reconciled_at: reconciled_at,
-        updated_at: Time.current
+        updated_at: Time.current,
       )
     else
       false

--- a/lib/nucore.rb
+++ b/lib/nucore.rb
@@ -34,29 +34,6 @@ module NUCore
       end
     end
 
-    # Oracle has problems with doing `DISTINCT *` on a table that contains
-    # a CLOB (i.e. text) column.
-    # See https://github.com/rsim/oracle-enhanced/issues/112
-    module ClobSafeDistinct
-
-      extend ActiveSupport::Concern
-
-      module ClassMethods
-
-        def clob_safe_distinct
-          if NUCore::Database.oracle?
-            # `select` instead of `pluck` results in a subquery rather than
-            # two queries.
-            where(id: distinct.select(:id))
-          else
-            distinct
-          end
-        end
-
-      end
-
-    end
-
     module WhereIdsIn
 
       extend ActiveSupport::Concern

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -20,6 +20,21 @@ RSpec.describe Journal do
     it { is_expected.to validate_length_of(:reference).is_at_most(50) }
   end
 
+  describe "#order_details" do
+    let(:order_detail) { order.order_details.first }
+    before do
+      order_detail.to_complete!
+      journal.save!
+      journal.create_journal_rows!([order_detail, order_detail])
+    end
+
+    it "has three rows, but only one order detail" do
+      # one per order detail, plus one credit
+      expect(journal.journal_rows.where.not(order_detail: nil).count).to eq(2)
+      expect(journal.order_details.count).to eq(1)
+    end
+  end
+
   context "#amount" do
     context "when its order detail quantities change" do
       let(:order_details) { order.order_details }
@@ -367,4 +382,5 @@ RSpec.describe Journal do
       end
     end
   end
+
 end


### PR DESCRIPTION
Open source version of https://github.com/tablexi/nucore-nu/pull/259

When there are orders with a SplitAccount on a journal, the association was coming back with duplicate order details because there are multiple journal_rows per order detail (multiple journal rows is intentional). This works fine on MySQL because of the `distinct` scope.

However, the Oracle-specific `clob_safe_distinct` was not working because the inner `distinct` was not being scoped, so it was essentially coming out as `WHERE id IN (SELECT DISTINCT(*) FROM order_details)`. Using a normal `distinct` has problems in oracle because `DISTINCT *` does not work with CLOB fields (notes). `ORA-00932: inconsistent datatypes: expected - got CLOB 00932. 00000 -  "inconsistent datatypes: expected %s got %s"`.

I've made the existing association essentially private with a note that it may contain duplicates. There is now a regular method acting as a pseudo association for `Journal#order_details`

