### PR TITLE
[#73295] Filter sub-statuses of Canceled to current facility

### DIFF
--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -100,7 +100,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
       @order_statuses = [OrderStatus.complete, OrderStatus.canceled]
       @order_statuses << OrderStatus.reconciled if @order_detail.can_reconcile?
     elsif @order_detail.order_status.root == OrderStatus.canceled
-      @order_statuses = OrderStatus.canceled.self_and_descendants
+      @order_statuses = OrderStatus.canceled.self_and_descendants.for_facility(current_facility)
     else
       @order_statuses = OrderStatus.non_protected_statuses(current_facility)
     end


### PR DESCRIPTION
# Release Notes

Filter sub-statuses of Canceled to current facility in the order detail modal.

# Additional Context

When an order is canceled, the order status dropdown was including all sub-statuses of Canceled, even across facilities. This filters to only the current facility.
