### PR TITLE
[#142184] Allow customizing error message for non-existent users signing in via SAML

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1129,6 +1129,7 @@ en:
       invalid: "Invalid username or password."
       not_found_in_database: "Invalid username or password."
       inactive: "Invalid username or password."
+      saml_invalid: "Invalid username or password."
     mailer:
       # TODO
       reset_password_instructions:

--- a/vendor/engines/saml_authentication/lib/saml_authentication/engine.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/engine.rb
@@ -2,6 +2,7 @@ require "devise_saml_authenticatable"
 require "saml_authentication/routes"
 require "saml_authentication/model"
 require "saml_authentication/devise_configurator"
+require "saml_authentication/saml_authenticatable_with_custom_error"
 
 module SamlAuthentication
 
@@ -10,7 +11,7 @@ module SamlAuthentication
     config.to_prepare do
       next if Settings.saml.blank?
 
-      User.send(:devise, :saml_authenticatable)
+      User.send(:devise, :saml_authenticatable_with_custom_error)
       if Settings.saml.login_enabled
         ViewHook.add_hook "devise.sessions.new",
                           "before_login_form",

--- a/vendor/engines/saml_authentication/lib/saml_authentication/saml_authenticatable_with_custom_error.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/saml_authenticatable_with_custom_error.rb
@@ -16,7 +16,7 @@ module Devise
       # causes Devise to use the error message defined in devise.failure.invalid. That
       # error message is used by other strategies, including the email and password strategy
       # that we also use, so if we change the message we'll incorrectly affect the other
-      # strategies as well. Therefore, we override the m ethod responsible for failing
+      # strategies as well. Therefore, we override the method responsible for failing
       # authentication to call fail!(:saml_invalid), which allows us to specify a separate
       # failure message for authentication via SAML.
       def failed_auth(msg)

--- a/vendor/engines/saml_authentication/lib/saml_authentication/saml_authenticatable_with_custom_error.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/saml_authenticatable_with_custom_error.rb
@@ -1,0 +1,40 @@
+module Devise
+
+  module Models
+
+    SamlAuthenticatableWithCustomError = SamlAuthenticatable
+
+  end
+
+  module Strategies
+
+    class SamlAuthenticatableWithCustomError < SamlAuthenticatable
+
+      private
+
+      # In the original SamlAuthenticatable, this method calls fail!(:invalid), which
+      # causes Devise to use the error message defined in devise.failure.invalid. That
+      # error message is used by other strategies, including the email and password strategy
+      # that we also use, so if we change the message we'll incorrectly affect the other
+      # strategies as well. Therefore, we override the m ethod responsible for failing
+      # authentication to call fail!(:saml_invalid), which allows us to specify a separate
+      # failure message for authentication via SAML.
+      def failed_auth(msg)
+        DeviseSamlAuthenticatable::Logger.send(msg)
+        fail!(:saml_invalid)
+        Devise.saml_failed_callback.new.handle(@response, self) if Devise.saml_failed_callback # rubocop:disable Style/SafeNavigation
+      end
+
+    end
+
+  end
+
+end
+
+Warden::Strategies.add(:saml_authenticatable_with_custom_error, Devise::Strategies::SamlAuthenticatableWithCustomError)
+
+Devise.add_module(:saml_authenticatable_with_custom_error,
+                  route: :saml_authenticatable,
+                  strategy: true,
+                  controller: :saml_sessions,
+                  model: 'devise_saml_authenticatable/model')

--- a/vendor/engines/saml_authentication/spec/controllers/saml_authentication/sessions_controller_spec.rb
+++ b/vendor/engines/saml_authentication/spec/controllers/saml_authentication/sessions_controller_spec.rb
@@ -69,6 +69,20 @@ RSpec.describe SamlAuthentication::SessionsController, type: :controller do
       end
     end
 
+    context "when auto-creation of users is disabled and a user does not exist" do
+      around :each do |example|
+        original_value = Devise.saml_create_user
+        Devise.saml_create_user = false
+        example.run
+        Devise.saml_create_user = original_value
+      end
+
+      it "sets a user-friendly error message in the flash" do
+        post :create, SAMLResponse: saml_response
+        expect(flash[:alert]).to eq(I18n.t("devise.failure.saml_invalid"))
+      end
+    end
+
     describe "an email-based user exists" do
       around :each do |example|
         original_value = Devise.saml_create_user


### PR DESCRIPTION
# Release Notes

Allow customizing error message for non-existent users signing in via SAML

# Additional Context

The SAML authentication strategy for Devise currently uses the same i18n key for failed logins as other strategies (`devise.failure.invalid`). This PR makes SAML failed logins use `saml_invalid`, so we can customize the messaging in this flow separately from the email & password flow.