### PR TITLE
[#135577] Update RSpec metadata settings.

### DIFF
--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe Product do
       end
     end
 
-    context "can_purchase?", feature_setting: { user_based_price_groups: true } do
+    context "can_purchase?" do
       class TestPricePolicy < PricePolicy
 
         def rate_field
@@ -222,11 +222,7 @@ RSpec.describe Product do
         @product = TestProduct.create!(facility: @facility, name: "Test Product", url_name: "test")
         @price_group = FactoryGirl.create(:price_group, facility: @facility)
         @price_group2 = FactoryGirl.create(:price_group, facility: @facility)
-        @user = FactoryGirl.create(:user)
-        FactoryGirl.create(:user_price_group_member, user: @user, price_group: @price_group)
-        @user.reload
-
-        @user_price_group_ids = @user.price_groups.map(&:id)
+        @user_price_group_ids = [@price_group]
       end
 
       it "should not be purchasable if it is archived" do
@@ -339,6 +335,7 @@ RSpec.describe Product do
                                                         can_purchase: true)
         expect(@product).not_to be_can_purchase(@user_price_group_ids)
       end
+
       it "should be purchasable if there are no current policies, but two future policies, one of which is purchasable and one is not" do
         expect(@product.current_price_policies).to be_empty
         @price_policy_pg1 = TestPricePolicy.create!(price_group: @price_group,
@@ -351,8 +348,7 @@ RSpec.describe Product do
                                                     start_date: Time.zone.now + 2.days,
                                                     expire_date: Time.zone.now + 4.days + 1.second,
                                                     can_purchase: false)
-        FactoryGirl.create(:user_price_group_member, user: @user, price_group: @price_group2)
-        @user_price_group_ids = @user.reload.price_groups.map(&:id)
+        @user_price_group_ids = [@price_group, @price_group2]
         expect(@product).to be_can_purchase(@user_price_group_ids)
       end
 
@@ -378,8 +374,7 @@ RSpec.describe Product do
                                 start_date: 5.days.ago,
                                 expire_date: 4.days.ago,
                                 can_purchase: false)
-        FactoryGirl.create(:user_price_group_member, user: @user, price_group: @price_group2)
-        @user_price_group_ids = @user.reload.price_groups.map(&:id)
+        @user_price_group_ids = [@price_group, @price_group2]
         expect(@product).not_to be_can_purchase(@user_price_group_ids)
       end
     end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Product do
         @product = TestProduct.create!(facility: @facility, name: "Test Product", url_name: "test")
         @price_group = FactoryGirl.create(:price_group, facility: @facility)
         @price_group2 = FactoryGirl.create(:price_group, facility: @facility)
-        @user_price_group_ids = [@price_group]
+        @price_groups = [@price_group]
       end
 
       it "should not be purchasable if it is archived" do
@@ -240,7 +240,7 @@ RSpec.describe Product do
       end
 
       it "should not be purchasable if there are no pricing rules ever" do
-        expect(@product).not_to be_can_purchase(@user_price_group_ids)
+        expect(@product).not_to be_can_purchase(@price_groups)
       end
 
       it "should not be purchasable if there is no price rule for a user, but there are current price rules" do
@@ -249,7 +249,7 @@ RSpec.describe Product do
                                                 start_date: Time.zone.now - 1.day,
                                                 expire_date: Time.zone.now + 7.days,
                                                 can_purchase: true)
-        expect(@product).not_to be_can_purchase(@user_price_group_ids)
+        expect(@product).not_to be_can_purchase(@price_groups)
       end
 
       it "should be purchasable if there is a current price rule for the user's group" do
@@ -258,7 +258,7 @@ RSpec.describe Product do
                                                 start_date: Time.zone.now - 1.day,
                                                 expire_date: Time.zone.now + 7.days,
                                                 can_purchase: true)
-        expect(@product).to be_can_purchase(@user_price_group_ids)
+        expect(@product).to be_can_purchase(@price_groups)
       end
 
       it "should be purchasable if the user has an expired price rule where they were allowed to purchase" do
@@ -267,7 +267,7 @@ RSpec.describe Product do
                                                 start_date: Time.zone.now - 7.days,
                                                 expire_date: Time.zone.now - 1.day,
                                                 can_purchase: true)
-        expect(@product).to be_can_purchase(@user_price_group_ids)
+        expect(@product).to be_can_purchase(@price_groups)
       end
 
       it "should not be purchasable if there is a current rule, but marked as can_purchase = false" do
@@ -276,7 +276,7 @@ RSpec.describe Product do
                                                 start_date: Time.zone.now - 1.day,
                                                 expire_date: Time.zone.now + 7.days,
                                                 can_purchase: false)
-        expect(@product).not_to be_can_purchase(@user_price_group_ids)
+        expect(@product).not_to be_can_purchase(@price_groups)
       end
 
       it "should not be purchasable if the most recent expired policy is marked can_purchase = false" do
@@ -290,7 +290,7 @@ RSpec.describe Product do
                                                  start_date: Time.zone.now - 5.days,
                                                  expire_date: Time.zone.now + 4.days,
                                                  can_purchase: false)
-        expect(@product).not_to be_can_purchase(@user_price_group_ids)
+        expect(@product).not_to be_can_purchase(@price_groups)
       end
 
       it "should be purchasable if the most recent expired policy is can_purchase, but old ones arent" do
