### PR TITLE
[#140401] Replace orders in review with new search

### DIFF
--- a/app/controllers/facility_notifications_controller.rb
+++ b/app/controllers/facility_notifications_controller.rb
@@ -56,11 +56,15 @@ class FacilityNotificationsController < ApplicationController
   end
 
   # GET /facilities/notifications/in_review
-  def in_review_with_search
-    @order_details = @order_details.in_review
-    @order_details = @order_details.reorder(:reviewed_at)
+  def in_review
+    order_details = current_facility.order_details.in_review.reorder(:reviewed_at)
+
+    @search_form = TransactionSearch::SearchForm.new(params[:search])
+    @search = TransactionSearch::Searcher.new.search(order_details, @search_form)
+    @date_range_field = @search_form.date_params[:field]
+    @order_details = @search.order_details
+
     @order_detail_action = :mark_as_reviewed
-    order_details_sort(:reviewed_at)
     @extra_date_column = :reviewed_at
   end
 

--- a/app/controllers/facility_notifications_controller.rb
+++ b/app/controllers/facility_notifications_controller.rb
@@ -27,7 +27,7 @@ class FacilityNotificationsController < ApplicationController
     order_details = OrderDetail.need_notification.for_facility(current_facility)
 
     @search_form = TransactionSearch::SearchForm.new(params[:search])
-    @search = TransactionSearch::Searcher.new.search(order_details, @search_form)
+    @search = TransactionSearch::Searcher.search(order_details, @search_form)
     @date_range_field = @search_form.date_params[:field]
     @order_details = @search.order_details
 
@@ -60,7 +60,7 @@ class FacilityNotificationsController < ApplicationController
     order_details = current_facility.order_details.in_review.reorder(:reviewed_at)
 
     @search_form = TransactionSearch::SearchForm.new(params[:search])
-    @search = TransactionSearch::Searcher.new.search(order_details, @search_form)
+    @search = TransactionSearch::Searcher.search(order_details, @search_form)
     @date_range_field = @search_form.date_params[:field]
     @order_details = @search.order_details
 

--- a/app/views/facility_notifications/in_review.html.haml
+++ b/app/views/facility_notifications/in_review.html.haml
@@ -5,11 +5,11 @@
 = content_for :h2 do
   %h2= t(".head")
 = content_for :top_block do
-  = render :partial => 'shared/transactions/top', :locals => { :tab => "in_review" }
+  = render "shared/transactions/top2", tab: "in_review"
 
 - if @order_details.any?
   = content_for :action_instructions do
     %p.alert.alert-info= t(".instructions")
 
-  = render :partial => 'shared/transactions/table'
-  = render :partial => 'shared/reconcile_footnote'
+  = render "shared/transactions/table"
+  = render "shared/reconcile_footnote"

--- a/app/views/facility_notifications/in_review.html.haml
+++ b/app/views/facility_notifications/in_review.html.haml
@@ -13,3 +13,5 @@
 
   = render "shared/transactions/table"
   = render "shared/reconcile_footnote"
+- else
+  %p.alert.alert-info= text("facility_notifications.in_review.no_orders")

--- a/spec/controllers/facility_notifications_controller_spec.rb
+++ b/spec/controllers/facility_notifications_controller_spec.rb
@@ -1,6 +1,5 @@
 require "rails_helper"
 require "controller_spec_helper"
-require "transaction_search_spec_helper"
 
 RSpec.describe FacilityNotificationsController do
 
@@ -173,12 +172,6 @@ RSpec.describe FacilityNotificationsController do
         expect(assigns(:order_details) - [@order_detail1, @order_detail3]).to be_empty
         expect(assigns(:order_detail_action)).to eq(:mark_as_reviewed)
         is_expected.not_to set_flash
-      end
-
-      context "searching" do
-        before { @user = @admin }
-
-        it_should_support_searching
       end
     end
 


### PR DESCRIPTION
Extends from #1399 to replace the Orders in Review search/filtering.

Clean diff https://github.com/tablexi/nucore-open/compare/send_notifications_replace_searcher...replace_orders_in_review_with_new_search_140401?expand=1