### PR TITLE
Update Loofah to 2.2.1 for security warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,7 +354,7 @@ GEM
       railties (>= 4)
       request_store (~> 1.0)
     logstash-event (1.2.02)
-    loofah (2.2.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.11)


### PR DESCRIPTION
# Release Notes

TECH TASK: Addresses CVE-2018-8048

https://github.com/flavorjones/loofah/blob/master/CHANGELOG.md#221--2018-03-19

Addresses a medium-severity security issue identified within the loofah gem (used by rails-html-sanitizer)