### PR TITLE
[#121458] Fix admin ability to edit past reservations in cart

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -263,7 +263,9 @@ class ReservationsController < ApplicationController
       :actual_start_meridian,
     )
 
-    reservation_params.merge!(reservation_start_as_params) if fixed_start_time?
+    # If the start time is locked (only after purchase, don't allow the params
+    # to override the existing values)
+    reservation_params.merge!(reservation_start_as_params) if fixed_start_time? && !@reservation.in_cart?
 
     reservation_params
   end
@@ -333,7 +335,7 @@ class ReservationsController < ApplicationController
   end
 
   def editable_by_current_user?
-    if current_user.administrator? && @reservation.admin_editable?
+    if current_ability.can?(:manage, @reservation) && @reservation.admin_editable?
       true
     elsif @reservation.can_customer_edit?
       true

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -7,6 +7,7 @@ class ReservationsController < ApplicationController
   before_action :check_acting_as, only: [:switch_instrument, :list]
   before_action :load_basic_resources, only: [:new, :create, :edit, :update]
   before_action :load_and_check_resources, only: [:move, :switch_instrument]
+  authorize_resource only: [:edit, :update, :move]
 
   include TranslationHelper
   include FacilityReservationsHelper
@@ -97,6 +98,7 @@ class ReservationsController < ApplicationController
     creator = ReservationCreator.new(@order, @order_detail, params)
     if creator.save(session_user)
       @reservation = creator.reservation
+      authorize! :create, @reservation
       flash[:notice] = I18n.t "controllers.reservations.create.success"
       flash[:error] = I18n.t('controllers.reservations.create.admin_hold_warning') if creator.reservation.conflicting_admin_reservation?
 
@@ -126,6 +128,10 @@ class ReservationsController < ApplicationController
     options = current_user.can_override_restrictions?(@instrument) ? {} : { user: acting_user }
     next_available = @instrument.next_available_reservation(after: 1.minute.from_now, duration: default_reservation_mins.minutes, options: options)
     @reservation = next_available || default_reservation
+    @reservation.order_detail = @order_detail
+
+    authorize! :new, @reservation
+
     @reservation.round_reservation_times
     unless @instrument.can_be_used_by?(@order_detail.user)
       flash[:notice] = text(".acting_as_not_on_approval_list")
@@ -138,6 +144,7 @@ class ReservationsController < ApplicationController
     @order        = Order.find(params[:order_id])
     @order_detail = @order.order_details.find(params[:order_detail_id])
     @reservation  = Reservation.find(params[:id])
+    authorize! :show, @reservation
 
     raise ActiveRecord::RecordNotFound if @reservation != @order_detail.reservation
 

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -263,8 +263,9 @@ class ReservationsController < ApplicationController
       :actual_start_meridian,
     )
 
-    # If the start time is locked (only after purchase, don't allow the params
-    # to override the existing values)
+    # Prevent overriding of start time params after purchase if start time is locked,
+    # e.g. you are in the lock window or the reservation has already started and
+    # you are only allowed to extend the reservation.
     reservation_params.merge!(reservation_start_as_params) if fixed_start_time? && !@reservation.in_cart?
 
     reservation_params

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -66,11 +66,11 @@ module DateHelper
     Time.zone.at((time.to_f / precision).floor * precision)
   end
 
-  def time_select_tag(field, default_time = Time.zone.now)
+  def time_select_tag(field, default_time = Time.zone.now, html_options = {})
     output = ""
-    output << select_tag("#{field}[hour]", options_for_select(hour_options, default_time.strftime("%I").to_i))
-    output << select_tag("#{field}[minute]", options_for_select(minute_options, default_time.min))
-    output << select_tag("#{field}[ampm]", options_for_select(%w(AM PM), default_time.strftime("%p")))
+    output << select_tag("#{field}[hour]", options_for_select(hour_options, default_time.strftime("%I").to_i), html_options)
+    output << select_tag("#{field}[minute]", options_for_select(minute_options, default_time.min), html_options)
+    output << select_tag("#{field}[ampm]", options_for_select(%w(AM PM), default_time.strftime("%p")), html_options)
     output.html_safe
   end
 

--- a/app/views/orders/_edit_date.html.haml
+++ b/app/views/orders/_edit_date.html.haml
@@ -8,20 +8,23 @@
     = f.input :order_date,
       input_html: { value: params[:order_date] || format_usa_date(default_time),
           class: "datepicker__data",
-          data: { max_date: Time.current.iso8601 } }
+          data: { max_date: Time.current.iso8601 } },
+          disabled: true
 
     = label_tag :order_time
