### PR TITLE
Remove method Reservations::RelaySupport#can_kill_power?

### DIFF
--- a/app/support/reservations/relay_support.rb
+++ b/app/support/reservations/relay_support.rb
@@ -25,13 +25,6 @@ module Reservations::RelaySupport
     can_switch_instrument_off? || can_switch_instrument_on?
   end
 
-  def can_kill_power?
-    return false if actual_start_at.nil?
-    return false if Reservation.where("actual_start_at > ? AND product_id = ? AND id <> ? AND actual_end_at IS NULL", actual_start_at, product_id, id).present?
-    true
-  end
-  deprecate can_kill_power?: "Most likely not used anywhere"
-
   def other_reservations_using_relay
     order_detail.reservation.product.schedule.reservations
                 .active


### PR DESCRIPTION
# Release Notes

TECH TASK: Remove method Reservations::RelaySupport#can_kill_power?

# Additional Context

The method was [deprecated over 5 years ago](https://github.com/tablexi/nucore-open/commit/5e24403a6dcbd640ee560542970ae3928beea92f#diff-b39c6bac92522dc31e5c571520c942faR30), and it is not used anywhere.