### PR TITLE
[#140005] Prevent error on removing product/user access if already removed

### DIFF
--- a/app/controllers/product_users_controller.rb
+++ b/app/controllers/product_users_controller.rb
@@ -53,9 +53,12 @@ class ProductUsersController < ApplicationController
   # DELETE /facilities/:facility_id/services/service_id/users/:id
   def destroy
     product_user = ProductUser.find_by(product_id: @product.id, user_id: params[:id])
-    product_user.destroy
 
-    if product_user.destroyed?
+    if product_user.blank?
+      # Show success even if it doesn't exist because it is likely to be a
+      # multi-tab issue
+      flash[:notice] = text("destroy.success", model: downcase_product_type)
+    elsif product_user.destroy && product_user.destroyed?
       flash[:notice] = text("destroy.success", model: downcase_product_type)
     else
       flash[:error]  = text("destroy.failure", model: downcase_product_type)

--- a/app/models/product_user.rb
+++ b/app/models/product_user.rb
@@ -3,6 +3,7 @@ class ProductUser < ActiveRecord::Base
   belongs_to :user
   belongs_to :product
   belongs_to :product_access_group
+  belongs_to :approved_by_user, class_name: "User", foreign_key: "approved_by"
 
   validates_numericality_of :product_id, :user_id, :approved_by, only_integer: true
   validates_uniqueness_of :user_id, scope: :product_id, message: "is already approved"

--- a/app/models/product_user.rb
+++ b/app/models/product_user.rb
@@ -3,7 +3,7 @@ class ProductUser < ActiveRecord::Base
   belongs_to :user
   belongs_to :product
   belongs_to :product_access_group
-  belongs_to :approved_by_user, class_name: "User", foreign_key: "approved_by"
+  belongs_to :approved_by_user, class_name: "User", foreign_key: "approved_by", inverse_of: false
 
   validates_numericality_of :product_id, :user_id, :approved_by, only_integer: true
   validates_uniqueness_of :user_id, scope: :product_id, message: "is already approved"

--- a/spec/controllers/product_users_controller_spec.rb
+++ b/spec/controllers/product_users_controller_spec.rb
@@ -60,4 +60,29 @@ RSpec.describe ProductUsersController do
       expect(flash[:notice]).to be_present
     end
   end
+
+  describe "destroy" do
+    let!(:guest_product) { create(:product_user, product: instrument, user: guest, approved_by_user: admin) }
+
+    it "destroys the association" do
+      sign_in staff
+      expect {
+        delete :destroy,
+          facility_id: facility.url_name,
+          instrument_id: instrument.url_name,
+          id: guest
+      }.to change(ProductUser, :count).by(-1)
+      expect(flash[:notice]).to be_present
+    end
+
+    it "does not error if the association is not found" do
+      sign_in staff
+
+      delete :destroy,
+        facility_id: facility.url_name,
+        instrument_id: instrument.url_name,
+        id: admin
+      expect(flash[:notice]).to be_present
+    end
+  end
 end

--- a/spec/controllers/product_users_controller_spec.rb
+++ b/spec/controllers/product_users_controller_spec.rb
@@ -4,72 +4,60 @@ require "controller_spec_helper"
 RSpec.describe ProductUsersController do
   render_views
 
-  let(:facility) { @authable }
+  let(:facility) { create(:setup_facility) }
+  let(:instrument) { create(:setup_instrument, facility: facility, requires_approval: true) }
+  let(:guest) { create(:user) }
+  let(:admin) { create(:user, :administrator) }
+  let(:staff) { create(:user, :staff, facility: facility) }
 
-  before(:all) { create_users }
+  describe "index" do
+    let!(:guest_product) { ProductUser.create(product: instrument, user: guest, approved_by: admin.id, approved_at: Time.current) }
+    let!(:staff_product) { ProductUser.create(product: instrument, user: staff, approved_by: admin.id, approved_at: Time.current) }
 
-  before(:each) do
-    @authable         = FactoryBot.create(:facility)
-    @facility_account = @authable.facility_accounts.create(FactoryBot.attributes_for(:facility_account))
-    @price_group = FactoryBot.create(:price_group, facility: facility)
-    @instrument       = FactoryBot.create(:instrument,
-                                          facility: @authable,
-                                          facility_account: @facility_account,
-                                          requires_approval: true)
-    @price_policy     = @instrument.instrument_price_policies.create(FactoryBot.attributes_for(:instrument_price_policy).update(price_group_id: @price_group.id))
-    expect(@price_policy).to be_valid
-    @params = { facility_id: @authable.url_name, instrument_id: @instrument.url_name }
-
-    @rule = @instrument.schedule_rules.create(FactoryBot.attributes_for(:schedule_rule))
-    @level = FactoryBot.create(:product_access_group, product_id: @instrument.id)
-    @level2 = FactoryBot.create(:product_access_group, product_id: @instrument.id)
-  end
-
-  context "index" do
-    before :each do
-      @method = :get
-      @action = :index
-      @guest_product = ProductUser.create(product: @instrument, user: @guest, approved_by: @admin.id, approved_at: Time.zone.now)
-      @staff_product = ProductUser.create(product: @instrument, user: @staff, approved_by: @admin.id, approved_at: Time.zone.now)
+    def do_request
+      get :index, facility_id: facility.url_name, instrument_id: instrument.url_name
     end
 
     it "should only return the two users" do
-      sign_in @admin
+      sign_in admin
       do_request
-      expect(assigns[:product_users]).to eq([@guest_product, @staff_product])
+      expect(assigns[:product_users]).to eq([guest_product, staff_product])
     end
 
     it "should return empty and a flash if the product is not restricted" do
-      @instrument.update_attributes(requires_approval: false)
-      sign_in @admin
+      instrument.update_attributes!(requires_approval: false)
+      sign_in admin
       do_request
+
       expect(assigns[:product_users]).to be_nil
       expect(flash[:notice]).not_to be_empty
     end
 
   end
 
-  context "update_restrictions" do
-    before :each do
-      @guest_product = ProductUser.create(product: @instrument, user: @guest, approved_by: @admin.id, approved_at: Time.zone.now)
-      @staff_product = ProductUser.create(product: @instrument, user: @staff, approved_by: @admin.id, approved_at: Time.zone.now)
+  describe "update_restrictions" do
+    let(:level) { create(:product_access_group, product: instrument) }
+    let(:level2) { create(:product_access_group, product: instrument) }
 
-      @action = :update_restrictions
-      @method = :put
-      @params.deep_merge!(
+    let!(:guest_product) { create(:product_user, product: instrument, user: guest, approved_by_user: admin) }
+    let!(:staff_product) { create(:product_user, product: instrument, user: staff, approved_by_user: admin) }
+
+    it "updates the product_users" do
+      sign_in staff
+      put :update_restrictions, {
+        facility_id: facility.url_name,
+        instrument_id: instrument.url_name,
         instrument: {
           product_users: {
-            @guest_product.id => { product_access_group_id: @level.id },
-            @staff_product.id => { product_access_group_id: @level2.id },
+            guest_product.id => { product_access_group_id: level.id },
+            staff_product.id => { product_access_group_id: level2.id },
           },
         },
-      )
-    end
+      }
 
-    it_should_allow_operators_only :redirect, "update the product_users" do
-      expect(ProductUser.find(@guest_product.id).product_access_group).to eq(@level)
-      expect(ProductUser.find(@staff_product.id).product_access_group).to eq(@level2)
-      expect(flash[:notice]).not_to be_nil
+      expect(guest_product.reload.product_access_group).to eq(level)
+      expect(staff_product.reload.product_access_group).to eq(level2)
+      expect(flash[:notice]).to be_present
     end
   end
 end

--- a/spec/factories/product_users.rb
+++ b/spec/factories/product_users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :product_user do
+    approved_by_user { build_stubbed(:user) }
+
+    approved_at { Time.current }
+  end
+end


### PR DESCRIPTION
Steps to reproduce:

* Add a user to a restricted product
* Open a second tab of the access list
* Click "Remove" to remove the user on one tab
* Click "Remove" for the same user on the second tab

As part of this, I cleaned up the controller spec, so it's probably worth viewing the two commits separately.