### PR TITLE
[#133717] [#142698] Notify users on dispute resolution

### DIFF
--- a/app/mailers/order_detail_dispute_mailer.rb
+++ b/app/mailers/order_detail_dispute_mailer.rb
@@ -1,0 +1,22 @@
+class OrderDetailDisputeMailer < BaseMailer
+
+  add_template_helper DateHelper
+
+  def dispute_resolved(order_detail:, user:)
+    @order_detail = order_detail
+    @user = user
+    mail(
+      to: @user.email,
+      subject: text("subject",
+        facility_abbreviation: @order_detail.facility.abbreviation,
+      )
+    )
+  end
+
+  protected
+
+  def translation_scope
+    "views.order_detail_dispute_mailer.dispute_resolved"
+  end
+
+end

--- a/app/mailers/order_detail_dispute_mailer.rb
+++ b/app/mailers/order_detail_dispute_mailer.rb
@@ -8,8 +8,8 @@ class OrderDetailDisputeMailer < BaseMailer
     mail(
       to: @user.email,
       subject: text("subject",
-        facility_abbreviation: @order_detail.facility.abbreviation,
-      )
+                    facility_abbreviation: @order_detail.facility.abbreviation,
+                   ),
     )
   end
 

--- a/app/mailers/order_detail_dispute_mailer.rb
+++ b/app/mailers/order_detail_dispute_mailer.rb
@@ -7,9 +7,7 @@ class OrderDetailDisputeMailer < BaseMailer
     @user = user
     mail(
       to: @user.email,
-      subject: text("subject",
-                    facility_abbreviation: @order_detail.facility.abbreviation,
-                   ),
+      subject: text("subject", facility_abbreviation: @order_detail.facility.abbreviation),
     )
   end
 

--- a/app/services/order_details/assignment_notifier.rb
+++ b/app/services/order_details/assignment_notifier.rb
@@ -1,0 +1,19 @@
+module OrderDetails
+
+  class AssignmentNotifier < SimpleDelegator
+
+    def notify
+      if SettingsHelper.feature_on?(:order_assignment_notifications) && assigned_user_changed?
+        OrderAssignmentMailer.notify_assigned_user(self).deliver_now
+      end
+    end
+
+    private
+
+    def assigned_user_changed?
+      assigned_user_id_previously_changed? && assigned_user.present?
+    end
+
+  end
+
+end

--- a/app/services/order_details/assignment_notifier.rb
+++ b/app/services/order_details/assignment_notifier.rb
@@ -4,7 +4,7 @@ module OrderDetails
 
     def notify
       if SettingsHelper.feature_on?(:order_assignment_notifications) && assigned_user_changed?
-        OrderAssignmentMailer.notify_assigned_user(self).deliver_now
+        OrderAssignmentMailer.notify_assigned_user(__getobj__).deliver_later
       end
     end
 

--- a/app/services/order_details/dispute_resolved_notifier.rb
+++ b/app/services/order_details/dispute_resolved_notifier.rb
@@ -6,7 +6,7 @@ module OrderDetails
       if dispute_resolved_at_previously_changed? && dispute_resolved_at_previously_was.blank?
 
         users_to_notify.each do |user|
-          OrderDetailDisputeMailer.dispute_resolved(order_detail: self, user: user).deliver_now
+          OrderDetailDisputeMailer.dispute_resolved(order_detail: __getobj__, user: user).deliver_later
         end
       end
     end
@@ -14,7 +14,7 @@ module OrderDetails
     private
 
     def users_to_notify
-      ([dispute_by] + account.administrators).uniq
+      ([dispute_by] + account.administrators).uniq.compact
     end
 
     def dispute_resolved_at_previously_was

--- a/app/services/order_details/dispute_resolved_notifier.rb
+++ b/app/services/order_details/dispute_resolved_notifier.rb
@@ -1,0 +1,26 @@
+module OrderDetails
+
+  class DisputeResolvedNotifier < SimpleDelegator
+
+    def notify
+      if dispute_resolved_at_previously_changed? && dispute_resolved_at_previously_was.blank?
+
+        users_to_notify.each do |user|
+          OrderDetailDisputeMailer.dispute_resolved(order_detail: self, user: user).deliver_now
+        end
+      end
+    end
+
+    private
+
+    def users_to_notify
+      ([dispute_by] + account.administrators).uniq
+    end
+
+    def dispute_resolved_at_previously_was
+      previous_changes[:dispute_resolved_at].first
+    end
+
+  end
+
+end

--- a/app/services/order_details/dispute_resolved_notifier.rb
+++ b/app/services/order_details/dispute_resolved_notifier.rb
@@ -14,7 +14,7 @@ module OrderDetails
     private
 
     def users_to_notify
-      ([dispute_by] + account.administrators).uniq.compact
+      ([dispute_by] + account.administrators).compact.uniq
     end
 
     def dispute_resolved_at_previously_was

