### PR TITLE
[#140451] Upgrade LDAP gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,8 +23,8 @@ PATH
   remote: vendor/engines/ldap_authentication
   specs:
     ldap_authentication (0.0.1)
-      devise_ldap_authenticatable (~> 0.8.5)
-      rails (~> 4.2.9)
+      devise_ldap_authenticatable (>= 0.8.6)
+      rails (>= 4.2)
 
 PATH
   remote: vendor/engines/projects
@@ -220,9 +220,9 @@ GEM
       warden (~> 1.2.3)
     devise-encryptable (0.2.0)
       devise (>= 2.1.0)
-    devise_ldap_authenticatable (0.8.5)
+    devise_ldap_authenticatable (0.8.6)
       devise (>= 3.4.1)
-      net-ldap (>= 0.6.0, <= 0.11)
+      net-ldap (>= 0.16.0)
     devise_saml_authenticatable (1.3.2)
       devise (> 2.0.0)
       ruby-saml (~> 1.3)
@@ -375,7 +375,7 @@ GEM
       coffee-rails (>= 3.2.1)
       jquery-rails
       rails (>= 3.2.0)
-    net-ldap (0.11)
+    net-ldap (0.16.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)

--- a/vendor/engines/ldap_authentication/ldap_authentication.gemspec
+++ b/vendor/engines/ldap_authentication/ldap_authentication.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", "~> 4.2.9"
-  s.add_dependency "devise_ldap_authenticatable", "~> 0.8.5"
+  s.add_dependency "rails", ">= 4.2"
+  s.add_dependency "devise_ldap_authenticatable", ">= 0.8.6"
 end

--- a/vendor/engines/ldap_authentication/ldap_authentication.gemspec
+++ b/vendor/engines/ldap_authentication/ldap_authentication.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", ">= 4.2"
   s.add_dependency "devise_ldap_authenticatable", ">= 0.8.6"
+  s.add_dependency "rails", ">= 4.2"
 end


### PR DESCRIPTION
Upgrade devise_ldap_authenticatable which in turn upgrades net-ldap

https://github.com/cschiewek/devise_ldap_authenticatable/issues/242

```
Known vulnerability found
CVE-2017-17718
Moderate severity
The Net::LDAP (aka net-ldap) gem before 0.16.0 for Ruby has Missing SSL Certificate Validation.

Gemfile.lock update suggested:
net-ldap ~> 0.16.0
```