### PR TITLE
[#141837] Fix ability spec for account managers when `create_users` is turned off

### DIFF
--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -58,7 +58,7 @@ class Ability
         can [:create, :read, :update, :administer, :accounts, :new_external, :search], User
         can [:create, :read, :update, :suspend, :unsuspend], Account
         if SettingsHelper.feature_off?(:create_users)
-          cannot([:edit, :update], User)
+          cannot([:create, :update], User)
         end
       end
     end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -62,22 +62,34 @@ RSpec.describe Ability do
       it { is_expected.not_to be_allowed_to(:switch_to, other_user) }
     end
 
+    shared_examples_for "correct User permissions" do
+      context "when create_users feature is on", feature_setting: { create_users: true } do
+        it_is_allowed_to([:new, :create, :read, :edit, :update, :index, :accounts, :search], User)
+        it_is_not_allowed_to([:switch_to, :suspend, :unsuspend, :orders], User)
+      end
+
+      context "when create_users feature is off", feature_setting: { create_users: false } do
+        it_is_allowed_to([:read, :index, :accounts, :search], User)
+        it_is_not_allowed_to([:new, :create, :edit, :update, :switch_to, :suspend, :unsuspend, :orders], User)
+      end
+    end
+
     context "in cross-facility" do
       let(:facility) { Facility.cross_facility }
 
       it { is_expected.to be_allowed_to(:manage_accounts, facility) }
       it_is_allowed_to([:new, :create, :read, :edit, :update, :suspend, :unsuspend], Account)
       it { is_expected.to be_allowed_to(:manage, AccountUser) }
-      it_is_allowed_to([:new, :create, :read, :edit, :update, :index, :accounts], User)
-      it_is_not_allowed_to([:switch_to, :suspend, :unsuspend, :orders], User)
+
+      it_behaves_like "correct User permissions"
     end
 
     context "in no facility" do
       let(:facility) { nil }
 
       it { is_expected.to be_allowed_to(:manage, AccountUser) }
-      it_is_allowed_to([:new, :create, :read, :edit, :update, :index, :accounts, :search], User)
-      it_is_not_allowed_to([:switch_to, :suspend, :unsuspend, :orders], User)
+
+      it_behaves_like "correct User permissions"
     end
   end
 


### PR DESCRIPTION
# Release Notes

Fixes ability specs when `create_users` setting is turned off (e.g. UIC).

# Additional Context

Fixes #1542 when merged into UIC
