### PR TITLE
[#136143] Add an order edit link for each reservation on the product calendar

### DIFF
--- a/app/assets/javascripts/app/calendar.js.coffee
+++ b/app/assets/javascripts/app/calendar.js.coffee
@@ -46,14 +46,14 @@ class window.FullCalendarConfig
     # Default for our tooltip is to show, even if data-attribute is undefined.
     # Only hide if explicitly set to false.
     if $("#calendar").data("show-tooltip") != false
-      tooltip += [
+      tooltip = [
         @formattedEventPeriod(event),
         event.title,
         event.email,
         event.product,
         event.expiration,
         event.user_note,
-        @linkToEditOrder(event.orderId)
+        @linkToEditOrder(event)
       ].filter(
         (e) -> e? # remove undefined values
       ).join("<br/>")
@@ -81,5 +81,5 @@ class window.FullCalendarConfig
       map((date) -> $.fullCalendar.formatDate(date, "h:mmA")).
       join("&ndash;")
 
-  linkToEditOrder: (orderId) ->
-    "<a href='#{orders_path_base}/#{orderId}'>Edit</a>"
+  linkToEditOrder: (event) ->
+    "<a href='#{orders_path_base}/#{event.orderId}'>Edit</a>"

--- a/app/assets/javascripts/app/calendar.js.coffee
+++ b/app/assets/javascripts/app/calendar.js.coffee
@@ -42,7 +42,7 @@ class window.FullCalendarConfig
       $(".fc-button-prev").toggleClass("fc-state-disabled", startDate < window.minDate)
       $(".fc-button-next").toggleClass("fc-state-disabled", endDate > window.maxDate)
 
-  buildTooltip: (event, element) ->
+  buildTooltip: (event, element) =>
     tooltip = [
       $.fullCalendar.formatDate(event.start, "h:mmA"),
       $.fullCalendar.formatDate(event.end,   "h:mmA")
@@ -57,6 +57,7 @@ class window.FullCalendarConfig
         event.product,
         event.expiration,
         event.user_note,
+        @linkToEditOrder(event.orderId)
       ].filter(
         (e) -> e? # remove undefined values
       ).join("<br/>")
@@ -78,3 +79,6 @@ class window.FullCalendarConfig
   # window.minDate/maxDate are strings formatted like 20170714
   formatCalendarDate: (date) ->
     $.fullCalendar.formatDate(date, "yyyyMMdd")
+
+  linkToEditOrder: (orderId) ->
+    "<a href='#{orders_path_base}/#{orderId}'>Edit</a>"

--- a/app/assets/javascripts/app/calendar.js.coffee
+++ b/app/assets/javascripts/app/calendar.js.coffee
@@ -70,6 +70,9 @@ class window.FullCalendarConfig
           position:
             at: "bottom left"
             my: "topRight"
+          hide:
+            fixed: true
+            delay: 300
         )
 
   # window.minDate/maxDate are strings formatted like 20170714

--- a/app/assets/javascripts/app/calendar.js.coffee
+++ b/app/assets/javascripts/app/calendar.js.coffee
@@ -43,15 +43,11 @@ class window.FullCalendarConfig
       $(".fc-button-next").toggleClass("fc-state-disabled", endDate > window.maxDate)
 
   buildTooltip: (event, element) =>
-    tooltip = [
-      $.fullCalendar.formatDate(event.start, "h:mmA"),
-      $.fullCalendar.formatDate(event.end,   "h:mmA")
-    ].join("&ndash;") + "<br/>"
-
     # Default for our tooltip is to show, even if data-attribute is undefined.
     # Only hide if explicitly set to false.
     if $("#calendar").data("show-tooltip") != false
       tooltip += [
+        @formattedEventPeriod(event),
         event.title,
         event.email,
         event.product,
@@ -79,6 +75,11 @@ class window.FullCalendarConfig
   # window.minDate/maxDate are strings formatted like 20170714
   formatCalendarDate: (date) ->
     $.fullCalendar.formatDate(date, "yyyyMMdd")
+
+  formattedEventPeriod: (event) ->
+    [event.start, event.end].
+      map((date) -> $.fullCalendar.formatDate(date, "h:mmA")).
+      join("&ndash;")
 
   linkToEditOrder: (orderId) ->
     "<a href='#{orders_path_base}/#{orderId}'>Edit</a>"

--- a/app/presenters/reservations/calendar_presenter.rb
+++ b/app/presenters/reservations/calendar_presenter.rb
@@ -42,6 +42,7 @@ module Reservations
         title: model_name.human,
         product: product.name,
         id: id,
+        orderId: order.id
       }
     end
 

--- a/app/presenters/reservations/calendar_presenter.rb
+++ b/app/presenters/reservations/calendar_presenter.rb
@@ -14,6 +14,7 @@ module Reservations
           {
             title: order.user.full_name,
             email: order.user.email,
+            orderId: order.id,
           }
         else
           {}
@@ -42,7 +43,6 @@ module Reservations
         title: model_name.human,
         product: product.name,
         id: id,
-        orderId: order.id,
       }
     end
 