-    .time-select= time_select_tag :order_time, params[:order_datetime] || default_time
+    .time-select= time_select_tag :order_time, params[:order_datetime] || default_time, disabled: true
 
     = f.input :order_status_id,
       collection: @order_statuses,
       label_method: :name_with_level,
       selected:  params[:order_status_id] || @order_statuses.first.try(:id),
-      label: OrderDetail.human_attribute_name(:order_status)
+      label: OrderDetail.human_attribute_name(:order_status),
+      disabled: true
 
     = f.input :send_notification,
       as: :boolean,
       input_html: { value: 1 },
       default: params[:send_notification],
       label: false,
-      inline_label: true
+      inline_label: true,
+      disabled: true

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -219,11 +219,13 @@ class Ability
       # TODO: Add :accessory hash back in to hide hidden accessories from non-admin users
       # See task #55479
       can :read, ProductAccessory # , :accessory => { :is_hidden => false }
+
       if user.operator_of?(resource.product.facility)
         can :read, ProductAccessory
         can :manage, Reservation
+      elsif resource.order.try(:user_id) == user.id
+        can [:read, :create, :update, :destroy, :start_stop, :move], Reservation
       end
-      can :start_stop, Reservation if resource.order.try(:user_id) == user.id
 
     elsif resource.is_a?(TrainingRequest)
       can :create, TrainingRequest

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -877,59 +877,8 @@ RSpec.describe ReservationsController do
       end
     end
 
-    describe "#edit" do
-      before(:each) do
-        @method = :get
-        @action = :edit
-        @params.merge!(id: reservation.id)
-      end
-
-      it_should_allow_all facility_users do
-        expect(assigns[:reservation]).to eq(reservation)
-        expect(assigns[:order_detail]).to eq(reservation.order_detail)
-        expect(assigns[:order]).to eq(reservation.order_detail.order)
-        is_expected.to respond_with :success
-      end
-
-      context "when the reservation is canceled" do
-        before(:each) do
-          reservation.order_detail.update_attributes(canceled_at: 1.day.ago)
-          sign_in @admin
-          do_request
-        end
-
-        it "redirects to the show page" do
-          expect(response).to redirect_to([order, order_detail, reservation])
-        end
-      end
-
-      context "when the reservation is in the past" do
-        before(:each) do
-          reservation.reserve_start_at = 24.hours.ago
-          reservation.reserve_end_at = 23.hours.ago
-          reservation.save(validate: false)
-        end
-
-        context "when the user is an admin" do
-          before(:each) do
-            sign_in @admin
-            do_request
-          end
-
-          it { expect(response.response_code).to eq(200) }
-        end
-
-        context "when the user is not an admin" do
-          before(:each) do
-            maybe_grant_always_sign_in(:staff)
-            do_request
-          end
-
-          it { expect(response.response_code).to eq(302) }
-        end
-      end
-    end
-
+    # Many happy paths are tested in features purchasing_a_reservation,
+    # editing_a_reservation, and purchasing_a_reservation_on_behalf_of
     describe "#update" do
       before(:each) do
         @method = :put
@@ -944,23 +893,6 @@ RSpec.describe ReservationsController do
             duration_mins: "60",
           },
         )
-      end
-
-      it_should_allow_all facility_users, "to update reservation" do
-        expect(assigns[:order]).to eq(order)
-        expect(assigns[:order_detail]).to eq(order_detail)
-        expect(assigns[:instrument]).to eq(instrument)
-        expect(assigns[:reservation]).to be_valid
-        expect(assigns[:reservation]).not_to be_changed
-
-        expect(reservation.reload.reserve_start_hour).to eq(10)
-        expect(reservation.reserve_end_hour).to eq(11)
-        expect(reservation.duration_mins).to eq(60)
-        expect(assigns[:order_detail].estimated_cost).to be_present
-        expect(assigns[:order_detail].estimated_subsidy).to be_present
-
-        is_expected.to set_flash
-        assert_redirected_to cart_url
       end
 
       describe "updating the note" do

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -921,7 +921,7 @@ RSpec.describe ReservationsController do
 
         context "when the user is not an admin" do
           before(:each) do
-            sign_in @staff
+            maybe_grant_always_sign_in(:staff)
             do_request
           end
 
@@ -1005,7 +1005,7 @@ RSpec.describe ReservationsController do
       describe "when trying to update a running reservation" do
         context "as staff" do
           before(:each) do
