### PR TITLE
Fix specs when c2po not included

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -938,6 +938,11 @@ en:
       body: Your export is ready. Please see the attached file.
 
   users:
+    new_user:
+      success: You just created a new user
+      new_payment_source: Create a new payment source for this user
+      add_to_payment_source: Add this user to a payment source
+      order_for: Order on behalf of this user
     access_list:
       head: "%{name} Access List"
       no_products: "%{name} does not have any available products."

--- a/spec/features/admin/facility_statements_search_spec.rb
+++ b/spec/features/admin/facility_statements_search_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Statements Search" do
   let(:facility) { create(:setup_facility) }
   let(:director) { create(:user, :facility_director, facility: facility) }
   let(:item) { create(:setup_item, facility: facility) }
-  let(:accounts) { create_list(:purchase_order_account, 2, :with_account_owner) }
+  let(:accounts) { create_list(:account, 2, :with_account_owner, type: Account.config.statement_account_types.first) }
   let(:orders) do
     accounts.map { |account| create(:complete_order, product: item, account: account) }
   end

--- a/vendor/engines/c2po/config/locales/en.yml
+++ b/vendor/engines/c2po/config/locales/en.yml
@@ -32,13 +32,6 @@ en:
     credit_card: Credit Card
     po: Purchase Order
 
-  users:
-    new_user:
-      success: You just created a new user
-      new_payment_source: Create a new payment source for this user
-      add_to_payment_source: Add this user to a payment source
-      order_for: Order on behalf of this user
-
   activerecord:
     models:
       credit_card_account:


### PR DESCRIPTION
# Release Notes

A few specs were dependent on factories/translations that were specific to the C2PO engine. This PR moves some translations and uses a more generic factory so that specs will pass even when the engine is not included.