### PR TITLE
[#134974] ensure small bottom margin for side nav

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -46,6 +46,8 @@ nav ul.nav > li:hover {
   @extend .nav;
   @extend .nav-list;
 
+  margin-bottom: 10px;
+
   li {
     line-height: 1.3em;
     &.nav-header {


### PR DESCRIPTION
https://pm.tablexi.com/issues/134974

Aaron requested a small styling change to prevent the invalid payment sources alert from butting up against the sidenav.  We apparently didn't see this in open because of the extra "Projects" search bar which pushed the alert down just enough. The styling change makes no difference to the spacing in open, but fixes the issue on NU.

![screen shot 2017-06-14 at 11 53 10 am](https://user-images.githubusercontent.com/4624197/27144830-f2abf32c-50f8-11e7-8500-be53d25808b7.png)
