### PR TITLE
Both quicklink

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -157,6 +157,13 @@ li.nav-spacer {
   }
 }
 
+.product_listing{
+  display: flex;
+}
+.product_listing .add_to_cart{
+  margin-left: 5px;
+}
+
 /*
   Product View
 */

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -157,13 +157,17 @@ li.nav-spacer {
   }
 }
 
-.product_listing{
+.quick_links {
   display: flex;
 }
-.product_listing .add_to_cart{
+
+.quick_links .add_to_cart {
   margin-left: 5px;
 }
 
+.quick_links .view_product {
+  margin-left: 5px;
+}
 /*
   Product View
 */

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -44,7 +44,6 @@ class FacilitiesController < ApplicationController
     @order_form = Order.new if acting_user && current_facility.accepts_multi_add?
     @active_tab = "home"
     set_column_class
-    set_quicklinks
     render layout: "application"
   end
 
@@ -255,8 +254,9 @@ class FacilitiesController < ApplicationController
     @columns = "columns" if SettingsHelper.feature_on?(:product_list_columns)
   end
 
-  def set_quicklinks
-    @quicklinks = SettingsHelper.feature_on?(:product_quicklinks)
+  def quicklinks?
+    SettingsHelper.feature_on?(:product_quicklinks)
   end
+  helper_method :quicklinks?
 
 end

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -44,6 +44,7 @@ class FacilitiesController < ApplicationController
     @order_form = Order.new if acting_user && current_facility.accepts_multi_add?
     @active_tab = "home"
     set_column_class
+    set_quicklinks
     render layout: "application"
   end
 
@@ -252,6 +253,10 @@ class FacilitiesController < ApplicationController
   def set_column_class
     @columns = ""
     @columns = "columns" if SettingsHelper.feature_on?(:product_list_columns)
+  end
+
+  def set_quicklinks
+    @quicklinks = SettingsHelper.feature_on?(:product_quicklinks)
   end
 
 end

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -11,7 +11,7 @@
       - indent_for_icon = products.any? { |p| p.respond_to? :reservations }
       - products.sort.each do |product|
         .product_listing
-          %li{ class: product.class.model_name.to_s.downcase }
+          %li{ class: product.class.model_name.to_s.downcase + '_title' }
             = product.name
             - if local_assigns[:f]
               = f.fields_for :order_details do |builder|
@@ -29,7 +29,7 @@
                   No payment source
               - else
                 Cannot purchase
-            .view_product
+            %li{class: [product.class.model_name.to_s.downcase, 'view_product']}
               = public_calendar_link(product, indent: indent_for_icon)
               = link_to 'View' + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product)
               - if acting_user.present? && !product.can_be_used_by?(acting_user)

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -10,17 +10,29 @@
     %ul
       - indent_for_icon = products.any? { |p| p.respond_to? :reservations }
       - products.sort.each do |product|
-        %li{ class: product.class.model_name.to_s.downcase }
-          - if local_assigns[:f]
-            = f.fields_for :order_details do |builder|
-              - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
-                = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
-                = builder.hidden_field :product_id, value: product.id, index: nil
-          = public_calendar_link(product, indent: indent_for_icon)
-          = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product)
-          - if acting_user.present? && !product.can_be_used_by?(acting_user)
-            %i.fa.fa-lock
-            = " (#{product.class.human_attribute_name(:requires_approval_show)})"
+        .product_listing
+          %li{ class: product.class.model_name.to_s.downcase }
+            - if local_assigns[:f]
+              = f.fields_for :order_details do |builder|
+                - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
+                  = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
+                  = builder.hidden_field :product_id, value: product.id, index: nil
+                  
+            = public_calendar_link(product, indent: indent_for_icon)
+            = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product)
+            - if acting_user.present? && !product.can_be_used_by?(acting_user)
+              %i.fa.fa-lock
+              = " (#{product.class.human_attribute_name(:requires_approval_show)})"
 
-          - if product.offline?
-            = tooltip_icon "fa fa-exclamation-triangle icon-large", t("instruments.offline.note")
+            - if product.offline?
+              = tooltip_icon "fa fa-exclamation-triangle icon-large", t("instruments.offline.note")
+          %li{class: 'add_to_cart' }
+            - if not session_user
+              = link_to "Add to cart (requires login)", new_user_session_path
+            - elsif session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
+              - if not session_user.accounts.empty?
+                = link_to "Add to cart", add_order_path(acting_user.cart(session_user), order: {order_details: [{product_id: product.id, quantity: 1}] }), method: :put
+              - else
+                No payment source
+            - else
+              Cannot purchase

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -10,16 +10,13 @@
     %ul
       - indent_for_icon = products.any? { |p| p.respond_to? :reservations }
       - products.sort.each do |product|
