### PR TITLE
Fix hamburger menu

### DIFF
--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -6,6 +6,15 @@ $navbarActiveBorderColor: #aaa;
 
 /* 979px - 980px is where nav-collapse gets triggered */
 @media screen and (max-width: 979px) {
+
+  .navbar .btn-navbar {
+    padding: 5px 15px;
+
+    .fa-bars {
+      transform: scaleX(1.5); // Widen it
+    }
+  }
+
   .hidden-with-nav {
     display: inherit !important;
   }

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -7,12 +7,10 @@
           %li= link_to t("pages.login"), :new_user_session
       - else
         - if responsive?
-          %a.btn.btn-navbar.hide-from-print{"data-target" => ".nav-collapse", "data-toggle" => "collapse"}
-            %span.fa.fa-bars
-            %span.fa.fa-bars
-            %span.fa.fa-bars
+          %a.btn.btn-navbar.hide-from-print{ data: { target: ".nav-collapse", toggle: "collapse" } }
+            %span.fa.fa-lg.fa-bars
         -# collapsed at < 979px
-        .hide-from-print{class: ("nav-collapse collapse" if responsive?)}
+        .hide-from-print{ class: ("nav-collapse collapse" if responsive?) }
           - if responsive?
             -# .hidden-with-nav is hidden > 979px
             .hidden-with-nav


### PR DESCRIPTION
Looks like this was broken by the upgrade in Fontawesome. `icon-bars` is not quite what `fa-bars` is.

**Pre-upgrade:**
![hamburger-before](https://user-images.githubusercontent.com/1099111/31636710-39ebeaa4-b291-11e7-9964-53e437ef62b0.png)

**Post-upgrade (current behavior)** 
![hamburger-after](https://user-images.githubusercontent.com/1099111/31636736-4d4ff22a-b291-11e7-8d74-42d5e076c590.png)

**This PR**
![screen shot 2017-10-16 at 4 45 22 pm](https://user-images.githubusercontent.com/1099111/31636765-6c34236e-b291-11e7-9fa8-899e12e0e491.png)

