### PR TITLE
Update Capistrano lock to same version as gem

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock "~> 3.10.1"
+lock "~> 3.11.0"
 
 set :application, "nucore"
 


### PR DESCRIPTION
# Release Notes

TECH TASK: Update Capistrano lock to match updated gem version

# Additional Context

https://github.com/tablexi/nucore-open/pull/1582 broke deployments, because Capistrano includes a version lock in addition to the one in `Gemfile.lock`.