### PR TITLE
Add restart_grace for unicorn

### DIFF
--- a/config/eye.yml.erb.template
+++ b/config/eye.yml.erb.template
@@ -36,7 +36,7 @@ processes:
       restart_command: "kill -USR2 {PID}"
       start_timeout: 15 seconds
       restart_timeout: 15 seconds
-      restart_grace: 5 seconds
+      restart_grace: 15 seconds
       stdout: log/unicorn.stdout.log
       stderr: log/unicorn.stderr.log
       monitor_children:

--- a/config/eye.yml.erb.template
+++ b/config/eye.yml.erb.template
@@ -36,6 +36,7 @@ processes:
       restart_command: "kill -USR2 {PID}"
       start_timeout: 15 seconds
       restart_timeout: 15 seconds
+      restart_grace: 5 seconds
       stdout: log/unicorn.stdout.log
       stderr: log/unicorn.stderr.log
       monitor_children:


### PR DESCRIPTION
# Release Notes

TECH TASK: Prevent `eye restart unicorn` from thinking unicorn has crashed

This change has been made on txi stage and NU servers.

## Pulled up from

https://github.com/tablexi/nucore-nu/pull/361/files
