### PR TITLE
[#126403] Address feedback on admin hold recurrence

### DIFF
--- a/app/forms/admin_reservation_form.rb
+++ b/app/forms/admin_reservation_form.rb
@@ -87,7 +87,7 @@ class AdminReservationForm
 
   def cannot_exceed_max_end_date
     if repeat_end_date && repeat_end_date > max_end_date
-      errors.add :repeat_end_date, :too_far_in_future
+      errors.add :repeat_end_date, :too_far_in_future, time: "12 weeks"
     end
   end
 

--- a/app/views/facility_reservations/_admin_reservation_repeat_fields.html.haml
+++ b/app/views/facility_reservations/_admin_reservation_repeat_fields.html.haml
@@ -1,4 +1,4 @@
 .checkboxControl
   = f.input :repeats, as: :boolean, input_html: { data: { disables: ".admin_reservation_repeat_frequency, .admin_reservation_repeat_end_date" } }, wrapper_html: { class: "checkboxControl__checkbox" }
-  = f.input :repeat_frequency, collection: AdminReservationForm::REPEAT_OPTIONS.map { |option| [option.titleize, option]}, selected: "Weekly"
+  = f.input :repeat_frequency, collection: AdminReservationForm::REPEAT_OPTIONS.map { |option| [option.titleize, option] }, include_blank: false
   = f.input :repeat_end_date, input_html: { class: "datepicker__data", value: format_usa_date(f.object.repeat_end_date) }

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -6,6 +6,10 @@ en:
       auto_assign_account: "Could not find a valid payment source for purchasing %{product_name}"
 
   activemodel:
+    attributes:
+      admin_reservation_form:
+        expires?: Release In Advance
+        expires_mins_before: "Release hh:mm Prior To Start"
     errors:
       models:
         order_details/reconciler:
@@ -23,7 +27,7 @@ en:
           attributes:
             repeat_end_date:
               blank: must be a valid date
-              too_far_in_future: too far in future
+              too_far_in_future: Cannot be dated more than %{time} in the future
               must_be_after_initial_reservation: must occur after initial reservation
 
 
@@ -343,8 +347,6 @@ en:
         canceled_by: Canceled By
         canceled_at: Canceled At
         type: Type
-        expires?: Release In Advance?
-        expires_mins_before: "Release hh:mm Prior To Start"
       statement:
         id: "Invoice #"
         created_by: Sent By

--- a/spec/forms/admin_reservation_form_spec.rb
+++ b/spec/forms/admin_reservation_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AdminReservationForm do
       it "invalid past max end date" do
         form.assign_attributes(repeats: "1", repeat_frequency: "weekly", repeat_end_date: format_usa_date(start_date + 14.weeks))
         expect(form).not_to be_valid
-        expect(form.errors).to be_added(:repeat_end_date, :too_far_in_future)
+        expect(form.errors).to be_added(:repeat_end_date, :too_far_in_future, time: "12 weeks")
       end
 
       it "valid before max end date" do


### PR DESCRIPTION
* The "too far in future" error was considered vague. Now say “cannot
be dated more than 12 weeks in the future”
* Retain recurrence interval in dropdown after invalid submission
* Remove blank option in recurrence interval dropdown
* Fix labels for expiration (I18n got lost when we changed from
`Reservation` to `AdminReservationForm`)