### PR TITLE
[#136142] Add Instrument Name to calendar tooltip

### DIFF
--- a/app/assets/javascripts/_calendar.js.coffee
+++ b/app/assets/javascripts/_calendar.js.coffee
@@ -1,0 +1,63 @@
+$ ->
+  window.defaultCalendarOptions = {
+    editable: false
+    defaultView: 'agendaWeek'
+    allDaySlot: false
+    events: events_path
+    loading: (isLoading, view) ->
+      if isLoading
+        $("#overlay").addClass('on').removeClass('off')
+      else
+        $("#overlay").addClass('off').removeClass('on')
+        try
+          startDate = $.fullCalendar.formatDate(view.start, "yyyyMMdd")
+          endDate   = $.fullCalendar.formatDate(view.end, "yyyyMMdd")
+          # check calendar start date
+          if startDate < minDate
+            # hide the previous button
+            $("div.fc-button-prev").hide()
+          else
+            # show the previous button
+            $("div.fc-button-prev").show()
+
+          # check calendar end date
+          if endDate > maxDate
+            # hide the next button
+            $("div.fc-button-next").hide()
+          else
+            # show the next button
+            $("div.fc-button-next").show()
+
+    eventAfterRender: (event, element) ->
+      tooltip = [
+        $.fullCalendar.formatDate(event.start, 'h:mmTT'),
+        $.fullCalendar.formatDate(event.end,   'h:mmTT')
+      ].join('&ndash;') + '<br/>'
+
+      # Default for our tooltip is to show.
+      if $("#calendar").data("show-tooltip") != false
+        if event.admin # administrative reservation
+          tooltip += 'Admin Reservation<br/>'
+        else # normal reservation
+          tooltip += [
+            event.name,
+            event.email,
+            event.product
+          ].join('<br/>')
+
+        # create the tooltip
+        if element.qtip
+          $(element).qtip(
+            content: tooltip,
+            style:
+              classes: "qtip-light"
+            position:
+              at:  'bottom left'
+              my:  'topRight'
+          )
+  }
+  if window.minTime?
+    defaultCalendarOptions.minTime = window.minTime
+  if window.maxTime?
+    defaultCalendarOptions.maxTime = window.maxTime
+    defaultCalendarOptions.height = 42*(maxTime - minTime) + 75

--- a/app/assets/javascripts/app/calendar.js.coffee
+++ b/app/assets/javascripts/app/calendar.js.coffee
@@ -8,8 +8,9 @@ class window.FullCalendarConfig
     events: events_path
     loading: (isLoading, view) =>
       @toggleOverlay(isLoading)
-      @toggleNextPrev(view) if !isLoading
+
     eventAfterRender: @buildTooltip
+    eventAfterAllRender: @toggleNextPrev
 
   toggleOverlay: (isLoading) ->
     if isLoading
@@ -18,27 +19,13 @@ class window.FullCalendarConfig
       $("#overlay").addClass("off").removeClass("on")
 
   toggleNextPrev: (view) ->
+    # window.minDate/maxDate are strings formatted like 20170714
     try
       startDate = $.fullCalendar.formatDate(view.start, "yyyyMMdd")
       endDate   = $.fullCalendar.formatDate(view.end, "yyyyMMdd")
-      # check calendar start date
 
-      if startDate < window.minDate
-        # hide the previous button
-        $("div.fc-button-prev").hide()
-      else
-        # show the previous button
-        $("div.fc-button-prev").show()
-
-      # check calendar end date
-      if endDate > window.maxDate
-        # hide the next button
-        $("div.fc-button-next").hide()
-      else
-        # show the next button
-        $("div.fc-button-next").show()
-    catch e
-      console.debug e
+      $(".fc-button-prev").toggleClass("fc-state-disabled", startDate < window.minDate)
+      $(".fc-button-next").toggleClass("fc-state-disabled", endDate > window.maxDate)
 
   buildTooltip: (event, element) ->
     tooltip = [

--- a/app/assets/javascripts/app/calendar.js.coffee
+++ b/app/assets/javascripts/app/calendar.js.coffee
@@ -1,3 +1,4 @@
+
 $ ->
   window.defaultCalendarOptions = {
     editable: false
@@ -61,3 +62,9 @@ $ ->
   if window.maxTime?
     defaultCalendarOptions.maxTime = window.maxTime
     defaultCalendarOptions.height = 42*(maxTime - minTime) + 75
+  if window.initialDate
+    d = Date.parse(initialDate)
+    $.extend(defaultCalendarOptions,
+      year: d.getFullYear()
+      month: d.getMonth()
+      date: d.getDate())

--- a/app/assets/javascripts/app/calendar.js.coffee
+++ b/app/assets/javascripts/app/calendar.js.coffee
@@ -1,7 +1,25 @@
 class window.FullCalendarConfig
   constructor: (@$element) ->
 
+  init: (options) ->
+    @$element.fullCalendar($.extend(@options(), options))
+
   options: ->
+    options = @baseOptions()
+    if window.minTime?
+      options.minTime = window.minTime
+    if window.maxTime?
+      options.maxTime = window.maxTime
+      options.height = 42*(maxTime - minTime) + 75
+    if window.initialDate
+      d = Date.parse(initialDate)
+      $.extend(options,
+        year: d.getFullYear()
+        month: d.getMonth()
+        date: d.getDate())
+    options
+
+  baseOptions: ->
     editable: false
     defaultView: 'agendaWeek'
     allDaySlot: false
@@ -53,17 +71,3 @@ class window.FullCalendarConfig
             at:  'bottom left'
             my:  'topRight'
         )
-
-$ ->
-  window.defaultCalendarOptions = new FullCalendarConfig($("#calendar")).options()
-  if window.minTime?
-    defaultCalendarOptions.minTime = window.minTime
-  if window.maxTime?
-    defaultCalendarOptions.maxTime = window.maxTime
-    defaultCalendarOptions.height = 42*(maxTime - minTime) + 75
-  if window.initialDate
-    d = Date.parse(initialDate)
-    $.extend(defaultCalendarOptions,
-      year: d.getFullYear()
-      month: d.getMonth()
-      date: d.getDate())

--- a/app/assets/javascripts/app/calendar.js.coffee
+++ b/app/assets/javascripts/app/calendar.js.coffee
@@ -1,8 +1,8 @@
 class window.FullCalendarConfig
-  constructor: (@$element) ->
+  constructor: (@$element, @customOptions) ->
 
-  init: (options) ->
-    @$element.fullCalendar($.extend(@options(), options))
+  init: ->
+    @$element.fullCalendar($.extend(@options(), @customOptions))
 
   options: ->
     options = @baseOptions()
@@ -37,10 +37,9 @@ class window.FullCalendarConfig
       $("#overlay").addClass("off").removeClass("on")
 
   toggleNextPrev: (view) ->
-    # window.minDate/maxDate are strings formatted like 20170714
     try
-      startDate = $.fullCalendar.formatDate(view.start, "yyyyMMdd")
-      endDate   = $.fullCalendar.formatDate(view.end, "yyyyMMdd")
+      startDate = @formatCalendarDate(view.start)
+      endDate = @formatCalendarDate(view.end)
 
       $(".fc-button-prev").toggleClass("fc-state-disabled", startDate < window.minDate)
       $(".fc-button-next").toggleClass("fc-state-disabled", endDate > window.maxDate)
@@ -51,7 +50,8 @@ class window.FullCalendarConfig
       $.fullCalendar.formatDate(event.end,   "h:mmTT")
     ].join("&ndash;") + "<br/>"
 
-    # Default for our tooltip is to show.
+    # Default for our tooltip is to show, even if data-attribute is undefined.
+    # Only hide if explicitly set to false.
     if $("#calendar").data("show-tooltip") != false
       tooltip += [
         event.title,
@@ -71,3 +71,7 @@ class window.FullCalendarConfig
             at: "bottom left"
             my: "topRight"
         )
+
+  # window.minDate/maxDate are strings formatted like 20170714
+  formatCalendarDate: (date) ->
+    $.fullCalendar.formatDate(date, "yyyyMMdd")

--- a/app/assets/javascripts/app/calendar.js.coffee
+++ b/app/assets/javascripts/app/calendar.js.coffee
@@ -9,34 +9,8 @@ class window.FullCalendarConfig
     loading: (isLoading, view) =>
       @toggleOverlay(isLoading)
       @toggleNextPrev(view) if !isLoading
+    eventAfterRender: @buildTooltip
 
-    eventAfterRender: (event, element) ->
-      tooltip = [
-        $.fullCalendar.formatDate(event.start, 'h:mmTT'),
-        $.fullCalendar.formatDate(event.end,   'h:mmTT')
-      ].join('&ndash;') + '<br/>'
-
-      # Default for our tooltip is to show.
-      if $("#calendar").data("show-tooltip") != false
-        if event.admin # administrative reservation
-          tooltip += 'Admin Reservation<br/>'
-        else # normal reservation
-          tooltip += [
-            event.name,
-            event.email,
-            event.product
-          ].join('<br/>')
-
-        # create the tooltip
-        if element.qtip
-          $(element).qtip(
-            content: tooltip,
-            style:
-              classes: "qtip-light"
-            position:
-              at:  'bottom left'
-              my:  'topRight'
-          )
   toggleOverlay: (isLoading) ->
     if isLoading
       $("#overlay").addClass("on").removeClass("off")
@@ -48,7 +22,8 @@ class window.FullCalendarConfig
       startDate = $.fullCalendar.formatDate(view.start, "yyyyMMdd")
       endDate   = $.fullCalendar.formatDate(view.end, "yyyyMMdd")
       # check calendar start date
-      if startDate < minDate
+
+      if startDate < window.minDate
         # hide the previous button
         $("div.fc-button-prev").hide()
       else
@@ -56,12 +31,41 @@ class window.FullCalendarConfig
         $("div.fc-button-prev").show()
 
       # check calendar end date
-      if endDate > maxDate
+      if endDate > window.maxDate
         # hide the next button
         $("div.fc-button-next").hide()
       else
         # show the next button
         $("div.fc-button-next").show()
+    catch e
+      console.debug e
+
+  buildTooltip: (event, element) ->
+    tooltip = [
+      $.fullCalendar.formatDate(event.start, 'h:mmTT'),
+      $.fullCalendar.formatDate(event.end,   'h:mmTT')
+    ].join('&ndash;') + '<br/>'
+
+    # Default for our tooltip is to show.
+    if $("#calendar").data("show-tooltip") != false
+      tooltip += [
+        event.title,
+        event.email,
+        event.product,
+      ].filter(
+        (e) -> e? # remove undefined values
+      ).join('<br/>')
+
+      # create the tooltip
+      if element.qtip
+        $(element).qtip(
+          content: tooltip,
+          style:
+            classes: "qtip-light"
+          position:
+            at:  'bottom left'
+            my:  'topRight'
+        )
 
 $ ->
   window.defaultCalendarOptions = new FullCalendarConfig($("#calendar")).options()

--- a/app/assets/javascripts/app/calendar.js.coffee
+++ b/app/assets/javascripts/app/calendar.js.coffee
@@ -10,7 +10,7 @@ class window.FullCalendarConfig
       options.minTime = window.minTime
     if window.maxTime?
       options.maxTime = window.maxTime
-      options.height = 42*(maxTime - minTime) + 75
+      options.height = 42 * (maxTime - minTime) + 75
     if window.initialDate
       d = Date.parse(initialDate)
       $.extend(options,
@@ -21,7 +21,7 @@ class window.FullCalendarConfig
 
   baseOptions: ->
     editable: false
-    defaultView: 'agendaWeek'
+    defaultView: "agendaWeek"
     allDaySlot: false
     events: events_path
     loading: (isLoading, view) =>
@@ -47,9 +47,9 @@ class window.FullCalendarConfig
 
   buildTooltip: (event, element) ->
     tooltip = [
-      $.fullCalendar.formatDate(event.start, 'h:mmTT'),
-      $.fullCalendar.formatDate(event.end,   'h:mmTT')
-    ].join('&ndash;') + '<br/>'
+      $.fullCalendar.formatDate(event.start, "h:mmTT"),
+      $.fullCalendar.formatDate(event.end,   "h:mmTT")
+    ].join("&ndash;") + "<br/>"
 
     # Default for our tooltip is to show.
     if $("#calendar").data("show-tooltip") != false
@@ -59,7 +59,7 @@ class window.FullCalendarConfig
         event.product,
       ].filter(
         (e) -> e? # remove undefined values
-      ).join('<br/>')
+      ).join("<br/>")
 
       # create the tooltip
       if element.qtip
