### PR TITLE
[#141541] Fix oracle 1000+ issue on statement filter on reconciliation pages

### DIFF
--- a/app/services/transaction_search/account_owner_searcher.rb
+++ b/app/services/transaction_search/account_owner_searcher.rb
@@ -2,10 +2,9 @@ module TransactionSearch
 
   class AccountOwnerSearcher < BaseSearcher
 
-    # TODO: Remove :suspended_at once the old transaction search is gone
     def options
-      User.select(:id, :first_name, :last_name, :suspended_at)
-          .where(id: order_details.select("distinct account_users.user_id").joins(account: :owner_user))
+      User.select(:id, :first_name, :last_name)
+          .where(id: order_details.distinct.select("account_users.user_id").joins(account: :owner_user))
           .order(:last_name, :first_name)
     end
 

--- a/app/services/transaction_search/account_searcher.rb
+++ b/app/services/transaction_search/account_searcher.rb
@@ -4,7 +4,7 @@ module TransactionSearch
 
     def options
       Account.select("accounts.id, accounts.account_number, accounts.description, accounts.type")
-             .where(id: order_details.select("distinct order_details.account_id"))
+             .where(id: order_details.distinct.select(:account_id))
              .order(:account_number, :description)
     end
 

--- a/app/services/transaction_search/ordered_for_searcher.rb
+++ b/app/services/transaction_search/ordered_for_searcher.rb
@@ -4,7 +4,7 @@ module TransactionSearch
 
     def options
       User.select(:id, :first_name, :last_name)
-          .where(id: order_details.select("distinct orders.user_id"))
+          .where(id: order_details.distinct.select("orders.user_id"))
           .order(:last_name, :first_name)
     end
 

--- a/app/services/transaction_search/product_searcher.rb
+++ b/app/services/transaction_search/product_searcher.rb
@@ -3,7 +3,9 @@ module TransactionSearch
   class ProductSearcher < BaseSearcher
 
     def options
-      Product.where(id: order_details.select("distinct order_details.product_id")).order(:name)
+      # Uses a subquery, i.e. SELECT "PRODUCTS".* FROM "PRODUCTS"
+      # WHERE "PRODUCTS"."ID" IN (SELECT distinct order_details.product_id FROM "ORDER_DETAILS" ...
+      Product.where(id: order_details.distinct.select(:product_id)).order(:name)
     end
 
     def search(params)

--- a/app/services/transaction_search/statement_searcher.rb
+++ b/app/services/transaction_search/statement_searcher.rb
@@ -3,7 +3,9 @@ module TransactionSearch
   class StatementSearcher < BaseSearcher
 
     def options
-      Statement.where(id: order_details.pluck(:statement_id)).reorder(:account_id, :id)
+      # Uses a subquery: SELECT "STATEMENTS".* FROM "STATEMENTS"
+      # WHERE "STATEMENTS"."ID" IN (SELECT DISTINCT "ORDER_DETAILS"."STATEMENT_ID" FROM "ORDER_DETAILS" ...
+      Statement.where(id: order_details.distinct.select(:statement_id)).reorder(:account_id, :id)
     end
 
     def search(params)


### PR DESCRIPTION
# Release Notes

Fix issue on reconcile credit card/purchase order where having more than 1000 orders would cause an error.

# Additional Context

There was no distinct on the `order_details.statement_id` so we were hitting Oracle's 1000-item limit in a `WHERE IN` clause. This adds the distinct as well as turning it into a subquery rather than a `pluck` and a `WHERE IN`.

Includes the NU production hotfix: https://github.com/tablexi/nucore-nu/pull/367

This also does a little cleanup to some of the other searchers.


