### PR TITLE
[#137282] Add timed service to existing order

### DIFF
--- a/app/assets/javascripts/app/merge_orders.coffee
+++ b/app/assets/javascripts/app/merge_orders.coffee
@@ -6,20 +6,21 @@ class window.MergeOrder
     return unless @$form.length
 
     @$quantity_field = @$form.find(".js--edit-order__quantity")
-    @$timed_quantity_display_field = @$form.find(".js--edit-order__duration")
+    @$duration_display_field = @$form.find(".js--edit-order__duration")
 
     # clockpunch converts the original field into a field with name _display.
     # We will need to disable both the visible display field and the hidden field
-    # so they don't get sent as part of the POST.
-    @$timed_quantity_display_field.timeinput()
-    @$timed_quantity_hidden_field = @$timed_quantity_display_field.data("timeparser").$hidden_field
+    # so they don't get sent as part of the POST unless a timed service is
+    # selected.
+    @$duration_display_field.timeinput()
+    @$duration_hidden_field = @$duration_display_field.data("timeparser").$hidden_field
 
     @$form.find(".js--edit-order__product").on "change", (event) =>
       is_timed = $(event.target).find(":selected").data("timed-product")
 
-      @$timed_quantity_display_field.toggle(is_timed)
-      @$timed_quantity_display_field.prop("disabled", !is_timed)
-      @$timed_quantity_hidden_field.prop("disabled", !is_timed)
+      @$duration_display_field.toggle(is_timed)
+      @$duration_display_field.prop("disabled", !is_timed)
+      @$duration_hidden_field.prop("disabled", !is_timed)
 
       @$quantity_field.val(1) if is_timed
       @$quantity_field.prop("disabled", is_timed)

--- a/app/assets/javascripts/app/merge_orders.coffee
+++ b/app/assets/javascripts/app/merge_orders.coffee
@@ -3,10 +3,11 @@ class window.MergeOrder
     # empty body
 
   initTimeBasedServices: ->
+    return unless @$form.length
+
     @$quantity_field = @$form.find(".js--edit-order__quantity")
-    console.debug "quantity field", @$quantity_field
-    @$timed_quantity_display_field = @$form.find(".js--edit-order__timed-quantity")
-    console.debug "timed quantity field", @$timed_quantity_display_field
+    @$timed_quantity_display_field = @$form.find(".js--edit-order__duration")
+
     # clockpunch converts the original field into a field with name _display.
     # We will need to disable both the visible display field and the hidden field
     # so they don't get sent as part of the POST.

--- a/app/assets/javascripts/app/merge_orders.coffee
+++ b/app/assets/javascripts/app/merge_orders.coffee
@@ -1,0 +1,29 @@
+class window.MergeOrder
+  constructor: (@$form) ->
+    # empty body
+
+  initTimeBasedServices: ->
+    @$quantity_field = @$form.find(".js--edit-order__quantity")
+    console.debug "quantity field", @$quantity_field
+    @$timed_quantity_display_field = @$form.find(".js--edit-order__timed-quantity")
+    console.debug "timed quantity field", @$timed_quantity_display_field
+    # clockpunch converts the original field into a field with name _display.
+    # We will need to disable both the visible display field and the hidden field
+    # so they don't get sent as part of the POST.
+    @$timed_quantity_display_field.timeinput()
+    @$timed_quantity_hidden_field = @$timed_quantity_display_field.data("timeparser").$hidden_field
+
+    @$form.find(".js--edit-order__product").on "change", (event) =>
+      is_timed = $(event.target).find(":selected").data("timed-product")
+
+      @$timed_quantity_display_field.toggle(is_timed)
+      @$timed_quantity_display_field.prop("disabled", !is_timed)
+      @$timed_quantity_hidden_field.prop("disabled", !is_timed)
+
+      @$quantity_field.val(1) if is_timed
+      @$quantity_field.prop("disabled", is_timed)
+
+    @$form.find("#product_add").trigger("change")
+
+$ ->
+  new MergeOrder($(".js--edit-order")).initTimeBasedServices()

--- a/app/assets/javascripts/app/merge_orders.coffee
+++ b/app/assets/javascripts/app/merge_orders.coffee
@@ -24,7 +24,7 @@ class window.MergeOrder
       @$quantity_field.val(1) if is_timed
       @$quantity_field.prop("disabled", is_timed)
 
-    @$form.find("#product_add").trigger("change")
+    @$form.find(".js--edit-order__product").trigger("change")
 
 $ ->
   new MergeOrder($(".js--edit-order")).initTimeBasedServices()

--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -57,7 +57,8 @@ class FacilityOrdersController < ApplicationController
   # PUT/PATCH /facilities/:facility_id/orders/:id
   def update
     product = current_facility.products.find(params[:product_add])
-    quantity = params[:product_add_quantity].to_i
+    quantity = params.fetch(:product_add_quantity, 1).to_i
+    params[:duration] = params[:product_add_duration]
 
     if quantity <= 0
       flash[:notice] = text("update.zero_quantity")

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -77,7 +77,7 @@ class Product < ActiveRecord::Base
   end
 
   def self.mergeable_types
-    @mergeable_types ||= default_types
+    default_types
   end
 
   # Products that can be used as accessories

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -253,7 +253,13 @@ class Product < ActiveRecord::Base
     self.class.name.underscore.pluralize
   end
 
+  # Used when displaying quantities throughout the site and when editing an order.
   def quantity_as_time?
+    false
+  end
+
+  # Primarily used when adding to an existing order (merge orders)
+  def order_quantity_as_time?
     false
   end
 

--- a/app/models/timed_service.rb
+++ b/app/models/timed_service.rb
@@ -8,4 +8,8 @@ class TimedService < Product
     true
   end
 
+  def order_quantity_as_time?
+    true
+  end
+
 end

--- a/app/support/orders/item_adder.rb
+++ b/app/support/orders/item_adder.rb
@@ -50,7 +50,7 @@ class Orders::ItemAdder
 
   def add_timed_services(product, quantity, duration, attributes)
     Array.new(quantity) do
-      create_order_detail({ product_id: product.id, quantity: duration || DEFAULT_TIMED_SERVICES_DURATION}.merge(attributes))
+      create_order_detail({ product_id: product.id, quantity: duration || DEFAULT_TIMED_SERVICES_DURATION }.merge(attributes))
     end
   end
 

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -6,7 +6,7 @@
       = select_tag :product_add,
         options_for_select(current_facility.products.mergeable_into_order.alphabetized.map { |p| [p.name, p.id, {"data-timed-product" => p.quantity_as_time?}] }),
         class: "js--edit-order__product"
-      = text_field_tag :product_add_timed_quantity, 1, class: "js--edit-order__timed-quantity"
+      = text_field_tag :product_add_duration, 1, class: "js--edit-order__duration"
 
       = label_tag :order_status_id, OrderDetail.human_attribute_name(:order_status)
       = select_tag :order_status_id,

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -4,7 +4,7 @@
       = text_field_tag :product_add_quantity, 1, class: "js--edit-order__quantity"
 
       = select_tag :product_add,
-        options_for_select(current_facility.products.mergeable_into_order.alphabetized.map { |p| [p.name, p.id, {"data-timed-product" => p.quantity_as_time?}] }),
+        options_for_select(current_facility.products.mergeable_into_order.alphabetized.map { |p| [p.name, p.id, {"data-timed-product" => p.order_quantity_as_time?}] }),
         class: "js--edit-order__product"
       = text_field_tag :product_add_duration, 1, class: "js--edit-order__duration"
 

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -1,10 +1,12 @@
 - if @merge_orders.blank?
   .well
     = simple_form_for [current_facility, @order], method: :put, html: { class: "js--edit-order" } do |f|
-      = text_field_tag :product_add_quantity, 1
+      = text_field_tag :product_add_quantity, 1, class: "js--edit-order__quantity"
 
       = select_tag :product_add,
-        options_for_select(current_facility.products.mergeable_into_order.pluck(:name, :id))
+        options_for_select(current_facility.products.mergeable_into_order.alphabetized.map { |p| [p.name, p.id, {"data-timed-product" => p.quantity_as_time?}] }),
+        class: "js--edit-order__product"
+      = text_field_tag :product_add_timed_quantity, 1, class: "js--edit-order__timed-quantity"
 
       = label_tag :order_status_id, OrderDetail.human_attribute_name(:order_status)
       = select_tag :order_status_id,

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -55,7 +55,7 @@
   },
   "newlines_after_classes": {
     "value": 1,
-    "level": "error"
+    "level": "ignore"
   },
   "no_backticks": {
     "level": "error"

--- a/spec/features/admin/adding_to_an_order_spec.rb
+++ b/spec/features/admin/adding_to_an_order_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "Adding to an existing order" do
+  let(:facility) { item.facility }
+  let(:item) { create(:setup_item, :with_facility_account) }
+  let(:order) { create(:purchased_order, product: item) }
+  let(:user) { create(:user, :staff, facility: facility) }
+
+  before do
+    login_as user
+    visit facility_order_path(facility, order)
+  end
+
+  describe "adding an item" do
+    before do
+      fill_in "product_add_quantity", with: "2"
+      select item.name, from: "product_add"
+      fill_in "Note", with: "My Note"
+    end
+
+    describe "adding it as New" do
+      before do
+        click_button "Add To Order"
+      end
+
+      it "has a new order detail" do
+        expect(order.reload.order_details.count).to be(2)
+        expect(order.order_details.last.note).to eq("My Note")
+      end
+    end
+
+    describe "adding it as Complete" do
+      before do
+        select "Complete", from: "order_status_id"
+        fill_in "fulfilled_at", with: "10/14/2016"
+        click_button "Add To Order"
+      end
+
+      it "has a new order detail with the right status and fulfilled_at" do
+        expect(order.reload.order_details.count).to be(2)
+        expect(order.order_details.last).to be_complete
+        # TODO cannot be before previous fiscal year
+        expect(I18n.l(order.order_details.last.fulfilled_at, :usa)).to eq("10/14/2016")
+      end
+    end
+  end
+
+
+  # TODO: Adding a service with an order form
+  # TODO: Adding an instrument
+
+end

--- a/spec/features/admin/adding_to_an_order_spec.rb
+++ b/spec/features/admin/adding_to_an_order_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Adding to an existing order" do
       visit facility_order_path(facility, order)
       fill_in "product_add_quantity", with: "1"
       select instrument.name, from: "product_add"
-      click_button "Add to Order"
+      click_button "Add To Order"
     end
 
     it "requires a reservation to be set up before adding to the order" do
@@ -94,6 +94,23 @@ RSpec.describe "Adding to an existing order" do
 
       expect(order.reload.order_details.count).to be(2)
       expect(order.order_details.last.product).to eq(instrument)
+    end
+  end
+
+  describe "adding a timed service", feature_setting: { timed_services: true } do
+    let(:product) { create(:setup_timed_service, :with_facility_account) }
+
+    before do
+      visit facility_order_path(facility, order)
+      select product.name, from: "product_add"
+      fill_in "product_add_duration", with: "31"
+      click_button "Add To Order"
+    end
+
+    it "has a new order detail with the proper quantity" do
+      expect(order.reload.order_details.count).to be(2)
+      expect(order.order_details.last.product).to eq(product)
+      expect(order.order_details.last.quantity).to eq(31)
     end
   end
 

--- a/spec/features/admin/adding_to_an_order_spec.rb
+++ b/spec/features/admin/adding_to_an_order_spec.rb
@@ -1,20 +1,22 @@
 require "rails_helper"
 
 RSpec.describe "Adding to an existing order" do
-  let(:facility) { item.facility }
-  let(:item) { create(:setup_item, :with_facility_account) }
-  let(:order) { create(:purchased_order, product: item) }
+  let(:facility) { product.facility }
+  let(:order) { create(:purchased_order, product: product) }
   let(:user) { create(:user, :staff, facility: facility) }
 
   before do
     login_as user
-    visit facility_order_path(facility, order)
   end
 
   describe "adding an item" do
+    let(:product) { create(:setup_item, :with_facility_account) }
+
     before do
+      visit facility_order_path(facility, order)
+
       fill_in "product_add_quantity", with: "2"
-      select item.name, from: "product_add"
+      select product.name, from: "product_add"
       fill_in "Note", with: "My Note"
     end
 
@@ -30,23 +32,69 @@ RSpec.describe "Adding to an existing order" do
     end
 
     describe "adding it as Complete" do
+      let(:fulfilled_at_string) { I18n.l(1.day.ago.to_date, format: :usa) }
+
       before do
         select "Complete", from: "order_status_id"
-        fill_in "fulfilled_at", with: "10/14/2016"
+        fill_in "fulfilled_at", with: fulfilled_at_string
         click_button "Add To Order"
       end
 
       it "has a new order detail with the right status and fulfilled_at" do
         expect(order.reload.order_details.count).to be(2)
         expect(order.order_details.last).to be_complete
-        # TODO cannot be before previous fiscal year
-        expect(I18n.l(order.order_details.last.fulfilled_at, :usa)).to eq("10/14/2016")
+        expect(I18n.l(order.order_details.last.fulfilled_at.to_date, format: :usa)).to eq(fulfilled_at_string)
       end
     end
   end
 
+  describe "adding a backdated service with an order form" do
+    let(:product) { create(:setup_service, :with_facility_account, :with_order_form) }
+    let(:fulfilled_at_string) { I18n.l(1.day.ago.to_date, format: :usa) }
 
-  # TODO: Adding a service with an order form
-  # TODO: Adding an instrument
+    before do
+      visit facility_order_path(facility, order)
+
+      fill_in "product_add_quantity", with: "1"
+      select product.name, from: "product_add"
+      select "Complete", from: "order_status_id"
+      fill_in "fulfilled_at", with: fulfilled_at_string
+      click_button "Add To Order"
+    end
+
+    it "requires a file to be uploaded before adding to the order" do
+      expect(page).to have_content("The following order details need your attention.")
+
+      click_link "Upload Order Form"
+      attach_file "stored_file[file]", Rails.root.join("spec", "files", "template1.txt")
+      click_button "Upload"
+
+      expect(order.reload.order_details.count).to be(2)
+      expect(order.order_details.last).to be_complete
+      expect(I18n.l(order.order_details.last.fulfilled_at.to_date, format: :usa)).to eq(fulfilled_at_string)
+    end
+  end
+
+  describe "adding an instrument reservation" do
+    let(:product) { create(:setup_item, :with_facility_account) }
+    let!(:instrument) { create(:setup_instrument, facility: facility) }
+
+    before do
+      visit facility_order_path(facility, order)
+      fill_in "product_add_quantity", with: "1"
+      select instrument.name, from: "product_add"
+      click_button "Add to Order"
+    end
+
+    it "requires a reservation to be set up before adding to the order" do
+      expect(page).to have_content("The following order details need your attention.")
+
+      click_link "Make a Reservation"
+      click_button "Create"
+
+      expect(order.reload.order_details.count).to be(2)
+      expect(order.order_details.last.product).to eq(instrument)
+    end
+  end
 
 end

--- a/spec/javascripts/app/merge_orders_spec.coffee
+++ b/spec/javascripts/app/merge_orders_spec.coffee
@@ -49,7 +49,3 @@ describe "Merge Orders", ->
 
         it "enables the quantity", ->
           expect($("#quantity")).not.toBeDisabled()
-
-
-
-

--- a/spec/javascripts/app/merge_orders_spec.coffee
+++ b/spec/javascripts/app/merge_orders_spec.coffee
@@ -1,0 +1,55 @@
+#= require helpers/jasmine-jquery
+
+describe "Merge Orders", ->
+  describe "a page that doesn't have the form", ->
+    fixture.set ''
+    it "does not die", ->
+      new MergeOrder($(".js--edit-order")).initTimeBasedServices()
+
+  describe "with a valid form", ->
+    fixture.set '
+      <form class="js--edit-order">
+        <input id="quantity" class="js--edit-order__quantity" value="2" />
+        <select id="product" class="js--edit-order__product">
+          <option data-timed-product="false" selected="selected" value="untimed">Untimed Product</option>
+          <option data-timed-product="true" value="timed">Timed Product</option>
+        </select>
+        <input type="text" name="duration" id="duration" class="js--edit-order__duration" value="1" />
+      </form>
+    '
+
+    beforeEach ->
+      new MergeOrder($(".js--edit-order")).initTimeBasedServices()
+
+    it "does not have the duration visible", ->
+      expect($("#duration")).toBeHidden()
+      expect($("#duration")).toBeDisabled()
+
+    describe "when I switch to a timed product", ->
+      beforeEach ->
+        $("#product").val("timed").trigger("change")
+
+      it "will change a quantity to 1 if I switch to a timed product", ->
+        expect($("#quantity").val()).toEqual("1")
+
+      it "disables the quantity when I switch to a timed product", ->
+        expect($("#quantity")).toBeDisabled()
+
+      it "enables and shows the duration", ->
+        expect($("#duration")).not.toBeDisabled()
+        expect($("#duration")).toBeVisible()
+
+      describe "and I switch back to a regular product", ->
+        beforeEach ->
+          $("#product").val("untimed").trigger("change")
+
+        it "hides and disables the duration", ->
+          expect($("#duration")).toBeDisabled()
+          expect($("#duration")).toBeHidden()
+
+        it "enables the quantity", ->
+          expect($("#quantity")).not.toBeDisabled()
+
+
+
+


### PR DESCRIPTION
When adding a TimedService to an existing order, we will gray out the quantity field (and always adjust it back to 1) and display a new time input field.

![screen shot 2017-09-08 at 11 58 31 am](https://user-images.githubusercontent.com/1099111/30222673-323f7fd6-948d-11e7-9201-979f3c80fa3a.png)
![screen shot 2017-09-08 at 11 58 23 am](https://user-images.githubusercontent.com/1099111/30222674-324ec22a-948d-11e7-89d7-a7a5e4c66359.png)
