### PR TITLE
[#136038] Update default group scope for Batch

### DIFF
--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/batch.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/batch.rb
@@ -2,7 +2,7 @@ module SangerSequencing
 
   class Batch < ActiveRecord::Base
 
-    DEFAULT_GROUP = [nil, ""].freeze
+    DEFAULT_PRODUCT_GROUP_NAME = [nil, ""].freeze
 
     self.table_name = "sanger_sequencing_batches"
 
@@ -17,9 +17,9 @@ module SangerSequencing
       where(facility: facility)
     end
 
-    def self.for_product_group(product_group)
-      product_group = DEFAULT_GROUP if product_group.blank?
-      where(group: product_group)
+    def self.for_product_group(product_group_name)
+      product_group_name = DEFAULT_PRODUCT_GROUP_NAME if product_group_name.blank?
+      where(group: product_group_name)
     end
 
     def well_plates

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/batch.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/batch.rb
@@ -2,6 +2,8 @@ module SangerSequencing
 
   class Batch < ActiveRecord::Base
 
+    DEFAULT_GROUP = [nil, ""].freeze
+
     self.table_name = "sanger_sequencing_batches"
 
     belongs_to :created_by, class_name: "User"
@@ -15,8 +17,9 @@ module SangerSequencing
       where(facility: facility)
     end
 
-    def self.for_product_group(group)
-      where(group: group)
+    def self.for_product_group(product_group)
+      product_group = DEFAULT_GROUP if product_group.blank?
+      where(group: product_group)
     end
 
     def well_plates

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
@@ -26,7 +26,7 @@ module SangerSequencing
     scope :for_facility, ->(facility) { where(orders: { facility_id: facility.id }) }
 
     def self.for_product_group(product_group)
-      if product_group
+      if product_group.present?
         where(order_details: { product_id: ProductGroup.where(group: product_group).pluck(:product_id) })
       else
         where.not(order_details: { product_id: ProductGroup.pluck(:product_id) })

--- a/vendor/engines/sanger_sequencing/spec/factories/product_groups.rb
+++ b/vendor/engines/sanger_sequencing/spec/factories/product_groups.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :product_group, class: SangerSequencing::ProductGroup do
+    product factory: :setup_service
+
+    trait :default do
+      group :default
+    end
+
+    trait :fragment do
+      group :fragment
+    end
+  end
+end

--- a/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/batch_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/batch_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe SangerSequencing::Batch do
+  describe ".for_product_group" do
+    subject { described_class.for_product_group(group) }
+
+    before { FactoryGirl.create(:product_group, :fragment) }
+    let!(:blank_batch) { FactoryGirl.create(:sanger_sequencing_batch, group: "") }
+    let!(:nil_batch) { FactoryGirl.create(:sanger_sequencing_batch, group: nil) }
+    let!(:grouped_batch) { FactoryGirl.create(:sanger_sequencing_batch, group: "fragment") }
+
+    context "with group given as nil" do
+      let(:group) { nil }
+      it { is_expected.to eq [blank_batch, nil_batch] }
+    end
+
+    context "with group given as empty string" do
+      let(:group) { "" }
+      it { is_expected.to eq [blank_batch, nil_batch] }
+    end
+
+    context "with a group provided" do
+      let(:group) { "fragment" }
+      it { is_expected.to eq [grouped_batch] }
+    end
+  end
+end

--- a/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/batch_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/batch_spec.rb
@@ -11,17 +11,17 @@ RSpec.describe SangerSequencing::Batch do
 
     context "with group given as nil" do
       let(:group) { nil }
-      it { is_expected.to eq [blank_batch, nil_batch] }
+      it { is_expected.to match_array [blank_batch, nil_batch] }
     end
 
     context "with group given as empty string" do
       let(:group) { "" }
-      it { is_expected.to eq [blank_batch, nil_batch] }
+      it { is_expected.to match_array [blank_batch, nil_batch] }
     end
 
     context "with a group provided" do
       let(:group) { "fragment" }
-      it { is_expected.to eq [grouped_batch] }
+      it { is_expected.to match_array [grouped_batch] }
     end
   end
 end


### PR DESCRIPTION
If a user visits the Batch index page without specifying a `group` param, Batches with `group == ""` are not displayed.