### PR TITLE
[#134004] Remove order notification hint from facility edit

### DIFF
--- a/app/views/facilities/_facility_fields.html.haml
+++ b/app/views/facilities/_facility_fields.html.haml
@@ -27,4 +27,4 @@
 
 .well
   %p= text(".order_notification")
-  = f.input :order_notification_recipient, hint: f.object.email
+  = f.input :order_notification_recipient


### PR DESCRIPTION
> The primary facility email address appears in the bottom section, under the "Order notification recipient" entry box. See attachment: Facility Email in Edit Mode. It needs to be removed.

![facility email in edit mode](https://user-images.githubusercontent.com/1099111/27499325-ddb5c42a-5828-11e7-8602-9637700515f8.png)
