### PR TITLE
[#139351] add note for timed service quantity

### DIFF
--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -2,7 +2,7 @@
   .product_list{class: products.first.class.model_name.to_s.pluralize.downcase}
     %h3= product_list_title products, local_assigns[:title_extra]
     - if products.first.class.model_name == "TimedService"
-      %p Please note: Quantity below are individual orders, not minutes per order.
+      %p= t("facilities.show.timed_services_note")
     %ul
       - products.sort.each_with_index do |product, index|
         %li{class: product.class.model_name.to_s.downcase}

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -1,6 +1,8 @@
 - if products.any?
   .product_list{class: products.first.class.model_name.to_s.pluralize.downcase}
     %h3= product_list_title products, local_assigns[:title_extra]
+    - if products.first.class.model_name == "TimedService"
+      %p Please note: Quantity below are individual orders, not minutes per order.
     %ul
       - products.sort.each_with_index do |product, index|
         %li{class: product.class.model_name.to_s.downcase}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -829,6 +829,7 @@ en:
 
     show:
       daily_view: 'daily view'
+      timed_services_note: "Please note: Quantity below are individual orders, not minutes per order."
 
     movable_transactions:
       head: "Move Transactions"


### PR DESCRIPTION
Add note to mitigate confusion over the meaning of the quantity field for timed services.