### PR TITLE
[#139183] display calendar time range header

### DIFF
--- a/app/assets/stylesheets/calendar/fullcalendar.extensions.scss
+++ b/app/assets/stylesheets/calendar/fullcalendar.extensions.scss
@@ -46,12 +46,12 @@
 }
 
 #calendar .fc-header-left, #calendar .fc-header-right,  {
-  width: 50%;
+  width: 34%;
   vertical-align: bottom;
 }
 
 #calendar .fc-header-center {
-  width: 0;
+  width: 32%;
 }
 
 #calendar .fc-header-title {


### PR DESCRIPTION
Now looks like this:

![screen shot 2018-01-29 at 5 37 50 pm](https://user-images.githubusercontent.com/4624197/35540885-b31af0f8-051d-11e8-9484-52f06aaa417a.png)
![screen shot 2018-01-29 at 5 38 11 pm](https://user-images.githubusercontent.com/4624197/35540887-b3bd7148-051d-11e8-88eb-de620552d217.png)
![screen shot 2018-01-29 at 5 38 26 pm](https://user-images.githubusercontent.com/4624197/35540888-b3dd2cea-051d-11e8-918e-b36310cde217.png)
