### PR TITLE
[#137451] Extend journal row description field length

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -18,7 +18,8 @@ class Product < ActiveRecord::Base
   # Allow us to use `product.hidden?`
   alias_attribute :hidden, :is_hidden
 
-  validates_presence_of :name, :type
+  validates :type, presence: true
+  validates :name, presence: true, length: { maximum: 200 }
   validate_url_name :url_name, :facility_id
   validates :user_notes_field_mode, presence: true, inclusion: Products::UserNoteMode.all
   validates :user_notes_label, length: { maximum: 255 }

--- a/db/migrate/20170816180831_lengthen_journal_row_description_column.rb
+++ b/db/migrate/20170816180831_lengthen_journal_row_description_column.rb
@@ -1,0 +1,11 @@
+class LengthenJournalRowDescriptionColumn < ActiveRecord::Migration
+
+  def up
+    change_column :journal_rows, :description, :string, limit: 512
+  end
+
+  def down
+    change_column :journal_rows, :description, :string, limit: 200
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170803181918) do
+ActiveRecord::Schema.define(version: 20170816180831) do
 
   create_table "account_users", force: :cascade do |t|
     t.integer  "account_id", limit: 4,  null: false
@@ -206,7 +206,7 @@ ActiveRecord::Schema.define(version: 20170803181918) do
     t.integer "order_detail_id", limit: 4
     t.string  "account",         limit: 5
     t.decimal "amount",                      precision: 9, scale: 2, null: false
-    t.string  "description",     limit: 200
+    t.string  "description",     limit: 512
     t.integer "account_id",      limit: 4
   end
 


### PR DESCRIPTION
`OrderDetail#long_description` is what gets put into the
`JournalRow#description` field. If you have a really long product name
(that field is limited to 200 characters), then the description is too
long for the journal row field.

The 512 is somewhat arbitrary, but should be more than enough for
fitting long product names, the order detail and a user’s name.