### PR TITLE
[#146399533] Require complete? to view description

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -864,7 +864,7 @@ class OrderDetail < ActiveRecord::Base
 
   def problem_description_key
     time_data_problem_key = time_data.problem_description_key
-    price_policy_problem_key = :missing_price_policy if price_policy.blank?
+    price_policy_problem_key = :missing_price_policy if missing_price_policy?
 
     time_data_problem_key || price_policy_problem_key
   end

--- a/spec/features/viewing_an_order_spec.rb
+++ b/spec/features/viewing_an_order_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe "Viewing an order" do
+  let(:facility) { product.facility }
+  let(:product) { create(:setup_item, :with_facility_account) }
+  let(:order) { create(:purchased_order, product: product) }
+  let!(:order_detail) { order.order_details.first }
+  let(:user) { create(:user, :staff, facility: facility) }
+
+  before do
+    login_as user
+  end
+
+  describe "badge displays" do
+    describe "a complete order missing a price policy" do
+      before do
+        order_detail.complete!
+        order_detail.update(price_policy: nil)
+      end
+
+      it "displays a badge" do
+        visit facility_order_path(facility, order)
+        within("#order-management") do
+          expect(page).to have_content "Missing Price Policy"
+        end
+      end
+    end
+
+    describe "a canceled order missing a price policy" do
+      before do
+        order_detail.to_canceled!
+        order_detail.update(price_policy: nil)
+      end
+
+      it "displays no stinkin' badges" do
+        visit facility_order_path(facility, order)
+        within("#order-management") do
+          expect(page).not_to have_content "Missing Price Policy"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This was using the wrong method, originally the logic was `#missing_price_policy?` which includes `complete?` like so:
```
def missing_price_policy?
  complete? && price_policy.nil?
end
```