### PR TITLE
[#137478] add hint for reservation duration field

### DIFF
--- a/app/views/reservations/_reservation_fields.html.haml
+++ b/app/views/reservations/_reservation_fields.html.haml
@@ -12,7 +12,7 @@
           .span4
             = time_select f, :reserve_start, { minute_step: @instrument.reserve_interval }, disabled: start_disabled
       .span5
-        = f.input :duration_mins, hint: t(".duration_hint"), input_html: { value: f.object.duration_mins || default_duration, class: "timeinput", disabled: end_time_editing_disabled?(f.object), display: 'inline' }
+        = f.input :duration_mins, hint: text(".duration_hint"), input_html: { value: f.object.duration_mins || default_duration, class: "timeinput", disabled: end_time_editing_disabled?(f.object) }
     .row
       .span7
         = label_tag :reservation_reserve_end_date, "Reserve End", class: "string optional control-label"

--- a/app/views/reservations/_reservation_fields.html.haml
+++ b/app/views/reservations/_reservation_fields.html.haml
@@ -11,13 +11,12 @@
               .started-at= "Started: #{l(f.object.actual_start_at, format: :usa)}"
           .span4
             = time_select f, :reserve_start, { minute_step: @instrument.reserve_interval }, disabled: start_disabled
-      .span5
-        = f.input :duration_mins, hint: text(".duration_hint"), input_html: { value: f.object.duration_mins || default_duration, class: "timeinput", disabled: end_time_editing_disabled?(f.object) }
-    .row
-      .span7
         = label_tag :reservation_reserve_end_date, "Reserve End", class: "string optional control-label"
         .row
           .span3
             = text_field_tag "reservation[reserve_end_date]", f.object.reserve_end_date, class: "datepicker string optional span3"
           .span4
             = time_select f, :reserve_end, { minute_step: @instrument.reserve_interval }
+
+      .span5
+        = f.input :duration_mins, hint: text(".duration_hint"), input_html: { value: f.object.duration_mins || default_duration, class: "timeinput", disabled: end_time_editing_disabled?(f.object) }

--- a/app/views/reservations/_reservation_fields.html.haml
+++ b/app/views/reservations/_reservation_fields.html.haml
@@ -12,7 +12,7 @@
           .span4
             = time_select f, :reserve_start, { minute_step: @instrument.reserve_interval }, disabled: start_disabled
       .span5
-        = f.input :duration_mins, input_html: { value: f.object.duration_mins || default_duration, class: "timeinput", disabled: end_time_editing_disabled?(f.object) }
+        = f.input :duration_mins, hint: t(".duration_hint"), input_html: { value: f.object.duration_mins || default_duration, class: "timeinput", disabled: end_time_editing_disabled?(f.object), display: 'inline' }
     .row
       .span7
         = label_tag :reservation_reserve_end_date, "Reserve End", class: "string optional control-label"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -537,8 +537,6 @@ en:
       documentation: "Documentation"
       crumb: "Create Reservation"
       notify: Send Notification
-    reservation_fields:
-      duration_hint: enter time as "total minutes" or "hours:minutes"
     list:
       status:
         upcoming: Upcoming

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -537,6 +537,8 @@ en:
       documentation: "Documentation"
       crumb: "Create Reservation"
       notify: Send Notification
+    reservation_fields:
+      duration_hint: enter time as "total minutes" or "hours:minutes"
     list:
       status:
         upcoming: Upcoming

--- a/config/locales/views/en.reservations.yml
+++ b/config/locales/views/en.reservations.yml
@@ -10,3 +10,5 @@ en:
         actions: Actions
         reservation: "Reservation (Edit/Extend)"
         short_reservation: "Reservation"
+      reservation_fields:
+        duration_hint: Enter time as "total minutes" or "hours:minutes"


### PR DESCRIPTION
# Release Notes

Add a hint for the reservation duration field on the reservation new/edit views.

# Screenshot
![screen shot 2018-04-19 at 2 40 24 pm](https://user-images.githubusercontent.com/4624197/39014451-09c36b50-43e0-11e8-8697-3d48218c38ee.png)

![screen shot 2018-04-19 at 3 29 31 pm](https://user-images.githubusercontent.com/4624197/39016636-a13fb1cc-43e6-11e8-9c89-b43fc043c460.png)
