### PR TITLE
[#98881] Auto-Log Out after Begin Reservation

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -270,12 +270,13 @@ class ReservationsController < ApplicationController
       ReservationInstrumentSwitcher.new(@reservation).switch_off!
       flash[:notice] = "The instrument has been deactivated successfully"
     end
-    session[:reservation_ended] = true if params[:reservation_ended].present?
+    session[:reservation_auto_logout] = true if params[:reservation_ended].present?
   end
 
   def switch_instrument_on!
     ReservationInstrumentSwitcher.new(@reservation).switch_on!
     flash[:notice] = "The instrument has been activated successfully"
+    session[:reservation_auto_logout] = true if params[:reservation_started].present?
   end
 
   def load_basic_resources

--- a/app/presenters/reservation_user_action_presenter.rb
+++ b/app/presenters/reservation_user_action_presenter.rb
@@ -57,10 +57,14 @@ class ReservationUserActionPresenter
   def switch_actions
     if can_switch_instrument_on?
       link_to I18n.t("reservations.switch.start"),
-              order_order_detail_reservation_switch_instrument_path(order, order_detail, reservation, switch: "on")
+              order_order_detail_reservation_switch_instrument_path(
+                order, order_detail, reservation,
+                switch: "on", reservation_started: "on")
     elsif can_switch_instrument_off?
       link_to I18n.t("reservations.switch.end"),
-              order_order_detail_reservation_switch_instrument_path(order, order_detail, reservation, switch: "off", reservation_ended: "on"),
+              order_order_detail_reservation_switch_instrument_path(
+                order, order_detail, reservation,
+                switch: "off", reservation_ended: "on"),
               class: end_reservation_class(reservation),
               data: { refresh_on_cancel: true }
     end

--- a/app/views/order_details/show.html.haml
+++ b/app/views/order_details/show.html.haml
@@ -105,3 +105,5 @@
             %td.actual_cost.currency= show_actual_total(@order_detail)
 
 = render :partial => '/price_display_footnote'
+
+= render "shared/auto_logout"

--- a/app/views/reservations/list.html.haml
+++ b/app/views/reservations/list.html.haml
@@ -13,12 +13,4 @@
 - else
   %p.notice= text("none")
 
-- if session[:reservation_ended]
-  - session.delete(:reservation_ended)
-  .modal.hide.fade#logout_modal
-    .modal-body= t("reservations.logout.body")
-    .modal-footer
-      = link_to t("reservations.logout.cancel"), reservations_path, class: "btn"
-      = link_to t("pages.logout"),
-        sign_out_user_path,
-        class: "btn btn-primary logout"
+= render "shared/auto_logout"

--- a/app/views/shared/_auto_logout.html.haml
+++ b/app/views/shared/_auto_logout.html.haml
@@ -1,0 +1,9 @@
+- if session[:reservation_auto_logout]
+  - session.delete(:reservation_auto_logout)
+  .modal.hide.fade#logout_modal
+    .modal-body= t("reservations.logout.body")
+    .modal-footer
+      = link_to t("reservations.logout.cancel"), reservations_path, class: "btn"
+      = link_to t("pages.logout"),
+        sign_out_user_path,
+        class: "btn btn-primary logout"

--- a/spec/presenters/reservation_user_action_presenter_spec.rb
+++ b/spec/presenters/reservation_user_action_presenter_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe ReservationUserActionPresenter do
       end
 
       context "can switch on" do
-        let(:link_args) { { switch: "on" } }
+        let(:link_args) { { switch: "on", reservation_started: "on" } }
 
         before :each do
           expect(reservation)


### PR DESCRIPTION
NUCore should automatically log out users (in customer mode only) after they click "Begin Reservation" from "My Reservations". Identical functionality as what happens when users click "End Reservation", including the 60 second delay and possibility of remaining logged in. T

The existing usage didn’t work from the order page, but it does now. I don’t think this presenter is used any place else, so this shouldn’t trigger anyplace else.