### PR TITLE
Fix spec broken when training request feature is disabled

### DIFF
--- a/spec/models/product_for_cart_spec.rb
+++ b/spec/models/product_for_cart_spec.rb
@@ -69,8 +69,7 @@ RSpec.describe ProductForCart do
         allow(SettingsHelper).to receive(:feature_on?).and_return(true)
       end
 
-      context "and training requests are turned on" do
-        before(:each) { allow(SettingsHelper).to receive(:feature_on?).with(:training_requests).and_return(true) }
+      context "and training requests are turned on", feature_setting: { training_requests: true } do
 
         context "and the user has already submitted a training request" do
           before(:each) { allow(TrainingRequest).to receive(:submitted?).and_return(true) }


### PR DESCRIPTION
# Release Notes

TECH TASK: When the feature is disabled, the route is not available.

# Error message

```
NoMethodError:
       undefined method `new_facility_product_training_request_path' for #<Module:0x007fbeaaca4f98>
       Did you mean?  new_facility_instrument_product_access_group_path
     # ./app/models/product_for_cart.rb:66:in `block in check_that_product_can_be_used'
     # ./app/models/product_for_cart.rb:16:in `block in purchasable_by?'
     # ./app/models/product_for_cart.rb:15:in `each'
     # ./app/models/product_for_cart.rb:15:in `all?'
     # ./app/models/product_for_cart.rb:15:in `purchasable_by?'
     # ./spec/models/product_for_cart_spec.rb:93:in `block (6 levels) in <top (required)>'
```