### PR TITLE
[#136836/#136829] 500 when reservation has `:base` errors

### DIFF
--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -115,8 +115,9 @@ class OrderDetails::ParamUpdater
 
   # Occupancies use accepts_nested_attributes which handles this.
   def merge_reservation_errors
-    @order_detail.reservation.errors.each do |error, message|
-      @order_detail.errors.add(Reservation.human_attribute_name(error), message)
+    @order_detail.reservation.errors.each do |field, message|
+      field = Reservation.human_attribute_name(field) if field != :base
+      @order_detail.errors.add(field, message)
     end
   end
 

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -2,7 +2,7 @@
     url: manage_facility_order_order_detail_path(current_facility, @order, @order_detail),
     remote: modal?,
     html: { class: ["manage_order_detail", edit_disabled? ? "disabled" : ""] } do |f|
-  = f.input :editing_time_data, value: true, as: :hidden
+  = f.input :editing_time_data, as: :hidden, input_html: { value: true }
 
   %div{class: modal? ? "modal-body" : ""}
     .row

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -260,9 +260,30 @@ RSpec.describe OrderManagement::OrderDetailsController do
 
               it "renders an error", :aggregate_failures do
                 expect(flash[:error]).to be_present
+                expect(assigns(:order_detail).errors.full_messages).to include("The reservation conflicts with another reservation.")
                 expect(response).to render_template(:edit)
                 expect(response.code).to eq("406")
               end
+            end
+          end
+
+          describe "trying to set zero minutes" do
+            before do
+              @params[:order_detail] = {
+                reservation: reservation_params(order_detail.reservation.reserve_start_at).merge(duration_mins: 0),
+              }
+              do_request
+            end
+
+            it "does not save the reservation" do
+              expect(assigns(:order_detail).reservation).to be_changed
+            end
+
+            it "renders an error", :aggregate_failures do
+              expect(flash[:error]).to be_present
+              expect(assigns(:order_detail).errors.full_messages).to include("Duration must be at least 1 minute")
+              expect(response).to render_template(:edit)
+              expect(response.code).to eq("406")
             end
           end
 


### PR DESCRIPTION
First ticket number is NU, second is UIC.

An error like “The reservation conflicts with another reservation.” was
erroring with

```
An ActionView::Template::Error occurred in order_details#update:

undefined method `humanize' for nil:NilClass
app/views/order_management/order_details/_warnings.html.haml:14:in
`_app_views_order_management_order_details__warn
```

The `errors` was getting an empty string for a key:
` @messages=
{:""=>
["The reservation conflicts with another reservation.",
"The reservation spans time that the instrument is unavailable for
reservation"]}>`

This would then choke when trying to call `full_messages`