### PR TITLE
[#137409] Handle invalid dates for reservations on completed

### DIFF
--- a/app/models/instrument_price_policy_calculations.rb
+++ b/app/models/instrument_price_policy_calculations.rb
@@ -40,6 +40,8 @@ module InstrumentPricePolicyCalculations
 
   # CHARGE_FOR[:reservation] uses reserve start and end time for calculation
   def calculate_reservation(reservation)
+    # One or both of these could be blank if we parse an invalid date in a form
+    return unless reservation.reserve_start_at && reservation.reserve_end_at
     calculate_for_time(reservation.reserve_start_at, reservation.reserve_end_at)
   end
 

--- a/spec/models/instrument_price_policy_calculations_spec.rb
+++ b/spec/models/instrument_price_policy_calculations_spec.rb
@@ -181,6 +181,18 @@ RSpec.describe InstrumentPricePolicyCalculations do
       policy.calculate_cost_and_subsidy reservation
     end
 
+    it "returns nil when reserve_start at is nil and charging for reservation" do
+      policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[:reservation]
+      allow(reservation).to receive(:reserve_start_at).and_return nil
+      expect(policy.calculate_cost_and_subsidy(reservation)).to be_nil
+    end
+
+    it "returns nil when reserve_start at is nil and charging for reservation" do
+      policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[:reservation]
+      allow(reservation).to receive(:reserve_end_at).and_return nil
+      expect(policy.calculate_cost_and_subsidy(reservation)).to be_nil
+    end
+
     %w(usage overage).each do |charge_for|
       it "returns nil if actual_start_at is missing and we are charging by #{charge_for}" do
         policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[charge_for.to_sym]


### PR DESCRIPTION
Looks like we had fixed the non-completed scenario in #1201, where it
goes through estimate_cost_and_subsidy, but not the completed order
scenario where it goes through calculate_cost_and_subsidy.

I think we didn’t have the guard clause here because it was assumed
that we would only ever try to calculate pricing on a valid order
(which would always have these fields), but in the `PriceChecker` used
on the order detail popup as an ajax call, it’s possible for the
reservation to become invalid if there is an error parsing the date.