### PR TITLE
Support transaction search with strong params enabled

### DIFF
--- a/app/forms/transaction_search/search_form.rb
+++ b/app/forms/transaction_search/search_form.rb
@@ -17,7 +17,7 @@ module TransactionSearch
       # everything needed, even if the provided defaults are missing one of our
       # defaults.
       full_defaults = defaults.reverse_merge(default_params)
-      super(params.to_h.reverse_merge(full_defaults))
+      super(Hash(params).reverse_merge(full_defaults))
     end
 
     def [](field)


### PR DESCRIPTION
With strong params enabled, `to_h` will return a hash with only
permitted parameters included. We were using `to_h` to support `nil`,
i.e. `nil.to_h => {}`.

```
Hash({}) == {}
Hash(nil) == {}
Hash(normal_hash) == normal_hash
Hash(strong_params) == strong_params
```