### PR TITLE
remove ordering clause that causes oracle compatibility issue

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -138,7 +138,7 @@ class FacilitiesController < ApplicationController
     @search_form = TransactionSearch::SearchForm.new(params[:search])
     @search = TransactionSearch::Searcher.search(order_details, @search_form)
     @date_range_field = @search_form.date_params[:field]
-    @order_details = @search.order_details.paginate(page: params[:page])
+    @order_details = @search.order_details.reorder(:dispute_at).paginate(page: params[:page])
   end
 
   # GET /facilities/:facility_id/movable_transactions

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -171,7 +171,6 @@ class OrderDetail < ActiveRecord::Base
     where("dispute_at IS NOT NULL")
       .where(dispute_resolved_at: nil)
       .where("order_details.state != ?", "canceled")
-      .order("dispute_at")
   end
 
   def self.purchased_active_reservations


### PR DESCRIPTION
# Release Notes

Remove order clause from query that causes an oracle compatibility issue.