### PR TITLE
[#137629] admin hold schedule over

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -259,6 +259,9 @@ class OrdersController < ApplicationController
     end
 
     if order_purchaser.success?
+      should_show_admin_hold_warning = @order.order_details.map(&:reservation).compact.map(&:conflicting_admin_reservation).any?
+      flash[:error] = I18n.t("controllers.reservations.create.admin_hold_warning") if should_show_admin_hold_warning
+
       if single_reservation? && !acting_as?
         flash[:notice] = I18n.t("controllers.orders.purchase.reservation.success")
         if can_switch_instrument_on?

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -259,7 +259,7 @@ class OrdersController < ApplicationController
     end
 
     if order_purchaser.success?
-      should_show_admin_hold_warning = @order.order_details.map(&:reservation).compact.map(&:conflicting_admin_reservation).any?
+      should_show_admin_hold_warning = @order.order_details.map(&:reservation).compact.any?(&:conflicting_admin_reservation)
       flash[:error] = I18n.t("controllers.reservations.create.admin_hold_warning") if should_show_admin_hold_warning
 
       if single_reservation? && !acting_as?

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -99,6 +99,9 @@ class ReservationsController < ApplicationController
       @reservation = creator.reservation
       flash[:notice] = I18n.t "controllers.reservations.create.success"
 
+      should_show_admin_hold_warning = creator.reservation.conflicting_admin_reservation.present?
+      flash[:error] = I18n.t('controllers.reservations.create.admin_hold_warning') if should_show_admin_hold_warning
+
       if creator.merged_order?
         redirect_to facility_order_path(@order_detail.facility, @order_detail.order.merge_order || @order_detail.order)
       elsif creator.instrument_only_order?

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -98,9 +98,7 @@ class ReservationsController < ApplicationController
     if creator.save(session_user)
       @reservation = creator.reservation
       flash[:notice] = I18n.t "controllers.reservations.create.success"
-
-      should_show_admin_hold_warning = creator.reservation.conflicting_admin_reservation.present?
-      flash[:error] = I18n.t('controllers.reservations.create.admin_hold_warning') if should_show_admin_hold_warning
+      flash[:error] = I18n.t('controllers.reservations.create.admin_hold_warning') if creator.reservation.conflicting_admin_reservation?
 
       if creator.merged_order?
         redirect_to facility_order_path(@order_detail.facility, @order_detail.order.merge_order || @order_detail.order)

--- a/app/models/concerns/products/scheduling_support.rb
+++ b/app/models/concerns/products/scheduling_support.rb
@@ -162,10 +162,11 @@ module Products::SchedulingSupport
       while time < day_end
         reservation = reserver.reservations.new(reserve_start_at: time, reserve_end_at: time + duration)
 
-        conflict = reservation.conflicting_user_reservation
-        return reservation if conflict.nil?
+        conflict = reservation.conflicting_user_reservation(exclude: @options[:exclude])
+        admin_conflict = reservation.conflicting_admin_reservation if !reserved_by_admin
+        return reservation if [conflict, admin_conflict].none?
 
-        time = conflict.reserve_end_at
+        time = [conflict, admin_conflict].compact.max_by(&:reserve_end_at)
       end
     end
 

--- a/app/models/concerns/products/scheduling_support.rb
+++ b/app/models/concerns/products/scheduling_support.rb
@@ -162,7 +162,7 @@ module Products::SchedulingSupport
       while time < day_end
         reservation = reserver.reservations.new(reserve_start_at: time, reserve_end_at: time + duration)
 
-        conflict = reservation.conflicting_reservation(exclude: @options[:exclude])
+        conflict = reservation.conflicting_user_reservation
         return reservation if conflict.nil?
 
         time = conflict.reserve_end_at

--- a/app/models/concerns/products/scheduling_support.rb
+++ b/app/models/concerns/products/scheduling_support.rb
@@ -163,10 +163,10 @@ module Products::SchedulingSupport
         reservation = reserver.reservations.new(reserve_start_at: time, reserve_end_at: time + duration)
 
         conflict = reservation.conflicting_user_reservation(exclude: @options[:exclude])
-        admin_conflict = reservation.conflicting_admin_reservation if !reserved_by_admin
+        admin_conflict = reservation.conflicting_admin_reservation
         return reservation if [conflict, admin_conflict].none?
 
-        time = [conflict, admin_conflict].compact.max_by(&:reserve_end_at)
+        time = [conflict, admin_conflict].compact.max_by(&:reserve_end_at).reserve_end_at
       end
     end
 

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -172,10 +172,10 @@ class Reservation < ActiveRecord::Base
 
   def save_as_user(user)
     if user.operator_of?(product.facility)
-      @reserved_by_admin = true
+      self.reserved_by_admin = true
       save
     else
-      @reserved_by_admin = false
+      self.reserved_by_admin = false
       save_extended_validations
     end
   end
@@ -268,7 +268,8 @@ class Reservation < ActiveRecord::Base
     satisfies_minimum_length? &&
       satisfies_maximum_length? &&
       instrument_is_available_to_reserve? &&
-      does_not_conflict_with_other_reservation?
+      does_not_conflict_with_other_user_reservation? &&
+      (reserved_by_admin || does_not_conflict_with_admin_reservation?)
   end
 
   def has_actuals?

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -65,7 +65,7 @@ module Reservations::Validations
   # Look for a reservation on the same instrument that conflicts in time with a
   # purchased, admin, or in-cart reservation. Should not check reservations that
   # are unpurchased in other user's carts.
-  def conflicting_user_reservation
+  def conflicting_user_reservation(options = {})
     order_id = order_detail.try(:order_id) || 0
 
     conflicting_reservations =
@@ -73,7 +73,7 @@ module Reservations::Validations
       .joins_order
       .where(product_id: product.schedule.product_ids)
       .user
-      .not_this_reservation(self)
+      .not_this_reservation(options[:exclude] || self)
       .not_canceled
       .not_ended
       .where("(orders.state = 'purchased' OR orders.state IS NULL OR orders.id = ?)", order_id)

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -93,6 +93,7 @@ module Reservations::Validations
   def conflicting_admin_reservation
     conflicting_reservations =
       Reservation
+      .joins_order
       .where(product_id: product.schedule.product_ids)
       .not_canceled
       .not_ended

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -90,6 +90,10 @@ module Reservations::Validations
     errors.add(:base, :conflict) if conflicting_admin_reservation
   end
 
+  def conflicting_admin_reservation?
+    conflicting_admin_reservation.present?
+  end
+
   def conflicting_admin_reservation
     conflicting_reservations =
       Reservation

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -116,6 +116,7 @@ en:
       create:
         no_selection: "You must select a payment source before reserving"
         success: "The reservation was successfully created."
+        admin_hold_warning: "Warning: You have scheduled over an administrative hold."
       order_detail_removed: |
         The instrument order has been removed from your cart.
         Please add it again to make a reservation.
@@ -161,7 +162,7 @@ en:
         future_dating_error: "Order dates in the future are not allowed"
         quantities_changed: Quantities have changed. Please review updated prices then click "Purchase"
         reservation:
-          success: Reservation completed successfully
+          success: Reservation created successfully
 
     order_imports:
       create:

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -409,7 +409,7 @@ RSpec.describe OrdersController do
       it "redirects to my reservations on a successful purchase of a single reservation" do
         sign_in @staff
         do_request
-        expect(flash[:notice]).to eq("Reservation completed successfully")
+        expect(flash[:notice]).to eq("Reservation created successfully")
         expect(response).to redirect_to reservations_path
       end
 

--- a/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
+++ b/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
         click_button "Create"
 
         expect(page).to have_content "Order Receipt"
-        # save_and_open_page
         expect(page).to have_content "Warning: You have scheduled over an administrative hold."
         expect(page).to have_content "10:00 AM - 11:30 AM"
       end

--- a/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
+++ b/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
@@ -34,8 +34,35 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
     end
 
     it "returns to My Reservations" do
-      expect(page).to have_content "My Reservations"
+      expect(page).to have_content "Order Receipt"
       expect(Reservation.last.note).to eq("A note")
     end
+  end
+
+  describe "ordering over an administrative hold" do
+    let!(:admin_reservation) { create(:admin_reservation, product: instrument, reserve_start_at: 30.minutes.from_now, duration: 1.hour) }
+
+    describe "when you create a reservation" do
+      it "can purchase" do
+        click_link instrument.name
+
+        # time is frozen to 9:30am, we expect the default time to be the end of the admin reservation
+        expect(page.find_field("reservation_reserve_start_date").value).to match(%r[09/11/\d{4}])
+        expect(page.find_field("reservation_reserve_start_hour").value).to eq "11"
+        expect(page.find_field("reservation_reserve_start_min").value).to eq "0"
+        expect(page.find_field("reservation_reserve_start_meridian").value).to eq "AM"
+
+        fill_in "Duration", with: 90
+        select 10, from: "reservation_reserve_start_hour"
+        select user.accounts.first.description, from: "Payment Source"
+        click_button "Create"
+
+        expect(page).to have_content "Order Receipt"
+        # save_and_open_page
+        expect(page).to have_content "Warning: You have scheduled over an administrative hold."
+        expect(page).to have_content "10:00 AM - 11:30 AM"
+      end
+    end
+
   end
 end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -567,6 +567,22 @@ RSpec.describe Reservation do
       assert_equal ["The reservation conflicts with another reservation in your cart. Please purchase or remove it then continue."], @reservation2.errors[:base]
     end
 
+
+    context "with admin reservations" do
+      let!(:admin_reservation) { create(:admin_reservation,
+                                product: instrument,
+                                reserve_start_at: 30.minutes.ago,
+                                duration: 1.hour) }
+      let(:reservation) { create(:reservation,
+        product: instrument,
+        reserve_start_at: 1.hour.from_now,
+        duration: 1.hour)}
+
+      it "suggests a time that does not overlap with an existing admin reservation" do
+        expect(reservation.earliest_possible.reserve_start_at).to eq 30.minutes.from_now
+      end
+    end
+
     it "should allow reservations with the same time and date on different instruments" do
       expect(@reservation1).to be_valid
 

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -830,9 +830,9 @@ RSpec.describe Reservation do
       let(:admin_user) { FactoryGirl.create(:user, :staff, facility: facility) }
       let(:new_user_reservation) do
         instrument.reservations.build(
-                                      reserve_start_at: 1.day.from_now.change(hour: 11, min: 0),
-                                      reserve_end_at: 1.day.from_now.change(hour: 12, min: 0)
-                                      )
+          reserve_start_at: 1.day.from_now.change(hour: 11, min: 0),
+          reserve_end_at: 1.day.from_now.change(hour: 12, min: 0),
+        )
       end
       it "can schedule over an admin reservation if order is placed by admin" do
         expect(new_user_reservation.save_as_user(admin_user)).to be_truthy

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -567,16 +567,19 @@ RSpec.describe Reservation do
       assert_equal ["The reservation conflicts with another reservation in your cart. Please purchase or remove it then continue."], @reservation2.errors[:base]
     end
 
