### PR TITLE
[#137711] reservations sort by date orders by ordered_at

### DIFF
--- a/app/controllers/facility_reservations_controller.rb
+++ b/app/controllers/facility_reservations_controller.rb
@@ -225,7 +225,7 @@ class FacilityReservationsController < ApplicationController
 
   def sort_lookup_hash
     {
-      "date" => "reservations.reserve_start_at",
+      "date" => "orders.ordered_at",
       "reserve_range" => ["reservations.reserve_start_at", "reservations.reserve_end_at"],
       "product_name"  => "products.name",
       "status"        => "order_statuses.name",


### PR DESCRIPTION
# Release Notes

The "Ordered Date" sort now sorts by ordered_at, not by reservation start time.