### PR TITLE
Read database.yml for docker setup with aliases

### DIFF
--- a/docker/oracle/create_databases.rb
+++ b/docker/oracle/create_databases.rb
@@ -4,7 +4,8 @@ require 'erb'
 puts "Loading database config"
 config_file_path = File.expand_path('../../../config/database.yml', __FILE__)
 erb = ERB.new(File.read(config_file_path)).result
-config = YAML.safe_load(erb)
+# (yaml, whitelist_classes, whitelist_symbols, allow_aliases)
+config = YAML.safe_load(erb, [], [], true)
 
 sql_file = File.expand_path("../setup.sql", __FILE__)
 


### PR DESCRIPTION
Not sure how I didn't run into this before (or maybe I did and missed pushing a PR for it). Without this extra parameter, you're not allowed to use aliases when loading `YAML.safe_load`.