### PR TITLE
[#142184] Allow clickable links in failure message for SAML sign-in

### DIFF
--- a/vendor/engines/saml_authentication/lib/saml_authentication/saml_authenticatable_with_custom_error.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/saml_authenticatable_with_custom_error.rb
@@ -21,7 +21,7 @@ module Devise
       # failure message for authentication via SAML.
       def failed_auth(msg)
         DeviseSamlAuthenticatable::Logger.send(msg)
-        fail!(:saml_invalid)
+        fail!(I18n.t("devise.failure.saml_invalid").html_safe)
         Devise.saml_failed_callback.new.handle(@response, self) if Devise.saml_failed_callback # rubocop:disable Style/SafeNavigation
       end
 

--- a/vendor/engines/saml_authentication/spec/controllers/saml_authentication/sessions_controller_spec.rb
+++ b/vendor/engines/saml_authentication/spec/controllers/saml_authentication/sessions_controller_spec.rb
@@ -81,6 +81,11 @@ RSpec.describe SamlAuthentication::SessionsController, type: :controller do
         post :create, SAMLResponse: saml_response
         expect(flash[:alert]).to eq(I18n.t("devise.failure.saml_invalid"))
       end
+
+      it "marks the message in :saml_invalid as html_safe to allow including links" do
+        post :create, SAMLResponse: saml_response
+        expect(flash[:alert].html_safe?).to be true
+      end
     end
 
     describe "an email-based user exists" do


### PR DESCRIPTION
# Release Notes

Allow clickable links in failure message for SAML sign-in

# Additional Context

If `fail!` is used with a symbol, Devise performs its own `I18n.t` lookup, which is not marked as `html_safe`. If the argument is a string, it only calls `to_s` on it, so we take advantage of that code path to pass in our own html-safe string.