### PR TITLE
[#73287] Add ability to suspend a user

### DIFF
--- a/app/controllers/reports/reports_controller.rb
+++ b/app/controllers/reports/reports_controller.rb
@@ -30,11 +30,7 @@ module Reports
     end
 
     def self.format_username(user)
-      name = ""
-      name += (user.last_name || "")
-      name += ", " unless name.blank?
-      name += (user.first_name || "")
-      "#{name} (#{user.username})"
+      Users::NamePresenter.new(user, username_label: true).last_first_name
     end
 
     def export_raw_visible?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,7 +19,7 @@ class UsersController < ApplicationController
   before_action :check_acting_as
 
   load_and_authorize_resource except: [:create, :password, :password_reset, :edit, :update, :show], id_param: :user_id
-  load_and_authorize_resource only: [:edit, :update, :show], id_param: :id
+  load_and_authorize_resource only: [:edit, :update, :show, :suspend, :activate], id_param: :id
 
   layout "two_column"
 
@@ -129,6 +129,17 @@ class UsersController < ApplicationController
       flash[:error] = text("update.error", message: @user_form.errors.full_messages.to_sentence)
       render action: "edit"
     end
+  end
+
+  def suspend
+    @user.suspended_at ||= Time.current
+    @user.save!
+    redirect_to facility_user_path(current_facility, @user), notice: "User suspended"
+  end
+
+  def activate
+    @user.update!(suspended_at: nil)
+    redirect_to facility_user_path(current_facility, @user), notice: "User activated"
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,7 +19,7 @@ class UsersController < ApplicationController
   before_action :check_acting_as
 
   load_and_authorize_resource except: [:create, :password, :password_reset, :edit, :update, :show], id_param: :user_id
-  load_and_authorize_resource only: [:edit, :update, :show, :suspend, :activate], id_param: :id
+  load_and_authorize_resource only: [:edit, :update, :show, :suspend, :unsuspend], id_param: :id
 
   layout "two_column"
 
@@ -137,9 +137,9 @@ class UsersController < ApplicationController
     redirect_to facility_user_path(current_facility, @user), notice: "User suspended"
   end
 
-  def activate
+  def unsuspend
     @user.update!(suspended_at: nil)
-    redirect_to facility_user_path(current_facility, @user), notice: "User activated"
+    redirect_to facility_user_path(current_facility, @user), notice: "User re-activated"
   end
 
   private

--- a/app/inputs/transaction_chosen2_input.rb
+++ b/app/inputs/transaction_chosen2_input.rb
@@ -39,11 +39,12 @@ class TransactionChosen2Input < SimpleForm::Inputs::CollectionInput
 
   private
 
+  # Pass an array if you want arguments, [:full_name, suspended_label: true]
   def option_elems(label_method, value_method)
     collection.map do |i|
       [
-        i.public_send(label_method),
-        i.public_send(value_method),
+        i.public_send(*label_method),
+        i.public_send(*value_method),
         data_for_item(i),
       ]
     end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -718,8 +718,7 @@ class OrderDetail < ActiveRecord::Base
   end
 
   def long_description
-    "##{self}: #{order.user}: #{I18n.l(fulfilled_at.to_date, format: :usa)}: "\
-    "#{product} x#{quantity}"
+    OrderDetailJournalDescriptionPresenter.new(self).long_description
   end
 
   def cost_estimated?

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -717,6 +717,8 @@ class OrderDetail < ActiveRecord::Base
     "Order # #{self}"
   end
 
+  # Only used by Journals. Consider pulling into the journal/journal row
+  # (NU uses this method in their engines).
   def long_description
     OrderDetailJournalDescriptionPresenter.new(self).long_description
   end

--- a/app/models/reports/export_raw.rb
+++ b/app/models/reports/export_raw.rb
@@ -95,8 +95,8 @@ module Reports
         reconciled_note: :reconciled_note,
         reconciled_at: :reconciled_at,
         price_change_reason: :price_change_reason,
-        price_changed_by_user: ->(od) { od.price_changed_by_user.try(:full_name) },
-        assigned_user: ->(od) { od.assigned_user.try(:full_name) },
+        price_changed_by_user: ->(od) { od.price_changed_by_user&.full_name(suspended_label: false) },
+        assigned_user: ->(od) { od.assigned_user&.full_name(suspended_label: false) },
       }
       if SettingsHelper.has_review_period?
         hash
