### PR TITLE
[#139182] capitalize placeholder text for bulk email selection

### DIFF
--- a/app/inputs/transaction_chosen_old_input.rb
+++ b/app/inputs/transaction_chosen_old_input.rb
@@ -49,7 +49,7 @@ class TransactionChosenOldInput < SimpleForm::Inputs::Base # CollectionSelectInp
   end
 
   def placeholder_label
-    "Select #{options[:label].downcase}"
+    "Select #{options[:label].capitalize}"
   end
 
   def option_data


### PR DESCRIPTION
# Release Notes

Capitalize the placeholder text in Bulk Email filter page.