### PR TITLE
[#137464] Allow user to edit order detail note

### DIFF
--- a/app/views/reservations/edit.html.haml
+++ b/app/views/reservations/edit.html.haml
@@ -25,6 +25,13 @@
 
   = render "reservation_fields", f: f
 
+  .well
+    .container
+      .row
+        .span
+          %h4= OrderDetail.model_name.human
+          = f.input :note
+
   %ul.inline
     %li= f.submit 'Save', class: 'btn'
     - if @order.purchased?


### PR DESCRIPTION
https://pm.tablexi.com/issues/137105

The story mentions "We should review statuses and editing capability to make sure we keep this editable appropriately. For example, as long as the reservation is not yet complete."

As far as I can tell, the edit page is still accessible for a completed reservation (go directly to the `/edit`), but it is not linked to anymore. Is that a problem? If so, it seems like a different story, given that other fields are also editable from there.