### PR TITLE
rails 4 compatible prep for rails 5

### DIFF
--- a/app/controllers/accessories_controller.rb
+++ b/app/controllers/accessories_controller.rb
@@ -46,7 +46,7 @@ class AccessoriesController < ApplicationController
 
   def respond_success
     if request.xhr?
-      render nothing: true, status: 200
+      render head :ok
     else
       redirect_to core_manager_context? ? [current_facility, @order] : reservations_path
     end

--- a/app/controllers/accessories_controller.rb
+++ b/app/controllers/accessories_controller.rb
@@ -46,7 +46,7 @@ class AccessoriesController < ApplicationController
 
   def respond_success
     if request.xhr?
-      render head :ok
+      head :ok
     else
       redirect_to core_manager_context? ? [current_facility, @order] : reservations_path
     end

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -7,14 +7,14 @@ module Admin
     def process_one_minute_tasks
       InstrumentOfflineReservationCanceler.new.cancel!
       AdminReservationExpirer.new.expire!
-      render head :ok
+      head :ok
     end
 
     def process_five_minute_tasks
       self.class.five_minute_tasks.each do |worker|
         worker.new.perform
       end
-      render head :ok
+      head :ok
     end
 
     def self.five_minute_tasks

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -7,14 +7,14 @@ module Admin
     def process_one_minute_tasks
       InstrumentOfflineReservationCanceler.new.cancel!
       AdminReservationExpirer.new.expire!
-      render nothing: true
+      render head :ok
     end
 
     def process_five_minute_tasks
       self.class.five_minute_tasks.each do |worker|
         worker.new.perform
       end
-      render nothing: true
+      render head :ok
     end
 
     def self.five_minute_tasks

--- a/app/controllers/file_uploads_controller.rb
+++ b/app/controllers/file_uploads_controller.rb
@@ -125,9 +125,10 @@ class FileUploadsController < ApplicationController
       @product = current_facility.send(klass).find_by!(url_name: params[:product_id])
     else
       id_param = params.except(:facility_id).keys.detect { |k| k.end_with?("_id") }
-      clazz = id_param.sub(/_id\z/, "").camelize
+      class_name = id_param.sub(/_id\z/, "").camelize
       @product = current_facility
-                 .products(clazz)
+                 .products
+                 .of_type(class_name)
                  .find_by!(url_name: params[id_param])
     end
   end

--- a/app/controllers/file_uploads_controller.rb
+++ b/app/controllers/file_uploads_controller.rb
@@ -64,7 +64,7 @@ class FileUploadsController < ApplicationController
       ResultsFileNotifier.new(@upload).notify if @upload.sample_result?
       respond_to do |format|
         format.json { render json: { success: true } }
-        format.html { render head :ok }
+        format.html { head :ok }
       end
     else
       errors = @upload.errors.map { |_k, msg| msg }.to_sentence
@@ -103,7 +103,7 @@ class FileUploadsController < ApplicationController
     @return_to = params[:return_to]
 
     if request.xhr?
-      render head :ok
+      head :ok
     elsif @file.file_type == "template"
       redirect_to(@return_to || product_survey_path(current_facility, @product.parameterize, @product))
     else

--- a/app/controllers/file_uploads_controller.rb
+++ b/app/controllers/file_uploads_controller.rb
@@ -64,7 +64,7 @@ class FileUploadsController < ApplicationController
       ResultsFileNotifier.new(@upload).notify if @upload.sample_result?
       respond_to do |format|
         format.json { render json: { success: true } }
-        format.html { render nothing: true }
+        format.html { render head :ok }
       end
     else
       errors = @upload.errors.map { |_k, msg| msg }.to_sentence
@@ -103,7 +103,7 @@ class FileUploadsController < ApplicationController
     @return_to = params[:return_to]
 
     if request.xhr?
-      render nothing: true
+      render head :ok
     elsif @file.file_type == "template"
       redirect_to(@return_to || product_survey_path(current_facility, @product.parameterize, @product))
     else

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -28,14 +28,14 @@ class OrderManagement::OrderDetailsController < ApplicationController
 
     updater = OrderDetails::ParamUpdater.new(@order_detail, user: session_user, cancel_fee: params[:with_cancel_fee] == "1")
 
-    if updater.update_attributes(params[:order_detail])
+    if updater.update_attributes(params[:order_detail] || empty_params)
       flash[:notice] = "The order was successfully updated."
       if @order_detail.updated_children.any?
         flash[:notice] << " Auto-scaled accessories have been updated as well."
         flash[:updated_order_details] = @order_detail.updated_children.map(&:id)
       end
       if modal?
-        render nothing: true
+        render head :ok
       else
         redirect_to [current_facility, @order]
       end
@@ -48,7 +48,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
   # GET /facilities/:facility_id/orders/:order_id/order_details/:id/pricing
   def pricing
     checker = OrderDetails::PriceChecker.new(@order_detail)
