### PR TITLE
handle strong params for facility facility accounts sections

### DIFF
--- a/app/controllers/facility_facility_accounts_controller.rb
+++ b/app/controllers/facility_facility_accounts_controller.rb
@@ -57,7 +57,7 @@ class FacilityFacilityAccountsController < ApplicationController
   private
 
   def facility_facility_account_params
-    params.require(:facility_account).permit(:revenue_account, :account_number, :is_active)
+    params.require(:facility_account).permit(:revenue_account, :account_number, :is_active, account_number_parts: FacilityAccount.account_number_field_names)
   end
 
 end


### PR DESCRIPTION
Northwestern and Dartmouth both have fork-specific `account_number_fields` (overriding AccountNumberSectionable) that need to be included in strong params.