-            sign_in @staff
+            maybe_grant_always_sign_in(:staff)
             reservation.update_attribute(:actual_start_at, @start.to_date)
           end
 

--- a/spec/features/placing_an_order_on_behalf_of_spec.rb
+++ b/spec/features/placing_an_order_on_behalf_of_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe "Placing an item order" do
+  let!(:product) { FactoryBot.create(:setup_item) }
+  let!(:account) { FactoryBot.create(:nufs_account, :with_account_owner, owner: user) }
+  let(:facility) { product.facility }
+  let!(:price_policy) do
+    FactoryBot.create(:item_price_policy,
+                      price_group: PriceGroup.base,
+                      product: product,
+                      unit_cost: 33.25,
+                      start_date: 2.days.ago)
+  end
+  let!(:account_price_group_member) do
+    FactoryBot.create(:account_price_group_member, account: account, price_group: price_policy.price_group)
+  end
+  let(:user) { FactoryBot.create(:user) }
+  let(:facility_admin) { FactoryBot.create(:user, :facility_administrator, facility: facility) }
+
+  before do
+    login_as facility_admin
+    visit facility_users_path(facility)
+    fill_in "search_term", with: user.email
+    click_button "Search"
+    click_link "Order For"
+  end
+
+  it "can place an order" do
+    visit facility_path(facility)
+    click_link product.name
+    click_link "Add to cart"
+    choose account.to_s
+    click_button "Continue"
+
+    click_button "Purchase"
+    expect(page).to have_content "Order Receipt"
+    expect(page).to have_content "Ordered For#{user.full_name}"
+    expect(page).to have_content "$33.25"
+  end
+
+  it "can backdate an order", :js do # js needed for More options expansion
+    visit facility_path(facility)
+    click_link product.name
+    click_link "Add to cart"
+    choose account.to_s
+    click_button "Continue"
+
+    find("label", text: "More options").click
+    fill_in "Order date", with: I18n.l(2.days.ago.to_date, format: :usa)
+    select "Complete", from: "Order Status"
+
+    click_button "Purchase"
+
+    expect(page).to have_content "Order Receipt"
+    expect(page).to have_content "Ordered For #{user.full_name}"
+    expect(page).to have_css(".currency .estimated_cost", count: 0)
+    expect(page).to have_css(".currency .actual_cost", count: 2) # Cost and Total
+  end
+end

--- a/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
+++ b/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
       expect(page).to have_content("#{1.day.from_now.strftime('%m/%d/%Y')} 11:00 AM - 12:30 PM")
     end
 
-    xit "can modify a reservation in the past" do
+    it "can modify a reservation in the past" do
       fill_in "order[order_details][][quantity]", with: "2"
       click_button "Create Order"
       choose account.to_s

--- a/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
+++ b/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
@@ -111,6 +111,28 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
       expect(page).to have_css(".currency .actual_cost", count: 4) # Cost and Total x 2 orders
     end
 
+    it "can modify a reservation in the future" do
+      fill_in "order[order_details][][quantity]", with: "2"
+      click_button "Create Order"
+      choose account.to_s
+      click_button "Continue"
+
+      click_link "Make a Reservation", match: :first
+      fill_in "Reserve Start", with: I18n.l(1.day.from_now.to_date, format: :usa)
+      select "10", from: "reservation[reserve_start_hour]"
+      select "00", from: "reservation[reserve_start_min]"
+      fill_in "Duration", with: "90"
+      click_button "Create"
+
+      reservation_time = "#{1.day.from_now.strftime('%m/%d/%Y')} 10:00 AM - 11:30 AM"
+      expect(page).to have_content(reservation_time)
+      click_link reservation_time
+
+      select "11", from: "reservation[reserve_start_hour]"
+      click_button "Save"
+      expect(page).to have_content("#{1.day.from_now.strftime('%m/%d/%Y')} 11:00 AM - 12:30 PM")
+    end
+
     xit "can modify a reservation in the past" do
       fill_in "order[order_details][][quantity]", with: "2"
       click_button "Create Order"
@@ -124,13 +146,13 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
       fill_in "Duration", with: "90"
       click_button "Create"
 
-      reservation_time = "#{1.day.ago.strftime("%m/%d/%Y")} 10:00 AM - 11:30 AM"
+      reservation_time = "#{1.day.ago.strftime('%m/%d/%Y')} 10:00 AM - 11:30 AM"
       expect(page).to have_content(reservation_time)
       click_link reservation_time
 
       select "11", from: "reservation[reserve_start_hour]"
