### PR TITLE
[#139725] Public calendar icon should respect admin reservations

### DIFF
--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -55,7 +55,7 @@ module ProductsHelper
     if product.offline?
       { class: ["fa fa-calendar fa-2x", "in-use"],
         title: text("instruments.offline.note") }
-    elsif product.available?
+    elsif product.walkup_available?
       { class: ["fa fa-calendar fa-2x", "available"],
         title: text("instruments.public_schedule.available") }
     else

--- a/app/models/concerns/products/scheduling_support.rb
+++ b/app/models/concerns/products/scheduling_support.rb
@@ -43,7 +43,7 @@ module Products::SchedulingSupport
     schedule.reservations.active
   end
 
-  def available?(time = Time.zone.now)
+  def walkup_available?(time = Time.zone.now)
     # zero and nil should default to 1 minute
     reservation_length = [min_reserve_mins.to_i, reserve_interval.to_i].max
     reservation = Reservation.new(
@@ -52,7 +52,7 @@ module Products::SchedulingSupport
       reserve_end_at: time + reservation_length.minutes,
       blackout: true # so it's not considered an admin and allowed to overlap
     )
-    reservation.valid?
+    reservation.valid?(:walkup_available)
   end
 
   # find the next available reservation based on schedule rules and existing reservations

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -178,7 +178,7 @@ class Reservation < ActiveRecord::Base
       save
     else
       self.reserved_by_admin = false
-      save_extended_validations
+      save(context: :user_purchase)
     end
   end
 

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -123,7 +123,7 @@ module Reservations::Validations
   end
 
   def satisfies_minimum_length
-    errors.add(:base, "The reservation is too short") unless satisfies_minimum_length?
+    errors.add(:base, :too_short, length: product.min_reserve_mins) unless satisfies_minimum_length?
   end
 
   def satisfies_maximum_length?
@@ -139,11 +139,11 @@ module Reservations::Validations
   end
 
   def satisfies_maximum_length
-    errors.add(:base, "The reservation is too long") unless satisfies_maximum_length?
+    errors.add(:base, :too_long, length: product.max_reserve_mins) unless satisfies_maximum_length?
   end
 
   def instrument_is_available_to_reserve
-    errors.add(:base, "The reservation spans time that the instrument is unavailable for reservation") unless instrument_is_available_to_reserve?
+    errors.add(:base, :unavailable_to_reserve) unless instrument_is_available_to_reserve?
   end
 
   def instrument_is_available_to_reserve?(start_at = reserve_start_at, end_at = reserve_end_at)
@@ -165,7 +165,7 @@ module Reservations::Validations
 
   def in_the_future
     if reserve_start_at_changed?
-      errors.add(:reserve_start_at, "The reservation must start at a future time") unless in_the_future?
+      errors.add(:reserve_start_at, :in_past) unless in_the_future?
     end
   end
 
@@ -178,7 +178,7 @@ module Reservations::Validations
   end
 
   def in_window
-    errors.add(:base, "The reservation is too far in advance") unless in_window?
+    errors.add(:base, :out_of_window) unless in_window?
   end
 
   # return the longest available reservation window for the groups

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -81,8 +81,14 @@ en:
             base:
               conflict: The reservation conflicts with another reservation.
               conflict_in_cart: The reservation conflicts with another reservation in your cart. Please purchase or remove it then continue.
+              out_of_window: The reservation is too far in advance
+              unavailable_to_reserve: The reservation spans time that the instrument is unavailable for reservation
+              too_long: The reservation is too long. It cannot be longer than %{length} minutes.
+              too_short: The reservation is too short. It must be at least %{length} minutes.
             reserve_start_at:
-              after_cutoff: must be at least %{hours} hours in the future.
+              after_cutoff: must be at least %{hours} hours in the future
+              in_past: must be in the future
+
         stored_file:
           attributes:
             name:

--- a/spec/features/purchasing_a_reservation_spec.rb
+++ b/spec/features/purchasing_a_reservation_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Purchasing a reservation" do
     end
 
     it "has an error" do
-      expect(page).to have_content "must start at a future time"
+      expect(page).to have_content "must be in the future"
     end
   end
 

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -682,31 +682,42 @@ RSpec.describe Instrument do
 
   end
 
-  describe "available?" do
+  describe "walkup_available?" do
     subject(:instrument) { FactoryGirl.create :setup_instrument }
 
-    it { is_expected.to be_available }
+    it { is_expected.to be_walkup_available }
 
     context "there is not a current schedule rule" do
       before :each do
         instrument.schedule_rules.destroy_all
       end
 
-      it { is_expected.not_to be_available }
+      it { is_expected.not_to be_walkup_available }
     end
 
     context "zero minimum reservation" do
       before :each do
         instrument.update_attributes(min_reserve_mins: 0)
       end
-      it { is_expected.to be_available }
+      it { is_expected.to be_walkup_available }
     end
 
     context "with nil minimum reservation" do
       before :each do
         instrument.update_attributes(min_reserve_mins: nil)
       end
-      it { is_expected.to be_available }
+      it { is_expected.to be_walkup_available }
+    end
+
+    context "with an admin reservation" do
+      let!(:reservation) do
+        FactoryGirl.create(:admin_reservation,
+                           reserve_start_at: 30.minutes.ago,
+                           reserve_end_at: 30.minutes.from_now,
+                           product: instrument)
+      end
+
+      it { is_expected.not_to be_walkup_available }
     end
 
     context "reservation only instrument" do
@@ -718,7 +729,7 @@ RSpec.describe Instrument do
                              product: instrument
         end
 
-        it { is_expected.not_to be_available }
+        it { is_expected.not_to be_walkup_available }
 
         context "but it was canceled" do
           let(:user) { FactoryGirl.build :user }
@@ -729,7 +740,7 @@ RSpec.describe Instrument do
             end
           end
 
-          it { is_expected.to be_available }
+          it { is_expected.to be_walkup_available }
         end
       end
 
@@ -738,7 +749,7 @@ RSpec.describe Instrument do
           instrument.update_attributes!(min_reserve_mins: nil)
         end
 
-        it { is_expected.to be_available }
+        it { is_expected.to be_walkup_available }
       end
     end
 
@@ -761,7 +772,7 @@ RSpec.describe Instrument do
                                           actual_start_at: 30.minutes.ago)
           end
 
