### PR TITLE
TECH TASK: add env var to mysql template config

### DIFF
--- a/config/database.yml.mysql.template
+++ b/config/database.yml.mysql.template
@@ -1,6 +1,6 @@
 defaults: &defaults
   adapter: mysql2
-  host: 127.0.0.1
+  host: <%= ENV["MYSQL_HOST"] || "127.0.0.1" %>
   username: <%= ENV["MYSQL_USER"] || "root" %>
   password: <%= ENV["MYSQL_PASSWORD"] %>
   encoding: utf8


### PR DESCRIPTION
Adding the standard MYSQL_HOST environment variable to the template configuration file allows for deployment without the use of `sed`. This would greatly simplify scripts that deploy NUcore with a non-localhost database.