@@ -130,7 +130,7 @@ module Reports
       if order_detail.canceled_by.try(:zero?)
         I18n.t("reports.fields.auto_cancel_name")
       else
-        order_detail.canceled_by_user.try(:full_name)
+        order_detail.canceled_by_user&.full_name(suspended_label: false)
       end
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,8 @@ class User < ActiveRecord::Base
   # Gem ldap_authenticatable expects User to respond_to? :login. For us that's #username.
   alias_attribute :login, :username
 
-  # TODO: Update downstreams to use `suspended_at`
+  # TODO: This allows downstream forks that reference deactivated_at to not break. Once
+  # those are cleaned up, remove me.
   alias_attribute :deactivated_at, :suspended_at
 
   #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,9 @@ class User < ActiveRecord::Base
   # Gem ldap_authenticatable expects User to respond_to? :login. For us that's #username.
   alias_attribute :login, :username
 
+  # TODO: Update downstreams to use `suspended_at`
+  alias_attribute :deactivated_at, :suspended_at
+
   #
   # Gem ldap_authenticatable expects User to respond_to? :ldap_attributes. For us should return nil.
   attr_accessor :ldap_attributes
@@ -142,13 +145,11 @@ class User < ActiveRecord::Base
     OrderDetail.where(account_id: Account.administered_by(self))
   end
 
-  # TODO: Rename the column
-  alias_attribute :suspended_at, :deactivated_at
-
   def full_name(suspended_label: true)
     Users::NamePresenter.new(self, suspended_label: suspended_label).full_name
   end
   alias to_s full_name
+  alias name full_name
 
   def last_first_name(suspended_label: true)
     Users::NamePresenter.new(self, suspended_label: suspended_label).last_first_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -155,43 +155,38 @@ class User < ActiveRecord::Base
   end
 
   def last_first_name
-    "#{last_name}, #{first_name}" + deactivated_string
+    "#{last_name}, #{first_name}" + suspended_string
   end
 
   def to_s
-    full_name + deactivated_string
+    full_name + suspended_string
   end
   alias name to_s
 
-  def deactivated_string
+  def suspended_string
     if active?
       ""
     else
-      " (#{self.class.human_attribute_name(:deactivated)})"
+      " (#{self.class.human_attribute_name(:suspended)})"
     end
   end
 
   # Devise uses this method for determining if a user is allowed to log in. It
-  # also gets called on each request, so if a user gets deactivated, they'll be
+  # also gets called on each request, so if a user gets suspended, they'll be
   # kicked out of their session.
   def active_for_authentication?
     super && active?
   end
 
-  def deactivate
-    update_attribute(:deactivated_at, deactivated_at || Time.current)
-  end
-
-  def activate
-    update_attribute(:deactivated_at, nil)
-  end
+  # TODO: Rename the column
+  alias_attribute :suspended_at, :deactivated_at
 
   def active?
-    deactivated_at.blank?
+    suspended_at.blank?
   end
 
   def self.active
-    where(deactivated_at: nil)
+    where(suspended_at: nil)
   end
 
   def internal?

--- a/app/presenters/order_detail_journal_description_presenter.rb
+++ b/app/presenters/order_detail_journal_description_presenter.rb
@@ -1,0 +1,8 @@
+class OrderDetailJournalDescriptionPresenter < SimpleDelegator
+
+  def long_description
+    "##{self}: #{order.user.full_name(suspended_label: false)}: #{I18n.l(fulfilled_at.to_date, format: :usa)}: "\
+    "#{product} x#{quantity}"
+  end
+
+end

