### PR TITLE
[#139955] fix price group params bug

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -169,7 +169,7 @@ class UsersController < ApplicationController
   end
 
   def price_group_params
-    params.require(:user).permit(:internal) if current_user.administrator?
+    current_user.administrator? ? params.require(:user).permit(:internal) : {}
   end
 
   def update_access_list_approvals

--- a/spec/features/admin/managing_user_spec.rb
+++ b/spec/features/admin/managing_user_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe "Managing User Details", :aggregate_failures do
+
+  let(:facility) { FactoryBot.create(:facility) }
+
+  describe "edit" do
+    describe "as a facility admin" do
+      let(:admin) { FactoryBot.create(:user, :administrator) }
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        login_as admin
+        visit facility_user_path(facility, user)
+      end
+
+
+      it "allows admin to edit internal/external pricing" do
+        expect(page).to have_content("Internal PricingYes")
+
+        click_link "Edit"
+
+        select "No", from: "user_internal"
+
+        click_button "Update"
+
+        expect(page).to have_content("Internal PricingNo")
+      end
+
+    end
+
+    describe "as an account admin" do
+      let!(:account_admin) { FactoryBot.create(:user, :account_manager) }
+      let!(:user) { FactoryBot.create(:user) }
+
+      before do
+        login_as account_admin
+        visit facility_user_path(Facility.cross_facility, user)
+      end
+
+
+      it "does not allow account admin to edit internal/external pricing" do
+        expect(page).to have_content("Internal PricingYes")
+
+        click_link "Edit"
+
+        expect(page).not_to have_content("Internal Pricing")
+      end
+
+    end
+
+  end
+end

--- a/spec/features/admin/managing_user_spec.rb
+++ b/spec/features/admin/managing_user_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe "Managing User Details", :aggregate_failures do
         visit facility_user_path(facility, user)
       end
 
-
       it "allows admin to edit internal/external pricing" do
         expect(page).to have_content("Internal PricingYes")
 
@@ -37,7 +36,6 @@ RSpec.describe "Managing User Details", :aggregate_failures do
         login_as account_admin
         visit facility_user_path(Facility.cross_facility, user)
       end
-
 
       it "does not allow account admin to edit internal/external pricing" do
         expect(page).to have_content("Internal PricingYes")


### PR DESCRIPTION
https://pm.tablexi.com/issues/139955

Steps to reproduce:

Log in as an account administrator
Click "Users" tab. URL should be `/facilities/all/users`
Click on a user's name
Click "Edit" button
Click "Update"
This happens because we are expecting a value for `params[:internal]`, which global admins would see as a dropdown for allowing them to manually override if the user should get internal or external pricing. Account managers don't have that dropdown.