### PR TITLE
[#136529] Responsive sanger receipt

### DIFF
--- a/app/assets/javascripts/app/responsive_table.js.coffee
+++ b/app/assets/javascripts/app/responsive_table.js.coffee
@@ -20,7 +20,10 @@ class window.ResponsiveTable
     @table.find("tbody tr").each (index, row) => @add_header_to_row($(row))
 
   add_header_to_row: ($row) ->
-    $row.find("> td").prepend (index) => @responsive_header($row, index)
+    # Only get the immediate child cells of the row. Without the `>`, it could
+    # also find cells in nested tables.
+    cells = $row.find("> td")
+    cells.prepend (index) => @responsive_header($row, index)
 
   responsive_header: ($row, index) ->
     $("<div>").addClass("responsive-header").text(@text_for_header($row, index))

--- a/app/assets/javascripts/app/responsive_table.js.coffee
+++ b/app/assets/javascripts/app/responsive_table.js.coffee
@@ -28,7 +28,7 @@ class window.ResponsiveTable
   responsive_header: ($row, index) ->
     $("<div>").addClass("responsive-header").text(@text_for_header($row, index))
 
-  text_for_header: ($row, index) =>
+  text_for_header: ($row, index) ->
     header = $($row.closest("table").find("thead th").eq(index))
     header.data("mobile-header") || header.text()
 

--- a/app/assets/javascripts/app/responsive_table.js.coffee
+++ b/app/assets/javascripts/app/responsive_table.js.coffee
@@ -20,13 +20,13 @@ class window.ResponsiveTable
     @table.find("tbody tr").each (index, row) => @add_header_to_row($(row))
 
   add_header_to_row: ($row) ->
-    $row.find("td").prepend (index) => @responsive_header(index)
+    $row.find("> td").prepend (index) => @responsive_header($row, index)
 
-  responsive_header: (index) ->
-    $("<div>").addClass("responsive-header").text(@text_for_header(index))
+  responsive_header: ($row, index) ->
+    $("<div>").addClass("responsive-header").text(@text_for_header($row, index))
 
-  text_for_header: (index) =>
-    header = $(@table.find("thead th").eq(index))
+  text_for_header: ($row, index) =>
+    header = $($row.closest("table").find("thead th").eq(index))
     header.data("mobile-header") || header.text()
 
 $ ->

--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -85,10 +85,9 @@ $navbarActiveBorderColor: #aaa;
 
       .responsive-header {
         display: block;
-        position: absolute;
-        left: 6px;
+        float: left;
+        margin-left: -52%;
         width: 30%;
-        padding-right: 10px;
         font-weight: bold;
       }
 

--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -86,7 +86,6 @@ $navbarActiveBorderColor: #aaa;
       .responsive-header {
         display: block;
         position: absolute;
-        top: 6px;
         left: 6px;
         width: 30%;
         padding-right: 10px;
@@ -101,6 +100,10 @@ $navbarActiveBorderColor: #aaa;
 
     th.currency, td.currency {
       text-align: left;
+    }
+
+    caption {
+      display: block;
     }
 
   }

--- a/spec/javascripts/fixtures/nested_table.html
+++ b/spec/javascripts/fixtures/nested_table.html
@@ -1,0 +1,37 @@
+<table class="table" id="outer-table">
+  <thead>
+    <tr>
+      <th data-mobile-header="Invoice #">Invoice Number</th>
+      <th>Facility</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>12</td>
+      <td>Large Hadron Collider</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>
+        <table id="inner-table">
+          <thead>
+            <tr>
+              <th>Inner Header 1</th>
+              <th>Inner Header 2</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Inner Column 1-1</td>
+              <td>Inner Column 1-2</td>
+            </tr>
+            <tr>
+              <td>Inner Column 2-1</td>
+              <td>Inner Column 2-2</td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/spec/javascripts/responsive_tables_spec.coffee
+++ b/spec/javascripts/responsive_tables_spec.coffee
@@ -54,7 +54,3 @@ describe "Responsive table support", ->
       expect($innerTableHeaders.eq(1).text()).toEqual("Inner Header 2")
       expect($innerTableHeaders.eq(2).text()).toEqual("Inner Header 1")
       expect($innerTableHeaders.eq(3).text()).toEqual("Inner Header 2")
-
-
-
-

--- a/spec/javascripts/responsive_tables_spec.coffee
+++ b/spec/javascripts/responsive_tables_spec.coffee
@@ -32,3 +32,29 @@ describe "Responsive table support", ->
     ResponsiveTable.respond()
     expect($("td").eq(2).text()).toEqual(expected)
     expect($("td").eq(3).text()).toEqual("FacilitySmall Hadron Collider")
+
+  describe "when there is a sub-table", ->
+    beforeEach ->
+      loadFixtures("nested_table.html")
+      $(".table").addClass("js--responsive_table")
+      ResponsiveTable.respond()
+
+    it "sets the outer table headers", ->
+      $outerTableHeaders = $("#outer-table > tbody > tr > td > .responsive-header")
+      expect($outerTableHeaders.size()).toEqual(4)
+      expect($outerTableHeaders.eq(0).text()).toEqual("Invoice #")
+      expect($outerTableHeaders.eq(1).text()).toEqual("Facility")
+      expect($outerTableHeaders.eq(2).text()).toEqual("Invoice #")
+      expect($outerTableHeaders.eq(3).text()).toEqual("Facility")
+
+    it "sets the inner table headers", ->
+      $innerTableHeaders = $("#inner-table .responsive-header")
+      expect($innerTableHeaders.size()).toEqual(4)
+      expect($innerTableHeaders.eq(0).text()).toEqual("Inner Header 1")
+      expect($innerTableHeaders.eq(1).text()).toEqual("Inner Header 2")
+      expect($innerTableHeaders.eq(2).text()).toEqual("Inner Header 1")
+      expect($innerTableHeaders.eq(3).text()).toEqual("Inner Header 2")
+
+
+
+


### PR DESCRIPTION
This includes #1100 and #1099.

The main change here is updating the responsive table JS to handle nested tables.

This does some fixing, but I'm wondering if there's a way we can get the height of the row to fit the header if it spans multiple lines. I wasn't having very much luck. I'd rather not use the data attribute with a shorter name, but we could fall back to that if there's no other way.

![screen shot 2017-06-06 at 6 01 00 pm](https://user-images.githubusercontent.com/1099111/26855738-5a501cd2-4ae2-11e7-9dd3-22f7c408c547.png)
