### PR TITLE
[#139964] throw 404 for circuitous multitab error

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -298,7 +298,11 @@ class ReservationsController < ApplicationController
     @facility = @instrument.facility
   rescue ActiveRecord::RecordNotFound
     flash[:error] = text("order_detail_removed")
-    redirect_to facility_path(@order.facility)
+    if @order
+      redirect_to facility_path(@order.facility)
+    else
+      raise
+    end
   end
 
   def load_and_check_resources


### PR DESCRIPTION
https://pm.tablexi.com/issues/139964

This can happen with multiple tabs within the "Add to existing order" flow. Steps to reproduce:

As a facility staff/admin, go into an existing order
In the form at the bottom of the page, choose an instrument from the dropdown and click "Add to order"
Right click on the "Make a reservation" and open the form in a new tab. This should open a new reservation form
In the original page, click "Remove" to remove it from the "cart"
In the other tab, submit the form
You should see this same error