### PR TITLE
Fix spacing on access list index

### DIFF
--- a/app/views/product_users/index.html.haml
+++ b/app/views/product_users/index.html.haml
@@ -13,7 +13,7 @@
 
 %p= text("explanation", product_type: @product.model_name.human.downcase)
 
-= link_to text("add"), [:new, current_facility, @product, :user], class: "btn-add"
+%p= link_to text("add"), [:new, current_facility, @product, :user], class: "btn-add"
 
 - if @product_users.nil?
 - elsif @product_users.empty?


### PR DESCRIPTION
# Release Notes

Fix spacing on access list index when there are no users on the list.

# Screenshot

Before:
![screen shot 2018-05-22 at 1 28 28 pm](https://user-images.githubusercontent.com/1099111/40382491-31e3c064-5dc4-11e8-90ff-041f69038683.png)

After:
![screen shot 2018-05-22 at 1 28 17 pm](https://user-images.githubusercontent.com/1099111/40382514-38634414-5dc4-11e8-936a-8c897743b02a.png)
