### PR TITLE
[#143112] Enhance account price group member search results

### DIFF
--- a/app/controllers/account_price_group_members_controller.rb
+++ b/app/controllers/account_price_group_members_controller.rb
@@ -47,7 +47,8 @@ class AccountPriceGroupMembersController < ApplicationController
   end
 
   def set_search_conditions
-    @accounts = Account.where(search_conditions)
+    @accounts = Account.for_facility(current_facility)
+                       .where(search_conditions)
                        .order(:account_number)
                        .limit(@limit)
   end

--- a/app/views/account_price_group_members/search_results.html.haml
+++ b/app/views/account_price_group_members/search_results.html.haml
@@ -11,16 +11,15 @@
     %table.table.table-striped.table-hover
       %thead
         %tr
-          %th Account Number
-          %th Owner
-          %th Email
+          %th= Account.human_attribute_name(:account_number)
+          %th= Account.human_attribute_name(:owner)
+          %th= Account.human_attribute_name(:expires_at)
       %tbody
         - @accounts.each do |account|
           %tr
-            %td= link_to account.account_number, facility_price_group_account_price_group_members_path(current_facility, @price_group, account_id: account.id), method: :post
-            - owner=account.owner_user
-            %td= owner.full_name if owner
-            %td= owner.email if owner
+            %td= link_to account, facility_price_group_account_price_group_members_path(current_facility, @price_group, account_id: account.id), method: :post
+            %td= account.owner_user.full_name if account.owner_user
+            %td= human_date(account.expires_at)
     - if @accounts.count > @limit
       %p.notice= t(".notice", count: @count - @limit)
 - else

--- a/spec/controllers/account_price_group_members_controller_spec.rb
+++ b/spec/controllers/account_price_group_members_controller_spec.rb
@@ -133,19 +133,18 @@ RSpec.describe AccountPriceGroupMembersController do
   end
 
   context "search_results" do
-    let!(:account) { FactoryBot.create(:account, :with_account_owner, account_number: "TESTING123") }
+    let!(:account) { FactoryBot.create(:nufs_account, :with_account_owner, account_number: "TESTING123") }
 
     before :each do
       @method = :get
       @action = :search_results
-      @params = { facility_id: @authable.url_name, price_group_id: price_group.id, search_term: "TESTING123" }
+      @params = { facility_id: facility.url_name, price_group_id: price_group.id, search_term: "TESTING123" }
     end
 
     it_should_require_login
 
     it_should_deny :guest
 
-    # it_should_allow_all facility_operators do
     it_should_allow :admin do
       expect(assigns(:accounts)).to include(account)
       expect(assigns(:limit)).to be_kind_of Integer

--- a/vendor/engines/c2po/spec/controllers/account_price_group_members_controller_spec.rb
+++ b/vendor/engines/c2po/spec/controllers/account_price_group_members_controller_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe AccountPriceGroupMembersController do
+  let(:facility) { create(:facility) }
+
+  describe "search_results" do
+    let(:price_group) { create(:price_group, facility: facility) }
+    let!(:global_account) { create(:nufs_account, :with_account_owner, account_number: "TESTING123") }
+    let!(:facility_purchase_order) { create(:purchase_order_account, :with_account_owner, account_number: "TESTING1234", facility: facility) }
+    let!(:other_facility_purchase_order) { create(:purchase_order_account, :with_account_owner, account_number: "TESTING4321", facility: create(:facility)) }
+
+    let(:user) { create(:user, :facility_administrator, facility: facility) }
+
+    it "limits the results to global and the facility" do
+      sign_in user
+
+      get :search_results, params: { facility_id: facility.url_name, price_group_id: price_group.id, search_term: "TESTING" }
+      expect(assigns[:accounts]).to contain_exactly(global_account, facility_purchase_order)
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

Enhance account price group member search results to include full account number. Also, limit the results to only include global payment sources or ones specific to that facility.

# Additional Context

Before, we were just displaying the account number. Instead, let's display the
full account number with description like we do everywhere else.