-
     context "with admin reservations" do
-      let!(:admin_reservation) { create(:admin_reservation,
-                                product: instrument,
-                                reserve_start_at: 30.minutes.ago,
-                                duration: 1.hour) }
-      let(:reservation) { create(:reservation,
-        product: instrument,
-        reserve_start_at: 1.hour.from_now,
-        duration: 1.hour)}
+      let!(:admin_reservation) do
+        create(:admin_reservation,
+               product: instrument,
+               reserve_start_at: 30.minutes.ago,
+               duration: 1.hour)
+      end
+      let(:reservation) do
+        create(:reservation,
+               product: instrument,
+               reserve_start_at: 1.hour.from_now,
+               duration: 1.hour)
+      end
 
       it "suggests a time that does not overlap with an existing admin reservation" do
         expect(reservation.earliest_possible.reserve_start_at).to eq 30.minutes.from_now

--- a/spec/models/reservations_validations_spec.rb
+++ b/spec/models/reservations_validations_spec.rb
@@ -66,14 +66,14 @@ RSpec.describe Reservations::Validations do
   describe "conditionally run validations" do
     context "with reserve_start_at, reserve_end_at, and reservation_changed? is true" do
       it "runs conditional validations" do
-        expect(reservation).to receive :does_not_conflict_with_other_reservation
+        expect(reservation).to receive :does_not_conflict_with_other_user_reservation
         reservation.save
       end
     end
 
     context "with missing reserve_start_at" do
       it "does not run conditional validations" do
