### PR TITLE
Match against the first configured account type instead of hard-coding NufsAccount in test

### DIFF
--- a/vendor/engines/c2po/spec/controllers/facility_accounts_controller_spec.rb
+++ b/vendor/engines/c2po/spec/controllers/facility_accounts_controller_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe FacilityAccountsController do
 
     describe "as an account administrator" do
       let(:account_manager) { create(:user, :account_manager) }
+      let(:chartstring_class_name) { Account.config.account_types.first }
 
       before do
         sign_in account_manager
@@ -117,7 +118,7 @@ RSpec.describe FacilityAccountsController do
 
         it "falls back to using a chartstring" do
           expect(response).to be_success
-          expect(assigns(:account)).to be_a(NufsAccount)
+          expect(assigns(:account).class.name).to eq(chartstring_class_name)
         end
       end
 
@@ -126,7 +127,7 @@ RSpec.describe FacilityAccountsController do
 
         it "falls back to using a chartstring" do
           expect(response).to be_success
-          expect(assigns(:account)).to be_a(NufsAccount)
+          expect(assigns(:account).class.name).to eq(chartstring_class_name)
         end
       end
     end


### PR DESCRIPTION
# Release Notes

TECH TASK: Match against the first configured account type instead of hard-coding NufsAccount in test

# Additional Context

`FacilityAccountsController` checks the list of configured account types, and picks the first one available. When another engine modifies the list in addition to the `c2po` engine, as some school-specific engines do, `NufsAccount` may not be the first configured account type, and these tests fail because they expect incorrect behavior. Hence, this PR modifies the test to assert against the configured account type instead of assuming it will always be `NufsAccount`.