### PR TITLE
Disable bullet by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ gem "split_accounts", "~> 0.0.1", path: "vendor/engines/split_accounts"
 gem "synaccess_connect"
 
 group :development do
-  gem "bullet"
+  gem "bullet" # Detect N+1s and recommends eager loading
   gem "coffeelint"
   gem "haml_lint"
   gem "letter_opener"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,7 +44,7 @@ Nucore::Application.configure do
   config.action_view.raise_on_missing_translations = true
 
   config.after_initialize do
-    Bullet.enable = true
+    Bullet.enable = false
     Bullet.bullet_logger = true
     Bullet.rails_logger = true
   end


### PR DESCRIPTION
We should take advantage of bullet from time time time, but it should probably not be run by default as it slows down development when you're not paying attention to its output.