### PR TITLE
[#139111] Do not show canceled reservations on My Reservations screen

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -68,15 +68,15 @@ class ReservationsController < ApplicationController
     notices = []
 
     relation = acting_user.order_details
-    in_progress = relation.in_progress_reservations
+    in_progress = relation.with_in_progress_reservation
     @status = params[:status]
     @available_statuses = [in_progress.blank? ? "upcoming" : "upcoming_and_in_progress", "all"]
 
     if @status == "all"
-      @order_details = relation.all_reservations
+      @order_details = relation.with_reservation
     elsif @status == "upcoming"
       @status = @available_statuses.first
-      @order_details = in_progress + relation.upcoming_reservations
+      @order_details = in_progress + relation.with_upcoming_reservation
     else
       return redirect_to reservations_status_path(status: "upcoming")
     end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -285,7 +285,12 @@ class OrderDetail < ApplicationRecord
   scope :pending, -> { joins(:order).where(state: %w(new inprocess)).purchased }
 
   scope :with_reservation, -> { purchased.joins(:reservation).order("reservations.reserve_start_at DESC") }
-  scope :with_upcoming_reservation, -> { with_reservation.where(reservations: { actual_start_at: nil }).merge(Reservation.ends_in_the_future) }
+  scope :with_upcoming_reservation, -> {
+    non_canceled.
+    with_reservation.
+      where(reservations: { actual_start_at: nil }).
+      merge(Reservation.ends_in_the_future)
+  }
   scope :with_in_progress_reservation, lambda { with_reservation.merge(Reservation.relay_in_progress) }
 
   scope :for_accounts, ->(accounts) { where("order_details.account_id in (?)", accounts) unless accounts.nil? || accounts.empty? }

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -284,9 +284,9 @@ class OrderDetail < ApplicationRecord
 
   scope :pending, -> { joins(:order).where(state: %w(new inprocess)).purchased }
 
-  scope :all_reservations, -> { purchased.joins(:reservation).order("reservations.reserve_start_at DESC") }
-  scope :upcoming_reservations, -> { all_reservations.where(reservations: { actual_start_at: nil }).merge(Reservation.ends_in_the_future) }
-  scope :in_progress_reservations, lambda { all_reservations.merge(Reservation.relay_in_progress) }
+  scope :with_reservation, -> { purchased.joins(:reservation).order("reservations.reserve_start_at DESC") }
+  scope :with_upcoming_reservation, -> { with_reservation.where(reservations: { actual_start_at: nil }).merge(Reservation.ends_in_the_future) }
+  scope :with_in_progress_reservation, lambda { with_reservation.merge(Reservation.relay_in_progress) }
 
   scope :for_accounts, ->(accounts) { where("order_details.account_id in (?)", accounts) unless accounts.nil? || accounts.empty? }
   scope :for_facilities, ->(facilities) { joins(:order).where("orders.facility_id in (?)", facilities) unless facilities.nil? || facilities.empty? }

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -291,7 +291,7 @@ class OrderDetail < ApplicationRecord
       where(reservations: { actual_start_at: nil }).
       merge(Reservation.ends_in_the_future)
   }
-  scope :with_in_progress_reservation, lambda { with_reservation.merge(Reservation.relay_in_progress) }
+  scope :with_in_progress_reservation, -> { non_canceled.with_reservation.merge(Reservation.relay_in_progress) }
 
   scope :for_accounts, ->(accounts) { where("order_details.account_id in (?)", accounts) unless accounts.nil? || accounts.empty? }
   scope :for_facilities, ->(facilities) { joins(:order).where("orders.facility_id in (?)", facilities) unless facilities.nil? || facilities.empty? }

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -283,21 +283,10 @@ class OrderDetail < ApplicationRecord
   scope :purchased, -> { joins(:order).merge(Order.purchased) }
 
   scope :pending, -> { joins(:order).where(state: %w(new inprocess)).purchased }
-  scope :confirmed_reservations, -> { reservations.joins(:order).includes(:reservation).purchased }
 
-  scope :upcoming_reservations, lambda {
-                                  confirmed_reservations
-                                    .where("reservations.reserve_end_at > ? AND reservations.actual_start_at IS NULL", Time.zone.now)
-                                    .order("reservations.reserve_start_at ASC")
-                                }
-
-  scope :in_progress_reservations, lambda {
-    confirmed_reservations
-      .merge(Reservation.relay_in_progress)
-      .order("reservations.reserve_start_at ASC")
-  }
-
-  scope :all_reservations, -> { confirmed_reservations.order("reservations.reserve_start_at DESC") }
+  scope :all_reservations, -> { purchased.joins(:reservation).order("reservations.reserve_start_at DESC") }
+  scope :upcoming_reservations, -> { all_reservations.where(reservations: { actual_start_at: nil }).merge(Reservation.ends_in_the_future) }
+  scope :in_progress_reservations, lambda { all_reservations.merge(Reservation.relay_in_progress) }
 
   scope :for_accounts, ->(accounts) { where("order_details.account_id in (?)", accounts) unless accounts.nil? || accounts.empty? }
   scope :for_facilities, ->(facilities) { joins(:order).where("orders.facility_id in (?)", facilities) unless facilities.nil? || facilities.empty? }

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -285,11 +285,11 @@ class OrderDetail < ApplicationRecord
   scope :pending, -> { joins(:order).where(state: %w(new inprocess)).purchased }
 
   scope :with_reservation, -> { purchased.joins(:reservation).order("reservations.reserve_start_at DESC") }
