### PR TITLE
[#136900] User details being shown on calendar

### DIFF
--- a/app/assets/javascripts/reservations.js
+++ b/app/assets/javascripts/reservations.js
@@ -1,4 +1,7 @@
 $(document).ready(function() {
+
+  $calendar = $('#calendar');
+
   // initialize fullcalendar
   var calendarOptions = {
     editable: false,
@@ -11,7 +14,8 @@ $(document).ready(function() {
         $.fullCalendar.formatDate(event.end,   'hh:mmTT')
       ].join('&mdash;') + '<br/>';
 
-      if (typeof withDetails != 'undefined' && withDetails) {
+      // Default for our tooltip is to show.
+      if ($calendar.data("show-tooltip") != false) {
         if (event.admin) {  // administrative reservation
           tooltip += 'Admin Reservation<br/>';
         } else {            // normal reservation
@@ -73,7 +77,7 @@ $(document).ready(function() {
 	  $.extend(calendarOptions, {year: d.getFullYear(), month: d.getMonth(), date: d.getDate()});
   }
 
-  $('#calendar').fullCalendar(calendarOptions);
+  $calendar.fullCalendar(calendarOptions);
 
   init_datepickers();
 

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -54,8 +54,8 @@ class ReservationsController < ApplicationController
     respond_to do |format|
       as_calendar_object_options = { start_date: @start_at.beginning_of_day, with_details: @show_details }
       format.js do
-        render json: @reservations.map { |r| r.as_calendar_object(as_calendar_object_options) } +
-                     Array(@unavailable).map { |r| r.as_calendar_object(as_calendar_object_options) }
+        render json: Reservation.as_calendar_objects(@reservations, as_calendar_object_options) +
+                     ScheduleRule.as_calendar_objects(@unavailable, as_calendar_object_options)
       end
     end
   end

--- a/app/models/schedule_rule.rb
+++ b/app/models/schedule_rule.rb
@@ -53,6 +53,11 @@ class ScheduleRule < ActiveRecord::Base
     end
   end
 
+  # Returns a single array of calendar objects representing the set of schedule_rules
+  def self.as_calendar_objects(schedule_rules, options = {})
+    ScheduleRuleCalendarPresenter.to_json(schedule_rules, options)
+  end
+
   def at_least_one_day_selected
     errors.add(:base, "Please select at least one day") unless
       on_sun? || on_mon? || on_tue? || on_wed? || on_thu? || on_fri? || on_sat?
@@ -140,8 +145,10 @@ class ScheduleRule < ActiveRecord::Base
     dt_int >= start_time_int && dt_int <= end_time_int
   end
 
-  # build weekly calendar object
-  def as_calendar_object(options = {})
+  # Build weekly calendar hashes
+  # Returns an array of hashes. A Mon-Fri 9-5 rule would return 5 hashes, one for
+  # each day.
+  def as_calendar_objects(options = {})
     ScheduleRuleCalendarPresenter.new(self, options).to_json
   end
 
@@ -163,6 +170,12 @@ class ScheduleRule < ActiveRecord::Base
     overlap / duration
   end
 
+  # Inverts a set of rules into another set of rules representing the times the
+  # product is unavailable.
+  #
+  # Example:
+  # Input: A set of rules representing every day, available from 9-noon and 1-5.
+  # Output: A set of rules for each day, midnight-9, noon-1, and 5-midnight
   def self.unavailable(rules)
     # rules is always a collection
     rules     = Array(rules)

--- a/app/presenters/schedule_rule_calendar_presenter.rb
+++ b/app/presenters/schedule_rule_calendar_presenter.rb
@@ -6,9 +6,10 @@ class ScheduleRuleCalendarPresenter
 
   delegate :end_hour, :end_min, :instrument, :start_hour, :start_min, :unavailable, to: :schedule_rule
 
-  def self.to_json(schedule_rules)
-    schedule_rules.flat_map do |schedule_rule|
-      new(schedule_rule).to_json
+  # Returns a single array of Hashes
+  def self.to_json(schedule_rules, options = {})
+    Array(schedule_rules).flat_map do |schedule_rule|
+      new(schedule_rule, options).to_json
     end
   end
 
@@ -17,6 +18,8 @@ class ScheduleRuleCalendarPresenter
     @options = options
   end
 
+  # Returns an array of hashes. A Mon-Fri 9-5 rule would return 5 hashes, one for
+  # each day.
   def to_json
     Range.new(0, 6).map do |day_index|
       date = (start_date + day_index.days).to_datetime

--- a/app/support/reservations/rendering.rb
+++ b/app/support/reservations/rendering.rb
@@ -8,6 +8,12 @@ module Reservations::Rendering
     delegate :as_calendar_object, to: :calendar_presenter
   end
 
+  class_methods do
+    def as_calendar_objects(reservations, options = {})
+      Array(reservations).map { |r| r.as_calendar_object(options) }
+    end
+  end
+
   def display_start_at
     actual_start_at || reserve_start_at
   end

--- a/app/views/reservations/_js_variables.html.haml
+++ b/app/views/reservations/_js_variables.html.haml
@@ -1,12 +1,11 @@
 :javascript
-  var events_path     = "#{facility_instrument_reservations_path(@instrument.facility, @instrument, :format => 'js', :with_details => @instrument.show_details?)}";
+  var events_path     = "#{facility_instrument_reservations_path(@instrument.facility, @instrument, format: 'js', with_details: @instrument.show_details?)}";
   var minDate         = "#{@min_date}";
   var maxDate         = "#{@max_date}";
   var maxDaysFromNow  = #{@max_window};
   var minDaysFromNow  = #{@max_days_ago};
   var minTime         = #{@instrument.first_available_hour};
   var maxTime         = #{@instrument.last_available_hour+1};
-  var withDetails     = #{@instrument.show_details? || false};
   var isBundle        = #{@order_detail.bundled? || @order.order_details.count > 1};
   var ctrlMechanism   = "#{@instrument.control_mechanism}";
   var ordering_on_behalf = #{acting_as?};

--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -65,4 +65,4 @@
 #overlay
   #spinner
     #hide
-      #calendar
+      #calendar{ data: { show_tooltip: @instrument.show_details.to_s } }

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe ReservationsController do
           do_request
         end
 
-        it { expect(assigns[:unavailable]).to be_empty }
+        it { expect(assigns[:unavailable]).to be_blank }
       end
 
       context "schedule rules" do
@@ -190,6 +190,55 @@ RSpec.describe ReservationsController do
 
       it "includes instrument1 and instrument2 reservations" do
         expect(assigns(:reservations)).to match_array(reservations)
+      end
+    end
+
+    describe "showing details" do
+      describe "as a guest" do
+        before { sign_in @guest }
+
+        it "defaults to false" do
+          do_request
+          expect(assigns(:show_details)).to be_falsy
+        end
+
+        it "is false even if I request it and the instrument is not configured to show it" do
+          instrument.update!(show_details: false)
+          @params[:with_details] = "true"
+          do_request
+
+          expect(assigns(:show_details)).to be_falsy
+        end
+
+        it "is true if I request details and it is not configured" do
+          instrument.update!(show_details: true)
+          @params[:with_details] = "true"
+          do_request
+          expect(assigns(:show_details)).to be_truthy
+        end
+      end
+
+      describe "as a facility staff" do
+        before { maybe_grant_always_sign_in :staff }
+
+        it "is falsy if I don't request details" do
+          do_request
+          expect(assigns(:show_details)).to be_falsy
+        end
+
+        it "is true if I request details" do
+          @params[:with_details] = "true"
+          do_request
+
+          expect(assigns(:show_details)).to be_truthy
+        end
+
+        it "is falsy if I request with the string false" do
+          @params[:with_details] = "false"
+          do_request
+
+          expect(assigns(:show_details)).to be_falsy
+        end
       end
     end
   end

--- a/spec/models/schedule_rule_spec.rb
+++ b/spec/models/schedule_rule_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe ScheduleRule do
 
       # find past sunday, and build calendar object
       @sunday = Time.current.beginning_of_week(:sunday).to_date
-      @calendar = @rule.as_calendar_object
+      @calendar = @rule.as_calendar_objects
 
       # each title should be the same
       @calendar.each do |hash|
@@ -247,7 +247,7 @@ RSpec.describe ScheduleRule do
       expect(@not_available.size).to eq(14)
       # should mark each rule as unavailable
       assert_equal true, @not_available.first.unavailable
-      @not_calendar = @not_available.collect(&:as_calendar_object).flatten
+      @not_calendar = @not_available.collect(&:as_calendar_objects).flatten
 
       # days should be same as above
       # even times should be 12 am to 9 am
@@ -300,14 +300,14 @@ RSpec.describe ScheduleRule do
       @tuesday = Time.current.beginning_of_week(:sunday).to_date + 2
 
       # times should be tue 1 am - 3 am
-      @calendar1 = @rule1.as_calendar_object
+      @calendar1 = @rule1.as_calendar_objects
       @calendar1.each_with_index do |hash, _i|
         expect(Time.zone.parse(hash["start"])).to eq(@tuesday + 1.hour)
         expect(Time.zone.parse(hash["end"])).to eq(@tuesday + 3.hours)
       end
 
       # times should be tue 7 am - 9 am
-      @calendar2 = @rule2.as_calendar_object
+      @calendar2 = @rule2.as_calendar_objects
       @calendar2.each_with_index do |hash, _i|
         expect(Time.zone.parse(hash["start"])).to eq(@tuesday + 7.hours)
         expect(Time.zone.parse(hash["end"])).to eq(@tuesday + 9.hours)
@@ -316,7 +316,7 @@ RSpec.describe ScheduleRule do
       # build not available rules from the available rules collection, 3 for tue and 1 each for rest of days
       @not_available = ScheduleRule.unavailable([@rule1, @rule2])
       expect(@not_available.size).to eq(9)
-      @not_calendar = @not_available.collect(&:as_calendar_object).flatten
+      @not_calendar = @not_available.collect(&:as_calendar_objects).flatten
 
       # rules for tuesday should be 12am-1am, 3am-7am, 9pm-12pm
       @tuesday_times = @not_calendar.select { |hash| Time.zone.parse(hash["start"]).to_date == @tuesday }.collect do |hash|
@@ -361,14 +361,14 @@ RSpec.describe ScheduleRule do
       @wednesday = @tuesday + 1
 
       # times should be tue 9 pm - 12 am
-      @calendar1 = @rule1.as_calendar_object
+      @calendar1 = @rule1.as_calendar_objects
       @calendar1.each_with_index do |hash, _i|
         expect(Time.zone.parse(hash["start"])).to eq(@tuesday + 21.hours)
         expect(Time.zone.parse(hash["end"])).to eq(@tuesday + 24.hours)
       end
 
       # times should be tue 12 am - 9 am
-      @calendar2 = @rule2.as_calendar_object
+      @calendar2 = @rule2.as_calendar_objects
       @calendar2.each_with_index do |hash, _i|
         expect(Time.zone.parse(hash["start"])).to eq(@wednesday + 0.hours)
         expect(Time.zone.parse(hash["end"])).to eq(@wednesday + 9.hours)
@@ -387,7 +387,7 @@ RSpec.describe ScheduleRule do
 
       # set start_date as wednesday
       @wednesday = Time.current.beginning_of_week(:sunday).to_date + 3
-      @calendar = @rule.as_calendar_object(start_date: @wednesday)
+      @calendar = @rule.as_calendar_objects(start_date: @wednesday)
 
       # should start on wednesday
       expect(@calendar.size).to eq(7)


### PR DESCRIPTION
There is a `show_details` “Show reservation details (name, email, etc)
on schedule” option on instruments that should only show users’ name
and email if the option is on.

However, what was happening is we were sending the string `”false”`
into `Reservations::CalendarPresenter`, which is `present?`, so we were
rending the details if if we didn’t want to.

Even if that was fixed, using a query parameter like this isn’t very
secure. Anyone could conceivably change the query parameter to “true”.
This changes the logic so that if you request details (which happens in
most of the facility-side views), it also checks to make sure that
either the `show_details` option is on or that you have facility-level
permissions.

I also did a little bit of JS cleanup getting rid of the `withDetails`
javascript global since it’s only used in the one case of a user
placing a reservation to disable the tooltips.

There's definitely more that could be done on refactoring #index, but this seemed like enough for getting the bug fixed.