### PR TITLE
[#137762] hide user based price group field unless feature is on

### DIFF
--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -19,7 +19,7 @@
     = f.input :last_name, readonly: !@user.admin_editable?
     = f.input :email, readonly: !@user.admin_editable?
     = f.input :username, readonly: true
-    - if current_user.administrator?
+    - if current_user.administrator? && SettingsHelper.feature_on?(:user_based_price_groups)
       = f.input :internal?, label: text(".internal"), as: :select, default: false
     = f.button :submit, text("shared.update"), class: ["btn", "btn-primary"]
     &nbsp;

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -14,7 +14,7 @@
   = f.input :username
   = f.input :email
   = f.input :last_sign_in_at, default_value: "none"
-  = f.input :internal?, label: text("views.users.edit.internal")
+  = f.input :internal?, label: text("views.users.edit.internal") if SettingsHelper.feature_on?(:user_based_price_groups)
   = f.input :deactivated_at unless f.object.active?
   = render_view_hook "additional_user_fields", f: f
 


### PR DESCRIPTION
https://pm.tablexi.com/issues/137762

Hide user-based price group field on user show/edit unless feature is on.