### PR TITLE
Add settings override for default ruby-saml params

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -145,6 +145,8 @@ paperclip:
 # saml:
 #   idp_metadata: "https://websso.example.com/idp/metadata"
 #   # certificate_file: path/to/file.p12 # Optional. Do not check in to version control.
+#   # driver: # Optional. Useful to override inferred SAML settings if need be.
+#   #   "idp_sso_target_url": "https://websso.example.com/idp/profile/SAML2/Redirect/SSO"
 #   attribute_map:
 #     "PersonImmutableID": "username"
 #     "User.email": "email"

--- a/vendor/engines/saml_authentication/README.md
+++ b/vendor/engines/saml_authentication/README.md
@@ -32,6 +32,10 @@ saml:
 * `attribute_map`: A mapping from the IdP's attributes to the NUcore's `users` table
   columns. `username` and `email` are absolutely required while entries for `first_name`
   and `last_name` are recommended.
+* `driver`: An optional mapping of settings to pass to the underlying ruby-saml
+  gem. See *What Needs to be Configured* at https://developers.onelogin.com/saml/ruby
+  for a list of valid keys. This useful if the default inferred SAML settings
+  need to be overrided.
 
 ## Handling Users
 

--- a/vendor/engines/saml_authentication/lib/saml_authentication/devise_configurator.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/devise_configurator.rb
@@ -19,6 +19,9 @@ module SamlAuthentication
         config.saml_configure do |settings|
           settings.assertion_consumer_service_url = Rails.application.routes.url_helpers.auth_saml_user_session_url
           settings.issuer = Rails.application.routes.url_helpers.metadata_saml_user_session_url
+          Hash(Settings.saml.driver).each do |key, value|
+            settings.public_send("#{key}=", value)
+          end
 
           configure_security(settings)
         end


### PR DESCRIPTION
The University of Connecticut Shibboleth server prefers the HTTP Redirect SAML binding for sign-in. Changing this required overriding the idp_sso_target_url SAML setting passed to ruby-saml.

This is my first pull request for the project, so let me just note the following: I am perfectly fine modifying/improving anything that may not be up to maintainer expectations. I wouldn't call myself a Ruby expert, so if I'm doing something that's not a best practice, please feel free to be blunt and call me out on it. This follows for any future pull requests I make.