### PR TITLE
[#136765] Remove create tabs for CCs or POs for account managers

### DIFF
--- a/app/controllers/facility_accounts_controller.rb
+++ b/app/controllers/facility_accounts_controller.rb
@@ -39,14 +39,10 @@ class FacilityAccountsController < ApplicationController
   end
 
   # GET /facilities/:facility_id/accounts/new
-  def new
-    @available_account_types = available_account_types
-  end
+  def new; end
 
   # POST /facilities/:facility_id/accounts
   def create
-    @available_account_types = available_account_types
-
     # The builder might add some errors to base. If those exist,
     # we don't want to try saving as that would clear the original errors
     if @account.errors[:base].empty? && @account.save
@@ -163,18 +159,20 @@ class FacilityAccountsController < ApplicationController
   private
 
   def available_account_types
-    Account.config.account_types_for_facility(current_facility, :create).select do |account_type|
+    @available_account_types ||= Account.config.account_types_for_facility(current_facility, :create).select do |account_type|
       current_ability.can?(:create, account_type.constantize)
     end
   end
+  helper_method :available_account_types
 
   def current_account_type
-    if available_account_types.include?(params[:account_type])
-      params[:account_type]
-    else
-      available_account_types.first
-    end
+    @current_account_type ||= if available_account_types.include?(params[:account_type])
+                                params[:account_type]
+                              else
+                                available_account_types.first
+                              end
   end
+  helper_method :current_account_type
 
   def init_account
     if params.key? :id
@@ -188,7 +186,6 @@ class FacilityAccountsController < ApplicationController
     raise CanCan::AccessDenied if current_account_type.blank?
 
     @owner_user = User.find(params[:owner_user_id])
-    @current_account_type = current_account_type
     @account = AccountBuilder.for(current_account_type).new(
       account_type: current_account_type,
       facility: current_facility,

--- a/app/models/account_config.rb
+++ b/app/models/account_config.rb
@@ -69,8 +69,8 @@ class AccountConfig
   # and the NullObject always returns `true` for cross_facility?.
   def account_types_for_facility(facility, action)
     types = account_types
-    types = account_types.select { |type| type.constantize.cross_facility? } if facility.try(:cross_facility?)
-    types = account_types - creation_disabled_types if action == :create
+    types = types.select { |type| type.constantize.cross_facility? } if facility.try(:cross_facility?)
+    types = types - creation_disabled_types if action == :create
     types
   end
 

--- a/app/views/facility_accounts/_account_type_tabs.html.haml
+++ b/app/views/facility_accounts/_account_type_tabs.html.haml
@@ -1,6 +1,5 @@
-- if available_account_types.present? && available_account_types.size > 1
-  %ul.nav.nav-tabs
-    - available_account_types.each do |account_type|
-      %li{class: ("active" if current_account_type == account_type)}
-        = link_to new_facility_account_path(owner_user_id: owner_user.id, account_type: account_type) do
-          = account_type.constantize.model_name.human
+%ul.nav.nav-tabs
+  - available_account_types.each do |account_type|
+    %li{ class: ("active" if current_account_type == account_type) }
+      = link_to new_facility_account_path(owner_user_id: owner_user.id, account_type: account_type) do
+        = account_type.constantize.model_name.human

--- a/app/views/facility_accounts/new.html.haml
+++ b/app/views/facility_accounts/new.html.haml
@@ -15,7 +15,7 @@
   = f.input :owner, as: :readonly, input_html: { class: "show_always", value: @owner_user.full_name }
 
   = hidden_field_tag :account_type, @current_account_type
-  = render "facility_accounts/account_type_tabs", available_account_types: @available_account_types, current_account_type: @current_account_type, owner_user: @owner_user
+  = render "facility_accounts/account_type_tabs", owner_user: @owner_user
   = render "facility_accounts/account_fields/#{@current_account_type.to_s.underscore}", f: f, is_new: true
 
   %ul.inline

--- a/vendor/engines/c2po/spec/controllers/facility_accounts_controller_spec.rb
+++ b/vendor/engines/c2po/spec/controllers/facility_accounts_controller_spec.rb
@@ -69,32 +69,65 @@ RSpec.describe FacilityAccountsController do
   end
 
   describe "GET #new" do
-    let(:director) { FactoryBot.create(:user, :facility_director, facility: facility) }
+    describe "as a facility director" do
+      let(:director) { FactoryBot.create(:user, :facility_director, facility: facility) }
 
-    before do
-      sign_in director
-      get :new, params: {
-        facility_id: facility.url_name,
-        account_type: account_type,
-        owner_user_id: account_owner.id,
-      }
-    end
+      before do
+        sign_in director
+        get :new, params: {
+            facility_id: facility.url_name,
+            account_type: account_type,
+            owner_user_id: account_owner.id,
+        }
+      end
 
-    context "PurchaseOrderAccount" do
-      let(:account_type) { "PurchaseOrderAccount" }
+      context "PurchaseOrderAccount" do
+        let(:account_type) { "PurchaseOrderAccount" }
 
-      it "loads the account" do
-        expect(response).to be_success
-        expect(assigns(:account)).to be_a(PurchaseOrderAccount)
+        it "loads the account" do
+          expect(response).to be_success
+          expect(assigns(:account)).to be_a(PurchaseOrderAccount)
+        end
+      end
+
+      context "CreditCardAccount" do
+        let(:account_type) { "CreditCardAccount" }
+
+        it "loads the account" do
+          expect(response).to be_success
+          expect(assigns(:account)).to be_a(CreditCardAccount)
+        end
       end
     end
 
-    context "CreditCardAccount" do
-      let(:account_type) { "CreditCardAccount" }
+    describe "as an account administrator" do
+      let(:account_manager) { create(:user, :account_manager) }
 
-      it "loads the account" do
-        expect(response).to be_success
-        expect(assigns(:account)).to be_a(CreditCardAccount)
+      before do
+        sign_in account_manager
+        get :new, params: {
+            facility_id: "all",
+            account_type: account_type,
+            owner_user_id: account_owner.id
+        }
+      end
+
+      context "PurchaseOrderAccount" do
+        let(:account_type) { "PurchaseOrderAccount" }
+
+        it "falls back to using a chartstring" do
+          expect(response).to be_success
+          expect(assigns(:account)).to be_a(NufsAccount)
+        end
+      end
+
+      context "CreditCardAccount" do
+        let(:account_type) { "CreditCardAccount" }
+
+        it "falls back to using a chartstring" do
+          expect(response).to be_success
+          expect(assigns(:account)).to be_a(NufsAccount)
+        end
       end
     end
   end


### PR DESCRIPTION
# Release Notes

Remove create tabs for CCs or POs for account managers. Previously, the tabs were available, but would 404.

# Screenshot

Optional.

# Additional Context

This changes the behavior a bit, though the old behavior was unexpected. Now, it will fall back to the first available type, which is what the controller makes it look like it _should_ be doing anyway.

The spec might make it a little funky to backport to 4.2, so we should decide what we want to do about that.