### PR TITLE
Update capistrano server

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,4 +1,4 @@
-server "nucore.stage.tablexi.com", user: "nucore", roles: %w(web app db)
+server "tablexi-shared02.txihosting.com", user: "nucore", roles: %w(web app db)
 set :deploy_to, "/home/nucore/nucore.stage.tablexi.com"
 set :rails_env, "stage"
 set :branch, ENV["CIRCLE_SHA1"] || ENV["REVISION"] || ENV["BRANCH_NAME"] || "master"


### PR DESCRIPTION
This changes the capistrano configuration to use tablexi-shared02.txihosting.com as the server. For more details see the discussion on tablexi/chef-repo#1781