### PR TITLE
Disable editing of recharge chart strings

### DIFF
--- a/app/controllers/facility_facility_accounts_controller.rb
+++ b/app/controllers/facility_facility_accounts_controller.rb
@@ -9,6 +9,8 @@ class FacilityFacilityAccountsController < ApplicationController
 
   layout "two_column"
 
+  cattr_accessor(:form_class) { ::FacilityAccountForm }
+
   def initialize
     @active_tab = "admin_facility"
     super
@@ -21,12 +23,16 @@ class FacilityFacilityAccountsController < ApplicationController
 
   # GET /facilities/:facility_id/facility_accounts/new(.:format)
   def new
-    @facility_account = current_facility.facility_accounts.new(is_active: true, revenue_account: Settings.accounts.revenue_account_default)
+    @facility_account = form_class.new(
+      current_facility.facility_accounts.new(is_active: true, revenue_account: Settings.accounts.revenue_account_default)
+    )
   end
 
   # POST /facilities/:facility_id/facility_accounts(.:format)
   def create
-    @facility_account = current_facility.facility_accounts.new(facility_facility_account_params)
+    @facility_account = form_class.new(
+      current_facility.facility_accounts.new(facility_facility_account_params)
+    )
     @facility_account.created_by = session_user.id
 
     if @facility_account.save
@@ -39,12 +45,12 @@ class FacilityFacilityAccountsController < ApplicationController
 
   # GET /facilities/:facility_id/facility_accounts/:id/edit(.:format)
   def edit
-    @facility_account = current_facility.facility_accounts.find(params[:id])
+    @facility_account = form_class.new(current_facility.facility_accounts.find(params[:id]))
   end
 
   # PUT /facilities/:facility_id/facility_accounts/:id(.:format)
   def update
-    @facility_account = current_facility.facility_accounts.find(params[:id])
+    @facility_account = form_class.new(current_facility.facility_accounts.find(params[:id]))
 
     if @facility_account.update_attributes(facility_facility_account_params)
       flash[:notice] = text("update.success", model: FacilityAccount.model_name.human)

--- a/app/controllers/facility_facility_accounts_controller.rb
+++ b/app/controllers/facility_facility_accounts_controller.rb
@@ -24,14 +24,14 @@ class FacilityFacilityAccountsController < ApplicationController
   # GET /facilities/:facility_id/facility_accounts/new(.:format)
   def new
     @facility_account = form_class.new(
-      current_facility.facility_accounts.new(is_active: true, revenue_account: Settings.accounts.revenue_account_default)
+      current_facility.facility_accounts.new(is_active: true, revenue_account: Settings.accounts.revenue_account_default),
     )
   end
 
   # POST /facilities/:facility_id/facility_accounts(.:format)
   def create
     @facility_account = form_class.new(
-      current_facility.facility_accounts.new(create_params)
+      current_facility.facility_accounts.new(create_params),
     )
     @facility_account.created_by = session_user.id
 

--- a/app/controllers/facility_facility_accounts_controller.rb
+++ b/app/controllers/facility_facility_accounts_controller.rb
@@ -31,7 +31,7 @@ class FacilityFacilityAccountsController < ApplicationController
   # POST /facilities/:facility_id/facility_accounts(.:format)
   def create
     @facility_account = form_class.new(
-      current_facility.facility_accounts.new(facility_facility_account_params)
+      current_facility.facility_accounts.new(create_params)
     )
     @facility_account.created_by = session_user.id
 
@@ -45,14 +45,14 @@ class FacilityFacilityAccountsController < ApplicationController
 
   # GET /facilities/:facility_id/facility_accounts/:id/edit(.:format)
   def edit
-    @facility_account = form_class.new(current_facility.facility_accounts.find(params[:id]))
+    @facility_account = current_facility.facility_accounts.find(params[:id])
   end
 
   # PUT /facilities/:facility_id/facility_accounts/:id(.:format)
   def update
-    @facility_account = form_class.new(current_facility.facility_accounts.find(params[:id]))
+    @facility_account = current_facility.facility_accounts.find(params[:id])
 
