### PR TITLE
Rake task for reverting engine migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ exist in the `vendor/engines` directory.
 * [Sanger Sequencing order form and well plate management](vendor/engines/sanger_sequencing/README.md)
 * [Split charges between different accounts](vendor/engines/split_accounts/README.md)
 
+Engine-specific migrations should live in the engine's `db/migrate` directory and
+use an engine initializer to add that path to the list of paths Rails checks. If
+you need to disable an engine, you can undo all of the engine's migrations with
+the `rake engines:db:migrate_down[ENGINE_NAME]` task.
+
 ## Learn more
 
 There are valuable resources in the NUcore's doc directory.

--- a/lib/tasks/engines.rake
+++ b/lib/tasks/engines.rake
@@ -1,0 +1,20 @@
+namespace :engines do
+
+  namespace :db do
+
+    desc "Run `down` for each migration within an engine. Useful when disabling an engine."
+    task :migrate_down, [:engine_name] => :environment do |_t, args|
+      engine_name = args[:engine_name]
+      path = "vendor/engines/#{engine_name}/db/migrate"
+      raise "Invalid engine '#{engine_name}'" unless Dir.exist?(path)
+
+      ActiveRecord::Migrator.migrations(path).reverse.each do |migration|
+        ActiveRecord::Migrator.run(:down, path, migration.version)
+      end
+
+      Rake::Task["db:schema:dump"].invoke
+    end
+
+  end
+
+end


### PR DESCRIPTION
Example: `rake engines:db:migrate_down[projects]`

Conveniently (and honestly a little surprisingly), this will happily run even if the engine is disabled in the Gemfile. 

If the engine is enabled, then following this up with a `db:migrate` should leave the schema in a similar state (column ordering might be different).