### PR TITLE
[#137627] Homepage and facility page styling updates

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -146,7 +146,6 @@ li.nav-spacer {
   a.fa-calendar {
     text-decoration: none;
     color: $textColor;
-    font-size: 175%;
     &.available {
       color: $successText;
     }

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -142,6 +142,8 @@ li.nav-spacer {
   input {
     width: 2em;
     padding: 0 3px;
+    margin-top: 5px;
+    margin-bottom: 5px;
   }
   a.fa-calendar {
     text-decoration: none;

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -46,20 +46,20 @@ module ProductsHelper
     if current_facility&.show_instrument_availability? || !current_facility && product.facility.show_instrument_availability?
       public_calendar_availability_options(product)
     else
-      { class: ["fa fa-calendar fa-2x"],
+      { class: ["fa fa-calendar fa-lg fa-fw"],
         title: t("instruments.public_schedule.icon") }
     end
   end
 
   def public_calendar_availability_options(product)
     if product.offline?
-      { class: ["fa fa-calendar fa-2x", "in-use"],
+      { class: ["fa fa-calendar fa-lg fa-fw", "in-use"],
         title: text("instruments.offline.note") }
     elsif product.walkup_available?
-      { class: ["fa fa-calendar fa-2x", "available"],
+      { class: ["fa fa-calendar fa-lg fa-fw", "available"],
         title: text("instruments.public_schedule.available") }
     else
-      { class: ["fa fa-calendar fa-2x", "in-use"],
+      { class: ["fa fa-calendar fa-lg fa-fw", "in-use"],
         title: text("instruments.public_schedule.unavailable") }
     end
   end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -25,10 +25,12 @@ module ProductsHelper
     }
   end
 
-  def public_calendar_link(product)
+  def public_calendar_link(product, should_show_icon)
     if product.respond_to? :reservations
       opts = public_calendar_options(product)
       link_to "", facility_instrument_public_schedule_path(product.facility, product), opts
+    elsif should_show_icon
+      content_tag :span, "", class: "fa-lg fa-fw", style: "display: inline-block"
     end
   end
 

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -7,14 +7,15 @@
       - if products.first.class.model_name == "TimedService"
         %p= t("facilities.show.timed_services_note")
     %ul
+      - should_show_cal_icon = products.any? {|p| p.respond_to? :reservations }
       - products.sort.each do |product|
         %li{ class: product.class.model_name.to_s.downcase }
-          = public_calendar_link(product)
           - if local_assigns[:f]
             = f.fields_for :order_details do |builder|
               - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
                 = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
                 = builder.hidden_field :product_id, value: product.id, index: nil
+          = public_calendar_link(product, should_show_cal_icon)
           = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product)
           - if acting_user.present? && !product.can_be_used_by?(acting_user)
             %i.fa.fa-lock

--- a/app/views/facilities/index.html.haml
+++ b/app/views/facilities/index.html.haml
@@ -1,8 +1,5 @@
 - if SettingsHelper.feature_on?(:equipment_list)
   = render "shared/nav/equipment_list_nav"
-- else
-  = content_for :h1 do
-    = Facility.model_name.human(count: 2)
 
 .alert.alert-info= text(".welcome")
 


### PR DESCRIPTION
# Release Notes
- Remove "Facilities" heading from home page
- Make calendar icon smaller to match text size
- Use consistent indentation and move the calendar icon to the right of the order form
- Center order form inputs vertically with respect to text

# Screenshots

![screen shot 2018-04-19 at 5 30 32 pm](https://user-images.githubusercontent.com/4624197/39021691-7d80feb0-43f7-11e8-85a7-4c9e8cb92813.png)
![screen shot 2018-04-19 at 5 30 49 pm](https://user-images.githubusercontent.com/4624197/39021692-7d93c658-43f7-11e8-8073-42618f478eb6.png)
