### PR TITLE
Fix price calculation for overage products when a reservation lacks reservation times

### DIFF
--- a/app/models/instrument_price_policy_calculations.rb
+++ b/app/models/instrument_price_policy_calculations.rb
@@ -54,7 +54,7 @@ module InstrumentPricePolicyCalculations
   # CHARGE_FOR[:overage] charges for all the time that was initially reserved,
   # plus any actual time used beyond the scheduled end time.
   def calculate_overage(reservation)
-    return unless reservation.has_actual_times?
+    return unless reservation.has_reserved_times? && reservation.has_actual_times?
     end_at = [reservation.reserve_end_at, reservation.actual_end_at].max
     calculate_for_time(reservation.reserve_start_at, end_at)
   end

--- a/app/models/instrument_price_policy_calculations.rb
+++ b/app/models/instrument_price_policy_calculations.rb
@@ -41,20 +41,20 @@ module InstrumentPricePolicyCalculations
   # CHARGE_FOR[:reservation] uses reserve start and end time for calculation
   def calculate_reservation(reservation)
     # One or both of these could be blank if we parse an invalid date in a form
-    return unless reservation.reserve_start_at && reservation.reserve_end_at
+    return unless reservation.has_reserved_times?
     calculate_for_time(reservation.reserve_start_at, reservation.reserve_end_at)
   end
 
   # CHARGE_FOR[:usage] uses the actual start/end times for calculation
   def calculate_usage(reservation)
-    return unless reservation.actual_start_at && reservation.actual_end_at
+    return unless reservation.has_actual_times?
     calculate_for_time(reservation.actual_start_at, reservation.actual_end_at)
   end
 
   # CHARGE_FOR[:overage] charges for all the time that was initially reserved,
   # plus any actual time used beyond the scheduled end time.
   def calculate_overage(reservation)
-    return unless reservation.actual_start_at && reservation.actual_end_at
+    return unless reservation.has_actual_times?
     end_at = [reservation.reserve_end_at, reservation.actual_end_at].max
     calculate_for_time(reservation.reserve_start_at, end_at)
   end

--- a/app/support/reservations/date_support.rb
+++ b/app/support/reservations/date_support.rb
@@ -115,6 +115,14 @@ module Reservations::DateSupport
     meridian_field(:actual_end)
   end
 
+  def has_actual_times?
+    actual_start_at.present? && actual_end_at.present?
+  end
+
+  def has_reserved_times?
+    reserve_start_at.present? && reserve_end_at.present?
+  end
+
   private
 
   def instance_variable_fetch(field, options = {})

--- a/spec/app_support/reservations/date_support_spec.rb
+++ b/spec/app_support/reservations/date_support_spec.rb
@@ -228,4 +228,44 @@ RSpec.describe Reservations::DateSupport do
       end
     end
   end
+
+  describe "#has_actual_times?" do
+    it "returns false when actual_start_at is blank" do
+      reservation.actual_start_at = nil
+      expect(reservation.has_actual_times?).to be false
+    end
+
+    it "returns false when actual_end_at is blank" do
+      reservation.actual_end_at = nil
+      expect(reservation.has_actual_times?).to be false
+    end
+
+    it "returns true when actual_start_at and actual_end_at are set" do
+      reservation.assign_attributes(
+        actual_start_at: 45.minutes.ago,
+        actual_end_at: 15.minutes.ago
+      )
+      expect(reservation.has_actual_times?).to be true
+    end
+  end
+
+  describe "#has_reserves_times?" do
+    it "returns false when reserve_start_at is blank" do
+      reservation.reserve_start_at = nil
+      expect(reservation.has_reserved_times?).to be false
+    end
+
+    it "returns false when reserve_end_at is blank" do
+      reservation.reserve_end_at = nil
+      expect(reservation.has_reserved_times?).to be false
+    end
+
+    it "returns true when reserve_start_at and reserve_end_at are set" do
+      reservation.assign_attributes(
+        reserve_start_at: 45.minutes.ago,
+        reserve_end_at: 15.minutes.ago
+      )
+      expect(reservation.has_reserved_times?).to be true
+    end
+  end
 end

--- a/spec/models/instrument_price_policy_calculations_spec.rb
+++ b/spec/models/instrument_price_policy_calculations_spec.rb
@@ -190,6 +190,11 @@ RSpec.describe InstrumentPricePolicyCalculations do
         allow(reservation).to receive(:has_actual_times?).and_return false
         expect(policy.calculate_cost_and_subsidy(reservation)).to be_nil
       end
+
+      it "returns nil if has_reserved_times? is false" do
+        allow(reservation).to receive(:has_reserved_times?).and_return false
+        expect(policy.calculate_cost_and_subsidy(reservation)).to be_nil
+      end
     end
 
     context "when configured to charge for reservation" do

--- a/spec/models/instrument_price_policy_calculations_spec.rb
+++ b/spec/models/instrument_price_policy_calculations_spec.rb
@@ -154,56 +154,59 @@ RSpec.describe InstrumentPricePolicyCalculations do
       policy.calculate_cost_and_subsidy reservation
     end
 
