### PR TITLE
[#140234] cancel does not require pricing note

### DIFF
--- a/spec/features/admin/manage_order_detail_spec.rb
+++ b/spec/features/admin/manage_order_detail_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe "Managing an order detail" do
     context "canceling a reservation" do
       before do
         instrument.price_policies.update_all(cancellation_cost: 5)
-        instrument.update_attribute(:min_cancel_hours, 1)
+        # reservation is set for tomorrow, we need min_cancel_hours to be longer than time to reserve_start_at
+        instrument.update_attribute(:min_cancel_hours, 48)
       end
 
       it "cancels without a fee" do
@@ -67,9 +68,7 @@ RSpec.describe "Managing an order detail" do
         check "Add reservation cost"
         click_button "Save"
 
-        # save_and_open_page
-
-        expect(page).to have_content("Canceled")
+        expect(page).to have_content("Complete")
         expect(page).to have_css('tfoot .currency', text: "$5.00", count: 2)
       end
     end

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -1635,6 +1635,18 @@ RSpec.describe OrderDetail do
             expect(order_detail.cancellation_fee).to eq 0
           end
 
+          it "sets canceled_at" do
+            cancel_order_detail(admin: true, apply_cancel_fee: true)
+
+            expect(order_detail.canceled_at).to be_present
+          end
+
+          it "sets canceled_by" do
+            cancel_order_detail(admin: true, apply_cancel_fee: true)
+
+            expect(order_detail.canceled_by_user).to eq user
+          end
+
           it "is removed from its statement" do
             expect { cancel_order_detail(admin: true, apply_cancel_fee: true) }
               .to change { order_detail.statement }.from(statement).to(nil)


### PR DESCRIPTION
Steps to reproduce:
- Start with a complete order
- Go to the order detail modal
- Choose cancel
- We get the "Pricing Note is required" message

Make sure to handle both a normal cancelation where the actual costs are set to $0 and instrument cancelation with a fee (which technically keeps the order in "complete" state)