### PR TITLE
[#136975] Order import errors appearing in "Notes" field

### DIFF
--- a/app/support/order_row_importer.rb
+++ b/app/support/order_row_importer.rb
@@ -70,10 +70,14 @@ class OrderRowImporter
     @order_key ||= [user_field, chart_string_field, order_date_field]
   end
 
-  def row_with_errors # TODO: refactor
-    new_row = @row.dup
+  def row_with_errors
+    # Start with a hash of HEADERS keys with nil values to ensure optional columns
+    # are included in the report even if they are not in the uploaded CSV.
+    new_row = Hash[HEADERS.values.zip []]
+    new_row.merge!(@row)
     new_row[HEADERS[:errors]] = errors.join(", ")
-    new_row
+
+    CSV::Row.new(new_row.keys, new_row.values)
   end
 
   def user

--- a/app/support/order_row_importer.rb
+++ b/app/support/order_row_importer.rb
@@ -73,7 +73,7 @@ class OrderRowImporter
   def row_with_errors
     # Start with a hash of HEADERS keys with nil values to ensure optional columns
     # are included in the report even if they are not in the uploaded CSV.
-    new_row = Hash[HEADERS.values.zip []]
+    new_row = HEADERS.values.each_with_object({}) { |header, hash| hash[header] = nil }
     new_row.merge!(@row)
     new_row[HEADERS[:errors]] = errors.join(", ")
 

--- a/spec/app_support/order_row_importer_spec.rb
+++ b/spec/app_support/order_row_importer_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe OrderRowImporter do
   let(:quantity) { "column4" }
   let(:order_date) { "column5" }
   let(:fulfillment_date) { "column6" }
-  let(:notes) { "column8" }
+  let(:notes) { "column7" }
 
   describe "#import" do
     shared_examples_for "an order was created" do

--- a/spec/app_support/order_row_importer_spec.rb
+++ b/spec/app_support/order_row_importer_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe OrderRowImporter do
       "Quantity" => quantity,
       "Order Date" => order_date,
       "Fulfillment Date" => fulfillment_date,
-      "Errors" => errors,
       "Note" => notes,
     }
     CSV::Row.new(ref.keys, ref.values)
@@ -56,7 +55,6 @@ RSpec.describe OrderRowImporter do
   let(:quantity) { "column4" }
   let(:order_date) { "column5" }
   let(:fulfillment_date) { "column6" }
-  let(:errors) { "column7" }
   let(:notes) { "column8" }
 
   describe "#import" do
@@ -385,7 +383,6 @@ RSpec.describe OrderRowImporter do
           "Quantity" => quantity,
           "Order Date" => order_date,
           "Fulfillment Date" => fulfillment_date,
-          "Errors" => errors,
           "Note" => notes,
         }
         CSV::Row.new(ref.keys, ref.values)
@@ -436,7 +433,31 @@ RSpec.describe OrderRowImporter do
 
   describe "#row_with_errors" do
     let(:errors) { %w(one two three) }
-    let(:row) { { "Errors" => "" } }
+    let(:row) do
+      {
+        "Netid / Email" => username,
+        "Chart String" => chart_string,
+        "Product Name" => product_name,
+        "Quantity" => quantity,
+        "Order Date" => order_date,
+        "Fulfillment Date" => fulfillment_date,
+      }
+    end
+
+    it "has all of the columns in the correct order" do
+      expect(subject.row_with_errors.headers).to eq(
+        [
+          "Netid / Email",
+          "Chart String",
+          "Product Name",
+          "Quantity",
+          "Order Date",
+          "Fulfillment Date",
+          "Note",
+          "Errors",
+        ],
+      )
+    end
 
     context "when the import has no errors" do
       it "does not add errors to the error column" do

--- a/spec/models/order_import_spec.rb
+++ b/spec/models/order_import_spec.rb
@@ -3,21 +3,22 @@ require "controller_spec_helper"
 
 require "stringio"
 
-CSV_HEADERS = [
-  "Netid / Email",
-  "Chart String",
-  "Product Name",
-  "Quantity",
-  "Order Date",
-  "Fulfillment Date",
-  "Note",
-].freeze
-
-def nucore_format_date(date)
-  date.strftime("%m/%d/%Y")
-end
-
 RSpec.describe OrderImport, :time_travel do
+
+  CSV_HEADERS = [
+    "Netid / Email",
+    "Chart String",
+    "Product Name",
+    "Quantity",
+    "Order Date",
+    "Fulfillment Date",
+    "Note",
+  ].freeze
+
+  def nucore_format_date(date)
+    date.strftime("%m/%d/%Y")
+  end
+
   let(:now) { fiscal_year_beginning + 5.days }
 
   subject(:order_import) do


### PR DESCRIPTION
If the uploaded import file does not have a notes column (the current template
does have this column, but older versions of the template might not), then any
import errors in the error report appear in the "Notes" column as opposed to the
"Errors" column.

There are definitely opportunities for refactoring here, but didn't seem worth the effort for this bug fix.