-        .product_listing
-          %li{ class: product.class.model_name.to_s.downcase + '_title' }
-            = product.name if quicklinks?
-            = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product), :id => product.name unless quicklinks?
-            - if local_assigns[:f]
-              = f.fields_for :order_details do |builder|
-                - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
-                  = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
-                  = builder.hidden_field :product_id, value: product.id, index: nil
-          - if quicklinks?
-            = render :partial => "facilities/quicklinks", locals: {product: product, indent_for_icon:indent_for_icon}
-          
-            
+        %li{ class: product.class.model_name.to_s.downcase + '_title' }
+          = product.name if quicklinks?
+          = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product), :id => product.name unless quicklinks?
+          - if local_assigns[:f]
+            = f.fields_for :order_details do |builder|
+              - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
+                = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
+                = builder.hidden_field :product_id, value: product.id, index: nil
+        - if quicklinks?
+          = render :partial => "facilities/quicklinks", locals: {product: product, indent_for_icon:indent_for_icon}

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -31,7 +31,7 @@
                 Cannot purchase
             %li{class: [product.class.model_name.to_s.downcase, 'view_product']}
               = public_calendar_link(product, indent: indent_for_icon)
-              = link_to 'View' + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product)
+              = link_to 'View' + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product), :id => product.name
               - if acting_user.present? && !product.can_be_used_by?(acting_user)
                 %i.fa.fa-lock
                 = " (#{product.class.human_attribute_name(:requires_approval_show)})"

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -12,14 +12,14 @@
       - products.sort.each do |product|
         .product_listing
           %li{ class: product.class.model_name.to_s.downcase + '_title' }
-            = product.name if @quicklinks
-            = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product), :id => product.name unless @quicklinks
+            = product.name if quicklinks?
+            = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product), :id => product.name unless quicklinks?
             - if local_assigns[:f]
               = f.fields_for :order_details do |builder|
                 - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
                   = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
                   = builder.hidden_field :product_id, value: product.id, index: nil
-          - if @quicklinks 
+          - if quicklinks?
             = render :partial => "facilities/quicklinks", locals: {product: product, indent_for_icon:indent_for_icon}
           
             

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -10,13 +10,15 @@
     %ul
       - indent_for_icon = products.any? { |p| p.respond_to? :reservations }
       - products.sort.each do |product|
-        %li{ class: product.class.model_name.to_s.downcase + '_title' }
-          = product.name if quicklinks?
-          = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product), :id => product.name unless quicklinks?
-          - if local_assigns[:f]
-            = f.fields_for :order_details do |builder|
-              - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
-                = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
-                = builder.hidden_field :product_id, value: product.id, index: nil
         - if quicklinks?
-          = render :partial => "facilities/quicklinks", locals: {product: product, indent_for_icon:indent_for_icon}
+          %li{ class: product.class.model_name.to_s.downcase + '_title' }
+          = render :partial => "facilities/quicklinks", locals: {product: product, indent_for_icon: indent_for_icon}
+        - else
+          %li{ class: product.class.model_name.to_s.downcase + '_title' }
+            = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product), :id => product.name
+            - if local_assigns[:f]
+              = f.fields_for :order_details do |builder|
+                - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
+                  = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
+                  = builder.hidden_field :product_id, value: product.id, index: nil
+        

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -12,30 +12,14 @@
       - products.sort.each do |product|
         .product_listing
           %li{ class: product.class.model_name.to_s.downcase + '_title' }
-            = product.name
+            = product.name if @quicklinks
+            = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product), :id => product.name unless @quicklinks
             - if local_assigns[:f]
               = f.fields_for :order_details do |builder|
                 - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
                   = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
                   = builder.hidden_field :product_id, value: product.id, index: nil
-          .quick_links
-            .add_to_cart
-              - if not session_user
-                = link_to "Add to cart (requires login)", new_user_session_path
-              - elsif session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
-                - if not session_user.accounts.empty?
-                  = link_to "Add to cart", add_order_path(acting_user.cart(session_user), order: {order_details: [{product_id: product.id, quantity: 1}] }), method: :put
-                - else
-                  No payment source
-              - else
-                Cannot purchase
-            %li{class: [product.class.model_name.to_s.downcase, 'view_product']}
-              = public_calendar_link(product, indent: indent_for_icon)
-              = link_to 'View' + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product), :id => product.name
-              - if acting_user.present? && !product.can_be_used_by?(acting_user)
-                %i.fa.fa-lock
-                = " (#{product.class.human_attribute_name(:requires_approval_show)})"
-
-              - if product.offline?
-                = tooltip_icon "fa fa-exclamation-triangle icon-large", t("instruments.offline.note")
+          - if @quicklinks 
+            = render :partial => "facilities/quicklinks", locals: {product: product, indent_for_icon:indent_for_icon}
+          
             

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -12,27 +12,30 @@
       - products.sort.each do |product|
         .product_listing
           %li{ class: product.class.model_name.to_s.downcase }