@@ -68,6 +68,6 @@ class window.FullCalendarConfig
           style:
             classes: "qtip-light"
           position:
-            at:  'bottom left'
-            my:  'topRight'
+            at: "bottom left"
+            my: "topRight"
         )

--- a/app/assets/javascripts/app/calendar.js.coffee
+++ b/app/assets/javascripts/app/calendar.js.coffee
@@ -1,33 +1,14 @@
+class window.FullCalendarConfig
+  constructor: (@$element) ->
 
-$ ->
-  window.defaultCalendarOptions = {
+  options: ->
     editable: false
     defaultView: 'agendaWeek'
     allDaySlot: false
     events: events_path
-    loading: (isLoading, view) ->
-      if isLoading
-        $("#overlay").addClass('on').removeClass('off')
-      else
-        $("#overlay").addClass('off').removeClass('on')
-        try
-          startDate = $.fullCalendar.formatDate(view.start, "yyyyMMdd")
-          endDate   = $.fullCalendar.formatDate(view.end, "yyyyMMdd")
-          # check calendar start date
-          if startDate < minDate
-            # hide the previous button
-            $("div.fc-button-prev").hide()
-          else
-            # show the previous button
-            $("div.fc-button-prev").show()
-
-          # check calendar end date
-          if endDate > maxDate
-            # hide the next button
-            $("div.fc-button-next").hide()
-          else
-            # show the next button
-            $("div.fc-button-next").show()
+    loading: (isLoading, view) =>
+      @toggleOverlay(isLoading)
+      @toggleNextPrev(view) if !isLoading
 
     eventAfterRender: (event, element) ->
       tooltip = [
@@ -56,7 +37,34 @@ $ ->
               at:  'bottom left'
               my:  'topRight'
           )
-  }
+  toggleOverlay: (isLoading) ->
+    if isLoading
+      $("#overlay").addClass("on").removeClass("off")
+    else
+      $("#overlay").addClass("off").removeClass("on")
+
+  toggleNextPrev: (view) ->
+    try
+      startDate = $.fullCalendar.formatDate(view.start, "yyyyMMdd")
+      endDate   = $.fullCalendar.formatDate(view.end, "yyyyMMdd")
+      # check calendar start date
+      if startDate < minDate
+        # hide the previous button
+        $("div.fc-button-prev").hide()
+      else
+        # show the previous button
+        $("div.fc-button-prev").show()
+
+      # check calendar end date
+      if endDate > maxDate
+        # hide the next button
+        $("div.fc-button-next").hide()
+      else
+        # show the next button
+        $("div.fc-button-next").show()
+
+$ ->
+  window.defaultCalendarOptions = new FullCalendarConfig($("#calendar")).options()
   if window.minTime?
     defaultCalendarOptions.minTime = window.minTime
   if window.maxTime?