-    if @facility_account.update_attributes(facility_facility_account_params)
+    if @facility_account.update_attributes(update_params)
       flash[:notice] = text("update.success", model: FacilityAccount.model_name.human)
       redirect_to facility_facility_accounts_path
     else
@@ -62,8 +62,12 @@ class FacilityFacilityAccountsController < ApplicationController
 
   private
 
-  def facility_facility_account_params
+  def create_params
     params.require(:facility_account).permit(:revenue_account, :account_number, :is_active, account_number_parts: FacilityAccount.account_number_field_names)
+  end
+
+  def update_params
+    params.require(:facility_account).permit(:is_active)
   end
 
 end

--- a/app/forms/facility_account_form.rb
+++ b/app/forms/facility_account_form.rb
@@ -1,0 +1,53 @@
+class FacilityAccountForm < SimpleDelegator
+
+  include ActiveModel::Validations
+  include ActiveModel::Callbacks
+
+  define_model_callbacks :validate_chart_string
+
+  validate :validate_chart_string
+
+  def model_name
+    ActiveModel::Name.new(facility_account.class)
+  end
+
+  def to_model
+    self
+  end
+
+  def valid?
+    if facility_account.valid? && super
+      true
+    else
+      facility_account.errors.each do |k, error_messages|
+        errors.add(k, error_messages)
+      end
+      false
+    end
+  end
+
+  def save
+    valid? && facility_account.save(validate: false) # skip validations because we've already done them
+  end
+
+  def update_attributes(*args)
+    assign_attributes(*args)
+    save
+  end
+
+  private
+
+  def facility_account
+    __getobj__
+  end
+
+  def validate_chart_string
+    run_callbacks :validate_chart_string do
+      ValidatorFactory.instance(account_number, revenue_account).account_is_open!
+    end
+  rescue AccountNumberFormatError => e
+    e.apply_to_model(self)
+  rescue ValidatorError => e
+    errors.add(:base, e.message)
+  end
+end

--- a/app/forms/facility_account_form.rb
+++ b/app/forms/facility_account_form.rb
@@ -7,8 +7,12 @@ class FacilityAccountForm < SimpleDelegator
 
   validate :validate_chart_string
 
-  def model_name
-    ActiveModel::Name.new(facility_account.class)
+  def self.model_name
+    ActiveModel::Name.new(FacilityAccount)
+  end
+
+  def self.i18n_scope
+    :activerecord
   end
 
   def to_model
@@ -16,6 +20,7 @@ class FacilityAccountForm < SimpleDelegator
   end
 
   def valid?
+    # Don't bother validating ourself if the object is already invalid
     if facility_account.valid? && super
       true
     else

--- a/app/forms/facility_account_form.rb
+++ b/app/forms/facility_account_form.rb
@@ -56,4 +56,5 @@ class FacilityAccountForm < SimpleDelegator
   rescue ValidatorError => e
     errors.add(:base, e.message)
   end
+
 end

--- a/app/forms/facility_account_form.rb
+++ b/app/forms/facility_account_form.rb
@@ -41,6 +41,7 @@ class FacilityAccountForm < SimpleDelegator
     __getobj__
   end
 
+  # Hook into the callbacks by declaring `before_validate_chart_string :my_method_to_run`
   def validate_chart_string
     run_callbacks :validate_chart_string do
       ValidatorFactory.instance(account_number, revenue_account).account_is_open!

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -192,7 +192,7 @@ class Account < ApplicationRecord
     return "The #{type_string} has insufficient price groups" unless product.can_purchase?((price_groups + user.price_groups).flatten.uniq.collect(&:id))
 
     # check chart string account number
-    if is_a?(NufsAccount)
+    if respond_to?(:account_open?)
       accts = product.is_a?(Bundle) ? product.products.collect(&:account) : [product.account]
       accts.uniq.each { |acct| return "The #{type_string} is not open for the required account" unless account_open?(acct) }
     end

--- a/app/models/facility_account.rb
+++ b/app/models/facility_account.rb
@@ -5,11 +5,12 @@ class FacilityAccount < ApplicationRecord
   belongs_to :facility
 
   validates :revenue_account, numericality: { only_integer: true }
