### PR TITLE
[#140057] Handle 1000+ orders for reconciliation

### DIFF
--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -12,7 +12,7 @@ module OrderDetails
 
     def initialize(order_detail_scope, params, reconciled_at)
       @params = params
-      @order_details = order_detail_scope.readonly(false).find(to_be_reconciled.keys)
+      @order_details = order_detail_scope.readonly(false).where_ids_in(to_be_reconciled.keys)
       @reconciled_at = reconciled_at
     end
 

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -12,7 +12,7 @@ module OrderDetails
 
     def initialize(order_detail_scope, params, reconciled_at)
       @params = params
-      @order_details = order_detail_scope.readonly(false).where_ids_in(to_be_reconciled.keys)
+      @order_details = order_detail_scope.readonly(false).find_ids(to_be_reconciled.keys)
       @reconciled_at = reconciled_at
     end
 

--- a/lib/nucore.rb
+++ b/lib/nucore.rb
@@ -43,6 +43,9 @@ module NUCore
 
       module ClassMethods
 
+        # Oracle has a limit of 1000 items in a WHERE IN clause. Use this in
+        # place of `where(id: ids)` when there might be more than 1000 ids.
+        # Example: facility.order_details.complete.where_ids_in(ids)
         def where_ids_in(ids)
           if NUCore::Database.oracle?
             return none if ids.blank?
@@ -56,11 +59,14 @@ module NUCore
           end
         end
 
-        # Oracle-safe find
+        # Handle `finds` of more than 1000 because Oracle does not allow 1000+
+        # items in a WHERE IN. Raises an error if all the items are not
+        # found, just like `find`
         def find_ids(ids)
           if NUCore::Database.oracle?
             results = where_ids_in(ids)
-            raise ActiveRecord::RecordNotFound unless results.length == ids.length
+            # This is the same method `find` uses to get an exception message like "(found 1 results, but was looking for 2)"
+            all.raise_record_not_found_exception!(ids, results.size, ids.size) unless results.length == ids.length
             results
           else
             find(ids)

--- a/lib/nucore.rb
+++ b/lib/nucore.rb
@@ -56,6 +56,17 @@ module NUCore
           end
         end
 
+        # Oracle-safe find
+        def find_ids(ids)
+          if NUCore::Database.oracle?
+            results = where_ids_in(ids)
+            raise ActiveRecord::RecordNotFound unless results.length == ids.length
+            results
+          else
+            find(ids)
+          end
+        end
+
       end
 
     end

--- a/spec/services/order_details/reconciler_spec.rb
+++ b/spec/services/order_details/reconciler_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe OrderDetails::Reconciler do
+  let(:product) { create(:setup_item) }
+  let(:user) { create(:user) }
+  let!(:order) { create(:order, user: user, created_by_user: user) }
+  let(:order_details) do
+    Array.new(number_of_order_details).map do
+      OrderDetail.create!(product: product, quantity: 1, actual_cost: 1, actual_subsidy: 0, state: "complete", journal: journal, order_id: order.id, created_by_user: user)
+    end
+  end
+  let(:params) { order_details.each_with_object({}) { |od, h| h[od.id.to_s] = ActionController::Parameters.new(reconciled: "1") } }
+  let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current) }
+  let(:journal) { create(:journal, facility: product.facility) }
+
+  describe "reconciling" do
+    let(:number_of_order_details) { 5 }
+
+    it "reconciles all the orders" do
+      expect { reconciler.reconcile_all }.to change { OrderDetail.reconciled.count }.from(0).to(5)
+    end
+  end
+
+  # describe "reconciling more than 1000 order details (because of oracle)" do
+  #   let(:number_of_order_details) { 1001 }
+
+  #   it "reconciles all the orders" do
+  #     expect { reconciler.reconcile_all }.to change { OrderDetail.reconciled.count }.from(0).to(1001)
+  #   end
+  # end
+end


### PR DESCRIPTION
Oracle has its 1000 limit on `WHERE IN` items, so we need to accommodate that.

I tested this on NU, and left the spec commented out because of how slow it is.