-      click_button "Update"
-      expect(page).to have_content("#{1.day.ago.strftime("%m/%d/%Y")} 11:00 AM - 12:30 PM")
+      click_button "Save"
+      expect(page).to have_content("#{1.day.ago.strftime('%m/%d/%Y')} 11:00 AM - 12:30 PM")
     end
   end
 end

--- a/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
+++ b/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
   let!(:instrument) { FactoryBot.create(:setup_instrument) }
   let!(:facility) { instrument.facility }
   let!(:account) { FactoryBot.create(:nufs_account, :with_account_owner, owner: user) }
-  let!(:price_policy) { FactoryBot.create(:instrument_price_policy, price_group: PriceGroup.base, product: instrument) }
+  let!(:price_policy) { FactoryBot.create(:instrument_price_policy, price_group: PriceGroup.base, product: instrument, start_date: 2.days.ago) }
   let(:user) { FactoryBot.create(:user) }
   let(:facility_admin) { FactoryBot.create(:user, :facility_administrator, facility: facility) }
   let!(:account_price_group_member) do
@@ -13,6 +13,7 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
   end
 
   before do
+    facility.update(accepts_multi_add: true)
     login_as facility_admin
     visit facility_users_path(facility)
     fill_in "search_term", with: user.email
@@ -62,6 +63,74 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
         expect(page).to have_content "10:00 AM - 11:30 AM"
       end
     end
+  end
 
+  describe "creating multiple reservations" do
+    it "can create reservations in the future" do
+      fill_in "order[order_details][][quantity]", with: "2"
+      click_button "Create Order"
+      choose account.to_s
+      click_button "Continue"
+
+      click_link "Make a Reservation", match: :first
+      fill_in "Reserve Start", with: I18n.l(1.day.from_now.to_date, format: :usa)
+      click_button "Create"
+
+      all(:link, "Make a Reservation").last.click
+      fill_in "Reserve Start", with: I18n.l(2.days.from_now.to_date, format: :usa)
+      click_button "Create"
+
+      click_button "Purchase"
+
+      expect(page).to have_content "Order Receipt"
+      expect(page).to have_css(".currency .estimated_cost", count: 4) # Cost and Total x 2 orders
+      expect(page).to have_css(".currency .actual_cost", count: 0)
+    end
+
+    it "can create reservations in the past" do
+      fill_in "order[order_details][][quantity]", with: "2"
+      click_button "Create Order"
+      choose account.to_s
+      click_button "Continue"
+
+      click_link "Make a Reservation", match: :first
+      fill_in "Reserve Start", with: I18n.l(1.day.ago.to_date, format: :usa)
+      click_button "Create"
+
+      all(:link, "Make a Reservation").last.click
+      fill_in "Reserve Start", with: I18n.l(2.days.ago.to_date, format: :usa)
+      click_button "Create"
+
+      # this would normally be hidden and the default would be to complete backdated
+      # reservations. This might change in #121458
+      select "Complete", from: "Order Status"
+      click_button "Purchase"
+
+      expect(page).to have_content "Order Receipt"
+      expect(page).to have_css(".currency .estimated_cost", count: 0)
+      expect(page).to have_css(".currency .actual_cost", count: 4) # Cost and Total x 2 orders
+    end
+
+    xit "can modify a reservation in the past" do
+      fill_in "order[order_details][][quantity]", with: "2"
+      click_button "Create Order"
+      choose account.to_s
+      click_button "Continue"
+
+      click_link "Make a Reservation", match: :first
+      fill_in "Reserve Start", with: I18n.l(1.day.ago.to_date, format: :usa)
+      select "10", from: "reservation[reserve_start_hour]"
+      select "00", from: "reservation[reserve_start_min]"
+      fill_in "Duration", with: "90"
+      click_button "Create"
+
+      reservation_time = "#{1.day.ago.strftime("%m/%d/%Y")} 10:00 AM - 11:30 AM"
+      expect(page).to have_content(reservation_time)
+      click_link reservation_time
+
+      select "11", from: "reservation[reserve_start_hour]"
+      click_button "Update"
+      expect(page).to have_content("#{1.day.ago.strftime("%m/%d/%Y")} 11:00 AM - 12:30 PM")
+    end
   end
 end

--- a/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
+++ b/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
@@ -101,9 +101,6 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
       fill_in "Reserve Start", with: I18n.l(2.days.ago.to_date, format: :usa)
       click_button "Create"
 
