### PR TITLE
fix fiscal year dependent specs

### DIFF
--- a/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
+++ b/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
         click_link instrument.name
 
         # time is frozen to 9:30am ten days after fiscal year start, we expect the default time to be the end of the admin reservation
-        expect(page.find_field("reservation_reserve_start_date").value).to eq Date.today.strftime("%m/%d/%Y")
+        expect(page.find_field("reservation_reserve_start_date").value).to eq Time.zone.today.strftime("%m/%d/%Y")
         expect(page.find_field("reservation_reserve_start_hour").value).to eq "11"
         expect(page.find_field("reservation_reserve_start_min").value).to eq "0"
         expect(page.find_field("reservation_reserve_start_meridian").value).to eq "AM"

--- a/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
+++ b/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
       it "can purchase" do
         click_link instrument.name
 
-        # time is frozen to 9:30am, we expect the default time to be the end of the admin reservation
-        expect(page.find_field("reservation_reserve_start_date").value).to match(%r[09/11/\d{4}])
+        # time is frozen to 9:30am ten days after fiscal year start, we expect the default time to be the end of the admin reservation
+        expect(page.find_field("reservation_reserve_start_date").value).to eq Date.today.strftime("%m/%d/%Y")
         expect(page.find_field("reservation_reserve_start_hour").value).to eq "11"
         expect(page.find_field("reservation_reserve_start_min").value).to eq "0"
         expect(page.find_field("reservation_reserve_start_meridian").value).to eq "AM"

--- a/spec/features/purchasing_a_reservation_spec.rb
+++ b/spec/features/purchasing_a_reservation_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Purchasing a reservation" do
         select user.accounts.first.description, from: "Payment Source"
 
         # time is frozen to 9:30am ten days after fiscal year start, we expect the default time to be the end of the admin reservation
-        expect(page.find_field("reservation_reserve_start_date").value).to eq Date.today.strftime("%m/%d/%Y")
+        expect(page.find_field("reservation_reserve_start_date").value).to eq Time.zone.today.strftime("%m/%d/%Y")
         expect(page.find_field("reservation_reserve_start_hour").value).to eq "11"
         expect(page.find_field("reservation_reserve_start_min").value).to eq "0"
         expect(page.find_field("reservation_reserve_start_meridian").value).to eq "AM"

--- a/spec/features/purchasing_a_reservation_spec.rb
+++ b/spec/features/purchasing_a_reservation_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe "Purchasing a reservation" do
         click_link instrument.name
         select user.accounts.first.description, from: "Payment Source"
 
-        # time is frozen to 9:30am, we expect the default time to be the end of the admin reservation
-        expect(page.find_field("reservation_reserve_start_date").value).to match(%r[09/11/\d{4}])
+        # time is frozen to 9:30am ten days after fiscal year start, we expect the default time to be the end of the admin reservation
+        expect(page.find_field("reservation_reserve_start_date").value).to eq Date.today.strftime("%m/%d/%Y")
         expect(page.find_field("reservation_reserve_start_hour").value).to eq "11"
         expect(page.find_field("reservation_reserve_start_min").value).to eq "0"
         expect(page.find_field("reservation_reserve_start_meridian").value).to eq "AM"


### PR DESCRIPTION
Specs were breaking in forks, as the schools have different fiscal year starts.

https://circleci.com/gh/tablexi/nucore-dartmouth/774?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link