### PR TITLE
[#137105] Persist note on updating a reservation

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -166,8 +166,10 @@ class ReservationsController < ApplicationController
     end
 
     @reservation.assign_times_from_params(reservation_params)
+    reservation_update_attributes = params.require(:reservation).permit(:note)
+    @reservation.assign_attributes(reservation_update_attributes)
 
-    render_edit && return unless duration_change_valid?
+    render_edit && return unless changes_valid_for_update?
 
     Reservation.transaction do
       begin
@@ -390,6 +392,10 @@ class ReservationsController < ApplicationController
   def render_edit
     set_windows
     render action: "edit"
+  end
+
+  def changes_valid_for_update?
+    duration_change_valid? && NotePresenceValidator.new(@reservation).valid?
   end
 
   def duration_change_valid?

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -963,6 +963,32 @@ RSpec.describe ReservationsController do
         assert_redirected_to cart_url
       end
 
+      describe "updating the note" do
+        before(:each) do
+          sign_in reservation.user
+          @params[:reservation][:note] = "This is an updated note"
+          do_request
+        end
+
+        it "updates the note" do
+          expect(reservation.reload.note).to eq("This is an updated note")
+        end
+      end
+
+      describe "updating to blank on a required note instrument" do
+        before(:each) do
+          instrument.update!(user_notes_field_mode: "required")
+          sign_in reservation.user
+          @params[:reservation][:note] = ""
+          do_request
+        end
+
+        it "renders with an error" do
+          expect(response).to render_template(:edit)
+          expect(response.body).to include("may not be blank")
+        end
+      end
+
       describe "when trying to update a past reservation" do
         before(:each) do
           sign_in @admin


### PR DESCRIPTION
We did the front end piece in
https://github.com/tablexi/nucore-open/pull/1208 but didn’t verify it
actually persisted.

This also adds the note required validation so the user can’t remove
it. It would be possible to abstract the validation out, but we
probably want this list to be different from the on-purchase
validation. It just didn’t seem worth it right now. If we start adding
other validations (for example, I don’t think we need to run the NU
research safety validations), then it might be at that point.

This largely works because because Reservation delegates `note` and
`note=` to the order detail so in this case they can be treated
interchangeably.