### PR TITLE
[#139830] Fix schedule rule discount precision

### DIFF
--- a/app/models/schedule_rule.rb
+++ b/app/models/schedule_rule.rb
@@ -216,6 +216,11 @@ class ScheduleRule < ActiveRecord::Base
     not_rules
   end
 
+  # If we're at, say, 4:00, return 3. If we're at 4:01, return 4.
+  def hour_floor
+    end_min == 0 ? end_hour - 1 : end_hour
+  end
+
   private
 
   def percent_overlap(start_at, end_at)
@@ -241,9 +246,5 @@ class ScheduleRule < ActiveRecord::Base
     overlap_mins
   end
 
-  # If we're at, say, 4:00, return 3. If we're at 4:01, return 4.
-  def hour_floor
-    end_min == 0 ? end_hour - 1 : end_hour
-  end
 
 end

--- a/app/models/schedule_rule.rb
+++ b/app/models/schedule_rule.rb
@@ -246,5 +246,4 @@ class ScheduleRule < ActiveRecord::Base
     overlap_mins
   end
 
-
 end

--- a/spec/models/instrument_price_policy_calculations_spec.rb
+++ b/spec/models/instrument_price_policy_calculations_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe InstrumentPricePolicyCalculations do
 
   describe "calculating with two effective schedule rules, one discounting one not" do
     describe "no minimum cost" do
-      let(:friday_evening) { Time.zone.parse("2017-04-21 23:00") }
-      let(:saturday_morning) { Time.zone.parse("2017-04-22 1:00") }
+      let(:friday_evening) { Time.zone.parse("2017-04-21 23:00:15") }
+      let(:saturday_morning) { Time.zone.parse("2017-04-22 1:00:37") }
       before :each do
         policy.product.schedule_rules.first.update_attributes!(
           start_hour: 0,

--- a/vendor/engines/secure_rooms/spec/models/secure_room_price_policy_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/secure_room_price_policy_spec.rb
@@ -32,5 +32,15 @@ RSpec.describe SecureRoomPricePolicy do
       let(:occupancy) { build_stubbed(:occupancy, entry_at: nil, exit_at: 1.day.ago) }
       it { is_expected.to be_blank }
     end
+
+    describe "with a discount" do
+      before { schedule_rule.discount_percent = 10 }
+
+      describe "rounding seconds" do
+        let(:occupancy) { build_stubbed(:occupancy, entry_at: 1.hour.ago + 15.seconds, exit_at: Time.current) }
+
+        it { is_expected.to eq(cost: 54, subsidy: 13.5) }
+      end
+    end
   end
 end


### PR DESCRIPTION
Here's an example of what was happening from a local test:

* $60/hour ($1/minute) price policy 
* 24 hour/day schedule rule with a 10% discount.
* Time without relay
* Started 12:34:09, ended 12:41:41 

This should be calculated for 7 minutes, so $7 with a 10% discount = $6.30. Instead it is coming out as $6.26.

The way we calculate a discount is to find the effective discount percent. We find the percent of time a reservation overlaps with each schedule rule, multiply by the discount and sum them up. In this case we have the one rule which should be 100% * 10%, but because we're not trimming the seconds in this part of the calculation we're using 7.53 minutes, it's coming out to 106% overlap with the schedule rule. We then multiply that by the discount (10%), so we come out with as a 10.619% discount.

I know that logic is confusing, so it might make more sense to see a normal case when you span multiple schedule rules with different discounts. An example:
* 9am-5pm schedule rule with a 10%
* 5pm-midnight 20% discount
* Reservation runs from 4:30-5:30.

30 minutes is in rule 1 (50%)
30 minutes in in rule 2 (50%)
50% * 10% + 50% * 20% = 15% effective discount