### PR TITLE
circle sends slack notifications only for master/develop branches

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,6 +25,13 @@ test:
       --format junit > $CIRCLE_TEST_REPORTS/teaspoon.xml
     - bundle exec report_coverage
 
+experimental:
+  notify:
+    branches:
+      only:
+        - master
+        - develop
+
 deployment:
   staging:
     branch: master


### PR DESCRIPTION
- Adding circle config to send slack notifications for builds on master/develop branches only (per https://circleci.com/docs/1.0/configuration/#per-branch-notifications)
- Currently the integration is turned on only for open--once this gets merged down into the school-specific forks I'll turn on the integration for those projects as well.