--- a/app/presenters/users/name_presenter.rb
+++ b/app/presenters/users/name_presenter.rb
@@ -1,0 +1,49 @@
+module Users
+
+  class NamePresenter < SimpleDelegator
+
+    def initialize(user, suspended_label: true, username_label: false)
+      super(user)
+      @suspended_label = suspended_label
+      @username_label = username_label
+    end
+
+    def full_name
+      render [first_name, last_name]
+    end
+
+    def last_first_name
+      render [last_name, first_name].join(", ")
+    end
+
+    def render(name)
+      parts = Array(name)
+      parts << "(#{username})" if username_label?
+      parts << "(#{user.class.human_attribute_name(:suspended)})" if suspended_label? && suspended?
+      parts.join(" ")
+    end
+
+    def user
+      __getobj__
+    end
+
+    private
+
+    def username_label?
+      @username_label
+    end
+
+    def suspended_label?
+      @suspended_label
+    end
+
+    def append_suspended_string(string)
+      if suspended?
+        "#{string} (#{self.class.human_attribute_name(:suspended)})"
+      else
+        string
+      end
+    end
+  end
+
+end

--- a/app/presenters/users/name_presenter.rb
+++ b/app/presenters/users/name_presenter.rb
@@ -37,13 +37,6 @@ module Users
       @suspended_label
     end
 
-    def append_suspended_string(string)
-      if suspended?
-        "#{string} (#{self.class.human_attribute_name(:suspended)})"
-      else
-        string
-      end
-    end
   end
 
 end

--- a/app/services/transaction_search/account_owner_searcher.rb
+++ b/app/services/transaction_search/account_owner_searcher.rb
@@ -2,8 +2,9 @@ module TransactionSearch
 
   class AccountOwnerSearcher < BaseSearcher
 
+    # TODO: Remove :suspended_at once the old transaction search is gone
     def options
-      User.select("users.id, users.first_name, users.last_name")
+      User.select(:id, :first_name, :last_name, :suspended_at)
           .where(id: order_details.select("distinct account_users.user_id").joins(account: :owner_user))
           .order(:last_name, :first_name)
     end
@@ -17,7 +18,7 @@ module TransactionSearch
     end
 
     def label_method
-      :full_name
+      [:full_name, suspended_label: false]
     end
 
     def label

--- a/app/services/transaction_search/ordered_for_searcher.rb
+++ b/app/services/transaction_search/ordered_for_searcher.rb
@@ -13,7 +13,7 @@ module TransactionSearch
     end
 
     def label_method
-      :full_name
+      [:full_name, suspended_label: false]
     end
 
     def label

--- a/app/support/statement_pdf.rb
+++ b/app/support/statement_pdf.rb
@@ -75,7 +75,7 @@ class StatementPdf
     pdf.text @facility.to_s, size: 20, font_style: :bold
     pdf.text "Invoice ##{@statement.invoice_number}"
     pdf.text "Account: #{@account}"
-    pdf.text "Owner: #{@account.owner.user}"
+    pdf.text "Owner: #{@account.owner.user.full_name(suspended_label: false)}"
     pdf.move_down(10)
   end
 

--- a/app/views/accounts/_member_table.html.haml
+++ b/app/views/accounts/_member_table.html.haml
@@ -27,7 +27,7 @@
                 data: { confirm: t("shared.confirm_message") },
                 method: :delete
 
-        %td= "#{au.user} (#{au.user.username})"
+        %td= Users::NamePresenter.new(au.user, username_label: true).full_name
         %td= au.user.email
         %td= au.user_role
         = render_view_hook("member_table_columns", account_user: au)

--- a/app/views/accounts/_suspend_button.html.haml
+++ b/app/views/accounts/_suspend_button.html.haml
@@ -1,8 +1,8 @@
 - if SettingsHelper.feature_on? :suspend_accounts
   - if @account.suspended?
     - if current_ability.can?(:unsuspend, @account)
