### PR TITLE
[#134979] Move new export raw columns to better locations

### DIFF
--- a/app/models/reports/export_raw.rb
+++ b/app/models/reports/export_raw.rb
@@ -60,6 +60,7 @@ module Reports
         owner_last_name: ->(od) { od.account.owner_user.last_name },
         owner_email: ->(od) { od.account.owner_user.email },
         price_group: ->(od) { od.price_policy.try(:price_group).try(:name) },
+        charge_for: ->(od) { ChargeMode.for_order_detail(od).to_s.titleize },
         estimated_cost: ->(od) { as_currency(od.estimated_cost) },
         estimated_subsidy: ->(od) { as_currency(od.estimated_subsidy) },
         estimated_total: ->(od) { as_currency(od.estimated_total) },
@@ -81,11 +82,10 @@ module Reports
         dispute_resolved_reason: :dispute_resolved_reason,
         reviewed_at: :reviewed_at,
         statemented_on: ->(od) { od.statement.created_at if od.statement },
+        invoice_number: ->(od) { od.statement.try(:invoice_number) },
         journal_date: ->(od) { od.journal.journal_date if od.journal },
         reconciled_note: :reconciled_note,
         reconciled_at: :reconciled_at,
-        invoice_number: ->(od) { od.statement.try(:invoice_number) },
-        charge_for: ->(od) { ChargeMode.for_order_detail(od).to_s.titleize },
       }
       if SettingsHelper.has_review_period?
         hash

--- a/vendor/engines/projects/app/models/projects/export_raw_transformer.rb
+++ b/vendor/engines/projects/app/models/projects/export_raw_transformer.rb
@@ -7,7 +7,7 @@ module Projects
     include HashHelper
 
     def transform(original_hash)
-      insert_into_hash_after(original_hash, :price_group, project: :project)
+      insert_into_hash_after(original_hash, :charge_for, project: :project)
     end
 
   end


### PR DESCRIPTION
New columns introduced in https://github.com/tablexi/nucore-open/pull/1104

Per client request:

* Move "Charge For" to just right of "Price Group"
* Move "Invoice Number" to just right of "Statemented On"