### PR TITLE
[#137627] add links to 10 most recently purchased products to home page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -88,7 +88,7 @@ class ApplicationController < ActionController::Base
       when current_facility.blank?
         session_user.manageable_facilities
       when current_facility.cross_facility?
-        Facility.sorted
+        Facility.alphabetized
       else
         Facility.where(id: current_facility.id)
       end

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -31,8 +31,8 @@ class FacilitiesController < ApplicationController
 
   # GET /facilities
   def index
-    @facilities = Facility.active.sorted
-    @recently_used_facilities = MostRecentlyUsedSearcher.new(acting_user).recently_used_facilities.sorted
+    @facilities = Facility.active.alphabetized
+    @recently_used_facilities = MostRecentlyUsedSearcher.new(acting_user).recently_used_facilities.alphabetized
     @active_tab = "home"
     @recent_products = MostRecentlyUsedSearcher.new(acting_user).recently_used_products.alphabetized
     render layout: "application"
@@ -53,7 +53,7 @@ class FacilitiesController < ApplicationController
     # show list of operable facilities for current user, and admins manage all facilities
     @active_tab = "manage_facilites"
     if session_user.administrator?
-      @facilities = Facility.sorted
+      @facilities = Facility.alphabetized
       flash.now[:notice] = "No facilities have been added" if @facilities.empty?
     else
       @facilities = operable_facilities

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -32,9 +32,9 @@ class FacilitiesController < ApplicationController
   # GET /facilities
   def index
     @facilities = Facility.active.sorted
-    @recently_used_facilities = MostRecentlyUsedSearcher.new(acting_user).recently_used_facilities
+    @recently_used_facilities = MostRecentlyUsedSearcher.new(acting_user).recently_used_facilities.sorted
     @active_tab = "home"
-    @products = MostRecentlyUsedSearcher.new(acting_user).recently_used_products
+    @recent_products = MostRecentlyUsedSearcher.new(acting_user).recently_used_products.alphabetized
     render layout: "application"
   end
 

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -34,8 +34,7 @@ class FacilitiesController < ApplicationController
     @facilities = Facility.active.alphabetized
     @recently_used_facilities = MostRecentlyUsedSearcher.new(acting_user).recently_used_facilities.alphabetized
     @active_tab = "home"
-    # recent products get sorted alphabetically in the product_list partial
-    @recent_products = MostRecentlyUsedSearcher.new(acting_user).recently_used_products.includes(:facility)
+    @recent_products = MostRecentlyUsedSearcher.new(acting_user).recently_used_products.includes(:facility).alphabetized
     render layout: "application"
   end
 

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -39,7 +39,7 @@ class FacilitiesController < ApplicationController
   def index
     @facilities = Facility.active.sorted
     @active_tab = "home"
-    @products = Product.active.in_active_facility.recently_purchased
+    @products = Product.active.in_active_facility.recently_purchased(acting_user)
     render layout: "application"
   end
 

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -34,7 +34,7 @@ class FacilitiesController < ApplicationController
     @facilities = Facility.active.alphabetized
     @recently_used_facilities = MostRecentlyUsedSearcher.new(acting_user).recently_used_facilities.alphabetized
     @active_tab = "home"
-    @recent_products = MostRecentlyUsedSearcher.new(acting_user).recently_used_products.alphabetized
+    @recent_products = MostRecentlyUsedSearcher.new(acting_user).recently_used_products
     render layout: "application"
   end
 

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -35,7 +35,7 @@ class FacilitiesController < ApplicationController
     @recently_used_facilities = MostRecentlyUsedSearcher.new(acting_user).recently_used_facilities.alphabetized
     @active_tab = "home"
     # recent products get sorted alphabetically in the product_list partial
-    @recent_products = MostRecentlyUsedSearcher.new(acting_user).recently_used_products
+    @recent_products = MostRecentlyUsedSearcher.new(acting_user).recently_used_products.includes(:facility)
     render layout: "application"
   end
 

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -34,6 +34,7 @@ class FacilitiesController < ApplicationController
     @facilities = Facility.active.alphabetized
     @recently_used_facilities = MostRecentlyUsedSearcher.new(acting_user).recently_used_facilities.alphabetized
     @active_tab = "home"
+    # recent products get sorted alphabetically in the product_list partial
     @recent_products = MostRecentlyUsedSearcher.new(acting_user).recently_used_products
     render layout: "application"
   end

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -39,6 +39,7 @@ class FacilitiesController < ApplicationController
   def index
     @facilities = Facility.active.sorted
     @active_tab = "home"
+    @products = Product.active.in_active_facility.recently_purchased
     render layout: "application"
   end
 

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -28,7 +28,7 @@ module ProductsHelper
   def public_calendar_link(product)
     if product.respond_to? :reservations
       opts = public_calendar_options(product)
-      link_to "", facility_instrument_public_schedule_path(current_facility, product), opts
+      link_to "", facility_instrument_public_schedule_path( product.facility, product), opts
     end
   end
 
@@ -43,7 +43,7 @@ module ProductsHelper
   private
 
   def public_calendar_options(product)
-    if current_facility.show_instrument_availability?
+    if current_facility&.show_instrument_availability?
       public_calendar_availability_options(product)
     else
       { class: ["fa fa-calendar fa-2x"],

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -43,7 +43,7 @@ module ProductsHelper
   private
 
   def public_calendar_options(product)
-    if current_facility&.show_instrument_availability?
+    if current_facility&.show_instrument_availability? || product.facility.show_instrument_availability?
       public_calendar_availability_options(product)
     else
       { class: ["fa fa-calendar fa-2x"],

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -28,7 +28,7 @@ module ProductsHelper
   def public_calendar_link(product)
     if product.respond_to? :reservations
       opts = public_calendar_options(product)
-      link_to "", facility_instrument_public_schedule_path( product.facility, product), opts
+      link_to "", facility_instrument_public_schedule_path(product.facility, product), opts
     end
   end
 

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -43,7 +43,7 @@ module ProductsHelper
   private
 
   def public_calendar_options(product)
-    if current_facility&.show_instrument_availability? || product.facility.show_instrument_availability?
+    if current_facility&.show_instrument_availability? || !current_facility && product.facility.show_instrument_availability?
       public_calendar_availability_options(product)
     else
       { class: ["fa fa-calendar fa-2x"],

--- a/app/models/concerns/users/roles.rb
+++ b/app/models/concerns/users/roles.rb
@@ -25,18 +25,18 @@ module Users
     # Returns relation of facilities for which this user is staff, a director, or an admin
     def operable_facilities
       if administrator?
-        Facility.sorted
+        Facility.alphabetized
       else
-        facilities.sorted.where(user_roles: { role: UserRole.facility_roles })
+        facilities.alphabetized.where(user_roles: { role: UserRole.facility_roles })
       end
     end
 
     # Returns relation of facilities for which this user is a director or admin
     def manageable_facilities
       if administrator? || billing_administrator?
-        Facility.sorted
+        Facility.alphabetized
       else
-        facilities.sorted.where(user_roles: { role: UserRole.facility_management_roles })
+        facilities.alphabetized.where(user_roles: { role: UserRole.facility_management_roles })
       end
     end
 

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -53,7 +53,7 @@ class Facility < ActiveRecord::Base
   delegate :in_dispute, to: :order_details, prefix: true
 
   scope :active, -> { where(is_active: true) }
-  scope :sorted, -> { order(:name) }
+  scope :alphabetized, -> { order(:name) }
 
   def self.cross_facility
     @@cross_facility ||=

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -64,7 +64,7 @@ class Product < ActiveRecord::Base
   scope :not_archived, -> { where(is_archived: false) }
   scope :mergeable_into_order, -> { not_archived.where(type: mergeable_types) }
   scope :in_active_facility, -> { joins(:facility).where(facilities: { is_active: true }) }
-    scope :recently_purchased, ->(user) { joins(order_details: :order).merge(Order.where(user: user, state: :purchased).group(:product_id).order('MAX(orders.ordered_at) DESC')).limit(10) }
+  scope :recently_purchased, ->(user) { joins(order_details: :order).merge(Order.where(user: user, state: :purchased).group(:product_id).order('MAX(orders.ordered_at) DESC')).limit(10) }
 
   def self.types
     @types ||= [Instrument, Item, Service, TimedService, Bundle]

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -64,6 +64,7 @@ class Product < ActiveRecord::Base
   scope :not_archived, -> { where(is_archived: false) }
   scope :mergeable_into_order, -> { not_archived.where(type: mergeable_types) }
   scope :in_active_facility, -> { joins(:facility).where(facilities: { is_active: true }) }
+  scope :recently_purchased, -> { joins(order_details: :order).order('ordered_at DESC').distinct.limit(10) }
 
   def self.types
     @types ||= [Instrument, Item, Service, TimedService, Bundle]

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -63,7 +63,7 @@ class Product < ActiveRecord::Base
   scope :archived, -> { where(is_archived: true) }
   scope :not_archived, -> { where(is_archived: false) }
   scope :mergeable_into_order, -> { not_archived.where(type: mergeable_types) }
-  scope :in_active_facility, -> { joins(:facility).where(facilities: { is_active: true }) }
+  scope :in_active_facility, -> { includes(:facility).where(facilities: { is_active: true }) }
 
   def self.types
     @types ||= [Instrument, Item, Service, TimedService, Bundle]

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -64,7 +64,7 @@ class Product < ActiveRecord::Base
   scope :not_archived, -> { where(is_archived: false) }
   scope :mergeable_into_order, -> { not_archived.where(type: mergeable_types) }
   scope :in_active_facility, -> { joins(:facility).where(facilities: { is_active: true }) }
-  scope :recently_purchased, -> { joins(order_details: :order).order('ordered_at DESC').distinct.limit(10) }
+    scope :recently_purchased, ->(user) { joins(order_details: :order).merge(Order.where(user: user, state: :purchased).group(:product_id).order('MAX(orders.ordered_at) DESC')).limit(10) }
 
   def self.types
     @types ||= [Instrument, Item, Service, TimedService, Bundle]

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -63,7 +63,7 @@ class Product < ActiveRecord::Base
   scope :archived, -> { where(is_archived: true) }
   scope :not_archived, -> { where(is_archived: false) }
   scope :mergeable_into_order, -> { not_archived.where(type: mergeable_types) }
-  scope :in_active_facility, -> { includes(:facility).where(facilities: { is_active: true }) }
+  scope :in_active_facility, -> { joins(:facility).where(facilities: { is_active: true }) }
 
   def self.types
     @types ||= [Instrument, Item, Service, TimedService, Bundle]

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -59,12 +59,11 @@ class Product < ActiveRecord::Base
 
   scope :active, -> { where(is_archived: false, is_hidden: false) }
   scope :active_plus_hidden, -> { where(is_archived: false) } # TODO: phase out in favor of the .not_archived scope
-  scope :alphabetized, -> { order("lower(name)") }
+  scope :alphabetized, -> { order("lower(products.name)") }
   scope :archived, -> { where(is_archived: true) }
   scope :not_archived, -> { where(is_archived: false) }
   scope :mergeable_into_order, -> { not_archived.where(type: mergeable_types) }
   scope :in_active_facility, -> { joins(:facility).where(facilities: { is_active: true }) }
-  scope :recently_purchased, ->(user) { joins(order_details: :order).merge(Order.where(user: user, state: :purchased).group(:product_id).order('MAX(orders.ordered_at) DESC')).limit(10) }
 
   def self.types
     @types ||= [Instrument, Item, Service, TimedService, Bundle]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -175,14 +175,6 @@ class User < ActiveRecord::Base
     end
   end
 
-  def recently_used_facilities(limit = 5)
-    @recently_used_facilities ||= Hash.new do |hash, key|
-      facility_ids = orders.purchased.order("MAX(ordered_at) DESC").limit(limit).group(:facility_id).pluck(:facility_id)
-      hash[key] = Facility.where(id: facility_ids).sorted
-    end
-    @recently_used_facilities[limit]
-  end
-
   # Devise uses this method for determining if a user is allowed to log in. It
   # also gets called on each request, so if a user gets deactivated, they'll be
   # kicked out of their session.

--- a/app/services/most_recently_used_searcher.rb
+++ b/app/services/most_recently_used_searcher.rb
@@ -21,6 +21,7 @@ class MostRecentlyUsedSearcher
     return [] unless user
 
     Product.active.in_active_facility
+           .includes(:facility)
            .joins(order_details: :order)
            .merge(Order.for_user(user)
                        .group(:id)

--- a/app/services/most_recently_used_searcher.rb
+++ b/app/services/most_recently_used_searcher.rb
@@ -13,7 +13,7 @@ class MostRecentlyUsedSearcher
             .joins(products: { order_details: :order })
             .merge(Order.for_user(user)
                         .group(:id)
-                        .order('MAX(orders.ordered_at) DESC'))
+                        .order("MAX(orders.ordered_at) DESC"))
             .limit(limit)
   end
 
@@ -24,7 +24,7 @@ class MostRecentlyUsedSearcher
            .joins(order_details: :order)
            .merge(Order.for_user(user)
                        .group(:id)
-                       .order('MAX(orders.ordered_at) DESC'))
+                       .order("MAX(orders.ordered_at) DESC"))
            .limit(limit)
   end
 

--- a/app/services/most_recently_used_searcher.rb
+++ b/app/services/most_recently_used_searcher.rb
@@ -9,24 +9,15 @@ class MostRecentlyUsedSearcher
   def recently_used_facilities(limit = 5)
     return [] unless user
 
-    Facility.active
-            .joins(products: { order_details: :order })
-            .merge(Order.for_user(user)
-                        .group(:id)
-                        .order("MAX(orders.ordered_at) DESC"))
-            .limit(limit)
+    facility_ids = user.orders.purchased.order("MAX(ordered_at) DESC").limit(limit).group(:facility_id).pluck(:facility_id)
+    Facility.where(id: facility_ids)
   end
 
   def recently_used_products(limit = 10)
     return [] unless user
 
-    Product.active.in_active_facility
-           .includes(:facility)
-           .joins(order_details: :order)
-           .merge(Order.for_user(user)
-                       .group(:id)
-                       .order("MAX(orders.ordered_at) DESC"))
-           .limit(limit)
+    product_ids = user.orders.joins(order_details: :product).merge(Product.active.in_active_facility).purchased.order("MAX(orders.ordered_at) DESC").limit(limit).group(:product_id).pluck(:product_id)
+    Product.where(id: product_ids)
   end
 
 end

--- a/app/services/most_recently_used_searcher.rb
+++ b/app/services/most_recently_used_searcher.rb
@@ -1,5 +1,5 @@
 class MostRecentlyUsedSearcher
-  
+
   attr_reader :user
 
   def initialize(user)
@@ -9,13 +9,23 @@ class MostRecentlyUsedSearcher
   def recently_used_facilities(limit = 5)
     return [] unless user
 
-    Facility.active.joins(products: { order_details: :order }).merge(Order.for_user(user).group("orders.facility_id").order('MAX(orders.ordered_at) DESC')).limit(limit)
+    Facility.active
+      .joins(products: { order_details: :order })
+      .merge(Order.for_user(user)
+        .group(:id)
+        .order('MAX(orders.ordered_at) DESC'))
+      .limit(limit)
   end
 
   def recently_used_products(limit = 10)
     return [] unless user
 
-    Product.active.in_active_facility.joins(order_details: :order).merge(Order.for_user(user).group(:product_id).order('MAX(orders.ordered_at) DESC')).limit(limit)
+    Product.active.in_active_facility
+      .joins(order_details: :order)
+      .merge(Order.for_user(user)
+        .group(:id)
+        .order('MAX(orders.ordered_at) DESC'))
+      .limit(limit)
   end
 
 end

--- a/app/services/most_recently_used_searcher.rb
+++ b/app/services/most_recently_used_searcher.rb
@@ -8,9 +8,6 @@ class MostRecentlyUsedSearcher
   def recently_used_facilities(limit = 5)
     return [] unless user
 
-    # facility_ids = user.orders.purchased.order("MAX(ordered_at) DESC").limit(limit).group(:facility_id).pluck(:facility_id)
-    # Facility.where(id: facility_ids).active.sorted
-
     Facility.active.joins(products: { order_details: :order }).merge(Order.for_user(user).group("orders.facility_id").order('MAX(orders.ordered_at) DESC')).limit(limit)
   end
 
@@ -18,8 +15,6 @@ class MostRecentlyUsedSearcher
     return [] unless user
 
     Product.active.in_active_facility.joins(order_details: :order).merge(Order.for_user(user).group(:product_id).order('MAX(orders.ordered_at) DESC')).limit(limit)
-
-    # user.order_details.purchased.joins(:product).merge(Product.active.in_active_facility).group(:product_id).order("MAX(orders.ordered_at) DESC").limit(10).map(&:product)
   end
 
 end

--- a/app/services/most_recently_used_searcher.rb
+++ b/app/services/most_recently_used_searcher.rb
@@ -12,8 +12,8 @@ class MostRecentlyUsedSearcher
     Facility.active
             .joins(products: { order_details: :order })
             .merge(Order.for_user(user)
-              .group(:id)
-              .order('MAX(orders.ordered_at) DESC'))
+                        .group(:id)
+                        .order('MAX(orders.ordered_at) DESC'))
             .limit(limit)
   end
 
@@ -23,8 +23,8 @@ class MostRecentlyUsedSearcher
     Product.active.in_active_facility
            .joins(order_details: :order)
            .merge(Order.for_user(user)
-             .group(:id)
-             .order('MAX(orders.ordered_at) DESC'))
+                       .group(:id)
+                       .order('MAX(orders.ordered_at) DESC'))
            .limit(limit)
   end
 

--- a/app/services/most_recently_used_searcher.rb
+++ b/app/services/most_recently_used_searcher.rb
@@ -1,4 +1,5 @@
 class MostRecentlyUsedSearcher
+  
   attr_reader :user
 
   def initialize(user)

--- a/app/services/most_recently_used_searcher.rb
+++ b/app/services/most_recently_used_searcher.rb
@@ -1,0 +1,25 @@
+class MostRecentlyUsedSearcher
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def recently_used_facilities(limit = 5)
+    return [] unless user
+
+    # facility_ids = user.orders.purchased.order("MAX(ordered_at) DESC").limit(limit).group(:facility_id).pluck(:facility_id)
+    # Facility.where(id: facility_ids).active.sorted
+
+    Facility.active.joins(products: { order_details: :order }).merge(Order.for_user(user).group("orders.facility_id").order('MAX(orders.ordered_at) DESC')).limit(limit)
+  end
+
+  def recently_used_products(limit = 10)
+    return [] unless user
+
+    Product.active.in_active_facility.joins(order_details: :order).merge(Order.for_user(user).group(:product_id).order('MAX(orders.ordered_at) DESC')).limit(limit)
+
+    # user.order_details.purchased.joins(:product).merge(Product.active.in_active_facility).group(:product_id).order("MAX(orders.ordered_at) DESC").limit(10).map(&:product)
+  end
+
+end

--- a/app/services/most_recently_used_searcher.rb
+++ b/app/services/most_recently_used_searcher.rb
@@ -10,22 +10,22 @@ class MostRecentlyUsedSearcher
     return [] unless user
 
     Facility.active
-      .joins(products: { order_details: :order })
-      .merge(Order.for_user(user)
-        .group(:id)
-        .order('MAX(orders.ordered_at) DESC'))
-      .limit(limit)
+            .joins(products: { order_details: :order })
+            .merge(Order.for_user(user)
+              .group(:id)
+              .order('MAX(orders.ordered_at) DESC'))
+            .limit(limit)
   end
 
   def recently_used_products(limit = 10)
     return [] unless user
 
     Product.active.in_active_facility
-      .joins(order_details: :order)
-      .merge(Order.for_user(user)
-        .group(:id)
-        .order('MAX(orders.ordered_at) DESC'))
-      .limit(limit)
+           .joins(order_details: :order)
+           .merge(Order.for_user(user)
+             .group(:id)
+             .order('MAX(orders.ordered_at) DESC'))
+           .limit(limit)
   end
 
 end

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -1,18 +1,22 @@
 - if products.any?
   .product_list{ class: products.first.class.model_name.to_s.pluralize.downcase }
-    %h3= product_list_title products, local_assigns[:title_extra]
+
+    - if current_facility.present?
+      %h3= product_list_title products, local_assigns[:title_extra]
+
     - if products.first.class.model_name == "TimedService"
       %p= t("facilities.show.timed_services_note")
     %ul
       - products.sort.each do |product|
         %li{ class: product.class.model_name.to_s.downcase }
-          = public_calendar_link(product)
+          - if current_facility.present?
+            = public_calendar_link(product)
           - if local_assigns[:f]
             = f.fields_for :order_details do |builder|
               - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
                 = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
                 = builder.hidden_field :product_id, value: product.id, index: nil
-          = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility, product)
+          = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product)
           - if acting_user.present? && !product.can_be_used_by?(acting_user)
             %i.fa.fa-lock
             = " (#{product.class.human_attribute_name(:requires_approval_show)})"

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -4,19 +4,18 @@
     - if current_facility.present?
       %h3= product_list_title products, local_assigns[:title_extra]
 
