### PR TITLE
[#141334] Prevent errors on non-html 404s

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -119,16 +119,17 @@ class ApplicationController < ActionController::Base
   # Global exception handlers
   rescue_from ActiveRecord::RecordNotFound do |exception|
     Rails.logger.debug("#{exception.message}: #{exception.backtrace.join("\n")}") unless Rails.env.production?
-    render_404
+    render_404(exception)
   end
 
   rescue_from ActionController::RoutingError do |exception|
     Rails.logger.debug("#{exception.message}: #{exception.backtrace.join("\n")}") unless Rails.env.production?
-    render_404
+    render_404(exception)
   end
 
-  def render_404
-    render "/404", status: 404, layout: "application"
+  def render_404(_exception)
+    # Add :html in case the 404 is a PDF or XML so the view can be found
+    render "/404", status: 404, layout: "application", formats: request.formats + [:html]
   end
 
   rescue_from NUCore::PermissionDenied, CanCan::AccessDenied, with: :render_403

--- a/spec/features/accessing_invalid_files_spec.rb
+++ b/spec/features/accessing_invalid_files_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe "Accessing invalid formats" do
+
+  it "renders a 404 for a missing page in pdf" do
+    visit "/facilities/examp.pdf"
+
+    expect(page).to have_content("404")
+    expect(page).to have_content("Page Not Found")
+  end
+
+  describe "for a page I don't have access to" do
+    let(:user) { create(:user) }
+    let(:facility) { create(:facility) }
+
+    it "renders a 403 as html" do
+      login_as user
+      visit "facilities/list.pdf"
+
+      expect(page).to have_content("403")
+      expect(page).to have_content("Permission Denied")
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

Prevent hard errors when attempting to access a page not found with a non-html form, e.g. PDF or XML.

# Original Error

Some data redacted. This can happen on any 404 page, for example `/facili.pdf`.

```
An ActionView::MissingTemplate occurred in facility_accounts#show_statement:

Missing template /404 with {:locale=>[:en], :formats=>[:pdf], :variants=>[], :handlers=>[:erb, :builder, :raw, :ruby, :coffee, :prawn, :haml]}. Searched in: * 
... [redacted]
app/controllers/application_controller.rb:131:in `render_404'

-------------------------------
Request:
-------------------------------

URL : [redacted]/facilities/xxx/accounts/xxx/statements/xxxx.pdf
```