--- a/app/assets/javascripts/instruments.js
+++ b/app/assets/javascripts/instruments.js
@@ -1,4 +1,3 @@
-//= require _calendar
 $(document).ready(function() {
   var calendarOptions = $.extend({}, defaultCalendarOptions, {
                   header: {left: '', center: 'title', right: 'prev,next today agendaDay,agendaWeek,month'},

--- a/app/assets/javascripts/instruments.js
+++ b/app/assets/javascripts/instruments.js
@@ -1,7 +1,9 @@
 $(document).ready(function() {
-  var calendarOptions = $.extend({}, defaultCalendarOptions, {
-                  header: {left: '', center: 'title', right: 'prev,next today agendaDay,agendaWeek,month'},
-                });
-
-  $('#calendar').fullCalendar(calendarOptions);
-})
+  new FullCalendarConfig($("#calendar")).init({
+    header: {
+      left: '',
+      center: 'title',
+      right: 'prev,next today agendaDay,agendaWeek,month',
+    },
+  });
+});

--- a/app/assets/javascripts/instruments.js
+++ b/app/assets/javascripts/instruments.js
@@ -1,70 +1,8 @@
+//= require _calendar
 $(document).ready(function() {
-  var calendarOptions = ({
-                  editable: false,
-                  defaultView: 'agendaWeek',
-                  allDaySlot: false,
+  var calendarOptions = $.extend({}, defaultCalendarOptions, {
                   header: {left: '', center: 'title', right: 'prev,next today agendaDay,agendaWeek,month'},
-                  events: events_path,
-                  eventAfterRender: function(event, element) {
-                    var tooltip = [
-                      $.fullCalendar.formatDate(event.start, 'hh:mmTT'),
-                      $.fullCalendar.formatDate(event.end,   'hh:mmTT')
-                    ].join('&mdash;') + '<br/>';
-
-                    if (event.admin) {// administrative reservation
-                      tooltip += 'Admin Reservation<br/>';
-                    } else {          // normal reservation
-                      tooltip += [
-                        event.name,
-                        event.email
-                      ].join('<br/>');
-                    }
-                    element.qtip({
-                      content: tooltip,
-                      style: {
-                        classes: "qtip-light"
-                      },
-                      position: {
-                        at:  'bottom left',
-                        my:  'topRight'
-                      }
-                    });
-                  },
-                  loading: function(isLoading, view) {
-                    var startDate, endDate;
-                    if (isLoading) {
-                      $("#overlay").addClass('on').removeClass('off');
-                    } else {
-                      $("#overlay").addClass('off').removeClass('on');
-                      try {
-                        startDate = $.fullCalendar.formatDate(view.start, "yyyyMMdd")
-                        endDate   = $.fullCalendar.formatDate(view.end, "yyyyMMdd")
-
-                        // check calendar start date
-                        if (startDate < minDate) {
-                          // hide the previous button
-                          $("div.fc-button-prev").hide();
-                        } else {
-                          // show the previous button
-                          $("div.fc-button-prev").show();
-                        }
-                        // check calendar end date
-                        if (endDate > maxDate) {
-                          // hide the next button
-                          $("div.fc-button-next").hide();
-                        } else {
-                          // show the next button
-                          $("div.fc-button-next").show();
-                        }
-                      } catch(error) {}
-                    }
-                  }
                 });
-  if (typeof minTime!='undefined') { calendarOptions.minTime = minTime; };
-  if (typeof maxTime!='undefined') {
-    calendarOptions.maxTime = maxTime;
-    calendarOptions.height = (maxTime - minTime)*42 + 75
-  }
 
   $('#calendar').fullCalendar(calendarOptions);
 })

--- a/app/assets/javascripts/instruments.js
+++ b/app/assets/javascripts/instruments.js
@@ -1,9 +1,9 @@
 $(document).ready(function() {
-  new FullCalendarConfig($("#calendar")).init({
+  new FullCalendarConfig($("#calendar"), {
     header: {
       left: '',
       center: 'title',
       right: 'prev,next today agendaDay,agendaWeek,month',
-    },
-  });
+    }
+  }).init();
 });

--- a/app/assets/javascripts/reservations.js
+++ b/app/assets/javascripts/reservations.js
@@ -1,15 +1,7 @@
-//= require _calendar
-
 $(document).ready(function() {
 
   // initialize fullcalendar
   var calendarOptions = $.extend({}, defaultCalendarOptions);
-
-  if (window.initialDate) {
-	  var d = new Date(Date.parse(initialDate));
-	  $.extend(calendarOptions, {year: d.getFullYear(), month: d.getMonth(), date: d.getDate()});
-  }
-
   $('#calendar').fullCalendar(calendarOptions);
 
   init_datepickers();
@@ -19,10 +11,10 @@ $(document).ready(function() {
     if (typeof minDaysFromNow == "undefined") {
       window['minDaysFromNow'] = 0;
     }
-    $("#datepicker").datepicker({'minDate':minDaysFromNow, 'maxDate':maxDaysFromNow});
+    $("#datepicker").datepicker({'minDate': minDaysFromNow, 'maxDate': maxDaysFromNow});
 
     $('.datepicker').each(function(){
-      $(this).datepicker({'minDate':minDaysFromNow, 'maxDate':maxDaysFromNow})
+      $(this).datepicker({'minDate': minDaysFromNow, 'maxDate': maxDaysFromNow})
       		.change(function() {
       			var d = new Date(Date.parse($(this).val()));
       			$('#calendar').fullCalendar('gotoDate', d);

--- a/app/assets/javascripts/reservations.js
+++ b/app/assets/javascripts/reservations.js
@@ -1,83 +1,16 @@
+//= require _calendar
+
 $(document).ready(function() {
 
-  $calendar = $('#calendar');
-
   // initialize fullcalendar
-  var calendarOptions = {
-    editable: false,
-    defaultView: 'agendaWeek',
-    allDaySlot: false,
-    events: events_path,
-    eventAfterRender: function(event, element) {
-      var tooltip = [
-        $.fullCalendar.formatDate(event.start, 'hh:mmTT'),
-        $.fullCalendar.formatDate(event.end,   'hh:mmTT')
-      ].join('&mdash;') + '<br/>';
+  var calendarOptions = $.extend({}, defaultCalendarOptions);
 
-      // Default for our tooltip is to show.
-      if ($calendar.data("show-tooltip") != false) {
-        if (event.admin) {  // administrative reservation
-          tooltip += 'Admin Reservation<br/>';
-        } else {            // normal reservation
-          tooltip += [
-            event.name,
-            event.email
-          ].join('<br/>');
-        }
-
-        // create the tooltip
-        if (element.qtip) {
-          $(element).qtip({
-            content: tooltip,
-            style: {
-              classes: "qtip-light"
-            },
-            position: {
-              at:  'bottom left',
-              my:  'topRight'
-            }
-          });
-        }
-      }
-    },
-    minTime: minTime,
-    maxTime: maxTime,
-    height: (maxTime - minTime)*42 + 75,
-    loading: function(isLoading, view) {
-      if (isLoading) {
-        $("#overlay").addClass('on').removeClass('off');
-      } else {
-        $("#overlay").addClass('off').removeClass('on');
-        try {
-          var startDate = $.fullCalendar.formatDate(view.start, "yyyyMMdd")
-          var endDate   = $.fullCalendar.formatDate(view.end, "yyyyMMdd")
-          // check calendar start date
-          if (startDate < minDate) {
-            // hide the previous button
-            $("div.fc-button-prev").hide();
-          } else {
-            // show the previous button
-            $("div.fc-button-prev").show();
-          }
-          // check calendar end date
-          if (endDate > maxDate) {
-            // hide the next button
-            $("div.fc-button-next").hide();
-          } else {
-            // show the next button
-            $("div.fc-button-next").show();
-          }
-        } catch(error) {}
-      }
-    }
-
-  };
   if (window.initialDate) {
 	  var d = new Date(Date.parse(initialDate));
 	  $.extend(calendarOptions, {year: d.getFullYear(), month: d.getMonth(), date: d.getDate()});
   }
 
-  $calendar.fullCalendar(calendarOptions);
+  $('#calendar').fullCalendar(calendarOptions);
 
   init_datepickers();
 

--- a/app/assets/javascripts/reservations.js
+++ b/app/assets/javascripts/reservations.js
@@ -1,8 +1,6 @@
 $(document).ready(function() {
 
-  // initialize fullcalendar
-  var calendarOptions = $.extend({}, defaultCalendarOptions);
-  $('#calendar').fullCalendar(calendarOptions);
+  new FullCalendarConfig($("#calendar")).init()
 
   init_datepickers();
 
@@ -54,6 +52,5 @@ $(document).ready(function() {
   }
   $('.copy_actual_from_reservation a').click(copyReservationTimeIntoActual);
 
-  //$("div.fc-button-prev").hide();
 });
 

--- a/app/presenters/reservations/calendar_presenter.rb
+++ b/app/presenters/reservations/calendar_presenter.rb
@@ -3,27 +3,29 @@ module Reservations
   class CalendarPresenter < DelegateClass(Reservation)
 
     def as_calendar_object(options = {})
-      calendar_object_default.merge(
-        if order.present?
-          if options[:with_details].present?
-            {
-              "admin" => false,
-              "email" => order.user.email,
-              "name"  => order.user.full_name.to_s,
-              "title" => "#{order.user.first_name}\n#{order.user.last_name}",
-            }
-          else
-            {}
-          end
-        elsif offline?
-          { "admin" => true, "title" => "Instrument\nOffline" }
-        else
-          { "admin" => true, "title" => "Admin\nReservation" }
-        end,
-      )
+      calendar_object_default.merge(reservation_options(options))
     end
 
     private
+
+    def reservation_options(options)
+      if order.present?
+        if options[:with_details].present?
+          {
+            "email" => order.user.email,
+            "title" => order.user.full_name,
+          }
+        else
+          {}
+        end
+      elsif offline?
+        { "title" => "Instrument Offline" }
+      else
+        {
+          "title" => "Admin Reservation",
+        }
+      end
+    end
 
     def calendar_object_default
       {

--- a/app/views/instruments/public_schedule.html.haml
+++ b/app/views/instruments/public_schedule.html.haml
@@ -29,4 +29,4 @@
 #overlay
   #spinner
     #hide
-      #calendar
+      #calendar{ data: { show_tooltip: "false" } }

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -65,7 +65,7 @@
     "console": true
   },
   "no_empty_functions": {
-    "level": "error"
+    "level": "ignore"
   },
   "no_empty_param_list": {
     "level": "warn"

--- a/spec/app_support/reservations/rendering_spec.rb
+++ b/spec/app_support/reservations/rendering_spec.rb
@@ -58,15 +58,14 @@ RSpec.describe Reservations::Rendering do
   describe "#as_calendar_object" do
     let(:actual_start_at) { Time.zone.local(2015, 8, 1, 9, 15, 16) }
     let(:actual_end_at) { Time.zone.local(2015, 8, 1, 10, 16, 17) }
-    let(:title) { "Admin\nReservation" }
+    let(:title) { "Admin Reservation" }
 
-    let(:hash_without_details) do
+    let(:base_hash) do
       {
-        "allDay" => false,
+        "start" => "Sat, 01 Aug 2015 09:15:16",
         "end" => "Sat, 01 Aug 2015 10:16:17",
         "product" => "Generic",
-        "start" => "Sat, 01 Aug 2015 09:15:16",
-        "title" => title,
+        "allDay" => false,
       }
     end
 
@@ -76,47 +75,35 @@ RSpec.describe Reservations::Rendering do
       let(:order) { build_stubbed(:order, user: user) }
       let(:user) { build_stubbed(:user) }
 
-      let(:hash_with_details) do
-        hash_without_details.merge(
-          "admin" => false,
-          "email" => user.email,
-          "name" => user.full_name,
-        )
-      end
-
       before { allow(reservation).to receive(:order).and_return(order) }
 
       context "with details requested" do
-        let(:title) { "#{user.first_name}\n#{user.last_name}" }
+        let(:title) { user.full_name }
 
         it "returns a hash with extra details about the order" do
           expect(reservation.as_calendar_object(with_details: true))
-            .to eq(hash_with_details)
+            .to eq(base_hash.merge("email" => user.email, "title" => user.full_name))
         end
       end
 
       context "without details requested" do
-        let(:title) { "Reservation" }
-
         it "returns a hash without extra details about the order" do
-          expect(reservation.as_calendar_object).to eq(hash_without_details)
+          expect(reservation.as_calendar_object).to eq(base_hash.merge("title" => "Reservation"))
         end
       end
     end
 
     context "without an order" do
-      let(:hash_with_no_order) { hash_without_details.merge("admin" => true) }
-
       context "with details requested" do
         it "returns a hash without extra details about the order" do
           expect(reservation.as_calendar_object(with_details: true))
-            .to eq(hash_with_no_order)
+            .to eq(base_hash.merge("title" => "Admin Reservation"))
         end
       end
 
       context "without details requested" do
         it "returns a hash without extra details about the order" do
-          expect(reservation.as_calendar_object).to eq(hash_with_no_order)
+          expect(reservation.as_calendar_object).to eq(base_hash.merge("title" => "Admin Reservation"))
         end
       end
     end


### PR DESCRIPTION
> This is specifically useful for shared calendars.

There was a lot of copy/pasted code between `reservations.js` and `instruments.js` for setting up the calendar. This consolidates it into one single class, and then is initialized through those two files.

This will conflict with #1168 in the calendar presenter, but should be straightforward to reconcile.

New reservation:
![screen shot 2017-07-14 at 5 57 08 pm](https://user-images.githubusercontent.com/1099111/28233670-00e470a4-68be-11e7-8de4-56ec4b6092dc.png)

Public calendar (with details disabled):
![screen shot 2017-07-14 at 5 57 58 pm](https://user-images.githubusercontent.com/1099111/28233673-098962be-68be-11e7-96e0-25deaa302a64.png)
