### PR TITLE
[#141665] Support both unix timestamps and iso8601 in calendar endpoint

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -399,9 +399,9 @@ class ReservationsController < ApplicationController
   def parse_time_param(value)
     return unless value
 
-    if value.to_s =~ /\A\d{10}\z/ # unix timestamp
+    if value.to_s.match?(/\A\d{10}\z/) # unix timestamp
       Time.zone.at(value.to_i)
-    elsif value.to_s =~ /\A\d{13}\z/ # unix timestamp with milliseconds
+    elsif value.to_s.match?(/\A\d{13}\z/) # unix timestamp with milliseconds
       Time.zone.at(value.to_i / 1000)
     else
       Time.zone.parse(value)

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -399,8 +399,10 @@ class ReservationsController < ApplicationController
   def parse_time_param(value)
     return unless value
 
-    if value.to_s =~ /\A\d+{10}\z/ # unix timestamp
+    if value.to_s =~ /\A\d{10}\z/ # unix timestamp
       Time.zone.at(value.to_i)
+    elsif value.to_s =~ /\A\d{13}\z/ # unix timestamp with milliseconds
+      Time.zone.at(value.to_i / 1000)
     else
       Time.zone.parse(value)
     end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -396,16 +396,11 @@ class ReservationsController < ApplicationController
 
   # Some browsers are not updating their cached JS and have an out-of-date calendar
   # JS library which uses unix timestamps for the parameters. This allows us to handle both.
-  def parse_time_param(value)
-    return unless value
-
-    if value.to_s.match?(/\A\d{10}\z/) # unix timestamp
-      Time.zone.at(value.to_i)
-    elsif value.to_s.match?(/\A\d{13}\z/) # unix timestamp with milliseconds
-      Time.zone.at(value.to_i / 1000)
-    else
-      Time.zone.parse(value)
-    end
+  def parse_time_param(string_value)
+    return unless string_value
+    Time.zone.parse(string_value)
+  rescue ArgumentError
+    Time.at(string_value.to_i)
   end
 
   def helpers

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -400,7 +400,7 @@ class ReservationsController < ApplicationController
     return unless string_value
     Time.zone.parse(string_value)
   rescue ArgumentError
-    Time.at(string_value.to_i)
+    Time.zone.at(string_value.to_i)
   end
 
   def helpers

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,6 +138,7 @@ class User < ApplicationRecord
   # purchasing that product
   def accounts_for_product(product)
     acts = accounts.active.for_facility(product.facility).to_a
+    puts acts.map { |acct| [acct, acct.validate_against_product(product, self)] }
     acts.reject! { |acct| !acct.validate_against_product(product, self).nil? }
     acts
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,7 +138,6 @@ class User < ApplicationRecord
   # purchasing that product
   def accounts_for_product(product)
     acts = accounts.active.for_facility(product.facility).to_a
-    puts acts.map { |acct| [acct, acct.validate_against_product(product, self)] }
     acts.reject! { |acct| !acct.validate_against_product(product, self).nil? }
     acts
   end

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -58,6 +58,38 @@ RSpec.describe ReservationsController do
       expect(assigns[:instrument]).to eq(instrument)
     end
 
+    describe "start/stop parameters" do
+      let(:start_range) { Time.zone.local(2018, 5, 15, 12, 13) }
+      let(:end_range) { start_range + 1.week }
+
+      it "supports iso8601 parameters" do
+        @params.merge!(start: start_range.iso8601, end: end_range.iso8601)
+        do_request
+        expect(assigns(:start_at)).to eq(start_range)
+        expect(assigns(:end_at)).to eq(end_range)
+      end
+
+      it "supports unix timestamps" do
+        @params.merge!(start: start_range.to_i, end: end_range.to_i)
+        do_request
+        expect(assigns(:start_at)).to eq(start_range)
+        expect(assigns(:end_at)).to eq(end_range)
+      end
+
+      it "defaults to today with no parameters" do
+        do_request
+        expect(assigns(:start_at)).to eq(Time.current)
+        expect(assigns(:end_at)).to eq(Time.current.end_of_day)
+      end
+
+      it "defaults to the end of day with missing end param" do
+        @params.merge!(start: start_range.iso8601)
+        do_request
+        expect(assigns(:start_at)).to eq(start_range)
+        expect(assigns(:end_at)).to eq(start_range.end_of_day)
+      end
+    end
+
     context "schedule rules" do
       let(:now) { Time.current }
 

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -70,17 +70,9 @@ RSpec.describe ReservationsController do
         expect(assigns(:end_at)).to eq(end_range)
       end
 
-      it "supports unix timestamps without milliseconds" do
+      it "supports unix timestamps" do
         @params[:start] = start_range.to_i
         @params[:end] = end_range.to_i
-        do_request
-        expect(assigns(:start_at)).to eq(start_range)
-        expect(assigns(:end_at)).to eq(end_range)
-      end
-
-      it "supports unix timestamps with milliseconds" do
-        @params[:start] = start_range.to_i * 1000
-        @params[:end] = end_range.to_i * 1000
         do_request
         expect(assigns(:start_at)).to eq(start_range)
         expect(assigns(:end_at)).to eq(end_range)

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -63,14 +63,24 @@ RSpec.describe ReservationsController do
       let(:end_range) { start_range + 1.week }
 
       it "supports iso8601 parameters" do
-        @params.merge!(start: start_range.iso8601, end: end_range.iso8601)
+        @params[:start] = start_range.iso8601
+        @params[:end] = end_range.iso8601
         do_request
         expect(assigns(:start_at)).to eq(start_range)
         expect(assigns(:end_at)).to eq(end_range)
       end
 
-      it "supports unix timestamps" do
-        @params.merge!(start: start_range.to_i, end: end_range.to_i)
+      it "supports unix timestamps without milliseconds" do
+        @params[:start] = start_range.to_i
+        @params[:end] = end_range.to_i
+        do_request
+        expect(assigns(:start_at)).to eq(start_range)
+        expect(assigns(:end_at)).to eq(end_range)
+      end
+
+      it "supports unix timestamps with milliseconds" do
+        @params[:start] = start_range.to_i * 1000
+        @params[:end] = end_range.to_i * 1000
         do_request
         expect(assigns(:start_at)).to eq(start_range)
         expect(assigns(:end_at)).to eq(end_range)
@@ -83,7 +93,7 @@ RSpec.describe ReservationsController do
       end
 
       it "defaults to the end of day with missing end param" do
-        @params.merge!(start: start_range.iso8601)
+        @params[:start] = start_range.iso8601
         do_request
         expect(assigns(:start_at)).to eq(start_range)
         expect(assigns(:end_at)).to eq(start_range.end_of_day)


### PR DESCRIPTION
# Release Notes

Prevent "argument out of range" errors when browsers are still running old Fullcalendar code.

# Additional Context

For some reason, we’re continuing to get `reservations#index
(ArgumentError) "argument out of range”` errors caused by start/stop
parameters being in unix timestamp format. This format changed when we
upgraded Fullcalendar, so it seems like some browsers are continuing to
load the old code. That shouldn’t be happening because the library
should be fingerprinted.

This should stop the errors.

See: https://github.com/tablexi/nucore-open/pull/1478

Example:
https://nucore.northwestern.edu/facilities/imserc/instruments/nmr_a600/reservations.js?all=true&amp;with_details=true&start=1524373200&end=1524978000&_=1524755233886

Referrer: https://nucore.northwestern.edu/facilities/imserc/instruments/nmr_a600/schedule