### PR TITLE
enforce feature setting on for suspending a user spec

### DIFF
--- a/spec/features/admin/suspending_a_user_spec.rb
+++ b/spec/features/admin/suspending_a_user_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "User suspension" do
+RSpec.describe "User suspension", feature_setting: { create_users: true } do
   let(:facility) { create(:facility) }
   let(:user) { create(:user, email: "todelete@example.com", first_name: "Del", last_name: "User") }
 


### PR DESCRIPTION
# Release Notes

Fix spec for suspending a user, which was failing on forks where create_user is not turned on.