### PR TITLE
Fix SecureRooms migration

### DIFF
--- a/vendor/engines/secure_rooms/db/migrate/20170405182534_add_tablet_token_to_card_readers.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170405182534_add_tablet_token_to_card_readers.rb
@@ -1,6 +1,6 @@
 class AddTabletTokenToCardReaders < ActiveRecord::Migration
 
-  class SecureRooms::CardReader < ActiveRecord::Base
+  class SecureRooms::CardReader < ApplicationRecord
   end
 
   def change


### PR DESCRIPTION
# Release Notes

Tech task: Fix SecureRooms migration.

# Additional Context

The superclass of SecureRooms::CardReader in the migration needs to match the
superclass of the app class. We had originally run this migration on NU's stage
before the change to ApplicationRecord. Now that we're trying to deploy to production,
the migration is failing.


