### PR TITLE
[#139276] Add extra interpolation params to new user email

### DIFF
--- a/app/views/notifier/new_user.html.haml
+++ b/app/views/notifier/new_user.html.haml
@@ -1,6 +1,5 @@
 = html("intro_html", first_name: @user.first_name, last_name: @user.last_name, login_url: new_user_session_url)
 
-- binding.pry
 - if @password
   = html("username_and_password_html", username: @user.username, password: @password, login_url: new_user_session_url)
 - else

--- a/app/views/notifier/new_user.html.haml
+++ b/app/views/notifier/new_user.html.haml
@@ -1,8 +1,9 @@
-= html(".intro_html", first_name: @user.first_name, last_name: @user.last_name, login_url: new_user_session_url)
+= html("intro_html", first_name: @user.first_name, last_name: @user.last_name, login_url: new_user_session_url)
 
+- binding.pry
 - if @password
-  = html(".username_and_password_html", username: @user.username, password: @password)
+  = html("username_and_password_html", username: @user.username, password: @password, login_url: new_user_session_url)
 - else
-  = html(".only_username_html", username: @user.username)
+  = html("only_username_html", username: @user.username, login_url: new_user_session_url)
 
-= html(".outro_html")
+= html("outro_html")

--- a/app/views/notifier/new_user.text.erb
+++ b/app/views/notifier/new_user.text.erb
@@ -1,10 +1,10 @@
-<%= text(".intro_text", first_name: @user.first_name, last_name: @user.last_name, login_url: new_user_session_url) %>
+<%= text("intro_text", first_name: @user.first_name, last_name: @user.last_name, login_url: new_user_session_url) %>
 
 <% # non-standard indentation below is to prevent indents appearing in the text formatting of this email %>
 <% if @password %>
-<%= text(".username_and_password_text", username: @user.username, password: @password) %>
+<%= text("username_and_password_text", username: @user.username, password: @password, login_url: new_user_session_url) %>
 <% else %>
-<%= text(".only_username_text", username: @user.username) %>
+<%= text("only_username_text", username: @user.username, login_url: new_user_session_url) %>
 <% end %>
 
-<%= text(".outro_text") %>
+<%= text("outro_text") %>


### PR DESCRIPTION
# Release Notes

Add additional interpolation values into new user email for use in NU's updated message.

# Notes

Companion to NU's https://github.com/tablexi/nucore-nu/pull/386 

I considered doing further refactoring/cleanup (there's a lot of duplication between the text and html version), but I didn't want to affect DC, who also overrides this email.
