### PR TITLE
[#136497] Fix problem reservation badges

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -33,7 +33,7 @@ class OrderDetail < ActiveRecord::Base
 
   before_save :set_problem_order
   def set_problem_order
-    self.problem = complete? && problem_description_key.present?
+    self.problem = problem_description_key.present?
     update_fulfilled_at_on_resolve if time_data.present?
     true # problem might be false; we need the callback chain to continue
   end
@@ -769,10 +769,6 @@ class OrderDetail < ActiveRecord::Base
     problem
   end
 
-  def missing_price_policy?
-    complete? && price_policy.nil?
-  end
-
   def in_open_journal?
     journal && journal.open?
   end
@@ -863,8 +859,10 @@ class OrderDetail < ActiveRecord::Base
   end
 
   def problem_description_key
+    return unless complete?
+
     time_data_problem_key = time_data.problem_description_key
-    price_policy_problem_key = :missing_price_policy if missing_price_policy?
+    price_policy_problem_key = :missing_price_policy if price_policy.blank?
 
     time_data_problem_key || price_policy_problem_key
   end

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -401,6 +401,10 @@ RSpec.describe OrderDetail do
       it "is not a problem order" do
         expect(order_detail).not_to be_problem_order
       end
+
+      it "does not have a problem_description" do
+        expect(order_detail.problem_description_key).to be_nil
+      end
     end
 
     context "with instruments" do
@@ -496,12 +500,18 @@ RSpec.describe OrderDetail do
 
           it_behaves_like "it is complete"
           it_behaves_like "it is a problem order"
+          it "has a missing actual problem key" do
+            expect(order_detail.problem_description_key).to eq(:missing_actuals)
+          end
 
           context "and has a reservation_rate" do
             let(:order_detail) { order_detail_with_actuals_and_price_policy }
 
             it_behaves_like "it is complete"
             it_behaves_like "it is a problem order"
+            it "has a missing actual problem key" do
+              expect(order_detail.problem_description_key).to eq(:missing_actuals)
+            end
           end
         end
 
@@ -510,6 +520,19 @@ RSpec.describe OrderDetail do
 
           it_behaves_like "it is complete"
           it_behaves_like "it is a problem order"
+
+          describe "when it is missing and requiring actuals" do
+            it do
+              expect(order_detail.problem_description_key).to eq(:missing_actuals)
+            end
+          end
+
+          describe "when it has actuals" do
+            before { order_detail.reservation.update_attributes(actual_start_at: Time.current, actual_end_at: Time.current) }
+            it do
+              expect(order_detail.problem_description_key).to eq(:missing_price_policy)
+            end
+          end
 
           context "when a price policy is assigned" do
             let!(:price_policy) do
@@ -554,6 +577,10 @@ RSpec.describe OrderDetail do
         end
 
         it_behaves_like "it is a problem order"
+
+        it "has a missing price policy description" do
+          expect(order_detail.problem_description_key).to eq(:missing_price_policy)
+        end
 
         context "when adding a compatible price policy" do
           let!(:price_policy) do


### PR DESCRIPTION
The "Missing Actual" badge was appearing for new/inprogress orders.

This fixes `problem_description_key` so it only returns a key if the order is
complete.

PR #1085 was a first attempt to fix the issue, but that only handled the missing
price policy same issue.

The order detail problem spec is a mess, but refactoring it seemed outside the scope of this bug fix.