### PR TITLE
[#139390] Allow extending reservations inside lock window

### DIFF
--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -31,14 +31,14 @@ module ReservationsHelper
     ReservationUserActionPresenter.new(self, reservation).view_edit_link
   end
 
-  def start_time_disabled?(reservation)
+  def start_time_editing_disabled?(reservation)
     return false if !reservation.persisted? || reservation.in_cart?
 
     original = Reservation.find(reservation.id)
     !original.reserve_start_at_editable?
   end
 
-  def end_time_disabled?(reservation)
+  def end_time_editing_disabled?(reservation)
     return false if !reservation.persisted? || reservation.in_cart?
 
     original = Reservation.find(reservation.id)

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -82,7 +82,7 @@ class Reservation < ActiveRecord::Base
   scope :ongoing, -> { not_ended.where("actual_start_at <= ?", Time.current) }
 
   def self.today
-    for_date(Time.zone.now)
+    for_date(Time.current)
   end
 
   def self.for_date(date)
@@ -94,7 +94,7 @@ class Reservation < ActiveRecord::Base
       .where("reserve_start_at < ?", end_time)
   end
 
-  def self.upcoming(t = Time.zone.now)
+  def self.upcoming(t = Time.current)
     # If this is a named scope differences emerge between Oracle & MySQL on #reserve_end_at querying.
     # Eliminate by letting Rails filter by #reserve_end_at
     joins("LEFT JOIN order_details ON order_details.id = reservations.order_detail_id")
@@ -150,12 +150,12 @@ class Reservation < ActiveRecord::Base
 
   def start_reservation!
     product.schedule.products.flat_map(&:started_reservations).each(&:complete!)
-    self.actual_start_at = Time.zone.now
+    self.actual_start_at = Time.current
     save!
   end
 
   def end_reservation!
-    self.actual_end_at = Time.zone.now
+    self.actual_end_at = Time.current
     save!
     order_detail.complete!
   end
@@ -218,7 +218,7 @@ class Reservation < ActiveRecord::Base
 
   # can the CUSTOMER cancel the order
   def can_cancel?
-    !canceled? && reserve_start_at > Time.zone.now && actual_start_at.nil? && actual_end_at.nil?
+    !canceled? && reserve_start_at > Time.current && actual_start_at.nil? && actual_end_at.nil?
   end
 
   def can_customer_edit?
@@ -230,7 +230,7 @@ class Reservation < ActiveRecord::Base
   end
 
   def reserve_end_at_editable?
-    Time.zone.now <= reserve_end_at && extendable? && actual_end_at.blank?
+    Time.current <= reserve_end_at && extendable? && actual_end_at.blank?
   end
 
   def extendable?
@@ -321,7 +321,7 @@ class Reservation < ActiveRecord::Base
     end
   end
 
-  def in_grace_period?(at = Time.zone.now)
+  def in_grace_period?(at = Time.current)
     at = at.to_i
     grace_period_end = reserve_start_at.to_i
     grace_period_begin = (reserve_start_at - grace_period_duration).to_i

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -230,7 +230,7 @@ class Reservation < ActiveRecord::Base
   end
 
   def reserve_end_at_editable?
-    outside_lock_window? && Time.zone.now <= reserve_end_at && extendable? && actual_end_at.blank?
+    Time.zone.now <= reserve_end_at && extendable? && actual_end_at.blank?
   end
 
   def extendable?
@@ -245,11 +245,15 @@ class Reservation < ActiveRecord::Base
   end
 
   def before_lock_window?
-    Time.zone.now < reserve_start_at - product_lock_window.hours
+    Time.current < reserve_start_at - product_lock_window.hours
   end
 
   def outside_lock_window?
-    before_lock_window? || Time.zone.now >= reserve_start_at || in_grace_period?
+    before_lock_window? || Time.current >= reserve_start_at || in_grace_period?
+  end
+
+  def inside_lock_window?
+    !before_lock_window?
   end
 
   def admin_editable?

--- a/app/support/reservations/duration_change_validations.rb
+++ b/app/support/reservations/duration_change_validations.rb
@@ -35,10 +35,15 @@ class Reservations::DurationChangeValidations
   end
 
   def duration_not_shortened
-    reservation_started = reservation.actual_start_at || reservation.reserve_start_at < Time.zone.now
-    reservation_shortened = reservation.reserve_end_at_changed? && reservation.reserve_end_at < reservation.reserve_end_at_was
-    if reservation_started && reservation_shortened
-      errors.add(:reserve_end_at, I18n.t("activerecord.errors.models.reservation.shorten_reserve_end_at"))
+    duration_was = TimeRange.new(reservation.reserve_start_at_was, reservation.reserve_end_at_was).duration_mins
+    duration_is = TimeRange.new(reservation.reserve_start_at, reservation.reserve_end_at).duration_mins
+
+    if duration_is < duration_was
+      if reservation.started? || reservation.reserve_start_at < Time.current
+        errors.add(:reserve_end_at, I18n.t("activerecord.errors.models.reservation.shorten_reservation_once_started"))
+      elsif reservation.inside_lock_window?
+        errors.add(:reserve_end_at, I18n.t("activerecord.errors.models.reservation.shorten_reservation_in_lock_window"))
+      end
     end
   end
 

--- a/app/support/reservations/duration_change_validations.rb
+++ b/app/support/reservations/duration_change_validations.rb
@@ -40,9 +40,9 @@ class Reservations::DurationChangeValidations
 
     if duration_is < duration_was
       if reservation.started? || reservation.reserve_start_at < Time.current
-        errors.add(:reserve_end_at, I18n.t("activerecord.errors.models.reservation.shorten_reservation_once_started"))
+        errors.add(:duration_mins, I18n.t("activerecord.errors.models.reservation.shorten_reservation_once_started"))
       elsif reservation.inside_lock_window?
-        errors.add(:reserve_end_at, I18n.t("activerecord.errors.models.reservation.shorten_reservation_in_lock_window"))
+        errors.add(:duration_mins, I18n.t("activerecord.errors.models.reservation.shorten_reservation_in_lock_window", lock_window: reservation.product.lock_window))
       end
     end
   end

--- a/app/views/reservations/_reservation_fields.html.haml
+++ b/app/views/reservations/_reservation_fields.html.haml
@@ -1,4 +1,4 @@
-- start_disabled = start_time_disabled?(f.object)
+- start_disabled = start_time_editing_disabled?(f.object)
 .well.js--reservationValidations
   .container
     .row
@@ -6,13 +6,13 @@
         = label_tag :reservation_reserve_start_date, "Reserve Start", class: "string optional control-label"
         .row
           .span3
-            = text_field_tag "reservation[reserve_start_date]", f.object.reserve_start_date, class: "datepicker string optional span3"
+            = text_field_tag "reservation[reserve_start_date]", f.object.reserve_start_date, class: "datepicker string optional span3", disabled: start_disabled
             - if f.object.actual_start_at?
               .started-at= "Started: #{l(f.object.actual_start_at, format: :usa)}"
           .span4
             = time_select f, :reserve_start, { minute_step: @instrument.reserve_interval }, disabled: start_disabled
       .span5
-        = f.input :duration_mins, input_html: { value: f.object.duration_mins || default_duration, class: "timeinput", disabled: end_time_disabled?(f.object) }
+        = f.input :duration_mins, input_html: { value: f.object.duration_mins || default_duration, class: "timeinput", disabled: end_time_editing_disabled?(f.object) }
     .row
       .span7
         = label_tag :reservation_reserve_end_date, "Reserve End", class: "string optional control-label"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1138,7 +1138,7 @@ en:
           move_failed: Sorry, but your reservation could not be moved. Please try again later.
           change_reserve_start_at: cannot change once the reservation has started
           shorten_reservation_once_started: cannot be shortened once the reservation has started
-          shorten_reservation_in_lock_window: cannot be shortened inside the lock window
+          shorten_reservation_in_lock_window: cannot be shortened inside the lock window (%{lock_window} hours)
         user_role:
           taken: The user already has this role
           global_cannot_have_facility: Global role %{role} may not have a facility.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1137,7 +1137,8 @@ en:
           cannot_move: Sorry, but your reservation can no longer be moved.
           move_failed: Sorry, but your reservation could not be moved. Please try again later.
           change_reserve_start_at: cannot change once the reservation has started
-          shorten_reserve_end_at: cannot be shortened once the reservation has started
+          shorten_reservation_once_started: cannot be shortened once the reservation has started
+          shorten_reservation_in_lock_window: cannot be shortened inside the lock window
         user_role:
           taken: The user already has this role
           global_cannot_have_facility: Global role %{role} may not have a facility.

--- a/spec/app_support/reservations/duration_change_validations_spec.rb
+++ b/spec/app_support/reservations/duration_change_validations_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe Reservations::DurationChangeValidations do
             it "is not allowed to shorten the reservation" do
               reservation.reserve_end_at -= 5.minutes
               expect(validator).not_to be_valid
-              expect(validator.errors.full_messages)
-                .to include("Reserve end at cannot be shortened inside the lock window")
+              expect(reservation.errors.full_messages)
+                .to include("Duration cannot be shortened inside the lock window (24 hours)")
             end
           end
         end
@@ -100,15 +100,15 @@ RSpec.describe Reservations::DurationChangeValidations do
         it "denies changing start time" do
           reservation.reserve_start_at = 40.minutes.ago
           validator.valid?
-          expect(validator.errors.full_messages)
+          expect(reservation.errors.full_messages)
             .to include("Reserve start at cannot change once the reservation has started")
         end
 
         it "denies shortening end time" do
           reservation.reserve_end_at = 35.minutes.from_now
           validator.valid?
-          expect(validator.errors.full_messages)
-            .to include("Reserve end at cannot be shortened once the reservation has started")
+          expect(reservation.errors.full_messages)
+            .to include("Duration cannot be shortened once the reservation has started")
         end
 
         it "allows extending" do
@@ -153,7 +153,7 @@ RSpec.describe Reservations::DurationChangeValidations do
 
           it "denies changing the start time" do
             expect(validator).not_to be_valid
-            expect(validator.errors.full_messages)
+            expect(reservation.errors.full_messages)
               .to include("Reserve start at cannot change once the reservation has started")
           end
         end
@@ -171,8 +171,8 @@ RSpec.describe Reservations::DurationChangeValidations do
 
           it "denies shortening the reservation time" do
             expect(validator).not_to be_valid
-            expect(validator.errors.full_messages)
-              .to include("Reserve end at cannot be shortened once the reservation has started")
+            expect(reservation.errors.full_messages)
+              .to include("Duration cannot be shortened once the reservation has started")
           end
         end
       end

--- a/spec/features/editing_a_reservation_spec.rb
+++ b/spec/features/editing_a_reservation_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe "Editing your own reservation" do
+
+  include DateHelper
+
+  let!(:instrument) do
+    FactoryBot.create(:setup_instrument, user_notes_field_mode: "optional", lock_window: 12, min_reserve_mins: nil)
+  end
+  let!(:facility) { instrument.facility }
+  let!(:account) { FactoryBot.create(:nufs_account, :with_account_owner, owner: user) }
+  let!(:price_policy) { FactoryBot.create(:instrument_price_policy, price_group: PriceGroup.base, product: instrument) }
+  let(:user) { FactoryBot.create(:user) }
+  let!(:account_price_group_member) do
+    FactoryBot.create(:account_price_group_member, account: account, price_group: price_policy.price_group)
+  end
+
+  before do
+    login_as user
+  end
+
+  describe "a future reservation outside the lock windown" do
+    # 9:30-10:30am
+    let!(:reservation) { create(:purchased_reservation, :tomorrow, product: instrument, user: user) }
+
+    it "allows me to move and shorten the reservation" do
+      visit reservations_path
+      click_link reservation
+
+      fill_in "Reserve Start", with: format_usa_date(reservation.reserve_start_at + 1.day)
+      fill_in "Reserve End", with: format_usa_date(reservation.reserve_end_at + 1.day)
+      fill_in "Duration", with: "30"
+      click_button "Save"
+
+      expect(reservation.reload.duration_mins).to eq(30)
+    end
+
+    it "allows me to move the reservation into the lock window" do
+      visit reservations_path
+      click_link reservation
+
+      fill_in "Reserve Start", with: format_usa_date(reservation.reserve_start_at - 1.day)
+      fill_in "Reserve End", with: format_usa_date(reservation.reserve_end_at - 1.day)
+      click_button "Save"
+
+      expect(page).to have_content("My Reservations")
+    end
+  end
+
+  describe "a reservation inside the lock window" do
+    # Two hours from now
+    let!(:reservation) { create(:purchased_reservation, :later_today, product: instrument, user: user) }
+
+    it "prevents me from changing the start date, allows me to extend the reservation, but not shorten it" do
+      visit reservations_path
+      click_link reservation
+
+      expect(page).to have_field("Reserve Start", disabled: true)
+      fill_in "Duration", with: "90"
+      click_button "Save"
+
+      expect(page).to have_content("My Reservations")
+      expect(reservation.reload.duration_mins).to eq(90)
+
+      click_link reservation
+      fill_in "Duration", with: "75"
+      click_button "Save"
+
+      expect(page).to have_content "cannot be shortened inside the lock window"
+    end
+  end
+
+  describe "a started reservation" do
+    let!(:reservation) { create(:purchased_reservation, :running, product: instrument, user: user) }
+
+    it "prevents me from changing the start date, allows me to extend the reservation, but not shorten it" do
+      visit reservations_path
+      click_link reservation
+
+      expect(page).to have_field("Reserve Start", disabled: true)
+      fill_in "Duration", with: "90"
+      click_button "Save"
+
+      expect(page).to have_content("My Reservations")
+      expect(reservation.reload.duration_mins).to eq(90)
+
+      click_link reservation
+      fill_in "Duration", with: "75"
+      click_button "Save"
+
+      expect(page).to have_content "cannot be shortened once the reservation has started"
+    end
+  end
+end

--- a/spec/helpers/reservations_helper_spec.rb
+++ b/spec/helpers/reservations_helper_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 RSpec.describe ReservationsHelper do
-  describe "#end_time_disabled?" do
+  describe "#end_time_editing_disabled?" do
     context "when the reservation is not persisted" do
       subject(:reservation) { Reservation.new }
 
-      it { expect(end_time_disabled?(reservation)).to be false }
+      it { expect(end_time_editing_disabled?(reservation)).to be false }
     end
 
     context "when the reservation is persisted" do
@@ -15,13 +15,13 @@ RSpec.describe ReservationsHelper do
         context "and the reservation is in a cart" do
           before { reservation.order.ordered_at = nil }
 
-          it { expect(end_time_disabled?(reservation)).to be false }
+          it { expect(end_time_editing_disabled?(reservation)).to be false }
         end
 
         context "and the reservation has been ordered" do
           before { reservation.order.ordered_at = Time.zone.now }
 
-          it { expect(end_time_disabled?(reservation)).to be true }
+          it { expect(end_time_editing_disabled?(reservation)).to be true }
         end
       end
 
@@ -31,17 +31,17 @@ RSpec.describe ReservationsHelper do
         context "and reserve_end_at is set to a time in the past but not saved" do
           before { reservation.reserve_end_at = 1.day.ago }
 
-          it { expect(end_time_disabled?(reservation)).to be false }
+          it { expect(end_time_editing_disabled?(reservation)).to be false }
         end
       end
     end
   end
 
-  describe "#start_time_disabled?" do
+  describe "#start_time_editing_disabled?" do
     context "when the reservation is not persisted" do
       subject(:reservation) { Reservation.new }
 
-      it { expect(start_time_disabled?(reservation)).to be false }
+      it { expect(start_time_editing_disabled?(reservation)).to be false }
     end
 
     context "when the reservation is persisted" do
@@ -51,13 +51,13 @@ RSpec.describe ReservationsHelper do
         context "and the reservation is in a cart" do
           before { reservation.order.ordered_at = false }
 
-          it { expect(start_time_disabled?(reservation)).to be false }
+          it { expect(start_time_editing_disabled?(reservation)).to be false }
         end
 
         context "and the reservation has been ordered" do
           before { reservation.order.ordered_at = Time.zone.now }
 
-          it { expect(start_time_disabled?(reservation)).to be true }
+          it { expect(start_time_editing_disabled?(reservation)).to be true }
         end
       end
 
@@ -67,7 +67,7 @@ RSpec.describe ReservationsHelper do
         context "and reserve_start_at is set to a time in the past but not saved" do
           before { reservation.reserve_start_at = 1.day.ago }
 
-          it { expect(start_time_disabled?(reservation)).to be false }
+          it { expect(start_time_editing_disabled?(reservation)).to be false }
         end
       end
     end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -471,7 +471,7 @@ RSpec.describe Reservation do
                   travel_to(reservation.reserve_start_at - (window_hours - 2).hours)
                 end
 
-                it_behaves_like "a customer is not allowed to edit"
+                it_behaves_like "a customer is allowed to edit"
               end
             end
           end


### PR DESCRIPTION
You are now allowed to edit a reservation inside the lock window, but
you cannot change the start time and you cannot shorten the duration,
though you may extend it.