### PR TITLE
Add login screen announcement view hook

### DIFF
--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -11,3 +11,5 @@
 
 - if SettingsHelper.feature_on? :password_update
   = link_to "Forgot password?", :reset_password
+
+= render_view_hook("login_screen_announcement")


### PR DESCRIPTION
This was added to DC, but didn’t make it up into open.

https://github.com/tablexi/nucore-dartmouth/pull/118