### PR TITLE
[#139828] use humanized model names for bundle dropdown

### DIFF
--- a/app/models/bundle.rb
+++ b/app/models/bundle.rb
@@ -8,7 +8,7 @@ class Bundle < Product
   def products_for_group_select
     products = facility.products.where(type: bundleable_product_types).order(:type, :name)
     options = Hash.new { |h, k| h[k] = [] }
-    products.group_by { |product| product.class.name.pluralize }.each do |cname, ps|
+    products.group_by { |product| product.class.model_name.human.pluralize }.each do |cname, ps|
       options[cname] = ps.map { |p| [p.to_s_with_status, p.id] }
     end
     options


### PR DESCRIPTION
Drop-down for creating a bundle should read "Timed Services" instead of "TimedServices".