### PR TITLE
Fix date range ordering on All Transactions tab

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -343,9 +343,7 @@ class OrderDetail < ActiveRecord::Base
   }
 
   scope :ordered_by_action_date, lambda { |action|
-    if action.to_sym == :journal_or_statement_date
-      action = "COALESCE(journal_date, in_range_statements.created_at)"
-    end
+    action = "COALESCE(journal_date, in_range_statements.created_at)" if action.to_sym == :journal_or_statement_date
     order_by_desc_nulls_first(action)
   }
 

--- a/app/services/transaction_search/date_range_searcher.rb
+++ b/app/services/transaction_search/date_range_searcher.rb
@@ -24,10 +24,11 @@ module TransactionSearch
       start_date = to_date(params[:start])
       end_date = to_date(params[:end])
       @date_range_field = extract_date_range_field(params)
-      order_details.action_in_date_range(@date_range_field, start_date, end_date)
-    end
 
-    private
+      order_details
+        .action_in_date_range(@date_range_field, start_date, end_date)
+        .ordered_by_action_date(@date_range_field)
+    end
 
     def to_date(param_value)
       parse_usa_date(param_value.to_s.tr("-", "/"))
@@ -35,7 +36,7 @@ module TransactionSearch
 
     def extract_date_range_field(params)
       field = params.try(:[], :field)
-      FIELDS.include?(field) ? field : "fulfilled_at"
+      FIELDS.include?(field.to_s) ? field.to_s : "fulfilled_at"
     end
 
   end

--- a/lib/transaction_search.rb
+++ b/lib/transaction_search.rb
@@ -63,11 +63,7 @@ module TransactionSearch
   end
 
   def order_by_desc
-    field = @date_range_field
-    if @date_range_field.to_sym == :journal_or_statement_date
-      field = "COALESCE(journal_date, in_range_statements.created_at)"
-    end
-    @order_details.order_by_desc_nulls_first(field)
+    @order_details.ordered_by_action_date(@date_range_field)
   end
 
   def init_order_details

--- a/spec/factories/statements.rb
+++ b/spec/factories/statements.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :statement do
     association :account, factory: :setup_account
+    association :created_by_user, factory: :user
     created_at { Time.zone.now }
     facility
   end

--- a/spec/services/transaction_search/date_range_searcher_spec.rb
+++ b/spec/services/transaction_search/date_range_searcher_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe TransactionSearch::DateRangeSearcher do
   describe "fulfilled_at" do
     before do
       order_details[0].update!(fulfilled_at: 2.days.ago)
-      order_details[1].update!(fulfilled_at: 1.days.ago)
+      order_details[1].update!(fulfilled_at: 1.day.ago)
     end
 
     it "finds only the right ones when starting a day ago" do
@@ -66,7 +66,7 @@ RSpec.describe TransactionSearch::DateRangeSearcher do
     describe "journaled" do
       before do
         order_details[0].update!(journal: create(:journal, journal_date: 2.days.ago))
-        order_details[1].update!(journal: create(:journal, journal_date: 1.days.ago))
+        order_details[1].update!(journal: create(:journal, journal_date: 1.day.ago))
       end
 
       it "finds only the right ones when starting a day ago" do
@@ -93,7 +93,7 @@ RSpec.describe TransactionSearch::DateRangeSearcher do
     describe "statemented" do
       before do
         order_details[0].update!(statement: create(:statement, created_at: 2.days.ago))
-        order_details[1].update!(statement: create(:statement, created_at: 1.days.ago))
+        order_details[1].update!(statement: create(:statement, created_at: 1.day.ago))
       end
 
       it "finds only the right ones when starting a day ago" do
@@ -121,7 +121,7 @@ RSpec.describe TransactionSearch::DateRangeSearcher do
   describe "reconciled_at" do
     before do
       order_details[0].update!(reconciled_at: 2.days.ago)
-      order_details[1].update!(reconciled_at: 1.days.ago)
+      order_details[1].update!(reconciled_at: 1.day.ago)
     end
 
     it "finds only the right ones when starting a day ago" do

