### PR TITLE
[#139341] Fix error on BundleProducts#index when including a TimedService

### DIFF
--- a/app/views/bundle_products/index.html.haml
+++ b/app/views/bundle_products/index.html.haml
@@ -31,7 +31,7 @@
         - product = bundle_product.product
         %tr
           %td.centered= link_to text("shared.remove"), facility_bundle_bundle_product_path(current_facility, @bundle, bundle_product), :method => :delete if can? :delete, bundle_product
-          %td= link_to product.to_s_with_status, send("manage_facility_#{product.class.name.downcase}_path", current_facility, product)
+          %td= link_to product.to_s_with_status, [:manage, current_facility, product]
           - if product.is_a?(Instrument) or cannot? :edit, bundle_product
             %td= bundle_product.quantity
           - else


### PR DESCRIPTION
```
An ActionView::Template::Error occurred in bundle_products#index:

undefined method `manage_facility_timedservice_path' for #<#&lt;Class:0x0000000bb08aa0&gt;:0x0000000b51f648>
  app/views/bundle_products/index.html.haml:34:in `block in app_views_bundle_products_index_html_haml_145491216999438308_98089920'
```