### PR TITLE
[#136705] Disputed orders not displaying in Notices

### DIFF
--- a/app/models/message_summarizer.rb
+++ b/app/models/message_summarizer.rb
@@ -27,7 +27,7 @@ class MessageSummarizer
   end
 
   def visible_tab?
-    visible_summaries.any?
+    messages? || @controller.admin_tab?
   end
 
   def visible_summaries

--- a/app/models/message_summarizer/message_summary.rb
+++ b/app/models/message_summarizer/message_summary.rb
@@ -19,7 +19,7 @@ class MessageSummarizer::MessageSummary
   end
 
   def visible?
-    allowed? && in_context?
+    allowed? && in_context? && any?
   end
 
   private

--- a/app/models/message_summarizer/order_details_in_dispute_summary.rb
+++ b/app/models/message_summarizer/order_details_in_dispute_summary.rb
@@ -3,7 +3,7 @@ class MessageSummarizer::OrderDetailsInDisputeSummary < MessageSummarizer::Facil
   private
 
   def allowed?
-    ability.can?(:disputed_orders, facility)
+    ability.can?(:disputed_orders, Facility)
   end
 
   def get_count

--- a/app/models/message_summarizer/order_details_in_dispute_summary.rb
+++ b/app/models/message_summarizer/order_details_in_dispute_summary.rb
@@ -3,7 +3,7 @@ class MessageSummarizer::OrderDetailsInDisputeSummary < MessageSummarizer::Facil
   private
 
   def allowed?
-    ability.can?(:disputed, Order)
+    ability.can?(:disputed_orders, facility)
   end
 
   def get_count

--- a/app/views/shared/_message_summary.html.haml
+++ b/app/views/shared/_message_summary.html.haml
@@ -10,7 +10,7 @@
             data: { toggle: "dropdown" }
 
           %ul.dropdown-menu
-            - summarizer.select(&:any?).each do |message_summary|
+            - summarizer.each do |message_summary|
               %li= message_summary.link
   - else
     %li.navbar-text= summarizer.tab_label

--- a/spec/models/message_summarizer_spec.rb
+++ b/spec/models/message_summarizer_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe MessageSummarizer do
     before { order_detail.update_attribute(:dispute_at, 1.day.ago) }
 
     context "and the user can access disputed order details" do
-      before { ability.can(:disputed, Order) }
+      before { ability.can(:disputed_orders, Facility) }
 
       context "when in a manager context" do
         let(:admin_tab?) { true }


### PR DESCRIPTION
for facility admins. In the upper right "Notices" dropdown, "Disputed Orders" was no longer appearing.

When we got rid of the separate Disputed tabs on "Orders" and "Reservations". When we did that, we got rid of the permission those tabs were using. https://github.com/tablexi/nucore-open/pull/1059

The first commit is the simple change, but it was clear the way we were testing might have been a little too close to the code itself, which was how we missed the regression. So I started to refactor the specs to use actual users with a role instead of a stubbed ability. This led me to also refactor a little bit of the code itself. I also found were one of the specs was actually incorrect (it wasn't a big deal because it involved the training request feature being disabled, but there being a training request in the db).

For context, see https://github.com/tablexi/nucore-open/commit/bae6e5388ef893c01fcadf1d1bc2e79968225e66 for how this is expected to behave.