### PR TITLE
Optimize Export Raw performance

### DIFF
--- a/app/controllers/reports/general_reports_controller.rb
+++ b/app/controllers/reports/general_reports_controller.rb
@@ -79,6 +79,7 @@ module Reports
         date_range_field: date_range_field,
         date_range_start: @date_start,
         date_range_end: @date_end,
+        batch_size: 5_000,
       ).perform
     end
 

--- a/app/models/concerns/reports/csv_exporter.rb
+++ b/app/models/concerns/reports/csv_exporter.rb
@@ -65,7 +65,10 @@ module Reports
 
     def csv_body
       CSV.generate do |csv|
-        report_data.each { |row| csv << format_row(row) }
+        # When used in delayed_job, this will make sure the query cache is on
+        ActiveRecord::Base.cache do
+          report_data.each { |row| csv << format_row(row) }
+        end
       end
     end
 

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -354,8 +354,8 @@ class OrderDetail < ActiveRecord::Base
              .joins("LEFT JOIN statements in_range_statements ON in_range_statements.id = order_details.statement_id")
 
     journal_query = ["journal_id IS NOT NULL"]
-    journal_query << "journal_date >= :start_date" if start_date
-    journal_query << "journal_date < :end_date" if end_date
+    journal_query << "journals.journal_date >= :start_date" if start_date
+    journal_query << "journals.journal_date < :end_date" if end_date
 
     statement_query = ["statement_id IS NOT NULL"]
     statement_query << "in_range_statements.created_at >= :start_date" if start_date

--- a/app/models/reports/export_raw.rb
+++ b/app/models/reports/export_raw.rb
@@ -111,7 +111,8 @@ module Reports
         date_range_field: date_range_field,
         date_range_start: date_start,
         date_range_end: date_end,
-        includes: [:reservation, :statement],
+        includes: [:reservation, :statement, :journal, :reservation, order: [:user]],
+        preloads: [:created_by_user, order: [:facility], account: [:affiliate, :owner_user], price_policy: [:price_group]],
         transformer_options: { time_data: true },
       ).perform
     end

--- a/spec/controllers/reports/general_reports_controller_spec.rb
+++ b/spec/controllers/reports/general_reports_controller_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe Reports::GeneralReportsController do
       @account = create_nufs_account_with_owner :user
       define_open_account @item.account, @account.account_number
 
-      @order_detail_ordered_today_unfulfilled = place_product_order(@user, @authable, @item)
+      @order_detail_ordered_today_unfulfilled = place_product_order(@user, @authable, @item, @account)
 
-      @order_detail_ordered_yesterday_unfulfilled = place_product_order(@user, @authable, @item)
+      @order_detail_ordered_yesterday_unfulfilled = place_product_order(@user, @authable, @item, @account)
       @order_detail_ordered_yesterday_unfulfilled.order.update_attributes(ordered_at: 1.day.ago)
 
       @order_detail_ordered_yesterday_fulfilled_today_unreconciled = place_and_complete_item_order(@user, @authable, @account)
@@ -112,26 +112,26 @@ RSpec.describe Reports::GeneralReportsController do
       it "should search search unfulfilled" do
         @params[:status_filter] = [OrderStatus.new_status.id]
         do_request
-        expect(assigns[:report_data]).to contain_all [@order_detail_ordered_today_unfulfilled]
+        expect(assigns[:report_data].to_a).to contain_all [@order_detail_ordered_today_unfulfilled]
       end
 
       it "should search fulfilled" do
         @params[:status_filter] = [@complete.id]
         do_request
-        expect(assigns[:report_data]).to contain_all [@order_detail_ordered_today_fulfilled_today_unreconciled, @order_detail_ordered_today_fulfilled_next_month_unreconciled]
+        expect(assigns[:report_data].to_a).to contain_all [@order_detail_ordered_today_fulfilled_today_unreconciled, @order_detail_ordered_today_fulfilled_next_month_unreconciled]
       end
 
       it "should search reconciled" do
         @params[:status_filter] = [OrderStatus.reconciled.id]
         do_request
-        expect(assigns[:report_data]).to be_empty
+        expect(assigns[:report_data]).to be_none
       end
 
       it "should find reconciled that started yesterday" do
         @params[:status_filter] = [OrderStatus.reconciled.id]
         @params[:date_start] = 1.day.ago.strftime("%m/%d/%Y")
         do_request
-        expect(assigns[:report_data]).to contain_all [@order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_yesterday, @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today]
+        expect(assigns[:report_data].to_a).to contain_all [@order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_yesterday, @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today]
       end
     end
 
@@ -143,26 +143,26 @@ RSpec.describe Reports::GeneralReportsController do
       it "should have a problem if it searches unfulfilled" do
         @params[:status_filter] = [OrderStatus.new_status.id]
         do_request
-        expect(assigns[:report_data]).to be_empty
+        expect(assigns[:report_data]).to be_none
       end
 
       it "should search fulfilled" do
         @params[:status_filter] = [@complete.id]
         do_request
-        expect(assigns[:report_data]).to contain_all [@order_detail_ordered_yesterday_fulfilled_today_unreconciled, @order_detail_ordered_today_fulfilled_today_unreconciled]
+        expect(assigns[:report_data].to_a).to contain_all [@order_detail_ordered_yesterday_fulfilled_today_unreconciled, @order_detail_ordered_today_fulfilled_today_unreconciled]
       end
 
       it "should search reconciled" do
         @params[:status_filter] = [OrderStatus.reconciled.id]
         do_request
