### PR TITLE
Ensure that test checking for accounts does not fail due to a lack of price groups

### DIFF
--- a/spec/models/product_for_cart_spec.rb
+++ b/spec/models/product_for_cart_spec.rb
@@ -121,7 +121,10 @@ RSpec.describe ProductForCart do
     end
 
     context "when the acting user does not have any accounts that can purchase the product" do
-      before(:each) { allow(user).to receive(:accounts_for_product).and_return([]) }
+      before(:each) do
+        allow(item).to receive(:can_purchase?).and_return(true)
+        allow(user).to receive(:accounts_for_product).and_return([])
+      end
 
       it "sets error_message explaining that we could not find a valid payment source" do
         product_for_cart.purchasable_by?(user, user)

--- a/spec/models/product_for_cart_spec.rb
+++ b/spec/models/product_for_cart_spec.rb
@@ -122,6 +122,11 @@ RSpec.describe ProductForCart do
 
     context "when the acting user does not have any accounts that can purchase the product" do
       before(:each) do
+        # Some of the school-specific forks override Product#can_purchase?, which can
+        # cause the call to purchasable_by? below to fail on that check, instead of the
+        # check we’re interested in exercising in this context. Since we test can_purchase?
+        # in the context above, here we stub it away so we ensure that the check we’re
+        # interested in gets exercised.
         allow(item).to receive(:can_purchase?).and_return(true)
         allow(user).to receive(:accounts_for_product).and_return([])
       end


### PR DESCRIPTION
# Release Notes

TECH TASK: Ensure that test checking for accounts does not fail due to a lack of price groups

# Additional Context

Some of the school-specific forks contain engines that override `Product#can_purchase?` with rules beyond the default ones. As a result of this, the test which exercises the check that the acting user has appropriate accounts gets tripped up by the false return of `Product#can_purchase?`, which executes sooner. Since we test that path separately, in this context we stub it away to ensure that we get to the check we’re interested in testing.