### PR TITLE
[#137189] feature flag ready for journal badges/alerts

### DIFF
--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -11,7 +11,7 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
     statuses << Notice.new(:can_reconcile) if can_reconcile_journaled?
     statuses << Notice.new(:in_open_journal) if in_open_journal?
     statuses << Notice.new(:ready_for_statement) if ready_for_statement?
-    statuses << Notice.new(:ready_for_journal) if ready_for_journal?
+    statuses << Notice.new(:ready_for_journal) if ready_for_journal? && SettingsHelper.feature_on?(:ready_for_journal)
     statuses << Notice.new(:awaiting_payment) if awaiting_payment?
 
     statuses

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -11,7 +11,7 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
     statuses << Notice.new(:can_reconcile) if can_reconcile_journaled?
     statuses << Notice.new(:in_open_journal) if in_open_journal?
     statuses << Notice.new(:ready_for_statement) if ready_for_statement?
-    statuses << Notice.new(:ready_for_journal) if ready_for_journal? && SettingsHelper.feature_on?(:ready_for_journal)
+    statuses << Notice.new(:ready_for_journal) if ready_for_journal? && SettingsHelper.feature_on?(:ready_for_journal_notice)
     statuses << Notice.new(:awaiting_payment) if awaiting_payment?
 
     statuses

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -125,7 +125,7 @@ feature:
   set_statement_search_start_date_on: false
   send_statement_emails_on: true
   responsive_on: true
-  ready_for_journal_on: true
+  ready_for_journal_notice_on: true
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -125,6 +125,7 @@ feature:
   set_statement_search_start_date_on: false
   send_statement_emails_on: true
   responsive_on: true
+  ready_for_journal_on: true
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/spec/presenters/order_detail_notice_presenter_spec.rb
+++ b/spec/presenters/order_detail_notice_presenter_spec.rb
@@ -120,7 +120,6 @@ RSpec.describe OrderDetailNoticePresenter do
       expect(presenter.alerts_to_html).to be_empty
     end
 
-
     it "shows an important badge for a problem order" do
       allow(order_detail).to receive_messages(problem?: true, problem_description_key: :missing_price_policy)
       expect(presenter.alerts_to_html).to have_alert(/does not have a price policy/).with_level(:error)

--- a/spec/presenters/order_detail_notice_presenter_spec.rb
+++ b/spec/presenters/order_detail_notice_presenter_spec.rb
@@ -36,6 +36,16 @@ RSpec.describe OrderDetailNoticePresenter do
       expect(presenter.badges_to_html).to have_badge("Can Reconcile")
     end
 
+    it "shows ready for journal if setting is on", feature_setting: { ready_for_journal: true } do
+      allow(order_detail).to receive(:ready_for_journal?).and_return(true)
+      expect(presenter.badges_to_html).to have_badge("Ready for Journal")
+    end
+
+    it "does not show ready for journal if setting is off", feature_setting: { ready_for_journal: false } do
+      allow(order_detail).to receive(:ready_for_journal?).and_return(true)
+      expect(presenter.badges_to_html).not_to have_badge("Ready for Journal")
+    end
+
     it "shows in open journal" do
       allow(order_detail).to receive(:in_open_journal?).and_return(true)
       expect(presenter.badges_to_html).to have_badge("Open Journal")
@@ -99,6 +109,17 @@ RSpec.describe OrderDetailNoticePresenter do
       allow(order_detail).to receive(:in_open_journal?).and_return(true)
       expect(presenter.alerts_to_html).to have_alert(/pending journal/)
     end
+
+    it "shows ready for journal if setting is on", feature_setting: { ready_for_journal: true } do
+      allow(order_detail).to receive(:ready_for_journal?).and_return(true)
+      expect(presenter.alerts_to_html).to have_alert(/ready to be journaled/)
+    end
+
+    it "does not show ready for journal if setting is off", feature_setting: { ready_for_journal: false } do
+      allow(order_detail).to receive(:ready_for_journal?).and_return(false)
+      expect(presenter.alerts_to_html).to be_empty
+    end
+
 
     it "shows an important badge for a problem order" do
       allow(order_detail).to receive_messages(problem?: true, problem_description_key: :missing_price_policy)

--- a/spec/presenters/order_detail_notice_presenter_spec.rb
+++ b/spec/presenters/order_detail_notice_presenter_spec.rb
@@ -36,12 +36,12 @@ RSpec.describe OrderDetailNoticePresenter do
       expect(presenter.badges_to_html).to have_badge("Can Reconcile")
     end
 
-    it "shows ready for journal if setting is on", feature_setting: { ready_for_journal: true } do
+    it "shows ready for journal if setting is on", feature_setting: { ready_for_journal_notice: true } do
       allow(order_detail).to receive(:ready_for_journal?).and_return(true)
       expect(presenter.badges_to_html).to have_badge("Ready for Journal")
     end
 
-    it "does not show ready for journal if setting is off", feature_setting: { ready_for_journal: false } do
+    it "does not show ready for journal if setting is off", feature_setting: { ready_for_journal_notice: false } do
       allow(order_detail).to receive(:ready_for_journal?).and_return(true)
       expect(presenter.badges_to_html).not_to have_badge("Ready for Journal")
     end
@@ -110,12 +110,12 @@ RSpec.describe OrderDetailNoticePresenter do
       expect(presenter.alerts_to_html).to have_alert(/pending journal/)
     end
 
-    it "shows ready for journal if setting is on", feature_setting: { ready_for_journal: true } do
+    it "shows ready for journal if setting is on", feature_setting: { ready_for_journal_notice: true } do
       allow(order_detail).to receive(:ready_for_journal?).and_return(true)
       expect(presenter.alerts_to_html).to have_alert(/ready to be journaled/)
     end
 
-    it "does not show ready for journal if setting is off", feature_setting: { ready_for_journal: false } do
+    it "does not show ready for journal if setting is off", feature_setting: { ready_for_journal_notice: false } do
       allow(order_detail).to receive(:ready_for_journal?).and_return(false)
       expect(presenter.alerts_to_html).to be_empty
     end


### PR DESCRIPTION
- https://pm.tablexi.com/issues/137189

UIC doesn't use internal billing currently, and would like "ready for journal" badges and notices hidden to avoid confusing facility directors.