### PR TITLE
Remove reference to non-existent JS

### DIFF
--- a/app/views/facility_accounts_reconciliation/index.html.haml
+++ b/app/views/facility_accounts_reconciliation/index.html.haml
@@ -1,4 +1,3 @@
-= javascript_include_tag "reconciliation"
 = javascript_include_tag "transaction_history"
 
 = content_for :h1 do


### PR DESCRIPTION
# Release Notes

Tech task: remove call to non-existent javascript file.

# Additional Context

The javascript was removed in https://github.com/tablexi/nucore-open/pull/1297 but
the reference to it was still there, so I was seeing a 404 in my logs.

