### PR TITLE
[#143237] Make "account is not open" text localized and overridable

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -196,7 +196,9 @@ class Account < ApplicationRecord
     # check chart string account number
     if respond_to?(:account_open?)
       accts = product.is_a?(Bundle) ? product.products.collect(&:account) : [product.account]
-      accts.uniq.each { |acct| return "The #{type_string} is not open for the required account" unless account_open?(acct) }
+      accts.uniq.each do |acct|
+        return I18n.t("not_open", model: type_string, scope: "activerecord.errors.models.account") unless account_open?(acct)
+      end
     end
 
     nil

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -549,7 +549,7 @@ class OrderDetail < ApplicationRecord
     return "The account is expired and cannot be used" if account.expires_at < Time.zone.now || account.suspended_at
 
     # TODO: if chart string, is chart string + account valid
-    return "The #{account.type_string} is not open for the required account" if account.respond_to?(:account_open?) && !account.account_open?(product.account)
+    return I18n.t("not_open", model: account.type_string, scope: "activerecord.errors.models.account") if account.respond_to?(:account_open?) && !account.account_open?(product.account)
 
     # is the user approved for the product
     return "You are not approved to purchase this #{product.class.name.downcase}" unless product.can_be_used_by?(order.user) || order.created_by_user.can_override_restrictions?(product)

--- a/config/locales/models/en.account.yml
+++ b/config/locales/models/en.account.yml
@@ -1,0 +1,6 @@
+en:
+  activerecord:
+    errors:
+      models:
+        account:
+          not_open: "The %{model} is not open for the required account"


### PR DESCRIPTION
# Release Notes

Tech task: Make "account is not open" text localized so it can be overridden.


# Additional Context

Dartmouth would like a different message than "The Chart String is not open for the required account".

Extracted from https://github.com/tablexi/nucore-dartmouth/pull/226 which was merged in to expedite a release.
