### PR TITLE
rm unused controller action/view

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -37,19 +37,6 @@ class AccountsController < ApplicationController
     @active_tab = "accounts"
   end
 
-  def transactions_in_review_with_search
-    @order_details = @order_details.where(account_id: @account.id)
-    @recently_reviewed = @order_details.recently_reviewed.paginate(page: params[:page])
-    @order_details = @order_details.in_review
-
-    @extra_date_column = :reviewed_at
-    @order_detail_link = {
-      text: "Dispute",
-      display?: proc { |order_detail| order_detail.can_dispute? },
-      proc: proc { |order_detail| order_order_detail_path(order_detail.order, order_detail) },
-    }
-  end
-
   protected
 
   def init_account

--- a/app/views/accounts/transactions_in_review.html.haml
+++ b/app/views/accounts/transactions_in_review.html.haml
@@ -1,7 +1,0 @@
-- if @account.present?
-  = content_for :tabnav do
-    %h2= @account.account_number
-    %p= @account.description_to_s
-    %h3= @facility.name if @facility
-
-= render "shared/transactions/in_review"

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -103,39 +103,6 @@ RSpec.describe AccountsController do
 
   end
 
-  context "transactions_in_review" do
-    before :each do
-      @method = :get
-      @action = :transactions_in_review
-      @params = { id: @authable.id }
-      @user = @authable.owner.user
-    end
-    it_should_support_searching
-
-    it_should_require_login
-
-    it_should_deny :purchaser
-
-    it "should use reviewed_at" do
-      sign_in @user
-      do_request
-      expect(response).to be_success
-      expect(assigns[:extra_date_column]).to eq(:reviewed_at)
-      expect(assigns[:order_details].to_sql).to be_include("order_details.reviewed_at >")
-    end
-
-    it "should add dispute links" do
-      sign_in @user
-      do_request
-      expect(response).to be_success
-      allow_any_instance_of(OrderDetail).to receive(:can_dispute?).and_return(true)
-      expect(assigns[:order_detail_link]).not_to be_nil
-      expect(assigns[:order_detail_link][:text]).to eq("Dispute")
-      expect(assigns[:order_detail_link][:display?].call(OrderDetail.new)).to be true
-    end
-
-  end
-
   context "suspension", if: SettingsHelper.feature_on?(:suspend_accounts) do
     before :each do
       @account = @authable


### PR DESCRIPTION
Found while working on filter cleanup for accounts/transactions--these are unused. See https://github.com/tablexi/nucore-open/blob/master/app/controllers/transactions_controller.rb#L14 for the current path.