### PR TITLE
fix oj version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,7 +125,7 @@ group :stage, :production do
   gem "exception_notification", "~> 4.0.1"
   gem "lograge"
   gem "logstash-event"
-  gem "oj"
+  gem "oj", "~> 3.2.0"
   gem "rollbar"
   gem "unicorn", require: false
   gem "whenever", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -627,7 +627,7 @@ DEPENDENCIES
   nested_form_fields
   net-telnet
   nokogiri (~> 1.7.1)
-  oj
+  oj (~> 3.2.0)
   paperclip (~> 4.2.0)
   poltergeist
   prawn (= 0.12)


### PR DESCRIPTION
Inadvertently dropped the version specifier in https://github.com/tablexi/nucore-open/pull/1150/files#diff-8b7db4d5cc4b8f6dc8feb7030baa2478R128, which caused issues bundling in the UIC fork. Pinning `oj` to the current version.