### PR TITLE
[#137474] Handle invalid dates in price policies

### DIFF
--- a/app/assets/javascripts/price_policy.js.coffee
+++ b/app/assets/javascripts/price_policy.js.coffee
@@ -1,8 +1,4 @@
 $(document).ready ->
-  $ ->
-    $("#start_datepicker").datepicker minDate: null
-    $("#expire_datepicker").datepicker minDate: null
-
   $interval = $("#interval")
 
   $interval.change ->

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -34,8 +34,7 @@ class PricePoliciesController < ApplicationController
     # If there are active policies, start tomorrow. If none, start today
     @start_date = Date.today + (active_policies? ? 1 : 0)
 
-    @price_policies = PricePolicyBuilder.get_new_policies_based_on_most_recent(@product, @start_date, @max_expire_date)
-
+    @price_policies = PricePolicyBuilder.get_new_policies_based_on_most_recent(@product, @start_date)
     raise ActiveRecord::RecordNotFound if @price_policies.blank?
   end
 

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -31,8 +31,7 @@ class PricePoliciesController < ApplicationController
 
   # GET /facilities/:facility_id/{product_type}/:product_id/price_policies/new
   def new
-    # If there are active policies, start tomorrow. If none, start today
-    @start_date = Date.today + (active_policies? ? 1 : 0)
+    @start_date = active_policies? ? Date.tomorrow : Date.today
 
     @price_policies = PricePolicyBuilder.get_new_policies_based_on_most_recent(@product, @start_date)
     raise ActiveRecord::RecordNotFound if @price_policies.blank?
@@ -40,7 +39,7 @@ class PricePoliciesController < ApplicationController
 
   # POST /facilities/:facility_id/{product_type}/:product_id/price_policies
   def create
-    if update_policies_from_params!
+    if update_policies_from_params
       redirect_to facility_product_price_policies_path, notice: text("create.success")
     else
       flash.now[:error] = text("errors.save")
@@ -50,7 +49,7 @@ class PricePoliciesController < ApplicationController
 
   # PUT /facilities/:facility_id/{product_type}/:product_id/price_policies/:id
   def update
-    if update_policies_from_params!
+    if update_policies_from_params
       redirect_to facility_product_price_policies_path, notice: text("update.success")
     else
       flash.now[:error] = text("errors.save")
@@ -121,8 +120,8 @@ class PricePoliciesController < ApplicationController
     @max_expire_date = PricePolicy.generate_expire_date(@start_date)
   end
 
-  def update_policies_from_params!
-    PricePolicyUpdater.update_all!(
+  def update_policies_from_params
+    PricePolicyUpdater.update_all(
       @price_policies,
       parse_usa_date(params[:start_date])&.beginning_of_day,
       parse_usa_date(params[:expire_date])&.end_of_day,

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -8,10 +8,8 @@ class PricePoliciesController < ApplicationController
   before_action :init_current_facility
   before_action :init_product
   before_action :init_price_policy, except: [:index, :new]
-  before_action :build_price_policies!, only: [:create, :update]
-  before_action :build_price_policies_for_edit!, only: :edit
-  before_action :set_expire_date_from_params, only: [:create, :update]
-  before_action :set_max_expire_date, only: [:edit, :update]
+  before_action :build_price_policies, only: [:create, :edit, :update]
+  before_action :set_max_expire_date, only: [:new, :edit, :update]
 
   load_and_authorize_resource instance_name: :price_policy
 
@@ -33,28 +31,37 @@ class PricePoliciesController < ApplicationController
 
   # GET /facilities/:facility_id/{product_type}/:product_id/price_policies/new
   def new
-    @start_date = new_start_date
-    @expire_date = set_max_expire_date
-    @price_policies = PricePolicyBuilder.get_new_policies_based_on_most_recent(@product, @start_date)
+    # If there are active policies, start tomorrow. If none, start today
+    @start_date = Date.today + (active_policies? ? 1 : 0)
+
+    @price_policies = PricePolicyBuilder.get_new_policies_based_on_most_recent(@product, @start_date, @max_expire_date)
+
     raise ActiveRecord::RecordNotFound if @price_policies.blank?
-    render "price_policies/new"
   end
 
   # POST /facilities/:facility_id/{product_type}/:product_id/price_policies
   def create
-    create_or_update(:new)
+    if update_policies_from_params!
+      redirect_to facility_product_price_policies_path, notice: text("create.success")
+    else
+      flash.now[:error] = text("errors.save")
+      render :new
+    end
   end
 
   # PUT /facilities/:facility_id/{product_type}/:product_id/price_policies/:id
   def update
-    create_or_update(:edit)
+    if update_policies_from_params!
+      redirect_to facility_product_price_policies_path, notice: text("update.success")
+    else
+      flash.now[:error] = text("errors.save")
+      render :edit
+    end
   end
 
   # GET /facilities/:facility_id/{product_type}/:product_id/price_policies/:id/edit
   def edit
-    @expire_date = @price_policies.map(&:expire_date).compact.first
-
-    render "price_policies/edit"
+    raise ActiveRecord::RecordNotFound if @price_policies.blank?
   end
 
   # DELETE /facilities/:facility_id/{product_type}/:product_id/price_policies/:id
@@ -83,36 +90,13 @@ class PricePoliciesController < ApplicationController
     @price_policies ||= PricePolicyBuilder.get(@product, @start_date)
   end
 
-  def build_price_policies!
-    build_price_policies
-    if @price_policies.blank?
-      redirect_to facility_product_price_policies_path,
-                  alert: text("errors.same_start_date")
-    end
-  end
-
-  def build_price_policies_for_edit!
-    build_price_policies
-    raise ActiveRecord::RecordNotFound if @price_policies.blank?
-  end
-
-  def create_or_update(action)
-    if update_policies_from_params!
-      flash[:notice] = text("#{action}.success")
-      redirect_to facility_product_price_policies_path
-    else
-      flash[:error] = text("errors.save")
-      render "price_policies/#{action}"
-    end
-  end
-
   def facility_product_price_policies_path
     [current_facility, @product, PricePolicy]
   end
 
   # Override CanCan's find -- it won't properly search by zoned date
   def init_price_policy
-    @start_date = start_date_from_params
+    @start_date = parse_usa_date(params[:id] || params[:start_date])
 
     @price_policy = @product
                     .price_policies
@@ -128,36 +112,21 @@ class PricePoliciesController < ApplicationController
                                .find_by!(url_name: params[id_param])
   end
 
-  def new_start_date
-    # If there are active policies, start tomorrow. If none, start today
-    Date.today + (active_policies? ? 1 : 0)
-  end
-
   def flash_remove_active_policy_warning_and_redirect
     flash[:error] =
       text("errors.remove_active_policy")
     redirect_to facility_product_price_policies_path
   end
 
-  def set_expire_date_from_params
-    @expire_date = params[:expire_date]
-  end
-
   def set_max_expire_date
     @max_expire_date = PricePolicy.generate_expire_date(@start_date)
-  end
-
-  def start_date_from_params
-    start_date = params[:id] || params[:start_date] || return
-    format = start_date.include?("/") ? :usa : :ymd
-    Date.strptime(start_date, I18n.t("date.formats.#{format}"))
   end
 
   def update_policies_from_params!
     PricePolicyUpdater.update_all!(
       @price_policies,
-      parse_usa_date(params[:start_date]).beginning_of_day,
-      parse_usa_date(@expire_date).end_of_day,
+      parse_usa_date(params[:start_date])&.beginning_of_day,
+      parse_usa_date(params[:expire_date])&.end_of_day,
       params,
     )
   end

--- a/app/helpers/price_policies_helper.rb
+++ b/app/helpers/price_policies_helper.rb
@@ -1,9 +1,5 @@
 module PricePoliciesHelper
 
-  def format_date(date)
-    date.is_a?(String) ? date : date.strftime("%m/%d/%Y")
-  end
-
   def price_policy_path(price_policy_or_product, url_date)
     product = price_policy_or_product.respond_to?(:product) ? price_policy_or_product.product : price_policy_or_product
     [current_facility, product, :price_policy, id: url_date]

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -21,7 +21,6 @@ class PricePolicy < ApplicationRecord
   end
 
   before_save :set_default_subsidy
-  before_validation :set_expire_date
   before_create :truncate_existing_policies
 
   scope :for_date, ->(start_date) { where("start_date >= ? AND start_date <= ?", start_date.beginning_of_day, start_date.end_of_day) if start_date }
@@ -167,10 +166,6 @@ class PricePolicy < ApplicationRecord
   end
 
   private
-
-  def set_expire_date
-    self.expire_date ||= self.class.generate_expire_date(self)
-  end
 
   # TODO: Refactor
   def start_date_is_unique

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -21,7 +21,7 @@ class PricePolicy < ApplicationRecord
   end
 
   before_save :set_default_subsidy
-  before_create :set_expire_date
+  before_validation :set_expire_date
   before_create :truncate_existing_policies
 
   scope :for_date, ->(start_date) { where("start_date >= ? AND start_date <= ?", start_date.beginning_of_day, start_date.end_of_day) if start_date }

--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -59,6 +59,7 @@ class PricePolicyBuilder
     price_policies.each { |price_policy| price_policy.can_purchase = true }
   end
 
+
   def model_class
     @model_class ||= "#{product.class}PricePolicy".constantize
   end
@@ -90,6 +91,7 @@ class PricePolicyBuilder
   end
 
   def price_policies_for_start_date
+    return [] if start_date.blank?
     product.price_policies.for_date(start_date)
   end
 

--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -23,11 +23,13 @@ class PricePolicyBuilder
 
   def new_policies_based_on_most_recent
     new_price_policies = price_policies.map do |price_policy|
-      last_price_policy_for_price_group(price_policy.price_group) || price_policy
+      policy = last_price_policy_for_price_group(price_policy.price_group) || price_policy
+      policy.start_date = start_date
+      policy.expire_date = expire_date
+      policy
     end
     return new_price_policies if price_policies != new_price_policies
     make_all_price_policies_purchaseable
-    set_expiration_dates
 
     price_policies
   end
@@ -61,11 +63,9 @@ class PricePolicyBuilder
     price_policies.each { |price_policy| price_policy.can_purchase = true }
   end
 
-  def set_expiration_dates
-    expire_date = PricePolicy.generate_expire_date(start_date)
-    price_policies.each { |price_policy| price_policy.expire_date = expire_date }
+  def expire_date
+    @expire_date ||= PricePolicy.generate_expire_date(start_date)
   end
-
 
   def model_class
     @model_class ||= "#{product.class}PricePolicy".constantize

--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -27,6 +27,8 @@ class PricePolicyBuilder
     end
     return new_price_policies if price_policies != new_price_policies
     make_all_price_policies_purchaseable
+    set_expiration_dates
+
     price_policies
   end
 
@@ -57,6 +59,11 @@ class PricePolicyBuilder
 
   def make_all_price_policies_purchaseable
     price_policies.each { |price_policy| price_policy.can_purchase = true }
+  end
+
+  def set_expiration_dates
+    expire_date = PricePolicy.generate_expire_date(start_date)
+    price_policies.each { |price_policy| price_policy.expire_date = expire_date }
   end
 
 

--- a/app/services/price_policy_updater.rb
+++ b/app/services/price_policy_updater.rb
@@ -1,7 +1,7 @@
 class PricePolicyUpdater
 
-  def self.update_all!(price_policies, start_date, expire_date, params)
-    new(price_policies, start_date, expire_date, params).update_all!
+  def self.update_all(price_policies, start_date, expire_date, params)
+    new(price_policies, start_date, expire_date, params).update_all
   end
 
   def self.destroy_all_for_product!(product, start_date)
@@ -23,8 +23,8 @@ class PricePolicyUpdater
     end
   end
 
-  def update_all!
-    update && save!
+  def update_all
+    update && save
   end
 
   private
@@ -35,7 +35,7 @@ class PricePolicyUpdater
     end
   end
 
-  def save!
+  def save
     ActiveRecord::Base.transaction do
       @price_policies.all?(&:save) || raise(ActiveRecord::Rollback)
     end

--- a/app/views/price_policies/_dates.html.haml
+++ b/app/views/price_policies/_dates.html.haml
@@ -1,8 +1,2 @@
-= f.input :start_date, input_html: { value: format_usa_date(price_policy.start_date), id: "start_datepicker" }, label: "Effective"
-= f.input :expire_date, input_html: { id: "expire_datepicker", value: format_usa_date(price_policy.expire_date) }, label: "Expires"
-
-:javascript
-  $(function() {
-    $("#start_datepicker").datepicker("option", {minDate: new Date()});
-    $("#expire_datepicker").datepicker("option", {maxDate: "#{@max_expire_date}"});
-  });
+= f.input :start_date, input_html: { value: format_usa_date(price_policy.start_date), class: "datepicker__data" }, label: "Effective"
+= f.input :expire_date, input_html: { value: format_usa_date(price_policy.expire_date), class: "datepicker__data" }, label: "Expires"

--- a/app/views/price_policies/_dates.html.haml
+++ b/app/views/price_policies/_dates.html.haml
@@ -1,5 +1,5 @@
-= f.input :start_date, :input_html => { :value => format_date(@start_date), :id => 'start_datepicker' }, :label => 'Effective'
-= f.input :expire_date, :input_html => { :id => 'expire_datepicker', :value => format_date(@expire_date) }, :label => 'Expires'
+= f.input :start_date, input_html: { value: format_usa_date(price_policy.start_date), id: "start_datepicker" }, label: "Effective"
+= f.input :expire_date, input_html: { id: "expire_datepicker", value: format_usa_date(price_policy.expire_date) }, label: "Expires"
 
 :javascript
   $(function() {

--- a/app/views/price_policies/_price_policy_fields.html.haml
+++ b/app/views/price_policies/_price_policy_fields.html.haml
@@ -1,9 +1,8 @@
 = content_for :head_content do
   = javascript_include_tag "price_policy"
 
-= render "price_policies/dates", f: f
-
 - price_policy = @price_policies.first
+= render "price_policies/dates", f: f, price_policy: price_policy
 
 %table.table.table-striped.table-hover.price-policy-table
   %thead

--- a/app/views/time_based_price_policies/_price_policy_fields.html.haml
+++ b/app/views/time_based_price_policies/_price_policy_fields.html.haml
@@ -1,9 +1,9 @@
 = content_for :head_content do
   = javascript_include_tag "price_policy"
 
-= render "price_policies/dates", f: f
-
 - price_policy = @price_policies.first
+= render "price_policies/dates", f: f, price_policy: price_policy
+
 - if local_assigns[:charge_for_collection]
   = f.input :charge_for,
     collection: charge_for_collection,

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -147,14 +147,14 @@ en:
       destroy:
         success: Price Rules were successfully removed.
         failure: An error was encountered while trying to remove the Price Rules
-      edit:
-        success: Price Rules were successfully updated.
       errors:
         remove_active_policy: "Sorry, but you cannot remove an active price policy. If you really want to do so move the start date to the future and try again."
         save: There was an error saving the policy
         same_start_date: "You have chosen a start date that matches an active policy with existing orders. Please choose another start date."
-      new:
+      create:
         success: Price Rules were successfully created.
+      update:
+        success: Price Rules were successfully updated.
 
     product_users:
       new:

--- a/spec/app_support/price_policy_mass_assigner_spec.rb
+++ b/spec/app_support/price_policy_mass_assigner_spec.rb
@@ -41,19 +41,19 @@ RSpec.describe PricePolicyMassAssigner do
       end
 
       let!(:previous_price_policy) do
-        product.item_price_policies.create(attributes_for(:item_price_policy,
-                                                          price_group_id: price_group.id,
-                                                          start_date: 8.years.ago,
-                                                          expire_date: nil,
-                                                         ))
+        create(:item_price_policy,
+               product: product,
+               price_group: price_group,
+               start_date: 8.years.ago,
+              )
       end
 
       let!(:current_price_policy) do
-        product.item_price_policies.create(attributes_for(:item_price_policy,
-                                                          price_group_id: price_group.id,
-                                                          start_date: 1.day.ago,
-                                                          expire_date: nil,
-                                                         ))
+        create(:item_price_policy,
+               product: product,
+               price_group: price_group,
+               start_date: 1.day.ago,
+              )
       end
 
       context "when order details are fulfilled" do

--- a/spec/factories/price_policies.rb
+++ b/spec/factories/price_policies.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     minimum_cost 1
     can_purchase true
     start_date { Time.zone.now.beginning_of_day }
-    expire_date { PricePolicy.generate_expire_date(Time.zone.now.beginning_of_day) }
+    expire_date { PricePolicy.generate_expire_date(start_date) }
   end
 
   factory :instrument_usage_price_policy, parent: :instrument_price_policy do
@@ -24,7 +24,7 @@ FactoryBot.define do
     unit_cost 1
     unit_subsidy 0
     start_date { Time.zone.now.beginning_of_day }
-    expire_date { PricePolicy.generate_expire_date(Date.today) }
+    expire_date { PricePolicy.generate_expire_date(start_date) }
   end
 
   factory :service_price_policy do
@@ -32,7 +32,7 @@ FactoryBot.define do
     unit_cost 1
     unit_subsidy 0
     start_date { Time.zone.now.beginning_of_day }
-    expire_date { PricePolicy.generate_expire_date(Date.today) }
+    expire_date { PricePolicy.generate_expire_date(start_date) }
   end
 
   factory :timed_service_price_policy do
@@ -42,6 +42,6 @@ FactoryBot.define do
     minimum_cost 1
     can_purchase true
     start_date { Time.zone.now.beginning_of_day }
-    expire_date { PricePolicy.generate_expire_date(Time.zone.now.beginning_of_day) }
+    expire_date { PricePolicy.generate_expire_date(start_date) }
   end
 end

--- a/spec/models/item_price_policy_spec.rb
+++ b/spec/models/item_price_policy_spec.rb
@@ -51,11 +51,11 @@ RSpec.describe ItemPricePolicy do
     it "is valid for for today if no active price policy already exists" do
       is_expected.to allow_value(Date.today).for(:start_date)
       ipp = @item.item_price_policies.create!(unit_cost: 1, unit_subsidy: 0, start_date: Date.today - 7, expire_date: Date.today - 6,
-                                             price_group: @price_group)
+                                              price_group: @price_group)
       ipp.save(validate: false)
 
       ipp_new = @item.item_price_policies.build(unit_cost: 1, unit_subsidy: 0, start_date: Date.today, expire_date: 1.day.from_now,
-                                                 price_group: @price_group)
+                                                price_group: @price_group)
       expect(ipp_new).to be_valid
     end
 
@@ -74,7 +74,7 @@ RSpec.describe ItemPricePolicy do
     end
 
     it "calculates the cost for multiple item when given a quantity" do
-      ipp  = build(:item_price_policy, product: @item, unit_cost: 10.75, unit_subsidy: 0.75, price_group: @price_group)
+      ipp = build(:item_price_policy, product: @item, unit_cost: 10.75, unit_subsidy: 0.75, price_group: @price_group)
       costs = ipp.calculate_cost_and_subsidy(2)
       expect(costs[:cost].to_f).to eq(21.5)
       expect(costs[:subsidy].to_f).to eq(1.5)

--- a/spec/models/item_price_policy_spec.rb
+++ b/spec/models/item_price_policy_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe ItemPricePolicy do
       expect(pp.errors.keys).to be_include :unit_subsidy
     end
   end
+
   context "test requiring items" do
     before(:each) do
       @facility         = FactoryBot.create(:facility)
@@ -36,69 +37,72 @@ RSpec.describe ItemPricePolicy do
       @price_group_product = FactoryBot.create(:price_group_product, product: @item, price_group: @price_group, reservation_window: nil)
     end
 
-    it "should create using factory" do
+    it "has a valid factory" do
       # price policy belongs to an item and a price group
-      ipp = @item.item_price_policies.create(FactoryBot.attributes_for(:item_price_policy, price_group: @price_group))
+      ipp = build(:item_price_policy, product: @item, price_group: @price_group)
       expect(ipp).to be_valid
     end
 
-    it "should return the item" do
-      ipp = @item.item_price_policies.create(FactoryBot.attributes_for(:item_price_policy, start_date: Date.today, price_group_id: @price_group.id))
+    it "set the inverse association correctly" do
+      ipp = @item.item_price_policies.create!(FactoryBot.attributes_for(:item_price_policy, start_date: Date.today, price_group_id: @price_group.id))
       expect(ipp.product).to eq(@item)
     end
 
-    it "should create a price policy for today if no active price policy already exists" do
+    it "is valid for for today if no active price policy already exists" do
       is_expected.to allow_value(Date.today).for(:start_date)
-      ipp = @item.item_price_policies.create(unit_cost: 1, unit_subsidy: 0, start_date: Date.today - 7,
+      ipp = @item.item_price_policies.create!(unit_cost: 1, unit_subsidy: 0, start_date: Date.today - 7, expire_date: Date.today - 6,
                                              price_group: @price_group)
       ipp.save(validate: false)
-      ipp_new = @item.item_price_policies.create(unit_cost: 1, unit_subsidy: 0, start_date: Date.today,
+
+      ipp_new = @item.item_price_policies.build(unit_cost: 1, unit_subsidy: 0, start_date: Date.today, expire_date: 1.day.from_now,
                                                  price_group: @price_group)
-      expect(ipp_new.errors_on(:start_date)).not_to be_nil
+      expect(ipp_new).to be_valid
     end
 
-    it "should not create a price policy for a day that a policy already exists for" do
-      ipp_new = @item.item_price_policies.create(FactoryBot.attributes_for(:item_price_policy, start_date: Date.today + 7, price_group_id: @price_group.id))
-      expect(ipp_new.errors_on(:start_date)).not_to be_nil
+    it "is invalid for a day that a policy already exists for" do
+      ipp_old = create(:item_price_policy, product: @item, start_date: Date.today + 7, price_group: @price_group)
+      ipp_new = build(:item_price_policy, product: @item, start_date: Date.today + 7, price_group: @price_group)
+      expect(ipp_new).to be_invalid
+      expect(ipp_new.errors_on(:start_date)).to be_present
     end
 
-    it "should calculate the cost for an 1 item" do
-      ipp   = @item.item_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75, start_date: Date.today, price_group_id: @price_group.id, can_purchase: true)
+    it "calculates the cost for an 1 item" do
+      ipp = build(:item_price_policy, product: @item, unit_cost: 10.75, unit_subsidy: 0.75, price_group: @price_group)
       costs = ipp.calculate_cost_and_subsidy
       expect(costs[:cost].to_f).to eq(10.75)
       expect(costs[:subsidy].to_f).to eq(0.75)
     end
 
-    it "should calculate the cost for multiple item when given a quantity" do
-      ipp   = @item.item_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75, start_date: Date.today, price_group_id: @price_group.id, can_purchase: true)
+    it "calculates the cost for multiple item when given a quantity" do
+      ipp  = build(:item_price_policy, product: @item, unit_cost: 10.75, unit_subsidy: 0.75, price_group: @price_group)
       costs = ipp.calculate_cost_and_subsidy(2)
       expect(costs[:cost].to_f).to eq(21.5)
       expect(costs[:subsidy].to_f).to eq(1.5)
     end
 
-    it "should estimate the same as calculate" do
-      ipp = @item.item_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75, start_date: Date.today, price_group_id: @price_group.id, can_purchase: true)
+    it "estimates the same as calculate" do
+      ipp = build(:item_price_policy, product: @item, unit_cost: 10.75, unit_subsidy: 0.75, price_group: @price_group)
       expect(ipp.estimate_cost_and_subsidy(2)).to eq(ipp.calculate_cost_and_subsidy(2))
     end
 
-    it "should return a cost of nil if the purchase is restricted" do
+    it "returns a cost of nil if the purchase is restricted" do
       @price_group_product.destroy
-      ipp = @item.item_price_policies.create(start_date: Date.today, price_group_id: @price_group.id)
+      ipp = build(:item_price_policy, product: @item, price_group: @price_group, can_purchase: false)
       expect(ipp.calculate_cost_and_subsidy).to be_nil
     end
 
-    it "should return the date for the current policies" do
-      ipp = @item.item_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75, start_date: Date.today - 7.days, price_group_id: @price_group.id, can_purchase: true)
-      @item.item_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75, start_date: Date.today + 7.days, price_group_id: @price_group.id)
+    it "returns the date for the current policies" do
+      ipp = create(:item_price_policy, product: @item, start_date: Date.today - 7.days, price_group: @price_group)
+      ipp2 = create(:item_price_policy, product: @item, start_date: Date.today + 7.days, price_group: @price_group)
       expect(ItemPricePolicy.current_date(@item).to_date).to eq(ipp.start_date.to_date)
