### PR TITLE
Only run teaspoon on one CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,11 +52,14 @@ jobs:
                               "spec/**/*_spec.rb" \
                               "vendor/engines/**/spec/**/*_spec.rb" \
                               | circleci tests split --split-by=timings)
+
       - run:
           command: |
-            bundle exec teaspoon \
-              --suppress-log \
-              --format junit > /tmp/test-results/teaspoon.xml
+            if [ "${CIRCLE_NODE_INDEX}" == "0" ]; then
+              bundle exec teaspoon \
+                --suppress-log \
+                --format junit > /tmp/test-results/teaspoon.xml
+            fi
 
       # Save artifacts
       - store_test_results:


### PR DESCRIPTION
# Release Notes

Tech Task: Only run `teaspoon` (javascript tests) on a single CI job.

# Context

We were getting a bunch of failures where PhantomJS was crashing. While I couldn't find any logs detailing _why_ it crashed, I suspect that it's because it was trying to start up the teaspoon server on each job on the same port. Ports are shared across all the jobs since they're all run on the same host, so they can conflict with each other.

Before this, I was seeing errors about 50% of the time. I ran this a few times w/o `rspec` and I haven't seen it yet. https://circleci.com/gh/tablexi/nucore-open/tree/phantom_js3