### PR TITLE
Fix Date to Time conversion so it uses the app's timezone

### DIFF
--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -26,13 +26,11 @@ module DateHelper
     date = format_usa_date(Date.parse(date)) if date =~ /\A\d{4}-\d{2}-\d{2}/
 
     return unless usa_formatted_date?(date)
-    date = Date.strptime(date, "%m/%d/%Y")
 
-    if time_string
-      Time.zone.parse("#{date} #{time_string}")
-    else
-      date.to_time
-    end
+    date_string = Date.strptime(date, "%m/%d/%Y").to_s
+    date_string += " #{time_string}" if time_string
+
+    Time.zone.parse(date_string)
   rescue ArgumentError
     nil
   end


### PR DESCRIPTION
`to_time` uses the system's timezone, not the app's.

This was broken by changes made in https://github.com/tablexi/nucore-open/pull/1134

Circle is set to central time as is the application, so that's why this was fine until we merged to DC, which has circle set to central and the app set to eastern. I'm going to open another PR for trying to deal with that.