+            = product.name
             - if local_assigns[:f]
               = f.fields_for :order_details do |builder|
                 - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
                   = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
                   = builder.hidden_field :product_id, value: product.id, index: nil
-                  
-            = public_calendar_link(product, indent: indent_for_icon)
-            = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product)
-            - if acting_user.present? && !product.can_be_used_by?(acting_user)
-              %i.fa.fa-lock
-              = " (#{product.class.human_attribute_name(:requires_approval_show)})"
-
-            - if product.offline?
-              = tooltip_icon "fa fa-exclamation-triangle icon-large", t("instruments.offline.note")
-          %li{class: 'add_to_cart' }
-            - if not session_user
-              = link_to "Add to cart (requires login)", new_user_session_path
-            - elsif session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
-              - if not session_user.accounts.empty?
-                = link_to "Add to cart", add_order_path(acting_user.cart(session_user), order: {order_details: [{product_id: product.id, quantity: 1}] }), method: :put
+          .quick_links
+            .add_to_cart
+              - if not session_user
+                = link_to "Add to cart (requires login)", new_user_session_path
+              - elsif session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
+                - if not session_user.accounts.empty?
+                  = link_to "Add to cart", add_order_path(acting_user.cart(session_user), order: {order_details: [{product_id: product.id, quantity: 1}] }), method: :put
+                - else
+                  No payment source
               - else
-                No payment source
-            - else
-              Cannot purchase
+                Cannot purchase
+            .view_product
+              = public_calendar_link(product, indent: indent_for_icon)
+              = link_to 'View' + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product)
+              - if acting_user.present? && !product.can_be_used_by?(acting_user)
+                %i.fa.fa-lock
+                = " (#{product.class.human_attribute_name(:requires_approval_show)})"
+
+              - if product.offline?
+                = tooltip_icon "fa fa-exclamation-triangle icon-large", t("instruments.offline.note")
+            

--- a/app/views/facilities/_quicklinks.html.haml
+++ b/app/views/facilities/_quicklinks.html.haml
@@ -3,7 +3,7 @@
     - if not session_user
       = link_to text("add_to_cart") + ' ' + text("require_login"), new_user_session_path
     - elsif session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
-      - if not session_user.accounts.empty?
+      - if session_user.accounts.any?
         = link_to text("add_to_cart"), add_order_path(acting_user.cart(session_user), order: {order_details: [{product_id: product.id, quantity: 1}] }), method: :put
       - else
         .label.label-important= text("no_payment")

--- a/app/views/facilities/_quicklinks.html.haml
+++ b/app/views/facilities/_quicklinks.html.haml
@@ -18,4 +18,3 @@
 
       - if product.offline?
         = tooltip_icon "fa fa-exclamation-triangle icon-large", t("instruments.offline.note")
-    

--- a/app/views/facilities/_quicklinks.html.haml
+++ b/app/views/facilities/_quicklinks.html.haml
@@ -1,0 +1,21 @@
+.quick_links 
+  .add_to_cart
+    - if not session_user
+      = link_to "Add to cart (requires login)", new_user_session_path
+    - elsif session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
+      - if not session_user.accounts.empty?
+        = link_to "Add to cart", add_order_path(acting_user.cart(session_user), order: {order_details: [{product_id: product.id, quantity: 1}] }), method: :put
+      - else
+        No payment source
+    - else
+      Cannot purchase
+  %li{class: [product.class.model_name.to_s.downcase, 'view_product']}
+    = public_calendar_link(product, indent: indent_for_icon)
+    = link_to 'View' + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product), :id => product.name
+    - if acting_user.present? && !product.can_be_used_by?(acting_user)
+      %i.fa.fa-lock
+      = " (#{product.class.human_attribute_name(:requires_approval_show)})"
+
+      - if product.offline?
+        = tooltip_icon "fa fa-exclamation-triangle icon-large", t("instruments.offline.note")
+    

--- a/app/views/facilities/_quicklinks.html.haml
+++ b/app/views/facilities/_quicklinks.html.haml
@@ -1,17 +1,17 @@
 .quick_links 
   .add_to_cart
     - if not session_user
