### PR TITLE
Disable UnnecessaryStringOutput haml linter

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -3,3 +3,6 @@ inherits_from: .haml-lint_todo.yml
 linters:
   LineLength:
     enabled: false
+
+  UnnecessaryStringOutput:
+    enabled: false


### PR DESCRIPTION
The linter prefers `%p Note: #{order_detail.note}` to `%p= "Note:
#{order_detail.note}”`. We usually go with the latter where the string
interpolation is explicit.

I'm open to debate on this. This can probably wait until Meara is back so she can weigh in on it.