### PR TITLE
Prevent spurious test failures when factory sequence adds a character

### DIFF
--- a/spec/factories/nufs_accounts.rb
+++ b/spec/factories/nufs_accounts.rb
@@ -1,6 +1,6 @@
 overridable_factory :nufs_account do
-  sequence(:account_number) do |n|
-    "9#{'%02d' % n}-7777777" # fund3-dept7
+  sequence(:account_number, "0000000") do |n|
+    "999-#{n}" # fund3-dept7
   end
 
   sequence(:description, "aaaaaaaa") { |n| "nufs account #{n}" }


### PR DESCRIPTION
Before, we would occasionally get test failures because `"9100-7777777" < "999-7777777"`
when we were dealing with sorting. This will allow us many more before it rolls over
to add an extra character.

NU overrides this factory to do something similar, but abides by its custom
validation rules.

Example of failure, when the test is checking ordering.
```
expected: "nufs account aaaaabml / 91000-7777777"
     got: "nufs account aaaaabmk / 9999-7777777"
```
