### PR TITLE
[#137257] charge mode matches accessory

### DIFF
--- a/app/controllers/product_accessories_controller.rb
+++ b/app/controllers/product_accessories_controller.rb
@@ -20,8 +20,11 @@ class ProductAccessoriesController < ApplicationController
   end
 
   def create
-    @product.product_accessories.create(params[:product_accessory])
-    flash[:notice] = I18n.t("product_accessories.create.success")
+    if @product_accessory.save
+      flash[:notice] = I18n.t("product_accessories.create.success")
+    else
+      flash[:error] = I18n.t("product_accessories.create.error")
+    end
     redirect_to action: :index
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -10,7 +10,7 @@ class Product < ActiveRecord::Base
   has_many   :stored_files
   has_many   :price_groups, through: :price_group_products
   has_many   :price_group_products
-  has_many :product_accessories, -> { where(deleted_at: nil) }, dependent: :destroy
+  has_many   :product_accessories, -> { where(deleted_at: nil) }, dependent: :destroy
   has_many   :accessories, through: :product_accessories, class_name: "Product"
   has_many   :price_policies
   has_many   :training_requests, dependent: :destroy

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -5,15 +5,15 @@ class Product < ActiveRecord::Base
   belongs_to :facility
   belongs_to :initial_order_status, class_name: "OrderStatus"
   belongs_to :facility_account
-  has_many   :product_users
-  has_many   :order_details
-  has_many   :stored_files
-  has_many   :price_groups, through: :price_group_products
-  has_many   :price_group_products
-  has_many   :product_accessories, -> { where(deleted_at: nil) }, dependent: :destroy
-  has_many   :accessories, through: :product_accessories, class_name: "Product"
-  has_many   :price_policies
-  has_many   :training_requests, dependent: :destroy
+  has_many :product_users
+  has_many :order_details
+  has_many :stored_files
+  has_many :price_groups, through: :price_group_products
+  has_many :price_group_products
+  has_many :product_accessories, -> { where(deleted_at: nil) }, dependent: :destroy
+  has_many :accessories, through: :product_accessories, class_name: "Product"
+  has_many :price_policies
+  has_many :training_requests, dependent: :destroy
 
   # Allow us to use `product.hidden?`
   alias_attribute :hidden, :is_hidden

--- a/app/models/product_accessory.rb
+++ b/app/models/product_accessory.rb
@@ -23,7 +23,7 @@ class ProductAccessory < ActiveRecord::Base
   def scaling_type_matches_product
     return if SCALING_TYPES[accessory.type.underscore].include?(scaling_type)
 
-    errors.add(:scaling_type, "does not match product type")
+    errors.add(:scaling_type)
   end
 
   def soft_delete

--- a/app/models/product_accessory.rb
+++ b/app/models/product_accessory.rb
@@ -1,6 +1,10 @@
 class ProductAccessory < ActiveRecord::Base
 
-  SCALING_TYPES = %w(quantity manual auto).freeze
+  SCALING_TYPES = {
+    item: ["quantity"],
+    service: ["quantity"],
+    timed_service: ["manual", "auto"]
+  }.with_indifferent_access
 
   ## relationships
   belongs_to :product
@@ -9,10 +13,17 @@ class ProductAccessory < ActiveRecord::Base
   ## validations
   validates :product, presence: true
   validates :accessory, presence: true
-  validates :scaling_type, presence: true, inclusion: SCALING_TYPES
+  validates :scaling_type, presence: true
+  validate :scaling_type_matches_product?
 
   def self.scaling_types
-    SCALING_TYPES
+    SCALING_TYPES.values.flatten.uniq
+  end
+
+  def scaling_type_matches_product?
+    return if SCALING_TYPES[accessory.type.underscore].include?(scaling_type)
+
+    errors.add(:scaling_type, "does not match product type")
   end
 
   def soft_delete

--- a/app/models/product_accessory.rb
+++ b/app/models/product_accessory.rb
@@ -5,6 +5,7 @@ class ProductAccessory < ActiveRecord::Base
     service: ["quantity"],
     timed_service: ["manual", "auto"],
   }.with_indifferent_access
+  SCALING_TYPES.default = ["quantity"]
 
   ## relationships
   belongs_to :product

