### PR TITLE
Split facility sub-items to their own columns

### DIFF
--- a/app/assets/stylesheets/app/product_list.scss
+++ b/app/assets/stylesheets/app/product_list.scss
@@ -5,7 +5,9 @@
 .product_list_container{
     display: flex;
     justify-content: space-between;
+    flex-wrap:wrap;
 }
 .product_list{
     flex: 0 0 calc(25% - 2em);
+    min-width: 200px;
 }

--- a/app/assets/stylesheets/app/product_list.scss
+++ b/app/assets/stylesheets/app/product_list.scss
@@ -11,3 +11,4 @@
     flex: 0 0 calc(25% - 2em);
     min-width: 200px;
 }
+

--- a/app/assets/stylesheets/app/product_list.scss
+++ b/app/assets/stylesheets/app/product_list.scss
@@ -1,0 +1,11 @@
+//Used existing class names such as:
+//vendor/engines/secure_rooms/app/views/secure_rooms/card_readers/index.html.haml
+//and
+//app/views/facilities/_product_list.html.haml
+.product_list_container{
+    display: flex;
+    justify-content: space-between;
+}
+.product_list{
+    flex: 0 0 calc(25% - 2em);
+}

--- a/app/assets/stylesheets/app/product_list.scss
+++ b/app/assets/stylesheets/app/product_list.scss
@@ -2,12 +2,12 @@
 //vendor/engines/secure_rooms/app/views/secure_rooms/card_readers/index.html.haml
 //and
 //app/views/facilities/_product_list.html.haml