-      = link_to t(".activate"), open_or_facility_path("account_unsuspend", @account), class: "btn"
+      = link_to t("shared.activate"), open_or_facility_path("account_unsuspend", @account), class: "btn"
 
   - else
     - if current_ability.can?(:suspend, @account)
-      = link_to t(".suspend"), open_or_facility_path("account_suspend", @account), class: "btn"
+      = link_to t("shared.suspend"), open_or_facility_path("account_suspend", @account), class: "btn"

--- a/app/views/product_users/_table.html.haml
+++ b/app/views/product_users/_table.html.haml
@@ -18,7 +18,7 @@
             data: { confirm: text("confirm_removal", product_type: @product.model_name.human.downcase) }
 
         %td
-          = link_to "#{user.last_name}, #{user.first_name}", [current_facility, user]
+          = link_to user.last_first_name, [current_facility, user]
 
         %td= user.username
         %td= user.email

--- a/app/views/search/_account_account_user_link.html.haml
+++ b/app/views/search/_account_account_user_link.html.haml
@@ -1,1 +1,1 @@
-= link_to user.last_first_name, new_account_account_user_path(@account, user_id: user.id)
+= link_to_if user.active?, user.last_first_name, new_account_account_user_path(@account, user_id: user.id)

--- a/app/views/search/_facility_account_account_user_link.html.haml
+++ b/app/views/search/_facility_account_account_user_link.html.haml
@@ -1,1 +1,1 @@
-= link_to user.last_first_name, new_facility_account_account_user_path(@facility, @account, user_id: user.id)
+= link_to_if user.active?, user.last_first_name, new_facility_account_account_user_path(@facility, @account, user_id: user.id)

--- a/app/views/search/_global_user_role_link.html.haml
+++ b/app/views/search/_global_user_role_link.html.haml
@@ -1,1 +1,1 @@
-= link_to user.last_first_name, edit_global_user_role_path(user.id)
+= link_to_if user.active?, user.last_first_name, edit_global_user_role_path(user.id)

--- a/app/views/search/_map_user_link.html.haml
+++ b/app/views/search/_map_user_link.html.haml
@@ -1,1 +1,1 @@
-= link_to user.last_first_name, facility_facility_user_map_user_path(@facility, user)
+= link_to_if user.active?, user.last_first_name, facility_facility_user_map_user_path(@facility, user)

--- a/app/views/search/_user_new_account_link.html.haml
+++ b/app/views/search/_user_new_account_link.html.haml
@@ -1,1 +1,1 @@
-= link_to user.last_first_name, new_facility_account_path(@facility, owner_user_id: user.id)
+= link_to_if user.active?, user.last_first_name, new_facility_account_path(@facility, owner_user_id: user.id)

--- a/app/views/search/_user_price_group_member_link.html.haml
+++ b/app/views/search/_user_price_group_member_link.html.haml
@@ -1,1 +1,1 @@
-= link_to user.last_first_name, facility_price_group_user_price_group_members_path(@facility, @price_group.id, user_id: user.id), method: :post
+= link_to_if user.active?, user.last_first_name, facility_price_group_user_price_group_members_path(@facility, @price_group.id, user_id: user.id), method: :post

--- a/app/views/search/_user_product_approval_link.html.haml
+++ b/app/views/search/_user_product_approval_link.html.haml
@@ -1,4 +1,3 @@
--# TODO: I18n confirmation
-= link_to user.last_first_name,
+= link_to_if user.active?, user.last_first_name,
   [:new, @facility, @product, :user, user: user],
-  data: { confirm: "Are you sure you wish to authorize this user to order this #{@product.class.model_name.human.downcase}?" }
+  data: { confirm: text("confirm", product_type: @product.class.model_name.human.downcase) }

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -15,9 +15,16 @@
   = f.input :email
   = f.input :last_sign_in_at, default_value: "none"
   = f.input :internal?, label: text("views.users.edit.internal") if SettingsHelper.feature_on?(:user_based_price_groups)
