### PR TITLE
Allow admin-defined logo in header

### DIFF
--- a/app/assets/stylesheets/app/header.scss
+++ b/app/assets/stylesheets/app/header.scss
@@ -12,7 +12,7 @@ header {
       font-size: 27px;
       color: $headerColor;
 
-      padding: 11px 20px 10px;
+      padding: 17px 20px 16px;
 
       img {
         height: 1em;

--- a/app/assets/stylesheets/app/header.scss
+++ b/app/assets/stylesheets/app/header.scss
@@ -14,7 +14,7 @@ header {
 
       padding: 17px 20px 16px;
 
-      img {
+      .img__brand {
         height: 1em;
       }
 

--- a/app/assets/stylesheets/app/header.scss
+++ b/app/assets/stylesheets/app/header.scss
@@ -11,12 +11,34 @@ header {
       text-shadow: none;
       font-size: 27px;
       color: $headerColor;
+
+      padding: 11px 20px 10px;
+
+      img {
+        height: 1em;
+      }
+
+      span {
+        vertical-align: middle;
+        line-height: 1;
+      }
     }
   }
 
   .navbar-inner, .dropdown-toggle {
-    padding: 10px 0;
     @include gradient-vertical($headerBackgroundColorHighLight, $headerBackgroundColor);
+  }
+
+  .container {
+    height: 60px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+  }
+
+  .container:before, .container:after {
+    content: none;
   }
 
   .navbar .nav {

--- a/app/assets/stylesheets/app/header.scss
+++ b/app/assets/stylesheets/app/header.scss
@@ -35,6 +35,7 @@ header {
     justify-content: space-between;
     align-items: center;
     width: 100%;
+    flex-flow: wrap;
   }
 
   .container:before, .container:after {

--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -25,6 +25,7 @@ $navbarActiveBorderColor: #aaa;
     background-color: $navCollapseBackgroundColor;
     position: relative;
     top: 10px;
+    width: 100%;
   }
   .nav-collapse .nav {
     margin: 0;

--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -24,7 +24,6 @@ $navbarActiveBorderColor: #aaa;
   .nav-collapse {
     background-color: $navCollapseBackgroundColor;
     position: relative;
-    top: 10px;
     width: 100%;
   }
   .nav-collapse .nav {

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -2,7 +2,7 @@
   .navbar-inner
     .container
       = link_to :root, class: "brand" do
-        - if Settings.header_logo_path.present? && ActionController::Base.helpers.resolve_asset_path(Settings.header_logo_path)
+        - if Settings.header_logo_path.present?
           = image_tag Settings.header_logo_path, class: "img__brand"
         %span= app_name
       - if session_user.nil?

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -3,7 +3,7 @@
     .container
       = link_to :root, class: "brand" do
         - if ActionController::Base.helpers.resolve_asset_path('logo-header.png')
-          = image_tag('logo-header.png')
+          = image_tag "logo-header.png", class: "img__brand"
         %span= app_name
       - if session_user.nil?
         %ul.nav.pull-right.hide-from-print

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -2,8 +2,8 @@
   .navbar-inner
     .container
       = link_to :root, class: "brand" do
-        - if ActionController::Base.helpers.resolve_asset_path('logo-header.png')
-          = image_tag "logo-header.png", class: "img__brand"
+        - if Settings.header_logo_path.present? && ActionController::Base.helpers.resolve_asset_path(Settings.header_logo_path)
+          = image_tag Settings.header_logo_path, class: "img__brand"
         %span= app_name
       - if session_user.nil?
         %ul.nav.pull-right.hide-from-print

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -1,7 +1,10 @@
 .navbar.navbar-static-top
   .navbar-inner
     .container
-      = link_to app_name, :root, class: "brand"
+      = link_to :root, class: "brand" do
+        - if ActionController::Base.helpers.resolve_asset_path('logo-header.png')
+          = image_tag('logo-header.png')
+        %span= app_name
       - if session_user.nil?
         %ul.nav.pull-right.hide-from-print
           %li= link_to t("pages.login"), :new_user_session

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,5 @@
+header_logo_path: ~
+
 price_group:
   name:
     base: 'Base Rate'


### PR DESCRIPTION
# Release Notes
This change allows administrators to add a logo to their header. The new logo image should be called "logo-header.png" and it should be placed in the "app/assets/images/" folder. The changes are not visible immediately, only after the asset pipeline is rebuilt (which just involves restarting Rails).

The diff is a little interesting because the header was redone in Flexbox. The new version is pixel-for-pixel the same, though, and it shouldn't affect user overrides as far as I can tell.

# Screenshot
## Before
<img width="1076" alt="screen shot 2018-05-18 at 4 46 16 pm" src="https://user-images.githubusercontent.com/3682844/40258292-19048ee6-5abf-11e8-870a-6484eb738728.png">

## After
<img width="1072" alt="screen shot 2018-05-18 at 4 46 24 pm" src="https://user-images.githubusercontent.com/3682844/40258293-191603b0-5abf-11e8-9930-9efe1f5750dd.png">
(this is px-for-px the same as "Before")

## After, with logo added
<img width="1081" alt="screen shot 2018-05-18 at 4 46 31 pm" src="https://user-images.githubusercontent.com/3682844/40258294-19436440-5abf-11e8-9ec0-fc9e90f8c164.png">

# Additional Context
This is part of a larger set of changes to the design.