### PR TITLE
Add gems to suport ed25519 keys in capistrano

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,13 @@ group :development, :deployment do
   gem "capistrano-rails",   require: false
   gem "capistrano-rvm",     require: false
   gem "capistrano-bundler", require: false
+
+  # net-ssh requires the gems below to support ed25519 keys
+  # for deploying via capistrano
+  # more info at https://github.com/net-ssh/net-ssh/issues/478
+  gem "bcrypt_pbkdf", ">= 1.0", "< 2.0"
+  gem "rbnacl", ">= 3.2", "< 5.0"
+  gem "rbnacl-libsodium"
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -93,12 +93,12 @@ group :development, :deployment do
   gem "capistrano-rvm",     require: false
   gem "capistrano-bundler", require: false
 
-  # net-ssh requires the gems below to support ed25519 keys
+  # net-ssh 4.2 requires the gems below to support ed25519 keys
   # for deploying via capistrano
   # more info at https://github.com/net-ssh/net-ssh/issues/478
-  gem "bcrypt_pbkdf", ">= 1.0", "< 2.0"
-  gem "rbnacl", ">= 3.2", "< 5.0"
-  gem "rbnacl-libsodium"
+  gem "bcrypt_pbkdf", ">= 1.0", "< 2.0", require: false
+  gem "rbnacl", ">= 3.2", "< 5.0", require: false
+  gem "rbnacl-libsodium", require: false
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
       activerecord (>= 4.0.0, < 5.3)
     awesome_print (1.8.0)
     bcrypt (3.1.11)
+    bcrypt_pbkdf (1.0.0)
     bindex (0.5.0)
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
@@ -487,6 +488,10 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rbnacl (4.0.2)
+      ffi
+    rbnacl-libsodium (1.0.16)
+      rbnacl (>= 3.0.1)
     redcarpet (3.4.0)
     ref (2.0.0)
     request_store (1.4.1)
@@ -637,6 +642,7 @@ DEPENDENCIES
   aasm
   awesome_nested_set
   awesome_print
+  bcrypt_pbkdf (>= 1.0, < 2.0)
   bootstrap-sass (~> 2.3.2)
   bulk_email!
   bullet
@@ -700,6 +706,8 @@ DEPENDENCIES
   rails-erd
   rails-observers
   rake
+  rbnacl (>= 3.2, < 5.0)
+  rbnacl-libsodium
   rollbar (= 2.15.5)
   rspec-activejob
   rspec-collection_matchers
@@ -734,4 +742,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
# Release Notes

TECH TASK: Allow using ed25519 keys to deploy via capistrano

# Additional Context

Without these gems, capistrano fails with the following message:

```
$ bundle exec cap staging deploy
(Backtrace restricted to imported tasks)
cap aborted!
NotImplementedError: unsupported key type `ssh-ed25519'
net-ssh requires the following gems for ed25519 support:
 * rbnacl (>= 3.2, < 5.0)
 * rbnacl-libsodium, if your system doesn't have libsodium installed.
 * bcrypt_pbkdf (>= 1.0, < 2.0)
See https://github.com/net-ssh/net-ssh/issues/478 for more information
Gem::LoadError : "rbnacl is not part of the bundle. Add it to your Gemfile."

Tasks: TOP => rvm:hook
(See full trace by running task with --trace)
```

https://blog.g3rt.nl/upgrade-your-ssh-keys.html is a good overview of Ed25519 SSH keys, and why it’s a good idea to migrate towards using them.