-  = f.input :deactivated_at unless f.object.active?
+  = f.input :suspended_at unless f.object.active?
   = render_view_hook "additional_user_fields", f: f
 
 - if can? :edit, @user
   %ul.inline
-    %li= link_to text("shared.edit"), edit_facility_user_path(current_facility, @user), class: "btn"
+    %li= link_to text("shared.edit"), edit_facility_user_path(current_facility, @user), class: "btn btn-primary"
+
+    - if can? :deactivate, @user
+      - if @user.active?
+        %li= link_to "Suspend", suspend_facility_user_path(current_facility, @user), class: "btn", method: :patch
+      - else
+        %li= link_to "Activate", activate_facility_user_path(current_facility, @user), class: "btn", method: :patch
+

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -24,7 +24,7 @@
 
     - if can? :deactivate, @user
       - if @user.active?
-        %li= link_to "Suspend", suspend_facility_user_path(current_facility, @user), class: "btn", method: :patch
+        %li= link_to t("shared.suspend"), suspend_facility_user_path(current_facility, @user), class: "btn", method: :patch
       - else
-        %li= link_to "Activate", activate_facility_user_path(current_facility, @user), class: "btn", method: :patch
+        %li= link_to t("share.activate"), unsuspend_facility_user_path(current_facility, @user), class: "btn", method: :patch
 

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -225,7 +225,7 @@ en:
         current_password: Current password
         last_sign_in_at: Last Login
         full_name: Full Name
-        deactivated: DEACTIVATED
+        suspended: SUSPENDED
       facility:
         fax_number: Fax Number
         is_active: Is Active?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,6 +107,8 @@ en:
     select_none: Select None
     upload: Upload
     unassigned: Unassigned
+    activate: Activate
+    suspend: Suspend
     footer:
       copyright_html: "&copy; Copyright 2010&ndash;%{to_date} Northwestern University"
       logo_alt: "Northwestern Logo"
@@ -822,9 +824,6 @@ en:
         role: Role
     show:
       head: "Payment Source Details"
-    suspend_button:
-      activate: Activate
-      suspend: Suspend
 
   facilities:
     disputed_orders:

--- a/config/locales/views/admin/en.search.yml
+++ b/config/locales/views/admin/en.search.yml
@@ -1,0 +1,5 @@
+en:
+  views:
+    search:
+      user_product_approval_link:
+        confirm: Are you sure you wish to authorize this user to order this %{product_type}?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,7 +135,7 @@ Nucore::Application.routes.draw do
           post "search"
         end
         patch "suspend", on: :member
-        patch "activate", on: :member
+        patch "unsuspend", on: :member
 
         get "switch_to",    to: 'users#switch_to'
         get "orders",       to: 'users#orders'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,6 +134,9 @@ Nucore::Application.routes.draw do
           get "new_external"
           post "search"
         end
+        patch "suspend", on: :member
+        patch "activate", on: :member
+
         get "switch_to",    to: 'users#switch_to'
         get "orders",       to: 'users#orders'
         resources :reservations, only: [:index], param: :order_detail_id, controller: "facility_user_reservations" do

--- a/db/migrate/20180406211501_rename_user_deactivated_at_to_suspended_at.rb
+++ b/db/migrate/20180406211501_rename_user_deactivated_at_to_suspended_at.rb
@@ -1,0 +1,7 @@
+class RenameUserDeactivatedAtToSuspendedAt < ActiveRecord::Migration
+
+  def change
+    rename_column :users, :deactivated_at, :suspended_at
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180330180908) do
+ActiveRecord::Schema.define(version: 20180406211501) do
 
   create_table "account_users", force: :cascade do |t|
     t.integer  "account_id", limit: 4,  null: false
