### PR TITLE
Fix naming of all_transactions_search spec

### DIFF
--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -33,6 +33,12 @@ FactoryBot.define do
       end
     end
 
+    factory :complete_order, parent: :purchased_order do
+      after(:create) do |order|
+        order.order_details.each(&:to_complete!)
+      end
+    end
+
     factory :merge_order do
       transient do
         merge_with_order { nil }

--- a/spec/features/admin/all_transactions_search_spec.rb
+++ b/spec/features/admin/all_transactions_search_spec.rb
@@ -6,16 +6,8 @@ RSpec.describe "All Transactions Search" do
   let(:director) { create(:user, :facility_director, facility: facility) }
   let(:item) { create(:setup_item, facility: facility) }
   let(:accounts) { create_list(:setup_account, 2) }
-  let(:orders) do
-    accounts.map { |account| create(:purchased_order, product: item, account: account) }
-  end
-  let(:statements) do
-    accounts.map { |account| create(:statement, account: account, facility: facility, created_by_user: director, created_at: 2.days.ago) }
-  end
-  let(:director) { create(:user, :facility_director, facility: facility) }
-
-  before do
-    orders.flat_map(&:order_details).each(&:to_complete!)
+  let!(:orders) do
+    accounts.map { |account| create(:complete_order, product: item, account: account) }
   end
 
   let(:order_detail) { orders.first.order_details.first }
@@ -27,7 +19,7 @@ RSpec.describe "All Transactions Search" do
     expect(page).to have_field("Start Date", with: I18n.l(expected_default_date.to_date, format: :usa))
 
     select accounts.first.account_list_item, from: "Payment Sources"
-    click_button "Search"
+    click_button "Filter"
     expect(page).to have_link(order_detail.id, href: manage_facility_order_order_detail_path(facility, orders.first, orders.first.order_details.first))
     expect(page).not_to have_link(orders.second.order_details.first.id)
   end


### PR DESCRIPTION
It wasn’t running because it didn’t end in `_spec`. It should have been
failing due to the “Search” -> “Filter” change.