-  validates_uniqueness_of :account_number, scope: [:revenue_account, :facility_id]
-  validate :validate_chartstring
+  validates :account_number, uniqueness: { scope: [:revenue_account, :facility_id] }
 
   scope :active, -> { where(is_active: true) }
   scope :inactive, -> { where(is_active: false) }
+
+  alias_attribute :active, :is_active
 
   def to_s
     "#{account_number} (#{revenue_account})"
@@ -32,14 +33,6 @@ class FacilityAccount < ApplicationRecord
     rescue
       return false
     end
-  end
-
-  def validate_chartstring
-    ValidatorFactory.instance(account_number, revenue_account).account_is_open!
-  rescue AccountNumberFormatError => e
-    e.apply_to_model(self)
-  rescue ValidatorError => e
-    errors.add(:account_number, e.message)
   end
 
 end

--- a/app/models/facility_account.rb
+++ b/app/models/facility_account.rb
@@ -5,7 +5,7 @@ class FacilityAccount < ApplicationRecord
   belongs_to :facility
 
   validates :revenue_account, numericality: { only_integer: true }
-  validates :account_number, uniqueness: { scope: [:revenue_account, :facility_id] }
+  validates :account_number, presence: true, uniqueness: { scope: [:revenue_account, :facility_id] }
 
   scope :active, -> { where(is_active: true) }
   scope :inactive, -> { where(is_active: false) }

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -547,7 +547,7 @@ class OrderDetail < ApplicationRecord
     return "The account is expired and cannot be used" if account.expires_at < Time.zone.now || account.suspended_at
 
     # TODO: if chart string, is chart string + account valid
-    return "The #{account.type_string} is not open for the required account" if account.is_a?(NufsAccount) && !account.account_open?(product.account)
+    return "The #{account.type_string} is not open for the required account" if account.respond_to?(:account_open?) && !account.account_open?(product.account)
 
     # is the user approved for the product
     return "You are not approved to purchase this #{product.class.name.downcase}" unless product.can_be_used_by?(order.user) || order.created_by_user.can_override_restrictions?(product)

--- a/app/views/facility_facility_accounts/_facility_account_fields.html.haml
+++ b/app/views/facility_facility_accounts/_facility_account_fields.html.haml
@@ -1,7 +1,7 @@
 .well
-  = render "shared/account_fields", f: f, account_class: FacilityAccount
+  = render "shared/account_fields", f: f, account_class: FacilityAccount, readonly: local_assigns[:readonly]
   = f.label :revenue_account, class: "require"
-  = f.text_field :revenue_account, maxLength: 5, size: 10
+  = f.text_field :revenue_account, maxLength: 5, size: 10, readonly: local_assigns[:readonly]
 
   = f.label :is_active do
     = f.check_box :is_active

--- a/app/views/facility_facility_accounts/edit.html.haml
+++ b/app/views/facility_facility_accounts/edit.html.haml
@@ -11,7 +11,7 @@
 %p= text(".main")
 = form_for @facility_account, url: facility_facility_account_path do |f|
   = f.error_messages
-  = render "facility_account_fields", f: f
+  = render "facility_account_fields", f: f, readonly: true
   %ul.inline
     %li= f.submit t("shared.save"), class: "btn"
     %li= link_to t("shared.cancel"), facility_facility_accounts_path

--- a/app/views/facility_facility_accounts/index.html.haml
+++ b/app/views/facility_facility_accounts/index.html.haml
@@ -20,15 +20,11 @@
   %table.table.table-striped.table-hover
     %thead
       %tr
-        %th
         %th= FacilityAccount.human_attribute_name(:account_number)
     %tbody
       - @accounts.each do |account|
         %tr
           %td
-            = link_to t("shared.edit"),
-              edit_facility_facility_account_path(current_facility, account)
-          %td
-            = account
+            = link_to account, edit_facility_facility_account_path(current_facility, account)
             - unless account.is_active?
               = text("inactive")

--- a/app/views/shared/_account_fields.html.haml
+++ b/app/views/shared/_account_fields.html.haml
@@ -10,6 +10,7 @@
         = p.text_field section,
           size: (options[:length] || 30) + 2,
           maxlength: options[:length] || 30,
