### PR TITLE
[#136550] Journal date search should allow exact match

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -332,11 +332,11 @@ class OrderDetail < ActiveRecord::Base
              .joins("LEFT JOIN statements in_range_statements ON in_range_statements.id = order_details.statement_id")
 
     journal_query = ["journal_id IS NOT NULL"]
-    journal_query << "journal_date > :start_date" if start_date
+    journal_query << "journal_date >= :start_date" if start_date
     journal_query << "journal_date < :end_date" if end_date
 
     statement_query = ["statement_id IS NOT NULL"]
-    statement_query << "in_range_statements.created_at > :start_date" if start_date
+    statement_query << "in_range_statements.created_at >= :start_date" if start_date
     statement_query << "in_range_statements.created_at < :end_date" if end_date
 
     search.where(


### PR DESCRIPTION
Journal dates are always to midnight of the requested date. The search
was doing a `>`, so it was excluding the very beginning of the day. So
if you had a journal date of `2017-06-05 05:00` and you searched
journal date `6/5/2017`-`6/5/2017`, it was being excluded erroneously.

I did add a spec, but the rest is just organization changes.