### PR TITLE
[#141448] Prevent hard error on unauthorized access to ICS file

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -136,7 +136,7 @@ class ApplicationController < ActionController::Base
   def render_403(_exception)
     # if current_user is nil, the user should be redirected to login
     if current_user
-      render "/403", status: 403, layout: "application"
+      render "/403", status: 403, layout: "application", formats: request.formats + [:html]
     else
       store_location_for(:user, request.fullpath)
       redirect_to new_user_session_path
@@ -145,7 +145,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from NUCore::NotPermittedWhileActingAs, with: :render_acting_error
   def render_acting_error
-    render "/acting_error", status: 403, layout: "application"
+    render "/acting_error", status: 403, layout: "application", formats: request.formats + [:html]
   end
 
   def after_sign_out_path_for(_)

--- a/spec/features/accessing_invalid_files_spec.rb
+++ b/spec/features/accessing_invalid_files_spec.rb
@@ -12,10 +12,11 @@ RSpec.describe "Accessing invalid formats" do
   describe "for a page I don't have access to" do
     let(:user) { create(:user) }
     let(:facility) { create(:facility) }
+    let(:reservation) { create(:purchased_reservation) }
 
     it "renders a 403 as html" do
       login_as user
-      visit "#{I18n.t('facilities_downcase')}/list.pdf"
+      visit "orders/#{reservation.order.id}/order_details/#{reservation.order_detail.id}/reservations/#{reservation.id}.ics"
 
       expect(page).to have_content("403")
       expect(page).to have_content("Permission Denied")

--- a/spec/features/accessing_invalid_files_spec.rb
+++ b/spec/features/accessing_invalid_files_spec.rb
@@ -12,14 +12,39 @@ RSpec.describe "Accessing invalid formats" do
   describe "for a page I don't have access to" do
     let(:user) { create(:user) }
     let(:facility) { create(:facility) }
-    let(:reservation) { create(:purchased_reservation) }
 
-    it "renders a 403 as html" do
-      login_as user
-      visit "orders/#{reservation.order.id}/order_details/#{reservation.order_detail.id}/reservations/#{reservation.id}.ics"
+    describe "a pdf version of a regular page" do
+      it "renders a 403 as html" do
+        login_as user
+        visit "#{I18n.t('facilities_downcase')}/list.pdf"
 
-      expect(page).to have_content("403")
-      expect(page).to have_content("Permission Denied")
+        expect(page).to have_content("403")
+        expect(page).to have_content("Permission Denied")
+      end
+    end
+
+    describe "a statement pdf" do
+      let(:statement) { create(:statement, facility: facility) }
+
+      it "renders a 403 as html" do
+        login_as user
+        visit "accounts/#{statement.account.id}/statements/#{statement.id}.pdf"
+
+        expect(page).to have_content("403")
+        expect(page).to have_content("Permission Denied")
+      end
+    end
+
+    describe "a calendar .ics file" do
+      let(:reservation) { create(:purchased_reservation) }
+
+      it "renders a 403 as html" do
+        login_as user
+        visit "orders/#{reservation.order.id}/order_details/#{reservation.order_detail.id}/reservations/#{reservation.id}.ics"
+
+        expect(page).to have_content("403")
+        expect(page).to have_content("Permission Denied")
+      end
     end
   end
 end


### PR DESCRIPTION
# Release Notes

Prevent hard error when accessing a reservation calendar invitation (.ics file) that does not belong to you.

# Error

```
ActionView::MissingTemplate: Missing template /403 with {:locale=>[:en], :formats=>[:ics], :variants=>[], :handlers=>[:erb, :builder, :raw, :ruby, :coffee, :prawn, :haml]}. Searched in:
* "/home/nucore/nucore.northwestern.edu/releases/20180319223809/vendor/engines/jxml/app/views"
* "/home/nucore/nucore.northwestern.edu/releases/20180319223809/vendor/engines/c2po/app/views"
* "/home/nucore/nucore.northwestern.edu/releases/20180319223809/app/views"
* "/home/nucore/nucore.northwestern.edu/releases/20180319223809/vendor/engines/split_accounts/app/views"
* "/home/nucore/nucore.northwestern.edu/releases/20180319223809/vendor/engines/acgt/app/views"
* "/home/nucore/nucore.northwestern.edu/releases/20180319223809/vendor/engines/sanger_sequencing/app/views"
* "/home/nucore/nucore.northwestern.edu/releases/20180319223809/vendor/engines/nu_cardconnect/app/views"
* "/home/nucore/nucore.northwestern.edu/releases/20180319223809/vendor/engines/nu_research_safety/app/views"
* "/home/nucore/nucore.northwestern.edu/releases/20180319223809/vendor/engines/bulk_email/app/views"
* "/home/nucore/nucore.northwestern.edu/shared/bundle/ruby/2.4.0/gems/ckeditor-4.2.4/app/views"
* "/home/nucore/nucore.northwestern.edu/shared/bundle/ruby/2.4.0/gems/devise-4.4.1/app/views"
```
# Additional Context

We had a similar problem with PDF 404s a while back: https://github.com/tablexi/nucore-open/pull/1475 I will be honest, I do not understand why 403-ing PDFs display the html version of the 403 page and this one doesn't. I gave up before delving too deeply into ActionView source code.
