### PR TITLE
Replace "All Transactions" search with newer search method

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -19,7 +19,7 @@ class FacilitiesController < ApplicationController
 
   include FacilitiesHelper
 
-  layout -> {
+  layout lambda {
     action_name.in?(%w(disputed_orders movable_transactions transactions)) ? "two_column_head" : "two_column"
   }
 

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -9,7 +9,6 @@ class FacilitiesController < ApplicationController
   before_action :load_order_details, only: [:confirm_transactions, :move_transactions, :reassign_chart_strings]
   before_action :set_admin_billing_tab, only: [:confirm_transactions, :disputed_orders, :movable_transactions, :transactions]
   before_action :set_recently_used_facilities, only: [:index]
-  before_action :set_two_column_head_layout, only: [:disputed_orders, :movable_transactions, :transactions]
   before_action :store_fullpath_in_session, only: [:index, :show]
 
   load_and_authorize_resource find_by: :url_name
@@ -20,7 +19,9 @@ class FacilitiesController < ApplicationController
 
   include FacilitiesHelper
 
-  layout "two_column"
+  layout -> {
+    action_name.in?(%w(disputed_orders movable_transactions transactions)) ? "two_column_head" : "two_column"
+  }
 
   def set_recently_used_facilities
     @recently_used_facilities =
@@ -113,10 +114,20 @@ class FacilitiesController < ApplicationController
   end
 
   # GET /facilities/transactions
-  def transactions_with_search
-    set_default_start_date
+  def transactions
+    order_details = OrderDetail.purchased.for_facility(current_facility)
     @export_enabled = true
-    paginate_order_details
+
+    @search_form = TransactionSearch::SearchForm.new(
+      params[:search],
+      defaults: {
+        date_range_start: format_usa_date(1.month.ago.beginning_of_month),
+      },
+    )
+
+    @search = TransactionSearch::Searcher.new.search(order_details, @search_form)
+    @date_range_field = @search_form.date_params[:field]
+    @order_details = @search.order_details.paginate(page: params[:page])
   end
 
   # GET /facilities/:facility_id/disputed_orders
@@ -226,10 +237,6 @@ class FacilitiesController < ApplicationController
 
   def set_admin_billing_tab
     @active_tab = "admin_billing"
-  end
-
-  def set_two_column_head_layout
-    @layout = "two_column_head"
   end
 
 end

--- a/app/forms/transaction_search/search_form.rb
+++ b/app/forms/transaction_search/search_form.rb
@@ -24,15 +24,15 @@ module TransactionSearch
       end
     end
 
-    private
-
     def date_params
       {
-        field: date_range_field.presence || "ordered_at",
+        field: date_range_field,
         start: date_range_start,
         end: date_range_end,
       }
     end
+
+    private
 
     def default_params
       {

--- a/app/forms/transaction_search/search_form.rb
+++ b/app/forms/transaction_search/search_form.rb
@@ -28,7 +28,7 @@ module TransactionSearch
 
     def date_params
       {
-        field: date_range_field,
+        field: date_range_field.presence || "ordered_at",
         start: date_range_start,
         end: date_range_end,
       }

--- a/app/forms/transaction_search/search_form.rb
+++ b/app/forms/transaction_search/search_form.rb
@@ -13,7 +13,11 @@ module TransactionSearch
     end
 
     def initialize(params, defaults: default_params)
-      super(params.to_h.reverse_merge(defaults))
+      # If defaults are given, they are merged with the default_params (so we have
+      # everything needed, even if the provided defaults are missing one of our
+      # defaults.
+      full_defaults = defaults.reverse_merge(default_params)
+      super(params.to_h.reverse_merge(full_defaults))
     end
 
     def [](field)

--- a/app/inputs/transaction_chosen2_input.rb
+++ b/app/inputs/transaction_chosen2_input.rb
@@ -18,6 +18,7 @@ class TransactionChosen2Input < SimpleForm::Inputs::CollectionInput
 
     merged_input_options[:multiple] = true
     merged_input_options["data-placeholder"] = placeholder_label
+    merged_input_options[:object] = object
 
     # If there is only one possible value, then we want to show it as selected,
     # but we don't want to allow adding/removing it.

--- a/app/inputs/transaction_chosen2_input.rb
+++ b/app/inputs/transaction_chosen2_input.rb
@@ -18,7 +18,6 @@ class TransactionChosen2Input < SimpleForm::Inputs::CollectionInput
 
     merged_input_options[:multiple] = true
     merged_input_options["data-placeholder"] = placeholder_label
-    merged_input_options[:object] = object
 
     # If there is only one possible value, then we want to show it as selected,
     # but we don't want to allow adding/removing it.

--- a/app/services/transaction_search/base_searcher.rb
+++ b/app/services/transaction_search/base_searcher.rb
@@ -5,7 +5,7 @@ module TransactionSearch
     attr_reader :order_details
 
     def self.key
-      to_s.demodulize.sub(/Searcher\z/, '').pluralize.underscore
+      to_s.sub(/\ATransactionSearch::/, '').sub(/Searcher\z/, '').pluralize.underscore
     end
 
     def initialize(order_details)
@@ -26,6 +26,11 @@ module TransactionSearch
 
     def label
       nil
+    end
+
+    # `item` will be one element of the collection
+    def data_attrs(_item)
+      {}
     end
 
     def options

--- a/app/services/transaction_search/order_status_searcher.rb
+++ b/app/services/transaction_search/order_status_searcher.rb
@@ -17,6 +17,12 @@ module TransactionSearch
       order_details.preload(:order_status)
     end
 
+    def data_attrs(order_status)
+      {}.tap do |h|
+        h[:facility] = order_status.facility_id if order_status.facility_id
+      end
+    end
+
   end
 
 end

--- a/app/services/transaction_search/product_searcher.rb
+++ b/app/services/transaction_search/product_searcher.rb
@@ -14,6 +14,14 @@ module TransactionSearch
       order_details.includes(:product)
     end
 
+    def data_attrs(product)
+      {
+        facility: product.facility_id,
+        restricted: product.requires_approval?,
+        product_type: product.type.downcase,
+      }
+    end
+
   end
 
 end

--- a/app/services/transaction_search/searcher.rb
+++ b/app/services/transaction_search/searcher.rb
@@ -5,12 +5,12 @@ module TransactionSearch
     # Do not modify this directly. Use TransactionSearch.register instead.
     cattr_accessor(:default_searchers) do
       [
-        :facilities,
-        :accounts,
-        :products,
-        :account_owners,
-        :order_statuses,
-        :date_ranges,
+        TransactionSearch::FacilitySearcher,
+        TransactionSearch::AccountSearcher,
+        TransactionSearch::ProductSearcher,
+        TransactionSearch::AccountOwnerSearcher,
+        TransactionSearch::OrderStatusSearcher,
+        TransactionSearch::DateRangeSearcher,
       ]
     end
 

--- a/app/services/transaction_search/searcher.rb
+++ b/app/services/transaction_search/searcher.rb
@@ -2,8 +2,22 @@ module TransactionSearch
 
   class Searcher
 
+    # Do not modify this directly. Use TransactionSearch.register instead.
+    cattr_accessor(:default_searchers) do
+      [
+        :facilities,
+        :accounts,
+        :products,
+        :account_owners,
+        :order_statuses,
+        :date_ranges,
+      ]
+    end
+
     # Expects an array of `TransactionSearch::BaseSearcher`s
     def initialize(*searchers)
+      searchers = self.class.default_searchers if searchers.blank?
+
       @searchers = Array(searchers)
     end
 

--- a/app/services/transaction_search/searcher.rb
+++ b/app/services/transaction_search/searcher.rb
@@ -2,7 +2,9 @@ module TransactionSearch
 
   class Searcher
 
-    # Do not modify this directly. Use TransactionSearch.register instead.
+    # Do not modify this array directly. Use `TransactionSearch.register` instead.
+    # There is some additional setup that needs to happen (adding an atr_accessor
+    # to SearchForm) that `register` handles.
     cattr_accessor(:default_searchers) do
       [
         TransactionSearch::FacilitySearcher,
@@ -50,7 +52,7 @@ module TransactionSearch
       attr_reader :order_details
 
       # Return an array of options for a given key
-      delegate :[], to: :to_h
+      delegate :[], to: :to_options_by_searcher
 
       def initialize(order_details, search_options = [])
         @order_details = order_details
@@ -61,7 +63,7 @@ module TransactionSearch
         @search_options.dup
       end
 
-      def to_h
+      def to_options_by_searcher
         @to_h ||= options.each_with_object({}) do |searcher, hash|
           hash[searcher.key] = searcher.options
         end

--- a/app/services/transaction_search/searcher.rb
+++ b/app/services/transaction_search/searcher.rb
@@ -49,6 +49,9 @@ module TransactionSearch
 
       attr_reader :order_details
 
+      # Return an array of options for a given key
+      delegate :[], to: :to_h
+
       def initialize(order_details, search_options = [])
         @order_details = order_details
         @search_options = search_options.freeze
@@ -56,6 +59,12 @@ module TransactionSearch
 
       def options
         @search_options.dup
+      end
+
+      def to_h
+        @to_h ||= options.each_with_object({}) do |searcher, hash|
+          hash[searcher.key] = searcher.options
+        end
       end
 
     end

--- a/app/views/facilities/transactions.html.haml
+++ b/app/views/facilities/transactions.html.haml
@@ -6,5 +6,5 @@
   %h2= text(:history, scope: "admin.transaction_search.actions")
 
 = content_for :top_block do
-  = render "shared/transactions/top", tab: "transactions"
+  = render "shared/transactions/top2", tab: "transactions"
 = render partial: "shared/transactions/table"

--- a/app/views/shared/transactions/_search2.html.haml
+++ b/app/views/shared/transactions/_search2.html.haml
@@ -4,7 +4,7 @@
   .row
     %fieldset.span6#search
       - @search.options.reject(&:multipart?).each do |searcher|
-        = f.input searcher.key, as: :transaction_chosen2, collection: searcher.options, label: searcher.label, label_method: searcher.label_method
+        = f.input searcher.key, as: :transaction_chosen2, collection: searcher.options, label: searcher.label, label_method: searcher.label_method, data_attrs: searcher.method(:data_attrs)
 
     %fieldset.span4#calendar_filter
       - if @search.options.map(&:key).include?("date_ranges")

--- a/app/views/shared/transactions/_search2.html.haml
+++ b/app/views/shared/transactions/_search2.html.haml
@@ -4,7 +4,7 @@
   .row
     %fieldset.span6#search
       - @search.options.reject(&:multipart?).each do |searcher|
-        = f.input searcher.key, as: :transaction_chosen2, collection: searcher.options, label: searcher.label, label_method: searcher.label_method, data_attrs: searcher.method(:data_attrs)
+        = f.input searcher.key, as: :transaction_chosen2, collection: searcher.options, label: searcher.label, label_method: searcher.label_method, data_attrs: searcher.method(:data_attrs), input_html: { id: searcher.key }
 
     %fieldset.span4#calendar_filter
       - if @search.options.map(&:key).include?("date_ranges")

--- a/app/views/shared/transactions/_top2.html.haml
+++ b/app/views/shared/transactions/_top2.html.haml
@@ -1,0 +1,10 @@
+.row#header_billing
+  .span3
+    #sidebar
+      = render "admin/shared/sidenav_billing", sidenav_tab: tab
+  - if @empty_orders
+    .span9
+      %p.alert.alert-info= text("#{controller_name}.#{action_name}.no_orders")
+  - else
+    .span9
+      = render "shared/transactions/search2"

--- a/lib/transaction_search.rb
+++ b/lib/transaction_search.rb
@@ -7,6 +7,7 @@ module TransactionSearch
     base.extend(ClassMethods)
   end
 
+  # Deprecated. Use the newer searchers
   def self.searchers
     @searchers ||= {
       facilities: FacilitySearcher,
@@ -16,6 +17,13 @@ module TransactionSearch
       order_statuses: OrderStatusSearcher,
       date_range: DateRangeSearcher,
     }
+  end
+
+  # Register a TransactionSearch::BaseSearcher. Unless specified otherwise,
+  # it will be added to the list of default searchers.
+  def self.register(searcher, default: true)
+    Searcher.default_searchers << searcher if default
+    SearchForm.send(:attr_accessor, searcher.key)
   end
 
   module ClassMethods

--- a/spec/controllers/facilities_controller_spec.rb
+++ b/spec/controllers/facilities_controller_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe FacilitiesController do
     it "should use two column head" do
       sign_in @admin
       do_request
-      expect(assigns[:layout]).to eq "two_column_head"
+      expect(response).to render_template("two_column_head")
     end
 
     it "should query against the facility" do

--- a/spec/controllers/facilities_controller_spec.rb
+++ b/spec/controllers/facilities_controller_spec.rb
@@ -307,16 +307,6 @@ RSpec.describe FacilitiesController do
     it_should_allow_managers_only
   end
 
-  context "transactions" do
-    it_behaves_like "transactions", :transactions do
-      it "has a default date set" do
-        sign_in @admin
-        do_request
-        expect(controller.params[:date_range][:start]).to be_present
-      end
-    end
-  end
-
   context "disputed_orders" do
     it_behaves_like "transactions", :disputed_orders
   end

--- a/spec/features/admin/all_transactions_search.rb
+++ b/spec/features/admin/all_transactions_search.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "All Transactions Search" do
+
+  let(:facility) { create(:setup_facility) }
+  let(:director) { create(:user, :facility_director, facility: facility) }
+  let(:item) { create(:setup_item, facility: facility) }
+  let(:accounts) { create_list(:setup_account, 2) }
+  let(:orders) do
+    accounts.map { |account| create(:purchased_order, product: item, account: account) }
+  end
+  let(:statements) do
+    accounts.map { |account| create(:statement, account: account, facility: facility, created_by_user: director, created_at: 2.days.ago) }
+  end
+  let(:director) { create(:user, :facility_director, facility: facility) }
+
+  before do
+    orders.flat_map(&:order_details).each(&:to_complete!)
+  end
+
+  let(:order_detail) { orders.first.order_details.first }
+
+  it "can do a basic search" do
+    login_as director
+    visit facility_transactions_path(facility)
+    expected_default_date = 1.month.ago.beginning_of_month
+    expect(page).to have_field("Start Date", with: I18n.l(expected_default_date.to_date, format: :usa))
+
+    select accounts.first.account_list_item, from: "Payment Sources"
+    click_button "Search"
+    expect(page).to have_link(order_detail.id, href: manage_facility_order_order_detail_path(facility, orders.first, orders.first.order_details.first))
+    expect(page).not_to have_link(orders.second.order_details.first.id)
+  end
+end

--- a/vendor/engines/projects/app/services/projects/project_searcher.rb
+++ b/vendor/engines/projects/app/services/projects/project_searcher.rb
@@ -2,6 +2,10 @@ module Projects
 
   class ProjectSearcher < TransactionSearch::BaseSearcher
 
+    def self.key
+      :projects
+    end
+
     def options
       Project.where(id: order_details.select("distinct project_id")).order(:name)
     end
@@ -12,6 +16,10 @@ module Projects
       else
         order_details
       end
+    end
+
+    def label
+      Projects::Project.model_name.human(count: 2)
     end
 
   end

--- a/vendor/engines/projects/lib/projects/engine.rb
+++ b/vendor/engines/projects/lib/projects/engine.rb
@@ -30,7 +30,9 @@ module Projects
                         "acting_as",
                         "projects/shared/select_project"
 
+      TransactionSearch.register(Projects::ProjectSearcher)
       TransactionSearch.searchers[:projects] = Projects::ProjectSearcher
+
       ViewHook.add_hook "shared.transactions.search",
                         "end_of_first_column",
                         "projects/shared/transactions/search"

--- a/vendor/engines/projects/spec/controllers/facilities_controller_spec.rb
+++ b/vendor/engines/projects/spec/controllers/facilities_controller_spec.rb
@@ -18,18 +18,18 @@ RSpec.describe FacilitiesController do
     end
 
     it "returns both order details with no filter" do
-      get :transactions, facility_id: facility.url_name, projects: [], date_range: { field: "ordered_at" }
+      get :transactions, facility_id: facility.url_name, search: { projects: [], date_range_field: "ordered_at" }
       expect(assigns(:order_details)).to contain_all([order_detail, order_detail2])
     end
 
     it "returns only the order detail selected" do
-      get :transactions, facility_id: facility.url_name, projects: [project.id], date_range: { field: "ordered_at" }
+      get :transactions, facility_id: facility.url_name, search: { projects: [project.id], date_range_field: "ordered_at" }
       expect(assigns(:order_details)).to eq([order_detail])
     end
 
-    it "includes the projects" do
+    it "includes the projects in the search" do
       get :transactions, facility_id: facility.url_name
-      expect(assigns(:search_options)[:projects]).to eq([project])
+      expect(assigns(:search)[:projects]).to eq([project])
     end
   end
 end


### PR DESCRIPTION
This continues from #1294 and replaces the "All Transactions" search logic, e.g. http://localhost:3000/facilities/example/transactions with the new search. It gets rid of the `_with_search` metaprogramming. Hopefully, this is easier to reason about.

The feature spec I wrote works for both master and this branch. I think more specific unit tests are going to be better for testing the search criteria than the existing controller specs, which is why I did one happy-path feature spec and killed the controller specs for this action.
