### PR TITLE
[#142448] Cross facility bulk email

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -97,6 +97,9 @@ class UsersController < ApplicationController
 
   # GET /facilities/:facility_id/users/:user_id/access_list
   def access_list
+    # Unsupported in cross-facility mode
+    raise ActiveRecord::RecordNotFound if current_facility.cross_facility?
+
     @facility = current_facility
     @products_by_type = Product.for_facility(@facility).requiring_approval_by_type
     @training_requested_product_ids = @user.training_requests.pluck(:product_id)
@@ -104,6 +107,9 @@ class UsersController < ApplicationController
 
   # POST /facilities/:facility_id/users/:user_id/access_list/approvals
   def access_list_approvals
+    # Unsupported in cross-facility mode
+    raise ActiveRecord::RecordNotFound if current_facility.cross_facility?
+
     update_access_list_approvals
     redirect_to facility_user_access_list_path(current_facility, @user)
   end

--- a/app/models/serializable_facility.rb
+++ b/app/models/serializable_facility.rb
@@ -1,0 +1,17 @@
+class SerializableFacility < SimpleDelegator
+
+  include GlobalID::Identification
+
+  def id
+    super || "cross_facility"
+  end
+
+  def self.find(id)
+    if id == "cross_facility"
+      Facility.cross_facility
+    else
+      Facility.find(id)
+    end
+  end
+
+end

--- a/app/views/admin/shared/_tabnav_users.html.haml
+++ b/app/views/admin/shared/_tabnav_users.html.haml
@@ -18,7 +18,7 @@
       facility_user_accounts_path(current_facility, @user),
       secondary_tab == "accounts"
 
-  - if current_ability.can?(:administer, Product)
+  - if current_ability.can?(:access_list, User) && current_facility.single_facility?
     = tab t(".access_list"),
       facility_user_access_list_path(current_facility, @user),
       secondary_tab == "access_list"

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -22,10 +22,10 @@ class Ability
       else
         can :manage, :all
         unless user.billing_administrator?
-          cannot [:manage_accounts, :manage_billing, :manage_users], Facility.cross_facility
+          cannot [:manage_accounts, :manage_billing], Facility.cross_facility
         end
         unless user.account_manager?
-          cannot :manage, User unless resource.is_a?(Facility) && resource.single_facility?
+          cannot :manage, User unless resource.is_a?(Facility)
           if SettingsHelper.feature_off?(:create_users)
             cannot([:edit, :update], User)
           end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Ability do
 
     it { is_expected.to be_allowed_to(:manage, TrainingRequest) }
     it { is_expected.to be_allowed_to(:show_problems, Reservation) }
-    it { is_expected.not_to be_allowed_to(:manage_users, Facility.cross_facility) }
+    it { is_expected.to be_allowed_to(:manage_users, Facility.cross_facility) }
 
     context "in a single facility" do
       let(:internal_user) { FactoryBot.create(:user) }
@@ -170,7 +170,7 @@ RSpec.describe Ability do
     context "in cross-facility" do
       let(:facility) { Facility.cross_facility }
 
-      it { is_expected.not_to be_allowed_to(:manage, User) }
+      it { is_expected.to be_allowed_to(:manage, User) }
       it { is_expected.not_to be_allowed_to(:manage_accounts, facility) }
       it { is_expected.not_to be_allowed_to(:manage_billing, facility) }
     end

--- a/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
+++ b/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
@@ -60,7 +60,7 @@ module BulkEmail
       return if params[:bulk_email_delivery_form].blank?
       search_criteria = JSON.parse(params[:bulk_email_delivery_form][:search_criteria])
       params.merge!(search_criteria.slice("bulk_email", "start_date", "end_date", "products"))
-      params.merge!(params[:bulk_email_delivery_form].slice(:product_id, :recipient_ids))
+      params.merge!(params[:bulk_email_delivery_form].permit(:product_id, :recipient_ids))
     end
 
     def bulk_email_cancel_path
@@ -106,7 +106,7 @@ module BulkEmail
     def init_search_options
       @products = Product.for_facility(current_facility).active_plus_hidden.order("products.name").includes(:facility)
       @search_options = { products: @products }
-      @search_fields = params.merge(facility_id: current_facility.id)
+      @search_fields = params.merge(facility: current_facility)
       @user_types = user_types
       @user_types.delete(:authorized_users) unless @products.exists?(requires_approval: true)
     end

--- a/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
+++ b/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
@@ -104,12 +104,12 @@ module BulkEmail
     end
 
     def init_search_options
-      @products = Product.for_facility(current_facility).active_plus_hidden.alphabetized.includes(:facility)
-      @facilities = Facility.active.alphabetized if current_facility.cross_facility?
-      @search_options = { products: @products, facilities: @facilities }
+      products = Product.for_facility(current_facility).active_plus_hidden.alphabetized.includes(:facility)
+      facilities = Facility.active.alphabetized if current_facility.cross_facility?
+      @search_options = { products: products, facilities: facilities }
       @search_fields = params
       @user_types = user_types
-      @user_types.delete(:authorized_users) unless @products.exists?(requires_approval: true)
+      @user_types.delete(:authorized_users) unless products.exists?(requires_approval: true)
     end
 
     def datepicker_field_input(form, key)

--- a/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
+++ b/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
@@ -21,7 +21,7 @@ module BulkEmail
     helper_method :user_type_selected?
 
     def search
-      @searcher = RecipientSearcher.new(@search_fields)
+      @searcher = RecipientSearcher.new(current_facility, @search_fields)
       @users = @searcher.do_search
     end
 
@@ -59,7 +59,7 @@ module BulkEmail
     def populate_flow_state_params
       return if params[:bulk_email_delivery_form].blank?
       search_criteria = JSON.parse(params[:bulk_email_delivery_form][:search_criteria])
-      params.merge!(search_criteria.slice("bulk_email", "start_date", "end_date", "products"))
+      params.merge!(search_criteria.slice("bulk_email", "start_date", "end_date", "products", "facilities"))
       params.merge!(params[:bulk_email_delivery_form].permit(:product_id, :recipient_ids))
     end
 
@@ -104,9 +104,10 @@ module BulkEmail
     end
 
     def init_search_options
-      @products = Product.for_facility(current_facility).active_plus_hidden.order("products.name").includes(:facility)
-      @search_options = { products: @products }
-      @search_fields = params.merge(facility: current_facility)
+      @products = Product.for_facility(current_facility).active_plus_hidden.alphabetized.includes(:facility)
+      @facilities = Facility.active.alphabetized if current_facility.cross_facility?
+      @search_options = { products: @products, facilities: @facilities }
+      @search_fields = params
       @user_types = user_types
       @user_types.delete(:authorized_users) unless @products.exists?(requires_approval: true)
     end

--- a/vendor/engines/bulk_email/app/decorators/bulk_email/job_decorator.rb
+++ b/vendor/engines/bulk_email/app/decorators/bulk_email/job_decorator.rb
@@ -19,6 +19,11 @@ module BulkEmail
         Product.where(id: selected_product_ids).pluck(:name).join(", ")
     end
 
+    def facilities
+      @facilities ||=
+        Facility.where(id: search_criteria["facilities"]).join(", ")
+    end
+
     def start_date
       search_criteria["start_date"] || I18n.t("bulk_email.dates.unset")
     end

--- a/vendor/engines/bulk_email/app/helpers/bulk_email/application_helper.rb
+++ b/vendor/engines/bulk_email/app/helpers/bulk_email/application_helper.rb
@@ -34,6 +34,7 @@ module BulkEmail
                       :product_id,
                       :facility_id,
                       products: [],
+                      facilities: [],
                       bulk_email: { user_types: [] })
       end
     end

