### PR TITLE
[#137190] note error message

### DIFF
--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -2,7 +2,6 @@
     url: manage_facility_order_order_detail_path(current_facility, @order, @order_detail),
     remote: modal?,
     html: { class: ["manage_order_detail", edit_disabled? ? "disabled" : ""] } do |f|
-  = f.input :editing_time_data, as: :hidden, input_html: { value: true }
 
   %div{class: modal? ? "modal-body" : ""}
     .row

--- a/app/views/order_management/order_details/_reservation.html.haml
+++ b/app/views/order_management/order_details/_reservation.html.haml
@@ -14,6 +14,7 @@
 
   .datetime-block.js--pricingUpdate
     - if reservation.can_edit_actuals? && !reservation.canceled?
+      = f.input :editing_time_data, as: :hidden, input_html: { value: true }
       = r.input :actual_start_date, input_html: { class: "datepicker" }
       .control-group
         .controls

--- a/spec/features/admin/manage_order_detail_spec.rb
+++ b/spec/features/admin/manage_order_detail_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "Managing an order detail" do
 
   let(:director) { create(:user, :facility_director, facility: facility) }
 
-
   before do
     login_as director
     visit manage_facility_order_order_detail_path(facility, order, order_detail)

--- a/spec/features/admin/manage_order_detail_spec.rb
+++ b/spec/features/admin/manage_order_detail_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Managing an order detail" do
+
+  let(:facility) { create(:setup_facility) }
+  let(:instrument) { FactoryGirl.create(:setup_instrument, facility: facility, control_mechanism: "timer") }
+  let(:reservation) { create(:purchased_reservation, product: instrument) }
+  let(:order_detail) { reservation.order_detail }
+  let(:order) { reservation.order }
+
+  let(:director) { create(:user, :facility_director, facility: facility) }
+
+
+  before do
+    login_as director
+    visit manage_facility_order_order_detail_path(facility, order, order_detail)
+  end
+
+  describe "editing an order detail with a reservation" do
+    it "can change the note" do
+      fill_in "Note", with: "hello"
+      click_button "Save"
+      expect(order_detail.reload.note).to eq "hello"
+      expect(page).to have_content("successfully updated")
+    end
+
+    it "can change reservation duration" do
+      fill_in "Duration", with: "90"
+      click_button "Save"
+      new_end_at = order_detail.reservation.reload.reserve_start_at + 90.minutes
+
+      expect(order_detail.reservation.reload.reserve_end_at).to eq(new_end_at)
+      expect(page).to have_content("successfully updated")
+    end
+  end
+end

--- a/vendor/engines/secure_rooms/app/views/order_management/order_details/secure_rooms/_occupancy.html.haml
+++ b/vendor/engines/secure_rooms/app/views/order_management/order_details/secure_rooms/_occupancy.html.haml
@@ -1,4 +1,5 @@
 .datetime-block.js--timeFieldAdjustor
+  = f.input :editing_time_data, as: :hidden, input_html: { value: true }
   = f.simple_fields_for :occupancy_attributes, f.object.time_data do |of|
     = of.input :entry_at, as: :time_dropdown, error: false
 

--- a/vendor/engines/secure_rooms/spec/features/admin_edit_occupancy_spec.rb
+++ b/vendor/engines/secure_rooms/spec/features/admin_edit_occupancy_spec.rb
@@ -71,6 +71,12 @@ RSpec.describe "Editing an occupancy" do
       expect(occupancy.exit_at).to eq(Time.zone.parse("2017-09-12 09:45"))
       expect(order_detail.reload.fulfilled_at).to eq(occupancy.exit_at)
     end
+
+    it "errors if no end time is set" do
+      click_button "Save"
+
+      expect(page).to have_content("Error while updating order")
+    end
   end
 
   describe "with an orphaned swipe out" do


### PR DESCRIPTION
- https://pm.tablexi.com/issues/137190

If you try to change a note of an in-progress reservation, you receive the error message "Actual duration may not be blank" but it still lets the note get changed even though you have to use cancel to get out of the screen.

In process Reservation
Click on the Order Number
Change note
Click Save
See error message
Click Cancel
Note is changed