### PR TITLE
[#125709] Show post-complete badges for account admins

### DIFF
--- a/app/helpers/facility_orders_helper.rb
+++ b/app/helpers/facility_orders_helper.rb
@@ -4,6 +4,11 @@ module FacilityOrdersHelper
     OrderDetailNoticePresenter.new(order_detail).badges_to_html
   end
 
+  def order_detail_status_badges(order_detail)
+    # Only return status badges, no warning (problem order) badges
+    OrderDetailNoticePresenter.new(order_detail).badges_to_html(only: :status)
+  end
+
   def banner_date_label(object, field, label = nil)
     banner_label(object, field, label) do |value|
       value = human_datetime value

--- a/app/helpers/facility_orders_helper.rb
+++ b/app/helpers/facility_orders_helper.rb
@@ -1,26 +1,7 @@
 module FacilityOrdersHelper
 
-  def order_detail_notices(order_detail)
-    notices = []
-
-    notices << "in_review" if order_detail.in_review?
-    # notices << 'reviewed' if order_detail.reviewed?
-    notices << "in_dispute" if order_detail.in_dispute?
-    notices << "can_reconcile" if order_detail.can_reconcile_journaled?
-    notices << "in_open_journal" if order_detail.in_open_journal?
-
-    warnings = Array(order_detail.problem_description_key)
-
-    { warnings: warnings, notices: notices }
-  end
-
   def order_detail_badges(order_detail)
-    notices = order_detail_notices(order_detail)
-
-    output = build_badges(notices[:notices], "label-info")
-    output += build_badges(notices[:warnings], "label-important")
-
-    safe_join(output)
+    OrderDetailNoticePresenter.new(order_detail).badges_to_html
   end
 
   def banner_date_label(object, field, label = nil)
@@ -39,14 +20,6 @@ module FacilityOrdersHelper
         content_tag(:dt, label || object.class.human_attribute_name(field)) +
           content_tag(:dd, value)
       end
-    end
-  end
-
-  private
-
-  def build_badges(notices, label_class)
-    notices.map do |notice|
-      content_tag(:span, t("order_details.notices.#{notice}.badge"), class: ["label", label_class])
     end
   end
 

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -1,0 +1,61 @@
+class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
+
+  include ActionView::Helpers::OutputSafetyHelper
+
+  def statuses
+    [].tap do |statuses|
+      statuses << Notice.new(:in_review) if in_review?
+      statuses << Notice.new(:in_dispute) if in_dispute?
+      statuses << Notice.new(:can_reconcile) if can_reconcile_journaled?
+      statuses << Notice.new(:in_open_journal) if in_open_journal?
+    end
+  end
+
+  def warnings
+    [].tap do |warnings|
+      warnings << Notice.new(problem_description_key, :warning) if problem?
+    end
+  end
+
+  def notices
+    statuses + warnings
+  end
+
+  def badges_to_html
+    safe_join(notices.map(&:badge_to_html))
+  end
+
+  # Not meant to be used outside the presenter class
+  class Notice
+
+    include ActionView::Helpers::TagHelper
+
+    def initialize(key, severity = :status)
+      @key = key
+      @severity = severity
+    end
+
+    def badge_text
+      I18n.t("order_details.notices.#{@key}.badge")
+    end
+
+    def alert_text
+      I18n.t("order_details.notices.#{@key}.alert")
+    end
+
+    def badge_to_html
+      content_tag(:span, badge_text, class: ["label", label_class])
+    end
+
+    private
+
+    def label_class
+      {
+        status: "label-info",
+        warning: "label-important",
+      }.fetch(@severity)
+    end
+
+  end
+
+end

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -22,8 +22,11 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
     statuses + warnings
   end
 
-  def badges_to_html
-    safe_join(notices.map(&:badge_to_html))
+  # Filter to only status or warnings by passing `only: :status` or `only: :warning`
+  def badges_to_html(only: [:status, :warning])
+    filtered = notices.select { |notice| Array(only).include?(notice.severity) }
+
+    safe_join(filtered.map(&:badge_to_html))
   end
 
   def alerts_to_html
@@ -48,6 +51,8 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
   class Notice
 
     include ActionView::Helpers::TagHelper
+
+    attr_reader :severity
 
     def initialize(key, severity = :status)
       @key = key

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -1,5 +1,6 @@
 class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
 
+  include ActionView::Helpers::TagHelper
   include ActionView::Helpers::OutputSafetyHelper
 
   def statuses
@@ -23,6 +24,24 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
 
   def badges_to_html
     safe_join(notices.map(&:badge_to_html))
+  end
+
+  def alerts_to_html
+    blocks = [
+      build_alert(warnings, "error"),
+      build_alert(statuses, "info"),
+    ].compact
+
+    safe_join(blocks)
+  end
+
+  private
+
+  def build_alert(notices, severity_class)
+    return if notices.none?
+
+    text = safe_join(notices.map(&:alert_text), content_tag(:br))
+    content_tag(:div, text, class: ["alert", "alert-#{severity_class}"])
   end
 
   # Not meant to be used outside the presenter class

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -4,18 +4,22 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
   include ActionView::Helpers::OutputSafetyHelper
 
   def statuses
-    [].tap do |statuses|
-      statuses << Notice.new(:in_review) if in_review?
-      statuses << Notice.new(:in_dispute) if in_dispute?
-      statuses << Notice.new(:can_reconcile) if can_reconcile_journaled?
-      statuses << Notice.new(:in_open_journal) if in_open_journal?
-    end
+    statuses = []
+
+    statuses << Notice.new(:in_review) if in_review?
+    statuses << Notice.new(:in_dispute) if in_dispute?
+    statuses << Notice.new(:can_reconcile) if can_reconcile_journaled?
+    statuses << Notice.new(:in_open_journal) if in_open_journal?
+
+    statuses
   end
 
   def warnings
-    [].tap do |warnings|
-      warnings << Notice.new(problem_description_key, :warning) if problem?
-    end
+    warnings = []
+
+    warnings << Notice.new(problem_description_key, :warning) if problem?
+
+    warnings
   end
 
   def notices

--- a/app/views/order_details/show.html.haml
+++ b/app/views/order_details/show.html.haml
@@ -87,7 +87,9 @@
                 = link_to t(".link.view.order_file"), order_detail_first_template_result_path(@order_detail)
             - unless @order_detail.note.blank?
               .order-detail-extra.order-detail-note= render "shared/order_detail_note", order_detail: @order_detail
-          %td= @order_detail.order_status
+          %td
+            = @order_detail.order_status
+            = order_detail_status_badges(@order_detail)
           - if @order_detail.cost_estimated?
             %td.estimated_cost.currency= show_estimated_cost(@order_detail)
             - if @order_detail.has_subsidies?

--- a/app/views/order_management/order_details/_warnings.html.haml
+++ b/app/views/order_management/order_details/_warnings.html.haml
@@ -1,13 +1,12 @@
-- notices = order_detail_notices(@order_detail)
-- if notices[:warnings].any?
-  .alert.alert-error
-    - notices[:warnings].each do |warning|
-      = t("order_details.notices.#{warning}.alert")
+- presenter = OrderDetailNoticePresenter.new(@order_detail)
 
-- if notices[:notices].any?
+- if presenter.warnings.any?
+  .alert.alert-error
+    = safe_join(presenter.warnings.map(&:alert_text), content_tag(:br))
+
+- if presenter.statuses.any?
   .alert.alert-info
-    - notices[:notices].each do |notice|
-      = t("order_details.notices.#{notice}.alert")
+    = safe_join(presenter.statuses.map(&:alert_text), content_tag(:br))
 
 - if @order_detail.errors.any?
   .alert.alert-error

--- a/app/views/order_management/order_details/_warnings.html.haml
+++ b/app/views/order_management/order_details/_warnings.html.haml
@@ -1,12 +1,4 @@
-- presenter = OrderDetailNoticePresenter.new(@order_detail)
-
-- if presenter.warnings.any?
-  .alert.alert-error
-    = safe_join(presenter.warnings.map(&:alert_text), content_tag(:br))
-
-- if presenter.statuses.any?
-  .alert.alert-info
-    = safe_join(presenter.statuses.map(&:alert_text), content_tag(:br))
+= OrderDetailNoticePresenter.new(@order_detail).alerts_to_html
 
 - if @order_detail.errors.any?
   .alert.alert-error

--- a/app/views/shared/_problem_order_details.html.haml
+++ b/app/views/shared/_problem_order_details.html.haml
@@ -29,7 +29,7 @@
         %td= order_detail_description(order_detail)
         %td= order_detail.account
         %td.centered
-          = OrderDetailNoticePresenter.new(order_detail).badges_to_html
+          = order_detail_badges(order_detail)
           = link_to text("shared.update"), manage_order_detail_path(order_detail), class: "manage-order-detail"
 
 = will_paginate(@order_details)

--- a/app/views/shared/_problem_order_details.html.haml
+++ b/app/views/shared/_problem_order_details.html.haml
@@ -29,7 +29,7 @@
         %td= order_detail_description(order_detail)
         %td= order_detail.account
         %td.centered
-          = t("order_details.notices.#{order_detail.problem_description_key}.badge")
+          = OrderDetailNoticePresenter.new(order_detail).badges_to_html
           = link_to text("shared.update"), manage_order_detail_path(order_detail), class: "manage-order-detail"
 
 = will_paginate(@order_details)

--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -60,7 +60,9 @@
         %td.currency
           - order_detail.send(:extend, PriceDisplayment)
           = order_detail.wrapped_total
-        %td.nowrap= order_detail.order_status
+        %td.nowrap
+          = order_detail.order_status
+          = order_detail_status_badges(order_detail)
         - if local_assigns[:show_statements]
           %td= link_to "Download", account_statement_path(@account, order_detail.statement_id, format: :pdf) if order_detail.statement
 = will_paginate(order_details) if order_details.respond_to? :total_pages

--- a/spec/presenters/order_detail_notice_presenter_spec.rb
+++ b/spec/presenters/order_detail_notice_presenter_spec.rb
@@ -1,0 +1,125 @@
+require "rails_helper"
+
+RSpec.describe OrderDetailNoticePresenter do
+  let(:order_detail) { OrderDetail.new(note: "Treat me like a double") }
+  let(:presenter) { described_class.new(order_detail) }
+
+  describe "badges_to_html" do
+    matcher :have_badge do |expected_text|
+      match do |string|
+        level = @level || "info"
+        html = Nokogiri::HTML(string)
+        @element = html.css(".label.label-#{level}").any? { |node| node.text == expected_text }
+      end
+
+      chain :with_level do |level|
+        @level = level
+      end
+    end
+
+    it "shows nothing for a blank order detail" do
+      expect(presenter.badges_to_html).to be_blank
+    end
+
+    it "shows in review if the order is in review" do
+      allow(order_detail).to receive(:in_review?).and_return(true)
+      expect(presenter.badges_to_html).to have_badge("In Review")
+    end
+
+    it "shows in dispute" do
+      allow(order_detail).to receive(:in_dispute?).and_return(true)
+      expect(presenter.badges_to_html).to have_badge("In Dispute")
+    end
+
+    it "shows can reconcile" do
+      allow(order_detail).to receive(:can_reconcile_journaled?).and_return(true)
+      expect(presenter.badges_to_html).to have_badge("Can Reconcile")
+    end
+
+    it "shows in open journal" do
+      allow(order_detail).to receive(:in_open_journal?).and_return(true)
+      expect(presenter.badges_to_html).to have_badge("Open Journal")
+    end
+
+    it "shows an important badge for a problem order" do
+      allow(order_detail).to receive_messages(problem?: true, problem_description_key: :missing_price_policy)
+      expect(presenter.badges_to_html).to have_badge("Missing Price Policy").with_level(:important)
+    end
+
+    it "can have multiple badges" do
+      # These examples are technically mutually exclusive, but this validates the
+      # presenter can handle it.
+      allow(order_detail).to receive_messages(
+        problem?: true,
+        problem_description_key: :missing_price_policy,
+        in_review?: true,
+        in_dispute?: true,
+      )
+
+      html = presenter.badges_to_html
+      expect(html).to have_badge("Missing Price Policy").with_level(:important)
+      expect(html).to have_badge("In Review")
+      expect(html).to have_badge("In Dispute")
+    end
+  end
+
+  describe "alerts_to_html" do
+    matcher :have_alert do |expected_text|
+      match do |string|
+        level = @level || "info"
+        html = Nokogiri::HTML(string)
+        html.at_css(".alert.alert-#{level}").text.match(expected_text)
+      end
+
+      chain :with_level do |level|
+        @level = level
+      end
+    end
+
+    it "shows nothing with no warnings/info" do
+      expect(presenter.alerts_to_html).to be_blank
+    end
+
+    it "shows in review if the order is in review" do
+      allow(order_detail).to receive(:in_review?).and_return(true)
+      expect(presenter.alerts_to_html).to have_alert(/in review/)
+    end
+
+    it "shows in dispute" do
+      allow(order_detail).to receive(:in_dispute?).and_return(true)
+      expect(presenter.alerts_to_html).to have_alert(/Resolve Dispute/)
+    end
+
+    it "shows can reconcile" do
+      allow(order_detail).to receive(:can_reconcile_journaled?).and_return(true)
+      expect(presenter.alerts_to_html).to have_alert(/can be reconciled/)
+    end
+
+    it "shows in open journal" do
+      allow(order_detail).to receive(:in_open_journal?).and_return(true)
+      expect(presenter.alerts_to_html).to have_alert(/pending journal/)
+    end
+
+    it "shows an important badge for a problem order" do
+      allow(order_detail).to receive_messages(problem?: true, problem_description_key: :missing_price_policy)
+      expect(presenter.alerts_to_html).to have_alert(/does not have a price policy/).with_level(:error)
+    end
+
+    it "can have multiple badges" do
+      # These examples are technically mutually exclusive, but this validates the
+      # presenter can handle it.
+      allow(order_detail).to receive_messages(
+        problem?: true,
+        problem_description_key: :missing_price_policy,
+        in_review?: true,
+        in_dispute?: true,
+      )
+
+      html = presenter.alerts_to_html
+      expect(html).to have_alert(/does not have a price policy/).with_level(:error)
+      expect(html).to have_alert(/in review/)
+      expect(html).to have_alert(/resolve dispute/i)
+    end
+  end
+
+end


### PR DESCRIPTION
Adds blue status badges to a couple views under "My Payment Sources" so that account managers and PIs can see the status beyond "complete".

* "In Review"
* "Open Journal"
* "Can Reconcile"
* "In Open Journal"

These badges were already being used on the facility's Order#show view. They are now available on the "Transaction History" and OrderDetail#show views.
![transaction history](https://user-images.githubusercontent.com/1099111/27408732-b6cbb72e-56a3-11e7-9827-e47415d8eb8b.png)
![order detail show](https://user-images.githubusercontent.com/1099111/27408731-b6cb0b30-56a3-11e7-8c57-9fc859c73c18.png)

Since the transaction history table partial is shared with the billing tab, these badges are now available there as well.
![billing tab](https://user-images.githubusercontent.com/1099111/27408754-d672b0aa-56a3-11e7-9ffb-523c47c7f3b6.png)

In order to DRY some things up, this changes the problem column of the problem orders tabs into badges.

![problem orders](https://user-images.githubusercontent.com/1099111/27408766-ece3363e-56a3-11e7-99b1-3dc5a2cda21a.png)

I currently have some questions out to the client confirming this behavior is all correct and acceptable.