--- a/vendor/engines/bulk_email/app/models/bulk_email/delivery_form.rb
+++ b/vendor/engines/bulk_email/app/models/bulk_email/delivery_form.rb
@@ -49,7 +49,7 @@ module BulkEmail
 
     def deliver(recipient)
       Mailer
-        .send_mail(recipient: recipient, subject: subject, body: body(recipient.full_name), reply_to: reply_to, facility: facility)
+        .send_mail(recipient: recipient, subject: subject, body: body(recipient.full_name), reply_to: reply_to, facility: SerializableFacility.new(facility))
         .deliver_later
     end
 

--- a/vendor/engines/bulk_email/app/services/bulk_email/recipient_searcher.rb
+++ b/vendor/engines/bulk_email/app/services/bulk_email/recipient_searcher.rb
@@ -86,7 +86,7 @@ module BulkEmail
     def product_ids_from_params
       # if we don't have any products, get all for the facility
       search_fields[:products].presence ||
-        Facility.find(search_fields[:facility_id]).products.pluck(:id)
+        Product.for_facility(search_fields[:facility]).pluck(:id)
     end
 
     def selected_user_types
@@ -101,7 +101,7 @@ module BulkEmail
     def find_order_details
       OrderDetail
         .for_products(search_fields[:products])
-        .for_facility_id(search_fields[:facility_id].presence)
+        .for_facility_id(search_fields[:facility].id)
         .ordered_or_reserved_in_range(start_date, end_date)
     end
 

