### PR TITLE
revert rubocop to latest version supported by codeclimate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ group :development do
   gem "haml_lint"
   gem "letter_opener"
   gem "rails-erd"
-  gem "rubocop", require: false
+  gem "rubocop", "0.52", require: false # temporarily locked until codeclimate adds 0.53 support
   gem "web-console"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,7 +400,7 @@ GEM
     parallel (1.12.1)
     paranoia (2.4.0)
       activerecord (>= 4.0, < 5.2)
-    parser (2.5.0.2)
+    parser (2.5.0.4)
       ast (~> 2.4.0)
     pdf-core (0.7.0)
     poltergeist (1.17.0)
@@ -502,9 +502,9 @@ GEM
     rspec-support (3.5.0)
     rspec_junit_formatter (0.3.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.53.0)
+    rubocop (0.52.0)
       parallel (~> 1.10)
-      parser (>= 2.5)
+      parser (>= 2.4.0.2, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
@@ -686,7 +686,7 @@ DEPENDENCIES
   rspec-collection_matchers
   rspec-rails
   rspec_junit_formatter
-  rubocop
+  rubocop (= 0.52)
   ruby-oci8
   rubyzip
   saml_authentication!


### PR DESCRIPTION
# Release Notes

TECH TASK: Revert Rubocop to latest version supported by CodeClimate

# Additional Context

Will update back to 0.53.0 when official support is added: https://github.com/codeclimate/codeclimate-rubocop/issues/118