### PR TITLE
Remove timezone setting from circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ jobs:
         environment:
           - RAILS_ENV: "test"
           - MYSQL_USER: root
-          - TZ: "/usr/share/zoneinfo/America/Chicago"
       - image: circleci/mysql:5.7.22-ram
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: "yes"


### PR DESCRIPTION
# Release Notes

Tech task: Remove timezone setting from circle configuration.

# Additional Context

On a whim, I decided to test this out. So far, looking good. I want to kick it off one more time in the  it's today here, but tomorrow in UTC.