--- a/vendor/engines/bulk_email/app/services/bulk_email/recipient_searcher.rb
+++ b/vendor/engines/bulk_email/app/services/bulk_email/recipient_searcher.rb
@@ -5,12 +5,13 @@ module BulkEmail
     include DateHelper
     include ActionView::Helpers::FormTagHelper
 
-    attr_reader :search_fields
+    attr_reader :search_fields, :facility
 
     DEFAULT_SORT = [:last_name, :first_name].freeze
 
-    def initialize(search_fields)
+    def initialize(facility, search_fields)
       @search_fields = search_fields
+      @facility = facility
     end
 
     def self.user_types
@@ -41,6 +42,7 @@ module BulkEmail
         hidden_tags_for(:end_date, search_fields[:end_date]),
         hidden_tags_for("bulk_email[user_types][]", search_fields[:bulk_email][:user_types]),
         hidden_tags_for("products[]", search_fields[:products]),
+        hidden_tags_for("facilities[]", search_fields[:facilities]),
       ].flatten
     end
 
@@ -65,7 +67,7 @@ module BulkEmail
       users
         .joins(:product_users)
         .distinct
-        .where(product_users: { product_id: product_ids_from_params })
+        .where(product_users: { product: products_from_params })
         .reorder(*self.class::DEFAULT_SORT)
     end
 
@@ -73,7 +75,7 @@ module BulkEmail
       users
         .joins(:training_requests)
         .distinct
-        .where(training_requests: { product_id: product_ids_from_params })
+        .where(training_requests: { product: products_from_params })
         .reorder(*self.class::DEFAULT_SORT)
     end
 
@@ -83,10 +85,11 @@ module BulkEmail
       Array(values).map { |value| hidden_field_tag(key, value, id: nil) }
     end
 
-    def product_ids_from_params
-      # if we don't have any products, get all for the facility
-      search_fields[:products].presence ||
-        Product.for_facility(search_fields[:facility]).pluck(:id)
+    def products_from_params
+      query = Product.for_facility(facility)
+      query = query.where(facility: search_fields[:facilities]) if search_fields[:facilities].present?
+      query = query.where(id: search_fields[:products]) if search_fields[:products].present?
+      query
     end
 
     def selected_user_types
@@ -101,7 +104,8 @@ module BulkEmail
     def find_order_details
       OrderDetail
         .for_products(search_fields[:products])
-        .for_facility_id(search_fields[:facility].id)
+        .for_facility(facility) # If cross_facility, will not add any restrictions
+        .for_facilities(search_fields[:facilities])
         .ordered_or_reserved_in_range(start_date, end_date)
     end
 

--- a/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_fields.html.haml
+++ b/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_fields.html.haml
@@ -12,9 +12,9 @@
           = label_text
 
     .span4.full-width
-      = f.input :products,
-        as: :transaction_chosen_old,
-        data_method: :product_options
+      - if @facilities.present?
+        = f.input :facilities, as: :transaction_chosen_old
+      = f.input :products, as: :transaction_chosen_old, data_method: :product_options
 
   .row
     %h4.span8= t("bulk_email.dates.label")

--- a/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_fields.html.haml
+++ b/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_fields.html.haml
@@ -12,7 +12,7 @@
           = label_text
 
     .span4.full-width
-      - if @facilities.present?
+      - if @search_options[:facilities].present?
         = f.input :facilities, as: :transaction_chosen_old
       = f.input :products, as: :transaction_chosen_old, data_method: :product_options
 

--- a/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/create.html.haml
+++ b/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/create.html.haml
@@ -21,7 +21,7 @@
   .row.span6
     %div
       = label_tag text("bulk_email.recipients")
-      = text_area_tag nil,
+      = text_area_tag text("bulk_email.recipients"),
         @users.map(&:email).join(", "),
         disabled: true,
         class: "input-xxlarge"

--- a/vendor/engines/bulk_email/app/views/bulk_email/jobs/show.html.haml
+++ b/vendor/engines/bulk_email/app/views/bulk_email/jobs/show.html.haml
@@ -21,5 +21,7 @@
   = f.input :user_types
   - if @bulk_email_job.products.present?
     = f.input :products
+  - if @bulk_email_job.facilities.present?
+    = f.input :facilities
   = f.input :start_date
   = f.input :end_date

--- a/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
+++ b/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
@@ -70,8 +70,7 @@ RSpec.describe BulkEmail::BulkEmailController do
                   commit: "Search",
                   bulk_email: {
                     user_types: %w[customers],
-                  },
-                }
+                  } }
               end
 
               it "finds users" do
