### PR TITLE
[#141580] [#137466] Fixes from full calendar changes

### DIFF
--- a/app/assets/javascripts/schedule_rules.js
+++ b/app/assets/javascripts/schedule_rules.js
@@ -4,7 +4,7 @@ $(document).ready(function() {
                   defaultView: 'agendaWeek',
                   allDaySlot: false,
                   header: {left: '', center: '', right: ''},
-                  columnFormat: {week: 'ddd'},
+                  columnHeaderFormat: 'ddd',
                   events: events_path
                 })
 })

--- a/app/views/reservations/edit.html.haml
+++ b/app/views/reservations/edit.html.haml
@@ -42,7 +42,6 @@
     - else
       %li= link_to 'Cancel', cart_path
 
-= start_time_editing_disabled?(@reservation).to_s
 #overlay
   #spinner
     #hide


### PR DESCRIPTION
# Release Notes

Fixes: true/false appearing on reservations edit view. and schedule rule column headers were showing up as “object Object”.

# Additional Context

[#141580] Schedule rule issues was due to an API change to Full Calendar. https://fullcalendar.io/docs/columnFormat
[#137466] true/false was accidentally left in from debugging on #1478. 
