### PR TITLE
[#137710] Improve schedule group error message

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -272,7 +272,7 @@ class Reservation < ApplicationRecord
   def valid_before_purchase?
     satisfies_minimum_length? &&
       satisfies_maximum_length? &&
-      instrument_is_available_to_reserve? &&
+      allowed_in_scheduled_rules? &&
       does_not_conflict_with_other_user_reservation? &&
       (reserved_by_admin || does_not_conflict_with_admin_reservation?)
   end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -272,7 +272,7 @@ class Reservation < ApplicationRecord
   def valid_before_purchase?
     satisfies_minimum_length? &&
       satisfies_maximum_length? &&
-      allowed_in_scheduled_rules? &&
+      allowed_in_schedule_rules? &&
       does_not_conflict_with_other_user_reservation? &&
       (reserved_by_admin || does_not_conflict_with_admin_reservation?)
   end

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -149,8 +149,6 @@ module Reservations::Validations
   def allowed_in_schedule_rules_error
     # Everyone, including admins, are beholden to the full schedule rules
     if in_all_schedule_rules?
-      # Check for order_detail and order because some old specs don't set an order detail.
-      return if order_detail&.order.nil?
       :no_schedule_group unless in_allowed_schedule_rules?
     else
       :no_schedule_rule
@@ -169,7 +167,8 @@ module Reservations::Validations
   def in_allowed_schedule_rules?
     # If we're saving as an administrator, they can override the user's schedule rules.
     return true if reserved_by_admin
-    product.available_schedule_rules(order_detail.order.user).cover?(reserve_start_at, reserve_end_at)
+    # Some old specs don't set an order detail, so we need to safe-navigate
+    product.available_schedule_rules(order_detail&.order&.user).cover?(reserve_start_at, reserve_end_at)
   end
 
   def in_the_future?

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -10,7 +10,7 @@ module Reservations::Validations
     validates :reserve_start_at, presence: true
     validates :reserve_end_at, presence: true, if: :end_at_required?
     validate :does_not_conflict_with_other_user_reservation,
-             :instrument_is_available_to_reserve,
+             :allowed_in_scheduled_rules,
              :satisfies_minimum_length,
              :satisfies_maximum_length,
              if: ->(r) { r.reserve_start_at && r.reserve_end_at && r.reservation_changed? },
@@ -142,11 +142,11 @@ module Reservations::Validations
     errors.add(:base, :too_long, length: product.max_reserve_mins) unless satisfies_maximum_length?
   end
 
-  def instrument_is_available_to_reserve
-    errors.add(:base, :unavailable_to_reserve) unless instrument_is_available_to_reserve?
+  def allowed_in_scheduled_rules
+    errors.add(:base, :no_schedule_rule) unless allowed_in_scheduled_rules?
   end
 
-  def instrument_is_available_to_reserve?(start_at = reserve_start_at, end_at = reserve_end_at)
+  def allowed_in_scheduled_rules?(start_at = reserve_start_at, end_at = reserve_end_at)
     # Check for order_detail and order because some old specs don't set an order detail.
     # If we're saving as an administrator, they can override the user's schedule rules.
     rules = if order_detail.try(:order).nil? || reserved_by_admin

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -97,7 +97,7 @@ en:
               conflict: The reservation conflicts with another reservation.
               conflict_in_cart: The reservation conflicts with another reservation in your cart. Please purchase or remove it then continue.
               out_of_window: The reservation is too far in advance
-              unavailable_to_reserve: The reservation spans time that the instrument is unavailable for reservation
+              no_schedule_rule: The reservation spans time that the instrument is unavailable for reservation
               too_long: The reservation is too long. It cannot be longer than %{length} minutes.
               too_short: The reservation is too short. It must be at least %{length} minutes.
             reserve_start_at:

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -98,6 +98,7 @@ en:
               conflict_in_cart: The reservation conflicts with another reservation in your cart. Please purchase or remove it then continue.
               out_of_window: The reservation is too far in advance
               no_schedule_rule: The reservation spans time that the instrument is unavailable for reservation
+              no_schedule_group: You do not have permission to make a reservation at this time
               too_long: The reservation is too long. It cannot be longer than %{length} minutes.
               too_short: The reservation is too short. It must be at least %{length} minutes.
             reserve_start_at:

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1218,14 +1218,14 @@ RSpec.describe Reservation do
         describe "a user who is not approved" do
           it "does not allow the user" do
             expect(reservation).to be_invalid
-            expect(reservation.errors).to be_added(:base, :unavailable_to_reserve)
+            expect(reservation.errors).to be_added(:base, :no_schedule_rule)
           end
 
           it "does not allow the user to place the reservation 5 minutes ahead" do
             reservation.valid? # to set times
             travel_to_and_return(reservation.reserve_start_at - 5.minutes) do
               expect(reservation).to be_invalid
-              expect(reservation.errors).to be_added(:base, :unavailable_to_reserve)
+              expect(reservation.errors).to be_added(:base, :no_schedule_rule)
             end
           end
         end
@@ -1235,7 +1235,7 @@ RSpec.describe Reservation do
 
           it "does not allow the user" do
             expect(reservation).to be_invalid
-            expect(reservation.errors).to be_added(:base, :unavailable_to_reserve)
+            expect(reservation.errors).to be_added(:base, :no_schedule_rule)
           end
         end
 
@@ -1260,11 +1260,13 @@ RSpec.describe Reservation do
 
           it "should not allow a regular user to save in a restricted scheduling rule" do
             expect { reservation.save_as_user!(user) }.to raise_error(ActiveRecord::RecordInvalid)
+            expect(reservation.errors).to be_added(:base, :no_schedule_rule)
           end
 
           it "should not allow an administrator to save outside of scheduling rules" do
             reservation.update_attributes(reserve_start_hour: 10)
             expect { reservation.save_as_user!(admin) }.to raise_error(ActiveRecord::RecordInvalid)
+            expect(reservation.errors).to be_added(:base, :no_schedule_rule)
           end
         end
       end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -456,11 +456,11 @@ RSpec.describe Reservation do
                 reservation.reload
               end
 
-              after { travel_to(@current_time) }
+              after(:each) { travel_to(@current_time, safe: true) }
 
               context "before the lock window begins" do
                 before :each do
-                  travel_to(reservation.reserve_start_at - (window_hours + 2).hours)
+                  travel_to(reservation.reserve_start_at - (window_hours + 2).hours, safe: true)
                 end
 
                 it_behaves_like "a customer is allowed to edit"
@@ -468,7 +468,7 @@ RSpec.describe Reservation do
 
               context "after the lock window has begun" do
                 before :each do
-                  travel_to(reservation.reserve_start_at - (window_hours - 2).hours)
+                  travel_to(reservation.reserve_start_at - (window_hours - 2).hours, safe: true)
                 end
 
                 it_behaves_like "a customer is allowed to edit"

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1218,14 +1218,14 @@ RSpec.describe Reservation do
         describe "a user who is not approved" do
           it "does not allow the user" do
             expect(reservation).to be_invalid
-            expect(reservation.errors).to be_added(:base, :no_schedule_rule)
+            expect(reservation.errors).to be_added(:base, :no_schedule_group)
           end
 
           it "does not allow the user to place the reservation 5 minutes ahead" do
             reservation.valid? # to set times
             travel_to_and_return(reservation.reserve_start_at - 5.minutes) do
               expect(reservation).to be_invalid
-              expect(reservation.errors).to be_added(:base, :no_schedule_rule)
+              expect(reservation.errors).to be_added(:base, :no_schedule_group)
             end
           end
         end
@@ -1235,7 +1235,7 @@ RSpec.describe Reservation do
 
           it "does not allow the user" do
             expect(reservation).to be_invalid
-            expect(reservation.errors).to be_added(:base, :no_schedule_rule)
+            expect(reservation.errors).to be_added(:base, :no_schedule_group)
           end
         end
 
@@ -1260,7 +1260,7 @@ RSpec.describe Reservation do
 
           it "should not allow a regular user to save in a restricted scheduling rule" do
             expect { reservation.save_as_user!(user) }.to raise_error(ActiveRecord::RecordInvalid)
-            expect(reservation.errors).to be_added(:base, :no_schedule_rule)
+            expect(reservation.errors).to be_added(:base, :no_schedule_group)
           end
 
           it "should not allow an administrator to save outside of scheduling rules" do


### PR DESCRIPTION
# Release Notes

Improve error message when a user is not in the proper schedule group when placing a reservation.

# Additional Context

If there are no schedule groups, then we continue to get the old message if the reservation is outside the schedule rules.

A few cases (hopefully all covered by the specs):

* Not restricted - "The reservation spans time that the instrument is unavailable for reservation"
* On behalf of, not restricted - "The reservation spans time that the instrument is unavailable for reservation"
* Restricted, no schedule groups - "The reservation spans time that the instrument is unavailable for reservation"
* On behalf of, restricted, no schedule groups - "The reservation spans time that the instrument is unavailable for reservation"
* Restricted, plus a 5-midnight "Night" group, user not in group - "You do not have permission to make a reservation at this time"
* On behalf of, restricted, plus a 5-midnight "Night" group, user not in group, 4:30 - 5:30 - Allowed to place reservation
* Restricted, plus a 5-midnight "Night" group, user is in the group - Allowed to place reservation
* On behalf of, Restricted, plus a 5-midnight "Night" group, user is in the group - Allowed to place reservation
