### PR TITLE
Update factory definitions

### DIFF
--- a/spec/factories/accessories.rb
+++ b/spec/factories/accessories.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
   factory :accessory, parent: :setup_item do
     transient do
       parent { create :setup_instrument, facility: facility }
-      scaling_type "quantity"
+      scaling_type { "quantity" }
     end
 
     after(:create) do |item, evaluator|
@@ -23,7 +23,7 @@ FactoryBot.define do
   factory :time_based_accessory, parent: :setup_timed_service do
     transient do
       parent { create :setup_instrument, facility: facility }
-      scaling_type "auto"
+      scaling_type { "auto" }
     end
 
     after(:create) do |item, evaluator|

--- a/spec/factories/account_users.rb
+++ b/spec/factories/account_users.rb
@@ -1,23 +1,23 @@
 FactoryBot.define do
   factory :account_user do
-    user_role "Owner" # TODO: explicitly use the :owner trait
-    created_by 0
+    user_role { "Owner" } # TODO: explicitly use the :owner trait
+    created_by { 0 }
 
     trait :inactive do
       deleted_at { 1.day.ago }
-      deleted_by 0
+      deleted_by { 0 }
     end
 
     trait :owner do
-      user_role AccountUser::ACCOUNT_OWNER
+      user_role { AccountUser::ACCOUNT_OWNER }
     end
 
     trait :business_administrator do
-      user_role AccountUser::ACCOUNT_ADMINISTRATOR
+      user_role { AccountUser::ACCOUNT_ADMINISTRATOR }
     end
 
     trait :purchaser do
-      user_role AccountUser::ACCOUNT_PURCHASER
+      user_role { AccountUser::ACCOUNT_PURCHASER }
     end
   end
 end

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :account do
-    type "Account"
+    type { "Account" }
     sequence(:account_number) { |n| n }
-    description "Account description"
+    description { "Account description" }
     expires_at { 50.years.from_now }
-    created_by 0
+    created_by { 0 }
   end
 
   trait :with_account_owner do

--- a/spec/factories/external_services.rb
+++ b/spec/factories/external_services.rb
@@ -1,18 +1,18 @@
 FactoryBot.define do
 
   factory :external_service, class: UrlService do
-    location "http://survey.test.local"
+    location { "http://survey.test.local" }
   end
 
   factory :external_service_passer do
     external_service
-    active false
+    active { false }
     association :passer, factory: :setup_service
   end
 
   factory :external_service_receiver do
     external_service
-    response_data({ show_url: "http://survey.test.local/show", edit_url: "http://survey.test.local/edit" }.to_json)
+    response_data { { show_url: "http://survey.test.local/show", edit_url: "http://survey.test.local/edit" }.to_json }
 
     after :build do |esr|
       service = create :setup_service

--- a/spec/factories/facilities.rb
+++ b/spec/factories/facilities.rb
@@ -3,9 +3,9 @@ FactoryBot.define do
     sequence(:name, "AAAAAAAA") { |n| "Facility#{n}" }
     sequence(:email) { |n| "facility-#{n}@example.com" }
     sequence(:abbreviation) { |n| "FA#{n}" }
-    short_description "Short Description"
-    description "Facility Description"
-    is_active true
+    short_description { "Short Description" }
+    description { "Facility Description" }
+    is_active { true }
     sequence(:url_name) { |n| "facility#{n}" }
 
     trait :with_order_notification do

--- a/spec/factories/facility_accounts.rb
+++ b/spec/factories/facility_accounts.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
       "134-7#{'%06d' % n}"
     end
 
-    is_active true
-    created_by 1
+    is_active { true }
+    created_by { 1 }
 
     after(:build) do |facility_account|
       define_open_account(facility_account.revenue_account, facility_account.account_number)

--- a/spec/factories/journals.rb
+++ b/spec/factories/journals.rb
@@ -1,14 +1,14 @@
 FactoryBot.define do
   factory :journal do
