### PR TITLE
[#139135] Disable cross-facility journal creation

### DIFF
--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -27,6 +27,8 @@ class FacilityJournalsController < ApplicationController
 
   # GET /facilities/journals/new
   def new_with_search
+    raise ActiveRecord::RecordNotFound if current_facility.cross_facility?
+
     set_default_variables
     @layout = "two_column_head"
 
@@ -70,6 +72,8 @@ class FacilityJournalsController < ApplicationController
 
   # POST /facilities/journals
   def create_with_search
+    raise ActiveRecord::RecordNotFound if current_facility.cross_facility?
+
     new_journal_from_params
     verify_journal_date_format
 

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -2,7 +2,7 @@ require "set"
 
 class Journal < ActiveRecord::Base
 
-  class CreationError < StandardError; end
+  class CreationError < NUCore::Error; end
 
   module Overridable
 
@@ -197,9 +197,8 @@ class Journal < ActiveRecord::Base
   end
 
   def set_facility_id
-    # detect if this should be a multi-facility journal, set facility_id appropriately
     self.facility_id = if @order_details_for_creation.collect { |od| od.order.facility_id }.uniq.size > 1
-                         nil
+                         raise CreationError, "Cannot create a cross facility journal"
                        else
                          @order_details_for_creation.first.order.facility_id
                        end

--- a/app/views/admin/shared/_sidenav_billing.html.haml
+++ b/app/views/admin/shared/_sidenav_billing.html.haml
@@ -18,7 +18,8 @@
 
   %li.divider
   %li.nav-header= Journal.model_name.human.pluralize
-  = tab t_create_model(Journal), new_facility_journal_path, (sidenav_tab == 'new_journal')
+  - if current_facility.single_facility?
+    = tab t_create_model(Journal), new_facility_journal_path, (sidenav_tab == 'new_journal')
   = tab t_manage_models(Journal), facility_journals_path, (sidenav_tab == 'journals')
 
   = render "shared/sidenav_billing/statements", sidenav_tab: sidenav_tab

--- a/lib/nucore.rb
+++ b/lib/nucore.rb
@@ -3,13 +3,16 @@ module NUCore
   class PermissionDenied < SecurityError
   end
 
-  class MixedFacilityCart < StandardError
+  class Error < StandardError
   end
 
-  class NotPermittedWhileActingAs < StandardError
+  class MixedFacilityCart < NUCore::Error
   end
 
-  class PurchaseException < StandardError; end
+  class NotPermittedWhileActingAs < NUCore::Error
+  end
+
+  class PurchaseException < NUCore::Error; end
 
   def self.portal
     "nucore"

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -339,22 +339,16 @@ RSpec.describe FacilityJournalsController do
       it_should_support_searching
     end
 
-    context "with a mixed facility journal", feature_setting: { billing_administrator: true } do
+    context "in cross facility", feature_setting: { billing_administrator: true } do
       before :each do
-        ignore_account_validations
-        create_order_details
-
-        @facility2 = create(:facility)
-        @account2 = create(:nufs_account, account_users_attributes: account_users_attributes_hash(user: @admin), facility_id: @facility2.id)
-        @facility2_order_detail = place_and_complete_item_order(@user, @facility2, @account2, true)
-
         @params[:facility_id] = "all"
-        @params[:order_detail_ids] = [@order_detail1.id, @facility2_order_detail.id]
         sign_in create(:user, :billing_administrator)
         do_request
       end
 
-      it { expect(assigns(:journal).facility_id).to be_nil }
+      it "renders a 404" do
+        expect(response.code).to eq("404")
+      end
     end
 
     # SLOW
@@ -462,6 +456,18 @@ RSpec.describe FacilityJournalsController do
         @user = @admin
       end
       it_should_support_searching
+    end
+
+    context "in cross facility", feature_setting: { billing_administrator: true } do
+      before :each do
+        @params[:facility_id] = "all"
+        sign_in create(:user, :billing_administrator)
+        do_request
+      end
+
+      it "renders a 404" do
+        expect(response.code).to eq("404")
+      end
     end
   end
 

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -233,7 +233,6 @@ RSpec.describe Journal do
         end
 
         journal = Journal.create!(
-          facility_id: (facilities_list.size == 1 ? facilities_list.first.id : nil),
           created_by: @admin.id,
           journal_date: Time.zone.now,
         )
@@ -251,6 +250,20 @@ RSpec.describe Journal do
 
       it "should not allow creation of a journal for A" do
         expect { create_pending_journal_for(@facilitya) }.to raise_error(Journal::CreationError)
+      end
+    end
+
+    describe "cross facility journal" do
+      let(:journal) { Journal.new(created_by: @admin.id, journal_date: Time.current, order_details_for_creation: order_details) }
+      let(:order_details) do
+        [
+          place_and_complete_item_order(@admin, @facilitya, @account, true),
+          place_and_complete_item_order(@admin, @facilityb, @account, true),
+        ]
+      end
+
+      it "cannot create the journal" do
+        expect { journal.save }.to raise_error(Journal::CreationError)
       end
     end
 


### PR DESCRIPTION
DC accidentally created one and it caused confusion. NU times out on this
view and they don't really use the billing admin role. UIC does their journaling
using an outside system (Banner Feeder).