### PR TITLE
[#140939] Add alert banner style and hooks

### DIFF
--- a/app/assets/stylesheets/app/global_alert_banner.scss
+++ b/app/assets/stylesheets/app/global_alert_banner.scss
@@ -1,0 +1,23 @@
+.global-alert-banner {
+  font-size: 1.2em;
+  text-align: center;
+  width: auto;
+  padding: 0.5em;
+  box-sizing: border-box;
+
+  color: $errorText;
+  background-color: $errorBackground;
+
+  p {
+    line-height: 1.8em;
+    margin-bottom: 0.4em;
+  }
+
+  @media screen and (max-width: 767px) {
+    & {
+      font-size: 1em;
+      margin-left: -$gridGutterWidth;
+      margin-right: -$gridGutterWidth;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,6 +31,7 @@ $chosen-sprite-retina: image-url("chosen-sprite@2x.png");
 @import "app/tables";
 @import "app/cart";
 @import "app/chosen-override";
+@import "app/global_alert_banner";
 
 @import "fine-uploader/fine-uploader-new";
 @import "fine-uploader-override";

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,22 +1,23 @@
 <!DOCTYPE html>
 %html
   %head
-    = render :partial => '/shared/head'
+    = render "/shared/head"
   %body
     %header
-      = render :partial => '/shared/acting_as'
-      = render :partial => '/shared/header'
+      = render "/shared/acting_as"
+      = render_view_hook("banner")
+      = render "/shared/header"
     %nav
-      = render :partial => '/shared/nav'
-    = render :partial => '/shared/breadcrumb', :locals => { :breadcrumb => yield(:breadcrumb) }
+      = render "/shared/nav"
+    = render "/shared/breadcrumb", breadcrumb: yield(:breadcrumb)
     #content
       .container
         .row
           .span12
             %h1= yield :h1
             = yield :tabnav
-            = render partial: 'shared/flashes'
+            = render partial: "shared/flashes"
 
             = yield
     %footer
-      = render :partial => '/shared/footer'
+      = render "/shared/footer"


### PR DESCRIPTION
# Release Notes

Add hooks/styles for an alert banner (not used by default).

# Screenshot

Example from Dartmouth:

![39605956-8a49727e-4ef8-11e8-8975-0dd4bafea186](https://user-images.githubusercontent.com/1099111/39832412-b14cb460-538c-11e8-8902-d6954e894579.png)


# Additional Context

Companion to https://github.com/tablexi/nucore-dartmouth/pull/187/commits
