### PR TITLE
[#139111] Only show reservations with state new or inprocess in My Reservations

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -134,12 +134,7 @@ class OrderDetail < ApplicationRecord
 
   scope :by_ordered_at, -> { joins(:order).order("orders.ordered_at DESC") }
   scope :batch_updatable, -> { where(dispute_at: nil, state: %w(new inprocess)) }
-  scope :new_or_inprocess, lambda {
-    where(state: %w(new inprocess))
-      .joins(:order)
-      .merge(Order.purchased)
-  }
-
+  scope :new_or_inprocess, -> { purchased.where(state: %w(new inprocess)) }
   scope :non_canceled, -> { where.not(state: "canceled") }
 
   def self.for_facility(facility)

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -281,12 +281,12 @@ class OrderDetail < ApplicationRecord
 
   scope :with_reservation, -> { purchased.joins(:reservation).order("reservations.reserve_start_at DESC") }
   scope :with_upcoming_reservation, lambda {
-    non_canceled
+    new_or_inprocess
       .with_reservation
       .where(reservations: { actual_start_at: nil })
       .merge(Reservation.ends_in_the_future)
   }
-  scope :with_in_progress_reservation, -> { non_canceled.with_reservation.merge(Reservation.relay_in_progress) }
+  scope :with_in_progress_reservation, -> { new_or_inprocess.with_reservation.merge(Reservation.relay_in_progress) }
 
   scope :for_accounts, ->(accounts) { where("order_details.account_id in (?)", accounts) unless accounts.nil? || accounts.empty? }
   scope :for_facilities, ->(facilities) { joins(:order).where("orders.facility_id in (?)", facilities) unless facilities.nil? || facilities.empty? }

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -1856,10 +1856,15 @@ RSpec.describe OrderDetail do
   describe ".with_upcoming_reservation" do
     before do
       place_reservation facility, order_detail, 48.hours.from_now, reserve_end_at: 49.hours.from_now
-      order_detail.cancel_reservation(user, admin: true)
     end
 
     it "does not include canceled order details" do
+      order_detail.cancel_reservation(user, admin: true)
+      expect(OrderDetail.with_upcoming_reservation).not_to include(order_detail)
+    end
+
+    it "does not include order details canceled with a cost" do
+      order_detail.update!(state: "complete", canceled_at: 5.minutes.ago)
       expect(OrderDetail.with_upcoming_reservation).not_to include(order_detail)
     end
   end
@@ -1867,11 +1872,11 @@ RSpec.describe OrderDetail do
   describe ".with_in_progress_reservation" do
     before do
       place_reservation facility, order_detail, 10.minutes.ago, actual_start_at: 10.minutes.ago, reserve_end_at: 50.minutes.from_now
-      order_detail.cancel_reservation(user, admin: true)
     end
 
-    it "does not include canceled order details" do
-      expect(OrderDetail.with_in_progress_reservation).not_to include(order_detail)
+    it "does not include order details canceled with a cost" do
+      order_detail.update!(state: "complete", canceled_at: 5.minutes.ago)
+      expect(OrderDetail.with_upcoming_reservation).not_to include(order_detail)
     end
   end
 end


### PR DESCRIPTION
# Release Notes

Only show reservations with state new or inprocess reservations in My Reservations

# Additional Context

After #1591, reservations that are canceled with a cost continued to appear in My Reservations, since these have a state of `completed` along with a `canceled_at` timestamp. Since we only want new or in-progress reservations, it is more direct and simpler to filter asking for those, instead of filter to reject canceled (or any other states that we don’t want).