### PR TITLE
[#139338] Cross Payment Source bounceback changes

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -12,8 +12,7 @@ class TransactionsController < ApplicationController
   end
 
   def index
-    account_ids = current_user.account_users.map(&:account_id)
-    order_details = OrderDetail.where(account_id: account_ids).joins(:order)
+    order_details = current_user.administered_order_details.joins(:order)
     @export_enabled = true
 
     @search_form = TransactionSearch::SearchForm.new(
@@ -28,6 +27,7 @@ class TransactionsController < ApplicationController
                                               TransactionSearch::ProductSearcher,
                                               TransactionSearch::DateRangeSearcher,
                                               TransactionSearch::OrderStatusSearcher,
+                                              TransactionSearch::AccountOwnerSearcher,
                                               TransactionSearch::OrderedForSearcher).search(order_details, @search_form)
     @date_range_field = @search_form.date_params[:field]
     @order_details = @search.order_details

--- a/app/views/transactions/index.html.haml
+++ b/app/views/transactions/index.html.haml
@@ -4,4 +4,7 @@
 
 = render "shared/transactions/search2"
 
-= render "shared/transactions/table", show_statements: true
+- if @order_details.any?
+  = render "shared/transactions/table", show_statements: true
+- else
+  %p.alert.alert-info= t(".no_transactions")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1119,6 +1119,7 @@ en:
   transactions:
     index:
       history: Transaction History
+      no_transactions: There are no transactions matching the search parameters.
     in_review: Transactions in Review
     none_in_review_found: No transactions in review were found.
     recently_reviewed: Recently Reviewed


### PR DESCRIPTION
- users can view only administered order details
- add account owner searcher
- add no results message rather than displaying empty table