### PR TITLE
[#137552] Better error message when beginning a reservation in grace period

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -244,11 +244,11 @@ class ReservationsController < ApplicationController
         switch_instrument_off!
       end
     rescue AASM::InvalidTransition => e
-      if e.failures.include?(:time_data_completeable?)
-        flash[:error] = text("switch_instrument.prior_is_still_running")
-      else
-        raise
-      end
+      flash[:error] = if e.failures.include?(:time_data_completeable?)
+                        text("switch_instrument.prior_is_still_running")
+                      else
+                        e.message
+                      end
     rescue => e
       flash[:error] = e.message
     end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -243,6 +243,12 @@ class ReservationsController < ApplicationController
       when params[:switch] == "off"
         switch_instrument_off!
       end
+    rescue AASM::InvalidTransition => e
+      if e.failures.include?(:time_data_completeable?)
+        flash[:error] = text("switch_instrument.prior_is_still_running")
+      else
+        raise
+      end
     rescue => e
       flash[:error] = e.message
     end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -149,14 +149,13 @@ class Reservation < ApplicationRecord
   end
 
   def start_reservation!
+    # Mark running reservations as complete, which will move them to problem orders
     product.schedule.products.flat_map(&:started_reservations).each(&:complete!)
-    self.actual_start_at = Time.current
-    save!
+    update!(actual_start_at: Time.current)
   end
 
   def end_reservation!
-    self.actual_end_at = Time.current
-    save!
+    update!(actual_end_at: Time.current)
     order_detail.complete!
   end
 

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -132,6 +132,8 @@ en:
         Please add it again to make a reservation.
       update:
         failure: The reservation cannot be updated.
+      switch_instrument:
+        prior_is_still_running: Cannot "Begin Reservation" when a previously scheduled reservation is ongoing.
 
     general_reports:
       headers:

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -1130,7 +1130,7 @@ RSpec.describe ReservationsController do
         @params[:reservation_id] = @reservation.id
         create(:relay, instrument: @instrument)
         @random_user = create(:user)
-        @instrument.update_attributes(min_reserve_mins: 30)
+        @instrument.update!(min_reserve_mins: 30)
         @instrument.schedule_rules.update_all(start_hour: 0)
       end
 
@@ -1174,8 +1174,8 @@ RSpec.describe ReservationsController do
         it_should_deny :random_user
 
         context "before the reservation start (in grace period)" do
-          let(:start_at) { 3.minutes.from_now.change(usec: 0) }
-          let(:end_at) { 63.minutes.from_now.change(usec: 0) }
+          let(:start_at) { 3.minutes.from_now }
+          let(:end_at) { 63.minutes.from_now }
 
           before :each do
             @reservation.update_attributes!(reserve_start_at: start_at, reserve_end_at: end_at)


### PR DESCRIPTION
# Release Notes

Improve error message when attempting to start a reservation in the grace period while the previous reservation is still running.

# Additional Context

Example: 
User 1 creates a reservation from 9-10 and starts their reservation
User 2 creates a reservation from 10-11

At 9:55, when the grace period begins, User 2 sees the "Begin Reservation" link. When clicking the link, they previously saw a confusing error generated by AASM. Now, display a more useful error message.

Unchanged behavior: once the grace period is over at 10:00 (i.e. the previous reservation is
technically over), “Begin Reservation” will start the reservation for User 2 and
move User 1's reservation to the problem queue.

Old message:
![unknown](https://user-images.githubusercontent.com/1099111/39439635-e845d904-4c6d-11e8-9898-ff4871cc82ee.jpeg)



