### PR TITLE
[#136759] Cancel on order detail show broken

### DIFF
--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -22,7 +22,9 @@ module ReservationsHelper
   end
 
   def reservation_actions(reservation)
-    ReservationUserActionPresenter.new(self, reservation).user_actions
+    delimiter = "&nbsp;|&nbsp;".html_safe
+    links = ReservationUserActionPresenter.new(self, reservation).user_actions
+    safe_join(links, delimiter)
   end
 
   def reservation_view_edit_link(reservation)

--- a/app/presenters/reservation_user_action_presenter.rb
+++ b/app/presenters/reservation_user_action_presenter.rb
@@ -28,7 +28,8 @@ class ReservationUserActionPresenter
     end
 
     actions << cancel_link if can_cancel?
-    actions.compact.join("&nbsp;|&nbsp;").html_safe
+
+    actions.compact
   end
 
   def view_edit_link

--- a/app/views/order_details/show.html.haml
+++ b/app/views/order_details/show.html.haml
@@ -74,12 +74,7 @@
         %tr
           %td.centered
             - if res
-              - if res.can_switch_instrument_on?
-                = link_to t('reservations.switch.start'), order_order_detail_reservation_switch_instrument_path(@order, @order_detail, res, :switch => 'on')
-              - elsif res.can_switch_instrument_off?
-                = link_to t('reservations.switch.end'), order_order_detail_reservation_switch_instrument_path(@order, @order_detail, res, :switch => 'off'), :class => end_reservation_class(res)
-              - elsif res.can_cancel?
-                = link_to t('.link.reservation.cancel'), "#"
+              = reservation_actions(res)
             - else
               &nbsp;
           %td.centered=h @order_detail.wrapped_quantity

--- a/app/views/order_details/show.html.haml
+++ b/app/views/order_details/show.html.haml
@@ -62,10 +62,10 @@
     %table.table.table-striped.table-hover.old-table.old-table.js--responsive_table
       %thead
         %tr
-          %th.centered= t('.th.action')
-          %th= t('.th.quantity')
-          %th= t('.th.product')
-          %th= t('.th.status')
+          %th.centered= text("views.reservations.my_table.actions")
+          %th= OrderDetail.human_attribute_name(:quantity)
+          %th= OrderDetail.human_attribute_name(:product)
+          %th= OrderDetail.human_attribute_name(:status)
           %th.currency= t('.th.cost')
           - if @order_detail.has_subsidies?
             %th.currency= t('.th.adjust')
@@ -77,7 +77,7 @@
               = reservation_actions(res)
             - else
               &nbsp;
-          %td.centered=h @order_detail.wrapped_quantity
+          %td.centered= @order_detail.wrapped_quantity
           %td.user-order-detail
             .order-detail-description= order_detail_description(@order_detail)
             - if res
@@ -90,22 +90,22 @@
               .order-detail-extra= link_to(t('.link.view.order_form'), @order_detail.external_service_receiver.show_url, :target => '_blank')
             - unless @order_detail.stored_files.template_result.empty?
               .order-detail-extra
-                =link_to t(".link.view.order_file"), order_detail_first_template_result_path(@order_detail)
+                = link_to t(".link.view.order_file"), order_detail_first_template_result_path(@order_detail)
             - unless @order_detail.note.blank?
               .order-detail-extra.order-detail-note= "Note: #{@order_detail.note}"
-          %td=h @order_detail.order_status
+          %td= @order_detail.order_status
           - if @order_detail.cost_estimated?
-            %td.estimated_cost.currency=show_estimated_cost(@order_detail)
+            %td.estimated_cost.currency= show_estimated_cost(@order_detail)
             - if @order_detail.has_subsidies?
-              %td.estimated_cost.currency=show_estimated_subsidy(@order_detail)
-            %td.estimated_cost.currency=show_estimated_total(@order_detail)
+              %td.estimated_cost.currency= show_estimated_subsidy(@order_detail)
+            %td.estimated_cost.currency= show_estimated_total(@order_detail)
           - elsif @order_detail.price_policy.nil?
-            %td{:colspan => 2}= t('.unassigned')
+            %td{ colspan: 2 }= t(".unassigned")
 
           - else
-            %td.actual_cost.currency=show_actual_cost(@order_detail)
+            %td.actual_cost.currency= show_actual_cost(@order_detail)
             - if @order_detail.has_subsidies?
-              %td.actual_cost.currency=show_actual_subsidy(@order_detail)
-            %td.actual_cost.currency=show_actual_total(@order_detail)
+              %td.actual_cost.currency= show_actual_subsidy(@order_detail)
+            %td.actual_cost.currency= show_actual_total(@order_detail)
 
 = render :partial => '/price_display_footnote'

--- a/app/views/order_details/show.html.haml
+++ b/app/views/order_details/show.html.haml
@@ -62,7 +62,8 @@
     %table.table.table-striped.table-hover.old-table.old-table.js--responsive_table
       %thead
         %tr
-          %th.centered= text("views.reservations.my_table.actions")
+          - if res
+            %th.centered= text("views.reservations.my_table.actions")
           %th= OrderDetail.human_attribute_name(:quantity)
           %th= OrderDetail.human_attribute_name(:product)
           %th= OrderDetail.human_attribute_name(:status)
@@ -72,27 +73,20 @@
           %th.currency= t('.th.total')
       %tbody
         %tr
-          %td.centered
-            - if res
-              = reservation_actions(res)
-            - else
-              &nbsp;
+          - if res
+            %td.centered= reservation_actions(res)
           %td.centered= @order_detail.wrapped_quantity
           %td.user-order-detail
             .order-detail-description= order_detail_description(@order_detail)
             - if res
-              .order-detail-extra
-                - if res.can_customer_edit?
-                  = link_to res, edit_order_order_detail_reservation_path(@order, @order_detail, res)
-                - else
-                  = link_to res, order_order_detail_reservation_path(@order, @order_detail, res)
+              .order-detail-extra= reservation_view_edit_link(res)
             - if @order_detail.survey_completed?
               .order-detail-extra= link_to(t('.link.view.order_form'), @order_detail.external_service_receiver.show_url, :target => '_blank')
             - unless @order_detail.stored_files.template_result.empty?
               .order-detail-extra
                 = link_to t(".link.view.order_file"), order_detail_first_template_result_path(@order_detail)
             - unless @order_detail.note.blank?
-              .order-detail-extra.order-detail-note= "Note: #{@order_detail.note}"
+              .order-detail-extra.order-detail-note= render "shared/order_detail_note", order_detail: @order_detail
           %td= @order_detail.order_status
           - if @order_detail.cost_estimated?
             %td.estimated_cost.currency= show_estimated_cost(@order_detail)

--- a/app/views/reservations/_my_table.html.haml
+++ b/app/views/reservations/_my_table.html.haml
@@ -3,7 +3,7 @@
     %tr
       %th.centered= OrderDetail.human_attribute_name(:id)
       %th.centered= text("actions")
-      %th{data: {"mobile-header" => text("short_reservation")}}= text("reservation")
+      %th{ data: { "mobile-header" => text("short_reservation") } }= text("reservation")
       %th.order-note.order-note--wide= OrderDetail.human_attribute_name(:product)
       %th.centered= OrderDetail.human_attribute_name(:status)
       %th.currency= OrderDetail.human_attribute_name(:unassigned_total)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -678,10 +678,6 @@ en:
       submit:
         dispute: "Dispute Purchase"
       th:
-        action: "Action"
-        quantity: "Quantity"
-        product: "Product"
-        status: "Status"
         cost: "Cost"
         adjust: "Adjustment"
         total: "Total"

--- a/spec/presenters/reservation_user_action_presenter_spec.rb
+++ b/spec/presenters/reservation_user_action_presenter_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ReservationUserActionPresenter do
       allow(order_detail).to receive(:reservation).and_return reservation
     end
 
-    subject(:text) { presenter.user_actions }
+    subject(:text) { presenter.user_actions.join("|") }
 
     it "is blank by default" do
       expect(text).to be_blank


### PR DESCRIPTION
The “Cancel” button had been broken since the beginning of git history:
the “Initial Fork”. This uses the same presenter the “My Reservations”
page uses, so we’ll get all the same options.

This also pulls the joining of the actions out into the helper. I
originally did it because I was going to use multi-lines or `ul` in
this view, but decided to stick with the pipe-delimited. I left the
change in because I do think it’s more intuitive if the presenter spits
out an array of links.

This also does some linting, I18n-ing, and other sharing from elsewhere.