### PR TITLE
[#140279] clean up queries

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -231,7 +231,7 @@ class OrderDetail < ActiveRecord::Base
   end
 
   def self.unreconciled
-    where.not(state: ["reconciled"])
+    where.not(state: "reconciled")
   end
 
   def self.with_actual_costs

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -182,7 +182,7 @@ class OrderDetail < ActiveRecord::Base
   scope :with_price_policy, -> { where.not(price_policy_id: nil) }
 
   scope :not_disputed, lambda {
-    where("dispute_at IS NULL OR dispute_resolved_at IS NOT NULL")
+    where(dispute_at: nil).or(where.not(dispute_resolved_at: nil))
   }
 
   scope :need_notification, lambda {
@@ -196,7 +196,7 @@ class OrderDetail < ActiveRecord::Base
 
   def self.all_movable
     where(journal_id: nil)
-      .where("order_details.state NOT IN('canceled', 'reconciled')")
+      .where.not(state: ["ordered", "reconciled"])
   end
 
   scope :in_review, lambda {
@@ -231,15 +231,15 @@ class OrderDetail < ActiveRecord::Base
   end
 
   def self.unreconciled
-    where("order_details.state <> ?", "reconciled")
+    where.not(state: ["reconciled"])
   end
 
   def self.with_actual_costs
-    where("actual_cost IS NOT NULL")
+    where.not(actual_cost: nil)
   end
 
   def self.with_estimated_costs
-    where("estimated_cost IS NOT NULL")
+    where.not(estimated_cost: nil)
   end
 
   def can_be_viewed_by?(user)

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -59,7 +59,7 @@ class Reservation < ActiveRecord::Base
   end
 
   scope :ends_in_the_future, lambda {
-    where("reserve_end_at IS NULL OR reserve_end_at > ?", Time.current)
+    where(reserve_end_at: nil).or(where("reserve_end_at > ?", Time.current))
   }
 
   def self.joins_order

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -116,13 +116,6 @@ RSpec.describe AccountsController do
 
     it_should_deny :purchaser
 
-    it_should_allow :owner do
-      expect(assigns[:account]).to eq(@authable)
-      expect(assigns[:order_details].where_values_hash).to be_has_key("account_id")
-      expect(assigns[:order_details].where_values_hash["account_id"]).to eq(@authable.id)
-      expect(assigns[:facility]).to be_nil
-    end
-
     it "should use reviewed_at" do
       sign_in @user
       do_request


### PR DESCRIPTION
https://pm.tablexi.com/issues/140279

Cleaned up a few queries to use the `.or` operator or otherwise modernize their syntax. There weren't as many spots where it made sense to use the `or` operator as expected, in part because of the very specific parallel structure requirements--gets very messy with joins etc.