### PR TITLE
[#136649] Users unable to tap facilities under "Manage Facilities" on phones

### DIFF
--- a/app/assets/javascripts/app/responsive_dropdown.js.coffee
+++ b/app/assets/javascripts/app/responsive_dropdown.js.coffee
@@ -5,6 +5,6 @@
 #
 
 $ ->
-  $("li.dropdown a").click (e) ->
-    e.stopPropagation();
-    $(this).next('ul.dropdown-menu').css("display", "block");
+  $("li.dropdown a").click (e) =>
+    e.stopPropagation()
+    $(@).next('ul.dropdown-menu').css("display", "block")

--- a/app/assets/javascripts/app/responsive_dropdown.js.coffee
+++ b/app/assets/javascripts/app/responsive_dropdown.js.coffee
@@ -1,0 +1,10 @@
+# Fixes an issue where the navigation dropdown in bootstrap does not
+# work in mobile safari
+# https://stackoverflow.com/questions/17178606/bootstrap-v2-dropdown-navigation-not-working-on-mobile-browsers
+#
+#
+
+$ ->
+  $("li.dropdown a").click (e) ->
+    e.stopPropagation();
+    $(this).next('ul.dropdown-menu').css("display", "block");

--- a/app/views/shared/nav/_manage_facilities.html.haml
+++ b/app/views/shared/nav/_manage_facilities.html.haml
@@ -3,7 +3,7 @@
 
 - elsif !acting_as? && menu_facilities.any?
   %li.dropdown.pull-right{class: controller.active_tab == "manage_facilites" ? "active" : ""}
-    = link_to :list_facilities, class: "dropdown-toggle", data: { toggle: :dropdown } do
+    = link_to "#", class: "dropdown-toggle", data: { toggle: :dropdown, target: "#" } do
       = t("pages.manage", model: t("activerecord.models.facility", count: 2))
       %b.caret
     %ul.dropdown-menu


### PR DESCRIPTION
https://pm.tablexi.com/issues/136649

See https://stackoverflow.com/questions/17178606/bootstrap-v2-dropdown-navigation-not-working-on-mobile-browsers for a description, but this is a bootstrap bug, and short of manipulating the bootsrap source, this seems to be the fix.