### PR TITLE
Fix constant not found problem on stage

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,11 +8,16 @@ require "will_paginate/array"
 Bundler.require(*Rails.groups)
 
 module Nucore
+
   class Application < Rails::Application
+
+    # Rails 5 disables autoloading in production by default.
+    # https://blog.bigbinary.com/2016/08/29/rails-5-disables-autoloading-after-booting-the-app-in-production.html
+    config.enable_dependency_loading = true
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
-
     config.autoload_paths += Dir["#{config.root}/lib/**/"]
     config.autoload_paths += Dir["#{config.root}/app/models/**/"]
     config.autoload_paths += Dir["#{config.root}/app/controllers/concerns"]
@@ -33,4 +38,5 @@ module Nucore
 
     config.active_record.observers = :order_detail_observer
   end
+
 end


### PR DESCRIPTION
# Release Notes

Fix Rails 5 auto/eager loading problem on stage.


# Additional Context
Rails 5 disables autoloading by default, so anything in `/lib` was not being found
when it is first used. The big one is

```
NameError: uninitialized constant ApplicationController::Ability
File "/home/nucore/nucore.stage.tablexi.com/releases/20180511175626/app/controllers/application_controller.rb" line 181 in current_ability
```

You can reproduce this problem locally by changing `config.cache_classes` and `config.eager_load` to `true` in `environments/development.rb`.

The other option would be to add these same paths to `eager_load_paths`. I just needed to get this out quickly so we can use open stage. 