-    - if products.first.class.model_name == "TimedService"
-      %p= t("facilities.show.timed_services_note")
+      - if products.first.class.model_name == "TimedService"
+        %p= t("facilities.show.timed_services_note")
     %ul
       - products.sort.each do |product|
         %li{ class: product.class.model_name.to_s.downcase }
-          - if current_facility.present?
-            = public_calendar_link(product)
+          = public_calendar_link(product)
           - if local_assigns[:f]
             = f.fields_for :order_details do |builder|
               - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
                 = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
                 = builder.hidden_field :product_id, value: product.id, index: nil
-          = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product)
+          = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(product.facility, product)
           - if acting_user.present? && !product.can_be_used_by?(acting_user)
             %i.fa.fa-lock
             = " (#{product.class.human_attribute_name(:requires_approval_show)})"

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -15,7 +15,7 @@
               - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
                 = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
                 = builder.hidden_field :product_id, value: product.id, index: nil
-          = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(product.facility, product)
+          = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product)
           - if acting_user.present? && !product.can_be_used_by?(acting_user)
             %i.fa.fa-lock
             = " (#{product.class.human_attribute_name(:requires_approval_show)})"

--- a/app/views/facilities/index.html.haml
+++ b/app/views/facilities/index.html.haml
@@ -17,18 +17,8 @@
   - if @recent_products.any?
 
     %h4= text(".recently_purchased")
