### PR TITLE
[#134550] Changes to support Qualtrics as external survey

### DIFF
--- a/app/controllers/api/order_details_controller.rb
+++ b/app/controllers/api/order_details_controller.rb
@@ -5,6 +5,14 @@ class Api::OrderDetailsController < ApplicationController
 
   http_basic_authenticate_with name: Settings.api.basic_auth_name, password: Settings.api.basic_auth_password
 
+  # Qualtrics requires that we use a query parameter rather than being part of
+  # the URL.
+  # /api/order_details.json?id=123
+  def index
+    show
+  end
+
+  # /api/order_details/123.json
   def show
     render json: Api::OrderDetail.new(order_detail).to_h
   end

--- a/app/models/api/order_detail.rb
+++ b/app/models/api/order_detail.rb
@@ -5,7 +5,11 @@ class Api::OrderDetail
   end
 
   def to_h
-    { account: account_to_hash, ordered_for: ordered_for_to_hash }
+    {
+      number: @order_detail.to_s,
+      account: account_to_hash,
+      ordered_for: ordered_for_to_hash
+    }
   end
 
   private

--- a/app/models/api/order_detail.rb
+++ b/app/models/api/order_detail.rb
@@ -6,7 +6,7 @@ class Api::OrderDetail
 
   def to_h
     {
-      number: @order_detail.to_s,
+      order_number: @order_detail.order_number,
       account: account_to_hash,
       ordered_for: ordered_for_to_hash
     }

--- a/app/models/api/order_detail.rb
+++ b/app/models/api/order_detail.rb
@@ -8,7 +8,7 @@ class Api::OrderDetail
     {
       order_number: @order_detail.order_number,
       account: account_to_hash,
-      ordered_for: ordered_for_to_hash
+      ordered_for: ordered_for_to_hash,
     }
   end
 

--- a/app/models/external_service/url_service.rb
+++ b/app/models/external_service/url_service.rb
@@ -25,6 +25,8 @@ class UrlService < ExternalService
       referer: referer_url(request),
       receiver_id: receiver.id,
     }
+
+    query[:order_number] = receiver.order_number if receiver.respond_to?(:order_number)
     query[:quantity] = receiver.quantity if receiver.respond_to?(:quantity)
     query.to_query
   end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -692,9 +692,10 @@ class OrderDetail < ActiveRecord::Base
     Account.for_order_detail(self)
   end
 
-  def to_s
+  def order_number
     "#{order_id}-#{id}"
   end
+  alias to_s order_number
 
   def description
     "Order # #{self}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -369,6 +369,6 @@ Nucore::Application.routes.draw do
 
   # api
   namespace :api do
-    resources :order_details, only: [:show]
+    resources :order_details, only: [:show, :index]
   end
 end

--- a/spec/models/api/order_detail_spec.rb
+++ b/spec/models/api/order_detail_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Api::OrderDetail do
               username: account_owner.username,
               email: account_owner.email,
             },
-          }
+          },
         )
       end
     end

--- a/spec/models/api/order_detail_spec.rb
+++ b/spec/models/api/order_detail_spec.rb
@@ -6,36 +6,34 @@ RSpec.describe Api::OrderDetail do
   let(:expected_hash) { { account: account_hash, ordered_for: ordered_for_hash } }
 
   let(:order) { double(Order, user: ordered_for) }
-  let(:order_detail) { double(OrderDetail, account: account, order: order) }
+  let(:order_detail) { double(OrderDetail, account: account, order: order, order_number: "12-3") }
   let(:ordered_for) { build(:user, id: 2) }
-  let(:ordered_for_hash) do
-    {
-      id: ordered_for.id,
-      name: ordered_for.name,
-      username: ordered_for.username,
-      email: ordered_for.email,
-    }
-  end
 
   describe "#to_h" do
     context "when the order_detail has an account" do
       let(:account) { double(Account, id: 1, owner: account_user) }
       let(:account_owner) { build(:user, id: 1) }
       let(:account_user) { double(AccountUser, user: account_owner) }
-      let(:account_hash) do
-        {
-          id: account.id,
-          owner: {
-            id: account_owner.id,
-            name: account_owner.name,
-            username: account_owner.username,
-            email: account_owner.email,
-          },
-        }
-      end
 
       it "generates the expected hash" do
-        expect(subject.to_h).to eq(expected_hash)
+        expect(subject.to_h).to match a_hash_including(
+          order_number: "12-3",
+          ordered_for: {
+            id: ordered_for.id,
+            name: ordered_for.name,
+            username: ordered_for.username,
+            email: ordered_for.email,
+          },
+          account: {
+            id: account.id,
+            owner: {
+              id: account_owner.id,
+              name: account_owner.name,
+              username: account_owner.username,
+              email: account_owner.email,
+            },
+          }
+        )
       end
     end
 
@@ -44,7 +42,11 @@ RSpec.describe Api::OrderDetail do
       let(:account_hash) { nil }
 
       it "generates the expected hash" do
-        expect(subject.to_h).to eq(expected_hash)
+        expect(subject.to_h).to match a_hash_including(
+          order_number: "12-3",
+          ordered_for: an_instance_of(Hash),
+          account: nil,
+        )
       end
     end
   end