@@ -792,7 +792,7 @@ ActiveRecord::Schema.define(version: 20180330180908) do
     t.string   "reset_password_token",   limit: 255
     t.datetime "reset_password_sent_at"
     t.integer  "uid",                    limit: 4
-    t.datetime "deactivated_at"
+    t.datetime "suspended_at"
     t.string   "card_number",            limit: 255
   end
 

--- a/spec/controllers/devise/sessions_controller_spec.rb
+++ b/spec/controllers/devise/sessions_controller_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Devise::SessionsController do
       end
     end
 
-    describe "a deactived user" do
-      let(:user) { FactoryBot.create(:user, password: "password", deactivated_at: 1.minute.ago) }
+    describe "a suspended user" do
+      let(:user) { create(:user, :suspended, password: "password") }
 
       specify "can not log in" do
         post :create, user: { username: user.username, password: "password" }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -305,8 +305,8 @@ RSpec.describe UsersController do
       assert_redirected_to facility_path(@authable)
     end
 
-    describe "a deactivated user" do
-      before(:each) { user.deactivate }
+    describe "a suspended user" do
+      let(:user) { create(:user, :suspended) }
 
       it_should_deny_all([:admin] + facility_operators)
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
     sequence(:last_name, &:to_s)
     sequence(:email) { |n| "user#{n}@example.com" }
 
+    trait :suspended do
+      suspended_at { 1.day.ago }
+    end
+
     after(:create) do |user, _|
       user.create_default_price_group!
     end

--- a/spec/features/admin/suspending_a_user_spec.rb
+++ b/spec/features/admin/suspending_a_user_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "User deletion" do
+RSpec.describe "User suspension" do
   let(:facility) { create(:facility) }
   let(:user) { create(:user, email: "todelete@example.com", first_name: "Del", last_name: "User") }
 

--- a/spec/features/admin/suspending_a_user_spec.rb
+++ b/spec/features/admin/suspending_a_user_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "User deletion" do
+  let(:facility) { create(:facility) }
+  let(:user) { create(:user, email: "todelete@example.com", first_name: "Del", last_name: "User") }
+
+  describe "as a global admin" do
+    let(:admin) { create(:user, :administrator) }
+
+    it "can suspend and reactivate a user" do
+      login_as admin
+      visit facility_user_path(facility, user)
+
+      expect(page).to have_content("todelete@example.com")
+      click_link "Suspend"
+      expect(page).to have_content("Del User (SUSPENDED)")
+
+      click_link "Activate"
+      expect(page).not_to have_content("(SUSPENDED)")
+    end
+  end
+
+  describe "as a facility admin" do
+    let(:admin) { create(:user, :facility_administrator, facility: facility) }
+
+    it "cannot suspend user" do
+      login_as admin
+      visit facility_user_path(facility, user)
+
+      expect(page).to have_content("todelete@example.com")
+      expect(page).not_to have_link("Suspend")
+      expect(page).not_to have_link("Activate")
+    end
+  end
+end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe Ability do
   shared_examples_for "it allows switch_to on active, but not deactivated users" do
     let(:stub_controller) { UsersController.new }
     let(:active_user) { FactoryBot.build(:user) }
-    let(:deactivated_user) { FactoryBot.build(:user, deactivated_at: 1.day.ago) }
+    let(:suspended_user) { FactoryBot.build(:user, :suspended) }
 
     it { is_expected.to be_allowed_to(:switch_to, active_user) }
-    it { is_expected.not_to be_allowed_to(:switch_to, deactivated_user) }
+    it { is_expected.not_to be_allowed_to(:switch_to, suspended_user) }
   end
 
   describe "account manager" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -190,30 +190,6 @@ RSpec.describe User do
     end
   end
 
