### PR TITLE
Calendar header cleanup

### DIFF
--- a/app/assets/javascripts/instruments.js
+++ b/app/assets/javascripts/instruments.js
@@ -1,8 +1,8 @@
 $(document).ready(function() {
   new FullCalendarConfig($("#calendar"), {
     header: {
-      left: '',
-      center: 'title',
+      left: 'title',
+      center: '',
       right: 'prev,next today agendaDay,agendaWeek,month',
     }
   }).init();

--- a/app/assets/stylesheets/calendar/fullcalendar.extensions.scss
+++ b/app/assets/stylesheets/calendar/fullcalendar.extensions.scss
@@ -23,60 +23,15 @@
   background: image-url('spinner.gif') top center no-repeat;
 }
 
-#calendar table.fc-header {
-	margin-bottom:15px;
+.fc-header-toolbar {
+  margin-bottom: 0;
 }
 
-#calendar table.fc-header tr,
-#calendar table.fc-header th,
-#calendar table.fc-header td {
-	border:1px solid white;
-}
-
-#calendar table {
-	margin-bottom:0;
-}
-
-#calendar table, #calendar tr {
-	border:none;
-}
-
-#calendar .fc-agenda-head tr.fc-last th {
-	padding:10px 0;
-}
-
-#calendar .fc-header-left, #calendar .fc-header-right,  {
-  width: 34%;
-  vertical-align: bottom;
-}
-
-#calendar .fc-header-center {
-  width: 32%;
-}
-
-#calendar .fc-header-title {
-  width: 100%;
-  vertical-align: bottom;
-}
-
-#calendar .fc-header-title h2 {
+.fc-header-toolbar h2 {
   font-size: 18px;
-  line-height: 1em;
-  margin-bottom: 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  line-height: 1.6em;
 }
 
-#calendar .fc-header .fc-button {
-  margin-bottom: 0;
-  vertical-align: bottom;
-}
-
-#calendar .fc-header {
-  table-layout: fixed;
-}
-
-#calendar .fc-agenda .fc-agenda-axis {
-  width: 3em;
+.fc-noheader .fc-toolbar.fc-header-toolbar {
+  display: none;
 }

--- a/app/views/schedule_rules/index.html.haml
+++ b/app/views/schedule_rules/index.html.haml
@@ -57,4 +57,4 @@
 #overlay
   #spinner
     #hide
-      #calendar
+      #calendar.fc-noheader


### PR DESCRIPTION
# Release Notes

Clean up styling issues from Fullcalendar upgrade.

# Screenshot

## Before

Note the extra space:
![screen shot 2018-04-25 at 11 39 10 am](https://user-images.githubusercontent.com/1099111/39259917-6846e7c8-487d-11e8-8707-15f680dc301d.png)

Large text:
![screen shot 2018-04-25 at 11 38 33 am](https://user-images.githubusercontent.com/1099111/39259940-75f23986-487d-11e8-9529-0358ccd8c379.png)

![screen shot 2018-04-25 at 11 39 01 am](https://user-images.githubusercontent.com/1099111/39259928-7099f91a-487d-11e8-86cd-aceecf0c18bf.png)

## After

Clean up date sizing and move to the left:
![screen shot 2018-04-25 at 11 38 20 am](https://user-images.githubusercontent.com/1099111/39259946-7bef9c3e-487d-11e8-91de-e12371d235cc.png)

![screen shot 2018-04-25 at 11 38 04 am](https://user-images.githubusercontent.com/1099111/39259969-95cd2bd0-487d-11e8-9583-4dc2f4510070.png)

Clean up extra vertical space on schedule rules page:
![screen shot 2018-04-25 at 11 38 15 am](https://user-images.githubusercontent.com/1099111/39259955-86a7081a-487d-11e8-854e-5a778c8811cd.png)

