### PR TITLE
Handle I18n-ed facilities route in spec

### DIFF
--- a/spec/models/external_service/url_service_spec.rb
+++ b/spec/models/external_service/url_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe UrlService do
 
     it "sets the correct success url" do
       expect(query_hash["success_url"])
-        .to eq("https://realdomain:8080/facilities/#{facility.url_name}/services/#{product.url_name}/surveys/#{url_service.id}/complete?receiver_id=#{order_detail.id}")
+        .to eq("https://realdomain:8080/#{I18n.t('facilities_downcase')}/#{facility.url_name}/services/#{product.url_name}/surveys/#{url_service.id}/complete?receiver_id=#{order_detail.id}")
     end
 
     it "returns a blank referer" do
@@ -52,7 +52,7 @@ RSpec.describe UrlService do
   describe "without a request" do
     it "sets the correct success url" do
       expect(query_hash["success_url"])
-        .to eq("http://defaulthost/facilities/#{facility.url_name}/services/#{product.url_name}/surveys/#{url_service.id}/complete?receiver_id=#{order_detail.id}")
+        .to eq("http://defaulthost/#{I18n.t('facilities_downcase')}/#{facility.url_name}/services/#{product.url_name}/surveys/#{url_service.id}/complete?receiver_id=#{order_detail.id}")
     end
 
     it "returns a blank referer" do

--- a/spec/services/default_facility_homepage_redirector_spec.rb
+++ b/spec/services/default_facility_homepage_redirector_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe DefaultFacilityHomepageRedirector do
       let!(:reservation) { create(:purchased_reservation) }
 
       it "returns the correct path" do
-        path = "/facilities/#{facility.url_name}/reservations/timeline"
+        path = "/#{I18n.t('facilities_downcase')}/#{facility.url_name}/reservations/timeline"
 
         expect(DefaultFacilityHomepageRedirector.redirect_path(facility)).to eq path
       end
     end
     context "without active instruments" do
       it "returns the correct path" do
-        path = "/facilities/#{facility.url_name}/orders"
+        path = "/#{I18n.t('facilities_downcase')}/#{facility.url_name}/orders"
 
         expect(DefaultFacilityHomepageRedirector.redirect_path(facility)).to eq path
       end


### PR DESCRIPTION
DC uses "resources", so this fails when we try to merge it down.