### PR TITLE
[#137332] bundle update thin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ group :development, :test do
   gem "spring-commands-rspec"
   gem "teaspoon-jasmine"
   gem "test-unit", "~> 3.0"
-  gem "thin", "~> 1.7.2"
+  gem "thin", ">= 1.7.2"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ group :development, :test do
   gem "spring-commands-rspec"
   gem "teaspoon-jasmine"
   gem "test-unit", "~> 3.0"
-  gem "thin"
+  gem "thin", "~> 1.7.2"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -661,7 +661,7 @@ DEPENDENCIES
   test-unit (~> 3.0)
   text_helpers
   therubyracer
-  thin (~> 1.7.2)
+  thin (>= 1.7.2)
   uglifier (~> 2.7.2)
   unicorn
   vuejs-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
     docile (1.1.5)
     dynamic_form (1.1.4)
     erubis (2.7.0)
-    eventmachine (1.2.2)
+    eventmachine (1.2.5)
     exception_notification (4.0.1)
       actionmailer (>= 3.0.4)
       activesupport (>= 3.0.4)
@@ -534,7 +534,7 @@ GEM
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
-    thin (1.7.0)
+    thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
@@ -661,7 +661,7 @@ DEPENDENCIES
   test-unit (~> 3.0)
   text_helpers
   therubyracer
-  thin
+  thin (~> 1.7.2)
   uglifier (~> 2.7.2)
   unicorn
   vuejs-rails


### PR DESCRIPTION
Fix deprecation warnings for older version of thin from Ruby 2.4 upgrade.