### PR TITLE
[#136943] Fix error when item/service and a bundle are in cart

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -316,7 +316,8 @@ class OrdersController < ApplicationController
     # Do not do any additional scopes on `@order.order_details` to ensure the list
     # of OrderDetail objects is memoized. Validations are run on `@order.order_details`
     # and we want to be able to render validation errors inline.
-    @order.order_details.sort_by(&:group_id).slice_when do |before, after|
+    sorted_order_details = @order.order_details.sort_by { |od| od.group_id.to_i }
+    sorted_order_details.slice_when do |before, after|
       before.group_id.nil? || before.group_id != after.group_id
     end
   end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -310,19 +310,6 @@ class OrdersController < ApplicationController
 
   private
 
-  # Group into chunks by the group id. If group_id is nil, then it should get its
-  # own chunk.
-  def grouped_order_details
-    # Do not do any additional scopes on `@order.order_details` to ensure the list
-    # of OrderDetail objects is memoized. Validations are run on `@order.order_details`
-    # and we want to be able to render validation errors inline.
-    sorted_order_details = @order.order_details.sort_by { |od| od.group_id.to_i }
-    sorted_order_details.slice_when do |before, after|
-      before.group_id.nil? || before.group_id != after.group_id
-    end
-  end
-  helper_method :grouped_order_details
-
   def build_order_date
     if params[:order_date].present? && params[:order_time].present?
       parse_usa_date(params[:order_date], join_time_select_values(params[:order_time]))

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -180,6 +180,15 @@ class Order < ActiveRecord::Base
     order_details.maximum(:group_id).to_i + 1
   end
 
+  # Group into chunks by the group_id so bundles stick together. If group_id is
+  # nil, it is not a bundle, so it should get its own chunk.
+  def grouped_order_details
+    sorted_order_details = order_details.sort_by(&:safe_group_id)
+    sorted_order_details.slice_when do |before, after|
+      before.group_id.nil? || before.group_id != after.group_id
+    end
+  end
+
   def has_subsidies?
     order_details.any?(&:has_subsidies?)
   end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -810,6 +810,11 @@ class OrderDetail < ActiveRecord::Base
     !bundle.nil?
   end
 
+  # Useful when sorting so we don't get `nil` to number comparisons
+  def safe_group_id
+    group_id.to_i
+  end
+
   def to_notice(notification_class, *_args)
     case notification_class.name
     when MergeNotification.name

--- a/app/views/orders/_form.html.haml
+++ b/app/views/orders/_form.html.haml
@@ -11,7 +11,7 @@
         %th.currency= OrderDetail.human_attribute_name(:estimated_total)
 
     %tbody
-      - grouped_order_details.each do |order_details|
+      - order.grouped_order_details.each do |order_details|
         = render partial: "cart_row", collection: order_details, as: :order_detail, locals: { order_details: order_details, f: f }
 
     %tfoot.cart


### PR DESCRIPTION
`comparison of Fixnum with nil failed`

Non-bundled order details have a nil group_id, so we can’t directly
compare a nil and a number.