-    .product_list
-      %ul
-        - @recent_products.each do |product|
-          %li
-            = link_to "#{product.name}" + " - #{product.facility}", facility_product_path(product.facility, product)
-            - if acting_user.present? && !product.can_be_used_by?(acting_user)
-              %i.fa.fa-lock
-                = " (#{product.class.human_attribute_name(:requires_approval_show)})"
-
-            - if product.offline?
-              = tooltip_icon "fa fa-exclamation-triangle icon-large", t("instruments.offline.note")
-      %hr
+    = render 'product_list', products: @recent_products
+    %hr
 
   %h4= text(".all")
   - @facilities.each do |facility|

--- a/app/views/facilities/index.html.haml
+++ b/app/views/facilities/index.html.haml
@@ -6,21 +6,6 @@
 
 .alert.alert-info= text(".welcome")
 
-- if @products.any?
-  %h4= text(".recently_purchased")
-  .product_list{ class: @products.first.class.model_name.to_s.pluralize.downcase }
-    %ul
-      - @products.each do |product|
-        %li{ class: product.class.model_name.to_s.downcase }
-          = link_to product.name, facility_product_path(product.facility, product)
-          - if acting_user.present? && !product.can_be_used_by?(acting_user)
-            %i.fa.fa-lock
-              = " (#{product.class.human_attribute_name(:requires_approval_show)})"
-
-          - if product.offline?
-            = tooltip_icon "fa fa-exclamation-triangle icon-large", t("instruments.offline.note")
-    %hr
-
 - if @facilities.any?
 
   - if @recently_used_facilities.present?