-          tabindex: i + 1
+          tabindex: i + 1,
+          readonly: local_assigns[:readonly]
 
         = "-&nbsp;".html_safe unless i >= fields.size - 1

--- a/config/locales/views/admin/en.facility_facility_accounts.yml
+++ b/config/locales/views/admin/en.facility_facility_accounts.yml
@@ -4,7 +4,7 @@ en:
       facility_account_fields:
         instruct: "Use hyphens to separate Chart String number groups e.g. 123-1234567-12345678"
       edit:
-        main: "Editing the !activerecord.models.facility_account.one! may effect the !facility_downcase!'s ability to collect funds. Edit the Chart String with caution!"
+        main: "You may not edit the chart string from a !activerecord.models.facility_account.one!. If necessary, please deactivate this one and create a new one."
       index:
         main: "Chart Strings that are approved by the Provost for collection of !facility_downcase! revenue."
         notice: "No !activerecord.models.facility_account.other! have been added to this !facility_downcase! yet."

--- a/lib/validator/validator_factory.rb
+++ b/lib/validator/validator_factory.rb
@@ -1,10 +1,6 @@
 class ValidatorFactory
 
-  @@validator_class = Settings.validator.class_name.constantize
-
-  def self.validator_class
-    @@validator_class
-  end
+  cattr_accessor(:validator_class) { Settings.validator.class_name.constantize }
 
   def self.instance(*args)
     validator_class.new(*args)

--- a/spec/controllers/facility_facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_facility_accounts_controller_spec.rb
@@ -110,18 +110,17 @@ RSpec.describe FacilityFacilityAccountsController, if: SettingsHelper.feature_on
     end
 
     it "allows a director to update the account if it is valid" do
-      expect_any_instance_of(ValidatorFactory.validator_class).to receive(:account_is_open!).and_return(true)
+      allow_any_instance_of(ValidatorFactory.validator_class).to receive(:account_is_open!).and_return(true)
 
       sign_in director
       expect { put :update, params: params }.to change { facility_account.reload.active? }.to be(true)
     end
 
-    it "prevents the director from updating it if it is invalid" do
-      expect_any_instance_of(ValidatorFactory.validator_class).to receive(:account_is_open!).and_raise(ValidatorError, "not open")
+    it "prevents the director from updating it even if it is invalid" do
+      allow_any_instance_of(ValidatorFactory.validator_class).to receive(:account_is_open!).and_raise(ValidatorError, "not open")
 
       sign_in director
-      expect { put :update, params: params }.not_to change { facility_account.reload.active? }
-      expect(assigns(:facility_account).errors[:base]).to include("not open")
+      expect { put :update, params: params }.to change { facility_account.reload.active? }.to be(true)
     end
 
     it "denies senior staff" do

--- a/spec/controllers/facility_facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_facility_accounts_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "controller_spec_helper"
 
-RSpec.describe FacilityFacilityAccountsController, if: SettingsHelper.feature_on?(:recharge_accounts) do
+RSpec.xdescribe FacilityFacilityAccountsController, if: SettingsHelper.feature_on?(:recharge_accounts) do
   render_views
 
   before(:all) { create_users }

--- a/spec/controllers/facility_facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_facility_accounts_controller_spec.rb
@@ -1,95 +1,134 @@
 require "rails_helper"
 require "controller_spec_helper"
 
-RSpec.xdescribe FacilityFacilityAccountsController, if: SettingsHelper.feature_on?(:recharge_accounts) do
+RSpec.describe FacilityFacilityAccountsController, if: SettingsHelper.feature_on?(:recharge_accounts) do
   render_views
 
-  before(:all) { create_users }
+  around(:each) do |example|
+    old_form = described_class.form_class
+    described_class.form_class = ::FacilityAccountForm
+    example.call
+    described_class.form_class = old_form
+  end
 
-  let(:facility) { @authable = create(:facility) }
-  let!(:facility_account) { create(:facility_account, facility: facility, created_by: @admin.id) }
+  let(:facility) { create(:facility) }
+  let(:director) { create(:user, :facility_director, facility: facility) }
+  let(:senior_staff) { create(:user, :senior_staff, facility: facility) }
 