-.product_list_container{
+.product_list_container.columns{
     display: flex;
     justify-content: space-between;
     flex-wrap:wrap;
 }
-.product_list{
+.product_list.columns{
     flex: 0 0 calc(25% - 2em);
     min-width: 200px;
 }

--- a/app/assets/stylesheets/app/product_list.scss
+++ b/app/assets/stylesheets/app/product_list.scss
@@ -1,14 +1,10 @@
-//Used existing class names such as:
-//vendor/engines/secure_rooms/app/views/secure_rooms/card_readers/index.html.haml
-//and
-//app/views/facilities/_product_list.html.haml
-.product_list_container.columns{
-    display: flex;
-    justify-content: space-between;
-    flex-wrap:wrap;
-}
-.product_list.columns{
-    flex: 0 0 calc(25% - 2em);
-    min-width: 200px;
+.product_list_container.columns {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap:wrap;
 }
 
+.product_list.columns {
+  flex: 0 0 calc(25% - 2em);
+  min-width: 200px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,7 @@ $chosen-sprite-retina: image-url("chosen-sprite@2x.png");
 @import "app/facility_accounts";
 @import "app/tables";
 @import "app/cart";
+@import "app/product_list";
 @import "app/chosen-override";
 @import "app/global_alert_banner";
 

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -43,6 +43,7 @@ class FacilitiesController < ApplicationController
     @order_form = nil
     @order_form = Order.new if acting_user && current_facility.accepts_multi_add?
     @active_tab = "home"
+    @columns = SettingsHelper.feature_on?(:product_list_columns) ? "columns" : ""
     render layout: "application"
   end
 

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -43,8 +43,7 @@ class FacilitiesController < ApplicationController
     @order_form = nil
     @order_form = Order.new if acting_user && current_facility.accepts_multi_add?
     @active_tab = "home"
-    @columns = ""
-    @columns =  "columns" if SettingsHelper.feature_on?(:product_list_columns)
+    get_column_class()
     render layout: "application"
   end
 
@@ -248,6 +247,11 @@ class FacilitiesController < ApplicationController
 
   def set_admin_billing_tab
     @active_tab = "admin_billing"
+  end
+
+  def get_column_class
+    @columns=""
+    @columns= "columns" if SettingsHelper.feature_on?(:product_list_columns)
   end
 
 end

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -43,7 +43,7 @@ class FacilitiesController < ApplicationController
     @order_form = nil
     @order_form = Order.new if acting_user && current_facility.accepts_multi_add?
     @active_tab = "home"
-    get_column_class()
+    set_column_class
     render layout: "application"
   end
 
@@ -249,9 +249,9 @@ class FacilitiesController < ApplicationController
     @active_tab = "admin_billing"
   end
 
-  def get_column_class
-    @columns=""
-    @columns= "columns" if SettingsHelper.feature_on?(:product_list_columns)
+  def set_column_class
+    @columns = ""
+    @columns = "columns" if SettingsHelper.feature_on?(:product_list_columns)
   end
 
 end

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -43,7 +43,8 @@ class FacilitiesController < ApplicationController
     @order_form = nil
     @order_form = Order.new if acting_user && current_facility.accepts_multi_add?
     @active_tab = "home"
-    @columns = SettingsHelper.feature_on?(:product_list_columns) ? "columns" : ""
+    @columns = ""
+    @columns =  "columns" if SettingsHelper.feature_on?(:product_list_columns)
     render layout: "application"
   end
 

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -1,5 +1,6 @@
 - if products.any?
-  .product_list{ class: products.first.class.model_name.to_s.pluralize.downcase }
+  .product_list{ class: [products.first.class.model_name.to_s.pluralize.downcase, 
+  @columns] }
 
     - if current_facility.present?
       %h3= product_list_title products, local_assigns[:title_extra]

--- a/app/views/facilities/show.html.haml
+++ b/app/views/facilities/show.html.haml
@@ -22,18 +22,19 @@
 
 .wysiwyg= current_facility.description
 
-- if @order_form
-  = form_for @order_form, url: add_order_path(acting_user.cart(session_user)), html: {method: :put } do |f|
-    = render partial: 'product_list', locals: {products: instruments, f: f, title_extra: daily_view_link }
-    = render partial: 'product_list', locals: {products: services, f: f}
-    = render partial: 'product_list', locals: {products: timed_services, f: f}
-    = render partial: 'product_list', locals: {products: items, f: f}
-    = render partial: 'product_list', locals: {products: bundles, f: f}
+.product_list_container
+  - if @order_form
+    = form_for @order_form, url: add_order_path(acting_user.cart(session_user)), html: {method: :put } do |f|
+      = render partial: 'product_list', locals: {products: instruments, f: f, title_extra: daily_view_link }
+      = render partial: 'product_list', locals: {products: services, f: f}
+      = render partial: 'product_list', locals: {products: timed_services, f: f}
+      = render partial: 'product_list', locals: {products: items, f: f}
+      = render partial: 'product_list', locals: {products: bundles, f: f}
 
-    = f.submit class: ['btn', 'btn-primary']
-- else
-  = render partial: 'product_list', locals: {products: instruments, title_extra: daily_view_link }
-  = render partial: 'product_list', locals: {products: services}
-  = render partial: 'product_list', locals: {products: timed_services}
-  = render partial: 'product_list', locals: {products: items}
-  = render partial: 'product_list', locals: {products: bundles}
+      = f.submit class: ['btn', 'btn-primary']
+  - else
+    = render partial: 'product_list', locals: {products: instruments, title_extra: daily_view_link }
+    = render partial: 'product_list', locals: {products: services}
+    = render partial: 'product_list', locals: {products: timed_services}
+    = render partial: 'product_list', locals: {products: items}
+    = render partial: 'product_list', locals: {products: bundles}

--- a/app/views/facilities/show.html.haml
+++ b/app/views/facilities/show.html.haml
@@ -22,7 +22,7 @@
 
 .wysiwyg= current_facility.description
 
-.product_list_container
+.product_list_container{class: @columns}
   - if @order_form
     = form_for @order_form, url: add_order_path(acting_user.cart(session_user)), html: {method: :put } do |f|
       = render partial: 'product_list', locals: {products: instruments, f: f, title_extra: daily_view_link }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -120,7 +120,7 @@ feature:
   price_change_reason_required_on: true
   can_manage_global_price_groups_on: true
   cross_facility_reports_on: false
-  facility_columns: false
+  product_list_columns_on: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -120,6 +120,7 @@ feature:
   price_change_reason_required_on: true
   can_manage_global_price_groups_on: true
   cross_facility_reports_on: false
+  facility_columns: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts


### PR DESCRIPTION
# Release Notes

Instead of a single list of objects belonging to a facility, multiple columns representing each type of object are used.

# Screenshot

## Before
![image](https://user-images.githubusercontent.com/5000430/40563007-3b8cbd36-6031-11e8-8ef7-c759a2786a5f.png)

## After
![image](https://user-images.githubusercontent.com/5000430/40562808-7e12d8e4-6030-11e8-8508-6bf64f4102ae.png)

