### PR TITLE
Allow SAML engine semi-enabling

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -134,6 +134,9 @@ paperclip:
 
 # saml:
 #   create_user: true
+#   # Use login_enabled: false if you want to allow access to metadata without yet
+#   # allowing login.
+#   login_enabled: true
 #   idp_metadata: "https://websso.example.com/idp/metadata"
 #   # certificate_file: path/to/file.p12 # Optional. Do not check in to version control.
 #   # driver: # Optional. Useful to override inferred SAML settings if need be.

--- a/vendor/engines/saml_authentication/lib/saml_authentication/engine.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/engine.rb
@@ -11,9 +11,11 @@ module SamlAuthentication
       next if Settings.saml.blank?
 
       User.send(:devise, :saml_authenticatable)
-      ViewHook.add_hook "devise.sessions.new",
-                        "before_login_form",
-                        "saml_authentication/sessions/new"
+      if Settings.saml.login_enabled
+        ViewHook.add_hook "devise.sessions.new",
+                          "before_login_form",
+                          "saml_authentication/sessions/new"
+      end
 
       OneLogin::RubySaml::Logging.logger.level = Rails.env.production? ? Logger::INFO : Logger::DEBUG
     end


### PR DESCRIPTION
# Release Notes

Tech task: Allow the `saml_authentication` engine to be enabled, but not user-accessible. This will allow the `/users/saml/metadata` endpoint to be accessible so an IdP can import it for configuration, but not yet allow users to log in with it.

# Additional Context

This basically hides the login button. In order to set up production for Dartmouth, we're going to need to provide them the metadata so they can import it into their system before the feature will work. So the "off" setting will only be a temporary measure.

There will be a DC PR that sets this configuration option.
