### PR TITLE
[#139828] explicitly list bundleable product types

### DIFF
--- a/app/models/bundle.rb
+++ b/app/models/bundle.rb
@@ -3,8 +3,11 @@ class Bundle < Product
   has_many :products, through: :bundle_products
   has_many :bundle_products, foreign_key: :bundle_product_id
 
+
+  cattr_accessor :bundleable_product_types { ["Instrument", "Item", "Service", "TimedService"] }
+
   def products_for_group_select
-    products = facility.products.where.not(type: "Bundle").order(:type, :name)
+    products = facility.products.where(type: bundleable_product_types).order(:type, :name)
     options = Hash.new { |h, k| h[k] = [] }
     products.group_by { |product| product.class.name.pluralize }.each do |cname, ps|
       options[cname] = ps.map { |p| [p.to_s_with_status, p.id] }


### PR DESCRIPTION
SecureRooms should not be available to add to bundles.