### PR TITLE
fix fragile spec

### DIFF
--- a/spec/features/editing_a_reservation_spec.rb
+++ b/spec/features/editing_a_reservation_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe "Editing your own reservation" do
       visit reservations_path
       click_link reservation
 
-      fill_in "Reserve Start", with: format_usa_date(reservation.reserve_start_at + 1.day)
-      fill_in "Reserve End", with: format_usa_date(reservation.reserve_end_at + 1.day)
+      fill_in "Reserve Start", with: format_usa_date(reservation.reserve_start_at + 1.hour)
+      fill_in "Reserve End", with: format_usa_date(reservation.reserve_end_at + 1.hour)
       fill_in "Duration", with: "30"
       click_button "Save"
 


### PR DESCRIPTION
Reservation was being moved "too far in advance" for the price group that the product had available in UIC.

The product has three price groups, base, external, and one coming from the factory. For some reason the factory-based group has a 1 day reservation window, whereas base/external have a 14 day window. In open, the user is part of base and so has an effective 14 day window, whereas in UIC they are not and so are constrained by the 1 day reservation window.