-        expect(assigns[:report_data]).to be_empty
+        expect(assigns[:report_data].to_a).to be_none
       end
 
       it "should find reconciled that started yesterday" do
         @params[:status_filter] = [OrderStatus.reconciled.id]
         @params[:date_start] = 1.day.ago.strftime("%m/%d/%Y")
         do_request
-        expect(assigns[:report_data]).to contain_all [@order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_yesterday, @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today]
+        expect(assigns[:report_data].to_a).to contain_all [@order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_yesterday, @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today]
       end
     end
 
@@ -175,26 +175,26 @@ RSpec.describe Reports::GeneralReportsController do
       it "should have a problem if it searches unfulfilled" do
         @params[:status_filter] = [OrderStatus.new_status.id]
         do_request
-        expect(assigns[:report_data]).to be_empty
+        expect(assigns[:report_data]).to be_none
       end
 
       it "should have a problem if it searches unjournaled" do
         @params[:status_filter] = [@complete.id]
         do_request
-        expect(assigns[:report_data]).to be_empty
+        expect(assigns[:report_data]).to be_none
       end
 
       it "should search reconciled" do
         @params[:status_filter] = [OrderStatus.reconciled.id]
         do_request
-        expect(assigns[:report_data]).to eq([@order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today])
+        expect(assigns[:report_data].to_a).to eq([@order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today])
       end
 
       it "should find reconciled that started yesterday" do
         @params[:status_filter] = [OrderStatus.reconciled.id]
         @params[:date_start] = 1.day.ago.strftime("%m/%d/%Y")
         do_request
-        expect(assigns[:report_data]).to contain_all [@order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today, @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_yesterday]
+        expect(assigns[:report_data].to_a).to contain_all [@order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today, @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_yesterday]
       end
     end
   end

--- a/vendor/engines/split_accounts/app/services/split_accounts/order_detail_list_transformer.rb
+++ b/vendor/engines/split_accounts/app/services/split_accounts/order_detail_list_transformer.rb
@@ -10,13 +10,36 @@ module SplitAccounts
 
     def perform(options = {})
       options ||= {} # in case it comes in as nil
-      order_details.each_with_object([]) do |order_detail, results|
-        # We will need to refactor the general_reports_controller_spec in
-        # order to remove the `try` methods below.
+
+      nested_map(order_details) do |order_detail|
         if order_detail.account.try(:splits).try(:present?)
-          results.concat SplitAccounts::OrderDetailSplitter.new(order_detail, split_time_data: options[:time_data]).split
+          SplitAccounts::OrderDetailSplitter.new(order_detail, split_time_data: options[:time_data]).split
         else
-          results << order_detail
+          order_detail
+        end
+      end
+    end
+
+    private
+
+    # Wraps a lazy enumerator with another enumerator so that if the block returns
+    # an Array, each value of that array gets yielded.
+    # Example:
+    # output = nested_map(1..Float::Infinity) do |i|
+    #   if i.even?
+    #     [i, i]
+    #   else
+    #     i
+    #   end
+    # end
+    #
+    # > output.take(5).to_a
+    # => [1, 2, 2, 3, 4]
+    def nested_map(enumerable)
+      Enumerator::Lazy.new(enumerable.to_enum) do |yielder, *values|
+        results = yield(*values)
+        Array(results).each do |val|
+          yielder << val
         end
       end
     end

--- a/vendor/engines/split_accounts/spec/services/order_detail_splitter_spec.rb
+++ b/vendor/engines/split_accounts/spec/services/order_detail_splitter_spec.rb
@@ -15,13 +15,14 @@ RSpec.describe SplitAccounts::OrderDetailSplitter, type: :service do
     let(:order) { build_stubbed(:order) }
 
     let(:order_detail) do
-      build_stubbed(:order_detail, created_by: 1,
+      build_stubbed(:order_detail, created_by: build_stubbed(:user),
                                    quantity: 3,
                                    actual_cost: BigDecimal("9.99"),
                                    actual_subsidy: BigDecimal("19.99"),
                                    estimated_cost: BigDecimal("29.99"),
                                    estimated_subsidy: BigDecimal("39.99"),
-                                   account: split_account)
+                                   account: split_account,
+                                   note: "this is a note")
     end
 
     it "can be initialized" do
@@ -37,7 +38,9 @@ RSpec.describe SplitAccounts::OrderDetailSplitter, type: :service do
 
       it "dups original order detail" do
         results.each do |result|
-          expect(result.created_by).to eq(order_detail.created_by)
+          expect(result.product).to eq(order_detail.product)
+          expect(result.created_by_user).to eq(order_detail.created_by_user)
+          expect(result.note).to eq(order_detail.note)
         end
       end
 


### PR DESCRIPTION
Extends from #1336 and replaces #1337.

Clean diff: https://github.com/tablexi/nucore-open/compare/139681-cross-facility-export-raw...export_raw_optimize_jh?expand=1

I mostly tested this on NU/Oracle since I have a large and realistic dataset locally.

With a 5500 row export (about 2 months of data for IMSERC), it originally took 450-500 seconds. Now it takes ~200 seconds. That same report, the memory in delayed_job would spike to around 250-300mb (this is locally). In this new version, it stays around 150mb.

I'm still experimenting with the batch size. In oracle, at least, we get significantly faster queries, but there are of course more of them.

One of the things I did was to enable the query cache, which is not on by default in delayed_job. This will have minimal effect on open, but for NU which has PMU, and likely DC with user affiliations it should save some trips to the database.

