### PR TITLE
Bump to synaccess 0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,8 +74,7 @@ gem "projects", "~> 0.0.1", path: "vendor/engines/projects"
 gem "sanger_sequencing", "~> 0.0.1", path: "vendor/engines/sanger_sequencing"
 gem "secure_rooms", path: "vendor/engines/secure_rooms"
 gem "split_accounts", "~> 0.0.1", path: "vendor/engines/split_accounts"
-gem "synaccess_connect", "0.2.2", github: "tablexi/synaccess"
-gem "net-telnet"
+gem "synaccess_connect", "~> 0.3.0"
 
 group :development do
   gem "bullet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: git@github.com:tablexi/synaccess.git
-  revision: d86e6afb7f930fd21ed84091400abab138a36ac6
-  specs:
-    synaccess_connect (0.2.2)
-      nokogiri (> 1.6)
-
 PATH
   remote: vendor/engines/bulk_email
   specs:
@@ -345,7 +338,6 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
-    net-telnet (0.1.1)
     nio4r (2.1.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
@@ -533,6 +525,8 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     state_machines (0.5.0)
+    synaccess_connect (0.3.0)
+      nokogiri (>= 1.6)
     sysexits (1.2.0)
     teaspoon (1.1.5)
       railties (>= 3.2.5, < 6)
@@ -634,7 +628,6 @@ DEPENDENCIES
   logstash-event
   mysql2 (~> 0.3.20)
   nested_form_fields
-  net-telnet
   nokogiri (>= 1.8.1)
   oj (~> 3.3.10)
   paper_trail
@@ -670,7 +663,7 @@ DEPENDENCIES
   spreadsheet (~> 1.1.5)
   spring
   spring-commands-rspec
-  synaccess_connect (= 0.2.2)!
+  synaccess_connect (~> 0.3.0)
   teaspoon-jasmine
   test-unit (~> 3.2)
   text_helpers

--- a/app/models/relay_synaccess_rev_a.rb
+++ b/app/models/relay_synaccess_rev_a.rb
@@ -11,8 +11,7 @@ class RelaySynaccessRevA < Relay
   end
 
   def relay_connection
-    clazz = "#{Settings.relays.connect_module}::RevA".constantize
-    @relay_connection ||= clazz.new(host, connection_options)
+    @relay_connection ||= NetBooter::Http::RevA.new(host, connection_options)
   end
 
 end

--- a/app/models/relay_synaccess_rev_b.rb
+++ b/app/models/relay_synaccess_rev_b.rb
@@ -11,8 +11,7 @@ class RelaySynaccessRevB < Relay
   end
 
   def relay_connection
-    clazz = "#{Settings.relays.connect_module}::RevB".constantize
-    @relay_connection ||= clazz.new(host, connection_options)
+    @relay_connection ||= NetBooter::Http::RevB.new(host, connection_options)
   end
 
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -73,8 +73,6 @@ external_services:
   survey: UrlService
 
 relays:
-  # can also be NetBooter::Telnet
-  connect_module: NetBooter::Http
   test:
     admin_enabled: false
     reservation_enabled: false


### PR DESCRIPTION
That version removes the telnet interface because it was unreliable. We
weren’t using it anywhere so it allowed some minor cleanup where it was
configurable.

We also don't need to be on the github master anymore since I pushed the latest versions to rubygems.