### PR TITLE
[#140980] Add Assigned User to export raw

### DIFF
--- a/app/models/reports/export_raw.rb
+++ b/app/models/reports/export_raw.rb
@@ -96,6 +96,7 @@ module Reports
         reconciled_at: :reconciled_at,
         price_change_reason: :price_change_reason,
         price_changed_by_user: ->(od) { od.price_changed_by_user.try(:full_name) },
+        assigned_user: ->(od) { od.assigned_user.try(:full_name) },
       }
       if SettingsHelper.has_review_period?
         hash

--- a/spec/models/reports/export_raw_spec.rb
+++ b/spec/models/reports/export_raw_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Reports::ExportRaw do
           estimated_cost: BigDecimal("39.99"),
           estimated_subsidy: BigDecimal("29.99"),
           price_change_reason: "note",
+          assigned_user: user,
         )
       end
     end
@@ -55,6 +56,7 @@ RSpec.describe Reports::ExportRaw do
         "Actual Subsidy" => "$9.99",
         "Actual Total" => "$10.00",
         "Charge For" => "Quantity",
+        "Assigned User" => user.full_name,
       )
     end
 


### PR DESCRIPTION
# Release Notes

Add Assigned User column to export raw

# Additional Context

Added as the last column because many use the export raw format in their reporting so adding the column earlier could mess up their templates by shifting columns to the right.
