### PR TITLE
[#136008] Use facility abbreviation in bulk email subject

### DIFF
--- a/spec/lib/nav_tab/link_spec.rb
+++ b/spec/lib/nav_tab/link_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe NavTab::Link do
-  include TextHelpers::RSpec::TestHelpers
-
   let(:cross_facility) { false }
   let(:link) do
     described_class.new(

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -106,6 +106,8 @@ RSpec.configure do |config|
 
   require "text_helpers/rspec"
 
+  config.include TextHelpers::RSpec::TestHelpers, locales: true
+
   config.before(:suite) do
     TextHelpers::RSpec.setup_spec_translations
   end

--- a/vendor/engines/bulk_email/app/services/bulk_email/content_generator.rb
+++ b/vendor/engines/bulk_email/app/services/bulk_email/content_generator.rb
@@ -2,6 +2,8 @@ module BulkEmail
 
   class ContentGenerator
 
+    include TextHelpers::Translation
+
     DEFAULT_RECIPIENT_NAME = "Firstname Lastname".freeze
 
     attr_reader :facility, :subject_product
@@ -13,9 +15,9 @@ module BulkEmail
 
     def subject_prefix
       if facility.single_facility?
-        "[#{I18n.t('app_name')} #{facility.name}]"
+        text("subject_prefix_with_facility", name: facility.name, abbreviation: facility.abbreviation)
       else
-        "[#{I18n.t('app_name')}]"
+        text("subject_prefix")
       end
     end
 
@@ -25,15 +27,19 @@ module BulkEmail
 
     def greeting(recipient_name = nil)
       [
-        I18n.t("bulk_email.body.greeting", recipient_name: recipient_name || DEFAULT_RECIPIENT_NAME),
+        text("body.greeting", recipient_name: recipient_name || DEFAULT_RECIPIENT_NAME),
         reason_statement,
       ].compact.join("\n\n")
     end
 
     def signoff
       if facility.single_facility?
-        I18n.t("bulk_email.body.signoff", facility_name: facility.name)
+        text("body.signoff", facility_name: facility.name)
       end
+    end
+
+    def translation_scope
+      "bulk_email"
     end
 
     private

--- a/vendor/engines/bulk_email/config/locales/en.yml
+++ b/vendor/engines/bulk_email/config/locales/en.yml
@@ -25,6 +25,8 @@ en:
     no_results: No users found
     compose_mail: Compose Mail
     export: Export
+    subject_prefix: "[!app_name!]"
+    subject_prefix_with_facility: "[!app_name! %{abbreviation}]"
     body:
       greeting: Hello %{recipient_name},
       signoff: If you have any questions, please contact %{facility_name}.

--- a/vendor/engines/bulk_email/spec/services/bulk_email/content_generator_spec.rb
+++ b/vendor/engines/bulk_email/spec/services/bulk_email/content_generator_spec.rb
@@ -44,10 +44,17 @@ RSpec.describe BulkEmail::ContentGenerator do
   end
 
   describe "#subject_prefix" do
-    context "when in a single-facility context" do
-      it "includes the app and facility names" do
+    context "when in a single-facility context", :locales do
+      before do
+        set_translation("bulk_email.subject_prefix_with_facility",
+                        "[!app_name! %{name} (%{abbreviation})]")
+      end
+
+      it "includes the app, facility name, and abbreviation" do
         expect(subject.subject_prefix)
-          .to eq("[#{I18n.t('app_name')} #{facility.name}]")
+          .to include(I18n.t("app_name"))
+          .and include(facility.name)
+          .and include(facility.abbreviation)
       end
     end
 


### PR DESCRIPTION
The default will now be `[NUcore EF]` instead of `[NUcore Example Facility]` as the subject prefix because many facilities have very long names.

I am passing both the name and abbreviation to the locale so a fork can easily
override it and revert back if they want.