### PR TITLE
[#147374881] Staff should not be allowed to access problem occupancies

### DIFF
--- a/vendor/engines/secure_rooms/app/models/secure_rooms/ability_extension.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/ability_extension.rb
@@ -14,9 +14,14 @@ module SecureRooms
         ability.can [
           :index,
           :dashboard,
+          :tab_counts,
+        ], Occupancy
+      end
+
+      if user.manager_of?(resource)
+        ability.can [
           :show_problems,
           :assign_price_policies_to_problem_orders,
-          :tab_counts,
         ], Occupancy
       end
     end

--- a/vendor/engines/secure_rooms/spec/features/view_facility_occupancies_spec.rb
+++ b/vendor/engines/secure_rooms/spec/features/view_facility_occupancies_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe "Viewing Occupancies" do
   let(:facility) { create(:setup_facility) }
   let(:secure_room) { create(:secure_room, facility: facility) }
-  let(:facility_staff) { create(:user, :staff, facility: facility) }
-  before { login_as facility_staff }
+  let(:facility_director) { create(:user, :facility_director, facility: facility) }
+  before { login_as facility_director }
 
   context "with no in-progress occupancies" do
     it "shows no occupancies" do

--- a/vendor/engines/secure_rooms/spec/models/ability_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/ability_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe Ability do
+  subject(:ability) { Ability.new(user, facility) }
+  let(:facility) { FactoryGirl.create(:facility) }
+
+  describe "facility staff" do
+    let(:user) { FactoryGirl.create(:user, :staff, facility: facility) }
+
+    it_is_allowed_to([:index, :dashboard, :tab_counts], SecureRooms::Occupancy)
+    it_is_not_allowed_to([:show_problems, :assign_price_policies_to_problem_orders], SecureRooms::Occupancy)
+  end
+
+  describe "facility senior staff" do
+    let(:user) { FactoryGirl.create(:user, :senior_staff, facility: facility) }
+
+    it_is_allowed_to([:index, :dashboard, :tab_counts], SecureRooms::Occupancy)
+    it_is_not_allowed_to([:show_problems, :assign_price_policies_to_problem_orders], SecureRooms::Occupancy)
+  end
+
+  describe "facility administrator" do
+    let(:user) { FactoryGirl.create(:user, :facility_administrator, facility: facility) }
+
+    it_is_allowed_to([:index, :dashboard, :tab_counts, :show_problems,
+                      :assign_price_policies_to_problem_orders], SecureRooms::Occupancy)
+  end
+
+  describe "facility director" do
+    let(:user) { FactoryGirl.create(:user, :facility_director, facility: facility) }
+    it_is_allowed_to([:index, :dashboard, :tab_counts, :show_problems,
+                      :assign_price_policies_to_problem_orders], SecureRooms::Occupancy)
+  end
+
+  describe "unprivileged user" do
+    let(:user) { FactoryGirl.create(:user) }
+
+    it_is_not_allowed_to([:index, :dashboard, :tab_counts, :show_problems,
+                          :assign_price_policies_to_problem_orders], SecureRooms::Occupancy)
+  end
+  describe "account manager" do
+    let(:user) { FactoryGirl.create(:user, :account_manager) }
+
+    it_is_not_allowed_to([:index, :dashboard, :tab_counts, :show_problems,
+                          :assign_price_policies_to_problem_orders], SecureRooms::Occupancy)
+  end
+
+  describe "billing admin" do
+    let(:user) { FactoryGirl.create(:user, :billing_administrator) }
+
+    it_is_not_allowed_to([:index, :dashboard, :tab_counts, :show_problems,
+                          :assign_price_policies_to_problem_orders], SecureRooms::Occupancy)
+  end
+
+  describe "global admin" do
+    let(:user) { FactoryGirl.create(:user, :administrator) }
+
+    it_is_allowed_to([:index, :dashboard, :tab_counts, :show_problems,
+                      :assign_price_policies_to_problem_orders], SecureRooms::Occupancy)
+  end
+end


### PR DESCRIPTION
Facility staff and senior staff are not allowed to access problem orders or problem reservations,
so they should not have access to occupancies.