-          it { is_expected.not_to be_available }
+          it { is_expected.not_to be_walkup_available }
 
           context "but it was ended already" do
             before :each do
@@ -769,7 +780,7 @@ RSpec.describe Instrument do
                                             actual_end_at: 10.minutes.ago)
             end
 
-            it { is_expected.to be_available }
+            it { is_expected.to be_walkup_available }
           end
         end
       end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -956,7 +956,7 @@ RSpec.describe Reservation do
                                                     duration_mins: 61,
                                                     split_times: true)
       expect(@reservation).not_to be_valid
-      expect(@reservation.errors[:base]).to include "The reservation is too long"
+      expect(@reservation.errors).to be_added(:base, :too_long, length: 60)
     end
 
     context "when the reservation does not exceed the maximum length" do
@@ -995,7 +995,7 @@ RSpec.describe Reservation do
                                                     duration_mins: 29,
                                                     split_times: true)
       expect(@reservation).not_to be_valid
-      expect(@reservation.errors[:base]).to include "The reservation is too short"
+      expect(@reservation.errors).to be_added(:base, :too_short, length: 30)
     end
 
     it "allows reservations over the minimum length" do


### PR DESCRIPTION
* Rename Instrument#available? to #walkup_available? to better clarify its use-case.
* Refactoring to how reservation validations are performed
* Remove Reservation#save_extended_reservation by using a :user_purchase context
* I18n reservation validation messages