### PR TITLE
[#141023] Avoid error when submitting order form with no file

### DIFF
--- a/app/controllers/order_detail_stored_files_controller.rb
+++ b/app/controllers/order_detail_stored_files_controller.rb
@@ -32,7 +32,7 @@ class OrderDetailStoredFilesController < ApplicationController
 
   # POST /orders/:order_id/order_details/:order_detail_id/upload_order_file
   def upload_order_file
-    @file = @order_detail.stored_files.new(params.require(:stored_file).permit(:file))
+    @file = @order_detail.stored_files.new(params[:stored_file]&.permit(:file))
     @file.file_type  = "template_result"
     @file.name       = "Order File"
     @file.product = @order_detail.product

--- a/spec/controllers/order_detail_stored_files_controller_spec.rb
+++ b/spec/controllers/order_detail_stored_files_controller_spec.rb
@@ -31,4 +31,25 @@ RSpec.describe OrderDetailStoredFilesController do
       end
     end
   end
+
+  describe "#upload_order_file" do
+    let(:product) { create(:setup_service, :with_order_form) }
+    let(:order_detail) { order.order_details.first }
+    let(:facility) { order.facility }
+    let(:order) { create(:setup_order, product: product) }
+
+    let(:params) { { order_id: order.id, order_detail_id: order_detail.id } }
+    before { sign_in user }
+
+
+    it "can upload the file" do
+      post :upload_order_file, params.merge(stored_file: { file: fixture_file_upload("#{Rails.root}/spec/files/template1.txt") })
+      expect(order_detail.stored_files.count).to eq(1)
+    end
+
+    it "gets an error if there is no file" do
+      post :upload_order_file, params
+      expect(assigns(:file).errors).to be_added(:file, :blank)
+    end
+  end
 end


### PR DESCRIPTION
# Release Notes

Prevent hard error when submitting an order form from the cart when the user does not specify a file.

# Original error

```
An ActionController::ParameterMissing occurred in order_detail_stored_files#upload_order_file:
param is missing or the value is empty: stored_file
  app/controllers/order_detail_stored_files_controller.rb:35:in `upload_order_file'
```