### PR TITLE
Better display when no transactions found

### DIFF
--- a/app/views/facilities/transactions.html.haml
+++ b/app/views/facilities/transactions.html.haml
@@ -7,4 +7,5 @@
 
 = content_for :top_block do
   = render "shared/transactions/top2", tab: "transactions"
-= render partial: "shared/transactions/table"
+- if @order_details.any?
+  = render partial: "shared/transactions/table"

--- a/app/views/shared/transactions/_top2.html.haml
+++ b/app/views/shared/transactions/_top2.html.haml
@@ -2,7 +2,7 @@
   .span3
     #sidebar
       = render "admin/shared/sidenav_billing", sidenav_tab: tab
-  - if @empty_orders
+  - if @order_details.none?
     .span9
       %p.alert.alert-info= text("#{controller_name}.#{action_name}.no_orders")
   - else


### PR DESCRIPTION
Related to #1295, on the all transaction view we were displaying the form and an empty table if the facility had no order details. This isn't that critical for All Transactions, but will become important when we switch over the other pages.

Before:
![screen shot 2018-02-07 at 1 46 58 pm](https://user-images.githubusercontent.com/1099111/35937975-6f2bb606-0c0d-11e8-88f8-709da6b34911.png)

---

After:
![screen shot 2018-02-07 at 1 46 41 pm](https://user-images.githubusercontent.com/1099111/35937983-75f4f3bc-0c0d-11e8-8505-6c1ef85bf3c8.png)

