### PR TITLE
[#139381] Gray out edit/remove price policy links for staff/senior staff

### DIFF
--- a/app/views/price_policies/_table.html.haml
+++ b/app/views/price_policies/_table.html.haml
@@ -9,23 +9,23 @@
       %th.currency= price_policy.class.human_attribute_name(:unit_adjustment)
       %th.currency= price_policy.class.human_attribute_name(:unit_net_cost)
   %tbody
-    - price_policies_to_show = price_policies.select { |pp| pp.can_purchase? }
+    - price_policies_to_show = price_policies.select(&:can_purchase?)
     - price_policies_to_show.each do |price_policy|
       %tr
         - if price_policies_to_show.first == price_policy
           %td.centered{ :rowspan => price_policies_to_show.length }
-            - unless price_policies.all?{|pp| pp.editable?}
-              %p.muted= t("shared.edit")
-              %p.muted= t("shared.remove")
-            - else
+            - if price_policies.all?(&:editable?) && can?(:edit, PricePolicy)
               %p
                 = link_to t("shared.edit"),
-                   [:edit, current_facility, @product, :price_policy, id: url_date]
+                  [:edit, current_facility, product, :price_policy, id: url_date]
               %p
                 = link_to t("shared.remove"),
                   price_policy_path(price_policy, url_date),
                   data: { confirm: t("shared.confirm_message") },
                   method: :delete
+            - else
+              %p.muted= t("shared.edit")
+              %p.muted= t("shared.remove")
 
         %td= "#{price_policy.price_group.name} (#{price_policy.price_group.type_string})"
         - if price_policy.valid?


### PR DESCRIPTION
# Release Notes

Gray out edit/remove item/service price policy links for staff/senior staff.

# Additional Context

The links already 403 correctly; this fixes the links. This is already restricted on instrument price policy views.

