### PR TITLE
[#141569] Prevent start for schedule groups in grace period

### DIFF
--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -147,8 +147,8 @@ module Reservations::Validations
   end
 
   def instrument_is_available_to_reserve?(start_at = reserve_start_at, end_at = reserve_end_at)
-    # check for order_detail and order because some old specs don't set an order detail
-    # if we're saving as an administrator
+    # Check for order_detail and order because some old specs don't set an order detail.
+    # If we're saving as an administrator, they can override the user's schedule rules.
     rules = if order_detail.try(:order).nil? || reserved_by_admin
               product.schedule_rules
             else

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -148,9 +148,8 @@ module Reservations::Validations
 
   def instrument_is_available_to_reserve?(start_at = reserve_start_at, end_at = reserve_end_at)
     # check for order_detail and order because some old specs don't set an order detail
-    # if we're saving as an administrator, or doing a starting in the grace period,
-    # we want access to all schedule rules
-    rules = if order_detail.try(:order).nil? || reserved_by_admin || in_grace_period?
+    # if we're saving as an administrator
+    rules = if order_detail.try(:order).nil? || reserved_by_admin
               product.schedule_rules
             else
               product.available_schedule_rules(order_detail.order.user)


### PR DESCRIPTION
# Release Notes

Prevent users from create & starting a reservation in the 5 minute grace period if they are not part of the required schedule groups.

# Steps to reproduce

* Create an instrument
  * Control mechanism: Timer without relay
  * Requires Approval: Yes
  * Usage or overage price rule
  * With a "Night" schedule group
  * Schedule rules
    * A 9-5 globally available schedule rule
    * A 5-midnight schedule rule for "Night"

A few test scenarios:

* As a user not in the "Night" group at anytime after 5:00, so say 5:30, adjust the fields for a 5:35 reservation. This will allow you to create the reservation, even though you are not in the required schedule group.
* As a user not in the "Night" group, at 4:55, create an hour-long reservation and "Create & Start". This should not create a reservation.
* As a user, at 4:31pm, create a reservation from 4:35pm-5:35pm and "Create & Start". This should not create a reservation.

## Additional Context

Appears related to https://github.com/tablexi/nucore-open/commit/7e28ed72954faedaccef092f44c6143796ac6f67 though, I found it odd that no tests failed when removing the `in_grace_period?` check.