### PR TITLE
Fix delegation on UserForm caused by simple_form 3.5.1

### DIFF
--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -2,6 +2,14 @@ class UserForm < SimpleDelegator
 
   include ActiveModel::Validations
 
+  def model_name
+    ActiveModel::Name.new(user.class)
+  end
+
+  def to_model
+    self
+  end
+
   def user
     __getobj__
   end


### PR DESCRIPTION
# Release Notes

Fix delegation on UserForm caused by simple_form 3.5.1. This will fix downstream forks that use custom UserForms.

# Additional Context

See #1410 for what we did to fix this on other forms. The form was being rendered
with the `User` as the form object, not the `UserForm` so any custom errors or
I18n were lost.

There will be a PR for Dartmouth coming soon.