-      ipp3 = @item.item_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75, start_date: Date.today, price_group_id: @price_group.id)
+      ipp3 = create(:item_price_policy, product: @item, start_date: Date.today, price_group: @price_group)
       expect(ItemPricePolicy.current_date(@item).to_date).to eq(ipp3.start_date.to_date)
     end
 
     it "should return the date for upcoming policies" do
-      @item.item_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75, start_date: Time.current.beginning_of_day, price_group_id: @price_group.id, can_purchase: true)
-      ipp2 = @item.item_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75,  start_date: Time.current.beginning_of_day + 7.days, price_group_id: @price_group.id, can_purchase: true)
-      ipp3 = @item.item_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75,  start_date: Time.current.beginning_of_day + 14.days, price_group_id: @price_group.id, can_purchase: true)
+      ipp = create(:item_price_policy, product: @item, start_date: Time.current.beginning_of_day, price_group: @price_group)
+      ipp2 = create(:item_price_policy, product: @item, start_date: Time.current.beginning_of_day + 7.days, price_group: @price_group)
+      ipp3 = create(:item_price_policy, product: @item, start_date: Time.current.beginning_of_day + 14.days, price_group: @price_group)
 
       expect(ItemPricePolicy.next_date(@item).to_date).to eq(ipp2.start_date.to_date)
       next_dates = ItemPricePolicy.next_dates(@item)

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -33,12 +33,12 @@ RSpec.describe OrderDetail do
 
     let!(:previous_price_policy) do
       create(:item_price_policy,
-        product: item,
-        unit_cost: 10.00,
-        unit_subsidy: 2.00,
-        price_group: price_group,
-        start_date: 8.years.ago,
-      )
+             product: item,
+             unit_cost: 10.00,
+             unit_subsidy: 2.00,
+             price_group: price_group,
+             start_date: 8.years.ago,
+            )
     end
 
     let!(:current_price_policy) do
