### PR TITLE
[#139318] Ignore ActionController::UnknownFormat in ExceptionNotifier

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,6 +75,7 @@ Nucore::Application.configure do
   # config.force_ssl = true
 
   config.middleware.use ExceptionNotification::Rack,
+                        ignore_exceptions: ["ActionController::UnknownHttpMethod", "ActionController::UnknownFormat"] + ExceptionNotifier.ignored_exceptions,
                         email: {
                           sender_address: Settings.email.exceptions.sender,
                           exception_recipients: Settings.email.exceptions.recipients,

--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -76,6 +76,7 @@ Nucore::Application.configure do
   # config.force_ssl = true
 
   # config.middleware.use ExceptionNotification::Rack,
+  #                       ignore_exceptions: ["ActionController::UnknownHttpMethod", "ActionController::UnknownFormat"] + ExceptionNotifier.ignored_exceptions,
   #                       email: {
   #                         sender_address: Settings.email.exceptions.sender,
   #                         exception_recipients: Settings.email.exceptions.recipients,

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -14,6 +14,7 @@ if defined?(Rollbar)
       "ActionController::RoutingError"     => "ignore",
       "AbstractController::ActionNotFound" => "ignore",
       "ActionController::UnknownFormat"    => "ignore",
+      "ActionController::UnknownHttpMethod" => "ignore",
     )
 
     # By default, Rollbar will try to call the `current_user` controller method


### PR DESCRIPTION
There's no real need to be notified of this error. This happens if a js/json path meant for ajax is called without a format header. It is already ignored by Rollbar.

This also ignores `ActionController::UnknownHttpMethod` in rollbar. We sometimes see those errors when we're getting vulnerability scanned.

This will get a little funky going into the schools. NU already has the `ActionController::UnknownHttpMethod` ignore and Dartmouth doesn't use ExceptionNotifier. But this should help get things closer in line.