### PR TITLE
[#137156] Redirect to In Review after disputing

### DIFF
--- a/app/controllers/order_details_controller.rb
+++ b/app/controllers/order_details_controller.rb
@@ -21,10 +21,10 @@ class OrderDetailsController < ApplicationController
   # Put /orders/:order_id/order_details/:id
   def update
     if @order_detail.update_attributes(order_detail_params)
-      flash[:notice] = I18n.t("order_details.update.success")
+      flash[:notice] = text("update.success")
       redirect_to action: :show
     else
-      flash.now[:error] = I18n.t("order_details.update.failure")
+      flash.now[:error] = text("update.error")
       render :edit
     end
   end
@@ -35,9 +35,9 @@ class OrderDetailsController < ApplicationController
     if @order_detail.reservation && @order_detail.reservation.can_cancel?
       @order_detail.transaction do
         if @order_detail.cancel_reservation(session_user)
-          flash[:notice] = "The reservation has been canceled successfully." # TODO: I18n
+          flash[:notice] = text("cancel.success") # TODO: I18n
         else
-          flash[:error] = "An error was encountered while canceling the order." # TODO: I18n
+          flash[:error] = text("cancel.error")
           raise ActiveRecord::Rollback
         end
       end
@@ -57,11 +57,11 @@ class OrderDetailsController < ApplicationController
         @order_detail.dispute_at = Time.zone.now
         @order_detail.dispute_by = current_user
         @order_detail.save!
-        flash[:notice] = "Your purchase has been disputed" # TODO: I18n
-        return_path = @order_detail.reservation ? reservations_path : orders_path
-        redirect_to return_path
+        flash[:notice] = text("dispute.success")
+
+        redirect_to transactions_in_review_path
       rescue => e # TODO: be more specific about what Exceptions to rescue
-        flash.now[:error] = "An error was encountered while disputing the order." # TODO: I18n
+        flash.now[:error] = text("dispute.error")
         @order_detail.dispute_at = nil # manually set this because rollback doesn't reset the unsaved value
         @order_detail.send(:extend, PriceDisplayment)
         render :show

--- a/app/controllers/order_details_controller.rb
+++ b/app/controllers/order_details_controller.rb
@@ -35,7 +35,7 @@ class OrderDetailsController < ApplicationController
     if @order_detail.reservation && @order_detail.reservation.can_cancel?
       @order_detail.transaction do
         if @order_detail.cancel_reservation(session_user)
-          flash[:notice] = text("cancel.success") # TODO: I18n
+          flash[:notice] = text("cancel.success")
         else
           flash[:error] = text("cancel.error")
           raise ActiveRecord::Rollback

--- a/app/services/transaction_search/searcher.rb
+++ b/app/services/transaction_search/searcher.rb
@@ -24,6 +24,11 @@ module TransactionSearch
       ]
     end
 
+    # Shorthand method if you only want the default searchers
+    def self.search(order_details, params)
+      new.search(order_details, params)
+    end
+
     # Expects an array of `TransactionSearch::BaseSearcher`s
     def initialize(*searchers)
       searchers = self.class.default_searchers if searchers.blank?

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -90,6 +90,17 @@ en:
         success: The downtime note has been updated
         error: An error occurred while attempting to update the downtime note
 
+    order_details:
+      cancel:
+        success: The reservation has been canceled successfully
+        error: An error was encountered while canceling the order
+      dispute:
+        success: Your purchase has been disputed
+        error: An error was encountered while disputing the order
+      update:
+        success: The order has been updated
+        error: There was a problem updating the order
+
     order_management:
       order_details:
         remove_from_journal:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -668,9 +668,6 @@ en:
   order_details:
     edit:
       failure: This order is not currently editable.
-    update:
-      success: "The order has been updated"
-      failure: "There was a problem updating the order"
     show:
       head:
         h1: "Order #%{order_number}"

--- a/spec/features/disputing_an_order_spec.rb
+++ b/spec/features/disputing_an_order_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Disputing an order" do
+  let(:item) { create(:setup_item) }
+  let(:owner) { create(:user) }
+  let(:account) { create(:account, :with_account_owner, owner: owner) }
+  let(:order) { create(:complete_order, product: item, account: account) }
+  let(:order_detail) { order.order_details.first }
+
+  before do
+    order_detail.update(reviewed_at: 1.week.from_now)
+  end
+
+  it "can dispute an order" do
+    login_as owner
+    visit accounts_path
+    click_link "You have one transaction in review"
+
+    click_link "Dispute"
+    fill_in "Dispute Reason", with: "It's bad"
+    click_button "Dispute"
+
+    expect(page).to have_content("Your purchase has been disputed")
+    expect(current_path).to eq(transactions_in_review_path)
+  end
+
+end


### PR DESCRIPTION
After a BA or account owner goes in to the Transactions in Review page
and they dispute an order, they should be returned to Transactions in
Review rather than the My Orders/My Reservations page.

Also I18n the controller flashes