--- a/spec/models/external_service/url_service_spec.rb
+++ b/spec/models/external_service/url_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe UrlService do
   let(:url_service) do
     described_class.create(
       location: "http://www.survey.com/survey1",
-      default_url_options: { host: "defaulthost"}
+      default_url_options: { host: "defaulthost" },
     )
   end
 

--- a/spec/models/external_service/url_service_spec.rb
+++ b/spec/models/external_service/url_service_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe UrlService do
       expect(query_hash["quantity"]).to eq("3")
     end
 
+    it "sets the order number" do
+      expect(query_hash["order_number"]).to eq(order_detail.to_s)
+    end
+
     it "sets the correct success url" do
       expect(query_hash["success_url"])
         .to eq("https://realdomain:8080/facilities/#{facility.url_name}/services/#{product.url_name}/surveys/#{url_service.id}/complete?receiver_id=#{order_detail.id}")

--- a/spec/models/external_service/url_service_spec.rb
+++ b/spec/models/external_service/url_service_spec.rb
@@ -2,47 +2,57 @@ require "rails_helper"
 
 RSpec.describe UrlService do
 
-  subject(:url_service) { described_class.create location: "http://www.survey.com" }
+  let(:url_service) do
+    described_class.create(
+      location: "http://www.survey.com/survey1",
+      default_url_options: { host: "defaulthost"}
+    )
+  end
 
   let(:service) { create :setup_service }
   let(:order) { create :setup_order, product: service }
-  let(:order_detail) { create :order_detail, order: order, product: service }
+  let(:order_detail) { create :order_detail, order: order, product: service, quantity: 3 }
 
-  let(:host_params) do
-    {
-      host: "localhost.test",
-      port: 8080,
-      protocol: "https",
-    }
+  let(:facility) { order_detail.product.facility }
+  let(:product) { order_detail.product }
+
+  let(:query_hash) { Rack::Utils.parse_query(uri.query) }
+  let(:uri) { URI(url_service.new_url(order_detail)) }
+
+  it "uses the service's location as its base" do
+    expect(uri.to_s).to start_with("http://www.survey.com/survey1?")
   end
 
-  let :url_components do
-    {
-      facility_id: order_detail.product.facility.url_name,
-      service_id: order_detail.product.url_name,
-      external_service_id: url_service.id,
-      receiver_id: order_detail.id,
-    }
-  end
+  describe "with a request" do
+    let(:request) { double(host_with_port: "realdomain:8080", fullpath: "/mysite", host: "realdomain", port: 8080, protocol: "https://") }
+    let(:uri) { URI(url_service.new_url(order_detail, request)) }
 
-  describe "with no request" do
-    it "uses the default host, port, and protocol if there is no request" do
-      url_service.default_url_options[:host] = "localhost"
-      complete_survey_url = url_service.complete_survey_url url_components
-      query_string = { quantity: 1, success_url: complete_survey_url, referer: nil, receiver_id: order_detail.id }
-      url = "#{url_service.location}?#{query_string.to_query}"
-      expect(url_service.new_url(order_detail)).to eq url
+    it "sets the correct receiver id" do
+      expect(query_hash["receiver_id"]).to eq(order_detail.id.to_s)
+    end
+
+    it "sets the quantity" do
+      expect(query_hash["quantity"]).to eq("3")
+    end
+
+    it "sets the correct success url" do
+      expect(query_hash["success_url"])
+        .to eq("https://realdomain:8080/facilities/#{facility.url_name}/services/#{product.url_name}/surveys/#{url_service.id}/complete?receiver_id=#{order_detail.id}")
+    end
+
+    it "returns a blank referer" do
+      expect(query_hash["referer"]).to eq("https://realdomain:8080/mysite")
     end
   end
 
-  it "uses the host, port, and protocol of the request" do
-    complete_survey_url = url_service.complete_survey_url url_components.merge(host_params)
-    host_params[:host_with_port] = "#{host_params[:host]}:#{host_params[:port]}"
-    host_params[:fullpath] = "/path/to/somewhere"
-    referer_url = "#{host_params[:protocol]}#{host_params[:host_with_port]}#{host_params[:fullpath]}"
-    query = { quantity: 1, success_url: complete_survey_url, referer: referer_url, receiver_id: order_detail.id }
-    url = "#{url_service.location}?#{query.to_query}"
-    expect(url_service.new_url(order_detail, double(host_params))).to eq url
-  end
+  describe "without a request" do
+    it "sets the correct success url" do
+      expect(query_hash["success_url"])
+        .to eq("http://defaulthost/facilities/#{facility.url_name}/services/#{product.url_name}/surveys/#{url_service.id}/complete?receiver_id=#{order_detail.id}")
+    end
 
+    it "returns a blank referer" do
+      expect(query_hash["referer"]).to be_blank
+    end
+  end
 end


### PR DESCRIPTION
The addition of the `/api/order_details.json?id=123` endpoint and the addition of `order_number` to the order details API are to allow use of the Qualtrics Web Service feature.

The addition of `order_number` to the query string will allow the receiver to use the full order number (e.g. "12345-34521") rather than just the receiver_id ("34521", the order detail id).

I also did some spec refactoring.