--- a/app/models/product_accessory.rb
+++ b/app/models/product_accessory.rb
@@ -3,7 +3,7 @@ class ProductAccessory < ActiveRecord::Base
   SCALING_TYPES = {
     item: ["quantity"],
     service: ["quantity"],
-    timed_service: ["manual", "auto"]
+    timed_service: ["manual", "auto"],
   }.with_indifferent_access
 
   ## relationships

--- a/app/models/product_accessory.rb
+++ b/app/models/product_accessory.rb
@@ -14,13 +14,13 @@ class ProductAccessory < ActiveRecord::Base
   validates :product, presence: true
   validates :accessory, presence: true
   validates :scaling_type, presence: true
-  validate :scaling_type_matches_product?
+  validate :scaling_type_matches_product
 
   def self.scaling_types
     SCALING_TYPES.values.flatten.uniq
   end
 
-  def scaling_type_matches_product?
+  def scaling_type_matches_product
     return if SCALING_TYPES[accessory.type.underscore].include?(scaling_type)
 
     errors.add(:scaling_type, "does not match product type")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -732,6 +732,7 @@ en:
       add: Add as Accessory
     create:
       success: The accessory has been added.
+      error: Unable to add accessory - please check that the scaling type matches the product type.
     destroy:
       success: The accessory has been removed.
     button:

--- a/spec/controllers/accessories_controller_spec.rb
+++ b/spec/controllers/accessories_controller_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe AccessoriesController do
   render_views
   before(:all) { create_users }
 
-  let(:instrument) { create(:instrument_with_accessory, :always_available) }
+  let(:instrument) { create(:setup_instrument, :always_available) }
   let(:facility) { instrument.facility }
-  let(:quantity_accessory) { instrument.accessories.first }
-  let(:auto_accessory) { create(:time_based_accessory, parent: instrument, scaling_type: "auto") }
-  let(:manual_accessory) { create(:time_based_accessory, parent: instrument, scaling_type: "manual") }
+  let(:quantity_accessory) { create(:accessory, parent: instrument, facility: facility) }
+  let(:auto_accessory) { create(:time_based_accessory, parent: instrument, scaling_type: "auto", facility: facility) }
+  let(:manual_accessory) { create(:time_based_accessory, parent: instrument, scaling_type: "manual", facility: facility) }
   let(:reservation) { create(:purchased_reservation, product: instrument, reserve_start_at: 1.hour.ago) }
   let(:order_detail) { reservation.order_detail }
   let(:order) { order_detail.order }
@@ -105,17 +105,17 @@ RSpec.describe AccessoriesController do
       end
     end
 
-    context "with a deleted accessory" do
+    context "with a soft-deleted accessory association" do
       before :each do
-        item = quantity_accessory
+        accessory = manual_accessory
         instrument.product_accessories.first.soft_delete
-        second_accessory = auto_accessory
+        instrument.product_accessories.create(accessory: accessory, scaling_type: "auto")
 
         expect(instrument.reload.product_accessories.count).to eq(1)
-        expect(ProductAccessory.where(product_id: instrument.id).count).to eq(2)
+        expect(ProductAccessory.where(product_id: instrument.id, accessory_id: accessory.id).count).to eq(2)
       end
 
-      it "returns the second accessory" do
+      it "the same accessory can be re-added" do
         maybe_grant_always_sign_in :admin
         do_request
 