-    is_successful true
-    created_by 1
+    is_successful { true }
+    created_by { 1 }
     journal_date { Time.zone.now }
 
     trait :with_completed_order do
       facility
 
       transient do
-        quantities [1]
+        quantities { [1] }
 
         facility_account { FactoryBot.create(:facility_account, facility: facility) }
         order { FactoryBot.create(:purchased_order, product: product) }

--- a/spec/factories/nufs_accounts.rb
+++ b/spec/factories/nufs_accounts.rb
@@ -14,7 +14,7 @@ FactoryBot.modify do
       with_account_owner
 
       transient do
-        product nil
+        product { nil }
       end
 
       account_users_attributes { [FactoryBot.attributes_for(:account_user, user: owner)] }

--- a/spec/factories/order_details.rb
+++ b/spec/factories/order_details.rb
@@ -1,20 +1,20 @@
 FactoryBot.define do
   factory :order_detail do
-    quantity 1
-    created_by 0
+    quantity { 1 }
+    created_by { 0 }
 
     trait :completed do
-      state "complete"
+      state { "complete" }
     end
 
     trait :canceled do
-      state "canceled"
+      state { "canceled" }
     end
 
     trait :canceled_with_cost do
-      state "complete"
+      state { "complete" }
       canceled_at { 30.minutes.ago }
-      actual_cost 5
+      actual_cost { 5 }
     end
 
     trait :disputed do
@@ -22,7 +22,7 @@ FactoryBot.define do
       reviewed_at { 5.days.ago }
       dispute_at { 3.days.ago }
       association :dispute_by, factory: :user
-      dispute_reason "No, sir. I don't like it."
+      dispute_reason { "No, sir. I don't like it." }
     end
   end
 

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :order do
-    account nil
+    account { nil }
   end
 
   # Must define product or facility
@@ -15,7 +15,7 @@ FactoryBot.define do
 
     trait :purchased do
       ordered_at { 1.week.ago }
-      state "purchased"
+      state { "purchased" }
     end
 
     after(:create) do |order, evaluator|

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :payment do
-    source :check
+    source { :check }
   end
 end

--- a/spec/factories/price_groups.rb
+++ b/spec/factories/price_groups.rb
@@ -2,9 +2,9 @@ FactoryBot.define do
   factory :price_group do
     facility
     sequence(:name, "AAAAAAAA") { |n| "Price Group #{n}" }
-    display_order 999
-    is_internal true
-    admin_editable true
+    display_order { 999 }
+    is_internal { true }
+    admin_editable { true }
 
     trait :skip_validations do
       to_create { |instance| instance.save(validate: false) }
@@ -13,18 +13,18 @@ FactoryBot.define do
     trait :global do
       # Global PriceGroups are technically invalid because they have no facility
       skip_validations
-      facility nil
-      admin_editable false
+      facility { nil }
+      admin_editable { false }
     end
 
     trait :cancer_center do
       global
-      admin_editable true
+      admin_editable { true }
     end
   end
 
   factory :price_group_product do
-    reservation_window 1
+    reservation_window { 1 }
   end
 
 end

--- a/spec/factories/price_policies.rb
+++ b/spec/factories/price_policies.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :instrument_price_policy do
     price_group
-    charge_for InstrumentPricePolicy::CHARGE_FOR[:reservation]
+    charge_for { InstrumentPricePolicy::CHARGE_FOR[:reservation] }
     association :product, factory: :setup_instrument
-    usage_rate 10 / 60.0
-    usage_subsidy 0
-    minimum_cost 1
-    can_purchase true
+    usage_rate { 10 / 60.0 }
+    usage_subsidy { 0 }
+    minimum_cost { 1 }
+    can_purchase { true }
     start_date { Time.zone.now.beginning_of_day }
     expire_date { PricePolicy.generate_expire_date(start_date) }
   end
