### PR TITLE
[#136823] Instrument util report errors on problem reservation

### DIFF
--- a/app/models/reports/instrument_utilization_report.rb
+++ b/app/models/reports/instrument_utilization_report.rb
@@ -53,7 +53,7 @@ class Reports::InstrumentUtilizationReport
     def +(other)
       DataRow.new(quantity + other.quantity,
                   reserved_mins + other.reserved_mins,
-                  actual_mins + other.actual_mins)
+                  actual_mins + other.actual_mins.to_f)
     end
 
     def /(other)

--- a/spec/models/reports/instrument_utilization_report_spec.rb
+++ b/spec/models/reports/instrument_utilization_report_spec.rb
@@ -42,4 +42,15 @@ RSpec.describe Reports::InstrumentUtilizationReport do
       expect(rows[1]).to eq([product2.name, "2", 1.2, "40.0%", 0, "0.0%"])
     end
   end
+
+  describe "with a problem reservation" do
+    let(:reservations) do
+      build_stubbed_list(:reservation, 3, duration_mins: 30,
+      actual_start_at: 1.hour.ago, actual_end_at: nil, product: product)
+    end
+
+    it "has the correct row" do
+      expect(report.rows[0]).to eq([product.name, "3", 1.5, "100.0%", 0, "0.0%"])
+    end
+  end
 end

--- a/spec/models/reports/instrument_utilization_report_spec.rb
+++ b/spec/models/reports/instrument_utilization_report_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Reports::InstrumentUtilizationReport do
   describe "with a problem reservation" do
     let(:reservations) do
       build_stubbed_list(:reservation, 3, duration_mins: 30,
-      actual_start_at: 1.hour.ago, actual_end_at: nil, product: product)
+                                          actual_start_at: 1.hour.ago, actual_end_at: nil, product: product)
     end
 
     it "has the correct row" do


### PR DESCRIPTION
When a problem reservation is missing its end time this report errors. The error
manifests when a problem reservation's fulfilled_at falls into the "Fulfilled between"
range.

```
nil can't be coerced into Fixnum
  app/models/reports/instrument_utilization_report.rb:56:in `+'
```