-  scope :with_upcoming_reservation, -> {
-    non_canceled.
-    with_reservation.
-      where(reservations: { actual_start_at: nil }).
-      merge(Reservation.ends_in_the_future)
+  scope :with_upcoming_reservation, lambda {
+    non_canceled
+      .with_reservation
+      .where(reservations: { actual_start_at: nil })
+      .merge(Reservation.ends_in_the_future)
   }
   scope :with_in_progress_reservation, -> { non_canceled.with_reservation.merge(Reservation.relay_in_progress) }
 

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -369,12 +369,12 @@ RSpec.describe ReservationsController do
         @params = { status: "all" }
       end
 
-      it "should respond with all reservations" do
+      it "should respond with all order details that have a reservation" do
         maybe_grant_always_sign_in :staff
         do_request
         expect(assigns(:status)).to eq("all")
         expect(assigns(:available_statuses).size).to eq(2)
-        expect(assigns(:order_details)).to eq(OrderDetail.all_reservations)
+        expect(assigns(:order_details)).to eq(OrderDetail.with_reservation)
         expect(assigns(:active_tab)).to eq("reservations")
         is_expected.to render_template("list")
       end

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -1863,4 +1863,15 @@ RSpec.describe OrderDetail do
       expect(OrderDetail.with_upcoming_reservation).not_to include(order_detail)
     end
   end
+
+  describe ".with_in_progress_reservation" do
+    before do
+      place_reservation facility, order_detail, 10.minutes.ago, actual_start_at: 10.minutes.ago, reserve_end_at: 50.minutes.from_now
+      order_detail.cancel_reservation(user, admin: true)
+    end
+
+    it "does not include canceled order details" do
+      expect(OrderDetail.with_in_progress_reservation).not_to include(order_detail)
+    end
+  end
 end

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -1852,4 +1852,15 @@ RSpec.describe OrderDetail do
       price_policy.update_attribute :cancellation_cost, cost
     end
   end
+
+  describe ".with_upcoming_reservation" do
+    before do
+      place_reservation facility, order_detail, 48.hours.from_now, reserve_end_at: 49.hours.from_now
+      order_detail.cancel_reservation(user, admin: true)
+    end
+
+    it "does not include canceled order details" do
+      expect(OrderDetail.with_upcoming_reservation).not_to include(order_detail)
+    end
+  end
 end

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -1092,7 +1092,7 @@ RSpec.describe OrderDetail do
       it "should be upcoming" do
         start_time = @now + 2.days
         place_reservation @facility, @order_detail, start_time, reserve_end_at: start_time + 1.hour
-        upcoming = OrderDetail.upcoming_reservations
+        upcoming = OrderDetail.with_upcoming_reservation
         expect(upcoming.size).to eq(1)
         expect(upcoming[0]).to eq(@order_detail)
       end
@@ -1100,31 +1100,31 @@ RSpec.describe OrderDetail do
       it "should not be upcoming because reserve_end_at is in the past" do
         start_time = @now - 2.days
         place_reservation @facility, @order_detail, start_time, reserve_end_at: start_time + 1.hour
-        expect(OrderDetail.upcoming_reservations).to be_blank
+        expect(OrderDetail.with_upcoming_reservation).to be_blank
       end
 
       it "should not be upcoming because actual_start_at exists" do
         start_time = @now + 2.days
         place_reservation @facility, @order_detail, start_time, reserve_end_at: start_time + 1.hour, actual_start_at: start_time
-        expect(OrderDetail.upcoming_reservations).to be_blank
+        expect(OrderDetail.with_upcoming_reservation).to be_blank
       end
 
       it "should be in progress" do
         place_reservation @facility, @order_detail, @now, actual_start_at: @now
-        upcoming = OrderDetail.in_progress_reservations
+        upcoming = OrderDetail.with_in_progress_reservation
         expect(upcoming.size).to eq(1)
         expect(upcoming[0]).to eq(@order_detail)
       end
 
       it "should not be in progress because actual_start_at missing" do
         place_reservation @facility, @order_detail, @now
-        expect(OrderDetail.in_progress_reservations).to be_empty
+        expect(OrderDetail.with_in_progress_reservation).to be_empty
       end
 
       it "should not be in progress because actual_end_at exists" do
         start_time = @now - 3.hours
         place_reservation @facility, @order_detail, start_time, actual_start_at: start_time, actual_end_at: start_time + 1.hour
-        expect(OrderDetail.in_progress_reservations).to be_empty
+        expect(OrderDetail.with_in_progress_reservation).to be_empty
       end
     end
 


### PR DESCRIPTION
# Release Notes

Do not show canceled reservations on My Reservations screen

# Additional Context

The ticket mentions that problem reservations should not appear on this screen either; however, from what I can [see in the code](https://github.com/tablexi/nucore-open/blob/0be253c1abda99036b59acb249a4b8a644028e00/app/models/order_detail.rb#L896-L904) only completed reservations can be problematic. Since completed reservations do not appear on the My Reservations screen (which shows only upcoming and in-progress reservations), there was nothing to be done there.