### PR TITLE
[#136702] Prevent invalid quantities from cart into Sanger form

### DIFF
--- a/app/assets/javascripts/app/cart.coffee
+++ b/app/assets/javascripts/app/cart.coffee
@@ -4,16 +4,28 @@ class window.CartQuantityReplacer
   toString: ->
     @originalPath.replace(/\bquantity=\d+(&|$)/, "quantity=#{@newQuantity}$1")
 
+class window.Cart
+  constructor: (cartSelector) ->
+    @$cart = $(cartSelector)
+    @$cart.find("[data-quantity-field]").each @setupQuantityListeners
+
+  setupQuantityListeners: (_i, link) ->
+    $link = $(link)
+    $quantityField = $("#" + $(link).data("quantity-field"))
+    originalHref = $link.attr("href")
+
+    $quantityField.change (e) ->
+      newQuantity = parseInt($quantityField.val())
+
+      if newQuantity > 0
+        $link
+          .removeClass("disabled")
+          .attr("href", new CartQuantityReplacer(originalHref, newQuantity))
+
+      else
+        $link
+          .addClass("disabled")
+          .removeAttr("href")
+
 $ ->
-  class Cart
-    constructor: (cartSelector) ->
-      @$cart = $(cartSelector)
-      @$cart.find("[data-quantity-field]").each @setupQuantityListeners
-
-    setupQuantityListeners: (i, link) ->
-      trackedField = $(link).data("quantity-field")
-      $("##{trackedField}").change ->
-        newQuantity = $(@).val()
-        link.href = new CartQuantityReplacer(link.href, newQuantity)
-
   new Cart ".js--cart"

--- a/spec/javascripts/app/cart_spec.coffee
+++ b/spec/javascripts/app/cart_spec.coffee
@@ -1,0 +1,56 @@
+describe "Cart", ->
+  fixture.set '
+    <form class="js--cart">
+      <input id="quantity" value="1">
+      <a id="link" href="?quantity=16" data-quantity-field="quantity">
+    </form>
+  '
+
+  beforeEach ->
+    new Cart ".js--cart"
+
+  describe "changing the quantity", ->
+    it "updates the path for a positive quantity", ->
+      $("#quantity").val("10").trigger("change")
+      expect($("#link").attr("href")).toMatch(/quantity=10$/)
+
+    describe "to a negative value", ->
+      beforeEach ->
+        $("#quantity").val("-10").trigger("change")
+
+      it "unsets the link's href", ->
+        expect($("#link").attr("href")).toBeUndefined()
+
+      it "adds the disabled class", ->
+        expect($("#link").hasClass("disabled")).toBeTruthy()
+
+    describe "to a blank value", ->
+      beforeEach ->
+        $("#quantity").val(" ").trigger("change")
+
+      it "unsets the link's href", ->
+        expect($("#link").attr("href")).toBeUndefined()
+
+      it "adds the disabled class", ->
+        expect($("#link").hasClass("disabled")).toBeTruthy()
+
+    describe "to a non-integer", ->
+      beforeEach ->
+        $("#quantity").val("abc").trigger("change")
+
+      it "unsets the link's href", ->
+        expect($("#link").attr("href")).toBeUndefined()
+
+      it "adds the disabled class", ->
+        expect($("#link").hasClass("disabled")).toBeTruthy()
+
+    describe "to an invalid value and back to valid", ->
+      beforeEach ->
+        $("#quantity").val("-10").trigger("change")
+        $("#quantity").val("17").trigger("change")
+
+      it "sets the link's href", ->
+        expect($("#link").attr("href")).toMatch(/quantity=17$/)
+
+      it "does not have the disabled class", ->
+        expect($("#link").hasClass("disabled")).toBeFalsy()

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
@@ -35,7 +35,9 @@ module SangerSequencing
 
     def create_samples!(quantity)
       quantity = quantity.to_i
-      raise ArgumentError, "quantity must be positive" if quantity <= 0
+      # Always create at least one sample, even if input was invalid
+      quantity = [1, quantity].max
+
       transaction do
         Array.new(quantity) { samples.create! }
       end

--- a/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/submission_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/submission_spec.rb
@@ -6,4 +6,32 @@ RSpec.describe SangerSequencing::Submission do
     submission = described_class.create!(order_detail: order_detail)
     expect(submission.order_detail).to eq(order_detail)
   end
+
+  describe "create_samples!" do
+    let(:submission) { create(:sanger_sequencing_submission) }
+    it "creates a series of samples" do
+      expect { submission.create_samples!(3) }
+        .to change(SangerSequencing::Sample, :count).by(3)
+    end
+
+    it "creates a series of samples from a string" do
+      expect { submission.create_samples!("3") }
+        .to change(SangerSequencing::Sample, :count).by(3)
+    end
+
+    it "creates a single sample if it receives nil" do
+      expect { submission.create_samples!(nil) }
+        .to change(SangerSequencing::Sample, :count).by(1)
+    end
+
+    it "creates a single sample if it receives a negative number" do
+      expect { submission.create_samples!(-1) }
+        .to change(SangerSequencing::Sample, :count).by(1)
+    end
+
+    it "creates a single sample if it receives a negative number as a string" do
+      expect { submission.create_samples!("-12") }
+        .to change(SangerSequencing::Sample, :count).by(1)
+    end
+  end
 end


### PR DESCRIPTION
In the cart, if the user changes the quantity field to be blank or negative and then clicks the "Complete Order Form" we end up passing a blank string or negative number in the quantity query parameter to the Sanger form. This was then triggering an `ArgumentError: quantity must be positive` in `Submission#create_samples!`.

I also tested with decimal numbers. Those were being passed as decimals, but the form was handling that by dropping the fractional part.

This now handles it at both the cart level and the create_samples level. The cart will disable the "Complete Order Form" button if the quantity is not a valid value. If an invalid value does slip through, then the Sanger form will default to having one sample.
