### PR TITLE
[#136662] Bundles showing "no current price policies"

### DIFF
--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -1,16 +1,10 @@
 module ProductsHelper
 
   def price_policy_errors(product)
-    @facility_price_groups ||= current_facility.price_groups.count
-    price_policy_count = product.price_policies.current.count
-    error_msg = ""
-    if price_policy_count == 0
+    if product.is_a?(Bundle)
+      error_msg = t("price_policies.errors.missing_for_bundle") if product.products_missing_price_policies.any?
+    elsif product.current_price_policies.none?
       error_msg = t("price_policies.errors.none_exist")
-    elsif price_policy_count < @facility_price_groups
-      # TODO: Add in once products have been updated with the newer can_purchase policies
-      # in the transition, its possible that a group who is restricted from purchasing may not have
-      # a price policy and we don't want to scare people
-      # error_msg = t('price_policies.errors.fewer_than_price_groups')
     end
     content_tag :span, error_msg, class: ["label", "label-important", "pull-right"] if error_msg
   end

--- a/app/models/bundle.rb
+++ b/app/models/bundle.rb
@@ -27,6 +27,10 @@ class Bundle < Product
     end
   end
 
+  def products_missing_price_policies
+    products.select { |p| p.current_price_policies.none? }
+  end
+
   private
 
   def requires_account?

--- a/app/views/bundle_products/edit.html.haml
+++ b/app/views/bundle_products/edit.html.haml
@@ -1,19 +1,17 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 = content_for :sidebar do
-  = render :partial => 'admin/shared/sidenav_product', :locals => { :sidenav_tab => 'bundles' }
+  = render "admin/shared/sidenav_product", sidenav_tab: "bundles"
 = content_for :tabnav do
-  = render :partial => 'admin/shared/tabnav_product', :locals => {:secondary_tab => 'products'}
+  = render "admin/shared/tabnav_product", secondary_tab: "products"
 
-%h2== Edit Bundled Product
-%h3=h @bundle_product.product
+%h2= text("admin.shared.edit", model: BundleProduct.model_name.human)
+%h3= @bundle_product.product
 
-= form_for([current_facility, @bundle, @bundle_product]) do |f|
+= simple_form_for([current_facility, @bundle, @bundle_product]) do |f|
   = f.error_messages
-  %ul.form
-    %li
-      = f.label :quantity, nil, :class => 'require'
-      = f.text_field :quantity
+  .form-inputs
+    = f.input :quantity, required: true
   %ul.inline
-    %li= f.submit 'Save', :class => 'btn'
-    %li= link_to 'Cancel', facility_bundle_bundle_products_path
+    %li= f.submit text("shared.save"), class: "btn btn-primary"
+    %li= link_to text("shared.cancel"), facility_bundle_bundle_products_path

--- a/app/views/bundle_products/index.html.haml
+++ b/app/views/bundle_products/index.html.haml
@@ -36,3 +36,4 @@
             %td= bundle_product.quantity
           - else
             %td= %(#{bundle_product.quantity} (#{link_to text("shared.edit"), edit_facility_bundle_bundle_product_path(current_facility, @bundle, bundle_product)})).html_safe
+          %td= price_policy_errors(product)

--- a/app/views/bundle_products/index.html.haml
+++ b/app/views/bundle_products/index.html.haml
@@ -1,39 +1,38 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 = content_for :sidebar do
-  = render :partial => 'admin/shared/sidenav_product', :locals => { :sidenav_tab => 'bundles' }
+  = render "admin/shared/sidenav_product", sidenav_tab: "bundles"
 = content_for :tabnav do
-  = render :partial => 'admin/shared/tabnav_product', :locals => {:secondary_tab => 'products'}
+  = render "admin/shared/tabnav_product", secondary_tab: "products"
 
+%h2= @bundle
 
-%h2=h @bundle
-
-%p The table below shows the products included in this bundle.
+%p= text("description")
 
 - unless @bundle.products_active?
-  %p.notice No products have been added to the bundle or some of the products added to this bundle are inactive.  Users will be unable to view or purchase this bundle until resolved.
+  %p.notice= text("none_or_inactive")
 
 #admin-subnav
   - if can? :create, BundleProduct
     %ul.inline
-      %li= link_to 'Add Bundled Product', new_facility_bundle_bundle_product_path
+      %li= link_to text("add"), new_facility_bundle_bundle_product_path, class: "btn-add"
 
 - if @bundle_products.empty?
-  %p.notice No products have been added to this bundle.
+  %p.notice= text("none")
 - else
   %table.table.table-striped.table-hover
     %thead
       %tr
         %th
-        %th Product
-        %th Quantity
+        %th= Product.model_name.human
+        %th= Bundle.human_attribute_name(:quantity)
     %tbody
       - @bundle_products.each do |bundle_product|
         - product = bundle_product.product
         %tr
-          %td.centered= link_to 'Remove', facility_bundle_bundle_product_path(current_facility, @bundle, bundle_product), :method => :delete if can? :delete, bundle_product
+          %td.centered= link_to text("shared.remove"), facility_bundle_bundle_product_path(current_facility, @bundle, bundle_product), :method => :delete if can? :delete, bundle_product
           %td= link_to product.to_s_with_status, send("manage_facility_#{product.class.name.downcase}_path", current_facility, product)
           - if product.is_a?(Instrument) or cannot? :edit, bundle_product
-            %td== #{bundle_product.quantity}
+            %td= bundle_product.quantity
           - else
-            %td== #{bundle_product.quantity} (#{link_to 'edit', edit_facility_bundle_bundle_product_path(current_facility, @bundle, bundle_product)})
+            %td= %(#{bundle_product.quantity} (#{link_to text("shared.edit"), edit_facility_bundle_bundle_product_path(current_facility, @bundle, bundle_product)})).html_safe

--- a/app/views/bundle_products/new.html.haml
+++ b/app/views/bundle_products/new.html.haml
@@ -7,20 +7,17 @@
 = content_for :tabnav do
   = render "admin/shared/tabnav_product", secondary_tab: "products"
 
-%h2= t(".head")
+%h2= text("admin.shared.add", model: BundleProduct.model_name.human)
 
-= form_for([current_facility, @bundle, @bundle_product]) do |f|
+= simple_form_for([current_facility, @bundle, @bundle_product]) do |f|
   = f.error_messages
 
-  %ul.form
-    %li
-      = f.label :product_id, nil, class: "require"
-      = f.select :product_id,
-        grouped_options_for_select(@bundle.products_for_group_select, @bundle_product.product_id, prompt: "")
+  .form-inputs
+    = f.label :product_id, nil, class: "require"
+    = f.select :product_id,
+      grouped_options_for_select(@bundle.products_for_group_select, @bundle_product.product_id, prompt: "")
 
-    %li
-      = f.label :quantity, nil, class: "require"
-      = f.text_field :quantity
+    = f.input :quantity, required: true
 
   %ul.inline
     %li= f.submit t("shared.create"), class: "btn"

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -123,6 +123,9 @@ en:
       bundle:
         one: Bundle
         other: Bundles
+      bundle_product:
+        one: Bundled Product
+        other: Bundled Products
       facility:
         one: Facility
         other: Facilities

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -851,6 +851,7 @@ en:
     errors:
       none_exist_for_date: No valid price policies exists for that date.
       none_exist: No current price policies
+      missing_for_bundle: Product missing current price policies
       fewer_than_price_groups: Some price groups are missing price policies
     rate: Rate
 

--- a/config/locales/views/admin/en.bundles.yml
+++ b/config/locales/views/admin/en.bundles.yml
@@ -1,0 +1,8 @@
+en:
+  views:
+    bundle_products:
+      index:
+        none_or_inactive: No products have been added to the bundle or some of the products added to this bundle are inactive. Users will be unable to view or purchase this bundle until resolved.
+        add: Add Bundled Product
+        description: The table below shows the products included in this bundle.
+        none: No products have been added to this bundle.


### PR DESCRIPTION
<img width="641" alt="screen shot 2017-06-13 at 1 45 51 pm" src="https://user-images.githubusercontent.com/1099111/27110594-06dc7b02-5070-11e7-9f1b-2cc121bb1ce4.png">

Show "Product missing current price policies" if one of the bundled products is missing current policies. Do not show anything if all the products have active policies. Show "No current price policies" on the bundle's product list.

![screen shot 2017-06-13 at 7 41 07 pm](https://user-images.githubusercontent.com/1099111/27110636-4a28053e-5070-11e7-9f19-22f8dafbcfe1.png)
![screen shot 2017-06-13 at 7 40 57 pm](https://user-images.githubusercontent.com/1099111/27110637-4a29907a-5070-11e7-855b-80a9c0b9061d.png)

Addresses NU's #134312
