### PR TITLE
[#136545] restyle filter button

### DIFF
--- a/app/assets/stylesheets/app/transaction_search.scss
+++ b/app/assets/stylesheets/app/transaction_search.scss
@@ -10,9 +10,15 @@
 }
 
 .search_form input[type=submit] {
-  clear:both;
-  float:right;
+  clear: both;
+  float: right;
   margin-bottom: 0.5em;
+}
+
+.search_form input[type=submit].submit--float-left {
+  float: left;
+  margin-left: 1.5em;
+  margin-bottom: 2em;
 }
 
 #table_billing {

--- a/app/assets/stylesheets/app/transaction_search.scss
+++ b/app/assets/stylesheets/app/transaction_search.scss
@@ -13,13 +13,14 @@
   clear: both;
   float: right;
   margin-bottom: 0.5em;
+
+  &.float-left {
+    float: left;
+    margin-left: 1.5em;
+    margin-bottom: 2em;
+  }
 }
 
-.search_form input[type=submit].submit--float-left {
-  float: left;
-  margin-left: 1.5em;
-  margin-bottom: 2em;
-}
 
 #table_billing {
   margin-top: 1em;

--- a/app/assets/stylesheets/app/transaction_search.scss
+++ b/app/assets/stylesheets/app/transaction_search.scss
@@ -16,7 +16,6 @@
 
   &.float-left {
     float: left;
-    margin-left: 1.5em;
     margin-bottom: 2em;
   }
 }

--- a/app/views/shared/transactions/_search2.html.haml
+++ b/app/views/shared/transactions/_search2.html.haml
@@ -13,7 +13,7 @@
         = f.input "date_range_start", input_html: {class: ["datepicker", "in_past"] }, label: t("reports.fields.date_start")
         = f.input "date_range_end", input_html: { class: ["datepicker", "in_past"] }, label: t("reports.fields.date_end")
 
-      .submit_button
-        = f.input :email, as: :hidden, input_html: { value: current_user.email }, disabled: true
-        = f.input :format, as: :hidden, input_html: { value: params[:format] }, disabled: true
-        = f.submit "Search", class: "btn"
+    .submit_button
+      = f.input :email, as: :hidden, input_html: { value: current_user.email }, disabled: true
+      = f.input :format, as: :hidden, input_html: { value: params[:format] }, disabled: true
+      = f.submit "Filter", class: "btn submit--float-left"

--- a/app/views/shared/transactions/_search2.html.haml
+++ b/app/views/shared/transactions/_search2.html.haml
@@ -6,14 +6,14 @@
       - @search.options.reject(&:multipart?).each do |searcher|
         = f.input searcher.key, as: :transaction_chosen2, collection: searcher.options, label: searcher.label, label_method: searcher.label_method
 
-    %fieldset.span2#calendar_filter
+    %fieldset.span4#calendar_filter
       - if @search.options.map(&:key).include?("date_ranges")
         %br
         = f.input "date_range_field", collection: TransactionSearch::DateRangeSearcher.options, label: false, include_blank: false
         = f.input "date_range_start", input_html: {class: ["datepicker", "in_past"] }, label: t("reports.fields.date_start")
         = f.input "date_range_end", input_html: { class: ["datepicker", "in_past"] }, label: t("reports.fields.date_end")
 
-    .submit_button
+    .submit_button.span6
       = f.input :email, as: :hidden, input_html: { value: current_user.email }, disabled: true
       = f.input :format, as: :hidden, input_html: { value: params[:format] }, disabled: true
       = f.submit "Filter", class: "btn float-left"

--- a/app/views/shared/transactions/_search2.html.haml
+++ b/app/views/shared/transactions/_search2.html.haml
@@ -16,4 +16,4 @@
     .submit_button
       = f.input :email, as: :hidden, input_html: { value: current_user.email }, disabled: true
       = f.input :format, as: :hidden, input_html: { value: params[:format] }, disabled: true
-      = f.submit "Filter", class: "btn submit--float-left"
+      = f.submit "Filter", class: "btn float-left"

--- a/vendor/engines/c2po/spec/features/account_reconciliation_spec.rb
+++ b/vendor/engines/c2po/spec/features/account_reconciliation_spec.rb
@@ -38,19 +38,19 @@ RSpec.describe "Account Reconciliation" do
       expect(page).to have_content(other_order_number)
 
       select accounts.first.account_list_item, from: "Payment Sources"
-      click_button "Search"
+      click_button "Filter"
       expect(page).to have_content(order_number)
       expect(page).not_to have_content(other_order_number)
 
       visit credit_cards_facility_accounts_path(facility)
       select accounts.first.owner_user.full_name, from: "Owners"
-      click_button "Search"
+      click_button "Filter"
       expect(page).to have_content(order_number)
       expect(page).not_to have_content(other_order_number)
 
       visit credit_cards_facility_accounts_path(facility)
       select statements.first.invoice_number, from: "Statements"
-      click_button "Search"
+      click_button "Filter"
       expect(page).to have_content(order_number)
       expect(page).not_to have_content(other_order_number)
 
@@ -78,7 +78,7 @@ RSpec.describe "Account Reconciliation" do
       expect(page).to have_content(other_order_number)
 
       select accounts.first.account_list_item, from: "Payment Sources"
-      click_button "Search"
+      click_button "Filter"
       expect(page).to have_content(order_number)
       expect(page).not_to have_content(other_order_number)
 


### PR DESCRIPTION
https://pm.tablexi.com/issues/136545

Update button name from "Search" to "Filter", move it beneath the statements field, and add padding to disconnect the search form from the table below.

Before: 
![screen shot 2018-01-04 at 2 57 14 pm](https://user-images.githubusercontent.com/4624197/34584019-ad7901b6-f15f-11e7-9906-a81f5a14513b.png)

After:
![screen shot 2018-01-04 at 2 56 07 pm](https://user-images.githubusercontent.com/4624197/34584027-b4b88cda-f15f-11e7-8f6e-9c39dfe7555b.png)

