### PR TITLE
[#136545] Default reconciliation page checkboxes to unchecked

### DIFF
--- a/app/assets/javascripts/reconciliation.js.coffee
+++ b/app/assets/javascripts/reconciliation.js.coffee
@@ -1,3 +1,0 @@
-$ ->
-  $('#selected_account').change ->
-    $(@).closest('form').submit()

--- a/app/views/facility_accounts_reconciliation/_action_row.html.haml
+++ b/app/views/facility_accounts_reconciliation/_action_row.html.haml
@@ -1,5 +1,5 @@
 .row.table-actions.form-horizontal
-  .span2.select_all_none= select_all_link(start_none: true)
+  .span2.select_all_none= select_all_link
 
   - if local_assigns[:date]
     .span5.control-group.fields

--- a/app/views/facility_accounts_reconciliation/_table.html.haml
+++ b/app/views/facility_accounts_reconciliation/_table.html.haml
@@ -10,7 +10,7 @@
   %tbody
     - @unreconciled_details.each do |order_detail|
       %tr
-        %td.centered= check_box_tag "order_detail[#{order_detail.id}][reconciled]", "1", true, class: "toggle"
+        %td.centered= check_box_tag "order_detail[#{order_detail.id}][reconciled]", "1", false, class: "toggle"
         %td= "##{order_detail.statement_invoice_number}"
         %td
           = order_detail.account

--- a/vendor/engines/c2po/spec/features/account_reconciliation_spec.rb
+++ b/vendor/engines/c2po/spec/features/account_reconciliation_spec.rb
@@ -54,8 +54,10 @@ RSpec.describe "Account Reconciliation" do
       expect(page).to have_content(order_number)
       expect(page).not_to have_content(other_order_number)
 
+      check "order_detail_#{order_detail.id}_reconciled"
       fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
       click_button "Reconcile Orders", match: :first
+
       expect(order_detail.reload).to be_reconciled
       expect(order_detail.reconciled_at).to eq(1.day.ago.beginning_of_day)
     end
@@ -80,8 +82,10 @@ RSpec.describe "Account Reconciliation" do
       expect(page).to have_content(order_number)
       expect(page).not_to have_content(other_order_number)
 
+      check "order_detail_#{order_detail.id}_reconciled"
       fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
       click_button "Reconcile Orders", match: :first
+
       expect(order_detail.reload).to be_reconciled
       expect(order_detail.reconciled_at).to eq(1.day.ago.beginning_of_day)
     end


### PR DESCRIPTION
Now that we've added filtering, we want the page to start off with nothing checked.