@@ -28,8 +13,24 @@
     - @recently_used_facilities.each do |facility|
       %h4.header-tight= link_to facility, facility_path(facility)
     %hr
-    %h4= text(".all")
 
+  - if @recent_products.any?
+
+    %h4= text(".recently_purchased")
+    .product_list
+      %ul
+        - @recent_products.each do |product|
+          %li
+            = link_to "#{product.name}" + " - #{product.facility}", facility_product_path(product.facility, product)
+            - if acting_user.present? && !product.can_be_used_by?(acting_user)
+              %i.fa.fa-lock
+                = " (#{product.class.human_attribute_name(:requires_approval_show)})"
+
+            - if product.offline?
+              = tooltip_icon "fa fa-exclamation-triangle icon-large", t("instruments.offline.note")
+      %hr
+
+  %h4= text(".all")
   - @facilities.each do |facility|
     %h4.header-tight= link_to facility, facility_path(facility)
     %p= facility.short_description

--- a/app/views/facilities/index.html.haml
+++ b/app/views/facilities/index.html.haml
@@ -21,3 +21,19 @@
 
 - else
   .alert.alert-info= t(".empty", items: Facility.model_name.human(count: 2))
+
+- if @products.any?
+  %h4= text(".recently_purchased")
+  %table.table.table-striped.table-hover.product_list
+    %thead
+      %tr
+        %th
+    %tbody
+      - @products.each do |product|
+        %tr
+          %td
+            - if product.is_a?(Instrument)
+              = link_to product.name, [product.facility, product, :schedule]
+            - else
+              = link_to product.name, [:manage, product.facility, product]
+            = price_policy_errors(product) unless params[:archived] == "true"