-      # this would normally be hidden and the default would be to complete backdated
-      # reservations. This might change in #121458
-      select "Complete", from: "Order Status"
       click_button "Purchase"
 
       expect(page).to have_content "Order Receipt"

--- a/spec/features/purchasing_a_reservation_spec.rb
+++ b/spec/features/purchasing_a_reservation_spec.rb
@@ -148,29 +148,5 @@ RSpec.describe "Purchasing a reservation" do
       click_button "Create"
       expect(page).to have_content("Reserve start at must be in the future")
     end
-
-    it "can place a reservation, but then if they wait a long time cannot edit it" do
-      pending "you currently can do this, but probably should not be able to"
-
-      click_link "Make a Reservation", match: :first
-      # Currently 9:30am
-      select "10", from: "reservation[reserve_start_hour]"
-      select "00", from: "reservation[reserve_start_min]"
-      fill_in "Duration", with: "90"
-      click_button "Create"
-
-      travel_to 3.hours.from_now do
-        reservation_time = "#{Time.current.strftime('%m/%d/%Y')} 10:00 AM - 11:30 AM"
-        click_link reservation_time
-        click_button "Save"
-
-        all(:link, "Remove")[1].click
-        click_button "Purchase"
-
-        expect(page).to have_content("must be in the future")
-
-      end
-    end
   end
-
 end

--- a/spec/features/purchasing_a_reservation_spec.rb
+++ b/spec/features/purchasing_a_reservation_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Purchasing a reservation" do
   end
 
   before do
+    facility.update(accepts_multi_add: true)
     login_as user
     visit root_path
     click_link facility.name
@@ -111,6 +112,65 @@ RSpec.describe "Purchasing a reservation" do
       end
     end
 
+  end
+
+  describe "ordering on an order form" do
+    before do
+      fill_in "order[order_details][][quantity]", with: "2"
+      click_button "Create Order"
+      choose account.to_s
+      click_button "Continue"
+    end
+
+    it "can place a reservation in the future and then edit it" do
+      click_link "Make a Reservation", match: :first
+      fill_in "Reserve Start", with: I18n.l(1.day.from_now.to_date, format: :usa)
+      select "10", from: "reservation[reserve_start_hour]"
+      select "00", from: "reservation[reserve_start_min]"
+      fill_in "Duration", with: "90"
+      click_button "Create"
+
+      reservation_time = "#{1.day.from_now.strftime('%m/%d/%Y')} 10:00 AM - 11:30 AM"
+      expect(page).to have_content(reservation_time)
+      click_link reservation_time
+
+      select "11", from: "reservation[reserve_start_hour]"
+      click_button "Save"
+      expect(page).to have_content("#{1.day.from_now.strftime('%m/%d/%Y')} 11:00 AM - 12:30 PM")
+    end
+
+    it "cannot place a reservtion in the past" do
+      click_link "Make a Reservation", match: :first
+      fill_in "Reserve Start", with: I18n.l(1.day.ago.to_date, format: :usa)
+      select "10", from: "reservation[reserve_start_hour]"
+      select "00", from: "reservation[reserve_start_min]"
+      fill_in "Duration", with: "90"
+      click_button "Create"
+      expect(page).to have_content("Reserve start at must be in the future")
+    end
+
+    it "can place a reservation, but then if they wait a long time cannot edit it" do
+      pending "you currently can do this, but probably should not be able to"
+
+      click_link "Make a Reservation", match: :first
+      # Currently 9:30am
+      select "10", from: "reservation[reserve_start_hour]"
+      select "00", from: "reservation[reserve_start_min]"
+      fill_in "Duration", with: "90"
+      click_button "Create"
+
+      travel_to 3.hours.from_now do
+        reservation_time = "#{Time.current.strftime('%m/%d/%Y')} 10:00 AM - 11:30 AM"
+        click_link reservation_time
+        click_button "Save"
+
+        all(:link, "Remove")[1].click
+        click_button "Purchase"
+
+        expect(page).to have_content("must be in the future")
+
+      end
+    end
   end
 
 end


### PR DESCRIPTION
To reproduce old issue:
* On a facility with an order form
* Order on behalf of another user
* Add "2" of an instrument to the cart
* "Create Reservation" on the other to the future. Click on the time to get to the edit page and change the start time. This one should have been working fine.
* "Create Reservation" on one of them to the past. 
* Click on the time. This is either not editable (if you're a director/staff), or if you're a global admin changing the start time would not persist.

This also adds authorizations for the reservation controller. Previously, you could copy a link, sign in as another user and still access the pages.