### PR TITLE
Add a ViewHook for journal download formats

### DIFF
--- a/app/views/facility_journals/_downloads.html.haml
+++ b/app/views/facility_journals/_downloads.html.haml
@@ -1,3 +1,4 @@
 - %i(xls xml csv).each do |format|
   - if Settings.financial.journal_format.public_send(format)
     %p= link_to t(".#{format}.#{label_size}"), facility_journal_path(facility, journal, format: format)
+= render_view_hook "other_formats", journal: journal


### PR DESCRIPTION
# Release Notes

Adds a ViewHook that allows Rails engines to add new file formats to the journal download section.

# Screenshot
<img width="1011" alt="39372862-a612af32-4a13-11e8-9718-13b1be64854c" src="https://user-images.githubusercontent.com/3682844/40183350-9b7b2394-59bb-11e8-80bc-304d6e4ed894.png">(the pictured change is what's possible with this ViewHook, not a change this PR makes)

# Additional Context

We're adding a custom journal download format for our financial system.