@@ -20,27 +20,27 @@ FactoryBot.define do
   end
 
   factory :item_price_policy do
-    can_purchase true
-    unit_cost 1
-    unit_subsidy 0
+    can_purchase { true }
+    unit_cost { 1 }
+    unit_subsidy { 0 }
     start_date { Time.zone.now.beginning_of_day }
     expire_date { PricePolicy.generate_expire_date(start_date) }
   end
 
   factory :service_price_policy do
-    can_purchase true
-    unit_cost 1
-    unit_subsidy 0
+    can_purchase { true }
+    unit_cost { 1 }
+    unit_subsidy { 0 }
     start_date { Time.zone.now.beginning_of_day }
     expire_date { PricePolicy.generate_expire_date(start_date) }
   end
 
   factory :timed_service_price_policy do
-    charge_for "usage"
-    usage_rate 15 / 60.0
-    usage_subsidy 0
-    minimum_cost 1
-    can_purchase true
+    charge_for { "usage" }
+    usage_rate { 15 / 60.0 }
+    usage_subsidy { 0 }
+    minimum_cost { 1 }
+    can_purchase { true }
     start_date { Time.zone.now.beginning_of_day }
     expire_date { PricePolicy.generate_expire_date(start_date) }
   end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :product do
-    description "Lorem ipsum..."
-    account 71_234
-    requires_approval false
-    is_archived false
-    is_hidden false
+    description { "Lorem ipsum..." }
+    account { 71_234 }
+    requires_approval { false }
+    is_archived { false }
+    is_hidden { false }
     initial_order_status_id { FactoryBot.create(:order_status, name: "New").id }
 
     after(:build) do |product|
@@ -17,14 +17,14 @@ FactoryBot.define do
 
     factory :instrument, class: Instrument do
       transient do
-        no_relay false
+        no_relay { false }
       end
 
       sequence(:name) { |n| "Instrument #{n}" }
       sequence(:url_name) { |n| "instrument#{n}" }
-      min_reserve_mins 60
-      max_reserve_mins 120
-      reserve_interval 1
+      min_reserve_mins { 60 }
+      max_reserve_mins { 120 }
+      reserve_interval { 1 }
 
       after(:create) do |inst, evaluator|
         inst.relay = FactoryBot.create(:relay_dummy, instrument: inst) unless evaluator.no_relay
@@ -48,10 +48,10 @@ FactoryBot.define do
 
     factory :bundle, class: Bundle do
       transient do
-        bundle_products []
+        bundle_products { [] }
       end
 
-      account nil # bundles don't have accounts
+      account { nil } # bundles don't have accounts
       sequence(:name) { |n| "Bundle #{n}" }
       sequence(:url_name) { |n| "bundle-#{n}" }
 
@@ -63,11 +63,11 @@ FactoryBot.define do
     end
 
     trait :archived do
-      is_archived true
+      is_archived { true }
     end
 
     trait :hidden do
-      is_hidden true
+      is_hidden { true }
     end
   end
 
@@ -76,14 +76,14 @@ FactoryBot.define do
 
     sequence(:name) { |n| "Product #{n}" }
     sequence(:url_name) { |n| "product-#{n}" }
-    description "Product description"
-    account 71_234
-    requires_approval false
-    is_archived false
-    is_hidden false
+    description { "Product description" }
+    account { 71_234 }
+    requires_approval { false }
+    is_archived { false }
+    is_hidden { false }
     initial_order_status { FactoryBot.create(:order_status, name: "New") }
-    min_reserve_mins 60
-    max_reserve_mins 120
+    min_reserve_mins { 60 }
+    max_reserve_mins { 120 }
 
     after(:build) do |product|
       product.facility_account ||= product.facility.facility_accounts.first
@@ -124,7 +124,7 @@ FactoryBot.define do
   end
 
   factory :setup_instrument, class: Instrument, parent: :setup_product do
-    reserve_interval 1
+    reserve_interval { 1 }
 
     schedule { create :schedule, facility: facility }
 