@@ -48,7 +48,7 @@ RSpec.describe OrderDetail do
              unit_subsidy: 3.00,
              price_group: price_group,
              start_date: 6.weeks.ago,
-      )
+            )
     end
   end
 

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -32,23 +32,23 @@ RSpec.describe OrderDetail do
     before { create(:account_price_group_member, account: account, price_group: price_group) }
 
     let!(:previous_price_policy) do
-      item.item_price_policies.create(attributes_for(:item_price_policy,
-                                                     unit_cost: 10.00,
-                                                     unit_subsidy: 2.00,
-                                                     price_group_id: price_group.id,
-                                                     start_date: 8.years.ago,
-                                                     expire_date: nil,
-                                                    ))
+      create(:item_price_policy,
+        product: item,
+        unit_cost: 10.00,
+        unit_subsidy: 2.00,
+        price_group: price_group,
+        start_date: 8.years.ago,
+      )
     end
 
     let!(:current_price_policy) do
-      item.item_price_policies.create(attributes_for(:item_price_policy,
-                                                     unit_cost: 20.00,
-                                                     unit_subsidy: 3.00,
-                                                     price_group_id: price_group.id,
-                                                     start_date: 1.day.ago,
-                                                     expire_date: nil,
-                                                    ))
+      create(:item_price_policy,
+             product: item,
+             unit_cost: 20.00,
+             unit_subsidy: 3.00,
+             price_group: price_group,
+             start_date: 6.weeks.ago,
+      )
     end
   end
 
