### PR TITLE
[#139829] SecureRooms: Always prompt for account selection, even if only one

### DIFF
--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/account_selection_rule.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/account_selection_rule.rb
@@ -12,8 +12,6 @@ module SecureRooms
           deny!(:no_accounts)
         elsif selected_account.present?
           grant!(:selected_account, selected_account: selected_account, accounts: accounts)
-        elsif accounts.present? && accounts.one?
-          grant!(:only_account, accounts: accounts)
         elsif accounts.present? && selected_account.blank?
           pending!(:selection_needed, accounts: accounts)
         end

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/verdict.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/verdict.rb
@@ -36,6 +36,10 @@ module SecureRooms
         has_result_code?(:grant)
       end
 
+      def pending?
+        has_result_code?(:pending)
+      end
+
       def has_result_code?(code)
         @result_code == code
       end

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/account_selection_rule_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/access_rules/account_selection_rule_spec.rb
@@ -18,6 +18,20 @@ RSpec.describe SecureRooms::AccessRules::AccountSelectionRule, type: :service do
     it { is_expected.to have_result_code(:deny) }
   end
 
+  context "one account exists" do
+    let(:account) { create(:account, :with_account_owner, owner: card_user) }
+
+    before do
+      allow_any_instance_of(User).to receive(:accounts_for_product).and_return([account])
+    end
+
+    context "wihtout a selection" do
+      let(:account_identifier) { nil }
+
+      it { is_expected.to have_result_code(:pending) }
+    end
+  end
+
   context "accounts exist" do
     let(:accounts) { create_list(:account, 3, :with_account_owner, owner: card_user) }
 

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/check_access_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/check_access_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe SecureRooms::CheckAccess, type: :service do
         before { secure_room.product_users.create!(user: card_user, approved_by: 0) }
         describe "and inside the schedule rules", :time_travel do
           let(:now) { Time.zone.local(2016, 5, 15, 12, 0) }
-          it { is_expected.to be_granted }
+          it { is_expected.to be_pending }
         end
 
         describe "but it is outside the schedule rules", :time_travel do


### PR DESCRIPTION
So that users always know exactly which account is going to be charged, we
want to always display an account selection, even if there is only one account.

With this change, there is no need to change anything on the nucore-rooms elixir
app or mobile app: as long as we respond with "pending" and the account list (of
only one thing), they behave appropriately.