### PR TITLE
#8 Create product listing quick purchase links

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -157,6 +157,13 @@ li.nav-spacer {
   }
 }
 
+.product_listing{
+  display: flex;
+}
+.product_listing .add_to_cart{
+  margin-left: 5px;
+}
+
 /*
   Product View
 */

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -10,17 +10,29 @@
     %ul
       - indent_for_icon = products.any? { |p| p.respond_to? :reservations }
       - products.sort.each do |product|
-        %li{ class: product.class.model_name.to_s.downcase }
-          - if local_assigns[:f]
-            = f.fields_for :order_details do |builder|
-              - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
-                = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
-                = builder.hidden_field :product_id, value: product.id, index: nil
-          = public_calendar_link(product, indent: indent_for_icon)
-          = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product)
-          - if acting_user.present? && !product.can_be_used_by?(acting_user)
-            %i.fa.fa-lock
-            = " (#{product.class.human_attribute_name(:requires_approval_show)})"
+        .product_listing
+          %li{ class: product.class.model_name.to_s.downcase }
+            - if local_assigns[:f]
+              = f.fields_for :order_details do |builder|
+                - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
+                  = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
+                  = builder.hidden_field :product_id, value: product.id, index: nil
+                  
+            = public_calendar_link(product, indent: indent_for_icon)
+            = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product)
+            - if acting_user.present? && !product.can_be_used_by?(acting_user)
+              %i.fa.fa-lock
+              = " (#{product.class.human_attribute_name(:requires_approval_show)})"
 
-          - if product.offline?
-            = tooltip_icon "fa fa-exclamation-triangle icon-large", t("instruments.offline.note")
+            - if product.offline?
+              = tooltip_icon "fa fa-exclamation-triangle icon-large", t("instruments.offline.note")
+          %li{class: 'add_to_cart' }
+            - if not session_user
+              = link_to "Add to cart (requires login)", new_user_session_path
+            - elsif session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
+              - if not session_user.accounts.empty?
+                = link_to "Add to cart", add_order_path(acting_user.cart(session_user), order: {order_details: [{product_id: product.id, quantity: 1}] }), method: :put
+              - else
+                No payment source
+            - else
+              Cannot purchase


### PR DESCRIPTION
# Release Notes

Created a quick link next to facility sub-products to add each product to the cart. This link skips multiple clicks that would otherwise be necessary.

# Screenshot

![image](https://user-images.githubusercontent.com/5000430/41792739-da39f852-7627-11e8-8cea-4974e81fa4e3.png)

## Not logged in
![image](https://user-images.githubusercontent.com/5000430/41792634-8353529a-7627-11e8-85fc-16f433381dc3.png)
When a user is not logged in, the add to cart will take them to login. Note this will redirect back to facility page after successful login.

## No payment source (admin)
![image](https://user-images.githubusercontent.com/5000430/41792692-b5f93868-7627-11e8-8d95-7e81c1b9c617.png)
If the user has no payment source, the link will become text that reflects this.

## No permission

If for some reason none of the above apply, such as if the user doesn't have permission for a specific facility, it will say "Cannot purchase"