@@ -235,7 +235,7 @@ RSpec.describe OrderDetail do
       include_context "define price policies"
 
       it "re-assigns actual pricing" do
-        order_detail.backdate_to_complete!(Time.current)
+        order_detail.backdate_to_complete!(current_price_policy.expire_date - 1.week)
         order_detail.quantity = new_quantity
         order_detail.save!
         expect(order_detail.reload.quantity).to eq new_quantity

--- a/spec/models/price_policy_spec.rb
+++ b/spec/models/price_policy_spec.rb
@@ -46,12 +46,6 @@ RSpec.describe PricePolicy do
       @start_date = Time.zone.parse("2020-5-5")
     end
 
-    it "should set default expire_date" do
-      @pp = FactoryBot.create(:item_price_policy, price_group_id: @price_group.id, product_id: @item.id, start_date: @start_date, expire_date: nil)
-      expect(@pp.expire_date).not_to be_nil
-      expect(@pp.expire_date).to be_within(1.second).of(Time.zone.parse("2020-9-30").end_of_day)
-    end
-
     it "should not allow an expire date the same as start date" do
       pp = ItemPricePolicy.new(
         FactoryBot.attributes_for(:item_price_policy,

--- a/spec/models/service_price_policy_spec.rb
+++ b/spec/models/service_price_policy_spec.rb
@@ -37,70 +37,72 @@ RSpec.describe ServicePricePolicy do
       @price_group_product = FactoryBot.create(:price_group_product, product: @service, price_group: @price_group, reservation_window: nil)
     end
 
-    it "should create using factory" do
+    it "has a valid using factory" do
       # price policy belongs to an service and a price group
-      ipp = @service.service_price_policies.create(FactoryBot.attributes_for(:service_price_policy, price_group: @price_group))
+      ipp = build(:service_price_policy, product: @service, price_group: @price_group)
       expect(ipp).to be_valid
     end
 
-    it "should return the item" do
-      ipp = @service.service_price_policies.create(FactoryBot.attributes_for(:service_price_policy, start_date: Date.today, price_group_id: @price_group.id))
+    it "sets the inverse association correctly return the item" do
+      ipp = @service.service_price_policies.create!(FactoryBot.attributes_for(:service_price_policy, price_group: @price_group))
       expect(ipp.product).to eq(@service)
     end
 
-    it "should create a price policy for today if no active price policy already exists" do
+    it "is valid for today if no active price policy already exists" do
       is_expected.to allow_value(Date.today).for(:start_date)
-      ipp = @service.service_price_policies.create(unit_cost: 1, unit_subsidy: 0, start_date: Date.today - 7,
+      ipp = @service.service_price_policies.create!(unit_cost: 1, unit_subsidy: 0, start_date: Date.today - 7, expire_date: Date.today - 6,
                                                    price_group: @price_group)
       ipp.save(validate: false)
-      ipp_new = @service.service_price_policies.create(unit_cost: 1, unit_subsidy: 0, start_date: Date.today,
+      ipp_new = @service.service_price_policies.build(unit_cost: 1, unit_subsidy: 0, start_date: Date.today, expire_date: 1.day.from_now,
                                                        price_group: @price_group)
+      expect(ipp_new).to be_valid
       expect(ipp_new.errors_on(:start_date)).not_to be_nil
     end
 
-    it "should not create a price policy for a day that a policy already exists for" do
-      ipp     = @service.service_price_policies.create(FactoryBot.attributes_for(:service_price_policy, start_date: Date.today + 7, price_group_id: @price_group.id))
-      ipp_new = @service.service_price_policies.create(FactoryBot.attributes_for(:service_price_policy, start_date: Date.today + 7, price_group_id: @price_group.id))
-      expect(ipp_new.errors_on(:start_date)).not_to be_nil
+    it "is invalid for a day that a policy already exists for" do
+      ipp = create(:service_price_policy, product: @service, start_date: Date.today + 7, price_group: @price_group)
+      ipp_new = build(:service_price_policy, product: @service, start_date: Date.today + 7, price_group: @price_group)
+      expect(ipp_new).to be_invalid
+      expect(ipp_new.errors_on(:start_date)).to be_present
     end
 
-    it "should calculate the cost for an 1 service" do
-      ipp   = @service.service_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75, start_date: Date.today, price_group_id: @price_group.id, can_purchase: true)
+    it "calculates the cost for an 1 service" do
+      ipp = build(:service_price_policy, product: @service, unit_cost: 10.75, unit_subsidy: 0.75)
       costs = ipp.calculate_cost_and_subsidy
       expect(costs[:cost].to_f).to eq(10.75)
       expect(costs[:subsidy].to_f).to eq(0.75)
     end
 
-    it "should calculate the cost for multiple service when given a quantity" do
-      ipp   = @service.service_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75, start_date: Date.today, price_group_id: @price_group.id, can_purchase: true)
+    it "calculates the cost for multiple service when given a quantity" do
+      ipp = build(:service_price_policy, product: @service, unit_cost: 10.75, unit_subsidy: 0.75)
       costs = ipp.calculate_cost_and_subsidy(2)
       expect(costs[:cost].to_f).to eq(21.5)
       expect(costs[:subsidy].to_f).to eq(1.5)
     end
 
-    it "should estimate the same as calculate" do
-      ipp = @service.service_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75, start_date: Date.today, price_group_id: @price_group.id)
+    it "estimates the same as it calculates" do
+      ipp = build(:service_price_policy, product: @service, unit_cost: 10.75, unit_subsidy: 0.75)
       expect(ipp.estimate_cost_and_subsidy(2)).to eq(ipp.calculate_cost_and_subsidy(2))
     end
 
-    it "should return a cost of nil if the purchase is restricted" do
+    it "returns a cost of nil if the purchase is restricted" do
       @price_group_product.destroy
-      ipp = @service.service_price_policies.create(start_date: Date.today, price_group_id: @price_group.id)
+      ipp = build(:service_price_policy, product: @service, price_group: @price_group, can_purchase: false)
       expect(ipp.calculate_cost_and_subsidy).to be_nil
     end
 
-    it "should return the date for the current policies" do
-      spp = @service.service_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75, start_date: Time.current.beginning_of_day - 7.days, price_group_id: @price_group.id)
-      @service.service_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75, start_date: Time.current.beginning_of_day + 7.days, price_group_id: @price_group.id)
+    it "returns the date for the current policies" do
+      spp = create(:service_price_policy, product: @service, start_date: Time.current.beginning_of_day - 7.days, price_group: @price_group)
+      spp2 = create(:service_price_policy, product: @service, start_date: Time.current.beginning_of_day + 7.days, price_group: @price_group)
       expect(ServicePricePolicy.current_date(@service)).to eq(spp.start_date.to_date)
