### PR TITLE
[#136650] Fix colors in responsive hamburger menu

### DIFF
--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -1,5 +1,6 @@
 /* Bootstrap overrides go here. This is included after bootstrap. */
 $navCollapseBackgroundColor: #f7f7f7;
+$navbarLinkColorActive: #e6e6e6;
 $navCollapseColor: #777;
 $navbarActiveBorderColor: #aaa;
 
@@ -31,11 +32,18 @@ $navbarActiveBorderColor: #aaa;
       `header .navbar .nav > li > a` and `!important` as well as target
       only the .nav-collapse links
   */
-  header .navbar .nav-collapse .nav > li > a, .nav-collapse .dropdown-menu a {
+  header .navbar .nav-collapse .nav > li > a,
+  .nav-collapse .dropdown-menu a {
     color: $navCollapseColor !important;
-    &:hover {
+    background: $navCollapseBackgroundColor;
+
+    &:hover, &:focus {
       color: $navCollapseColor !important;
+      background: $navbarLinkColorActive;
     }
+  }
+  header .navbar .nav-collapse .nav > li.active > a {
+    background: $navbarLinkColorActive;
   }
   header .navbar .nav > li.navbar-text {
     padding: 10px;


### PR DESCRIPTION
Some of these issues are not obvious in open, I've used examples from DC.

* Make sure dropdown menu elements are not a custom color
* Add gray color for hover

## Before:
![screen shot 2017-06-16 at 2 58 05 pm](https://user-images.githubusercontent.com/1099111/27242873-b85316d0-52a4-11e7-8e73-568e963fb94c.png)

### With hover:
![screen shot 2017-06-16 at 2 58 13 pm](https://user-images.githubusercontent.com/1099111/27242878-c0094a66-52a4-11e7-8961-4a028fa36ab9.png)

## After (while hovering on Payment Sources)
![screen shot 2017-06-16 at 2 59 26 pm](https://user-images.githubusercontent.com/1099111/27242882-c55acf94-52a4-11e7-9fc2-e68b81bae522.png)
