### PR TITLE
[#136391] Restore access to Account Managers to user's payment sources tab

### DIFF
--- a/app/views/admin/shared/_tabnav_users.html.haml
+++ b/app/views/admin/shared/_tabnav_users.html.haml
@@ -13,7 +13,7 @@
       facility_user_reservations_path(current_facility, @user),
       secondary_tab == "reservations"
 
-  - if current_ability.can?(:manage, Account)
+  - if current_ability.can?(:index, Account)
     = tab t(".accounts"),
       facility_user_accounts_path(current_facility, @user),
       secondary_tab == "accounts"


### PR DESCRIPTION
We tried to tighten up the permissions in #1094 so AMs only have the permissions
they need, not full `:manage`. Looks like we missed a spot where we were checking.

Cherry-picked from https://github.com/tablexi/nucore-nu/pull/275