-    @prices = checker.prices_from_params(params[:order_detail])
+    @prices = checker.prices_from_params(params[:order_detail] || empty_params)
 
     render json: @prices.to_json
   end
@@ -67,7 +67,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
       I18n.t "controllers.order_management.order_details.remove_from_journal.notice"
 
     if modal?
-      render nothing: true
+      render head :ok
     else
       redirect_to [current_facility, @order]
     end

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -35,7 +35,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
         flash[:updated_order_details] = @order_detail.updated_children.map(&:id)
       end
       if modal?
-        render head :ok
+        head :ok
       else
         redirect_to [current_facility, @order]
       end
@@ -67,7 +67,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
       I18n.t "controllers.order_management.order_details.remove_from_journal.notice"
 
     if modal?
-      render head :ok
+      head :ok
     else
       redirect_to [current_facility, @order]
     end

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -122,8 +122,9 @@ class PricePoliciesController < ApplicationController
 
   def init_product
     id_param = params.except(:facility_id).keys.detect { |k| k.end_with?("_id") }
-    clazz = id_param.sub(/_id\z/, "").camelize
-    @product = current_facility.products(clazz)
+    class_name = id_param.sub(/_id\z/, "").camelize
+    @product = current_facility.products
+                               .of_type(class_name)
                                .find_by!(url_name: params[id_param])
   end
 

--- a/app/controllers/reports/csv_export_controller.rb
+++ b/app/controllers/reports/csv_export_controller.rb
@@ -16,7 +16,7 @@ module Reports
       CsvReportMailer.delay.csv_report_email(email_to_address, raw_report) # TODO: use .deliver_later instead
 
       if request.xhr?
-        render head :ok
+        head :ok
       else
         flash[:notice] = I18n.t("controllers.reports.mail_queued", email: email_to_address)
         redirect_to success_redirect_path

--- a/app/controllers/reports/csv_export_controller.rb
+++ b/app/controllers/reports/csv_export_controller.rb
@@ -16,7 +16,7 @@ module Reports
       CsvReportMailer.delay.csv_report_email(email_to_address, raw_report) # TODO: use .deliver_later instead
 
       if request.xhr?
-        render nothing: true
+        render head :ok
       else
         flash[:notice] = I18n.t("controllers.reports.mail_queued", email: email_to_address)
         redirect_to success_redirect_path

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,4 +1,4 @@
-class Account < ActiveRecord::Base
+class Account < ApplicationRecord
 
   module Overridable
 

--- a/app/models/account_user.rb
+++ b/app/models/account_user.rb
@@ -1,4 +1,4 @@
-class AccountUser < ActiveRecord::Base
+class AccountUser < ApplicationRecord
 
   belongs_to :user
   belongs_to :account, inverse_of: :account_users

--- a/app/models/admin_reservation.rb
+++ b/app/models/admin_reservation.rb
@@ -1,7 +1,5 @@
 class AdminReservation < Reservation
 
