### PR TITLE
Use single quotes instead of correct apostrophe marks to appease rubocop

### DIFF
--- a/spec/models/product_for_cart_spec.rb
+++ b/spec/models/product_for_cart_spec.rb
@@ -124,8 +124,8 @@ RSpec.describe ProductForCart do
       before(:each) do
         # Some of the school-specific forks override Product#can_purchase?, which can
         # cause the call to purchasable_by? below to fail on that check, instead of the
-        # check we’re interested in exercising in this context. Since we test can_purchase?
-        # in the context above, here we stub it away so we ensure that the check we’re
+        # check we're interested in exercising in this context. Since we test can_purchase?
+        # in the context above, here we stub it away so we ensure that the check we're
         # interested in gets exercised.
         allow(item).to receive(:can_purchase?).and_return(true)
         allow(user).to receive(:accounts_for_product).and_return([])


### PR DESCRIPTION
# Release Notes

TECH TASK: Use single quotes instead of correct apostrophe marks to appease rubocop
