### PR TITLE
[#143112] Fix spec when account number is not valid

### DIFF
--- a/spec/controllers/account_price_group_members_controller_spec.rb
+++ b/spec/controllers/account_price_group_members_controller_spec.rb
@@ -133,6 +133,9 @@ RSpec.describe AccountPriceGroupMembersController do
   end
 
   context "search_results" do
+    # Ignore validation errors, e.g. number format
+    before { allow(ValidatorFactory).to receive(:instance).and_return(ValidatorDefault.new) }
+
     let!(:account) { FactoryBot.create(:nufs_account, :with_account_owner, account_number: "TESTING123") }
 
     before :each do


### PR DESCRIPTION
# Release Notes

Tech task: Fix spec when account number is not considered valid.

# Additional Context

In Dartmouth and possibly other schools, the "TESTING123" is not a valid format, but
for the sake of this spec, we don't care: we just need it to be considered a global
account type.

Fixes the merge of https://github.com/tablexi/nucore-open/pull/1659 into DC

