### PR TITLE
Remove devise_ldap_authenticatable require

### DIFF
--- a/config/initializers/01_nucore.rb
+++ b/config/initializers/01_nucore.rb
@@ -1,5 +1,4 @@
 require "nucore"
-require "devise_ldap_authenticatable/strategy"
 
 ActiveRecord::Base.class_eval do
   def self.validate_url_name(attr_name, scope = nil)


### PR DESCRIPTION
It now gets included by the ldap_authentication engine. If that gem isn't loaded,
this errors out. This change will be necessary for the non-NU forks to load.