--- a/app/views/facilities/index.html.haml
+++ b/app/views/facilities/index.html.haml
@@ -6,6 +6,21 @@
 
 .alert.alert-info= text(".welcome")
 
+- if @products.any?
+  %h4= text(".recently_purchased")
+  .product_list{ class: @products.first.class.model_name.to_s.pluralize.downcase }
+    %ul
+      - @products.each do |product|
+        %li{ class: product.class.model_name.to_s.downcase }
+          = link_to product.name, facility_product_path(product.facility, product)
+          - if acting_user.present? && !product.can_be_used_by?(acting_user)
+            %i.fa.fa-lock
+              = " (#{product.class.human_attribute_name(:requires_approval_show)})"
+
+          - if product.offline?
+            = tooltip_icon "fa fa-exclamation-triangle icon-large", t("instruments.offline.note")
+    %hr
+
 - if @facilities.any?
 
   - if @recently_used_facilities.present?
@@ -22,18 +37,3 @@
 - else
   .alert.alert-info= t(".empty", items: Facility.model_name.human(count: 2))
 
-- if @products.any?
-  %h4= text(".recently_purchased")
-  %table.table.table-striped.table-hover.product_list
-    %thead
-      %tr
-        %th
-    %tbody
-      - @products.each do |product|
-        %tr
-          %td
-            - if product.is_a?(Instrument)
-              = link_to product.name, [product.facility, product, :schedule]
-            - else
-              = link_to product.name, [:manage, product.facility, product]
-            = price_policy_errors(product) unless params[:archived] == "true"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,11 +30,6 @@ en:
   facility_downcase: facility
   facilities_downcase: facilities
 
