### PR TITLE
[#133776] offline reservations display on calendar/timeline

### DIFF
--- a/app/assets/stylesheets/app/timeline.scss
+++ b/app/assets/stylesheets/app/timeline.scss
@@ -134,7 +134,7 @@ body .unit {
 }
 
 /* tooltip_reservation should be hidden until it gets pulled into the popup */
-.tooltip_admin_reservation, .tooltip_reservation {
+.tooltip_admin_reservation, .tooltip_reservation, .tooltip_offline_reservation {
   display: none;
 }
 

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -35,9 +35,9 @@ class ReservationsController < ApplicationController
                                    .active
                                    .in_range(@start_at, @end_at)
                                    .includes(order_detail: { order: :user })
-    offine_reservations = @instrument.offline_reservations.in_range(@start_at, @end_at)
+    offline_reservations = @instrument.offline_reservations.in_range(@start_at, @end_at)
 
-    @reservations = admin_reservations + user_reservations + offine_reservations
+    @reservations = admin_reservations + user_reservations + offline_reservations
 
     # We don't need the unavailable hours month view
     unless month_view?

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -35,8 +35,9 @@ class ReservationsController < ApplicationController
                                    .active
                                    .in_range(@start_at, @end_at)
                                    .includes(order_detail: { order: :user })
+    offine_reservations = @instrument.offline_reservations.in_range(@start_at, @end_at)
 
-    @reservations = admin_reservations + user_reservations
+    @reservations = admin_reservations + user_reservations + offine_reservations
 
     # We don't need the unavailable hours month view
     unless month_view?

--- a/app/helpers/timeline_helper.rb
+++ b/app/helpers/timeline_helper.rb
@@ -50,6 +50,16 @@ module TimelineHelper
     classes
   end
 
+  def reservation_user_display(reservation)
+    if reservation.offline?
+      t(".offline_reservation")
+    elsif reservation.admin?
+      t(".admin_reservation")
+    else
+      reservation.user
+    end
+  end
+
   def reservation_date_range_display(date, reservation)
     # start = date.beginning_of_day >= reservation.display_start_at ?
     "#{reservation_date_in_day(date, reservation.display_start_at)} &ndash; #{reservation_date_in_day(date, reservation.display_end_at)}".html_safe

--- a/app/models/concerns/products/scheduling_support.rb
+++ b/app/models/concerns/products/scheduling_support.rb
@@ -30,11 +30,13 @@ module Products::SchedulingSupport
   def visible_reservations(date = nil)
     purchased = purchased_reservations.order(:reserve_start_at)
     admin = admin_reservations
+    offline = offline_reservations
     if date
       purchased = purchased.for_date(date)
       admin = admin.for_date(date)
+      offline = offline.for_date(date)
     end
-    purchased + admin
+    purchased + admin + offline
   end
 
   def active_schedule_reservations

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -183,6 +183,10 @@ class Reservation < ActiveRecord::Base
     raise ActiveRecord::RecordInvalid.new(self) unless save_as_user(user)
   end
 
+  def offline?
+    type == "OfflineReservation"
+  end
+
   def admin?
     order.nil? && !blackout?
   end

--- a/app/presenters/reservations/calendar_presenter.rb
+++ b/app/presenters/reservations/calendar_presenter.rb
@@ -16,7 +16,7 @@ module Reservations
             {}
           end
         elsif offline?
-          { "admin" => true, "title" => "Instrument\nOffline"}
+          { "admin" => true, "title" => "Instrument\nOffline" }
         else
           { "admin" => true, "title" => "Admin\nReservation" }
         end,

--- a/app/presenters/reservations/calendar_presenter.rb
+++ b/app/presenters/reservations/calendar_presenter.rb
@@ -15,6 +15,8 @@ module Reservations
           else
             {}
           end
+        elsif offline?
+          { "admin" => true, "title" => "Instrument\nOffline"}
         else
           { "admin" => true, "title" => "Admin\nReservation" }
         end,

--- a/app/views/shared/timeline/_facility_tooltip.html.haml
+++ b/app/views/shared/timeline/_facility_tooltip.html.haml
@@ -1,4 +1,4 @@
-%strong= reservation.admin? ? t(".admin_reservation") : reservation.user
+%strong= reservation_user_display(reservation)
 
 %br
 %span= reservation_date_range_display(@display_datetime, reservation)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,7 @@ en:
     timeline:
       facility_tooltip:
         admin_reservation: Administrative Reservation
+        offline_reservation: Instrument Offline
     update: Update
 
   global_search:


### PR DESCRIPTION
- https://pm.tablexi.com/issues/133776

- Show the offline blocks on the facility timeline view (I feel like this could be pretty useful). If we do this we should make sure auto-canceled reservations are in front of the offline block
- Show the offline blocks in the calendar on the place reservation view. Show when ordering on behalf of.
- Show the offline blocks in the calendar where you take the instrument online and offline

<img width="1429" alt="screen shot 2017-07-12 at 5 31 29 pm" src="https://user-images.githubusercontent.com/4624197/28143274-5515ef30-672a-11e7-9725-7f7a56317694.png">

<img width="1434" alt="screen shot 2017-07-12 at 5 45 50 pm" src="https://user-images.githubusercontent.com/4624197/28143278-588e57f6-672a-11e7-93c0-0626ba1c6917.png">

<img width="1434" alt="screen shot 2017-07-12 at 5 46 22 pm" src="https://user-images.githubusercontent.com/4624197/28143318-86ad77de-672a-11e7-8781-91daee04f711.png">