-  include ActiveModel::ForbiddenAttributesProtection
-
   CATEGORIES = %w(
     maintenance
     training

--- a/app/models/affiliate.rb
+++ b/app/models/affiliate.rb
@@ -1,4 +1,4 @@
-class Affiliate < ActiveRecord::Base
+class Affiliate < ApplicationRecord
 
   validates_presence_of :name
   validates_uniqueness_of :name

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,5 @@
+class ApplicationRecord < ActiveRecord::Base
+
+  self.abstract_class = true
+
+end

--- a/app/models/budgeted_chart_string.rb
+++ b/app/models/budgeted_chart_string.rb
@@ -1,4 +1,4 @@
-class BudgetedChartString < ActiveRecord::Base
+class BudgetedChartString < ApplicationRecord
 
   include NUCore::Database::DateHelper
 

--- a/app/models/bundle_product.rb
+++ b/app/models/bundle_product.rb
@@ -1,4 +1,4 @@
-class BundleProduct < ActiveRecord::Base
+class BundleProduct < ApplicationRecord
 
   belongs_to :bundle, foreign_key: :bundle_product_id
   belongs_to :product

--- a/app/models/concerns/async_file_processing.rb
+++ b/app/models/concerns/async_file_processing.rb
@@ -10,7 +10,7 @@
 #   * `process_file!` should raise an error if anything goes wrong
 #
 # Example:
-# class OrderImport < ActiveRecord::Base
+# class OrderImport < ApplicationRecord
 #   include AsyncFileProcessing
 #   def process_file!
 #     do_something(file.path)

--- a/app/models/email_event.rb
+++ b/app/models/email_event.rb
@@ -1,8 +1,6 @@
 # Never instantiate this class directly. Use the `notify` method.
 class EmailEvent < ApplicationRecord
 
-  include ActiveModel::ForbiddenAttributesProtection
-
   belongs_to :user
   validates :user, presence: true
   validates :key, presence: true, uniqueness: { scope: :user_id }

--- a/app/models/email_event.rb
+++ b/app/models/email_event.rb
@@ -1,5 +1,5 @@
 # Never instantiate this class directly. Use the `notify` method.
-class EmailEvent < ActiveRecord::Base
+class EmailEvent < ApplicationRecord
 
   include ActiveModel::ForbiddenAttributesProtection
 

--- a/app/models/external_service/external_service.rb
+++ b/app/models/external_service/external_service.rb
@@ -1,6 +1,6 @@
 #
 # Represents a 3rd party service in use by the system
-class ExternalService < ActiveRecord::Base
+class ExternalService < ApplicationRecord
 
   validates_presence_of :location
 

--- a/app/models/external_service/external_service_passer.rb
+++ b/app/models/external_service/external_service_passer.rb
@@ -2,7 +2,7 @@
 # A polymorphic join class between an +ExternalService+
 # and a class that passes off work to that service
 # (the passer).
-class ExternalServicePasser < ActiveRecord::Base
+class ExternalServicePasser < ApplicationRecord
 
   belongs_to :external_service
   belongs_to :passer, polymorphic: true

--- a/app/models/external_service/external_service_receiver.rb
+++ b/app/models/external_service/external_service_receiver.rb
@@ -2,7 +2,7 @@
 # A polymorphic join class between an +ExternalService+
 # and a class that receives the results of that service
 # (the receiver).
-class ExternalServiceReceiver < ActiveRecord::Base
+class ExternalServiceReceiver < ApplicationRecord
 
   belongs_to :external_service
   belongs_to :receiver, polymorphic: true

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -1,7 +1,5 @@
 class Facility < ApplicationRecord
 
-  include ActiveModel::ForbiddenAttributesProtection
-
   before_validation :set_journal_mask, on: :create
 
   has_many :items

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -56,14 +56,6 @@ class Facility < ApplicationRecord
       new(url_name: "all", name: "Cross-Facility", abbreviation: "ALL", is_active: true)
   end
 
-  def products(type = nil)
-    if type
-      self.public_send(type.to_s.pluralize.underscore.to_sym)
-    else
-      super
-    end
-  end
-
   def destroy
     # TODO: can you ever delete a facility? Currently no.
     # super

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -1,4 +1,4 @@
-class Facility < ActiveRecord::Base
+class Facility < ApplicationRecord
 
   include ActiveModel::ForbiddenAttributesProtection
 
@@ -60,7 +60,7 @@ class Facility < ActiveRecord::Base
 
   def products(type = nil)
     if type
-      super.where(type: type)
+      self.public_send(type.to_s.pluralize.underscore.to_sym)
     else
       super
     end

--- a/app/models/facility_account.rb
+++ b/app/models/facility_account.rb
@@ -1,4 +1,4 @@
-class FacilityAccount < ActiveRecord::Base
+class FacilityAccount < ApplicationRecord
 
   include Accounts::AccountNumberSectionable
 

--- a/app/models/instrument_status.rb
+++ b/app/models/instrument_status.rb
@@ -1,4 +1,4 @@
-class InstrumentStatus < ActiveRecord::Base
+class InstrumentStatus < ApplicationRecord
 
   belongs_to :instrument
 

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -1,6 +1,6 @@
 require "set"
 
-class Journal < ActiveRecord::Base
+class Journal < ApplicationRecord
 
   class CreationError < NUCore::Error; end
 
@@ -106,7 +106,7 @@ class Journal < ActiveRecord::Base
       _order_details.joins(:order)
                     .select("orders.facility_id")
                     .collect(&:facility_id)
-                    .uniq
+                    .distinct
     end
   end
 

--- a/app/models/journal_cutoff_date.rb
+++ b/app/models/journal_cutoff_date.rb
@@ -1,7 +1,5 @@
 class JournalCutoffDate < ApplicationRecord
 
-  include ActiveModel::ForbiddenAttributesProtection
-
   include DateTimeInput::Model
   date_time_inputable :cutoff_date
 

--- a/app/models/journal_cutoff_date.rb
+++ b/app/models/journal_cutoff_date.rb
@@ -1,4 +1,4 @@
-class JournalCutoffDate < ActiveRecord::Base
+class JournalCutoffDate < ApplicationRecord
 
   include ActiveModel::ForbiddenAttributesProtection
 

--- a/app/models/journal_row.rb
+++ b/app/models/journal_row.rb
@@ -1,4 +1,4 @@
-class JournalRow < ActiveRecord::Base
+class JournalRow < ApplicationRecord
 
   belongs_to :journal
   belongs_to :order_detail

--- a/app/models/log_event.rb
+++ b/app/models/log_event.rb
@@ -1,4 +1,4 @@
-class LogEvent < ActiveRecord::Base
+class LogEvent < ApplicationRecord
 
   belongs_to :user
   belongs_to :loggable, polymorphic: true

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,4 +1,4 @@
-class Notification < ActiveRecord::Base
+class Notification < ApplicationRecord
 
   belongs_to :user
   belongs_to :subject, polymorphic: true

--- a/app/models/offline_reservation.rb
+++ b/app/models/offline_reservation.rb
@@ -2,8 +2,6 @@ class OfflineReservation < Reservation
 
   CATEGORIES = I18n.t("offline_reservations.categories").keys.map(&:to_s).freeze
 
-  include ActiveModel::ForbiddenAttributesProtection
-
   validates :admin_note, presence: true
   validates :category, presence: true
   validates :category,

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,4 @@
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
 
   belongs_to :user
   belongs_to :created_by_user, class_name: "User", foreign_key: :created_by

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -1,4 +1,4 @@
-class OrderDetail < ActiveRecord::Base
+class OrderDetail < ApplicationRecord
 
   include ActiveModel::ForbiddenAttributesProtection
 

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -1,7 +1,5 @@
 class OrderDetail < ApplicationRecord
 
-  include ActiveModel::ForbiddenAttributesProtection
-
   include NUCore::Database::SortHelper
   include TranslationHelper
   include NotificationSubject

--- a/app/models/order_import.rb
+++ b/app/models/order_import.rb
@@ -1,6 +1,6 @@
 require "csv"
 
-class OrderImport < ActiveRecord::Base
+class OrderImport < ApplicationRecord
 
   belongs_to :facility
   belongs_to :upload_file, class_name: "StoredFile", dependent: :destroy

--- a/app/models/order_status.rb
+++ b/app/models/order_status.rb
@@ -1,4 +1,4 @@
-class OrderStatus < ActiveRecord::Base
+class OrderStatus < ApplicationRecord
 
   acts_as_nested_set
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,4 +1,4 @@
-class Payment < ActiveRecord::Base
+class Payment < ApplicationRecord
 
   belongs_to :account, inverse_of: :payments
   belongs_to :statement, inverse_of: :payments

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -1,4 +1,4 @@
-class PriceGroup < ActiveRecord::Base
+class PriceGroup < ApplicationRecord
 
   belongs_to :facility
   has_many   :order_details, through: :price_policies, dependent: :restrict_with_exception

--- a/app/models/price_group_member.rb
+++ b/app/models/price_group_member.rb
@@ -1,4 +1,4 @@
-class PriceGroupMember < ActiveRecord::Base
+class PriceGroupMember < ApplicationRecord
 
   belongs_to :price_group
 

--- a/app/models/price_group_product.rb
+++ b/app/models/price_group_product.rb
@@ -1,4 +1,4 @@
-class PriceGroupProduct < ActiveRecord::Base
+class PriceGroupProduct < ApplicationRecord
 
   DEFAULT_RESERVATION_WINDOW = 14
 

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -1,4 +1,4 @@
-class PricePolicy < ActiveRecord::Base
+class PricePolicy < ApplicationRecord
 
   include NUCore::Database::DateHelper
 
@@ -88,7 +88,7 @@ class PricePolicy < ActiveRecord::Base
     product.price_policies
            .where("start_date > ?", Time.zone.now.beginning_of_day)
            .order(:start_date)
-           .uniq
+           .distinct
            .pluck(:start_date)
            .map(&:to_date)
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,4 @@
-class Product < ActiveRecord::Base
+class Product < ApplicationRecord
 
   include TextHelpers::Translation
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -64,6 +64,7 @@ class Product < ApplicationRecord
   scope :not_archived, -> { where(is_archived: false) }
   scope :mergeable_into_order, -> { not_archived.where(type: mergeable_types) }
   scope :in_active_facility, -> { joins(:facility).where(facilities: { is_active: true }) }
+  scope :of_type, ->(type) { where(type: type) }
 
   def self.types
     @types ||= [Instrument, Item, Service, TimedService, Bundle]

--- a/app/models/product_access_group.rb
+++ b/app/models/product_access_group.rb
@@ -1,4 +1,4 @@
-class ProductAccessGroup < ActiveRecord::Base
+class ProductAccessGroup < ApplicationRecord
 
   belongs_to :product
   has_many :product_users, dependent: :nullify

--- a/app/models/product_accessory.rb
+++ b/app/models/product_accessory.rb
@@ -1,4 +1,4 @@
-class ProductAccessory < ActiveRecord::Base
+class ProductAccessory < ApplicationRecord
 
   SCALING_TYPES = {
     item: ["quantity"],

--- a/app/models/product_user.rb
+++ b/app/models/product_user.rb
@@ -1,4 +1,4 @@
-class ProductUser < ActiveRecord::Base
+class ProductUser < ApplicationRecord
 
   belongs_to :user
   belongs_to :product

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -1,6 +1,6 @@
 require "net/http"
 
-class Relay < ActiveRecord::Base
+class Relay < ApplicationRecord
 
   belongs_to :instrument, inverse_of: :relay
 

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -1,6 +1,6 @@
 require "date"
 
-class Reservation < ActiveRecord::Base
+class Reservation < ApplicationRecord
 
   acts_as_paranoid # soft deletes
 

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,4 +1,4 @@
-class Schedule < ActiveRecord::Base
+class Schedule < ApplicationRecord
 
   # Associations
   # --------

--- a/app/models/schedule_rule.rb
+++ b/app/models/schedule_rule.rb
@@ -1,4 +1,4 @@
-class ScheduleRule < ActiveRecord::Base
+class ScheduleRule < ApplicationRecord
 
   belongs_to :product
 

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -1,4 +1,4 @@
-class Statement < ActiveRecord::Base
+class Statement < ApplicationRecord
 
   has_many :order_details, inverse_of: :statement
   has_many :statement_rows, dependent: :destroy

--- a/app/models/statement_row.rb
+++ b/app/models/statement_row.rb
@@ -1,4 +1,4 @@
-class StatementRow < ActiveRecord::Base
+class StatementRow < ApplicationRecord
 
   belongs_to :statement
   belongs_to :order_detail

--- a/app/models/stored_file.rb
+++ b/app/models/stored_file.rb
@@ -1,4 +1,4 @@
-class StoredFile < ActiveRecord::Base
+class StoredFile < ApplicationRecord
 
   include DownloadableFile
 

--- a/app/models/training_request.rb
+++ b/app/models/training_request.rb
@@ -1,4 +1,4 @@
-class TrainingRequest < ActiveRecord::Base
+class TrainingRequest < ApplicationRecord
 
   belongs_to :user
   belongs_to :product

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,4 @@
-class User < ActiveRecord::Base
+class User < ApplicationRecord
 
   include ::Users::Roles
   include NUCore::Database::WhereIdsIn
@@ -11,7 +11,7 @@ class User < ActiveRecord::Base
   has_many :orders
   has_many :order_details, through: :orders
   has_many :price_group_members, class_name: "UserPriceGroupMember", dependent: :destroy
-  has_many :price_groups, -> { SettingsHelper.feature_on?(:user_based_price_groups) ? uniq : none }, through: :price_group_members
+  has_many :price_groups, -> { SettingsHelper.feature_on?(:user_based_price_groups) ? distinct : none }, through: :price_group_members
   has_many :product_users
   has_many :notifications
   has_many :products, through: :product_users

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -1,7 +1,5 @@
 class UserPreference < ApplicationRecord
 
-  include ActiveModel::ForbiddenAttributesProtection
-
   belongs_to :user
   validates :value, presence: true
   validates :name, presence: true, uniqueness: { scope: :user_id }

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -1,4 +1,4 @@
-class UserPreference < ActiveRecord::Base
+class UserPreference < ApplicationRecord
 
   include ActiveModel::ForbiddenAttributesProtection
 

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -1,4 +1,4 @@
-class UserRole < ActiveRecord::Base
+class UserRole < ApplicationRecord
 
   belongs_to :user
   belongs_to :facility

--- a/app/models/vestal_version.rb
+++ b/app/models/vestal_version.rb
@@ -4,7 +4,7 @@
 # once that data is no longer needed, this class can be removed
 # along with the has_many clause in OrderDetail
 
-class VestalVersion < ActiveRecord::Base
+class VestalVersion < ApplicationRecord
 
   belongs_to :versioned, polymorphic: true
 

--- a/app/services/order_detail_update_param_hash_extractor.rb
+++ b/app/services/order_detail_update_param_hash_extractor.rb
@@ -14,7 +14,8 @@ class OrderDetailUpdateParamHashExtractor
   # ...then the #to_h method would return:
   #   { 123 => { quantity: 2, note: "Noted" } }
   def to_h
-    params.each_with_object({}) do |(key, value), memo|
+    # TODO: clean up this and _cart_row.html.haml
+    params.permit!.to_h.each_with_object({}) do |(key, value), memo|
       match = key.match(/\A(note|quantity)(\d+)\z/) || next
       property = match[1].to_sym
       id = match[2].to_i

--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -33,7 +33,7 @@ class OrderDetails::ParamUpdater
   end
 
   def assign_attributes(params)
-    params = ActionController::Parameters.new(params.try(:dup))
+    params = params.dup
     params.delete(:quantity) unless params[:quantity].to_s =~ /\A\d+\z/
 
     assign_self_and_reservation_attributes(permitted_params(params))

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -11,7 +11,7 @@ module OrderDetails
     validate :all_journals_and_statements_must_be_before_reconciliation_date
 
     def initialize(order_detail_scope, params, reconciled_at)
-      @params = params
+      @params = params || ActionController::Parameters.new
       @order_details = order_detail_scope.readonly(false).find_ids(to_be_reconciled.keys)
       @reconciled_at = reconciled_at
     end

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -37,7 +37,7 @@ module OrderDetails
     # The params hash comes in with the unchecked IDs as well. Filter out to only
     # those we're going to reconcile. Returns an array of IDs.
     def to_be_reconciled
-      Hash(@params).select { |_order_detail_id, params| params[:reconciled] == "1" }
+      @params.select { |_order_detail_id, params| params[:reconciled] == "1" }
     end
 
     def reconcile(order_detail, params)

--- a/app/views/admin/shared/_sidenav_product.html.haml
+++ b/app/views/admin/shared/_sidenav_product.html.haml
@@ -1,6 +1,6 @@
 %ul.sidebar-nav
   - Product.types.each do |product_type|
-    = tab "#{product_type.model_name.human(count: 2)} (#{current_facility.products(product_type).count})",
+    = tab "#{product_type.model_name.human(count: 2)} (#{current_facility.products.of_type(product_type.name).count})",
       [current_facility, product_type],
       sidenav_tab == product_type.model_name.plural
 

--- a/app/views/shared/transactions/_search2.html.haml
+++ b/app/views/shared/transactions/_search2.html.haml
@@ -1,6 +1,6 @@
 -# This view, replaces _search, which relies on the TransactionSearch controller/concern.
 -# This view, along with TransactionSearch::Searcher is the more modern method. See FacilityAccountsReconciliationController
-= simple_form_for @search_form, url: url_for(params.permit(:search)), method: :get, html: { class: "search_form" }, defaults: { required: false } do |f|
+= simple_form_for @search_form, url: url_for(params.permit!), method: :get, html: { class: "search_form" }, defaults: { required: false } do |f|
   .row
     %fieldset.span6#search
       - @search.options.reject(&:multipart?).each do |searcher|

--- a/app/views/shared/transactions/_search2.html.haml
+++ b/app/views/shared/transactions/_search2.html.haml
@@ -1,6 +1,6 @@
 -# This view, replaces _search, which relies on the TransactionSearch controller/concern.
 -# This view, along with TransactionSearch::Searcher is the more modern method. See FacilityAccountsReconciliationController
-= simple_form_for @search_form, url: url_for(params.permit!), method: :get, html: { class: "search_form" }, defaults: { required: false } do |f|
+= simple_form_for @search_form, url: url_for, method: :get, html: { class: "search_form" }, defaults: { required: false } do |f|
   .row
     %fieldset.span6#search
       - @search.options.reject(&:multipart?).each do |searcher|

--- a/app/views/shared/transactions/_search2.html.haml
+++ b/app/views/shared/transactions/_search2.html.haml
@@ -1,6 +1,6 @@
 -# This view, replaces _search, which relies on the TransactionSearch controller/concern.
 -# This view, along with TransactionSearch::Searcher is the more modern method. See FacilityAccountsReconciliationController
-= simple_form_for @search_form, url: url_for(params), method: :get, html: { class: "search_form" }, defaults: { required: false } do |f|
+= simple_form_for @search_form, url: url_for(params.permit(:search)), method: :get, html: { class: "search_form" }, defaults: { required: false } do |f|
   .row
     %fieldset.span6#search
       - @search.options.reject(&:multipart?).each do |searcher|

--- a/spec/controllers/affiliates_controller_spec.rb
+++ b/spec/controllers/affiliates_controller_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe AffiliatesController do
     maybe_grant_always_sign_in :admin
     do_request
     yield if block_given?
-    expect(assigns(:affiliate).name).to be_nil
+    expect(assigns(:affiliate).name).to be_blank
     is_expected.to render_template template
   end
 

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe FacilityJournalsController do
         expect(@creation_errors).to be_empty
         expect(@order_detail1.reload.journal_id).not_to be_nil
         expect(@order_detail3.reload.journal_id).not_to be_nil
-        expect(@journal.order_details.uniq.size).to eq(2)
+        expect(@journal.order_details.distinct.size).to eq(2)
         expect(@journal.is_successful).to be_nil
       end
 

--- a/spec/services/order_detail_update_param_hash_extractor_spec.rb
+++ b/spec/services/order_detail_update_param_hash_extractor_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OrderDetailUpdateParamHashExtractor do
     subject { described_class.new(params).to_h }
 
     context "when the params contain a quantity key" do
-      let(:params) { ActionController::Parameters.new({ "quantity101" => quantity_value }) }
+      let(:params) { ActionController::Parameters.new("quantity101" => quantity_value) }
 
       context "with a value" do
         let(:quantity_value) { "5" }
@@ -21,7 +21,7 @@ RSpec.describe OrderDetailUpdateParamHashExtractor do
     end
 
     context "when the params contain a note key" do
-      let(:params) { ActionController::Parameters.new({ "note202" => note_value }) }
+      let(:params) { ActionController::Parameters.new("note202" => note_value) }
 
       context "with a value" do
         let(:note_value) { "This is a note" }

--- a/spec/services/order_detail_update_param_hash_extractor_spec.rb
+++ b/spec/services/order_detail_update_param_hash_extractor_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OrderDetailUpdateParamHashExtractor do
     subject { described_class.new(params).to_h }
 
     context "when the params contain a quantity key" do
-      let(:params) { { "quantity101" => quantity_value } }
+      let(:params) { ActionController::Parameters.new({ "quantity101" => quantity_value }) }
 
       context "with a value" do
         let(:quantity_value) { "5" }
@@ -21,7 +21,7 @@ RSpec.describe OrderDetailUpdateParamHashExtractor do
     end
 
     context "when the params contain a note key" do
-      let(:params) { { "note202" => note_value } }
+      let(:params) { ActionController::Parameters.new({ "note202" => note_value }) }
 
       context "with a value" do
         let(:note_value) { "This is a note" }

--- a/vendor/engines/bulk_email/app/models/bulk_email/job.rb
+++ b/vendor/engines/bulk_email/app/models/bulk_email/job.rb
@@ -1,6 +1,6 @@
 module BulkEmail
 
-  class Job < ActiveRecord::Base
+  class Job < ApplicationRecord
 
     self.table_name = "bulk_email_jobs"
 

--- a/vendor/engines/bulk_email/app/services/bulk_email/recipient_searcher.rb
+++ b/vendor/engines/bulk_email/app/services/bulk_email/recipient_searcher.rb
@@ -64,7 +64,7 @@ module BulkEmail
     def search_authorized_users
       users
         .joins(:product_users)
-        .uniq
+        .distinct
         .where(product_users: { product_id: product_ids_from_params })
         .reorder(*self.class::DEFAULT_SORT)
     end
@@ -72,7 +72,7 @@ module BulkEmail
     def search_training_requested
       users
         .joins(:training_requests)
-        .uniq
+        .distinct
         .where(training_requests: { product_id: product_ids_from_params })
         .reorder(*self.class::DEFAULT_SORT)
     end

--- a/vendor/engines/projects/app/controllers/projects/projects_controller.rb
+++ b/vendor/engines/projects/app/controllers/projects/projects_controller.rb
@@ -3,7 +3,7 @@ module Projects
   class ProjectsController < ApplicationController
 
     admin_tab :all
-    before_filter { @active_tab = "admin_projects" }
+    before_action { @active_tab = "admin_projects" }
 
     load_and_authorize_resource through: :current_facility
 

--- a/vendor/engines/projects/app/models/projects/project.rb
+++ b/vendor/engines/projects/app/models/projects/project.rb
@@ -1,6 +1,6 @@
 module Projects
 
-  class Project < ActiveRecord::Base
+  class Project < ApplicationRecord
 
     include ActiveModel::ForbiddenAttributesProtection
 

--- a/vendor/engines/projects/app/models/projects/project.rb
+++ b/vendor/engines/projects/app/models/projects/project.rb
@@ -2,8 +2,6 @@ module Projects
 
   class Project < ApplicationRecord
 
-    include ActiveModel::ForbiddenAttributesProtection
-
     belongs_to :facility, foreign_key: :facility_id
     has_many :order_details, inverse_of: :project
 

--- a/vendor/engines/projects/spec/controllers/projects/projects_controller_spec.rb
+++ b/vendor/engines/projects/spec/controllers/projects/projects_controller_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 require "controller_spec_helper" # for the #facility_operators helper method
 
-def facility_operator_roles # Translates helper roles to User factory traits
+def facility_operator_roles
+  # Translates helper roles to User factory traits
   facility_operators.map do |role|
     case role
     when :admin

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/batch.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/batch.rb
@@ -1,6 +1,6 @@
 module SangerSequencing
 
-  class Batch < ActiveRecord::Base
+  class Batch < ApplicationRecord
 
     DEFAULT_PRODUCT_GROUP_NAME = [nil, ""].freeze
 

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/product_group.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/product_group.rb
@@ -1,6 +1,6 @@
 module SangerSequencing
 
-  class ProductGroup < ActiveRecord::Base
+  class ProductGroup < ApplicationRecord
 
     # sanger_sequencing_product_groups is too long of a table name for Oracle
     self.table_name = "sanger_seq_product_groups"

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/sample.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/sample.rb
@@ -1,6 +1,6 @@
 module SangerSequencing
 
-  class Sample < ActiveRecord::Base
+  class Sample < ApplicationRecord
 
     include ActiveModel::ForbiddenAttributesProtection
 

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/sample.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/sample.rb
@@ -2,8 +2,6 @@ module SangerSequencing
 
   class Sample < ApplicationRecord
 
-    include ActiveModel::ForbiddenAttributesProtection
-
     self.table_name = "sanger_sequencing_samples"
     belongs_to :submission
 

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
@@ -1,6 +1,6 @@
 module SangerSequencing
 
-  class Submission < ActiveRecord::Base
+  class Submission < ApplicationRecord
 
     self.table_name = "sanger_sequencing_submissions"
 

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
@@ -4,8 +4,6 @@ module SangerSequencing
 
     self.table_name = "sanger_sequencing_submissions"
 
-    include ActiveModel::ForbiddenAttributesProtection
-
     validates :savable_samples, length: { minimum: 1 }, on: :update
 
     belongs_to :order_detail, class_name: "::OrderDetail"

--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms/card_readers_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms/card_readers_controller.rb
@@ -59,7 +59,7 @@ module SecureRooms
     private
 
     def init_product
-      @product = current_facility.products(SecureRoom).find_by!(url_name: params[:secure_room_id])
+      @product = current_facility.secure_rooms.find_by!(url_name: params[:secure_room_id])
     end
 
     def card_reader_params

--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms/facility_occupancies_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms/facility_occupancies_controller.rb
@@ -34,7 +34,7 @@ module SecureRooms
     end
 
     def dashboard
-      @secure_rooms = current_facility.products(SecureRoom).active_plus_hidden.alphabetized
+      @secure_rooms = current_facility.secure_rooms.active_plus_hidden.alphabetized
     end
 
     protected

--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/events_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/events_controller.rb
@@ -10,7 +10,7 @@ module SecureRoomsApi
         ),
       )
 
