### PR TITLE
[#142643] Rake task for new price polices in the current fiscal year

### DIFF
--- a/lib/tasks/price_policies.rake
+++ b/lib/tasks/price_policies.rake
@@ -1,7 +1,7 @@
 namespace :price_policies do
 
   desc "Duplicate the newest price policies for a facility's services to the current fiscal year"
-  task :duplicate_to_current_fiscal_year, [:url_name] => :environment do |t, args|
+  task :duplicate_to_current_fiscal_year, [:url_name] => :environment do |_t, args|
     facility = Facility.find_by!(url_name: args[:url_name])
 
     facility.services.active.each do |service|

--- a/lib/tasks/price_policies.rake
+++ b/lib/tasks/price_policies.rake
@@ -1,0 +1,19 @@
+namespace :price_policies do
+
+  desc "Duplicate the newest price policies for a facility's services to the current fiscal year"
+  task :duplicate_to_current_fiscal_year, [:url_name] => :environment do |t, args|
+    facility = Facility.find_by!(url_name: args[:url_name])
+
+    facility.services.active.each do |service|
+      service.price_policies.newest.each do |price_policy|
+        next unless price_policy.expired? # Don't duplicate a current policy
+
+        new_price_policy = price_policy.dup
+        new_price_policy.start_date = SettingsHelper.fiscal_year_beginning
+        new_price_policy.expire_date = SettingsHelper.fiscal_year_end
+        new_price_policy.save!
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
# Release Notes

Add a rake task for copying the all service price policies from the previous fiscal year into the current fiscal year.

# Additional Context

UIC has a facility with 200+ services. They requested that all of the
price policies be extended to 06/30/2019 (the end of the next fiscal
year). Since price policies are not allowed to span fiscal years in
NUcore, this makes new copies with the requested dates.
