### PR TITLE
[#139180] reports bug

### DIFF
--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -47,19 +47,6 @@ module DateHelper
     date.strftime("%B %e, %Y")
   end
 
-  def human_datetime(datetime, args = {})
-    return nil if datetime.blank?
-    begin
-      if args[:date_only]
-        format_usa_date(datetime)
-      else
-        format_usa_datetime(datetime)
-      end
-    rescue
-      ""
-    end
-  end
-
   def human_time(dt)
     return nil if dt.nil?
     begin

--- a/app/helpers/facility_orders_helper.rb
+++ b/app/helpers/facility_orders_helper.rb
@@ -11,7 +11,7 @@ module FacilityOrdersHelper
 
   def banner_date_label(object, field, label = nil)
     banner_label(object, field, label) do |value|
-      value = format_use_datetime(value)
+      value = format_usa_datetime(value)
       value = yield(value) if value && block_given?
       value
     end

--- a/app/helpers/facility_orders_helper.rb
+++ b/app/helpers/facility_orders_helper.rb
@@ -11,7 +11,7 @@ module FacilityOrdersHelper
 
   def banner_date_label(object, field, label = nil)
     banner_label(object, field, label) do |value|
-      value = human_datetime value
+      value = format_use_datetime(value)
       value = yield(value) if value && block_given?
       value
     end

--- a/app/helpers/problem_order_details_helper.rb
+++ b/app/helpers/problem_order_details_helper.rb
@@ -16,7 +16,7 @@ module ProblemOrderDetailsHelper
         order_detail.order.ordered_at
       end
 
-    human_datetime(date)
+    format_usa_datetime(date)
   end
 
 end

--- a/app/helpers/timeline_helper.rb
+++ b/app/helpers/timeline_helper.rb
@@ -69,7 +69,7 @@ module TimelineHelper
     if day_date.beginning_of_day < reservation_date && reservation_date < day_date.end_of_day
       human_time(reservation_date)
     else
-      human_datetime(reservation_date)
+      format_usa_datetime(reservation_date)
     end
   end
 

--- a/app/inputs/readonly_input.rb
+++ b/app/inputs/readonly_input.rb
@@ -18,8 +18,17 @@ class ReadonlyInput < SimpleForm::Inputs::Base
 
   private
 
-  def process_datetime(value)
-    human_datetime(value, options.slice(:date_only))
+  def process_datetime(datetime)
+    return nil if datetime.blank?
+    begin
+      if options[:date_only]
+        format_usa_date(datetime)
+      else
+        format_usa_datetime(datetime)
+      end
+    rescue
+      ""
+    end
   end
 
   def process_boolean(value)

--- a/app/presenters/order_detail_presenter.rb
+++ b/app/presenters/order_detail_presenter.rb
@@ -35,10 +35,6 @@ class OrderDetailPresenter < SimpleDelegator
     edit_facility_order_order_detail_reservation_path(facility, order, id, reservation)
   end
 
-  def ordered_at
-    human_datetime(order.ordered_at)
-  end
-
   def row_class
     reconcile_warning? ? "reconcile-warning" : ""
   end

--- a/app/support/statement_pdf.rb
+++ b/app/support/statement_pdf.rb
@@ -104,7 +104,7 @@ class StatementPdf
   def order_detail_rows
     @statement.order_details.includes(:product).order("fulfilled_at DESC").map do |order_detail|
       [
-        human_datetime(order_detail.fulfilled_at),
+        format_usa_datetime(order_detail.fulfilled_at),
         "##{order_detail}: #{order_detail.product}" + (order_detail.note.blank? ? "" : "\n#{order_detail.note}"),
         OrderDetailPresenter.new(order_detail).wrapped_quantity,
         number_to_currency(order_detail.actual_total),

--- a/app/views/account_price_group_members/search_results.html.haml
+++ b/app/views/account_price_group_members/search_results.html.haml
@@ -21,7 +21,7 @@
           %tr
             %td= link_to account.account_number, facility_price_group_account_price_group_members_path(current_facility, @price_group, :account_id => account.id), :method => :post
             - owner=account.owner_user
-            %td=h owner.full_name if owner
-            %td=h owner.email if owner
+            %td= owner.full_name if owner
+            %td= owner.email if owner
     - if @accounts.count > @limit
       %p.notice= t('.notice', :count => @count-@limit)

--- a/app/views/facilities/show.html.haml
+++ b/app/views/facilities/show.html.haml
@@ -18,7 +18,7 @@
   %ul.breadcrumb
     %li= link_to 'Home', :root
     %li== &raquo;
-    %li=h current_facility
+    %li= current_facility
 
 .wysiwyg= current_facility.description
 

--- a/app/views/facility_accounts/_accounts.html.haml
+++ b/app/views/facility_accounts/_accounts.html.haml
@@ -10,5 +10,5 @@
     - accounts.each do |account|
       %tr
         %td= link_to_if can?(:manage, account), account, facility_account_path(current_facility, account)
-        %td=h account.type_string
+        %td= account.type_string
         %td= role

--- a/app/views/facility_accounts/accounts_receivable.html.haml
+++ b/app/views/facility_accounts/accounts_receivable.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :sidebar do
   = render :partial => 'admin/shared/sidenav_billing', :locals => { :sidenav_tab => "accounts_receivable" }

--- a/app/views/facility_accounts/search.html.haml
+++ b/app/views/facility_accounts/search.html.haml
@@ -5,7 +5,7 @@
   = render :partial => 'admin/shared/tabnav_account', :locals => {:secondary_tab => 'search_by_account'}
 
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 -#%fieldset
 -#  = form_tag user_search_results_path, :id => 'ajax_form' do

--- a/app/views/facility_accounts/search_results.html.haml
+++ b/app/views/facility_accounts/search_results.html.haml
@@ -1,5 +1,5 @@
 - if flash[:errors]
-  %p.error=h flash[:errors]
+  %p.error= flash[:errors]
 
 - else
   = render :partial => 'account_table'

--- a/app/views/facility_accounts/user_search.html.haml
+++ b/app/views/facility_accounts/user_search.html.haml
@@ -5,7 +5,7 @@
   = render partial: "admin/shared/tabnav_account", locals: {secondary_tab: "search_by_user"}
 
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = form_tag user_search_results_path, id: "ajax_form", method: :get do
   = label_tag :search_term, t(".label.search_term")

--- a/app/views/facility_journals/history.html.haml
+++ b/app/views/facility_journals/history.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :sidebar do
   = render :partial => 'admin/shared/sidenav_billing', :locals => { :sidenav_tab => 'reconcile' }
@@ -21,7 +21,7 @@
       - @journals.each do |j|
         %tr
           %td.centered= link_to 'View', facility_journal_path(current_facility, j)
-          %td=h human_datetime(j.created_at)
-          %td=h human_date(j.journal_date)
-          %td=h j.reference
-          %td=h j.status_string
+          %td= format_usa_datetime(j.created_at)
+          %td= human_date(j.journal_date)
+          %td= j.reference
+          %td= j.status_string

--- a/app/views/facility_journals/index.html.haml
+++ b/app/views/facility_journals/index.html.haml
@@ -30,7 +30,7 @@
               %td
                 %ul.unstyled
                   = render "downloads", facility: current_facility, journal: pending_journal, label_size: :short
-              %td= human_datetime(pending_journal.created_at)
+              %td= format_usa_datetime(pending_journal.created_at)
               - if cross_facility?
                 %td= facility_abbreviations.join("<br>").html_safe
               %td= f.input :reference, label: false, input_html: { class: 'input-medium' }
@@ -63,7 +63,7 @@
       - @journals.each do |j|
         %tr
           %td.centered= link_to 'View', facility_journal_path(current_facility, j)
-          %td= human_datetime(j.created_at)
+          %td= format_usa_datetime(j.created_at)
           %td= human_date(j.journal_date)
           %td= j.reference
           %td= j.description

--- a/app/views/facility_journals/show.csv.erb
+++ b/app/views/facility_journals/show.csv.erb
@@ -50,8 +50,8 @@ output = CSV.generate do |csv|
 
     row = [od.facility,
            od.to_s,
-           human_datetime(order.ordered_at),
-           human_datetime(od.fulfilled_at)]
+           format_usa_datetime(order.ordered_at),
+           format_usa_datetime(od.fulfilled_at)]
 
            # Who placed the order
     row << buyer.uid if @show_uid
@@ -73,7 +73,7 @@ output = CSV.generate do |csv|
 
     row +=[account.account_number,
            account.description_to_s,
-           human_datetime(account.expires_at),
+           format_usa_datetime(account.expires_at),
 
            # account owner information
            owner.username,
@@ -90,10 +90,10 @@ output = CSV.generate do |csv|
 
     # review and dispute info
     if SettingsHelper::has_review_period?
-      row += [human_datetime(od.reviewed_at),
-              human_datetime(od.dispute_at),
+      row += [format_usa_datetime(od.reviewed_at),
+              format_usa_datetime(od.dispute_at),
               od.dispute_reason,
-              human_datetime(od.dispute_resolved_at),
+              format_usa_datetime(od.dispute_resolved_at),
               od.dispute_resolved_reason]
     end
 

--- a/app/views/facility_journals/show.html.haml
+++ b/app/views/facility_journals/show.html.haml
@@ -62,7 +62,7 @@
               - if order_detail.note?
                 %br
                 = order_detail.note
-            %td= human_datetime(order_detail.fulfilled_at)
+            %td= format_usa_datetime(order_detail.fulfilled_at)
             %td= order_detail.account
             %td= number_to_currency(order_detail.total)
             %td= order_detail.reconciled? ? t("boolean.true") : t("boolean.false")

--- a/app/views/facility_orders/_disputed_table.html.haml
+++ b/app/views/facility_orders/_disputed_table.html.haml
@@ -17,10 +17,10 @@
       %tr
         %td.centered= link_to od.order_id, facility_order_path(current_facility, od.order)
         %td.centered= link_to od.id, manage_order_detail_path(od), :class => 'manage-order-detail'
-        %td=h human_datetime(o.ordered_at)
-        %td=h User.find(o.created_by).full_name
-        %td=h User.find(o.user_id).full_name
+        %td= format_usa_datetime(o.ordered_at)
+        %td= User.find(o.created_by).full_name
+        %td= User.find(o.user_id).full_name
         %td= product_name
-        %td=h human_datetime(od.dispute_at)
-        %td=h od.dispute_reason
+        %td= format_usa_datetime(od.dispute_at)
+        %td= od.dispute_reason
 = will_paginate(@order_details)

--- a/app/views/facility_orders/index.html.haml
+++ b/app/views/facility_orders/index.html.haml
@@ -32,7 +32,7 @@
             %td.centered= check_box_tag("order_detail_ids[]", od.id, false, {:class => 'toggle', :id => nil })
             %td.centered= link_to od.order_id, facility_order_path(current_facility, od.order)
             %td.centered= link_to od.id, manage_order_detail_path(od), :class => 'manage-order-detail'
-            %td= human_datetime(od.order.ordered_at)
+            %td= format_usa_datetime(od.order.ordered_at)
             %td= od.order.user.full_name
             %td.centered= OrderDetailPresenter.new(od).wrapped_quantity
             = render :partial => 'shared/order_detail_cell', :locals => { :od => od }

--- a/app/views/facility_orders/index.html.haml
+++ b/app/views/facility_orders/index.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :tabnav do
   = render :partial => 'admin/shared/tabnav_order', :locals => { :secondary_tab => 'new'}

--- a/app/views/facility_orders/show_problems.html.haml
+++ b/app/views/facility_orders/show_problems.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :tabnav do
   = render partial: "admin/shared/tabnav_order",

--- a/app/views/facility_reservations/edit.html.haml
+++ b/app/views/facility_reservations/edit.html.haml
@@ -18,9 +18,9 @@
   = javascript_include_tag 'reservations.js'
 
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
-%h2=h @instrument.name
+%h2= @instrument.name
 
 = simple_form_for(@reservation, :url => facility_order_order_detail_reservation_path, :html => {:method => :put}) do |f|
   = f.error_messages

--- a/app/views/facility_reservations/edit_admin.html.haml
+++ b/app/views/facility_reservations/edit_admin.html.haml
@@ -12,7 +12,7 @@
   = javascript_include_tag 'reservations.js'
 
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 = content_for :sidebar do
   = render :partial => 'admin/shared/sidenav_product', :locals => { :sidenav_tab => 'instruments' }
 = content_for :tabnav do

--- a/app/views/facility_reservations/index.html.haml
+++ b/app/views/facility_reservations/index.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :tabnav do
   = render :partial => 'admin/shared/tabnav_reservation'
@@ -47,7 +47,7 @@
                   = link_to t('reservations.switch.start'), order_order_detail_reservation_switch_instrument_path(od.order, od, od.reservation, :switch => 'on') if od.reservation.can_switch_instrument_on?
                   = link_to t('reservations.switch.end'), order_order_detail_reservation_switch_instrument_path(od.order, od, od.reservation, :switch => 'off'), :class => end_reservation_class(od.reservation) if od.reservation.can_switch_instrument_off?
             = render :partial => 'shared/order_detail_cell', :locals => { :od => od, :show_reservation => false }
-            %td=h od.assigned_user.nil? ? '' : od.assigned_user.full_name
+            %td= od.assigned_user.nil? ? '' : od.assigned_user.full_name
             %td
               = od.order_status.name
             %td.currency

--- a/app/views/facility_reservations/index.html.haml
+++ b/app/views/facility_reservations/index.html.haml
@@ -35,7 +35,7 @@
             %td.centered= link_to od.id, manage_order_detail_path(od), :class => 'manage-order-detail'
             %td= order.user.full_name
             %td{:colspan => 2}
-              = human_datetime(order.ordered_at)
+              = format_usa_datetime(order.ordered_at)
             %td{:colspan => 2}
               - if res.admin_editable?
                 = link_to res, edit_facility_order_order_detail_reservation_path(current_facility, order, od, res)

--- a/app/views/facility_reservations/show.html.haml
+++ b/app/views/facility_reservations/show.html.haml
@@ -10,16 +10,16 @@
   = javascript_include_tag 'reservations.js'
 
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
-%h2=h @instrument
+%h2= @instrument
 %ul.form
   %li
     %label Reservation
-    =h @reservation
+    = @reservation
   %li
     %label Actual Usage
-    =h @reservation.actuals_string
+    = @reservation.actuals_string
 
 #overlay
   #spinner

--- a/app/views/facility_reservations/show_problems.html.haml
+++ b/app/views/facility_reservations/show_problems.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :tabnav do
   = render partial: "admin/shared/tabnav_reservation",

--- a/app/views/facility_statements/index.html.haml
+++ b/app/views/facility_statements/index.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :sidebar do
   = render "admin/shared/sidenav_billing", sidenav_tab: "statement_history"

--- a/app/views/facility_statements/show.html.haml
+++ b/app/views/facility_statements/show.html.haml
@@ -1,10 +1,10 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :sidebar do
   = render :partial => 'admin/shared/sidenav_billing', :locals => { :sidenav_tab => 'statement_history' }
 
-%p=h "Statement sent on #{human_datetime(@statement.created_at)} by #{begin User.find(@statement.created_by).full_name rescue 'Unknown' end}.  Notifications were emailed to the following accounts."
+%p= "Statement sent on #{format_usa_datetime(@statement.created_at)} by #{begin User.find(@statement.created_by).full_name rescue 'Unknown' end}.  Notifications were emailed to the following accounts."
 
 %table.table.table-striped.table-hover
   %thead

--- a/app/views/facility_statements/show.html.haml
+++ b/app/views/facility_statements/show.html.haml
@@ -20,4 +20,4 @@
       %td
         %ul
           %li= link_to @statement.account, facility_account_statement_path(current_facility, @statement.account, 'recent')
-      %td=h @statement.account.owner_user.full_name
+      %td= @statement.account.owner_user.full_name

--- a/app/views/facility_users/search.html.haml
+++ b/app/views/facility_users/search.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 = content_for :sidebar do
   = render partial: "admin/shared/sidenav_admin", locals: { sidenav_tab: "staff" }
 

--- a/app/views/file_uploads/index.html.haml
+++ b/app/views/file_uploads/index.html.haml
@@ -51,5 +51,5 @@
                 data: { confirm: t(".confirm_delete") }
 
           %td= link_to stored_file.name, product_file_path(stored_file)
-          %td= human_datetime(stored_file.created_at)
+          %td= format_usa_datetime(stored_file.created_at)
           %td= User.find(stored_file.created_by).full_name

--- a/app/views/file_uploads/product_survey.html.haml
+++ b/app/views/file_uploads/product_survey.html.haml
@@ -62,7 +62,7 @@
                 esp.external_service.location,
                 target: "_blank"
 
-            %td= human_datetime(esp.created_at)
+            %td= format_usa_datetime(esp.created_at)
 
 .box_no_fill
   %h3= t(".download_form.head")
@@ -104,5 +104,5 @@
                 data: { confirm: t(".download_form.confirm") }
 
             %td= link_to stored_file.name, product_file_path(stored_file)
-            %td= human_datetime(stored_file.created_at)
+            %td= format_usa_datetime(stored_file.created_at)
             %td= User.find(stored_file.created_by).full_name

--- a/app/views/global_search/_statements.html.haml
+++ b/app/views/global_search/_statements.html.haml
@@ -22,7 +22,7 @@
           - else
             = link_to t("statements.pdf.download"), account_facility_statement_path(statement.account, statement.facility, statement, format: :pdf)
         %td
-          = human_datetime(statement.created_at)
+          = format_usa_datetime(statement.created_at)
         %td
           = statement.facility
         %td

--- a/app/views/instruments/instrument_status.html.haml
+++ b/app/views/instruments/instrument_status.html.haml
@@ -1,3 +1,3 @@
 %ul
   %li= "#{@status.status_string} (#{link_to("Refresh", facility_instrument_status_path(current_facility, @product), :id => "instrument_status_link_#{@product.id}", :class => 'instrument_status_link')})".html_safe
-  %li=h human_datetime(@status.created_at)
+  %li= format_usa_datetime(@status.created_at)

--- a/app/views/my_files/index.html.haml
+++ b/app/views/my_files/index.html.haml
@@ -18,7 +18,7 @@
         %td= link_to file.order_detail, [file.order_detail.order, file.order_detail]
         %td= file.order_detail.facility
         %td= file.product
-        %td= human_datetime(file.created_at)
+        %td= format_usa_datetime(file.created_at)
         %td= file.creator
 
 = will_paginate(@files)

--- a/app/views/order_detail_stored_files/order_file.html.haml
+++ b/app/views/order_detail_stored_files/order_file.html.haml
@@ -11,7 +11,7 @@
 = content_for :h1 do
   Upload Order Form
 
-%h2=h @order_detail.product
+%h2= @order_detail.product
 
 = form_for(@file, url: order_order_detail_upload_order_file_path, html: { multipart: true, method: :post }) do |f|
   = f.error_messages

--- a/app/views/order_details/_result_file.html.haml
+++ b/app/views/order_details/_result_file.html.haml
@@ -1,4 +1,4 @@
 %li
   = link_to result_file.name, stored_file_path(result_file)
   &mdash;
-  = human_datetime(result_file.created_at)
+  = format_usa_datetime(result_file.created_at)

--- a/app/views/order_management/order_details/_result_file.html.haml
+++ b/app/views/order_management/order_details/_result_file.html.haml
@@ -1,6 +1,6 @@
 %li
   = link_to result_file.name, facility_sample_result_path(result_file)
-  = human_datetime(result_file.created_at)
+  = format_usa_datetime(result_file.created_at)
   = link_to [current_facility, @order_detail.product, :file_upload, id: result_file, return_to: facility_order_path(current_facility, @order)],
     method: :delete,
     data: { confirm: "Are you sure?" },

--- a/app/views/order_statuses/edit.html.haml
+++ b/app/views/order_statuses/edit.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 = content_for :sidebar do
   = render :partial => 'admin/shared/sidenav_admin', :locals => { :sidenav_tab => 'statuses' }
 

--- a/app/views/order_statuses/index.html.haml
+++ b/app/views/order_statuses/index.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 = content_for :sidebar do
   = render :partial => 'admin/shared/sidenav_admin', :locals => { :sidenav_tab => 'statuses' }
 

--- a/app/views/order_statuses/new.html.haml
+++ b/app/views/order_statuses/new.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 = content_for :sidebar do
   = render :partial => 'admin/shared/sidenav_admin', :locals => { :sidenav_tab => 'statuses' }
 

--- a/app/views/price_groups/_accounts.html.haml
+++ b/app/views/price_groups/_accounts.html.haml
@@ -16,10 +16,10 @@
         %tr
           - if @price_group_ability.can? :destroy, AccountPriceGroupMember
             %td= link_to 'Remove', [current_facility, @price_group, account_price_group_member], :confirm => 'Are you sure?', :method => :delete
-          %td=h account_price_group_member.account.account_number
+          %td= account_price_group_member.account.account_number
           - owner=account_price_group_member.account.owner_user
-          %td=h owner.full_name if owner
-          %td=h owner.email if owner
+          %td= owner.full_name if owner
+          %td= owner.email if owner
   = will_paginate(@account_members)
 - else
   %p.notice= t('price_groups.accounts.notice')

--- a/app/views/price_groups/_users.html.haml
+++ b/app/views/price_groups/_users.html.haml
@@ -18,7 +18,7 @@
         %tr{:class => cycle(:odd, :even)}
           - if @price_group_ability.can? :destroy, UserPriceGroupMember
             %td= link_to 'Remove', [current_facility, @price_group, user_price_group_member], :confirm => 'Are you sure?', :method => :delete
-          %td=h user_price_group_member.user.full_name
-          %td=h user_price_group_member.user.username
-          %td=h user_price_group_member.user.email
+          %td= user_price_group_member.user.full_name
+          %td= user_price_group_member.user.username
+          %td= user_price_group_member.user.email
   = will_paginate(@user_members)

--- a/app/views/price_groups/edit.html.haml
+++ b/app/views/price_groups/edit.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 = content_for :sidebar do
   = render :partial => 'admin/shared/sidenav_admin', :locals => { :sidenav_tab => 'price_groups' }
 = content_for :tabnav do

--- a/app/views/price_groups/index.html.haml
+++ b/app/views/price_groups/index.html.haml
@@ -1,4 +1,4 @@
-x= content_for :h1 do
+= content_for :h1 do
   = current_facility
 = content_for :sidebar do
   = render :partial => 'admin/shared/sidenav_admin', :locals => { :sidenav_tab => 'price_groups' }

--- a/app/views/price_groups/index.html.haml
+++ b/app/views/price_groups/index.html.haml
@@ -1,5 +1,5 @@
-= content_for :h1 do
-  =h current_facility
+x= content_for :h1 do
+  = current_facility
 = content_for :sidebar do
   = render :partial => 'admin/shared/sidenav_admin', :locals => { :sidenav_tab => 'price_groups' }
 

--- a/app/views/price_groups/new.html.haml
+++ b/app/views/price_groups/new.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 = content_for :sidebar do
   = render :partial => 'admin/shared/sidenav_admin', :locals => { :sidenav_tab => 'price_groups' }
 

--- a/app/views/reports/_date_range_fields.html.haml
+++ b/app/views/reports/_date_range_fields.html.haml
@@ -4,11 +4,11 @@
 
 %li= form.input :date_start,
   label: t("reports.fields.date_start"),
-  input_html: { value: human_datetime(@date_start, date_only: true), class: "datepicker" }
+  input_html: { value: format_usa_date(@date_start), class: "datepicker" }
 
 %li
   .field-clarifier= t("support.array.two_words_connector")
 
 %li= form.input :date_end,
   label: t("reports.fields.#{controller_name}.date_end", default: t("reports.fields.date_end")),
-  input_html: { value: human_datetime(@date_end, date_only: true), class: "datepicker" }
+  input_html: { value: format_usa_date(@date_end), class: "datepicker" }

--- a/app/views/reports/instrument_unavailable_reports/report_table.html.haml
+++ b/app/views/reports/instrument_unavailable_reports/report_table.html.haml
@@ -1,8 +1,8 @@
 -# TODO: this is very similar to reports/report_table
 
 .updated_values{style: "display: none"}
-  .date_start= human_datetime(@date_start, date_only: true)
-  .date_end= human_datetime(@date_end, date_only: true)
+  .date_start= format_usa_date(@date_start)
+  .date_end= format_usa_date(@date_end)
 
 .export_raw{data: { visible: export_raw_visible?.to_s } }
 

--- a/app/views/reports/report_table.html.haml
+++ b/app/views/reports/report_table.html.haml
@@ -1,8 +1,8 @@
 -# TODO: this is very similar to instrument_unavailable_reports/report_table
 
 .updated_values{style: "display: none"}
-  .date_start= human_datetime(@date_start, date_only: true)
-  .date_end= human_datetime(@date_end, date_only: true)
+  .date_start= format_usa_date(@date_start)
+  .date_end= format_usa_date(@date_end)
 
 .export_raw{data: { visible: export_raw_visible?.to_s } }
 

--- a/app/views/reservations/edit.html.haml
+++ b/app/views/reservations/edit.html.haml
@@ -16,9 +16,9 @@
 
 
 = content_for :h1 do
-  =h @instrument.facility
+  = @instrument.facility
 
-%h2=h @instrument
+%h2= @instrument
 
 = simple_form_for([@order, @order_detail, @reservation]) do |f|
   = f.error_messages

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -28,7 +28,7 @@
             %td= link_to s.account, facility_account_path(current_facility, s.account)
           - unless current_facility.try(:single_facility?)
             %td= s.facility.name
-          %td.currency=h s.order_details.count
+          %td.currency= s.order_details.count
           %td.currency= number_to_currency(s.total_cost)
           %td= t("statements.reconciled.#{s.reconciled?}")
 

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -22,7 +22,7 @@
             %br
             - path = current_facility ? statement_path(s) : account_statement_path(s.account, s, format: :pdf)
             = link_to t("statements.pdf.download"), path
-          %td= human_datetime(s.created_at)
+          %td= format_usa_datetime(s.created_at)
           %td= s.account.notify_users.map(&:full_name).join(', ')
           - unless @account
             %td= link_to s.account, facility_account_path(current_facility, s.account)

--- a/app/views/statements/list.html.haml
+++ b/app/views/statements/list.html.haml
@@ -3,7 +3,7 @@
 = content_for :h1 do
   = t('.head.h1')
 
-%h2=h @account
+%h2= @account
 %h3= t('.head.h3', :facility => @facility.to_s)
 
 

--- a/app/views/users/accounts.html.haml
+++ b/app/views/users/accounts.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :sidebar do
   = render :partial => 'admin/shared/sidenav_users', :locals => { :sidenav_tab => 'users' }

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :sidebar do
   = render :partial => 'admin/shared/sidenav_users', :locals => { :sidenav_tab => 'users' }

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  =h current_facility
+  = current_facility
 
 = content_for :sidebar do
   = render partial: "admin/shared/sidenav_users", locals: { sidenav_tab: "users" }

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -1151,10 +1151,10 @@ RSpec.describe ReservationsController do
       expect(assigns(:order_detail)).to eq(order_detail)
       expect(assigns(:instrument)).to eq(instrument)
       expect(assigns(:reservation)).to eq(reservation)
-      expect(human_datetime(assigns(:reservation).reserve_start_at))
-        .to eq(human_datetime(reservation.earliest_possible.reserve_start_at))
-      expect(human_datetime(assigns(:reservation).reserve_end_at))
-        .to eq(human_datetime(reservation.earliest_possible.reserve_end_at))
+      expect(format_usa_datetime(assigns(:reservation).reserve_start_at))
+        .to eq(format_usa_datetime(reservation.earliest_possible.reserve_start_at))
+      expect(format_usa_datetime(assigns(:reservation).reserve_end_at))
+        .to eq(format_usa_datetime(reservation.earliest_possible.reserve_end_at))
       is_expected.to set_flash
       assert_redirected_to reservations_status_path(status: "upcoming")
     end
@@ -1184,8 +1184,8 @@ RSpec.describe ReservationsController do
         expect(assigns(:order_detail)).to eq(@order_detail)
         expect(assigns(:instrument)).to eq(@instrument)
         expect(assigns(:reservation)).to eq(@reservation)
-        expect(human_datetime(assigns(:reservation).reserve_start_at)).to eq(human_datetime(@orig_start_at))
-        expect(human_datetime(assigns(:reservation).reserve_end_at)).to eq(human_datetime(@orig_end_at))
+        expect(format_usa_datetime(assigns(:reservation).reserve_start_at)).to eq(format_usa_datetime(@orig_start_at))
+        expect(format_usa_datetime(assigns(:reservation).reserve_end_at)).to eq(format_usa_datetime(@orig_end_at))
         is_expected.to set_flash
         assert_redirected_to reservations_status_path(status: "upcoming")
       end

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -111,39 +111,6 @@ RSpec.describe DateHelper do
 
   end
 
-  describe "#human_datetime" do
-    context "without a datetime" do
-      it "returns nil" do
-        expect(human_datetime(nil)).to be_nil
-      end
-    end
-
-    context "with a datetime" do
-      context "that is valid" do
-        context "when requesting date only" do
-
-          it "produces the expected formatted date" do
-            expect(human_datetime(Time.zone.parse("2012-05-10 13:13"), date_only: true))
-              .to eq "05/10/2012"
-          end
-        end
-
-        context "when not requesting date only" do
-          it "produces the expected formatted date" do
-            expect(human_datetime(Time.zone.parse("2012-05-10 13:13"), date_only: false))
-              .to eq "05/10/2012  1:13 PM"
-          end
-        end
-      end
-
-      context "that is invalid" do
-        it "returns an empty string" do
-          expect(human_datetime("not a datetime object")).to eq ""
-        end
-      end
-    end
-  end
-
   describe "#human_date"
   describe "#human_time"
 

--- a/spec/presenters/order_detail_presenter_spec.rb
+++ b/spec/presenters/order_detail_presenter_spec.rb
@@ -85,16 +85,6 @@ RSpec.describe OrderDetailPresenter do
     it { is_expected.to eq(expected_path) }
   end
 
-  describe "#ordered_at" do
-    subject { presented.ordered_at }
-    let(:order) { build_stubbed(:order, ordered_at: ordered_at) }
-    let(:ordered_at) { Time.zone.parse("2015-02-01T13:00:59") }
-
-    before { allow(order_detail).to receive(:order) { order } }
-
-    it { is_expected.to eq("02/01/2015  1:00 PM") }
-  end
-
   describe "#row_class" do
     subject { presented.row_class }
 

--- a/vendor/engines/secure_rooms/app/views/secure_rooms/facility_occupancies/index.html.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_rooms/facility_occupancies/index.html.haml
@@ -24,7 +24,7 @@
           %tr
             %td.centered= link_to od.order_id, facility_order_path(current_facility, order)
             %td.centered= link_to od.id, manage_order_detail_path(od), class: "manage-order-detail"
-            %td= human_datetime(occ.entry_at)
+            %td= format_usa_datetime(occ.entry_at)
             %td= od.user.nil? ? "" : od.user.try(:full_name)
             = render partial: "shared/order_detail_cell", locals: { od: od, show_occupancy: false }
             %td= od.account

--- a/vendor/engines/secure_rooms/app/views/secure_rooms/shared/_secure_rooms_dashboard.html.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_rooms/shared/_secure_rooms_dashboard.html.haml
@@ -1,5 +1,5 @@
 %label= text(:time_label)
-.refreshed_at= human_datetime(Time.current)
+.refreshed_at= format_usa_datetime(Time.current)
 .row
   .span6
     %h4= text(:current)
@@ -12,7 +12,7 @@
         - room.occupancies.current.each do |occupancy|
           %tr
             %td= occupancy.user.full_name
-            %td= human_datetime(occupancy.entry_at)
+            %td= format_usa_datetime(occupancy.entry_at)
   .span6
     %h4= text(:recent)
     %table.table.table-striped.table-hover.recent_occupants
@@ -24,4 +24,4 @@
         - room.occupancies.recent.each do |occupancy|
           %tr
             %td= occupancy.user.full_name
-            %td= human_datetime(occupancy.exit_at)
+            %td= format_usa_datetime(occupancy.exit_at)


### PR DESCRIPTION
https://pm.tablexi.com/issues/139180

Bug was occurring when the app tried to format a datetime that had been previously formatted as a string, creating a type error. Removing the formatting from `ordered_at` in the order detail presenter resolved that issue. As far as I have found, there's nowhere in the codebase that actually needs the formatted `ordered_at` from the order detail presenter.

https://rollbar.com/TableXI/nucore-nu/items/194/

This PR also includes some tech debt cleanup (removing unnecessary human_datetime method, and =h).