### PR TITLE
Fix missing translations and enable raising in errors in test/CI

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -26,5 +26,5 @@
       - if @user.active?
         %li= link_to t("shared.suspend"), suspend_facility_user_path(current_facility, @user), class: "btn", method: :patch
       - else
-        %li= link_to t("share.activate"), unsuspend_facility_user_path(current_facility, @user), class: "btn", method: :patch
+        %li= link_to t("shared.activate"), unsuspend_facility_user_path(current_facility, @user), class: "btn", method: :patch
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,6 +42,9 @@ Nucore::Application.configure do
   # Do not log assets path
   config.assets.quiet = true
 
+  # Raise exceptions when missing I18n translations
+  config.action_view.raise_on_missing_translations = true
+
   Rails.application.routes.default_url_options =
     config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 

--- a/config/locales/en.account_components.yml
+++ b/config/locales/en.account_components.yml
@@ -1,0 +1,16 @@
+# Labels for account components. These are often overridden/added to in the schools
+# to match their chart string fields (e.g. Fund, Org, Department, etc.)
+
+en:
+  nufs_account:
+    account_fields:
+      label:
+        account_number:
+          account_number: Account Number
+
+  facility_account:
+    # Components of the account
+    account_fields:
+      label:
+        account_number:
+          account_number: Account Number

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,8 +171,6 @@ en:
       label:
         owner_user: "Owner User"
         payment_type: "Payment Source Type"
-        account_number:
-          account_number: "Payment Source Number"
         affiliate_display_name: "Affiliate/Category"
         affiliate: "Name" # used for labeling affiliate_other field in forms
         remit: "Bill To"
@@ -839,12 +837,6 @@ en:
 
     transactions:
       no_orders: There are no orders in this !facility_downcase! matching the search parameters
-
-  nufs_account:
-    account_fields:
-      label:
-        account_number:
-          account_number: Account Number
 
   price_policies:
     adjustment: Adjustment

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -521,7 +521,7 @@ en:
 
   order_management:
     order_details:
-      edit:
+      shared_details:
         remove_from_journal: "Remove From Journal"
 
   product_access_groups:


### PR DESCRIPTION
# Release Notes

Fix missing translation errors in development. Tech task: raise missing translation errors in test.

# Additional Context

By turning on `raise_on_missing_translation` in test, we'll hopefully catch these issues sooner.

Recharge chart string issue was ntroduced in #1493 because I thought this was duplicated, but turns
out this is used by `t("#{account_class.name.underscore}.account_fields.label.account_number
.#{section}”),`

User activate was a typo in #1481

"Remove from journal" has been around for a while. It's never been a problem in production because `raise_on_missing_translation` is set to false on stage and prod, so it just falls back to the titleized version, "Remove From Journal", which is what the translation was anyways.

Resolves #1496