-  before { @params = { facility_id: facility.url_name } }
+  let(:params) { { facility_id: facility.url_name } }
 
   describe "GET #index" do
-    before(:each) do
-      @method = :get
-      @action = :index
+    let!(:facility_account) { create(:facility_account, facility: facility) }
+
+    it "allows a director" do
+      sign_in director
+      get :index, params: params
+
+      is_expected.to render_template "index"
+      expect(assigns(:accounts)).to eq([facility_account])
     end
 
-    it_should_allow_managers_only do
-      expect(assigns(:accounts)).to all be_kind_of(FacilityAccount)
-      expect(assigns(:accounts).size).to eq(1)
-      expect(assigns(:accounts).first).to eq(facility_account)
-      is_expected.to render_template "index"
+    it "denies senior staff" do
+      sign_in senior_staff
+      get :index, params: params
+
+      expect(response).to be_forbidden
     end
   end
 
   describe "GET #new" do
-    before(:each) do
-      @method = :get
-      @action = :new
-    end
+    it "allows a director" do
+      sign_in director
+      get :new, params: params
 
-    it_should_allow_managers_only do
-      expect(assigns(:facility_account))
-        .to be_kind_of(FacilityAccount).and be_new_record
       is_expected.to render_template "new"
-    end
-  end
-
-  describe "PUT #update" do
-    before(:each) do
-      @method = :put
-      @action = :update
-      @params.merge!(
-        id: facility_account.id,
-        facility_account: attributes_for(:facility_account).except(:created_by),
-      )
+      expect(assigns(:facility_account)).to be_new_record
     end
 
-    it_should_allow_managers_only :redirect do
-      expect(assigns(:facility_account))
-        .to be_kind_of(FacilityAccount).and eq(facility_account)
-      is_expected.to set_flash
-      is_expected.to redirect_to(facility_facility_accounts_path)
+    it "denies senior staff" do
+      sign_in senior_staff
+      get :new, params: params
+
+      expect(response).to be_forbidden
     end
   end
 
   describe "POST #create" do
-    before(:each) do
-      @method = :post
-      @action = :create
-      @params.merge!(facility_account: attributes_for(:facility_account).except(:created_by))
+    let(:params) { super().merge(facility_account: attributes_for(:facility_account).except(:created_by)) }
+
+    describe "as a director" do
+      before { sign_in director }
+
+      it "allows a director to create an account if it is open" do
+        expect_any_instance_of(ValidatorFactory.validator_class).to receive(:account_is_open!).and_return(true)
+
+        expect { put :create, params: params }.to change(FacilityAccount, :count).by(1)
+        expect(response).to redirect_to(facility_facility_accounts_path)
+      end
+
+      it "renders errors if the account is not open" do
+        expect_any_instance_of(ValidatorFactory.validator_class).to receive(:account_is_open!).and_raise(ValidatorError, "not open")
+
+        expect { post :create, params: params }.not_to change(FacilityAccount, :count)
+        expect(assigns(:facility_account)).to be_new_record
+        expect(assigns(:facility_account).errors[:base]).to include("not open")
+      end
     end
 
-    it_should_allow_managers_only :redirect do |user|
-      expect(assigns(:facility_account)).to be_kind_of(FacilityAccount)
-      expect(assigns(:facility_account).created_by).to eq(user.id)
-      is_expected.to set_flash
-      is_expected.to redirect_to(facility_facility_accounts_path)
+    it "denies senior staff" do
+      sign_in senior_staff
+      post :create, params: params
+
+      expect(response).to be_forbidden
     end
   end
 
   describe "GET #edit" do
-    before(:each) do
-      @method = :get
-      @action = :edit
-      @params.merge!(id: facility_account.id)
-    end
+    let!(:facility_account) { create(:facility_account, facility: facility) }
+    let(:params) { super().merge(id: facility_account.id) }
 
