### PR TITLE
[#136049] Allow reservation cost to be overridden

### DIFF
--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -262,7 +262,6 @@ en:
       price_group:
         is_internal: Is Internal?
       price_policy:
-        cancellation_cost: Reservation cost
         type: Type
         can_purchase: Can Purchase?
         minimum_cost: Minimum Cost

--- a/spec/features/admin/manage_order_detail_spec.rb
+++ b/spec/features/admin/manage_order_detail_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Managing an order detail" do
 
       it "cancels with a fee" do
         select "Canceled", from: "Status"
-        check "Add reservation cost"
+        check I18n.t("facility_order_details.edit.label.with_cancel_fee")
         click_button "Save"
 
         expect(page).to have_content("Complete")


### PR DESCRIPTION
# Release Notes

Tech task: Allow "Reservation Cost" text to be overridden.

# Additional Context

Taken from https://github.com/tablexi/nucore-dartmouth/pull/217
