### PR TITLE
[#140459] Fix display when no transactions on All Transactions

### DIFF
--- a/app/views/facilities/transactions.html.haml
+++ b/app/views/facilities/transactions.html.haml
@@ -8,4 +8,6 @@
 = content_for :top_block do
   = render "shared/transactions/top2", tab: "transactions"
 - if @order_details.any?
-  = render partial: "shared/transactions/table"
+  = render "shared/transactions/table"
+- else
+  %p.alert.alert-info= text("facilities.transactions.no_orders")

--- a/app/views/shared/transactions/_top2.html.haml
+++ b/app/views/shared/transactions/_top2.html.haml
@@ -2,9 +2,5 @@
   .span3
     #sidebar
       = render "admin/shared/sidenav_billing", sidenav_tab: tab
-  - if @order_details.none?
-    .span9
-      %p.alert.alert-info= text("#{controller_name}.#{action_name}.no_orders")
-  - else
-    .span9
-      = render "shared/transactions/search2"
+  .span9
+    = render "shared/transactions/search2"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -855,7 +855,7 @@ en:
       submit: "Reassign Chart String"
 
     transactions:
-      no_orders: There are no orders in this !facility_downcase!
+      no_orders: There are no orders in this !facility_downcase! matching the search parameters
 
   nufs_account:
     account_fields:


### PR DESCRIPTION
Broken by #1390, if there were no transactions matching the default
search on All Transactions (fulfilled since the beginning of last
month), the search form was not rendering.

Now, we will always render the form. This means the form might have no
values in any of the selects, but that should only happen until the
facility gets its first order.

![screen shot 2018-02-16 at 1 32 38 pm](https://user-images.githubusercontent.com/1099111/36325615-ff730978-131d-11e8-866e-b2d0c0ecb858.png)
![screen shot 2018-02-16 at 1 32 19 pm](https://user-images.githubusercontent.com/1099111/36325616-ff868980-131d-11e8-9c4a-3280b24a0875.png)