--- a/spec/services/transaction_search/date_range_searcher_spec.rb
+++ b/spec/services/transaction_search/date_range_searcher_spec.rb
@@ -1,0 +1,147 @@
+require "rails_helper"
+
+RSpec.describe TransactionSearch::DateRangeSearcher do
+  include DateHelper
+
+  let(:item) { create(:setup_item) }
+  let(:orders) { create_list(:purchased_order, 2, product: item) }
+  let(:order_details) { orders.flat_map(&:order_details) }
+  let(:searcher) { described_class.new(OrderDetail.all.joins(:order)) }
+
+  describe "ordered_at" do
+    before do
+      orders[0].update!(ordered_at: 2.days.ago)
+      orders[1].update!(ordered_at: 1.day.ago)
+    end
+
+    it "finds only the right ones when starting a day ago" do
+      results = searcher.search(field: :ordered_at, start: format_usa_date(1.day.ago))
+      expect(results).to eq([order_details.last])
+    end
+
+    it "finds only the right one when ending a day ago" do
+      results = searcher.search(field: :ordered_at, end: format_usa_date(2.days.ago))
+      expect(results).to eq([order_details.first])
+    end
+
+    it "finds nothing with an outside range" do
+      results = searcher.search(field: :ordered_at, start: format_usa_date(5.days.ago), end: format_usa_date(3.days.ago))
+      expect(results).to be_empty
+    end
+
+    it "finds all with a wide range in the ordered_at reverse chronological order" do
+      results = searcher.search(field: :ordered_at, start: format_usa_date(5.days.ago), end: format_usa_date(1.day.from_now))
+      expect(results).to eq(order_details.reverse)
+    end
+  end
+
+  describe "fulfilled_at" do
+    before do
+      order_details[0].update!(fulfilled_at: 2.days.ago)
+      order_details[1].update!(fulfilled_at: 1.days.ago)
+    end
+
+    it "finds only the right ones when starting a day ago" do
+      results = searcher.search(field: :fulfilled_at, start: format_usa_date(1.day.ago))
+      expect(results).to eq([order_details.last])
+    end
+
+    it "finds only the right one when ending a day ago" do
+      results = searcher.search(field: :fulfilled_at, end: format_usa_date(2.days.ago))
+      expect(results).to eq([order_details.first])
+    end
+
+    it "finds nothing with an outside range" do
+      results = searcher.search(field: :fulfilled_at, start: format_usa_date(5.days.ago), end: format_usa_date(3.days.ago))
+      expect(results).to be_empty
+    end
+
+    it "finds all with a wide range in the fulfilled_at reverse chronological order" do
+      results = searcher.search(field: :fulfilled_at, start: format_usa_date(5.days.ago), end: format_usa_date(1.day.from_now))
+      expect(results).to eq(order_details.reverse)
+    end
+  end
+
+  describe "journal_or_statement_date" do
+    describe "journaled" do
+      before do
+        order_details[0].update!(journal: create(:journal, journal_date: 2.days.ago))
+        order_details[1].update!(journal: create(:journal, journal_date: 1.days.ago))
+      end
+
+      it "finds only the right ones when starting a day ago" do
+        results = searcher.search(field: :journal_or_statement_date, start: format_usa_date(1.day.ago))
+        expect(results).to eq([order_details.last])
+      end
+
+      it "finds only the right one when ending a day ago" do
+        results = searcher.search(field: :journal_or_statement_date, end: format_usa_date(2.days.ago))
+        expect(results).to eq([order_details.first])
+      end
+
+      it "finds nothing with an outside range" do
+        results = searcher.search(field: :journal_or_statement_date, start: format_usa_date(5.days.ago), end: format_usa_date(3.days.ago))
+        expect(results).to be_empty
+      end
+
+      it "finds all with a wide range in the reverse chronological order" do
+        results = searcher.search(field: :journal_or_statement_date, start: format_usa_date(5.days.ago), end: format_usa_date(1.day.from_now))
+        expect(results).to eq(order_details.reverse)
+      end
+    end
+
+    describe "statemented" do
+      before do
+        order_details[0].update!(statement: create(:statement, created_at: 2.days.ago))
+        order_details[1].update!(statement: create(:statement, created_at: 1.days.ago))
+      end
+
+      it "finds only the right ones when starting a day ago" do
+        results = searcher.search(field: :journal_or_statement_date, start: format_usa_date(1.day.ago))
+        expect(results).to eq([order_details.last])
+      end
+
+      it "finds only the right one when ending a day ago" do
+        results = searcher.search(field: :journal_or_statement_date, end: format_usa_date(2.days.ago))
+        expect(results).to eq([order_details.first])
+      end
+
+      it "finds nothing with an outside range" do
+        results = searcher.search(field: :journal_or_statement_date, start: format_usa_date(5.days.ago), end: format_usa_date(3.days.ago))
+        expect(results).to be_empty
+      end
+
+      it "finds all with a wide range in the reverse chronological order" do
+        results = searcher.search(field: :journal_or_statement_date, start: format_usa_date(5.days.ago), end: format_usa_date(1.day.from_now))
+        expect(results).to eq(order_details.reverse)
+      end
+    end
+  end
+
+  describe "reconciled_at" do
+    before do
+      order_details[0].update!(reconciled_at: 2.days.ago)
+      order_details[1].update!(reconciled_at: 1.days.ago)
+    end
+
+    it "finds only the right ones when starting a day ago" do
+      results = searcher.search(field: :reconciled_at, start: format_usa_date(1.day.ago))
+      expect(results).to eq([order_details.last])
+    end
+
+    it "finds only the right one when ending a day ago" do
+      results = searcher.search(field: :reconciled_at, end: format_usa_date(2.days.ago))
+      expect(results).to eq([order_details.first])
+    end
+
+    it "finds nothing with an outside range" do
+      results = searcher.search(field: :reconciled_at, start: format_usa_date(5.days.ago), end: format_usa_date(3.days.ago))
+      expect(results).to be_empty
+    end
+
+    it "finds all with a wide range in the reconciled_at reverse chronological order" do
+      results = searcher.search(field: :reconciled_at, start: format_usa_date(5.days.ago), end: format_usa_date(1.day.from_now))
+      expect(results).to eq(order_details.reverse)
+    end
+  end
+end


### PR DESCRIPTION
In #1295 when we replaced the All Transactions search with the newer search logic, we lost the sorting, which should be reverse chronological by the date field in the dropdown (ordered at, fulfilled at, journal/statement at, reconciled at). This restores that ordering.