--- a/app/presenters/reservations/calendar_presenter.rb
+++ b/app/presenters/reservations/calendar_presenter.rb
@@ -42,7 +42,7 @@ module Reservations
         title: model_name.human,
         product: product.name,
         id: id,
-        orderId: order.id
+        orderId: order.id,
       }
     end
 

--- a/app/views/facility_reservations/edit_admin.html.haml
+++ b/app/views/facility_reservations/edit_admin.html.haml
@@ -4,7 +4,6 @@
     var events_path     = "#{facility_instrument_reservations_path(@instrument.facility, @instrument, :format => 'js', :with_details => true)}";
     var minTime         = #{@instrument.first_available_hour};
     var maxTime         = #{@instrument.last_available_hour+1};
-    var withDetails     = true;
     var initialDate     = "#{@reservation.reserve_start_at.strftime('%Y-%m-%d')}";
   = javascript_include_tag "reservations.js"
 

--- a/app/views/facility_reservations/new.html.haml
+++ b/app/views/facility_reservations/new.html.haml
@@ -4,7 +4,6 @@
     var events_path = "#{facility_instrument_reservations_path(@instrument.facility, @instrument, format: :js, with_details: true)}";
     var minTime = #{@instrument.first_available_hour};
     var maxTime = #{@instrument.last_available_hour + 1};
-    var withDetails = true
   = javascript_include_tag "reservations.js"
 
 = content_for :h1 do

--- a/app/views/facility_reservations/show.html.haml
+++ b/app/views/facility_reservations/show.html.haml
@@ -5,7 +5,6 @@
     var maxDaysFromNow  = #{@instrument.max_reservation_window};
     var minTime         = #{@instrument.first_available_hour};
     var maxTime         = #{@instrument.last_available_hour+1};
-    var withDetails     = true;
     var initialDate     = "#{@reservation.reserve_start_at.strftime('%Y-%m-%d')}";
   = javascript_include_tag 'reservations.js'
 

--- a/app/views/instruments/schedule.html.haml
+++ b/app/views/instruments/schedule.html.haml
@@ -14,7 +14,6 @@
 :javascript
   var events_path = "#{facility_instrument_reservations_path(current_facility, @product, format: 'js', with_details: true, all: true)}";
   var orders_path_base = "#{facility_orders_path(current_facility)}";
-  var withDetails = true;
 
 %h2= @product
 

--- a/app/views/instruments/schedule.html.haml
+++ b/app/views/instruments/schedule.html.haml
@@ -13,6 +13,7 @@
 
 :javascript
   var events_path = "#{facility_instrument_reservations_path(current_facility, @product, format: 'js', with_details: true, all: true)}";
+  var orders_path_base = "#{facility_orders_path(current_facility)}";
   var withDetails = true;
 
 %h2= @product

--- a/spec/app_support/reservations/rendering_spec.rb
+++ b/spec/app_support/reservations/rendering_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Reservations::Rendering do
 
         it "returns a hash with extra details about the order" do
           expect(reservation.as_calendar_object(with_details: true))
-            .to eq(base_hash.merge(email: user.email, title: user.full_name))
+            .to eq(base_hash.merge(email: user.email, title: user.full_name, orderId: order.id))
         end
       end
 


### PR DESCRIPTION
# Release Notes

Add an order edit link for each reservation on the product calendar

# Screenshot

## Before

<img width="374" alt="screen shot 2018-06-06 at 17 56 20" src="https://user-images.githubusercontent.com/7736/41050425-a250e48a-69b3-11e8-958c-57ece4305b7f.png">

## After

<img width="422" alt="screen shot 2018-06-06 at 17 56 02" src="https://user-images.githubusercontent.com/7736/41050473-c6d142be-69b3-11e8-974e-a5638f743263.png">

# Additional Context

For the reviewer: I went back and forth between adding an `orderId` attribute in `CalendarPresenter`, and adding an `editOrderPath` attribute (so that the JS code doesn’t have to construct a path). I chose the former approach because the serialization of a Reservation may be used in other contexts beyond this calendar, where that path does not make sense. Additionally, exposing the base path to edit orders mimics the way we expose `events_path` as a global (which I’m not in love with, but that’s a refactoring for another day).
