### PR TITLE
[#137315] feature flag validation for journals spanning fiscal years

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -54,7 +54,7 @@ class Journal < ActiveRecord::Base
   validates_length_of     :reference, maximum: 50
   validate :journal_date_cannot_be_in_future, if: "journal_date.present?"
   validate :must_have_order_details, on: :create, if: :order_details_for_creation
-  validate :must_not_span_fiscal_years, on: :create, if: :has_order_details_for_creation?
+  validate :must_not_span_fiscal_years, on: :create, if: :should_check_fiscal_years?
   validate :journal_date_cannot_be_before_last_fulfillment, on: :create, if: :has_order_details_for_creation?
   validates_with JournalDateMustBeAfterCutoffs, on: :create
   before_validation :set_facility_id, on: :create, if: :has_order_details_for_creation?
@@ -169,6 +169,10 @@ class Journal < ActiveRecord::Base
   delegate :to_s, to: :id
 
   private
+
+  def should_check_fiscal_years?
+    !SettingsHelper.feature_on?(:journals_may_span_fiscal_years) && has_order_details_for_creation?
+  end
 
   def has_order_details_for_creation?
     @order_details_for_creation.try(:any?)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -126,6 +126,7 @@ feature:
   send_statement_emails_on: true
   responsive_on: true
   ready_for_journal_notice_on: true
+  journals_may_span_fiscal_years_on: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -18,6 +18,23 @@ RSpec.describe Journal do
 
   describe "validations" do
     it { is_expected.to validate_length_of(:reference).is_at_most(50) }
+
+    describe "#must_not_span_fiscal_years" do
+      before do
+        order.add(product)
+        order.reload.order_details.first.update_attributes(fulfilled_at: Time.current)
+        order.order_details.last.update_attributes(fulfilled_at: 1.year.ago)
+        journal.order_details_for_creation = order.order_details
+      end
+
+      context "when journals may span fiscal years", feature_setting: { journals_may_span_fiscal_years: true } do
+        it { is_expected.to be_valid }
+      end
+
+      context "when journals may not span fiscal years", feature_setting: { journals_may_span_fiscal_years: false } do
+        it { is_expected.not_to be_valid }
+      end
+    end
   end
 
   describe "#order_details" do

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -33,6 +33,11 @@ RSpec.describe Journal do
 
       context "when journals may not span fiscal years", feature_setting: { journals_may_span_fiscal_years: false } do
         it { is_expected.not_to be_valid }
+
+        it "has the appropriate error" do
+          journal.save
+          expect(journal.errors).to be_added(:base, :fiscal_year_span)
+        end
       end
     end
   end


### PR DESCRIPTION
- NU wants to prevent journals being created with order details spanning fiscal years.
- Dartmouth wants to be able to create journals with order details spanning fiscal years.

Added a feature flag to enable/disable this validation per fork.