@@ -211,13 +211,11 @@ RSpec.describe AccessoriesController do
       describe "adding a manual-scaled accessory" do
         before :each do
           @params[:accessories] = {
-            quantity_accessory.id.to_s => {
+            manual_accessory.id.to_s => {
               quantity: "30",
               enabled: "true",
             },
           }
-
-          instrument.product_accessories.first.update_attributes(scaling_type: "manual")
         end
 
         it "creates the order detail" do
@@ -245,7 +243,7 @@ RSpec.describe AccessoriesController do
 
         context "adding a disabled accessory" do
           before :each do
-            @params[:accessories][quantity_accessory.id.to_s][:enabled] = "false"
+            @params[:accessories][manual_accessory.id.to_s][:enabled] = "false"
           end
 
           it "does not add the accessory" do
@@ -257,13 +255,11 @@ RSpec.describe AccessoriesController do
       describe "adding an autoscaled accessory" do
         before :each do
           @params[:accessories] = {
-            quantity_accessory.id.to_s => {
+            auto_accessory.id.to_s => {
               quantity: "40",
               enabled: "true",
             },
           }
-
-          instrument.product_accessories.first.update_attributes(scaling_type: "auto")
         end
 
         it "creates the order detail" do
@@ -290,7 +286,7 @@ RSpec.describe AccessoriesController do
 
         context "adding a disabled accessory" do
           before :each do
-            @params[:accessories][quantity_accessory.id.to_s][:enabled] = "false"
+            @params[:accessories][auto_accessory.id.to_s][:enabled] = "false"
           end
 
           it "does not add the accessory" do

--- a/spec/controllers/accessories_controller_spec.rb
+++ b/spec/controllers/accessories_controller_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe AccessoriesController do
   let(:instrument) { create(:instrument_with_accessory, :always_available) }
   let(:facility) { instrument.facility }
   let(:quantity_accessory) { instrument.accessories.first }
-  let(:auto_accessory) { create(:accessory, parent: instrument, scaling_type: "auto") }
-  let(:manual_accessory) { create(:accessory, parent: instrument, scaling_type: "manual") }
+  let(:auto_accessory) { create(:time_based_accessory, parent: instrument, scaling_type: "auto") }
+  let(:manual_accessory) { create(:time_based_accessory, parent: instrument, scaling_type: "manual") }
   let(:reservation) { create(:purchased_reservation, product: instrument, reserve_start_at: 1.hour.ago) }
   let(:order_detail) { reservation.order_detail }
   let(:order) { order_detail.order }
@@ -109,10 +109,10 @@ RSpec.describe AccessoriesController do
       before :each do
         item = quantity_accessory
         instrument.product_accessories.first.soft_delete
-        instrument.product_accessories.create(accessory: item, scaling_type: "auto")
+        second_accessory = auto_accessory
 
         expect(instrument.reload.product_accessories.count).to eq(1)
-        expect(ProductAccessory.where(product_id: instrument.id, accessory_id: item.id).count).to eq(2)
+        expect(ProductAccessory.where(product_id: instrument.id).count).to eq(2)
       end
 
       it "returns the second accessory" do

--- a/spec/controllers/product_accessories_controller_spec.rb
+++ b/spec/controllers/product_accessories_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe ProductAccessoriesController do
 
     context "permissions" do
       before do
-        @params.merge! product_accessory: { accessory_id: timed_service.id, scaling_type: "manual" }
+        @params[:product_accessory] = { accessory_id: timed_service.id, scaling_type: "manual" }
       end
 
       it_should_allow_managers_and_senior_staff_only(:redirect) {}
@@ -82,7 +82,7 @@ RSpec.describe ProductAccessoriesController do
     context "success" do
       before do
         maybe_grant_always_sign_in :admin
-        @params.merge! product_accessory: { accessory_id: accessory.id, scaling_type: "quantity" }
+        @params[:product_accessory] = { accessory_id: accessory.id, scaling_type: "quantity" }
       end
 
       context "with quantity-based accessory" do
@@ -107,7 +107,7 @@ RSpec.describe ProductAccessoriesController do
 
       context "with time-based accessory" do
         before do
-          @params.merge! product_accessory: { accessory_id: timed_service.id, scaling_type: "auto" }
+          @params[:product_accessory] = { accessory_id: timed_service.id, scaling_type: "auto" }
           do_request
         end
 

--- a/spec/controllers/product_accessories_controller_spec.rb
+++ b/spec/controllers/product_accessories_controller_spec.rb
@@ -66,19 +66,23 @@ RSpec.describe ProductAccessoriesController do
   end
 
   describe "create" do
-    let(:scaling_type) { "quantity" }
-
     before do
       @method = :post
       @action = :create
-      @params.merge! product_accessory: { accessory_id: accessory.id, scaling_type: scaling_type }
     end
 
-    it_should_allow_managers_and_senior_staff_only(:redirect) {}
+    context "permissions" do
+      before do
+        @params.merge! product_accessory: { accessory_id: timed_service.id, scaling_type: "manual" }
+      end
+
+      it_should_allow_managers_and_senior_staff_only(:redirect) {}
+    end
 
     context "success" do
       before do
         maybe_grant_always_sign_in :admin
+        @params.merge! product_accessory: { accessory_id: accessory.id, scaling_type: "quantity" }
       end
 
       context "with quantity-based accessory" do
@@ -102,10 +106,8 @@ RSpec.describe ProductAccessoriesController do
       end
 
       context "with time-based accessory" do
-        let(:accessory) { timed_service }
-        let(:scaling_type) { "auto" }
-
         before do
+          @params.merge! product_accessory: { accessory_id: timed_service.id, scaling_type: "auto" }
           do_request
         end
 

--- a/spec/factories/accessories.rb
+++ b/spec/factories/accessories.rb
@@ -19,4 +19,15 @@ FactoryGirl.define do
       evaluator.parent.product_accessories.create(accessory: item, scaling_type: evaluator.scaling_type)
     end
   end
+
+  factory :time_based_accessory, parent: :setup_timed_service do
+    transient do
+      parent { create :setup_instrument, facility: facility }
+      scaling_type "auto"
+    end
+
+    after(:create) do |item, evaluator|
+      evaluator.parent.product_accessories.create(accessory: item, scaling_type: evaluator.scaling_type)
+    end
+  end
 end

--- a/spec/factories/price_policies.rb
+++ b/spec/factories/price_policies.rb
@@ -36,7 +36,6 @@ FactoryGirl.define do
   end
 
   factory :timed_service_price_policy do
-    price_group
     charge_for "usage"
     usage_rate 15 / 60.0
     usage_subsidy 0

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -96,6 +96,12 @@ FactoryGirl.define do
     factory :setup_service, class: Service do
     end
 
+    factory :setup_timed_service, class: TimedService do
+      after(:create) do |product|
+        product.timed_service_price_policies.create(FactoryGirl.attributes_for(:timed_service_price_policy, price_group: product.facility.price_groups.last))
+      end
+    end
+
     factory :setup_item, class: Item do
       after(:create) do |product|
         product.item_price_policies.create(FactoryGirl.attributes_for(:item_price_policy, price_group: product.facility.price_groups.last))

--- a/spec/models/order_details/accessorized_order_detail_spec.rb
+++ b/spec/models/order_details/accessorized_order_detail_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe OrderDetail do
   let(:instrument) { FactoryGirl.create(:instrument_with_accessory, :timer) }
   let(:accessory) { instrument.accessories.first }
+  let(:auto_accessory) { create(:time_based_accessory, parent: instrument, scaling_type: "auto") }
+  let(:manual_accessory) { create(:time_based_accessory, parent: instrument, scaling_type: "manual") }
   let(:reservation) { FactoryGirl.create(:completed_reservation, product: instrument) }
   let(:order_detail) { reservation.order_detail.tap { |od| od.update(note: "original") } }
   let(:accessorizer) { Accessories::Accessorizer.new(order_detail) }
@@ -61,6 +63,7 @@ RSpec.describe OrderDetail do
   end
 
   context "manual scaled accessory" do
+    let(:accessory) { manual_accessory }
     let(:accessory_order_detail) { accessorizer.add_accessory(accessory) }
     before :each do
       accessorizer.send(:product_accessory, accessory).update_attributes!(scaling_type: "manual")
@@ -103,6 +106,7 @@ RSpec.describe OrderDetail do
   end
 
   context "auto scaled accessory" do
+    let(:accessory) { auto_accessory }
     # reload in order to avoid timestamp truncation causing false-positives on `changes`
     let(:accessory_order_detail) { accessorizer.add_accessory(accessory).reload }
     before :each do

--- a/spec/services/accessorizer_spec.rb
+++ b/spec/services/accessorizer_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Accessories::Accessorizer do
   let(:product) { create(:instrument_with_accessory) }
   let(:quantity_accessory) { product.accessories.first }
-  let!(:auto_scaled_accessory) { create(:time_based_accessory, parent: product, scaling_type: "auto")  }
+  let!(:auto_scaled_accessory) { create(:time_based_accessory, parent: product, scaling_type: "auto") }
 
   let(:order) { build_stubbed :order }
   let(:reservation) do

--- a/spec/services/accessorizer_spec.rb
+++ b/spec/services/accessorizer_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Accessories::Accessorizer do
   let(:product) { create(:instrument_with_accessory) }
   let(:quantity_accessory) { product.accessories.first }
-  let!(:auto_scaled_accessory) { create(:accessory, parent: product, scaling_type: "auto") }
+  let!(:auto_scaled_accessory) { create(:time_based_accessory, parent: product, scaling_type: "auto")  }
 
   let(:order) { build_stubbed :order }
   let(:reservation) do


### PR DESCRIPTION
When adding accessories to products, the scaling type chosen must make sense with the accessory that is chosen (i.e. items must have quantity, not a time-based scaling type).