### PR TITLE
[#137555] toggle account groups changes in open

### DIFF
--- a/app/services/account_builder.rb
+++ b/app/services/account_builder.rb
@@ -88,21 +88,19 @@ class AccountBuilder
   def after_update
   end
 
+  # Needs to be overridable by engines
+  cattr_accessor :common_permitted_account_params { [:description] }
+
   # Override in subclassed builder to define additional strong_param attributes
   # for build action. Returns an array of "permitted" params.
   def account_params_for_build
-    [
-      :account_number,
-      :description,
-    ]
+    self.class.common_permitted_account_params + [:account_number]
   end
 
   # Override in subclassed builder to define additional strong_param attributes
   # for update action. Returns an array of "permitted" params.
   def account_params_for_update
-    [
-      :description,
-    ]
+    self.class.common_permitted_account_params.dup
   end
 
   # Applies strong_param rules to the passed in params based on the current

--- a/app/services/nufs_account_builder.rb
+++ b/app/services/nufs_account_builder.rb
@@ -6,11 +6,7 @@ class NufsAccountBuilder < AccountBuilder
 
   # Override strong_params for `build` account.
   def account_params_for_build
-    [
-      { account_number_parts: NufsAccount.account_number_field_names },
-      :account_number,
-      :description,
-    ]
+    super + [{ account_number_parts: NufsAccount.account_number_field_names }]
   end
 
   # Hooks into superclass's `build` method.

--- a/app/views/facility_accounts/edit.html.haml
+++ b/app/views/facility_accounts/edit.html.haml
@@ -11,6 +11,7 @@
   = f.error_messages
 
   = render "facility_accounts/account_fields/#{@account.class.name.underscore}", f: f
+  = render_view_hook("end_of_form", f: f, account: @account)
 
   %ul.inline
     %li= f.submit t(".save"), class: "btn btn-primary"

--- a/app/views/facility_accounts/show.html.haml
+++ b/app/views/facility_accounts/show.html.haml
@@ -27,6 +27,8 @@
 
   = f.input :display_status, input_html: { class: @account.suspended? ? "suspended-account" : "" }
 
+
+  = render_view_hook("end_of_readonly_form", f: f, account: @account)
   = render_view_hook("after_end_of_form", f: f, account: @account)
 
 %ul.inline


### PR DESCRIPTION
Changes in open for Dartmouth's feature to enable accounts to be designated as internal/external.

Companion to https://github.com/tablexi/nucore-dartmouth/pull/142.