### PR TITLE
[#133717] Backport #1624 to Rails 4.2

### DIFF
--- a/app/mailers/order_detail_dispute_mailer.rb
+++ b/app/mailers/order_detail_dispute_mailer.rb
@@ -1,0 +1,20 @@
+class OrderDetailDisputeMailer < BaseMailer
+
+  add_template_helper DateHelper
+
+  def dispute_resolved(order_detail:, user:)
+    @order_detail = order_detail
+    @user = user
+    mail(
+      to: @user.email,
+      subject: text("subject", facility_abbreviation: @order_detail.facility.abbreviation),
+    )
+  end
+
+  protected
+
+  def translation_scope
+    "views.order_detail_dispute_mailer.dispute_resolved"
+  end
+
+end

--- a/app/services/order_details/assignment_notifier.rb
+++ b/app/services/order_details/assignment_notifier.rb
@@ -1,0 +1,19 @@
+module OrderDetails
+
+  class AssignmentNotifier < SimpleDelegator
+
+    def notify
+      if SettingsHelper.feature_on?(:order_assignment_notifications) && assigned_user_changed?
+        OrderAssignmentMailer.notify_assigned_user(__getobj__).deliver_later
+      end
+    end
+
+    private
+
+    def assigned_user_changed?
+      assigned_user_id_previously_changed? && assigned_user.present?
+    end
+
+  end
+
+end

--- a/app/services/order_details/assignment_notifier.rb
+++ b/app/services/order_details/assignment_notifier.rb
@@ -14,6 +14,10 @@ module OrderDetails
       assigned_user_id_previously_changed? && assigned_user.present?
     end
 
+    def assigned_user_id_previously_changed?
+      previous_changes.key?(:assigned_user_id)
+    end
+
   end
 
 end

--- a/app/services/order_details/dispute_resolved_notifier.rb
+++ b/app/services/order_details/dispute_resolved_notifier.rb
@@ -17,6 +17,11 @@ module OrderDetails
       ([dispute_by] + account.administrators).compact.uniq
     end
 
+    # In Rails 5, this method exists, but not in Rails 4.2.
+    def dispute_resolved_at_previously_changed?
+      previous_changes.key?(:dispute_resolved_at)
+    end
+
     def dispute_resolved_at_previously_was
       previous_changes[:dispute_resolved_at].first
     end

--- a/app/services/order_details/dispute_resolved_notifier.rb
+++ b/app/services/order_details/dispute_resolved_notifier.rb
@@ -1,0 +1,26 @@
+module OrderDetails
+
+  class DisputeResolvedNotifier < SimpleDelegator
+
+    def notify
+      if dispute_resolved_at_previously_changed? && dispute_resolved_at_previously_was.blank?
+
+        users_to_notify.each do |user|
+          OrderDetailDisputeMailer.dispute_resolved(order_detail: __getobj__, user: user).deliver_later
+        end
+      end
+    end
+
+    private
+
+    def users_to_notify
+      ([dispute_by] + account.administrators).compact.uniq
+    end
+
+    def dispute_resolved_at_previously_was
+      previous_changes[:dispute_resolved_at].first
+    end
+
+  end
+
+end

--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -57,8 +57,6 @@ class OrderDetails::ParamUpdater
 
     assign_attributes(params)
 
-    user_newly_assigned = @order_detail.assigned_user_id_changed? && @order_detail.assigned_user.present?
-
     @order_detail.manually_priced! # don't auto-reassign price
     assign_price_changed_by_user
 
@@ -70,14 +68,15 @@ class OrderDetails::ParamUpdater
         @order_detail.save_as_user(@editing_user) || raise(ActiveRecord::Rollback)
       end
     end
-
     merge_reservation_errors if @order_detail.reservation.present?
+    trigger_notifications if @order_detail.errors.none?
 
-    if user_newly_assigned && SettingsHelper.feature_on?(:order_assignment_notifications)
-      OrderAssignmentMailer.notify_assigned_user(@order_detail).deliver_later
-    end
+    @order_detail.errors.none?
+  end
 
-    is_order_detail_clean
+  def trigger_notifications
+    OrderDetails::DisputeResolvedNotifier.new(@order_detail).notify
+    OrderDetails::AssignmentNotifier.new(@order_detail).notify
   end
 
   private
@@ -132,10 +131,6 @@ class OrderDetails::ParamUpdater
       field = Reservation.human_attribute_name(field) if field != :base
       @order_detail.errors.add(field, message)
     end
-  end
-
-  def is_order_detail_clean
-    @order_detail.errors.none?
   end
 
 end

--- a/app/views/order_detail_dispute_mailer/dispute_resolved.html.haml
+++ b/app/views/order_detail_dispute_mailer/dispute_resolved.html.haml
@@ -1,0 +1,9 @@
+= html("body",
+  user: @user,
+  facility: @order_detail.facility.name,
+  order_detail: @order_detail,
+  order_detail_link: order_order_detail_url(@order_detail.order, @order_detail),
+  dispute_resolved_at: format_usa_date(@order_detail.dispute_resolved_at),
+  dispute_resolved_reason: @order_detail.dispute_resolved_reason,
+  facility_email: @order_detail.facility.email,
+  )

--- a/app/views/order_detail_dispute_mailer/dispute_resolved.text.erb
+++ b/app/views/order_detail_dispute_mailer/dispute_resolved.text.erb
@@ -1,0 +1,10 @@
+<%= text("body",
+  user: @user,
+  facility: @order_detail.facility.name,
+  order_detail: @order_detail,
+  order_detail_link: order_order_detail_url(@order_detail.order, @order_detail),
+  dispute_resolved_at: format_usa_date(@order_detail.dispute_resolved_at),
+  dispute_resolved_reason: @order_detail.dispute_resolved_reason,
+  facility_email: @order_detail.facility.email,
+  ).gsub("<br>", "")
+%>

--- a/config/locales/views/en.order_detail_dispute_mailer.yml
+++ b/config/locales/views/en.order_detail_dispute_mailer.yml
@@ -1,0 +1,21 @@
+en:
+  views:
+    order_detail_dispute_mailer:
+        dispute_resolved:
+          subject: "!app_name! Disputed Order Resolved: %{facility_abbreviation}"
+          body: |
+            Dear %{user},
+
+            Based on information provided, the %{facility} has resolved the following
+            disputed order in !app_name!:
+
+            Order Number: [#%{order_detail}](%{order_detail_link})<br>
+            Resolution Date: %{dispute_resolved_at}<br>
+            Resolution Note: %{dispute_resolved_reason}
+
+            The order will be billed against its designated payment source shortly.
+            Please [contact the %{facility}](mailto:%{facility_email}) if you have any questions.
+
+            Thank you,
+
+            %{facility}

--- a/spec/factories/order_details.rb
+++ b/spec/factories/order_details.rb
@@ -16,6 +16,14 @@ FactoryBot.define do
       canceled_at { 30.minutes.ago }
       actual_cost 5
     end
+
+    trait :disputed do
+      completed
+      reviewed_at { 5.days.ago }
+      dispute_at { 3.days.ago }
+      association :dispute_by, factory: :user
+      dispute_reason "No, sir. I don't like it."
+    end
   end
 
 end

--- a/spec/mailers/previews/order_detail_dispute_mailer_preview.rb
+++ b/spec/mailers/previews/order_detail_dispute_mailer_preview.rb
@@ -1,0 +1,8 @@
+class OrderDetailDisputeMailerPreview < ActionMailer::Preview
+
+  def dispute_resolved
+    order_detail = NUCore::Database.random(OrderDetail.where.not(dispute_resolved_at: nil))
+    OrderDetailDisputeMailer.dispute_resolved(order_detail: order_detail, user: order_detail.user)
+  end
+
+end

--- a/spec/services/order_details/dispute_resolved_notifier_spec.rb
+++ b/spec/services/order_details/dispute_resolved_notifier_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe OrderDetails::DisputeResolvedNotifier do
+  let(:item) { create(:setup_item) }
+  let(:order) { create(:complete_order, product: item) }
+  let(:order_detail) { create(:order_detail, :disputed, order: order, product: item, account: order.account) }
+  subject(:notifier) { described_class.new(order_detail) }
+
+  def resolve_dispute_and_notify
+    order_detail.update!(dispute_resolved_at: Time.current, dispute_resolved_reason: "resolved")
+    notifier.notify
+  end
+
+  it "does not notify on a clean object" do
+    expect { notifier.notify }.not_to change(ActionMailer::Base, :deliveries)
+  end
+
+  it "triggers an email if the resolved at moves from blank to present" do
+    expect { resolve_dispute_and_notify }.to change(ActionMailer::Base, :deliveries)
+  end
+
+  it "does not trigger an email if the resolve changes" do
+    order_detail.update!(dispute_resolved_at: Time.current, dispute_resolved_reason: "resolved")
+    order_detail.clear_changes_information
+
+    expect { resolve_dispute_and_notify }.not_to change(ActionMailer::Base, :deliveries)
+  end
+
+  context "with a business business_administrator" do
+    let!(:business_administrator) { create(:user, :business_administrator, email: "ba@example.com", account: order_detail.account) }
+
+    it "triggers an email to the dispute_by and the account administrators" do
+      expect { resolve_dispute_and_notify }.to change { ActionMailer::Base.deliveries.map(&:to) }
+        .by(containing_exactly(
+              [order_detail.dispute_by.email],
+              [order_detail.account.owner_user.email],
+              [business_administrator.email],
+        ))
+    end
+  end
+
+end


### PR DESCRIPTION
# Release Notes

Tech task: Backport #1624 Notify users on dispute resolution to Rails 4.2

# Additional Context

Has an additional change beyond the original PR as the code was relying on some Rails 5 functionality (`[attribute]_previously_changed?` existing).
