### PR TITLE
[#137466] Enable calendar drag-and-drop by default

### DIFF
--- a/app/assets/javascripts/app/reservation_calendar.js
+++ b/app/assets/javascripts/app/reservation_calendar.js
@@ -6,22 +6,18 @@ ReservationCalendar.prototype = {
     this.$calendar = $calendar;
     this.$reservationForm = $reservationForm;
 
-    if ($calendar.data("drag-and-drop-enabled")) {
-      self = this; // so our callbacks have access to this object
+    self = this; // so our callbacks have access to this object
 
-      fullCalendarOptions = {
-        eventDrop: this._handleEventDragDrop,
-        eventResize: this._handleEventDragDrop,
-        dayClick: this._handleClick,
-        eventOverlap: false,
-      }
-
-      new FullCalendarConfig($calendar, fullCalendarOptions).init();
-      $calendar.on("calendar:rendered", this._removeSelfFromSource);
-      this._addReservationFormListener();
-    } else {
-      new FullCalendarConfig($calendar).init();
+    fullCalendarOptions = {
+      eventDrop: this._handleEventDragDrop,
+      eventResize: this._handleEventDragDrop,
+      dayClick: this._handleClick,
+      eventOverlap: false,
     }
+
+    new FullCalendarConfig($calendar, fullCalendarOptions).init();
+    $calendar.on("calendar:rendered", this._removeSelfFromSource);
+    this._addReservationFormListener();
   },
 
   renderCurrentEvent: function(start, end) {

--- a/app/views/reservations/edit.html.haml
+++ b/app/views/reservations/edit.html.haml
@@ -45,4 +45,4 @@
 #overlay
   #spinner
     #hide
-      #calendar{ data: { show_tooltip: @instrument.show_details.to_s, drag_and_drop_enabled: SettingsHelper.feature_on?(:reservation_drag_and_drop).to_s, start_editable: start_time_editing_enabled?(@reservation).to_s } }
+      #calendar{ data: { show_tooltip: @instrument.show_details.to_s, start_editable: start_time_editing_enabled?(@reservation).to_s } }

--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -64,4 +64,4 @@
 #overlay
   #spinner
     #hide
-      #calendar{ data: { show_tooltip: @instrument.show_details.to_s, drag_and_drop_enabled: SettingsHelper.feature_on?(:reservation_drag_and_drop).to_s, start_editable: "true" } }
+      #calendar{ data: { show_tooltip: @instrument.show_details.to_s, start_editable: "true" } }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -118,7 +118,6 @@ feature:
   price_change_reason_required_on: true
   can_manage_global_price_groups_on: true
   cross_facility_reports_on: false
-  reservation_drag_and_drop_on: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts


### PR DESCRIPTION
# Release Notes

Enable calendar drag and drop for everyone.

# Additional Context

Enables #1478 for everyone by removing the feature flag. NU has been running with this feature for a while, so let's enable it for everyone else.
