### PR TITLE
Fix migration from scratch caused by paranoia

### DIFF
--- a/db/migrate/20160614185348_add_type_to_reservations.rb
+++ b/db/migrate/20160614185348_add_type_to_reservations.rb
@@ -1,9 +1,12 @@
 class AddTypeToReservations < ActiveRecord::Migration
 
+  class Reservation < ActiveRecord::Base
+  end
+
   def up
     add_column :reservations, :type, :string
     change_column :reservations, :reserve_end_at, :datetime, null: true
-    admin_reservations = Reservation.where(order_detail: nil)
+    admin_reservations = Reservation.where(order_detail_id: nil)
     admin_reservations.where(reserve_end_at: nil).update_all(type: "OfflineReservation")
     admin_reservations.where.not(reserve_end_at: nil).update_all(type: "AdminReservation")
   end

--- a/db/migrate/20170501201633_add_canceled_to_order_detail.rb
+++ b/db/migrate/20170501201633_add_canceled_to_order_detail.rb
@@ -1,5 +1,9 @@
 class AddCanceledToOrderDetail < ActiveRecord::Migration
 
+  class Reservation < ActiveRecord::Base
+    belongs_to :order_detail
+  end
+
   def up
     add_column :order_details, :canceled_at, :datetime
     add_column :order_details, :canceled_by, :integer


### PR DESCRIPTION
# Release Notes

Tech task: Migration from scratch became broken after we introduced Paranoia.

# Additional Context

Errors because `deleted_at` column does not exist on earlier migrations of `Reservation`