-      render head :ok
+      head :ok
     end
 
     private

--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/events_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms_api/events_controller.rb
@@ -10,7 +10,7 @@ module SecureRoomsApi
         ),
       )
 
-      render nothing: true
+      render head :ok
     end
 
     private

--- a/vendor/engines/secure_rooms/app/models/secure_room.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_room.rb
@@ -5,6 +5,7 @@ class SecureRoom < Product
   has_many :card_readers, foreign_key: :product_id, class_name: SecureRooms::CardReader
   has_many :events, foreign_key: :product_id, class_name: SecureRooms::Event
   has_many :occupancies, foreign_key: :product_id, class_name: SecureRooms::Occupancy
+  belongs_to :facility
 
   before_validation :set_secure_room_defaults, on: :create
   validates :dashboard_token, presence: true

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/alarm_event.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/alarm_event.rb
@@ -1,6 +1,6 @@
 module SecureRooms
 
-  class AlarmEvent < ActiveRecord::Base
+  class AlarmEvent < ApplicationRecord
 
   end
 

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/card_reader.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/card_reader.rb
@@ -1,6 +1,6 @@
 module SecureRooms
 
-  class CardReader < ActiveRecord::Base
+  class CardReader < ApplicationRecord
 
     MAC_ADDRESS_FORMAT = /\A([0-9A-F]{2}:){5}([0-9A-F]{2})\z/
 

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/event.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/event.rb
@@ -1,6 +1,6 @@
 module SecureRooms
 