@@ -304,7 +304,7 @@ RSpec.describe Product do
                                                  start_date: Time.zone.now - 5.days,
                                                  expire_date: Time.zone.now + 4.days,
                                                  can_purchase: true)
-        expect(@product).to be_can_purchase(@user_price_group_ids)
+        expect(@product).to be_can_purchase(@price_groups)
       end
 
       it "should be purchasable if there is a current policy with can_purchase, but a future one that cant" do
@@ -319,7 +319,7 @@ RSpec.describe Product do
                                                         expire_date: Time.zone.now + 4.days,
                                                         can_purchase: false)
         expect(@product.current_price_policies).to eq([@current_price_policy])
-        expect(@product).to be_can_purchase(@user_price_group_ids)
+        expect(@product).to be_can_purchase(@price_groups)
       end
 
       it "should not be purchasable if there is a current policy without can_purchase, but a future one that can" do
@@ -333,7 +333,7 @@ RSpec.describe Product do
                                                         start_date: Time.zone.now + 2.days,
                                                         expire_date: Time.zone.now + 4.days,
                                                         can_purchase: true)
-        expect(@product).not_to be_can_purchase(@user_price_group_ids)
+        expect(@product).not_to be_can_purchase(@price_groups)
       end
 
       it "should be purchasable if there are no current policies, but two future policies, one of which is purchasable and one is not" do
@@ -348,8 +348,8 @@ RSpec.describe Product do
                                                     start_date: Time.zone.now + 2.days,
                                                     expire_date: Time.zone.now + 4.days + 1.second,
                                                     can_purchase: false)
-        @user_price_group_ids = [@price_group, @price_group2]
-        expect(@product).to be_can_purchase(@user_price_group_ids)
+        @price_groups = [@price_group, @price_group2]
+        expect(@product).to be_can_purchase(@price_groups)
       end
 
       it "should not be purchasable if there are no current policies, and most recent for each group cannot can_purchase" do
@@ -374,8 +374,8 @@ RSpec.describe Product do
                                 start_date: 5.days.ago,
                                 expire_date: 4.days.ago,
                                 can_purchase: false)
-        @user_price_group_ids = [@price_group, @price_group2]
-        expect(@product).not_to be_can_purchase(@user_price_group_ids)
+        @price_groups = [@price_group, @price_group2]
+        expect(@product).not_to be_can_purchase(@price_groups)
       end
     end
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe Product do
 
         @user_price_group_ids = @user.price_groups.map(&:id)
       end
-      
+
       it "should not be purchasable if it is archived" do
         @product.update_attributes is_archived: true
         expect(@product).not_to be_available_for_purchase

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,34 +40,38 @@ RSpec.describe User do
     it "default has the base price group" do
       expect(user.price_groups).to eq [PriceGroup.base]
     end
+
     it "external user has external price group" do
       external_user = FactoryGirl.create(:user, :external)
       expect(external_user.price_groups).to eq [PriceGroup.external]
     end
   end
 
-  it "is a member of any explicitly mapped price groups" do
-    pg = FactoryGirl.create(:price_group, facility: facility)
-    UserPriceGroupMember.create(user: user, price_group: pg)
-    expect(user.price_groups.include?(pg)).to eq(true)
-  end
+  describe "price groups", feature_setting: { user_based_price_groups: true } do
 
-  it "belongs to price groups of accounts" do
-    cc = create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: user))
-    pg = FactoryGirl.create(:price_group, facility: facility)
-    AccountPriceGroupMember.create(account: cc, price_group: pg)
-    expect(user.account_price_groups.include?(pg)).to be true
-  end
+    it "is a member of any explicitly mapped price groups" do
+      pg = FactoryGirl.create(:price_group, facility: facility)
+      UserPriceGroupMember.create(user: user, price_group: pg)
+      expect(user.price_groups.include?(pg)).to eq(true)
+    end
 
-  it "belongs to price groups of the account owner" do
-    owner = create(:user)
-    cc = create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: owner))
-    pg = FactoryGirl.create(:price_group, facility: facility)
-    UserPriceGroupMember.create(user: owner, price_group: pg)
+    it "belongs to price groups of accounts" do
+      cc = create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: user))
+      pg = FactoryGirl.create(:price_group, facility: facility)
+      AccountPriceGroupMember.create(account: cc, price_group: pg)
+      expect(user.account_price_groups.include?(pg)).to be true
+    end
 
-    cc.account_users.create(user: user, created_by: owner.id, user_role: "Purchaser")
+    it "belongs to price groups of the account owner" do
+      owner = create(:user)
+      cc = create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: owner))
+      pg = FactoryGirl.create(:price_group, facility: facility)
+      UserPriceGroupMember.create(user: owner, price_group: pg)
 
-    expect(user.account_price_groups.include?(pg)).to be true
+      cc.account_users.create(user: user, created_by: owner.id, user_role: "Purchaser")
+
+      expect(user.account_price_groups.include?(pg)).to be true
+    end
   end
 
   it { is_expected.to be_authenticated_locally }


### PR DESCRIPTION
Per https://github.com/tablexi/nucore-dartmouth/pull/104 some tests were
dependent on the `user_based_price_groups` setting, while I was there,
cleaned up some settings changes to use metadata