### PR TITLE
Fix Circle 2.0 coverage reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,19 +59,19 @@ jobs:
               --suppress-log \
               --format junit > /tmp/test-results/teaspoon.xml
 
+      # Save artifacts
+      - store_test_results:
+          path: /tmp/test-results
+
       - store_artifacts:
          path: coverage/.resultset.json
          prefix: coverage
 
-      - run: bundle exec report_coverage
-
-      # Save artifacts
-      - type: store_test_results
-        path: /tmp/test-results
+      # - run: bundle exec report_coverage
 
       - deploy:
-          name: Stage deploy of develop branch
+          name: Stage deploy of master branch
           command: |
-              if [ "${CIRCLE_BRANCH}" == "develop" ]; then
+              if [ "${CIRCLE_BRANCH}" == "master" ]; then
                 bundle exec cap staging deploy
               fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2
 jobs:
   build:
     parallelism: 4
-    working_directory: ~/nucore
     docker:
       - image: circleci/ruby:2.4.1-node-browsers
         environment:
@@ -67,7 +66,7 @@ jobs:
          path: coverage/.resultset.json
          prefix: coverage
 
-      # - run: bundle exec report_coverage
+      - run: bundle exec report_coverage
 
       - deploy:
           name: Stage deploy of master branch


### PR DESCRIPTION
# Release Notes

Tech task: (Hopefully) fix coverage report sending to CodeClimate. Also, fix stage deployment branch name. Also reorders some steps and fixes an indentation error.

## Additional notes

Related to #1626. Looking at the codeclimate_circle_ci_coverage gem, it looks like it doesn't play well if you have a working directory since it looks in `home/circleci/project/#{ARTIFACT_PREFIX}/.resultset.json"`. See https://github.com/rdunlop/codeclimate_circle_ci_coverage/blob/master/lib/codeclimate_circle_ci_coverage/circle_ci_2.rb

See https://github.com/rdunlop/codeclimate_circle_ci_coverage/issues/8

If this doesn't work, then we can just comment it out for now.


