### PR TITLE
Fix display of no transactions on movable transactions and send notifications

### DIFF
--- a/app/views/facilities/movable_transactions.html.haml
+++ b/app/views/facilities/movable_transactions.html.haml
@@ -12,3 +12,5 @@
 - if @order_details.present?
   = render "shared/transactions/table"
   = render "shared/reconcile_footnote"
+- else
+  %p.alert.alert-info= text("facilities.movable_transactions.no_orders")

--- a/app/views/facility_notifications/index.html.haml
+++ b/app/views/facility_notifications/index.html.haml
@@ -10,6 +10,5 @@
 - if @order_details.any?
   = render :partial => 'shared/transactions/table'
   = render :partial => 'shared/reconcile_footnote'
-
-
-
+- else
+  %p.alert.alert-info= text("facility_notifications.index.no_orders")


### PR DESCRIPTION
We changed how no transactions displayed in #1411. This broke the outstanding
PRs of #1399 and #1402