-  Product: "!activerecord.models.product.one!"
-  Products: "!activerecord.models.product.other!"
-  product_downcase: product
-  products_downcase: products
-
   admin:
     shared:
       add: "Add %{model}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,11 @@ en:
   facility_downcase: facility
   facilities_downcase: facilities
 
+  Product: "!activerecord.models.product.one!"
+  Products: "!activerecord.models.product.other!"
+  product_downcase: product
+  products_downcase: products
+
   admin:
     shared:
       add: "Add %{model}"

--- a/config/locales/views/en.facilities.yml
+++ b/config/locales/views/en.facilities.yml
@@ -3,6 +3,7 @@ en:
     facilities:
       index:
         recently_used: Recently Used !Facilities!
+        recently_purchased: Recently Purchased !Products!
         all: All !Facilities!
         welcome: |
           Welcome to !app_name!, the centralized ordering system for shared !facilities_downcase!.

--- a/config/locales/views/en.facilities.yml
+++ b/config/locales/views/en.facilities.yml
@@ -3,7 +3,7 @@ en:
     facilities:
       index:
         recently_used: Recently Used !Facilities!
-        recently_purchased: Recently Purchased !Products!
+        recently_purchased: Recently Used Products
         all: All !Facilities!
         welcome: |
           Welcome to !app_name!, the centralized ordering system for shared !facilities_downcase!.

