### PR TITLE
[#140541] add user facing note for admin reservations

### DIFF
--- a/app/assets/javascripts/app/calendar.js.coffee
+++ b/app/assets/javascripts/app/calendar.js.coffee
@@ -58,6 +58,7 @@ class window.FullCalendarConfig
         event.email,
         event.product,
         event.expiration,
+        event.user_note,
       ].filter(
         (e) -> e? # remove undefined values
       ).join("<br/>")

--- a/app/controllers/facility_reservations_controller.rb
+++ b/app/controllers/facility_reservations_controller.rb
@@ -174,6 +174,7 @@ class FacilityReservationsController < ApplicationController
                                  :reserve_end_meridian,
                                  :expires)
                          .permit(:admin_note,
+                                 :user_note,
                                  :expires_mins_before,
                                  :category,
                                  :repeats,

--- a/app/forms/admin_reservation_form.rb
+++ b/app/forms/admin_reservation_form.rb
@@ -14,7 +14,7 @@ class AdminReservationForm
   delegate :category, :reserve_start_date, :reserve_start_hour,
            :reserve_start_min, :reserve_start_meridian, :duration_mins,
            :reserve_end_date, :reserve_end_hour, :reserve_end_min,
-           :reserve_end_meridian, :admin_note, :expires?,
+           :reserve_end_meridian, :admin_note, :user_note, :expires?,
            :expires_mins_before, :reserve_start_at, to: :reservation
   delegate :assign_times_from_params, to: :reservation
 

--- a/app/presenters/reservations/calendar_presenter.rb
+++ b/app/presenters/reservations/calendar_presenter.rb
@@ -29,6 +29,7 @@ module Reservations
           email: created_by.try(:full_name),
         }
         hash[:expiration] = "Expires #{MinutesToTimeFormatter.new(expires_mins_before)} prior" if expires_mins_before.present?
+        hash[:user_note] = user_note
         hash
       end
     end

--- a/app/views/facility_reservations/_admin_reservation_fields.html.haml
+++ b/app/views/facility_reservations/_admin_reservation_fields.html.haml
@@ -19,6 +19,7 @@
 .clearfix
 
 = f.input :admin_note, input_html: { class: "span6" } unless @order_detail
+= f.input :user_note, input_html: { class: "span6" } unless @order_detail
 
 .checkboxControl
   = f.input :expires?, as: :boolean, label: t('activemodel.attributes.admin_reservation_form.expires?'), input_html: { data: { disables: ".admin_reservation_expires_mins_before" } }, wrapper_html: { class: "checkboxControl__checkbox" }

--- a/app/views/shared/timeline/_facility_tooltip.html.haml
+++ b/app/views/shared/timeline/_facility_tooltip.html.haml
@@ -16,6 +16,10 @@
   %br
   %span= reservation.admin_note
 
+- if reservation.user_note.present?
+  %br
+  %span= reservation.user_note
+
 - if reservation.created_by.present?
   %br
   %span= reservation.created_by.full_name

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -10,6 +10,7 @@ en:
       admin_reservation_form:
         expires?: Release In Advance
         expires_mins_before: "Release hh:mm Prior To Start"
+        user_note: Note for users
     errors:
       models:
         order_details/reconciler:

--- a/db/migrate/20180330180908_add_user_note_to_reservations.rb
+++ b/db/migrate/20180330180908_add_user_note_to_reservations.rb
@@ -1,0 +1,5 @@
+class AddUserNoteToReservations < ActiveRecord::Migration
+  def change
+    add_column :reservations, :user_note, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180111200920) do
+ActiveRecord::Schema.define(version: 20180330180908) do
 
   create_table "account_users", force: :cascade do |t|
     t.integer  "account_id", limit: 4,  null: false
@@ -555,6 +555,7 @@ ActiveRecord::Schema.define(version: 20180111200920) do
     t.integer  "created_by_id",       limit: 4
     t.datetime "deleted_at"
     t.string   "group_id",            limit: 255
+    t.string   "user_note",           limit: 255
   end
 
   add_index "reservations", ["created_by_id"], name: "index_reservations_on_created_by_id", using: :btree

--- a/spec/app_support/reservations/rendering_spec.rb
+++ b/spec/app_support/reservations/rendering_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe Reservations::Rendering do
           actual_start_at: actual_start_at,
           actual_end_at: actual_end_at,
           created_by: user,
+          user_note: "this is a note",
         )
       end
 
@@ -110,13 +111,13 @@ RSpec.describe Reservations::Rendering do
       context "with details requested" do
         it "returns a hash without extra details about the order" do
           expect(reservation.as_calendar_object(with_details: true))
-            .to eq(base_hash.merge(title: "Admin Hold", email: user.full_name))
+            .to eq(base_hash.merge(title: "Admin Hold", email: user.full_name, user_note: reservation.user_note))
         end
       end
 
       context "without details requested" do
         it "returns a hash without extra details about the order" do
-          expect(reservation.as_calendar_object).to eq(base_hash.merge(title: "Admin Hold", email: user.full_name))
+          expect(reservation.as_calendar_object).to eq(base_hash.merge(title: "Admin Hold", email: user.full_name, user_note: reservation.user_note))
         end
       end
     end


### PR DESCRIPTION
# Release Notes

Add a note for users on admin reservations and display in hover-over on the instrument calendar view.