@@ -85,8 +84,7 @@ RSpec.describe BulkEmail::BulkEmailController do
                   commit: "Search",
                   bulk_email: {
                     user_types: %w[authorized_users],
-                  },
-                }
+                  } }
               end
 
               it "finds users" do

--- a/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
+++ b/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe BulkEmail::BulkEmailController do
           let(:user_types) { %i(customers) }
 
           it "sets products, in order" do
-            expect(assigns[:products])
+            expect(assigns[:search_options][:products])
               .to eq([item, service, instrument, restricted_item].sort)
           end
 
@@ -102,7 +102,7 @@ RSpec.describe BulkEmail::BulkEmailController do
             FactoryBot.create(:item, :hidden, facility_account: facility_account)
           end
 
-          it { expect(assigns[:products]).to include(hidden_product) }
+          it { expect(assigns[:search_options][:products]).to include(hidden_product) }
         end
 
         context "when there is an archived product" do
@@ -112,7 +112,7 @@ RSpec.describe BulkEmail::BulkEmailController do
             FactoryBot.create(:item, :archived, facility_account: facility_account)
           end
 
-          it { expect(assigns[:products]).not_to include(archived_product) }
+          it { expect(assigns[:search_options][:products]).not_to include(archived_product) }
         end
       end
 

--- a/vendor/engines/bulk_email/spec/features/bulk_emailer_searching_spec.rb
+++ b/vendor/engines/bulk_email/spec/features/bulk_emailer_searching_spec.rb
@@ -1,27 +1,81 @@
 require "rails_helper"
 
 RSpec.describe "Bulk email search", feature_setting: { training_requests: true } do
-  let(:director) { create(:user, :facility_director, facility: facility) }
   let!(:training_request) { create(:training_request) }
   let(:facility) { training_request.product.facility }
   let(:instrument) { training_request.product }
   let(:user) { training_request.user }
 
-  before { login_as director }
+  describe "single facility context" do
+    let(:director) { create(:user, :facility_director, facility: facility) }
+    before { login_as director }
 
-  it "returns matching results" do
-    visit facility_bulk_email_path(facility)
+    it "can trigger an email" do
+      visit facility_bulk_email_path(facility)
 
-    check "Authorized Users"
+      check "Authorized Users"
+      click_button "Search"
 
-    click_button "Search"
+      expect(page).to have_content("No users found")
 
-    expect(page).to have_content("No users found")
+      check "Users on Training Request List"
+      click_button "Search"
+      expect(page).to have_content(user.email)
 
-    check "Users on Training Request List"
+      find("#format", visible: false).set "html" # Handled by JS normally
+      click_button "Compose Mail"
 
-    click_button "Search"
+      expect(page).to have_field("Recipients", with: user.email, disabled: true, type: "textarea")
 
-    expect(page).to have_content(user.email)
+      fill_in "Subject line", with: "Hello, friends"
+      fill_in "Message", with: "Howdy!"
+      click_button "Send Mail"
+      expect(page).to have_content("queued successfully")
+
+      click_link "History"
+      click_link "View details"
+      expect(page).to have_content("Hello, friends")
+    end
   end
+
+  describe "cross-facility context" do
+    let(:admin) { create(:user, :administrator) }
+    let!(:facility2) { create(:facility) }
+
+    before { login_as admin }
+
+    it "can trigger an email" do
+      visit root_path
+      click_link "Users", match: :first
+      click_link "Bulk Email"
+
+      check "Users on Training Request List"
+      click_button "Search"
+      expect(page).to have_content(user.email)
+
+      select facility2.name, from: "facilities" # The label's `for` does not match the `select`'s `id`
+      click_button "Search"
+      expect(page).to have_content("No users found")
+
+      select facility.name, from: "facilities"
+      click_button "Search"
+      expect(page).to have_content(user.email)
+
+      find("#format", visible: false).set "html" # Handled by JS normally
+      click_button "Compose Mail"
+
+      expect(page).to have_field("Recipients", with: user.email, disabled: true, type: "textarea")
+
+      fill_in "Subject line", with: "Hello, friends"
+      fill_in "Message", with: "Howdy!"
+      click_button "Send Mail"
+      expect(page).to have_content("queued successfully")
+
+      click_link "History"
+      click_link "View details"
+      expect(page).to have_content("Hello, friends")
+      expect(page).to have_content([facility, facility2].join(", "))
+    end
+  end
+
 end

--- a/vendor/engines/bulk_email/spec/features/bulk_emailer_searching_spec.rb
+++ b/vendor/engines/bulk_email/spec/features/bulk_emailer_searching_spec.rb
@@ -77,5 +77,4 @@ RSpec.describe "Bulk email search", feature_setting: { training_requests: true }
       expect(page).to have_content([facility, facility2].join(", "))
     end
   end