-      spp3 = @service.service_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75, start_date: Time.current.beginning_of_day, price_group_id: @price_group.id)
+      spp3 = create(:service_price_policy, product: @service, start_date: Time.current.beginning_of_day, price_group: @price_group)
       expect(ServicePricePolicy.current_date(@service)).to eq(spp3.start_date.to_date)
     end
 
-    it "should return the date for upcoming policies" do
-      @service.service_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75, start_date: Time.current.beginning_of_day, price_group_id: @price_group.id)
-      spp2 = @service.service_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75, start_date: Time.current.beginning_of_day + 7.days, price_group_id: @price_group.id)
-      spp3 = @service.service_price_policies.create(unit_cost: 10.75, unit_subsidy: 0.75, start_date: Time.current.beginning_of_day + 14.days, price_group_id: @price_group.id)
+    it "returns the date for upcoming policies" do
+      spp = create(:service_price_policy, product: @service, start_date: Time.current.beginning_of_day, price_group: @price_group)
+      spp2 = create(:service_price_policy, product: @service, start_date: Time.current.beginning_of_day + 7.days, price_group: @price_group)
+      spp3 = create(:service_price_policy, product: @service, start_date: Time.current.beginning_of_day + 14.days, price_group: @price_group)
 
       expect(ServicePricePolicy.next_date(@service)).to eq(spp2.start_date.to_date)
       next_dates = ServicePricePolicy.next_dates(@service)

