### PR TITLE
CIDER-36 Create purchase button next to facility product name

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -155,6 +155,12 @@ li.nav-spacer {
     }
   }
 }
+.product_listing{
+  display: flex;
+}
+.product_listing .add_to_cart{
+  margin-left: 5px;
+}
 
 /*
   Product View

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -7,18 +7,23 @@
       - if products.first.class.model_name == "TimedService"
         %p= t("facilities.show.timed_services_note")
     %ul
-      - products.sort.each do |product|
-        %li{ class: product.class.model_name.to_s.downcase }
-          = public_calendar_link(product)
-          - if local_assigns[:f]
-            = f.fields_for :order_details do |builder|
-              - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
-                = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
-                = builder.hidden_field :product_id, value: product.id, index: nil
-          = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product)
-          - if acting_user.present? && !product.can_be_used_by?(acting_user)
-            %i.fa.fa-lock
-            = " (#{product.class.human_attribute_name(:requires_approval_show)})"
+      .product_listing
+        - products.sort.each do |product|
+          %li{ class: product.class.model_name.to_s.downcase }
+            = public_calendar_link(product)
+            - if local_assigns[:f]
+              = f.fields_for :order_details do |builder|
+                - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
+                  = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
+                  = builder.hidden_field :product_id, value: product.id, index: nil
+            = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product)
+            - if acting_user.present? && !product.can_be_used_by?(acting_user)
+              %i.fa.fa-lock
+              = " (#{product.class.human_attribute_name(:requires_approval_show)})"
 
-          - if product.offline?
-            = tooltip_icon "fa fa-exclamation-triangle icon-large", t("instruments.offline.note")
+            - if product.offline?
+              = tooltip_icon "fa fa-exclamation-triangle icon-large", t("instruments.offline.note")
+
+          %li{ class: %w[product.class.model_name.to_s.downcase+"_purchase" add_to_cart] }
+            - if acting_user.present? && product.can_be_used_by?(acting_user) && !product.respond_to?(:reservations)
+              = link_to "Add to cart", add_order_path(acting_user.cart(session_user), order: {order_details: [{product_id: product.id, quantity: 1}] }), method: :put, class: "btn"


### PR DESCRIPTION
# Release Notes

Added an "Add to cart" button next to facility sub-items. This allows for users to easily skip multiple pages and instantly add objects such as services to the cart.

# Screenshot

![image](https://user-images.githubusercontent.com/5000430/40499691-b0b9a402-5f50-11e8-86ae-ce4320bf4511.png)