-
 end

--- a/vendor/engines/bulk_email/spec/services/bulk_email/recipient_searcher_spec.rb
+++ b/vendor/engines/bulk_email/spec/services/bulk_email/recipient_searcher_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe BulkEmail::RecipientSearcher do
     end
   end
 
-  subject(:searcher) { described_class.new(params) }
+  subject(:searcher) { described_class.new(facility, params) }
 
   let(:users) { searcher.do_search }
   let(:owner) { FactoryBot.create(:user) }
@@ -25,8 +25,7 @@ RSpec.describe BulkEmail::RecipientSearcher do
   let(:purchaser2) { FactoryBot.create(:user) }
   let(:purchaser3) { FactoryBot.create(:user) }
 
-  let(:facility) { facility_account.facility }
-  let(:facility_account) { FactoryBot.create(:facility_account) }
+  let(:facility) { FactoryBot.create(:setup_facility) }
 
   let(:product) { create_item }
   let(:product2) { create_item }
@@ -40,16 +39,13 @@ RSpec.describe BulkEmail::RecipientSearcher do
     {
       bulk_email: { user_types: [:customers] },
       commit: "Submit",
-      facility_id: facility.id,
     }
   end
 
   before { ignore_order_detail_account_validations }
 
   def create_item
-    FactoryBot.create(:item, facility_account: facility_account).tap do |item|
-      FactoryBot.create(:item_price_policy, product: item, price_group: price_group)
-    end
+    FactoryBot.create(:setup_item, facility: facility)
   end
 
   def place_order(purchaser:, product:, account:)
@@ -161,7 +157,7 @@ RSpec.describe BulkEmail::RecipientSearcher do
     context "when filtering by reservation dates" do
       let(:instrument) do
         FactoryBot.create(:instrument,
-                          facility_account: facility_account,
+                          facility: facility,
                           min_reserve_mins: 60,
                           max_reserve_mins: 60)
       end
@@ -248,6 +244,41 @@ RSpec.describe BulkEmail::RecipientSearcher do
 
         it "returns only the users that purchased those two products" do
           expect(users).to contain_exactly(purchaser, purchaser2)
+        end
+      end
+    end
+
+    context "filtered by facilities" do
+      let!(:facility2) { FactoryBot.create(:setup_facility) }
+      let!(:product_facility2) { FactoryBot.create(:item, facility: facility2) }
+      let!(:order_details) do
+        [
+          place_order(purchaser: purchaser, product: product, account: account),
+          place_order(purchaser: purchaser2, product: product_facility2, account: account)
+        ]
+      end
+
+      describe "when we're searching from within facility 1" do
+        before { params[:facilities] = [facility.id, facility2.id] }
+
+        it "does find anything in facility 2" do
+          expect(users).to contain_exactly(purchaser)
+        end
+      end
+
+      describe "when searching in cross-facility" do
+        subject(:searcher) { described_class.new(Facility.cross_facility, params) }
+
+        it "finds everything by default" do
+          expect(users).to contain_exactly(purchaser, purchaser2)
+        end
+
+        describe "when searching for a single facility" do
+          before { params[:facilities] = [facility2.id] }
+
+          it "filters to that facility" do
+            expect(users).to contain_exactly(purchaser2)
+          end
         end
       end
     end

--- a/vendor/engines/bulk_email/spec/services/bulk_email/recipient_searcher_spec.rb
+++ b/vendor/engines/bulk_email/spec/services/bulk_email/recipient_searcher_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe BulkEmail::RecipientSearcher do
       let!(:order_details) do
         [
           place_order(purchaser: purchaser, product: product, account: account),
-          place_order(purchaser: purchaser2, product: product_facility2, account: account)
+          place_order(purchaser: purchaser2, product: product_facility2, account: account),
         ]
       end
 


### PR DESCRIPTION
# Release Notes

Enable cross-facility bulk email for global admins. This also enables several of the Users tab features such as Payment Sources, and Secure Room card numbers. Access List remains disabled in cross-facility mode. 

# Screenshot

<img width="1221" alt="screen shot 2018-08-28 at 11 30 24 am" src="https://user-images.githubusercontent.com/1099111/44736801-cd010a00-aab5-11e8-9f7e-2b68a4976757.png">


# Additional Context

I decided to spend the extra time to get these other features to work as well since their tab gets opened up when I enable Bulk Email for global admins. Before, they had the global User tab disabled unless they were also a billing admin. Access List seemed outside the scope of this work to ensure it works properly with scheduling groups and it would probably get too unwieldy with every single product on the page.