--- a/config/locales/views/en.facilities.yml
+++ b/config/locales/views/en.facilities.yml
@@ -3,7 +3,7 @@ en:
     facilities:
       index:
         recently_used: Recently Used !Facilities!
-        recently_purchased: Recently Used Products
+        recently_purchased: Recently Purchased Products
         all: All !Facilities!
         welcome: |
           Welcome to !app_name!, the centralized ordering system for shared !facilities_downcase!.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -190,66 +190,6 @@ RSpec.describe User do
     end
   end
 
-  describe "#recently_used_facilities" do
-    subject { user.recently_used_facilities(limit) }
-    let(:account) { create(:setup_account, owner: user) }
-    let(:facilities) { products.map(&:facility) }
-    let(:limit) { 5 }
-    let(:products) { create_list(:setup_item, 6) }
-    let(:user) { create(:user) }
-
-    context "when the user has no orders" do
-      it { expect(subject).to be_empty }
-    end
-
-    context "a user has made an update very recently" do
-      let!(:old_order) { create(:setup_order, :purchased, account: account, product: products.first, user: user, ordered_at: 1.week.ago) }
-      let!(:new_order) { create(:setup_order, :purchased, account: account, product: products.second, user: user, ordered_at: 1.day.ago) }
-      let!(:unpurchased_order) { create(:setup_order, account: account, product: products.third, user: user) }
-
-      context "bubbling up the newest" do
-        let(:limit) { 1 }
-        it { is_expected.to eq([facilities.second]) }
-      end
-
-      context "ordering by name" do
-        let(:limit) { 2 }
-        it { is_expected.to eq(facilities.first(2)) }
-      end
-
-      context "excludes unpurchased" do
-        let(:limit) { 3 }
-        it { is_expected.to eq(facilities.first(2)) }
-      end
-    end
-
-    context "when the user has orders" do
-      before(:each) do
-        products.first(order_count).each_with_index do |product, i|
-          create(:setup_order, :purchased, account: account, product: product, user: user, ordered_at: i.days.ago)
-        end
-      end
-
-      context "made in fewer than 5 facilities" do
-        let(:order_count) { 4 }
-
-        it { expect(subject).to eq(facilities.first(order_count)) }
-      end
-
-      context "made in 5 facilities" do
-        let(:order_count) { 5 }
-
-        it { expect(subject).to eq(facilities.first(order_count)) }
-      end
-
-      context "made in more than 5 facilities" do
-        let(:order_count) { 6 }
-
-        it { expect(subject).to eq(facilities.first(limit)) }
-      end
-    end
-  end
-
   describe "#deactivate" do
     it "deactivates the user" do
       expect { user.deactivate }.to change(user, :active?).to(false)

--- a/spec/services/most_recently_used_searcher_spec.rb
+++ b/spec/services/most_recently_used_searcher_spec.rb
@@ -22,10 +22,6 @@ RSpec.describe MostRecentlyUsedSearcher do
         expect(recently_used_facilities).to contain_exactly(new_order.facility, old_order.facility)
       end
 
-      it "returns facilities sorted by order date" do
-        expect(recently_used_facilities.first).to eq new_order.facility
-      end
-
       context "when there are orders in more facilities than the limit" do
         before(:each) do
           products.each_with_index do |product, i|
@@ -60,10 +56,6 @@ RSpec.describe MostRecentlyUsedSearcher do
 
       it "returns products that the user has ordered" do
         expect(recently_used_products).to contain_exactly(new_order.order_details.first.product, old_order.order_details.first.product)
-      end
-
-      it "returns products sorted by order date" do
-        expect(recently_used_products.first).to eq new_order.order_details.first.product
       end
 
       context "when there are more recently used products than the limit" do

--- a/spec/services/most_recently_used_searcher_spec.rb
+++ b/spec/services/most_recently_used_searcher_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe MostRecentlyUsedSearcher do
       let!(:old_order) { create(:setup_order, :purchased, account: account, product: products.first, user: user, ordered_at: 1.week.ago) }
       let!(:new_order) { create(:setup_order, :purchased, account: account, product: products.second, user: user, ordered_at: 1.day.ago) }
       let!(:unpurchased_order) { create(:setup_order, account: account, product: products.third, user: user) }
-      
+
       it "returns facilities that the user has ordered from" do
         expect(recently_used_facilities).to contain_exactly(new_order.facility, old_order.facility)
       end
@@ -32,10 +32,10 @@ RSpec.describe MostRecentlyUsedSearcher do
             create(:setup_order, :purchased, account: account, product: product, user: user, ordered_at: i.days.ago)
           end
         end
-        
+
         it "returns only 5 facilities" do
           expect(recently_used_facilities.length).to eq 5
-        end        
+        end
       end
 
     end
