### PR TITLE
[#140608] Fix links from Accounts Receivable

### DIFF
--- a/app/views/facility_accounts/accounts_receivable.html.haml
+++ b/app/views/facility_accounts/accounts_receivable.html.haml
@@ -2,14 +2,14 @@
   = current_facility
 
 = content_for :sidebar do
-  = render :partial => 'admin/shared/sidenav_billing', :locals => { :sidenav_tab => "accounts_receivable" }
+  = render "admin/shared/sidenav_billing", sidenav_tab: "accounts_receivable"
 
 %h2= t(".head")
 
 - if params[:show_all]
-  = link_to t(".show_with_balance", :model => Account.model_name.human.pluralize.downcase), facility_accounts_receivable_path
+  = link_to t(".show_with_balance", model: Account.model_name.human.pluralize.downcase), facility_accounts_receivable_path
 - else
-  = link_to t(".show_all", :model => Account.model_name.human.pluralize.downcase), facility_accounts_receivable_path(:show_all => '1')
+  = link_to t(".show_all", model: Account.model_name.human.pluralize.downcase), facility_accounts_receivable_path(show_all: "1")
 
 %table.table.table-striped.table-hover
   %thead
@@ -28,8 +28,8 @@
       - balance[61] = a.facility_balance(current_facility, today - 61*24*60*60) - balance.values.inject{|sum, n| sum + n }
       - balance[31] = a.facility_balance(current_facility, today - 31*24*60*60) - balance.values.inject{|sum, n| sum + n }
       - balance[0]  = a.facility_balance(current_facility, today)               - balance.values.inject{|sum, n| sum + n }
-      %tr{:class => (balance[91] > 0 ? "reconcile-warning" : "")}
-        %td= link_to a, facility_transactions_path(current_facility, :accounts => [a.id])
+      %tr{ class: (balance[91] > 0 ? "reconcile-warning" : "") }
+        %td= link_to a, facility_transactions_path(current_facility, search: { accounts: [a.id] })
         %td.currency= number_to_currency(balance[0])
         %td.currency= number_to_currency(balance[31])
         %td.currency= number_to_currency(balance[61])


### PR DESCRIPTION
# Release Notes

Fix links from Accounts Receivable in the billing tab to properly redirect to All Transactions with the account prepopulated in the filter.