### PR TITLE
[#137258] receipt time display

### DIFF
--- a/app/support/price_displayment.rb
+++ b/app/support/price_displayment.rb
@@ -77,7 +77,7 @@ module PriceDisplayment
     end
 
     def html
-      content_tag :span, value, class: "timeinput"
+      MinutesToTimeFormatter.new(value).to_s
     end
 
   end

--- a/app/support/statement_pdf.rb
+++ b/app/support/statement_pdf.rb
@@ -84,8 +84,10 @@ class StatementPdf
     pdf.table([order_detail_headers] + order_detail_rows, header: true, width: 510) do
       row(0).style(LABEL_ROW_STYLE)
       column(0).width = 125
-      column(1).width = 300
+      column(1).width = 225
+      column(2).width = 75
       column(2).style(align: :right)
+      column(3).style(align: :right)
     end
   end
 
@@ -96,7 +98,7 @@ class StatementPdf
   end
 
   def order_detail_headers
-    ["Fulfillment Date", "Order", "Amount"]
+    ["Fulfillment Date", "Order", "Quantity", "Amount"]
   end
 
   def order_detail_rows
@@ -104,6 +106,7 @@ class StatementPdf
       [
         human_datetime(order_detail.fulfilled_at),
         "##{order_detail}: #{order_detail.product}" + (order_detail.note.blank? ? "" : "\n#{order_detail.note}"),
+        OrderDetailPresenter.new(order_detail).wrapped_quantity,
         number_to_currency(order_detail.actual_total),
       ]
     end

--- a/app/views/purchase_notifier/order_receipt.html.haml
+++ b/app/views/purchase_notifier/order_receipt.html.haml
@@ -43,7 +43,7 @@
           - if order_detail.reservation
             %br
             = order_detail.reservation
-        %td= order_detail.quantity
+        %td= order_detail.wrapped_quantity
         %td= order_detail.order_status.name
         %td= order_detail.display_cost
         %td= order_detail.display_subsidy

--- a/app/views/purchase_notifier/order_receipt.text.haml
+++ b/app/views/purchase_notifier/order_receipt.text.haml
@@ -14,7 +14,7 @@
   #{OrderDetailPresenter.new(order_detail).description_as_text}
   - if order_detail.reservation
     #{Reservation.model_name.to_s.titleize}: #{order_detail.reservation}
-  #{OrderDetail.human_attribute_name(:quantity)}: #{order_detail.quantity}
+  #{OrderDetail.human_attribute_name(:quantity)}: #{OrderDetailPresenter.new(order_detail).wrapped_quantity}
   #{OrderDetail.human_attribute_name(:status)}: #{order_detail.order_status.name}
   - label_key_prefix = display_cost_prefix_for_order_detail(order_detail)
   #{OrderDetail.human_attribute_name("#{label_key_prefix}_cost")}: #{OrderDetailPresenter.new(order_detail).display_cost}


### PR DESCRIPTION
https://pm.tablexi.com/issues/137258

Timed services receipts/statements should display duration appropriately
<img width="831" alt="screen shot 2017-09-08 at 4 50 10 pm" src="https://user-images.githubusercontent.com/4624197/30232472-de340398-94b5-11e7-8c58-af7e2abccf96.png">
<img width="664" alt="screen shot 2017-09-08 at 4 50 20 pm" src="https://user-images.githubusercontent.com/4624197/30232471-de31001c-94b5-11e7-91d6-920b5ec66a91.png">
[EF-4-1-09-08-2017 (2).pdf](https://github.com/tablexi/nucore-open/files/1289202/EF-4-1-09-08-2017.2.pdf)