-    it 'returns #calculate_usage when configured to charge for usage' do
-      policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[:usage]
-      expect(policy).to receive(:calculate_usage).with reservation
-      expect(policy).to_not receive :calculate_overage
-      expect(policy).to_not receive :calculate_reservation
-      expect(policy).to_not receive :calculate_cancellation_costs
-      policy.calculate_cost_and_subsidy reservation
-    end
-
-    it 'returns #calculate_overage when configured to charge for overage' do
-      policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[:overage]
-      expect(policy).to receive(:calculate_overage).with reservation
-      expect(policy).to_not receive :calculate_usage
-      expect(policy).to_not receive :calculate_reservation
-      expect(policy).to_not receive :calculate_cancellation_costs
-      policy.calculate_cost_and_subsidy reservation
-    end
-
-    it 'returns #calculate_reservation when configured to charge for reservation' do
-      policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[:reservation]
-      expect(policy).to receive(:calculate_reservation).with reservation
-      expect(policy).to_not receive :calculate_overage
-      expect(policy).to_not receive :calculate_usage
-      expect(policy).to_not receive :calculate_cancellation_costs
-      policy.calculate_cost_and_subsidy reservation
-    end
-
-    it "returns nil when reserve_start at is nil and charging for reservation" do
-      policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[:reservation]
-      allow(reservation).to receive(:reserve_start_at).and_return nil
-      expect(policy.calculate_cost_and_subsidy(reservation)).to be_nil
-    end
-
-    it "returns nil when reserve_start at is nil and charging for reservation" do
-      policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[:reservation]
-      allow(reservation).to receive(:reserve_end_at).and_return nil
-      expect(policy.calculate_cost_and_subsidy(reservation)).to be_nil
-    end
-
-    %w(usage overage).each do |charge_for|
-      it "returns nil if actual_start_at is missing and we are charging by #{charge_for}" do
-        policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[charge_for.to_sym]
-        allow(reservation).to receive(:actual_start_at).and_return nil
-        expect(policy.calculate_cost_and_subsidy(reservation)).to be_nil
+    context "when configured to charge for usage" do
+      before :each do
+        policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[:usage]
       end
 
-      it "returns nil if actual_end_at is missing and we are charging by #{charge_for}" do
-        policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[charge_for.to_sym]
-        allow(reservation).to receive(:actual_start_at).and_return now
-        allow(reservation).to receive(:actual_end_at).and_return nil
+      it 'returns #calculate_usage' do
+        expect(policy).to receive(:calculate_usage).with reservation
+        expect(policy).to_not receive :calculate_overage
+        expect(policy).to_not receive :calculate_reservation
+        expect(policy).to_not receive :calculate_cancellation_costs
+        policy.calculate_cost_and_subsidy reservation
+      end
+
+      it "returns nil if has_actual_times? is false" do
+        allow(reservation).to receive(:has_actual_times?).and_return false
+        expect(policy.calculate_cost_and_subsidy(reservation)).to be_nil
+      end
+    end
+
+    context "when configured to charge for overage" do
+      before :each do
+        policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[:overage]
+      end
+
+      it 'returns #calculate_overage when configured to charge for overage' do
+        expect(policy).to receive(:calculate_overage).with reservation
+        expect(policy).to_not receive :calculate_usage
+        expect(policy).to_not receive :calculate_reservation
+        expect(policy).to_not receive :calculate_cancellation_costs
+        policy.calculate_cost_and_subsidy reservation
+      end
+
+      it "returns nil if has_actual_times? is false" do
+        allow(reservation).to receive(:has_actual_times?).and_return false
+        expect(policy.calculate_cost_and_subsidy(reservation)).to be_nil
+      end
+    end
+
+    context "when configured to charge for reservation" do
+      before :each do
+        policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[:reservation]
+      end
+
+      it 'returns #calculate_reservation when configured to charge for reservation' do
+        expect(policy).to receive(:calculate_reservation).with reservation
+        expect(policy).to_not receive :calculate_overage
+        expect(policy).to_not receive :calculate_usage
+        expect(policy).to_not receive :calculate_cancellation_costs
+        policy.calculate_cost_and_subsidy reservation
+      end
+
+      it "returns nil if has_reserved_times? is false" do
+        allow(reservation).to receive(:has_reserved_times?).and_return false
         expect(policy.calculate_cost_and_subsidy(reservation)).to be_nil
       end
     end


### PR DESCRIPTION
Fixes [this bug](https://pm.tablexi.com/issues/137409), of which the remaining part is that deleting a portion of the reservation start date (thus making the value invalid, since it’s not a parseable date), made the overlay get stuck in an infinite “calculating price” loop:

![kapture 2018-04-26 at 18 25 29](https://user-images.githubusercontent.com/7736/39318831-77b0ce2e-497f-11e8-93e5-9e22c1df560e.gif)

Going commit-by-commit may be easiest for review, because in https://github.com/tablexi/nucore-open/commit/2f0b86e2d7c02d089cf08041e9da3f7f31ad8d9f I refactored the tests so they use Rspec contexts for clearer grouping, but the fix itself is 4621fec.