### PR TITLE
[#140541] add a hint that reservation note visible to admins only

### DIFF
--- a/app/views/reservations/_account_field.html.haml
+++ b/app/views/reservations/_account_field.html.haml
@@ -22,4 +22,5 @@
         .span6
           = f.input :note,
             label: @order_detail.product.user_notes_label.presence,
-            required: @order_detail.product.user_notes_field_mode.required?
+            required: @order_detail.product.user_notes_field_mode.required?,
+            hint: t(".note_hint")

--- a/app/views/reservations/edit.html.haml
+++ b/app/views/reservations/edit.html.haml
@@ -30,7 +30,8 @@
           .span
             = f.input :note,
               label: @order_detail.product.user_notes_label.presence,
-              required: @order_detail.product.user_notes_field_mode.required?
+              required: @order_detail.product.user_notes_field_mode.required?,
+              hint: t("reservations.account_field.note_hint")
 
   = render "reservation_fields", f: f
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -584,6 +584,7 @@ en:
       upcoming: You have an upcoming reservation for %{reservation}.
     account_field:
       prompt: "Please select a payment source"
+      note_hint: Visible to facility staff only
 
   statements:
     index:


### PR DESCRIPTION
# Release Notes

Add a hint clarifying that notes on reservations are visible to facility staff only.