### PR TITLE
[#139184] Exclude inactive/archived products from available accessories

### DIFF
--- a/app/controllers/product_accessories_controller.rb
+++ b/app/controllers/product_accessories_controller.rb
@@ -45,9 +45,9 @@ class ProductAccessoriesController < ApplicationController
   end
 
   def set_available_accessories
-    # Already set as an accessory, or is this instrument
+    # Exclude already included accessories as well as the current product.
     non_available_accessories = [@product.id] + Array(@product_accessories).map(&:accessory_id)
-    @available_accessories = current_facility.products.accessorizable.exclude(non_available_accessories).order(:name)
+    @available_accessories = current_facility.products.accessorizable.active.exclude(non_available_accessories).order(:name)
   end
 
 end

--- a/spec/controllers/product_accessories_controller_spec.rb
+++ b/spec/controllers/product_accessories_controller_spec.rb
@@ -18,9 +18,8 @@ RSpec.describe ProductAccessoriesController do
 
   describe "index" do
     let!(:unchosen_accessory) { FactoryBot.create(:setup_item, facility: facility) }
-    let!(:bundle) do
-      FactoryBot.create(:bundle, facility: facility)
-    end
+    let!(:inactive_product) { FactoryBot.create(:setup_item, is_archived: true, facility: facility)}   
+    let!(:bundle) { FactoryBot.create(:bundle, facility: facility) }
 
     before :each do
       @method = :get
@@ -52,6 +51,10 @@ RSpec.describe ProductAccessoriesController do
 
       it "does not include the bundle" do
         expect(assigns(:available_accessories)).not_to include(bundle)
+      end
+
+      it "does not include inactive products" do
+        expect(assigns(:available_accessories)).not_to include(inactive_product)
       end
     end
 

--- a/spec/controllers/product_accessories_controller_spec.rb
+++ b/spec/controllers/product_accessories_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ProductAccessoriesController do
 
   describe "index" do
     let!(:unchosen_accessory) { FactoryBot.create(:setup_item, facility: facility) }
-    let!(:inactive_product) { FactoryBot.create(:setup_item, is_archived: true, facility: facility)}   
+    let!(:inactive_product) { FactoryBot.create(:setup_item, is_archived: true, facility: facility) }
     let!(:bundle) { FactoryBot.create(:bundle, facility: facility) }
 
     before :each do


### PR DESCRIPTION
# Release Notes

Exclude archived, aka inactive, products from the available accessory dropdown within instrument management.

# Screenshot

Within this dropdown:

![screen shot 2018-06-18 at 1 08 08 pm](https://user-images.githubusercontent.com/1099111/41553866-ad203980-72f8-11e8-8b1d-6a10b66106a8.png)
