### PR TITLE
[#140401] Filtering: Replace Send Notifications with new searcher

### DIFF
--- a/app/controllers/facility_notifications_controller.rb
+++ b/app/controllers/facility_notifications_controller.rb
@@ -23,8 +23,14 @@ class FacilityNotificationsController < ApplicationController
   end
 
   # GET /facilities/notifications
-  def index_with_search
-    @order_details = @order_details.need_notification
+  def index
+    order_details = OrderDetail.need_notification.for_facility(current_facility)
+
+    @search_form = TransactionSearch::SearchForm.new(params[:search])
+    @search = TransactionSearch::Searcher.new.search(order_details, @search_form)
+    @date_range_field = @search_form.date_params[:field]
+    @order_details = @search.order_details
+
     @order_detail_action = :send_notifications
   end
 

--- a/app/views/facility_notifications/index.html.haml
+++ b/app/views/facility_notifications/index.html.haml
@@ -5,7 +5,7 @@
   %h2= t(".head")
 
 = content_for :top_block do
-  = render :partial => 'shared/transactions/top', :locals => { :tab => "notifications" }
+  = render "shared/transactions/top2", tab: "notifications"
 
 - if @order_details.any?
   = render :partial => 'shared/transactions/table'

--- a/app/views/shared/transactions/_search2.html.haml
+++ b/app/views/shared/transactions/_search2.html.haml
@@ -9,9 +9,9 @@
     %fieldset.span2#calendar_filter
       - if @search.options.map(&:key).include?("date_ranges")
         %br
-        = f.input "date_range_field", collection: TransactionSearch::DateRangeSearcher.options, label: false, include_blank: false
-        = f.input "date_range_start", input_html: {class: ["datepicker", "in_past"] }, label: t("reports.fields.date_start")
-        = f.input "date_range_end", input_html: { class: ["datepicker", "in_past"] }, label: t("reports.fields.date_end")
+        = f.input :date_range_field, collection: TransactionSearch::DateRangeSearcher.options, label: false, include_blank: false
+        = f.input :date_range_start, input_html: {class: ["datepicker", "in_past"] }, label: t("reports.fields.date_start")
+        = f.input :date_range_end, input_html: { class: ["datepicker", "in_past"] }, label: t("reports.fields.date_end")
 
     .submit_button.span6
       = hidden_field_tag :email, current_user.email, disabled: true

--- a/spec/controllers/facility_notifications_controller_spec.rb
+++ b/spec/controllers/facility_notifications_controller_spec.rb
@@ -53,12 +53,6 @@ RSpec.describe FacilityNotificationsController do
         expect(assigns(:order_detail_action)).to eq(:send_notifications)
         is_expected.not_to set_flash
       end
-
-      context "searching" do
-        before { @user = @admin }
-
-        it_should_support_searching
-      end
     end
 
     include_examples "zero-day review period"

--- a/spec/features/admin/sending_notifications_spec.rb
+++ b/spec/features/admin/sending_notifications_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe "Sending Notifications", billing_review_period: 7.days do
+
+  let(:facility) { create(:setup_facility) }
+  let(:director) { create(:user, :facility_director, facility: facility) }
+  let(:item) { create(:setup_item, facility: facility) }
+  let(:accounts) { create_list(:setup_account, 2) }
+  let(:orders) do
+    accounts.map { |account| create(:complete_order, product: item, account: account) }
+  end
+  let!(:order_details) { orders.flat_map(&:order_details) }
+
+  before do
+    order_details.each { |od| od.update(note: "OD ##{od.order_number}") }
+  end
+
+  it "can do a basic search" do
+    login_as director
+    visit facility_notifications_path(facility)
+
+    # Does not have default values for start/end
+    expect(find_field("Start Date").value).to be_blank
+    expect(find_field("End Date").value).to be_blank
+
+    # Has both orders
+    expect(page).to have_content("OD ##{order_details.first.order_number}")
+    expect(page).to have_content("OD ##{order_details.second.order_number}")
+
+    select accounts.first.account_list_item, from: "Payment Sources"
+    click_button "Filter"
+
+    # Has only the one from the selected account
+    expect(page).to have_content("OD ##{order_details.first.order_number}")
+    expect(page).not_to have_content("OD ##{order_details.second.order_number}")
+  end
+
+  it "can send notifications" do
+    login_as director
+    visit facility_notifications_path(facility)
+
+    find("input[value='#{order_details.first.id}']").click
+    find("input[value='#{order_details.second.id}']").click
+
+    click_button "Send Notifications"
+
+    within(".notice") do
+      expect(page).to have_content(accounts.first.account_list_item)
+      expect(page).to have_content(accounts.second.account_list_item)
+    end
+    expect(page).to have_content("No notifications are currently pending")
+
+    click_link "Orders In Review"
+
+    # Has both orders
+    expect(page).to have_content("OD ##{order_details.first.order_number}")
+    expect(page).to have_content("OD ##{order_details.second.order_number}")
+  end
+
+  describe "marking as reviewed" do
+    before do
+      order_details.each { |od| od.update!(reviewed_at: 1.week.from_now) }
+    end
+
+    it "can mark as reviewed and move them to the journal page" do
+      login_as director
+      visit facility_notifications_path(facility)
+      click_link "Orders In Review"
+
+      find("input[value='#{order_details.first.id}']").click
+      find("input[value='#{order_details.second.id}']").click
+
+      click_button "Mark as Reviewed"
+
+      expect(page).to have_content("The selected orders have been marked as reviewed")
+      expect(page).to have_content("No orders are currently in review")
+
+      # The orders have moved on to the Journaling stage
+      click_link "Create Journal"
+
+      expect(page).to have_content("OD ##{order_details.first.order_number}")
+      expect(page).to have_content("OD ##{order_details.second.order_number}")
+    end
+  end
+
+end


### PR DESCRIPTION
Part of a larger replacement of `_with_search` with `TransactionSearch::SearchForm`/`TransactionSearch::Searcher`

This is half the story. The other half will be the "Orders in Review" (though the new feature spec does start to cover that piece)