### PR TITLE
Update setup steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,19 +48,15 @@ Welcome to NUcore! This guide will help you get a development environment up and
 
   - Paste the output from `rake secret` into `config/secrets.yml` for both `development/secret_key_base` and `test/secret_key_base`
 
-5. Create your databases
+5. Set up databases
 
     ```
-    rake db:create
-    rake db:create RAILS_ENV=test
-    rake db:schema:load
-    rake db:schema:load RAILS_ENV=test
+    rake db:setup
     ```
 
 6. Seed your development database
 
     ```
-    rake db:seed
     rake demo:seed
     ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,16 @@ Welcome to NUcore! This guide will help you get a development environment up and
 
     Edit the adapter, database, username, and password settings for both the development and test DBs to match your database instance
 
-4. Create your databases
+4. Configure your secrets
+
+  ```
+  cp config/secrets.yml.template config/secrets.yml
+  rake secret
+  ```
+
+  - Paste the output from `rake secret` into `config/secrets.yml` for both `development/secret_key_base` and `test/secret_key_base`
+
+5. Create your databases
 
     ```
     rake db:create
@@ -48,21 +57,12 @@ Welcome to NUcore! This guide will help you get a development environment up and
     rake db:schema:load RAILS_ENV=test
     ```
 
-5. Seed your development database
+6. Seed your development database
 
     ```
     rake db:seed
     rake demo:seed
     ```
-
-6. Configure your secrets
-
-  ```
-  cp config/secrets.yml.template config/secrets.yml
-  rake secret
-  ```
-
-  - Paste the output from `rake secret` into `config/secrets.yml` for both `development/secret_key_base` and `test/secret_key_base`
 
 7. Configure your file storage
 


### PR DESCRIPTION
This PR does two things:

1. It moves the step to set up `config/secrets.yml` to be before the step for creating databases. Otherwise, `bundle exec rake db:create` results in an error complaining that `secret_key_base` is not set.
1. It simplifies the step to create local databases (development and test both) into a single `rake db:setup`. This tasks [does the creation and loading of seeds in one step](https://github.com/rails/rails/blob/v4.2.10/activerecord/lib/active_record/railties/databases.rake#L167-L168), and `db:create` [defaults to creating both the test and development databases when an environment is not specified](https://github.com/rails/rails/blob/v4.2.10/activerecord/lib/active_record/railties/databases.rake#L15), so we don’t have to run it twice.