### PR TITLE
Remove start/stop grace from eye config

### DIFF
--- a/config/eye.yml.erb.template
+++ b/config/eye.yml.erb.template
@@ -35,9 +35,7 @@ processes:
       start_command: bundle exec unicorn -E deployment -Dc config/unicorn/<%= rails_env %>.rb
       restart_command: "kill -USR2 {PID}"
       start_timeout: 15 seconds
-      start_grace: 15 seconds
       restart_timeout: 15 seconds
-      restart_grace: 15 seconds
       stdout: log/unicorn.stdout.log
       stderr: log/unicorn.stderr.log
       monitor_children:
@@ -72,9 +70,7 @@ processes:
       stdall: log/delayed_job.log
       pid_file: tmp/pids/delayed_job.pid
       start_timeout: 40 seconds
-      start_grace: 30 seconds
       stop_timeout: 40 seconds
-      stop_grace: 30 seconds
       notify:
         crash: error
     checks:


### PR DESCRIPTION
These settings are not useful. They mean eye is just sitting waiting for the process to come up even after it has returned a successful exit
status.

These will go downstream to the different schools. This is just a template file. I've applied the changes on all the servers.