### PR TITLE
[#136306] Fix reservation validations

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -111,7 +111,7 @@ class ReservationsController < ApplicationController
       end
     else
       @reservation = creator.reservation
-      flash.now[:error] = creator.error
+      flash.now[:error] = creator.error.html_safe
       set_windows
       render :new
     end

--- a/app/services/order_purchase_validator.rb
+++ b/app/services/order_purchase_validator.rb
@@ -1,19 +1,19 @@
 class OrderPurchaseValidator
 
-  # The AllDetailsOnOrderValidator will validate each individual OrderDetail
+  # The AllOrderDetailsValidator will validate each individual OrderDetail
   # within the order using the NotePresenceValidator.
-  cattr_accessor(:additional_validations) { [AllDetailsOnOrderValidator.build(NotePresenceValidator)] }
+  cattr_accessor(:additional_validations) { [AllOrderDetailsValidator.build(NotePresenceValidator)] }
 
   attr_reader :errors
 
-  def initialize(order)
-    @order = order
+  def initialize(order_details)
+    @order_details = Array(order_details)
     @errors = []
   end
 
   def valid?
     additional_validations.all? do |validator_class|
-      validator = validator_class.new(@order)
+      validator = validator_class.new(@order_details)
       if validator.valid?
         true
       else

--- a/app/services/order_purchaser.rb
+++ b/app/services/order_purchaser.rb
@@ -98,7 +98,7 @@ class OrderPurchaser
   end
 
   def do_additional_validations
-    validator = OrderPurchaseValidator.new(@order)
+    validator = OrderPurchaseValidator.new(@order.order_details)
     if validator.valid?
       true
     else

--- a/app/services/reservation_creator.rb
+++ b/app/services/reservation_creator.rb
@@ -42,8 +42,7 @@ class ReservationCreator
         @error = e.message
         raise ActiveRecord::Rollback
       rescue => e
-        @error = I18n.t("orders.purchase.error")
-        @error += " #{e.message}" if e.message
+        @error = I18n.t("orders.purchase.error", message: e.message).html_safe
         raise ActiveRecord::Rollback
       end
     end

--- a/app/services/reservation_creator.rb
+++ b/app/services/reservation_creator.rb
@@ -25,7 +25,7 @@ class ReservationCreator
 
         save_reservation_and_order_detail(session_user)
 
-        validator = OrderPurchaseValidator.new(@order)
+        validator = OrderPurchaseValidator.new(@order_detail)
         raise ActiveRecord::RecordInvalid, @order_detail if validator.invalid?
 
         if to_be_merged

--- a/app/validators/all_order_details_validator.rb
+++ b/app/validators/all_order_details_validator.rb
@@ -1,31 +1,32 @@
-class AllDetailsOnOrderValidator
+class AllOrderDetailsValidator
 
   cattr_accessor :order_detail_validator_class
+  attr_reader :order_details
 
-  # Build a validator that will take an Order in its constructor and validate each
-  # child order detail using the order_detail_validator_class.
+  # Build a validator that will take a collection of order details in its constructor
+  # and validate each one.
   #
   # Example:
   # validator = AllDetailsOnOrder.build(NotePresenceValidator)
-  # validator.new(order).valid?
+  # validator.new(order_details).valid?
   #
   # This will run NotePresenceValidator.new(order_detail).valid? for each
-  # element of @order.order_details
+  # element of @order_details
   def self.build(order_detail_validator_class)
-    Class.new(AllDetailsOnOrderValidator) do
+    Class.new(self) do
       self.order_detail_validator_class = order_detail_validator_class
     end
   end
 
   # This class should only be initialized through the `.build` method
-  def initialize(order)
+  def initialize(order_details)
     raise "Should not be initialized directly. Use the `.build` factory method instead" unless order_detail_validator_class
-    @order = order
+    @order_details = order_details
   end
 
   def valid?
     # Loop over everything so that all order details get `errors` applied to them
-    invalid_orders = @order.order_details.reject do |od|
+    invalid_orders = order_details.reject do |od|
       order_detail_validator_class.new(od).valid?
     end
 

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -614,7 +614,7 @@ RSpec.describe ReservationsController do
       sign_in @guest
       @params[:order_account] = 0 # Cause Account not found error
       expect { do_request }.not_to change(Reservation, :count)
-      expect(response.body).to include(I18n.t("orders.purchase.error"))
+      expect(response.body).to include(I18n.t("orders.purchase.error", message: ""))
     end
 
     context "with other things in the cart (bundle or multi-add)" do


### PR DESCRIPTION
Applies to NU's [#136043] for research safety and UIC's required note field.

If you have multiple line items in your cart that have validations including a reservation, when you try to create the reservation, it is validating every other line item in your cart.

So, add an item that requires a note and an instrument that doesn't to your cart. Click the "Make a Reservation" button. You will not be able to save the reservation, and you will get a "Validation failed:" flash. Part of this is because for reservations, we're displaying the order details's validations.

This changes the note and research safety validators to accept a list of order details (or single order detail) rather than an order. It also changes the research safety validator to place errors on the model itself.

These commits have been cherry-picked from https://github.com/tablexi/nucore-nu/pull/283