### PR TITLE
[#140309] Fix All Transactions Search

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -127,7 +127,12 @@ class FacilitiesController < ApplicationController
 
     @search = TransactionSearch::Searcher.new.search(order_details, @search_form)
     @date_range_field = @search_form.date_params[:field]
-    @order_details = @search.order_details.paginate(page: params[:page])
+    @order_details = @search.order_details
+
+    respond_to do |format|
+      format.html { @order_details = @order_details.paginate(page: params[:page]) }
+      format.csv { handle_csv_search }
+    end
   end
 
   # GET /facilities/:facility_id/disputed_orders

--- a/app/views/shared/transactions/_search.html.haml
+++ b/app/views/shared/transactions/_search.html.haml
@@ -16,7 +16,7 @@
       = f.input "date_range[start]", input_html: { value: @search_fields[:date_range].try(:[], :start).to_s.gsub("-","/"), class: ["datepicker", "in_past"] }, label: t("reports.fields.date_start")
       = f.input "date_range[end]", input_html: { value: @search_fields[:date_range].try(:[], :end).to_s.gsub("-","/"), class: ["datepicker", "in_past"] }, label: t("reports.fields.date_end")
 
-      .submit_button
-        = f.input :email, as: :hidden, input_html: { value: current_user.email }, disabled: true
-        = f.input :format, as: :hidden, input_html: { value: params[:format] }, disabled: true
-        = f.submit "Search", class: "btn"
+    .submit_button.span6
+      = f.input :email, as: :hidden, input_html: { value: current_user.email }, disabled: true
+      = f.input :format, as: :hidden, input_html: { value: params[:format] }, disabled: true
+      = f.submit t("shared.filter"), class: "btn float-left"

--- a/app/views/shared/transactions/_search2.html.haml
+++ b/app/views/shared/transactions/_search2.html.haml
@@ -16,4 +16,4 @@
     .submit_button.span6
       = hidden_field_tag :email, current_user.email, disabled: true
       = hidden_field_tag :format, params[:format], disabled: true
-      = f.submit "Filter", class: "btn float-left"
+      = f.submit t("shared.filter"), class: "btn float-left"

--- a/app/views/shared/transactions/_search2.html.haml
+++ b/app/views/shared/transactions/_search2.html.haml
@@ -6,7 +6,7 @@
       - @search.options.reject(&:multipart?).each do |searcher|
         = f.input searcher.key, as: :transaction_chosen2, collection: searcher.options, label: searcher.label, label_method: searcher.label_method, data_attrs: searcher.method(:data_attrs), input_html: { id: searcher.key }
 
-    %fieldset.span4#calendar_filter
+    %fieldset.span2#calendar_filter
       - if @search.options.map(&:key).include?("date_ranges")
         %br
         = f.input "date_range_field", collection: TransactionSearch::DateRangeSearcher.options, label: false, include_blank: false

--- a/app/views/shared/transactions/_search2.html.haml
+++ b/app/views/shared/transactions/_search2.html.haml
@@ -14,6 +14,6 @@
         = f.input "date_range_end", input_html: { class: ["datepicker", "in_past"] }, label: t("reports.fields.date_end")
 
     .submit_button.span6
-      = f.input :email, as: :hidden, input_html: { value: current_user.email }, disabled: true
-      = f.input :format, as: :hidden, input_html: { value: params[:format] }, disabled: true
+      = hidden_field_tag :email, current_user.email, disabled: true
+      = hidden_field_tag :format, params[:format], disabled: true
       = f.submit "Filter", class: "btn float-left"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,6 +101,7 @@ en:
     remove: Remove
     save: Save
     search: Search
+    filter: Filter
     select_all: Select All
     select_none: Select None
     upload: Upload

--- a/lib/transaction_search.rb
+++ b/lib/transaction_search.rb
@@ -157,7 +157,7 @@ module TransactionSearch
 
   def email_csv_export
     order_detail_ids = @order_details.respond_to?(:pluck) ? @order_details.pluck(:id) : @order_details.map(&:id)
-    AccountTransactionReportMailer.delay.csv_report_email(to_email, order_detail_ids, @date_range_field)
+    AccountTransactionReportMailer.csv_report_email(to_email, order_detail_ids, @date_range_field).deliver_later
   end
 
   def to_email


### PR DESCRIPTION
Related to changes from #1295 where we replaced the All Transaction search with the newer version from the reconciliation pages.

* "Export as CSV" was broken
  * Did not prepopulate email address in prompt
  * New controller action did not respond to `csv`
* Use "Filter" instead of "Search" for consistency with reconciliation page
* Move "Filter" button under the multi-select fields for consistency with reconciliation page

---
**Before:**
![screen shot 2018-02-06 at 3 36 15 pm](https://user-images.githubusercontent.com/1099111/35885530-c812c0e4-0b53-11e8-9f33-aeefa2720c28.png)
![screen shot 2018-02-06 at 3 35 59 pm](https://user-images.githubusercontent.com/1099111/35885531-c8213f66-0b53-11e8-8997-a1e607fdf0f0.png)

**After:**
![screen shot 2018-02-06 at 3 36 41 pm](https://user-images.githubusercontent.com/1099111/35885550-d59b578a-0b53-11e8-85b5-368e465c4a71.png)
![screen shot 2018-02-06 at 3 36 33 pm](https://user-images.githubusercontent.com/1099111/35885551-d5a88f90-0b53-11e8-8f51-32aa56d7f7df.png)


