### PR TITLE
Fix transaction search N+1s

### DIFF
--- a/app/services/transaction_search/base_optimizer.rb
+++ b/app/services/transaction_search/base_optimizer.rb
@@ -1,0 +1,17 @@
+module TransactionSearch
+
+  class BaseOptimizer
+
+    attr_reader :order_details
+
+    def initialize(order_details)
+      @order_details = order_details
+    end
+
+    def optimize
+      raise NotImplementedError
+    end
+
+  end
+
+end

--- a/app/services/transaction_search/n_plus_one_optimizer.rb
+++ b/app/services/transaction_search/n_plus_one_optimizer.rb
@@ -1,0 +1,13 @@
+module TransactionSearch
+
+  class NPlusOneOptimizer < BaseOptimizer
+
+    def optimize
+      order_details.includes(order: :user)
+        .includes(:reservation)
+        .preload(:bundle)
+    end
+
+  end
+
+end

--- a/app/services/transaction_search/n_plus_one_optimizer.rb
+++ b/app/services/transaction_search/n_plus_one_optimizer.rb
@@ -4,8 +4,8 @@ module TransactionSearch
 
     def optimize
       order_details.includes(order: :user)
-        .includes(:reservation)
-        .preload(:bundle)
+                   .includes(:reservation)
+                   .preload(:bundle)
     end
 
   end

--- a/lib/transaction_search.rb
+++ b/lib/transaction_search.rb
@@ -26,6 +26,10 @@ module TransactionSearch
     SearchForm.send(:attr_accessor, searcher.key)
   end
 
+  def self.register_optimizer(optimizer)
+    Searcher.optimizers << optimizer
+  end
+
   module ClassMethods
 
     # If a method is tagged with _with_search at the end, then define the normal controller

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/n_plus_one_occupancy_optimizer.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/n_plus_one_occupancy_optimizer.rb
@@ -1,0 +1,11 @@
+module SecureRooms
+
+  class NPlusOneOccupancyOptimizer < TransactionSearch::BaseOptimizer
+
+    def optimize
+      order_details.includes(:occupancy)
+    end
+
+  end
+
+end

--- a/vendor/engines/secure_rooms/lib/secure_rooms/engine.rb
+++ b/vendor/engines/secure_rooms/lib/secure_rooms/engine.rb
@@ -12,6 +12,8 @@ module SecureRooms
       User.send :include, SecureRooms::UserExtension
       ::OrderDetails::ParamUpdater.send :include, SecureRooms::OrderDetails::ParamUpdaterExtension
 
+      TransactionSearch.register_optimizer(SecureRooms::NPlusOneOccupancyOptimizer)
+
       ArrayUtil.insert_before(Product.types, SecureRoom, Bundle)
       ArrayUtil.insert_after(
         MessageSummarizer.summary_classes,


### PR DESCRIPTION
Extends from #1387. 

Gets rid of some N+1s in transaction search by adding a new array of optimizers. This also allows us to prevent the n+1 on secure room occupancies.