-  describe "#deactivate" do
-    it "deactivates the user" do
-      expect { user.deactivate }.to change(user, :active?).to(false)
-    end
-
-    describe "with a previously deactivated user" do
-      before { travel_and_return(-10.minutes) { user.deactivate } }
-
-      it "does not change the time" do
-        expect { user.deactivate }.not_to change(user, :deactivated_at)
-      end
-    end
-  end
-
-  describe "#activate" do
-    describe "with a deactivated user" do
-      before { user.deactivate }
-
-      it "reactivates the user" do
-        expect { user.activate }.to change(user, :active?).to(true)
-      end
-    end
-  end
-
   describe ".find_users_by_facility" do
     let!(:facility_director) { create(:user, :facility_director, facility: facility) }
     let!(:staff) { create(:user, :staff, facility: facility) }

--- a/spec/presenters/users/name_presenter_spec.rb
+++ b/spec/presenters/users/name_presenter_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+
+RSpec.describe Users::NamePresenter do
+  let(:active_user) { build(:user, first_name: "First", last_name: "Lasterson", username: "me@test.com") }
+  let(:suspended_user) { build(:user, first_name: "Del", last_name: "Leted", username: "del@test.com", suspended_at: 1.day.ago) }
+
+  describe "defaults" do
+    let(:active_name) { described_class.new(active_user) }
+    let(:suspended_name) { described_class.new(suspended_user) }
+
+    describe "full_name" do
+      it "renders the active user properly" do
+        expect(active_name.full_name).to eq("First Lasterson")
+      end
+
+      it "renders the suspended user with a tag" do
+        expect(suspended_name.full_name).to eq("Del Leted (SUSPENDED)")
+      end
+    end
+
+    describe "last_first_name" do
+      it "renders the active user properly" do
+        expect(active_name.last_first_name).to eq("Lasterson, First")
+      end
+
+      it "renders the suspended user with a tag" do
+        expect(suspended_name.last_first_name).to eq("Leted, Del (SUSPENDED)")
+      end
+    end
+  end
+
+  describe "no suspended_label" do
+    let(:active_name) { described_class.new(active_user, suspended_label: false) }
+    let(:suspended_name) { described_class.new(suspended_user, suspended_label: false) }
+
+    describe "full_name" do
+      it "renders the active user properly" do
+        expect(active_name.full_name).to eq("First Lasterson")
+      end
+
+      it "renders the suspended user with a tag" do
+        expect(suspended_name.full_name).to eq("Del Leted")
+      end
+    end
+
+    describe "last_first_name" do
+      it "renders the active user properly" do
+        expect(active_name.last_first_name).to eq("Lasterson, First")
+      end
+
+      it "renders the suspended user with a tag" do
+        expect(suspended_name.last_first_name).to eq("Leted, Del")
+      end
+    end
+  end
+
+  describe "with username_label" do
+    let(:active_name) { described_class.new(active_user, username_label: true) }
+    let(:suspended_name) { described_class.new(suspended_user, username_label: true) }
+
+    describe "full_name" do
+      it "renders the active user properly" do
+        expect(active_name.full_name).to eq("First Lasterson (me@test.com)")
+      end
+
+      it "renders the suspended user with a tag" do
+        expect(suspended_name.full_name).to eq("Del Leted (del@test.com) (SUSPENDED)")
+      end
+    end
+
+    describe "last_first_name" do
+      it "renders the active user properly" do
+        expect(active_name.last_first_name).to eq("Lasterson, First (me@test.com)")
+      end
+
+      it "renders the suspended user with a tag" do
+        expect(suspended_name.last_first_name).to eq("Leted, Del (del@test.com) (SUSPENDED)")
+      end
+    end
+  end
+
+  describe "with username_label but without suspended_label" do
+    let(:active_name) { described_class.new(active_user, username_label: true, suspended_label: false) }
+    let(:suspended_name) { described_class.new(suspended_user, username_label: true, suspended_label: false) }
+
+    describe "full_name" do
+      it "renders the active user properly" do
+        expect(active_name.full_name).to eq("First Lasterson (me@test.com)")
+      end
+
+      it "renders the suspended user with a tag" do
+        expect(suspended_name.full_name).to eq("Del Leted (del@test.com)")
+      end
+    end
+
+    describe "last_first_name" do
+      it "renders the active user properly" do
+        expect(active_name.last_first_name).to eq("Lasterson, First (me@test.com)")
+      end
+
+      it "renders the suspended user with a tag" do
+        expect(suspended_name.last_first_name).to eq("Leted, Del (del@test.com)")
+      end
+    end
+  end
+end
+

