### PR TITLE
[#137726] hiding badges for canceled order details

### DIFF
--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -4,6 +4,7 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
   include ActionView::Helpers::OutputSafetyHelper
 
   def statuses
+    return [] if canceled?
     statuses = []
 
     statuses << Notice.new(:in_review) if in_review?

--- a/spec/presenters/order_detail_notice_presenter_spec.rb
+++ b/spec/presenters/order_detail_notice_presenter_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe OrderDetailNoticePresenter do
       expect(presenter.badges_to_html).to be_blank
     end
 
+    it "shows nothing for a canceled order detail" do
+      allow(order_detail).to receive(:in_review?).and_return(true)
+      allow(order_detail).to receive(:canceled?).and_return(true)
+      expect(presenter.badges_to_html).to be_blank
+    end
+
     it "shows in review if the order is in review" do
       allow(order_detail).to receive(:in_review?).and_return(true)
       expect(presenter.badges_to_html).to have_badge("In Review")
@@ -87,6 +93,12 @@ RSpec.describe OrderDetailNoticePresenter do
     end
 
     it "shows nothing with no warnings/info" do
+      expect(presenter.alerts_to_html).to be_blank
+    end
+
+    it "shows nothing for a canceled order detail" do
+      allow(order_detail).to receive(:in_review?).and_return(true)
+      allow(order_detail).to receive(:canceled?).and_return(true)
       expect(presenter.alerts_to_html).to be_blank
     end
 


### PR DESCRIPTION
https://pm.tablexi.com/issues/137726

Canceled orders were still showing payment badges that were not actually relevant (ie "Ready for Journal").  Canceled orders now do not show any irrelevant payment badges. 

Before:
<img width="1216" alt="screen shot 2018-02-06 at 5 18 29 pm" src="https://user-images.githubusercontent.com/30355046/35889605-e68298ca-0b61-11e8-8471-5dad622d8068.png">

After:
<img width="1244" alt="screen shot 2018-02-06 at 5 17 55 pm" src="https://user-images.githubusercontent.com/30355046/35889614-efaaee5c-0b61-11e8-9eee-1db5660957d8.png">