-    let(:document) { Nokogiri::HTML(response.body) }
-
-    it_should_allow_managers_only do
-      expect(assigns(:facility_account))
-        .to be_kind_of(FacilityAccount).and eq(facility_account)
-
-      assigns(:facility_account).account_number_parts.to_h.each do |key, value|
-        expect(document.css("#facility_account_account_number_parts_#{key}").first[:value])
-          .to eq(value)
-      end
+    it "allows a director to edit" do
+      sign_in director
+      get :edit, params: params
 
       is_expected.to render_template "edit"
+      expect(assigns(:facility_account)).to eq(facility_account)
+    end
+
+    it "denies senior staff" do
+      sign_in senior_staff
+      get :edit, params: params
+
+      expect(response).to be_forbidden
+    end
+  end
+
+  describe "PUT #update" do
+    let!(:facility_account) { create(:facility_account, facility: facility, is_active: false) }
+    let(:params) do
+      super().merge(id: facility_account.id, facility_account: { is_active: true })
+    end
+
+    it "allows a director to update the account if it is valid" do
+      expect_any_instance_of(ValidatorFactory.validator_class).to receive(:account_is_open!).and_return(true)
+
+      sign_in director
+      expect { put :update, params: params }.to change { facility_account.reload.active? }.to be(true)
+    end
+
+    it "prevents the director from updating it if it is invalid" do
+      expect_any_instance_of(ValidatorFactory.validator_class).to receive(:account_is_open!).and_raise(ValidatorError, "not open")
+
+      sign_in director
+      expect { put :update, params: params }.not_to change { facility_account.reload.active? }
+      expect(assigns(:facility_account).errors[:base]).to include("not open")
+    end
+
+    it "denies senior staff" do
+      sign_in senior_staff
+
+      put :update, params: params
+      expect(response).to be_forbidden
     end
   end
 end

--- a/spec/factories/facility_accounts.rb
+++ b/spec/factories/facility_accounts.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :facility_account do
     facility
-    revenue_account 51_234
+    revenue_account { Settings.accounts.revenue_account_default }
     sequence(:account_number) do |n|
       # This sequence was often running into blacklist problems
       # s = "1#{n%10}#{rand(10)}-7777777" # fund3-dept7
@@ -12,7 +12,7 @@ FactoryBot.define do
     created_by 1
 
     after(:build) do |facility_account|
-      define_open_account(51_234, facility_account.account_number)
+      define_open_account(facility_account.revenue_account, facility_account.account_number)
     end
   end
 end

--- a/spec/factories/facility_accounts.rb
+++ b/spec/factories/facility_accounts.rb
@@ -5,12 +5,14 @@ FactoryBot.define do
     sequence(:account_number) do |n|
       # This sequence was often running into blacklist problems
       # s = "1#{n%10}#{rand(10)}-7777777" # fund3-dept7
-      s = "134-7#{'%06d' % n}"
-      define_open_account(51_234, s)
-      s
+      "134-7#{'%06d' % n}"
     end
 
     is_active true
     created_by 1
+
+    after(:build) do |facility_account|
+      define_open_account(51_234, facility_account.account_number)
+    end
   end
 end

--- a/spec/models/instrument_for_cart_spec.rb
+++ b/spec/models/instrument_for_cart_spec.rb
@@ -3,11 +3,8 @@ require "rails_helper"
 RSpec.describe InstrumentForCart do
 
   let(:facility) { FactoryBot.create(:setup_facility) }
-
   let(:instrument) { FactoryBot.create(:instrument, facility: facility, no_relay: true) }
-
   let(:user) { FactoryBot.create(:user) }
-
   let(:instrument_for_cart) { InstrumentForCart.new(instrument) }
 
   context "#purchasable_by?" do


### PR DESCRIPTION
# Release Notes

Disable editing of recharge chart strings. Tech task: Improve extensibility of recharge chart string validations.

# Additional Context

Extracted from https://github.com/tablexi/nucore-dartmouth/pull/206

Refactors out a form object so we can hook in callbacks around validation. For example, making a call to an API to populate a validation table in Dartmouth's case.

This also disables editing of existing FacilityAccounts. NU confirmed that this is good. There could have been the possibility of creating a valid chart string and then later the chart string becomes invalid. You wouldn't be able to mark it as invalid because it would have failed validation.