--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -69,9 +69,9 @@ class OrderDetails::ParamUpdater
       end
     end
     merge_reservation_errors if @order_detail.reservation.present?
-    trigger_notifications if order_detail_clean?
+    trigger_notifications if @order_detail.errors.none?
 
-    order_detail_clean?
+    @order_detail.errors.none?
   end
 
   def trigger_notifications
@@ -131,10 +131,6 @@ class OrderDetails::ParamUpdater
       field = Reservation.human_attribute_name(field) if field != :base
       @order_detail.errors.add(field, message)
     end
-  end
-
-  def order_detail_clean?
-    @order_detail.errors.none?
   end
 
 end

--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -130,10 +130,10 @@ class OrderDetails::ParamUpdater
     @order_detail.reservation.errors.each do |field, message|
       field = Reservation.human_attribute_name(field) if field != :base
       @order_detail.errors.add(field, message)
-        end
+    end
   end
 
-   def order_detail_clean?
+  def order_detail_clean?
     @order_detail.errors.none?
   end
 

--- a/app/views/order_detail_dispute_mailer/dispute_resolved.html.haml
+++ b/app/views/order_detail_dispute_mailer/dispute_resolved.html.haml
@@ -1,0 +1,9 @@
+= html("body",
+  user: @user,
+  facility: @order_detail.facility.name,
+  order_detail: @order_detail,
+  order_detail_link: order_order_detail_url(@order_detail.order, @order_detail),
+  dispute_resolved_at: format_usa_date(@order_detail.dispute_resolved_at),
+  dispute_resolved_reason: @order_detail.dispute_resolved_reason,
+  facility_email: @order_detail.facility.email,
+  )

--- a/app/views/order_detail_dispute_mailer/dispute_resolved.text.erb
+++ b/app/views/order_detail_dispute_mailer/dispute_resolved.text.erb
@@ -1,0 +1,10 @@
+<%= text("body",
+  user: @user,
+  facility: @order_detail.facility.name,
+  order_detail: @order_detail,
+  order_detail_link: order_order_detail_url(@order_detail.order, @order_detail),
+  dispute_resolved_at: format_usa_date(@order_detail.dispute_resolved_at),
+  dispute_resolved_reason: @order_detail.dispute_resolved_reason,
+  facility_email: @order_detail.facility.email,
+  ).gsub("<br>", "")
+%>

