### PR TITLE
drop roles table if exists

### DIFF
--- a/db/migrate/20170627182248_drop_roles_if_exists.rb
+++ b/db/migrate/20170627182248_drop_roles_if_exists.rb
@@ -1,9 +1,8 @@
 class DropRolesIfExists < ActiveRecord::Migration
-  def change
-    if table_exists?(:roles)
-      drop_table(:roles) do |t|
-        t.string "name", limit: 255
-      end
-    end
+  def up
+    drop_table(:roles) if table_exists?(:roles)
+  end
+
+  def down
   end
 end

--- a/db/migrate/20170627182248_drop_roles_if_exists.rb
+++ b/db/migrate/20170627182248_drop_roles_if_exists.rb
@@ -1,0 +1,9 @@
+class DropRolesIfExists < ActiveRecord::Migration
+  def change
+    if table_exists?(:roles)
+      drop_table(:roles) do |t|
+        t.string "name", limit: 255
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170619213358) do
+ActiveRecord::Schema.define(version: 20170627182248) do
 
   create_table "account_users", force: :cascade do |t|
     t.integer  "account_id", limit: 4,  null: false


### PR DESCRIPTION
NU and open do not have the roles table--UIC and Dartmouth do. None of the schools actually use this table. This migration will drop the table if it exists, in order to get the schools' schemas in line with each other.