--- a/spec/models/service_price_policy_spec.rb
+++ b/spec/models/service_price_policy_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe ServicePricePolicy do
     it "is valid for today if no active price policy already exists" do
       is_expected.to allow_value(Date.today).for(:start_date)
       ipp = @service.service_price_policies.create!(unit_cost: 1, unit_subsidy: 0, start_date: Date.today - 7, expire_date: Date.today - 6,
-                                                   price_group: @price_group)
+                                                    price_group: @price_group)
       ipp.save(validate: false)
       ipp_new = @service.service_price_policies.build(unit_cost: 1, unit_subsidy: 0, start_date: Date.today, expire_date: 1.day.from_now,
-                                                       price_group: @price_group)
+                                                      price_group: @price_group)
       expect(ipp_new).to be_valid
       expect(ipp_new.errors_on(:start_date)).not_to be_nil
     end

--- a/vendor/engines/secure_rooms/app/views/secure_room_price_policies/_price_policy_fields.html.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_room_price_policies/_price_policy_fields.html.haml
@@ -1,9 +1,9 @@
 = content_for :head_content do
   = javascript_include_tag "price_policy"
 
-= render "price_policies/dates", f: f
-
 - price_policy = @price_policies.first
+
+= render "price_policies/dates", f: f, price_policy: price_policy
 
 %table.table.table-striped.table-hover.price-policy-table
   %thead


### PR DESCRIPTION
# Release Notes

Better handling of errors for invalid dates in price policy forms.

# Screenshot

![screen shot 2018-05-21 at 12 11 23 pm](https://user-images.githubusercontent.com/1099111/40320238-8cb35240-5cf0-11e8-983a-7479679ae016.png)

![screen shot 2018-05-21 at 12 17 28 pm](https://user-images.githubusercontent.com/1099111/40320340-f6746502-5cf0-11e8-85b6-898dab4f283a.png)

# Additional Context

There was no validation on expire date before, but would hard error if the expire date was invalid/blank (`NoMethodError: undefined method `end_of_day' for nil:NilClass`). Adding that validation did cause some problems with specs that weren't setting it, but I think I got all those cleaned up.

This will now also include some JS validation as used elsewhere which does not actually block the submission. On submit, it will be treated as a null/blank field and on re-render will be blank.
