### PR TITLE
[#136869] Unable to add auto-scaled accessory to running reservation

### DIFF
--- a/app/support/accessories/scaling/auto.rb
+++ b/app/support/accessories/scaling/auto.rb
@@ -1,13 +1,17 @@
 # defaults to the duration length of the reservation
 # and auto-updates if the duration changes
-class Accessories::Scaling::Auto < Accessories::Scaling::Manual
+class Accessories::Scaling::Auto < Accessories::Scaling::Default
 
   def update_quantity
-    order_detail.quantity = order_detail.parent_order_detail.reservation.actual_duration_mins.to_i
+    order_detail.quantity = order_detail.parent_order_detail.reservation.actual_or_current_duration_mins.to_i
   end
 
   def quantity_editable?
     false
+  end
+
+  def quantity_as_time?
+    true
   end
 
 end

--- a/app/support/accessories/scaling/manual.rb
+++ b/app/support/accessories/scaling/manual.rb
@@ -3,7 +3,7 @@
 class Accessories::Scaling::Manual < Accessories::Scaling::Default
 
   def update_quantity
-    order_detail.quantity ||= order_detail.parent_order_detail.reservation.actual_duration_mins.to_i
+    order_detail.quantity ||= order_detail.parent_order_detail.reservation.actual_or_current_duration_mins.to_i
   end
 
   def quantity_as_time?

--- a/app/support/reservations/date_support.rb
+++ b/app/support/reservations/date_support.rb
@@ -67,11 +67,17 @@ module Reservations::DateSupport
     end
   end
 
-  def actual_duration_mins
+  # If the reservation is ongoing, we sometimes want to know how long a currently
+  # running reservation has been running for (e.g. accessories).
+  def actual_or_current_duration_mins
+    actual_duration_mins(actual_end_fallback: Time.current)
+  end
+
+  def actual_duration_mins(actual_end_fallback: nil)
     if @actual_duration_mins
       @actual_duration_mins.to_i
     elsif actual_start_at
-      TimeRange.new(actual_start_at, actual_end_at).duration_mins
+      TimeRange.new(actual_start_at, actual_end_at || actual_end_fallback).duration_mins
     else
       0
     end


### PR DESCRIPTION
* Create & Start a reservation on an instrument with accessories
* While it is running, click "Add Accessories"
* Manually scaled accessories are defaulting to "0:00". It should
default to the current duration
* Auto scaled accessories show "0:00", and then when you try to save,
it says "must be greater than or equal to 1"

Adding accessories works fine once the reservation has ended. That's because these are querying the reservation for its `actual_duration_mins`, which now is `nil` if the reservation is running or a problem. This adds a new method that allows you to fall back to using the current time like older behavior. See #1047.

![screen shot 2017-06-26 at 6 54 48 pm](https://user-images.githubusercontent.com/1099111/27614371-cea520a2-5b66-11e7-9846-7ba7e3e04a6f.png)