### PR TITLE
SAML Single Logout

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -32,8 +32,7 @@
               %li.visible-with-nav= link_to t('pages.cart') + " (#{current_cart.order_details.count})", :cart
               %li.divider-vertical
               = render "shared/message_summary"
-              %li= link_to t('pages.logout'), sign_out_user_path
-              %li= link_to "SSO Logout", destroy_saml_user_session_path
+              %li= render "shared/logout/link_#{warden.session(:user)[:strategy] || 'default'}"
               - if responsive? && !acting_as? && current_user
                 = form_tag global_search_path, class: "navbar-search pull-right hidden-with-nav" do
                   = text_field_tag :search, nil, placeholder: t("global_search.search"), class: "search-query span2"

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -33,6 +33,7 @@
               %li.divider-vertical
               = render "shared/message_summary"
               %li= link_to t('pages.logout'), sign_out_user_path
+              %li= link_to "SSO Logout", destroy_saml_user_session_path
               - if responsive? && !acting_as? && current_user
                 = form_tag global_search_path, class: "navbar-search pull-right hidden-with-nav" do
                   = text_field_tag :search, nil, placeholder: t("global_search.search"), class: "search-query span2"

--- a/app/views/shared/logout/_link_default.html.haml
+++ b/app/views/shared/logout/_link_default.html.haml
@@ -1,0 +1,1 @@
+= link_to t('pages.logout'), sign_out_user_path

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180406211501) do
+ActiveRecord::Schema.define(version: 20180413194031) do
 
   create_table "account_users", force: :cascade do |t|
     t.integer  "account_id", limit: 4,  null: false
@@ -794,10 +794,12 @@ ActiveRecord::Schema.define(version: 20180406211501) do
     t.integer  "uid",                    limit: 4
     t.datetime "suspended_at"
     t.string   "card_number",            limit: 255
+    t.string   "saml_session_index",     limit: 255
   end
 
   add_index "users", ["card_number"], name: "index_users_on_card_number", using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["saml_session_index"], name: "index_users_on_saml_session_index", using: :btree
   add_index "users", ["uid"], name: "index_users_on_uid", using: :btree
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 

--- a/vendor/engines/saml_authentication/app/controllers/saml_authentication/sessions_controller.rb
+++ b/vendor/engines/saml_authentication/app/controllers/saml_authentication/sessions_controller.rb
@@ -4,7 +4,8 @@ module SamlAuthentication
 
     # Some SSO providers are strict and require that the name_identifier matches
     # what's logged in on their system for SLO.
-    before_action(only: :destroy) { @signed_out_username = current_user.public_send(Devise.saml_default_user_key) }
+    before_action :store_logging_out_username, only: :destroy
+    after_action :store_winning_strategy, only: :create
 
     protected
 
@@ -19,6 +20,18 @@ module SamlAuthentication
       config = saml_config(idp_entity_id).dup
       config.name_identifier_value = @signed_out_username
       request.create(config)
+    end
+
+    private
+
+    def store_logging_out_username
+      @signed_out_username = current_user.public_send(Devise.saml_default_user_key)
+    end
+
+    # This will be used to choose which Logout link is shown to the user.
+    # https://github.com/apokalipto/devise_saml_authenticatable/wiki/Supporting-multiple-authentication-strategies
+    def store_winning_strategy
+      warden.session(resource_name)[:strategy] = warden.winning_strategies[resource_name].class.name.demodulize.underscore.to_sym
     end
 
   end

--- a/vendor/engines/saml_authentication/app/controllers/saml_authentication/sessions_controller.rb
+++ b/vendor/engines/saml_authentication/app/controllers/saml_authentication/sessions_controller.rb
@@ -2,11 +2,23 @@ module SamlAuthentication
 
   class SessionsController < Devise::SamlSessionsController
 
+    # Some SSO providers are strict and require that the name_identifier matches
+    # what's logged in on their system for SLO.
+    before_action(only: :destroy) { @signed_out_username = current_user.public_send(Devise.saml_default_user_key) }
+
     protected
 
     # Remove recall, so failures redirect back to sign_in page
     def auth_options
       { scope: resource_name }
+    end
+
+    def after_sign_out_path_for(_)
+      idp_entity_id = get_idp_entity_id(params)
+      request = OneLogin::RubySaml::Logoutrequest.new
+      config = saml_config(idp_entity_id).dup
+      config.name_identifier_value = @signed_out_username
+      request.create(config)
     end
 
   end

--- a/vendor/engines/saml_authentication/app/views/shared/logout/_link_saml_authenticatable.html.haml
+++ b/vendor/engines/saml_authentication/app/views/shared/logout/_link_saml_authenticatable.html.haml
@@ -1,0 +1,1 @@
+= link_to t('pages.logout'), destroy_saml_user_session_path

--- a/vendor/engines/saml_authentication/db/migrate/20180413194031_add_saml_session_index_to_user.rb
+++ b/vendor/engines/saml_authentication/db/migrate/20180413194031_add_saml_session_index_to_user.rb
@@ -1,0 +1,6 @@
+class AddSamlSessionIndexToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :saml_session_index, :string
+    add_index :users, :saml_session_index
+  end
+end

--- a/vendor/engines/saml_authentication/lib/saml_authentication/devise_configurator.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/devise_configurator.rb
@@ -1,5 +1,6 @@
 require "saml_authentication/user_locator"
 require "saml_authentication/user_updater"
+require "saml_authentication/idp_entity_id_reader"
 
 module SamlAuthentication
 
