### PR TITLE
Do not connect to relays if the feature is disabled

### DIFF
--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -109,7 +109,7 @@ class InstrumentsController < ProductsCommonController
   def instrument_status
     begin
       @relay = @product.relay
-      status = Rails.env.test? ? true : @relay.get_status
+      status = SettingsHelper.relays_enabled_for_admin? ? instrument.relay.get_status : true
       @status = @product.instrument_statuses.create!(is_on: status)
     rescue => e
       logger.error e

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -131,7 +131,8 @@ class InstrumentsController < ProductsCommonController
       # next if instrument.relay.is_a? RelayDummy
 
       begin
-        status = instrument.relay.get_status
+        # Always return true/on if the relay feature is disabled
+        status = SettingsHelper.relays_enabled_for_admin? ? instrument.relay.get_status : true
         instrument_status = instrument.current_instrument_status
         # if the status hasn't changed, don't create a new status
         @instrument_statuses << if instrument_status && status == instrument_status.is_on?

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -554,6 +554,7 @@ RSpec.describe InstrumentsController do
     context "instrument statuses" do
       before :each do
         # So it doesn't try to actually connect
+        allow(SettingsHelper).to receive(:relays_enabled_for_admin?).and_return(true)
         allow_any_instance_of(RelaySynaccessRevA).to receive(:query_status).and_return(false)
 
         @method = :get


### PR DESCRIPTION
This will save time when viewing the timeline view if the relay feature
is off (by default in development).

The feature is toggled in `settings.yml` under `relays`.