### PR TITLE
Add instructions for loading a database dump into Oracle/Docker

### DIFF
--- a/config/database.yml.oracle.template
+++ b/config/database.yml.oracle.template
@@ -1,15 +1,13 @@
 defaults: &defaults
   adapter: oracle_enhanced
-  username: nucore_open_development
-  password: password
-  database: localhost:1521/xe
+  database: <%= ENV["ORACLE_DATABASE"] || "localhost:1521/xe" %>
 
 development:
   <<: *defaults
-  username: nucore_open_development
-  password: password
+  username: <%= ENV["ORACLE_USERNAME"] || "nucore_open_development" %>
+  password: <%= ENV["ORACLE_PASSWORD"] || "password" %>
 
 test:
   <<: *defaults
-  username: nucore_open_test
-  password: password
+  username: <%= ENV["ORACLE_USERNAME"] || "nucore_open_test" %>
+  password: <%= ENV["ORACLE_PASSWORD"] || "password" %>

--- a/doc/HOWTO_oracle.md
+++ b/doc/HOWTO_oracle.md
@@ -13,18 +13,22 @@ Follow these instructions to set up the Oracle database to run in Docker, but th
 * Start the oracle container:
 
 ```
-docker run -d -p 1521:1521 --name nucore_db -v /u01/app/oracle:~/oracle_data sath89/oracle-12c
-# wait, it sometimes takes a few minutes to come up
-# "ORA-01033: ORACLE initialization or shutdown in progress" means wait.
+mkdir $HOME/oracle_data
+docker run -p 1521:1521 --name nucore_db -v $HOME/oracle_data:/u01/app/oracle sath89/oracle-12c
+# This will take several minutes as the database initializes.
+# Wait for "Database ready to use. Enjoy! ;)"
 ```
 
-Change the `~/oracle_data` to some path on your host machine. This volume will
-remain persistent even across re-creations of the container.
+`$HOME/oracle_data` is just a recommended location where your oracle data files will
+be saved. This will allow them to remain persistent even across re-creations of
+the container.
 
 * Next time you want to start the server, run:
 
 ```
 docker start nucore_db
+# wait, it sometimes takes a few minutes to come up
+# "ORA-01033: ORACLE initialization or shutdown in progress" means wait.
 ```
 
 ## Setting up the Oracle Client Drivers
@@ -126,12 +130,12 @@ rake demo:seed
 #### Restore from a backup
 
 Copy the `.dmp` file into your Oracle container (put it in a shared volume like `~/oracle_data`)
-and then move it to `/u01/app/oracle/datapump/`.
+and then move it to `/u01/app/oracle/admin/xe/dpdump/`.
 
 Get a bash shell inside your container:
 
 ```
-
+docker exec -it nucore_db bash
 ```
 
 Run this (replacing the DUMPFILE filename and the second part of REMAP_SCHEMA with your database's username):

--- a/doc/HOWTO_oracle.md
+++ b/doc/HOWTO_oracle.md
@@ -13,10 +13,13 @@ Follow these instructions to set up the Oracle database to run in Docker, but th
 * Start the oracle container:
 
 ```
-docker run -d -p 1521:1521 --name nucore_db sath89/oracle-12c
+docker run -d -p 1521:1521 --name nucore_db -v /u01/app/oracle:~/oracle_data sath89/oracle-12c
 # wait, it sometimes takes a few minutes to come up
 # "ORA-01033: ORACLE initialization or shutdown in progress" means wait.
 ```
+
+Change the `~/oracle_data` to some path on your host machine. This volume will
+remain persistent even across re-creations of the container.
 
 * Next time you want to start the server, run:
 
@@ -119,3 +122,19 @@ rake demo:seed
 * Download from: `http://www.oracle.com/technetwork/developer-tools/sql-developer/overview/index.html`
 
 * Install into `/Applications`
+
+#### Restore from a backup
+
+Copy the `.dmp` file into your Oracle container (put it in a shared volume like `~/oracle_data`)
+and then move it to `/u01/app/oracle/datapump/`.
+
+Get a bash shell inside your container:
+
+```
+
+```
+
+Run this (replacing the DUMPFILE filename and the second part of REMAP_SCHEMA with your database's username):
+```
+impdp system/oracle@//localhost:1521/xe.oracle.docker DIRECTORY=data_pump_dir DUMPFILE=expdp_schema_COR1PRD_201708191913.dmp REMAP_SCHEMA=bc_nucore:nucore_nu_development
+```

--- a/doc/HOWTO_oracle.md
+++ b/doc/HOWTO_oracle.md
@@ -129,8 +129,12 @@ rake demo:seed
 
 #### Restore from a backup
 
-Copy the `.dmp` file into your Oracle container (put it in a shared volume like `~/oracle_data`)
-and then move it to `/u01/app/oracle/admin/xe/dpdump/`.
+Run `bundle exec rake db:oracle_drop_severe`. This will ensure that your database
+is clean. Without it the import might skip tables due to them already existing.
+
+Assuming you used `$HOME/oracle_data` as the volume location when you did `docker run`:
+
+Copy the `.dmp` file to `$HOME/oracle_data/admin/xe/dpdump/`
 
 Get a bash shell inside your container:
 
@@ -140,5 +144,5 @@ docker exec -it nucore_db bash
 
 Run this (replacing the DUMPFILE filename and the second part of REMAP_SCHEMA with your database's username):
 ```
-impdp system/oracle@//localhost:1521/xe.oracle.docker DIRECTORY=data_pump_dir DUMPFILE=expdp_schema_COR1PRD_201708191913.dmp REMAP_SCHEMA=bc_nucore:nucore_nu_development
+impdp system/oracle@//localhost:1521/xe DIRECTORY=data_pump_dir DUMPFILE=expdp_schema_COR1PRD_201708191913.dmp REMAP_SCHEMA=bc_nucore:nucore_nu_development
 ```

--- a/docker/oracle/setup.sql
+++ b/docker/oracle/setup.sql
@@ -1,11 +1,18 @@
 alter profile default limit password_life_time unlimited;
 
+
+-- create tablespace BC_NUCORE
+--     DATAFILE 'bc_nucore.dat'
+--     SIZE 100M
+--     AUTOEXTEND ON;
+
 CREATE USER nucore_open_development
     IDENTIFIED BY password
     DEFAULT TABLESPACE users
     TEMPORARY TABLESPACE temp;
 
 GRANT connect, resource TO nucore_open_development;
+GRANT UNLIMITED TABLESPACE TO nucore_open_development;
 
 CREATE USER nucore_open_test
     IDENTIFIED BY password
@@ -13,8 +20,4 @@ CREATE USER nucore_open_test
     TEMPORARY TABLESPACE temp;
 
 GRANT connect, resource TO nucore_open_test;
-
--- create tablespace BC_NUCORE
---     DATAFILE 'bc_nucore.dat'
---     SIZE 100M
---     AUTOEXTEND ON;
+GRANT UNLIMITED TABLESPACE TO nucore_open_test;

--- a/docker/oracle/setup.sql
+++ b/docker/oracle/setup.sql
@@ -1,11 +1,5 @@
 alter profile default limit password_life_time unlimited;
 
-
--- create tablespace BC_NUCORE
---     DATAFILE 'bc_nucore.dat'
---     SIZE 100M
---     AUTOEXTEND ON;
-
 CREATE USER nucore_open_development
     IDENTIFIED BY password
     DEFAULT TABLESPACE users


### PR DESCRIPTION
I thought I had this documentation committed already, but turns out not.