@@ -136,12 +136,12 @@ FactoryBot.define do
 
     trait :timer do
       transient do
-        no_relay false
+        no_relay { false }
       end
 
-      min_reserve_mins 60
-      max_reserve_mins 120
-      reserve_interval 1
+      min_reserve_mins { 60 }
+      max_reserve_mins { 120 }
+      reserve_interval { 1 }
 
       after(:create) do |inst, evaluator|
         inst.relay = FactoryBot.create(:relay_dummy, instrument: inst) unless evaluator.no_relay

--- a/spec/factories/relays.rb
+++ b/spec/factories/relays.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :relay do
-    type "RelaySynaccessRevA"
-    ip "192.168.1.1"
+    type { "RelaySynaccessRevA" }
+    ip { "192.168.1.1" }
     sequence(:port) { |p| p }
     sequence(:username) { |n| "username#{n}" }
     sequence(:password) { |n| "password#{n}" }
@@ -10,11 +10,11 @@ FactoryBot.define do
     end
 
     factory :relay_synb, class: RelaySynaccessRevB do
-      type "RelaySynaccessRevB"
+      type { "RelaySynaccessRevB" }
     end
   end
 
   factory :relay_dummy, class: RelayDummy do
-    type "RelayDummy"
+    type { "RelayDummy" }
   end
 end

--- a/spec/factories/reservations.rb
+++ b/spec/factories/reservations.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :reservation do
     transient do
-      duration nil
+      duration { nil }
     end
 
     after(:build) do |reservation, evaluator|
@@ -46,7 +46,7 @@ FactoryBot.define do
     trait :long_running do
       yesterday
       actual_start_at { reserve_start_at }
-      actual_end_at nil
+      actual_end_at { nil }
     end
 
     trait :started_early do
@@ -68,18 +68,18 @@ FactoryBot.define do
   end
 
   factory :admin_reservation, class: AdminReservation, parent: :reservation do
-    order_detail nil
+    order_detail { nil }
     category { AdminReservation::CATEGORIES.sample }
   end
 
   factory :offline_reservation, class: OfflineReservation, parent: :reservation do
-    admin_note "Out of order"
-    category "out_of_order"
-    order_detail nil
+    admin_note { "Out of order" }
+    category { "out_of_order" }
+    order_detail { nil }
 
     OfflineReservation::CATEGORIES.each do |category_label|
       trait category_label.to_sym do
-        category category_label
+        category { category_label }
       end
     end
   end
@@ -97,7 +97,7 @@ FactoryBot.define do
   end
 
   factory :purchased_reservation, parent: :validated_reservation do
-    transient { user nil }
+    transient { user { nil } }
 
     after(:create) do |reservation, evaluator|
       reservation.order.update_attribute(:user_id, evaluator.user.id) if evaluator.user
@@ -107,7 +107,7 @@ FactoryBot.define do
     factory :completed_reservation do
       reserve_start_at { Time.zone.parse("#{Date.today} 10:00:00") - 1.day }
       reserve_end_at { Time.zone.parse("#{Date.today} 10:00:00") - 23.hours }
-      reserved_by_admin true
+      reserved_by_admin { true }
 
       after(:create) do |reservation|
         reservation.order_detail.backdate_to_complete! reservation.reserve_end_at

--- a/spec/factories/schedule_rules.rb
+++ b/spec/factories/schedule_rules.rb
@@ -1,41 +1,41 @@
 FactoryBot.define do
   factory :schedule_rule do
-    discount_percent 0.00
-    start_hour 9
-    start_min 00
-    end_hour 17
-    end_min 00
-    on_sun true
-    on_mon true
-    on_tue true
-    on_wed true
-    on_thu true
-    on_fri true
-    on_sat true
+    discount_percent { 0.00 }
+    start_hour { 9 }
+    start_min { 00 }
+    end_hour { 17 }
+    end_min { 00 }
+    on_sun { true }
+    on_mon { true }
+    on_tue { true }
+    on_wed { true }
+    on_thu { true }
+    on_fri { true }
+    on_sat { true }
 
     trait :weekday do
