### PR TITLE
[#137019] Only go responsive on screen, not print

### DIFF
--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -5,7 +5,7 @@ $navCollapseColor: #777;
 $navbarActiveBorderColor: #aaa;
 
 /* 979px - 980px is where nav-collapse gets triggered */
-@media (max-width: 979px) {
+@media screen and (max-width: 979px) {
   .hidden-with-nav {
     display: inherit !important;
   }
@@ -116,7 +116,7 @@ $navbarActiveBorderColor: #aaa;
   }
 }
 
-@media (min-width: 980px) {
+@media screen and (min-width: 980px) {
   .visible-with-nav {
     display: inherit !important;
   }


### PR DESCRIPTION
This will clear up an issue for DC where users are printing their receipt
for Sanger Sequencing orders (as they should) and the print view is using
responsive tables.

I'm confirming with the client that they do want the normal table view in the print view, but I figured I'd put this out there anyways.