### PR TITLE
[#136682] Lost tab when on Bulk Email or Payment Sources tab

### DIFF
--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -91,7 +91,7 @@ class NavTab::LinkCollection
   end
 
   def admin_users
-    if single_facility? && ability.can?(:index, User)
+    if single_facility? && ability.can?(:administer, User)
       NavTab::Link.new(tab: :admin_users, url: facility_users_path(facility))
     end
   end

--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -91,7 +91,7 @@ class NavTab::LinkCollection
   end
 
   def admin_users
-    if single_facility? && ability.can?(:administer, User)
+    if single_facility? && ability.can?(:index, User)
       NavTab::Link.new(tab: :admin_users, url: facility_users_path(facility))
     end
   end

--- a/app/views/admin/shared/_sidenav_users.html.haml
+++ b/app/views/admin/shared/_sidenav_users.html.haml
@@ -1,5 +1,5 @@
 %ul.sidebar-nav
-  - if current_ability.can?(:index, User)
+  - if current_ability.can?(:administer, User)
     = tab t("activerecord.models.user", count: 2), facility_users_path, (sidenav_tab == "users")
 
   = render_view_hook "after_facility_users", sidenav_tab: sidenav_tab

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -138,15 +138,13 @@ class Ability
           fileupload.file_type == "sample_result"
         end
 
-        can [:administer], User
+        can [:index, :administer], User # TODO: Can we get rid of :administer?
 
         if controller.is_a?(UsersController) || controller.is_a?(SearchController)
           can :manage, User
           cannot([:edit, :update], User)
           cannot(:switch_to, User) { |target_user| !target_user.active? }
         end
-
-        can :index, User if controller.is_a?(FacilityUserReservationsController)
 
         can [:list, :dashboard, :show], Facility
         can :act_as, Facility

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -67,7 +67,7 @@ class Ability
       can :manage, [Account, Journal, OrderDetail]
       can [:send_receipt, :show], Order
       if resource == Facility.cross_facility
-        can [:accounts, :index, :orders, :show], User
+        can [:accounts, :index, :orders, :show, :administer], User
       end
       can :manage_users, Facility.cross_facility if SettingsHelper.feature_on?(:billing_administrator_users_tab)
       can :manage_billing, Facility.cross_facility
@@ -138,7 +138,7 @@ class Ability
           fileupload.file_type == "sample_result"
         end
 
-        can [:index, :administer], User # TODO: Can we get rid of :administer?
+        can [:administer], User
 
         if controller.is_a?(UsersController) || controller.is_a?(SearchController)
           can :manage, User


### PR DESCRIPTION
When under the main "Users" tab, if you navigate to the Bulk Email tab or Payment Sources, the "Users" tab in the sidebar goes away. That's because it is checking for `:index, User` on the ability, but the admin is only granted `:administer`.

![screen shot 2017-06-19 at 3 12 04 pm](https://user-images.githubusercontent.com/1099111/27303840-b0fa2e3c-5501-11e7-9430-155b109a30a3.png)

See for reference:
* Changed from using `:administer` to `:index` in `_sidenav_users.html.haml` allowing Business Admins to view the tab in cross facility mode. https://github.com/tablexi/nucore-open/commit/2b73d4fb90ff0ef27f192964ac1fb5c0d18ac99f 
* Added the line around `FacilityUserReservationsController` that I am removing here #961