@@ -7,12 +8,14 @@ module SamlAuthentication
 
     def configure!
       Devise.setup do |config|
-        config.saml_session_index_key = :session_index
+        config.saml_session_index_key = :saml_session_index
         config.saml_default_user_key = :username
         config.saml_create_user = saml_create_user?
         config.saml_update_user = true
         config.saml_resource_locator = SamlAuthentication::UserLocator.new
         config.saml_update_resource_hook = saml_updater
+        config.saml_sign_out_success_url = Rails.application.routes.url_helpers.root_url
+        config.idp_entity_id_reader = SamlAuthentication::IdpEntityIdReader
 
         config.saml_config = fetch_metadata_config
 

--- a/vendor/engines/saml_authentication/lib/saml_authentication/engine.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/engine.rb
@@ -14,6 +14,8 @@ module SamlAuthentication
       ViewHook.add_hook "devise.sessions.new",
                         "before_login_form",
                         "saml_authentication/sessions/new"
+
+      OneLogin::RubySaml::Logging.logger.level = Logger::DEBUG
     end
 
     config.after_initialize do
@@ -22,6 +24,12 @@ module SamlAuthentication
       Rails.application.reload_routes!
 
       SamlAuthentication::DeviseConfigurator.new.configure!
+    end
+
+    initializer :append_migrations do |app|
+      config.paths["db/migrate"].expanded.each do |expanded_path|
+        app.config.paths["db/migrate"] << expanded_path
+      end
     end
 
   end

--- a/vendor/engines/saml_authentication/lib/saml_authentication/idp_entity_id_reader.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/idp_entity_id_reader.rb
@@ -1,0 +1,40 @@
+module SamlAuthentication
+
+  # The default IdpEntityIdReader triggers an error on SLO because that request to
+  # us has a SAMLResponse parameter, which does not get parsed by OneLogin::RubySaml::Response
+  # correctly: "Issuer of the Response not found or multiple."
+  # Overrides DeviseSamlAuthenticatable::DefaultIdpEntityIdReader.
+  class IdpEntityIdReader
+
+    def self.entity_id(params)
+      if params[:action] == "idp_sign_out" && params[:SAMLResponse]
+        OneLogin::RubySaml::Logoutresponse.new(
+          params[:SAMLResponse],
+          settings: Devise.saml_config,
+          allowed_clock_drift: Devise.allowed_clock_drift_in_seconds,
+        ).issuer
+      else
+        original_implementation(params)
+      end
+    end
+
+    # Copied rather than inherited from default class for clarity.
+    def self.original_implementation(params)
+      if params[:SAMLRequest]
+        OneLogin::RubySaml::SloLogoutrequest.new(
+          params[:SAMLRequest],
+          settings: Devise.saml_config,
+          allowed_clock_drift: Devise.allowed_clock_drift_in_seconds,
+        ).issuer
+      elsif params[:SAMLResponse]
+        OneLogin::RubySaml::Response.new(
+          params[:SAMLResponse],
+          settings: Devise.saml_config,
+          allowed_clock_drift: Devise.allowed_clock_drift_in_seconds,
+        ).issuers.first
+      end
+    end
+
+  end
+
+end

--- a/vendor/engines/saml_authentication/lib/saml_authentication/routes.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/routes.rb
@@ -9,7 +9,7 @@ ActionDispatch::Routing::Mapper.class_eval do
     resource :session, only: [], controller: "saml_authentication/sessions", path: "" do
       get :new, path: "saml/sign_in", as: "new_saml"
       post :create, path: "saml/auth", as: "auth_saml"
-      match :destroy, path: mapping.path_names[:sign_out], as: "destroy_saml", via: mapping.sign_out_via
+      match :destroy, path: "saml/" + mapping.path_names[:sign_out], as: "destroy_saml", via: mapping.sign_out_via
       get :metadata, path: "saml/metadata", as: "metadata_saml"
       match :idp_sign_out, path: "saml/idp_sign_out", via: [:get, :post]
     end

--- a/vendor/engines/saml_authentication/lib/saml_authentication/routes.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/routes.rb
@@ -9,7 +9,7 @@ ActionDispatch::Routing::Mapper.class_eval do
     resource :session, only: [], controller: "saml_authentication/sessions", path: "" do
       get :new, path: "saml/sign_in", as: "new_saml"
       post :create, path: "saml/auth", as: "auth_saml"
-      match :destroy, path: "saml/" + mapping.path_names[:sign_out], as: "destroy_saml", via: mapping.sign_out_via
+      match :destroy, path: "saml/#{mapping.path_names[:sign_out]}", as: "destroy_saml", via: mapping.sign_out_via
       get :metadata, path: "saml/metadata", as: "metadata_saml"
       match :idp_sign_out, path: "saml/idp_sign_out", via: [:get, :post]
     end


### PR DESCRIPTION
# Release Notes

Support SAML single logout. When you are logged in via SAML, when you click the "Logout" button, you will also be logged out of your identity provider. This will be critical for security on shared computers.

# Additional Context

This involved a little more hackery into the devise_saml_authenticatable gem than I really wanted to do. I might open some PRs or issues around that once we know everything is working.

One difference between OneLogin (where I was developing against) and Dartmouth's IDP is that DC requires as part of the logout request that `NameID` matches the logged in user's netid. This was not supported out of the box by the gem, so I had to hack that in. There's one setting change that also needs to happen for DC, but it'll be easy because of UConn's changes: `driver.name_identifier_format: "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"`

I also wasn't quite sure the best way to handle the different paths needed for the logout link, so I'm open to suggestions there.

