### PR TITLE
Avoid constantly looking up `User#user_roles`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ActiveRecord::Base
   has_many :notifications
   has_many :products, through: :product_users
   has_many :assigned_order_details, class_name: "OrderDetail", foreign_key: "assigned_user_id"
-  has_many :user_roles, dependent: :destroy
+  has_many :user_roles, -> { extending UserRole::AssociationExtension }, dependent: :destroy
   has_many :facilities, through: :user_roles
   has_many :training_requests, dependent: :destroy
   has_many :stored_files, through: :order_details, class_name: "StoredFile"

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -11,6 +11,16 @@ class UserRole < ActiveRecord::Base
   FACILITY_STAFF = "Facility Staff".freeze
   FACILITY_SENIOR_STAFF = "Facility Senior Staff".freeze
 
+  module AssociationExtension
+    def operator?(facility)
+      any? { |ur| ur.facility == facility && ur.in?(facility_roles) }
+    end
+
+    def manager?(facility)
+      any? { |ur| ur.facility == facility && ur.in?(facility_management_roles) }
+    end
+  end
+
   def self.account_manager
     [ACCOUNT_MANAGER]
   end
@@ -45,14 +55,6 @@ class UserRole < ActiveRecord::Base
 
   def self.global
     where(role: global_roles)
-  end
-
-  def self.operator?(facility)
-    any? { |ur| ur.facility == facility && ur.in?(facility_roles) }
-  end
-
-  def self.manager?(facility)
-    any? { |ur| ur.facility == facility && ur.in?(facility_management_roles) }
   end
 
   #

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -12,6 +12,7 @@ class UserRole < ActiveRecord::Base
   FACILITY_SENIOR_STAFF = "Facility Senior Staff".freeze
 
   module AssociationExtension
+
     def operator?(facility)
       any? { |ur| ur.facility == facility && ur.in?(facility_roles) }
     end
@@ -19,6 +20,7 @@ class UserRole < ActiveRecord::Base
     def manager?(facility)
       any? { |ur| ur.facility == facility && ur.in?(facility_management_roles) }
     end
+
   end
 
   def self.account_manager


### PR DESCRIPTION
While these methods were on UserRole itself, the results of `User#user_roles`
were not being memoized. It would hit the cache, but on some pages this would still
slow things down noticeably.