### PR TITLE
[#137205] text changes/UI cleanup

### DIFF
--- a/app/views/instrument_price_policies/_table.html.haml
+++ b/app/views/instrument_price_policies/_table.html.haml
@@ -3,18 +3,18 @@
 %table.table
   %thead
     %tr
-      %th.actions{rowspan: 2}
-      %th{rowspan: 2}= "#{PriceGroup.model_name.human} (#{price_policy.class.human_attribute_name(:type)}"
-      %th.currency{colspan: 2}= price_policy.class.human_attribute_name(:hourly_usage_rate)
-      %th.currency{rowspan: 2}= price_policy.class.human_attribute_name(:minimum_cost)
+      %th.actions{ rowspan: 2 }
+      %th{ rowspan: 2 }= "#{PriceGroup.model_name.human} (#{price_policy.class.human_attribute_name(:type)})"
+      %th.currency{ colspan: 2 }= price_policy.class.human_attribute_name(:hourly_usage_rate)
+      %th.currency{ rowspan: 2 }= price_policy.class.human_attribute_name(:minimum_cost)
       - if local_assigns[:cancellation] != false
-        %th.currency{rowspan: 2}= price_policy.class.human_attribute_name(:cancellation_cost)
+        %th.currency{ rowspan: 2 }= price_policy.class.human_attribute_name(:cancellation_cost)
   %tbody
     - price_policies_to_show = price_policies.select { |pp| pp.can_purchase? }
     - price_policies_to_show.each do |price_policy|
       %tr
         - if price_policies_to_show.first == price_policy
-          %td.centered{rowspan: price_policies_to_show.length}
+          %td.centered{ rowspan: price_policies_to_show.length }
             - if price_policies.all? { |pp| pp.editable? } && can?(:edit, PricePolicy)
               %p
                 = link_to t("shared.edit"),
@@ -31,7 +31,7 @@
         %td= "#{price_policy.price_group.name} (#{price_policy.price_group.type_string})"
 
         - if price_policy.valid?
-          %td.currency{colspan: 2}
+          %td.currency{ colspan: 2 }
             - if price_policy.has_rate?
               .rate= number_to_currency price_policy.hourly_usage_rate
               - if price_policy.has_subsidy?
@@ -53,6 +53,6 @@
             %td.currency= number_to_currency(price_policy.cancellation_cost)
 
         - else
-          %td.centered{colspan: 5}
+          %td.centered{ colspan: 5 }
             = t("price_policies.problem")
             = price_policy.errors.full_messages.to_sentence

--- a/app/views/price_policies/_table.html.haml
+++ b/app/views/price_policies/_table.html.haml
@@ -1,12 +1,13 @@
+- price_policy = price_policies.first
+
 %table.table
   %thead
     %tr
       %th.actions
-      %th Price Group
-      %th Type
-      %th.currency Unit Cost
-      %th.currency Unit Adjustment
-      %th.currency Unit Net Cost
+      %th{ rowspan: 2 }= "#{PriceGroup.model_name.human} (#{price_policy.class.human_attribute_name(:type)})"
+      %th.currency= price_policy.class.human_attribute_name(:unit_cost)
+      %th.currency= price_policy.class.human_attribute_name(:unit_adjustment)
+      %th.currency= price_policy.class.human_attribute_name(:unit_net_cost)
   %tbody
     - price_policies_to_show = price_policies.select { |pp| pp.can_purchase? }
     - price_policies_to_show.each do |price_policy|
@@ -14,8 +15,8 @@
         - if price_policies_to_show.first == price_policy
           %td.centered{ :rowspan => price_policies_to_show.length }
             - unless price_policies.all?{|pp| pp.editable?}
-              %p.muted Edit
-              %p.muted Remove
+              %p.muted= t("shared.edit")
+              %p.muted= t("shared.remove")
             - else
               %p
                 = link_to t("shared.edit"),
@@ -26,13 +27,12 @@
                   data: { confirm: t("shared.confirm_message") },
                   method: :delete
 
-        %td= price_policy.price_group.name
-        %td= price_policy.price_group.type_string
+        %td= "#{price_policy.price_group.name} (#{price_policy.price_group.type_string})"
         - if price_policy.valid?
           %td.currency= number_to_currency price_policy.unit_cost
           %td.currency= number_to_currency price_policy.unit_subsidy
           %td.currency= number_to_currency(price_policy.unit_cost - price_policy.unit_subsidy)
         - else
           %td.centered{ :colspan => 3 }
-            = t('price_policies.problem')
+            = t("price_policies.problem")
             = price_policy.errors.full_messages.to_sentence

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -241,6 +241,7 @@ en:
         cancellation_cost: Reservation Cost
         unit_cost: Unit Cost
         unit_adjustment: Unit Adjustment
+        unit_net_cost: Unit Net Cost
       user_role:
         username: User
       order:


### PR DESCRIPTION
- https://pm.tablexi.com/issues/137205

Two interrelated issues:

1) There is a missing "close parenthesis" on all Instrument Price Rule pages. It reads: "Price Group (Type"

2) The internal/external Price Group distinguish-er is not present for Service and Items; the UI should be consistent with the instrument price rule pages, listing whether these Price Groups are internal/external