### PR TITLE
[#133776] offline reservations are not editable/cancelable

### DIFF
--- a/app/helpers/facility_reservations_helper.rb
+++ b/app/helpers/facility_reservations_helper.rb
@@ -13,6 +13,8 @@ module FacilityReservationsHelper
   end
 
   def reservation_links(reservation)
+    return if reservation.offline?
+
     links = []
     if reservation.admin?
       links << link_to(I18n.t("reservations.edit.link"), edit_admin_reservation_path(reservation))


### PR DESCRIPTION
Aaron was encountering errors when trying to edit offline reservations through the admin reservation edit form. Offline reservations should not be editable--this will remove the problematic links.