-  class Event < ActiveRecord::Base
+  class Event < ApplicationRecord
 
     belongs_to :secure_room, foreign_key: :product_id
     belongs_to :account

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/facility_extension.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/facility_extension.rb
@@ -1,0 +1,13 @@
+module SecureRooms
+
+  module FacilityExtension
+
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :secure_rooms
+    end
+
+  end
+
+end

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
@@ -1,6 +1,6 @@
 module SecureRooms
 
-  class Occupancy < ActiveRecord::Base
+  class Occupancy < ApplicationRecord
 
     include DateTimeInput::Model
 

--- a/vendor/engines/secure_rooms/lib/secure_rooms/engine.rb
+++ b/vendor/engines/secure_rooms/lib/secure_rooms/engine.rb
@@ -9,6 +9,7 @@ module SecureRooms
 
       NavTab::LinkCollection.send :include, SecureRooms::LinkCollectionExtension
       OrderDetail.send :include, SecureRooms::OrderDetailExtension
+      Facility.send :include, SecureRooms::FacilityExtension
       User.send :include, SecureRooms::UserExtension
       ::OrderDetails::ParamUpdater.send :include, SecureRooms::OrderDetails::ParamUpdaterExtension
 

--- a/vendor/engines/split_accounts/app/models/split_accounts/split.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/split.rb
@@ -1,6 +1,6 @@
 module SplitAccounts
 
-  class Split < ActiveRecord::Base
+  class Split < ApplicationRecord
 
     belongs_to :parent_split_account, class_name: "SplitAccounts::SplitAccount", foreign_key: :parent_split_account_id, inverse_of: :splits
     belongs_to :subaccount, class_name: "Account", foreign_key: :subaccount_id, inverse_of: :parent_splits


### PR DESCRIPTION
# Release Notes

TECH TASK: Changes needed for Rails 5 that are compatible with Rails 4.

- Models inherit from ApplicationRecord
- Replace deprecated render nothing calls
- Replace method overriding an AR relation with scope
- Remove redundant calls to include ForbiddenAttributesProtection (now standard)
- Replace deprecated `uniq` calls with `distinct`
- Use ActionController::Parameters objects instead of hashes
- Replace deprecated `before_filter` with `before_action`