### PR TITLE
[#137187] reconciled order details are not ready_for_journal

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -768,7 +768,7 @@ class OrderDetail < ActiveRecord::Base
   end
 
   def ready_for_journal?
-    reviewed? && journal_id.blank? && Account.config.using_journal?(account.type)
+    reviewed? && journal_id.blank? && Account.config.using_journal?(account.type) && !reconciled?
   end
 
   def awaiting_payment?

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -970,6 +970,16 @@ RSpec.describe OrderDetail do
         @order_detail.journal_id = 1
         expect(@order_detail).not_to be_ready_for_journal
       end
+
+      it "is not ready if it was manually reconciled" do
+        @order_detail.reviewed_at = 1.day.ago
+        @order_detail.to_inprocess!
+        @order_detail.to_complete!
+        @order_detail.actual_cost = 100
+        @order_detail.actual_subsidy = 0
+        @order_detail.to_reconciled
+        expect(@order_detail).not_to be_ready_for_journal
+      end
     end
 
     describe "a non-statementable account" do


### PR DESCRIPTION
- https://pm.tablexi.com/issues/137187

Manually reconciled orders were still showing "Ready for Journal" badge, even though they were not available to be journaled.