### PR TITLE
Skip adding cancelation fields to reservations with missing order details

### DIFF
--- a/db/migrate/20170501201633_add_canceled_to_order_detail.rb
+++ b/db/migrate/20170501201633_add_canceled_to_order_detail.rb
@@ -5,6 +5,7 @@ class AddCanceledToOrderDetail < ActiveRecord::Migration
     add_column :order_details, :canceled_reason, :string
 
     Reservation.where.not(order_detail_id: nil, canceled_at: nil).includes(:order_detail).find_each do |reservation|
+      next unless reservation.order_detail
       reservation.order_detail.update_columns(canceled_at: reservation.canceled_at,
                                               canceled_by: reservation.canceled_by,
                                               canceled_reason: reservation.canceled_reason)


### PR DESCRIPTION
There are about 46 order_details in UIC that were deleted, but the reservations were
not. I suspect this was back when they were running MySQL 5.5, and possibly on MyISAM,
which does not support foreign keys. Likely, when they exported from the old
server and imported to the newer one, the importer temporarily disabled foreign
keys.