-      on_sun false
-      on_sat false
+      on_sun { false }
+      on_sat { false }
     end
 
     trait :weekend do
-      on_sun true
-      on_mon false
-      on_tue false
-      on_wed false
-      on_thu false
-      on_fri false
-      on_sat true
+      on_sun { true }
+      on_mon { false }
+      on_tue { false }
+      on_wed { false }
+      on_thu { false }
+      on_fri { false }
+      on_sat { true }
     end
 
     trait :all_day do
-      start_hour 0
-      end_hour 24
+      start_hour { 0 }
+      end_hour { 24 }
     end
 
     trait :evening do
-      start_hour 17
-      end_hour 24
+      start_hour { 17 }
+      end_hour { 24 }
     end
 
     factory :weekend_schedule_rule do

--- a/spec/factories/stored_files.rb
+++ b/spec/factories/stored_files.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :stored_file do
     swf_uploaded_data { fixture_file_upload("#{Rails.root}/spec/files/flash_file.swf", "application/x-shockwave-flash") }
     sequence(:name) { |n| "flash_file-#{n}.swf" }
-    file_type "info"
+    file_type { "info" }
   end
 
   factory :csv_stored_file, class: StoredFile do

--- a/spec/factories/user_preferences.rb
+++ b/spec/factories/user_preferences.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :user_preference do
     user
-    name "My Awesome Preference"
-    value "Yay!"
+    name { "My Awesome Preference" }
+    value { "Yay!" }
 
     trait :default_facility_home_page do
-      name "Facility Home Page"
-      value "Dashboard"
+      name { "Facility Home Page" }
+      value { "Dashboard" }
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :user do
     sequence(:username) { |n| "username#{n}" }
-    first_name "User"
-    password "password"
-    password_confirmation "password"
+    first_name { "User" }
+    password { "password" }
+    password_confirmation { "password" }
     sequence(:last_name, &:to_s)
     sequence(:email) { |n| "user#{n}@example.com" }
 
@@ -39,8 +39,8 @@ FactoryBot.define do
 
     trait :business_administrator do
       transient do
-        account nil
-        administrator nil
+        account { nil }
+        administrator { nil }
       end
 
       after(:create) do |user, evaluator|
@@ -54,7 +54,7 @@ FactoryBot.define do
     end
 
     trait :facility_administrator do
-      transient { facility nil }
+      transient { facility { nil } }
 
       after(:create) do |user, evaluator|
         UserRole.create!(
@@ -66,7 +66,7 @@ FactoryBot.define do
     end
 
     trait :facility_director do
-      transient { facility nil }
+      transient { facility { nil } }
 
       after(:create) do |user, evaluator|
         UserRole.create!(
@@ -79,8 +79,8 @@ FactoryBot.define do
 
     trait :purchaser do
       transient do
-        account nil
-        administrator nil
+        account { nil }
+        administrator { nil }
       end
 
       after(:create) do |user, evaluator|
@@ -94,7 +94,7 @@ FactoryBot.define do
     end
 
     trait :senior_staff do
-      transient { facility nil }
+      transient { facility { nil } }
 
       after(:create) do |user, evaluator|
         UserRole.create!(
@@ -106,7 +106,7 @@ FactoryBot.define do
     end
 
     trait :staff do
-      transient { facility nil }
+      transient { facility { nil } }
 
       after(:create) do |user, evaluator|
         UserRole.create!(


### PR DESCRIPTION
# Release Notes

Updates the factory definitions, as factory_bot is deprecating the static attributes (only block-style attributes are supported in the future).

# Additional Context

Ref: https://robots.thoughtbot.com/deprecating-static-attributes-in-factory_bot-4-11