-      = link_to "#{t("admin.shared.add_to",model:t("pages.cart"))} (#{t("pages.login")})", new_user_session_path
+      = link_to text("add_to_cart") + ' ' + text("require_login"), new_user_session_path
     - elsif session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
       - if not session_user.accounts.empty?
-        = link_to t("admin.shared.add_to",model:t("pages.cart")), add_order_path(acting_user.cart(session_user), order: {order_details: [{product_id: product.id, quantity: 1}] }), method: :put
+        = link_to text("add_to_cart"), add_order_path(acting_user.cart(session_user), order: {order_details: [{product_id: product.id, quantity: 1}] }), method: :put
       - else
-        = t("facility_accounts.account_table.notice")
+        .label.label-important= text("no_payment")
     - else
-      = t("facility_account_orders.cannot_purchase")
+      .label.label-important= text("cannot_purchase")
   %li{class: [product.class.model_name.to_s.downcase, 'view_product']}
     = public_calendar_link(product, indent: indent_for_icon)
-    = link_to 'View' + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product), :id => product.name
+    = link_to text("view") + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product), :id => product.name
     - if acting_user.present? && !product.can_be_used_by?(acting_user)
       %i.fa.fa-lock
       = " (#{product.class.human_attribute_name(:requires_approval_show)})"

--- a/app/views/facilities/_quicklinks.html.haml
+++ b/app/views/facilities/_quicklinks.html.haml
@@ -1,14 +1,14 @@
 .quick_links 
   .add_to_cart
     - if not session_user
-      = link_to "Add to cart (requires login)", new_user_session_path
+      = link_to "#{t("admin.shared.add_to",model:t("pages.cart"))} (#{t("pages.login")})", new_user_session_path
     - elsif session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
       - if not session_user.accounts.empty?
-        = link_to "Add to cart", add_order_path(acting_user.cart(session_user), order: {order_details: [{product_id: product.id, quantity: 1}] }), method: :put
+        = link_to t("admin.shared.add_to",model:t("pages.cart")), add_order_path(acting_user.cart(session_user), order: {order_details: [{product_id: product.id, quantity: 1}] }), method: :put
       - else
-        No payment source
+        = t("facility_accounts.account_table.notice")
     - else
-      Cannot purchase
+      = t("facility_account_orders.cannot_purchase")
   %li{class: [product.class.model_name.to_s.downcase, 'view_product']}
     = public_calendar_link(product, indent: indent_for_icon)
     = link_to 'View' + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product), :id => product.name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,6 +221,7 @@ en:
       instruct: "Search for an existing user by name, NetID, or username.  Click on the name of the user you wish to grant access to.  If the search does not return any acceptable matches, you may create a new user."
 
   facility_account_orders:
+    cannot_purcahse: "Cannot Purchase"
     index:
       h3: Purchased Orders
       no_orders: No transactions exist for this period.

--- a/config/locales/views/en.facilities.yml
+++ b/config/locales/views/en.facilities.yml
@@ -9,3 +9,9 @@ en:
           Welcome to !app_name!, the centralized ordering system for shared !facilities_downcase!.
           Please select the shared !facility_downcase! below to view and purchase services
           and products offered by the !facility_downcase!.
+      quicklinks:
+        cannot_purchase: Cannot Purchase.
+        no_payment: No Payment Sources Found.
+        add_to_cart: Add to Cart
+        view: View
+        require_login: (Requires Login)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -121,7 +121,7 @@ feature:
   can_manage_global_price_groups_on: true
   cross_facility_reports_on: false
   product_list_columns_on: false
-  product_quicklinks_on: false
+  product_quicklinks_on: true
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -121,7 +121,7 @@ feature:
   can_manage_global_price_groups_on: true
   cross_facility_reports_on: false
   product_list_columns_on: false
-  product_quicklinks_on: true
+  product_quicklinks_on: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -121,6 +121,7 @@ feature:
   can_manage_global_price_groups_on: true
   cross_facility_reports_on: false
   product_list_columns_on: false
+  product_quicklinks_on: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts


### PR DESCRIPTION
# Release Notes

Quick links for the facility page to purchase and view items. 

We previously submitted a Pull Request #1607, which introduced our purchase quicklink. Our final design has moved the hyperlink to view facility into its own button, which goes next to the purchase quick link. Here is our final quicklink design (localized as well!)

# Screenshot
![image](https://user-images.githubusercontent.com/5000430/43279311-96d6cd8c-90db-11e8-9b03-66df9dd76f5e.png)

# Additional Context

The behavior of the "Add to Cart" is the same as in #1607 