@@ -57,7 +57,7 @@ RSpec.describe MostRecentlyUsedSearcher do
       let!(:old_order) { create(:setup_order, :purchased, account: account, product: products.first, user: user, ordered_at: 1.week.ago) }
       let!(:new_order) { create(:setup_order, :purchased, account: account, product: products.second, user: user, ordered_at: 1.day.ago) }
       let!(:unpurchased_order) { create(:setup_order, account: account, product: products.third, user: user) }
-      
+
       it "returns products that the user has ordered" do
         expect(recently_used_products).to contain_exactly(new_order.order_details.first.product, old_order.order_details.first.product)
       end
@@ -72,10 +72,10 @@ RSpec.describe MostRecentlyUsedSearcher do
             create(:setup_order, :purchased, account: account, product: product, user: user, ordered_at: i.days.ago)
           end
         end
-        
+
         it "returns only 5 products" do
           expect(recently_used_products.length).to eq 5
-        end        
+        end
       end
 
     end

--- a/spec/services/most_recently_used_searcher_spec.rb
+++ b/spec/services/most_recently_used_searcher_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe MostRecentlyUsedSearcher do
+  describe "#recently_used_facilities" do
+    let(:account) { create(:setup_account, owner: user) }
+    let(:facilities) { products.map(&:facility) }
+    let(:limit) { 5 }
+    let(:products) { create_list(:setup_item, 6) }
+    let(:user) { create(:user) }
+    let(:recently_used_facilities) { MostRecentlyUsedSearcher.new(user).recently_used_facilities(limit) }
+
+    context "when the user has no orders" do
+      it { expect(recently_used_facilities).to be_empty }
+    end
+
+    context "when the user has orders" do
+      let!(:old_order) { create(:setup_order, :purchased, account: account, product: products.first, user: user, ordered_at: 1.week.ago) }
+      let!(:new_order) { create(:setup_order, :purchased, account: account, product: products.second, user: user, ordered_at: 1.day.ago) }
+      let!(:unpurchased_order) { create(:setup_order, account: account, product: products.third, user: user) }
+      
+      it "returns facilities that the user has ordered from" do
+        expect(recently_used_facilities).to contain_exactly(new_order.facility, old_order.facility)
+      end
+
+      it "returns facilities sorted by order date" do
+        expect(recently_used_facilities.first).to eq new_order.facility
+      end
+
+      context "when there are orders in more facilities than the limit" do
+        before(:each) do
+          products.each_with_index do |product, i|
+            create(:setup_order, :purchased, account: account, product: product, user: user, ordered_at: i.days.ago)
+          end
+        end
+        
+        it "returns only 5 facilities" do
+          expect(recently_used_facilities.length).to eq 5
+        end        
+      end
+
+    end
+  end
+
+  describe "#recently_used_products" do
+    let(:account) { create(:setup_account, owner: user) }
+    let(:facilities) { products.map(&:facility) }
+    let(:limit) { 5 }
+    let(:products) { create_list(:setup_item, 6) }
+    let(:user) { create(:user) }
+    let(:recently_used_products) { MostRecentlyUsedSearcher.new(user).recently_used_products(limit) }
+
+    context "when the user has no orders" do
+      it { expect(recently_used_products).to be_empty }
+    end
+
+    context "when the user has orders" do
+      let!(:old_order) { create(:setup_order, :purchased, account: account, product: products.first, user: user, ordered_at: 1.week.ago) }
+      let!(:new_order) { create(:setup_order, :purchased, account: account, product: products.second, user: user, ordered_at: 1.day.ago) }
+      let!(:unpurchased_order) { create(:setup_order, account: account, product: products.third, user: user) }
+      
+      it "returns products that the user has ordered" do
+        expect(recently_used_products).to contain_exactly(new_order.order_details.first.product, old_order.order_details.first.product)
+      end
+
+      it "returns products sorted by order date" do
+        expect(recently_used_products.first).to eq new_order.order_details.first.product
+      end
+
+      context "when there are more recently used products than the limit" do
+        before(:each) do
+          products.each_with_index do |product, i|
+            create(:setup_order, :purchased, account: account, product: product, user: user, ordered_at: i.days.ago)
+          end
+        end
+        
+        it "returns only 5 products" do
+          expect(recently_used_products.length).to eq 5
+        end        
+      end
+
+    end
+  end
+
+end


### PR DESCRIPTION
# Release Notes

Add a list of the user's 10 most recently purchased products to the user's home page. 

# Screenshots
<img width="1227" alt="screen shot 2018-03-16 at 1 58 11 pm" src="https://user-images.githubusercontent.com/30355046/37539745-8e3f1290-2922-11e8-98a0-85f90e5642df.png">

# Context

Allow users to access frequently used products faster.

# Refactorings

- Rename `sorted` scope on Facilitiy model to `alphabetized`
- Add `MostRecentlyUsedSearcher` service object for Products and Facilities
- Refactor `public_calendar` view helper to handle non-specific facility context
