### PR TITLE
Restore cross_facility_reports feature flag

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -127,6 +127,7 @@ feature:
   equipment_list_on: true
   price_change_reason_required_on: false
   can_manage_global_price_groups_on: true
+  cross_facility_reports_on: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts


### PR DESCRIPTION
Feature flag got lost in the merge somehow: https://github.com/tablexi/nucore-open/pull/1336/files#diff-646ad6b10917e4385cbcc8c8524e24a2R131

Should be false for UIC and NU, true for Dartmouth.