--- a/config/locales/views/en.order_detail_dispute_mailer.yml
+++ b/config/locales/views/en.order_detail_dispute_mailer.yml
@@ -1,0 +1,21 @@
+en:
+  views:
+    order_detail_dispute_mailer:
+        dispute_resolved:
+          subject: "!app_name! Dispute Resolved: %{facility_abbreviation}"
+          body: |
+            Dear %{user},
+
+            Based on information provided, the %{facility} has resolved the following
+            disputed order in !app_name!:
+
+            Order Number: [#%{order_detail}](%{order_detail_link})<br>
+            Resolution Date: %{dispute_resolved_at}<br>
+            Resolution Note: %{dispute_resolved_reason}
+
+            The order will be billed against its designated payment source shortly.
+            Please [contact the %{facility}](mailto:%{facility_email}) if you have any questions.
+
+            Thank you,
+
+            %{facility}

--- a/config/locales/views/en.order_detail_dispute_mailer.yml
+++ b/config/locales/views/en.order_detail_dispute_mailer.yml
@@ -2,7 +2,7 @@ en:
   views:
     order_detail_dispute_mailer:
         dispute_resolved:
-          subject: "!app_name! Dispute Resolved: %{facility_abbreviation}"
+          subject: "!app_name! Disputed Order Resolved: %{facility_abbreviation}"
           body: |
             Dear %{user},
 

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -792,8 +792,8 @@ RSpec.describe OrderManagement::OrderDetailsController, feature_setting: { price
               it "triggers an email to the dispute by and the account owner" do
                 expect { do_request }.to change { ActionMailer::Base.deliveries.map(&:to) }
                   .by(containing_exactly(
-                    [dispute_by.email],
-                    [order_detail.account.owner_user.email]
+                        [dispute_by.email],
+                        [order_detail.account.owner_user.email],
                   ))
               end
 

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -755,7 +755,7 @@ RSpec.describe OrderManagement::OrderDetailsController, feature_setting: { price
           end
         end
 
-        describe "resolving dispute", :mail_deliveries do
+        describe "resolving dispute" do
           let(:dispute_by) { create(:user, :facility_director, facility: facility) }
 
           before do

--- a/spec/factories/order_details.rb
+++ b/spec/factories/order_details.rb
@@ -16,6 +16,14 @@ FactoryBot.define do
       canceled_at { 30.minutes.ago }
       actual_cost 5
     end
+
+    trait :disputed do
+      completed
+      reviewed_at { 5.days.ago }
+      dispute_at { 3.days.ago }
+      association :dispute_by, factory: :user
+      dispute_reason "No, sir. I don't like it."
+    end
   end
 
 end

--- a/spec/mailers/previews/order_detail_dispute_mailer_preview.rb
+++ b/spec/mailers/previews/order_detail_dispute_mailer_preview.rb
@@ -1,0 +1,8 @@
+class OrderDetailDisputeMailerPreview < ActionMailer::Preview
+
+  def dispute_resolved
+    order_detail = NUCore::Database.random(OrderDetail.where.not(dispute_resolved_at: nil))
+    OrderDetailDisputeMailer.dispute_resolved(order_detail: order_detail, user: order_detail.user)
+  end
+
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -102,6 +102,13 @@ RSpec.configure do |config|
 
   config.after(:all) { travel_back }
 
+  # Use when writing tests that depend on checking for mail deliveries
+  config.around(:each, :mail_deliveries) do |example|
+    ActionMailer::Base.deliveries.clear
+    example.call
+    ActionMailer::Base.deliveries.clear
+  end
+
   # rspec-rails 3 will no longer automatically infer an example group's spec type
   # from the file location. You can explicitly opt-in to the feature using this
   # config option.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -102,13 +102,6 @@ RSpec.configure do |config|
 
   config.after(:all) { travel_back }
 
-  # Use when writing tests that depend on checking for mail deliveries
-  config.around(:each, :mail_deliveries) do |example|
-    ActionMailer::Base.deliveries.clear
-    example.call
-    ActionMailer::Base.deliveries.clear
-  end
-
   # rspec-rails 3 will no longer automatically infer an example group's spec type
   # from the file location. You can explicitly opt-in to the feature using this
   # config option.

--- a/spec/services/order_details/dispute_resolved_notifier_spec.rb
+++ b/spec/services/order_details/dispute_resolved_notifier_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe OrderDetails::DisputeResolvedNotifier do
+  let(:item) { create(:setup_item) }
+  let(:order) { create(:complete_order, product: item) }
+  let(:order_detail) { create(:order_detail, :disputed, order: order, product: item, account: order.account) }
+  subject(:notifier) { described_class.new(order_detail) }
+
+  def resolve_dispute_and_notify
+    order_detail.update!(dispute_resolved_at: Time.current, dispute_resolved_reason: "resolved")
+    notifier.notify
+  end
+
+  it "does not notify on a clean object" do
+    expect { notifier.notify }.not_to change(ActionMailer::Base, :deliveries)
+  end
+
+  it "triggers an email if the resolved at moves from blank to present" do
+    expect { resolve_dispute_and_notify }.to change(ActionMailer::Base, :deliveries)
+  end
+
+  it "does not trigger an email if the resolve changes" do
+    order_detail.update!(dispute_resolved_at: Time.current, dispute_resolved_reason: "resolved")
+    order_detail.clear_changes_information
+
+    expect { resolve_dispute_and_notify }.not_to change(ActionMailer::Base, :deliveries)
+  end
+
+  context "with a business business_administrator" do
+    let!(:business_administrator) { create(:user, :business_administrator, email: "ba@example.com", account: order_detail.account) }
+
+    it "triggers an email to the dispute_by and the account administrators" do
+      expect { resolve_dispute_and_notify }.to change { ActionMailer::Base.deliveries.map(&:to) }
+        .by(containing_exactly(
+          [order_detail.dispute_by.email],
+          [order_detail.account.owner_user.email],
+          [business_administrator.email],
+        ))
+    end
+  end
+
+end

--- a/spec/services/order_details/dispute_resolved_notifier_spec.rb
+++ b/spec/services/order_details/dispute_resolved_notifier_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe OrderDetails::DisputeResolvedNotifier do
     it "triggers an email to the dispute_by and the account administrators" do
       expect { resolve_dispute_and_notify }.to change { ActionMailer::Base.deliveries.map(&:to) }
         .by(containing_exactly(
-          [order_detail.dispute_by.email],
-          [order_detail.account.owner_user.email],
-          [business_administrator.email],
+              [order_detail.dispute_by.email],
+              [order_detail.account.owner_user.email],
+              [business_administrator.email],
         ))
     end
   end


### PR DESCRIPTION
# Release Notes

[#133717] When a dispute is resolved, send an email to the user who disputed the charges as well as the owner and business administrators of the order's account.

[#142698] Do not trigger email notifications to assigned users when the save is not successful (open/UIC only)

# Additional Context

I discovered the assigned user issue as I was working on the dispute notification and the refactoring idea I had applied to it as well, so I lumped them together. The order assignment notification feature is currently disabled on NU & Dartmouth but is enabled in open and UIC.

See see https://github.com/tablexi/nucore-open/pull/86 for the original order notification feature.

## How to reproduce assigned user issue
* Open the order detail in the popup
* Change the assigned user
* Do something to make the form invalid (clearing out the price field for example)
* Click "Save", you should see an error message like "is not a valid number"
* Close and reopen the modal for that order
* The old value for the assigned user should be selected
* The user you attempted to change the assignment to will have received an email
