### PR TITLE
[#140462] order on behalf of reservation statuses determined by dates

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -162,6 +162,8 @@ class Order < ActiveRecord::Base
     order_status = order_status.is_a?(OrderStatus) ? order_status : OrderStatus.find(order_status)
 
     order_details.each do |od|
+      next if od.reservation # reservations should always have order_status dictated by their dates
+
       if order_status.root == OrderStatus.complete
         od.backdate_to_complete!(ordered_at)
       else

--- a/app/services/order_purchaser.rb
+++ b/app/services/order_purchaser.rb
@@ -60,8 +60,8 @@ class OrderPurchaser
     end
 
     # update order detail statuses if you've changed it while acting as
-    if acting_as? && order_status_id.present?
-      backdate_order_details!(user, order_status_id)
+    if acting_as? && order_status.present?
+      backdate_order_details!(user, order_status)
     end
     complete_past_reservations!
   end
@@ -71,9 +71,6 @@ class OrderPurchaser
   end
 
   def backdate_order_details!(update_by, order_status)
-    # can accept either an order status or an id
-    order_status = order_status.is_a?(OrderStatus) ? order_status : OrderStatus.find(order_status)
-
     order.order_details.each do |od|
       next if od.reservation # reservations should always have order_status dictated by their dates
 
@@ -91,8 +88,8 @@ class OrderPurchaser
     end
   end
 
-  def order_status_id
-    params[:order_status_id]
+  def order_status
+    OrderStatus.find(params[:order_status_id]) if params[:order_status_id]
   end
 
   def order_update_params

--- a/app/services/order_purchaser.rb
+++ b/app/services/order_purchaser.rb
@@ -62,9 +62,8 @@ class OrderPurchaser
     # update order detail statuses if you've changed it while acting as
     if acting_as? && order_status_id.present?
       order.backdate_order_details!(user, order_status_id)
-    else
-      order.complete_past_reservations!
     end
+    order.complete_past_reservations!
   end
 
   def order_status_id

--- a/app/services/order_purchaser.rb
+++ b/app/services/order_purchaser.rb
@@ -55,15 +55,40 @@ class OrderPurchaser
   end
 
   def order_in_the_past!
-    unless order.can_backdate_order_details?
+    unless can_backdate_order_details?
       raise NUCore::PurchaseException.new(I18n.t("controllers.orders.purchase.future_dating_error"))
     end
 
     # update order detail statuses if you've changed it while acting as
     if acting_as? && order_status_id.present?
-      order.backdate_order_details!(user, order_status_id)
+      backdate_order_details!(user, order_status_id)
     end
-    order.complete_past_reservations!
+    complete_past_reservations!
+  end
+
+  def can_backdate_order_details?
+    order.ordered_at <= Time.zone.now
+  end
+
+  def backdate_order_details!(update_by, order_status)
+    # can accept either an order status or an id
+    order_status = order_status.is_a?(OrderStatus) ? order_status : OrderStatus.find(order_status)
+
+    order.order_details.each do |od|
+      next if od.reservation # reservations should always have order_status dictated by their dates
+
+      if order_status.root == OrderStatus.complete
+        od.backdate_to_complete!(order.ordered_at)
+      else
+        od.update_order_status!(update_by, order_status, admin: true)
+      end
+    end
+  end
+
+  def complete_past_reservations!
+    order.order_details.select { |od| od.reservation && od.reservation.reserve_end_at < Time.zone.now }.each do |od|
+      od.backdate_to_complete! od.reservation.reserve_end_at
+    end
   end
 
   def order_status_id

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -718,19 +718,15 @@ RSpec.describe OrdersController do
             expect(@order_detail.actual_cost).not_to be_nil
           end
 
-          context "canceled" do
+          context "with order status params" do
             before :each do
               @params[:order_status_id] = OrderStatus.canceled.id
               do_request
             end
 
-            it "is able to set order_detail states to canceled" do
-              expect(assigns[:order].order_details).to all(be_canceled)
-            end
-
-            it "sets the canceled time on the order_detail" do
-              assigns[:order].order_details.all? { |od| expect(od.canceled_at).not_to be_nil }
-              expect(reservation.order_detail.reload.canceled_at).not_to be_nil
+            it "does not change the reservation order detail state", :aggregate_failures do
+              expect(assigns[:order].order_details).to all(be_complete)
+              expect(assigns[:order].order_details.first.order_status).to eq OrderStatus.complete
             end
           end
         end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -31,16 +31,6 @@ RSpec.describe Order do
     expect(order).to be_new
   end
 
-  it "does not allow backdating with future dates" do
-    order.ordered_at = 1.day.from_now
-    expect(order).to_not be_can_backdate_order_details
-  end
-
-  it "does allow backdating with past dates" do
-    order.ordered_at = 1.day.ago
-    expect(order).to be_can_backdate_order_details
-  end
-
   it { is_expected.to belong_to :order_import }
 
   context "total cost" do


### PR DESCRIPTION
https://pm.tablexi.com/issues/140462

Instrument order details should always have order status determined by their dates.