### PR TITLE
[#140359] Fix SAML logout link error

### DIFF
--- a/vendor/engines/saml_authentication/app/controllers/saml_authentication/sessions_controller.rb
+++ b/vendor/engines/saml_authentication/app/controllers/saml_authentication/sessions_controller.rb
@@ -68,7 +68,7 @@ module SamlAuthentication
     # This will be used to choose which Logout link is shown to the user.
     # https://github.com/apokalipto/devise_saml_authenticatable/wiki/Supporting-multiple-authentication-strategies
     def store_winning_strategy
-      warden.session(resource_name)[:strategy] = warden.winning_strategies[resource_name].class.name.demodulize.underscore.to_sym
+      warden.session(resource_name)[:strategy] = "saml_authenticatable"
     end
 
   end


### PR DESCRIPTION
# Release Notes

Fix error on logout link when signed in via SSO.

# Additional Context

```
ActionView::Template::Error: undefined method `destroy_saml_authenticatable_with_custom_error_user_session_path
```

Broken after #1589 changed the strategy name to "saml_authenticatable_with_custom_error",
which causes a mismatch with the route. The old version is probably overly general. Within this controller, the winning strategy should always we `saml_authenticatable`.

