### PR TITLE
[#137627] recently used products/facilities still works when no logged in user

### DIFF
--- a/app/services/most_recently_used_searcher.rb
+++ b/app/services/most_recently_used_searcher.rb
@@ -7,14 +7,14 @@ class MostRecentlyUsedSearcher
   end
 
   def recently_used_facilities(limit = 5)
-    return [] unless user
+    return Facility.none unless user
 
     facility_ids = user.orders.purchased.order("MAX(ordered_at) DESC").limit(limit).group(:facility_id).pluck(:facility_id)
     Facility.where(id: facility_ids)
   end
 
   def recently_used_products(limit = 10)
-    return [] unless user
+    return Product.none unless user
 
     product_ids = user.orders.joins(order_details: :product).merge(Product.active.in_active_facility).purchased.order("MAX(orders.ordered_at) DESC").limit(limit).group(:product_id).pluck(:product_id)
     Product.where(id: product_ids)

--- a/spec/controllers/facilities_controller_spec.rb
+++ b/spec/controllers/facilities_controller_spec.rb
@@ -156,6 +156,11 @@ RSpec.describe FacilitiesController do
       @action = :index
     end
 
+    it "should render the page without a logged in user" do
+      do_request
+      expect(response).to be_successful
+    end
+
     it_should_allow_all [:admin, :guest] do
       expect(assigns[:facilities]).to eq([@authable])
       expect(response).to be_success.and render_template("facilities/index")


### PR DESCRIPTION
# Release Notes
Fix error on recently used products/facilities when there is no logged in user, follow up to https://github.com/tablexi/nucore-open/pull/1429.

# Additional Context

Error was occurring because we were trying to chain additional scopes onto `recently_used_facilities` and `recently_used_products` in `facilities#index`, which was an empty array rather than an empty AR relation when no user is present.
