### PR TITLE
Fix schedule rule foreign key index

### DIFF
--- a/db/migrate/20170531183710_fix_schedule_rule_product_index.rb
+++ b/db/migrate/20170531183710_fix_schedule_rule_product_index.rb
@@ -1,0 +1,5 @@
+class FixScheduleRuleProductIndex < ActiveRecord::Migration
+  def up
+    add_index :schedule_rules, :product_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170525143813) do
+ActiveRecord::Schema.define(version: 20170531183710) do
 
   create_table "account_users", force: :cascade do |t|
     t.integer  "account_id", limit: 4,  null: false
@@ -596,7 +596,7 @@ ActiveRecord::Schema.define(version: 20170525143813) do
     t.boolean "on_sat",                                                            null: false
   end
 
-  add_index "schedule_rules", ["product_id"], name: "fk_rails_bd1c8c4ecb", using: :btree
+  add_index "schedule_rules", ["product_id"], name: "index_schedule_rules_on_product_id", using: :btree
 
   create_table "schedules", force: :cascade do |t|
     t.string   "name",        limit: 255


### PR DESCRIPTION
This index was missing on Oracle because it doesn't automatically create indexes
for foreign keys the way MySQL does.

I was a little surprised this worked as is, but mysql didn't need a special condition.