--- a/spec/presenters/users/name_presenter_spec.rb
+++ b/spec/presenters/users/name_presenter_spec.rb
@@ -104,4 +104,3 @@ RSpec.describe Users::NamePresenter do
     end
   end
 end
-

--- a/vendor/engines/bulk_email/spec/services/bulk_email/recipient_searcher_spec.rb
+++ b/vendor/engines/bulk_email/spec/services/bulk_email/recipient_searcher_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe BulkEmail::RecipientSearcher do
     end
 
     describe "with an inactive user" do
-      before { user.deactivate }
+      before { user.update(suspended_at: Time.current) }
 
       it "does not include the user" do
         expect(users).not_to include(user)

--- a/vendor/engines/secure_rooms/app/views/secure_rooms/facility_occupancies/index.html.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_rooms/facility_occupancies/index.html.haml
@@ -33,7 +33,7 @@
               %td.centered= link_to od.order_id, facility_order_path(current_facility, order)
               %td.centered= link_to od.id, manage_order_detail_path(od), class: "manage-order-detail"
               %td= format_usa_datetime(occ.entry_at)
-              %td= od.user.nil? ? "" : od.user.try(:full_name)
+              %td= od.user&.full_name
               = render partial: "shared/order_detail_cell", locals: { od: od, show_occupancy: false }
               %td= od.account
 

--- a/vendor/engines/secure_rooms/app/views/secure_rooms/shared/_secure_rooms_dashboard.html.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_rooms/shared/_secure_rooms_dashboard.html.haml
@@ -11,7 +11,7 @@
       %tbody
         - room.occupancies.current.each do |occupancy|
           %tr
-            %td= occupancy.user.full_name
+            %td= occupancy.user.full_name(suspended_label: false)
             %td= format_usa_datetime(occupancy.entry_at)
   .span6
     %h4= text(:recent)
@@ -23,5 +23,5 @@
       %tbody
         - room.occupancies.recent.each do |occupancy|
           %tr
-            %td= occupancy.user.full_name
+            %td= occupancy.user.full_name(suspended_label: false)
             %td= format_usa_datetime(occupancy.exit_at)


### PR DESCRIPTION

# Release Notes

Adds the ability for a global administrator to suspend a user.

Suspended users are:
* no longer able to log into NUcore
* kicked out of their session if they have an active one
* tagged in most places with "(SUSPENDED)"
* excluded from bulk email searches
* unable to be ordered on behalf of

# Screenshot

![screen shot 2018-04-02 at 1 50 35 pm](https://user-images.githubusercontent.com/1099111/38448136-c8ca3380-39c7-11e8-88c5-f2cb943eecce.png)

![screen shot 2018-04-02 at 2 09 01 pm](https://user-images.githubusercontent.com/1099111/38448143-cf8032f6-39c7-11e8-8d55-dffe8e1e4919.png)

# Additional Context

The support for suspended users was originally added in #534 and #538, but never had an interface before.

I tried to exclude the "(SUSPENDED)" only when it seemed like it wouldn't make sense (e.g. journal rows and statements), but opted to show it most places because it seemed less confusing to see SUSPENDED and understand what it means than to not see it and wonder why they're still active.

Originally, I planned on updating the searches to exclude suspended user in situations like adding a new payment source or adding to a product access list, but ultimately decided it would be less confusing to see the result with a "SUSPENDED" tag than to not see the tag at all. Instead I opted to disable the link in those cases.