### PR TITLE
[#141837] Prevent account managers from suspending users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -38,6 +38,7 @@ class UsersController < ApplicationController
                  .paginate(page: params[:page])
   end
 
+  # POST /facilities/:facility_id/users/search
   def search
     @user = username_lookup(params[:username_lookup])
     render layout: false
@@ -47,6 +48,7 @@ class UsersController < ApplicationController
   def new
   end
 
+  # GET /facilities/:facility_id/users/new_external
   def new_external
     @user = User.new(email: params[:email], username: params[:email])
     @user_form = user_form_class.new(@user)
@@ -100,18 +102,10 @@ class UsersController < ApplicationController
     @training_requested_product_ids = @user.training_requests.pluck(:product_id)
   end
 
-  def training_requested_for?(product)
-    @training_requested_product_ids.include? product.id
-  end
-  helper_method :training_requested_for?
-
   # POST /facilities/:facility_id/users/:user_id/access_list/approvals
   def access_list_approvals
     update_access_list_approvals
     redirect_to facility_user_access_list_path(current_facility, @user)
-  end
-
-  def email
   end
 
   # GET /facilities/:facility_id/users/:id/edit
@@ -131,18 +125,25 @@ class UsersController < ApplicationController
     end
   end
 
+  # PATCH /facilities/:facility_id/users/:id/suspend
   def suspend
     @user.suspended_at ||= Time.current
     @user.save!
     redirect_to facility_user_path(current_facility, @user), notice: "User suspended"
   end
 
+  # PATCH /facilities/:facility_id/users/:id/unsuspend
   def unsuspend
     @user.update!(suspended_at: nil)
     redirect_to facility_user_path(current_facility, @user), notice: "User re-activated"
   end
 
   private
+
+  def training_requested_for?(product)
+    @training_requested_product_ids.include? product.id
+  end
+  helper_method :training_requested_for?
 
   def create_params
     params.require(:user).permit(:email, :first_name, :last_name, :username)

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -54,9 +54,9 @@ class Ability
       can [:manage_accounts, :manage_users], Facility.cross_facility
 
       if resource.blank? || resource == Facility.cross_facility
-        can :manage, [AccountUser, User]
+        can :manage, AccountUser
+        can [:create, :read, :update, :administer, :accounts, :new_external, :search], User
         can [:create, :read, :update, :suspend, :unsuspend], Account
-        cannot :switch_to, User
         if SettingsHelper.feature_off?(:create_users)
           cannot([:edit, :update], User)
         end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -68,16 +68,16 @@ RSpec.describe Ability do
       it { is_expected.to be_allowed_to(:manage_accounts, facility) }
       it_is_allowed_to([:new, :create, :read, :edit, :update, :suspend, :unsuspend], Account)
       it { is_expected.to be_allowed_to(:manage, AccountUser) }
-      it { is_expected.to be_allowed_to(:manage, User) }
-      it { is_expected.not_to be_allowed_to(:switch_to, other_user) }
+      it_is_allowed_to([:new, :create, :read, :edit, :update, :index, :accounts], User)
+      it_is_not_allowed_to([:switch_to, :suspend, :unsuspend, :orders], User)
     end
 
     context "in no facility" do
       let(:facility) { nil }
 
       it { is_expected.to be_allowed_to(:manage, AccountUser) }
-      it { is_expected.to be_allowed_to(:manage, User) }
-      it { is_expected.not_to be_allowed_to(:switch_to, other_user) }
+      it_is_allowed_to([:new, :create, :read, :edit, :update, :index, :accounts, :search], User)
+      it_is_not_allowed_to([:switch_to, :suspend, :unsuspend, :orders], User)
     end
   end
 


### PR DESCRIPTION
# Release Notes

Prevent account managers from suspending/unsuspending users.

# Additional Context

We were giving account managers full `:manage` access to `User`. This cuts down their access and whitelists only the things they should be able to do. I believe we had originally gone with `:manage` because there were a lot of actions. Hopefully, we've got them all here.
