### PR TITLE
[#137409] fix reservation validations

### DIFF
--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -6,13 +6,14 @@ module Reservations::Validations
     delegate :editing_time_data, to: :order_detail, allow_nil: true
 
     validates_uniqueness_of :order_detail_id, allow_nil: true
-    validates :product_id, :reserve_start_at, presence: true
+    validates :product_id, presence: true
     validates :reserve_end_at, presence: true, if: :end_at_required?
+    validates :reserve_start_at, presence: true
     validate :does_not_conflict_with_other_reservation,
              :instrument_is_available_to_reserve,
              :satisfies_minimum_length,
              :satisfies_maximum_length,
-             if: :reserve_start_at && :reserve_end_at && :reservation_changed?,
+             if: -> (r) { r.reserve_start_at && r.reserve_end_at && r.reservation_changed? },
              unless: :admin?
 
     validates_each [:actual_start_at, :actual_end_at] do |record, attr, value|

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -13,7 +13,7 @@ module Reservations::Validations
              :instrument_is_available_to_reserve,
              :satisfies_minimum_length,
              :satisfies_maximum_length,
-             if: -> (r) { r.reserve_start_at && r.reserve_end_at && r.reservation_changed? },
+             if: ->(r) { r.reserve_start_at && r.reserve_end_at && r.reservation_changed? },
              unless: :admin?
 
     validates_each [:actual_start_at, :actual_end_at] do |record, attr, value|

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -7,8 +7,8 @@ module Reservations::Validations
 
     validates_uniqueness_of :order_detail_id, allow_nil: true
     validates :product_id, presence: true
-    validates :reserve_end_at, presence: true, if: :end_at_required?
     validates :reserve_start_at, presence: true
+    validates :reserve_end_at, presence: true, if: :end_at_required?
     validate :does_not_conflict_with_other_reservation,
              :instrument_is_available_to_reserve,
              :satisfies_minimum_length,

--- a/spec/models/reservations_validations_spec.rb
+++ b/spec/models/reservations_validations_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Reservations::Validations do
 
   let(:now) { Time.zone.now }
 
+  it { is_expected.to validate_presence_of(:reserve_start_at) }
+
   it 'validates with #duration_is_interval' do
     expect(reservation).to receive :duration_is_interval
     reservation.save
@@ -57,6 +59,22 @@ RSpec.describe Reservations::Validations do
             expect(reservation.save_as_user(user)).to be(true)
           end
         end
+      end
+    end
+  end
+
+  describe "conditionally run validations" do
+    context "with reserve_start_at, reserve_end_at, and reservation_changed? is true" do
+      it "runs conditional validations" do
+        expect(reservation).to receive :does_not_conflict_with_other_reservation
+        reservation.save
+      end
+    end
+
+    context "with missing reserve_start_at" do
+      it "does not run conditional validations" do
+        expect(reservation).not_to receive :does_not_conflict_with_other_reservation
+        reservation.update_attributes(reserve_start_at: nil)
       end
     end
   end


### PR DESCRIPTION
- https://pm.tablexi.com/issues/137409
- Certain time-related validations should only be run if reserve_start_at and reserve_end_at have valid values to avoid hard-errors.