### PR TITLE
Lock rollbar to 2.15.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,7 +129,9 @@ group :stage, :production do
   gem "lograge"
   gem "logstash-event"
   gem "oj"
-  gem "rollbar"
+  # 2.15.6 has a problem during cap deploy
+  # https://github.com/rollbar/rollbar-gem/issues/713
+  gem "rollbar", "2.15.5"
   gem "unicorn", require: false
   gem "whenever", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -498,7 +498,7 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    rollbar (2.15.6)
+    rollbar (2.15.5)
       multi_json
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -707,7 +707,7 @@ DEPENDENCIES
   rails-erd
   rails-observers
   rake
-  rollbar
+  rollbar (= 2.15.5)
   rspec-activejob
   rspec-collection_matchers
   rspec-rails


### PR DESCRIPTION
# Release Notes

Lock rollbar to 2.15.5 due to an issue with the 2.15.6 version.
# Additional Context

See https://github.com/rollbar/rollbar-gem/issues/713