-        expect(reservation).not_to receive :does_not_conflict_with_other_reservation
+        expect(reservation).not_to receive :does_not_conflict_with_other_user_reservation
         reservation.update_attributes(reserve_start_at: nil)
       end
     end


### PR DESCRIPTION
What the flash messages look like:

<img width="1303" alt="screen shot 2017-11-01 at 2 33 50 pm" src="https://user-images.githubusercontent.com/4624197/32350669-0a45d6d8-bfe9-11e7-9d61-4ec7d15658fa.png">
<img width="1303" alt="screen shot 2017-11-01 at 2 34 04 pm" src="https://user-images.githubusercontent.com/4624197/32350670-0a51470c-bfe9-11e7-8a4d-8f4f1f52e24d.png">
<img width="1344" alt="screen shot 2017-11-01 at 2 39 20 pm" src="https://user-images.githubusercontent.com/4624197/32350671-0a5c33a6-bfe9-11e7-9045-cc09c4f26655.png">
<img width="1391" alt="screen shot 2017-11-02 at 4 14 27 pm" src="https://user-images.githubusercontent.com/4624197/32350672-0a6698dc-bfe9-11e7-80f1-44ab00e0da7b.png">


to do:

- [x] add feature specs for placing reservations over admin reservations
- [x] write a test to verify earliest possible (whichever method that is) gives expected results (reservation_spec.rb:589)
- [x] After the reservation is submitted, include a flash message notifying the facility staff member that they've scheduled over an admin reservation. Text: Warning, you've scheduled over an administrative hold.