### PR TITLE
[#137695] Fix sporadic test failures

### DIFF
--- a/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
+++ b/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
   before do
     login_as facility_admin
     visit facility_users_path(facility)
-    fill_in "search_term", with: user.full_name
+    fill_in "search_term", with: user.email
     click_button "Search"
     click_link "Order For"
   end

--- a/vendor/engines/projects/spec/features/placing_an_order_on_a_project_spec.rb
+++ b/vendor/engines/projects/spec/features/placing_an_order_on_a_project_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Placing an order with a project" do
   before do
     login_as facility_admin
     visit facility_users_path(facility)
-    fill_in "search_term", with: user.full_name
+    fill_in "search_term", with: user.email
     click_button "Search"
     click_link "Order For"
   end

--- a/vendor/engines/projects/spec/features/reserving_an_instrument_on_a_project_spec.rb
+++ b/vendor/engines/projects/spec/features/reserving_an_instrument_on_a_project_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Reserving an instrument on a project" do
   before do
     login_as facility_admin
     visit facility_users_path(facility)
-    fill_in "search_term", with: user.full_name
+    fill_in "search_term", with: user.email
     click_button "Search"
     click_link "Order For"
   end


### PR DESCRIPTION
Before this change, I was able to reliably reproduce the error with:
`rspec
'./spec/features/purchasing_a_reservation_on_behalf_of_spec.rb[1:1]'
'./spec/models/user_spec.rb[1:2:1]' --seed 45377 --format documentation`

The FactoryGirl sequences for last_name, username, and email don't 
increment if one of those fields is explicitly declared (see the context on line 16 of `models/user_spec`). That's how we end up with first+last "User 2" with a username of "username1".

From a `save_and_open_age` in a failure case:
![screen shot 2017-09-05 at 6 08 17 pm](https://user-images.githubusercontent.com/1099111/30131249-b3ef39b8-9311-11e7-9e2a-ea9262076f70.png)

---
Our user search is pretty broad. Here's what the sql looks like:

```sql
SELECT `users`.* FROM `users` WHERE (      (
          LOWER(first_name) LIKE '%user%2%'
        OR
          LOWER(last_name) LIKE '%user%2%'
        OR
          LOWER(username) LIKE '%user%2%'
        OR
          LOWER(CONCAT(first_name, last_name)) LIKE '%user%2%'
        OR
          LOWER(email) LIKE '%user%2%'
      )
)
```
So we were occasionaly getting multiple matching users matching. This
now searches a more specific term so it should not match multiple.