### PR TITLE
[#140361] refactor user creation/updating to use user form object (open)

### DIFF
--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -1,0 +1,49 @@
+class UserForm < SimpleDelegator
+
+  include ActiveModel::Validations
+
+  def user
+    __getobj__
+  end
+
+  def valid?
+    success = [super, user.valid?].all?
+
+    user.errors.each do |k, error_messages|
+      errors.add(k, error_messages)
+    end
+
+    success
+  end
+
+  def save
+    set_password if user.new_record?
+
+    valid? && user.save
+  end
+
+  def update_attributes(params)
+    user.assign_attributes(params)
+    save
+  end
+
+  def admin_editable?
+    user.email_user?
+  end
+
+  def username_editable?
+    false
+  end
+
+  private
+
+  def set_password
+    user.password = generate_new_password
+  end
+
+  def generate_new_password
+    chars = ("a".."z").to_a + ("1".."9").to_a + ("A".."Z").to_a
+    chars.sample(8).join
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,10 +71,6 @@ class User < ActiveRecord::Base
     username.casecmp(email.downcase).zero?
   end
 
-  def admin_editable?
-    email_user?
-  end
-
   def password_updatable?
     email_user?
   end

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -13,12 +13,12 @@
 %h2= text("head", user: @user.full_name)
 %p= text("subhead")
 
-= simple_form_for [current_facility, @user] do |f|
+= simple_form_for [current_facility, @user_form] do |f|
   .form-inputs
-    = f.input :first_name, readonly: !@user.admin_editable?
-    = f.input :last_name, readonly: !@user.admin_editable?
-    = f.input :email, readonly: !@user.admin_editable?
-    = f.input :username, readonly: true
+    = f.input :first_name, readonly: !@user_form.admin_editable?
+    = f.input :last_name, readonly: !@user_form.admin_editable?
+    = f.input :email, readonly: !@user_form.admin_editable?
+    = f.input :username, readonly: !@user_form.username_editable?
     - if current_user.administrator? && SettingsHelper.feature_on?(:user_based_price_groups)
       = f.input :internal?, label: text(".internal"), as: :select, default: false
     = f.button :submit, text("shared.update"), class: ["btn", "btn-primary"]

--- a/app/views/users/new_external.html.haml
+++ b/app/views/users/new_external.html.haml
@@ -1,5 +1,5 @@
 = content_for :head_content do
-  = render "form_head"
+  = render "form_head" if !@user_form.username_editable?
 
 = content_for :h1 do
   = current_facility
@@ -10,12 +10,12 @@
 %h2= text("users.new_external.head")
 %p= text("users.new_external.main")
 
-= simple_form_for [current_facility, @user] do |f|
+= simple_form_for [current_facility, @user_form] do |f|
   .form-inputs
     = f.input :first_name
     = f.input :last_name
     = f.input :email
-    = f.input :username, readonly: true
+    = f.input :username, readonly: !@user_form.username_editable?
     = f.button :submit, text("shared.create"), class: ["btn", "btn-primary"]
     &nbsp;
     = link_to text("shared.cancel"), facility_users_path

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -65,14 +65,14 @@ RSpec.describe UsersController do
       @method = :put
       @action = :update
       @params[:id] = user.id
-      @params[:user] = { first_name: "New", last_name: "Name", email: "newemail@example.com", username: "newemail@example.com" }
+      @params[:user] = { first_name: "New", last_name: "Name", email: "newemail@example.com", username: "user234" }
     end
 
     it_should_allow_admin_only(:found) do
       expect(user.reload.first_name).to eq("New")
       expect(user.last_name).to eq("Name")
       expect(user.email).to eq("newemail@example.com")
-      expect(user.username).to eq("newemail@example.com")
+      expect(user.username).to eq("user234")
       expect(response).to redirect_to facility_user_path(facility, user)
     end
   end
@@ -177,8 +177,7 @@ RSpec.describe UsersController do
         end
 
         it_should_allow_operators_only do
-          expect(assigns(:user)).to be_kind_of User
-          expect(assigns(:user)).to be_new_record
+          expect(assigns(:user_form)).to be_kind_of UserForm
         end
       end
 
@@ -191,13 +190,12 @@ RSpec.describe UsersController do
         context "external user" do
           context "with successful parameters" do
             before :each do
-              @params.merge!(user: FactoryBot.attributes_for(:user).except(:password, :password_confirmation))
+              user_params = FactoryBot.attributes_for(:user, username: 'user123').except(:password, :password_confirmation)
+              @params.merge!(user: user_params)
             end
 
             it_should_allow_operators_only :redirect do
-              expect(assigns(:user)).to be_kind_of User
-              expect(assigns(:user)).to be_persisted
-              assert_redirected_to facility_users_url(user: assigns[:user].id)
+              assert_redirected_to facility_users_url(user: assigns[:user_form].user.id)
             end
           end
 
@@ -207,20 +205,7 @@ RSpec.describe UsersController do
             end
 
             it_should_allow_operators_only do
-              expect(assigns(:user)).to be_new_record
               expect(response).to render_template "new_external"
-            end
-          end
-
-          describe "with extra spaces around the username/email" do
-            before do
-              @params[:user] = FactoryBot.attributes_for(:user, username: " email@example.com", email: "email@example.com").except(:password, :password_confirmation)
-            end
-
-            it_should_allow_operators_only :redirect do
-              expect(assigns(:user)).to be_persisted
-              expect(assigns(:user).email).to eq("email@example.com")
-              expect(assigns(:user).username).to eq("email@example.com")
             end
           end
         end

--- a/spec/features/admin/managing_user_spec.rb
+++ b/spec/features/admin/managing_user_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Managing User Details", :aggregate_failures, feature_setting: { 
   describe "edit" do
     describe "as a facility admin" do
       let(:admin) { FactoryBot.create(:user, :administrator) }
-      let(:user) { FactoryBot.create(:user) }
+      let(:user) { FactoryBot.create(:user, username: 'user123') }
 
       before do
         login_as admin


### PR DESCRIPTION
# Release Notes
Refactor user creation and updating to use a form object, enabling custom validations etc on a per-school basis.

# Additional Context
Changes in open to enable requested Dartmouth features, see https://github.com/tablexi/nucore-dartmouth/pull/179 for additional context. Companion to https://github.com/tablexi/nucore-dartmouth/pull/181.
