### PR TITLE
Implement Use/Manage Separation

### DIFF
--- a/app/controllers/concerns/nav_tab.rb
+++ b/app/controllers/concerns/nav_tab.rb
@@ -12,7 +12,7 @@ module NavTab
     helper_method(:admin_tab?)
     helper_method(:global_navigation_links)
     helper_method(:navigation_links)
-    helper_method(:home_button)
+    helper_method(:use_button)
   end
 
   module ClassMethods
@@ -46,8 +46,9 @@ module NavTab
       link_collection.default
     end
   end
-  def home_button
-    link_collection.home_button
+  
+  def use_button
+    link_collection.use_button
   end
 
   def global_navigation_links

--- a/app/controllers/concerns/nav_tab.rb
+++ b/app/controllers/concerns/nav_tab.rb
@@ -46,10 +46,8 @@ module NavTab
       link_collection.default
     end
   end
-  
-  def home_button
-    link_collection.home_button
-  end
+
+  delegate :home_button, to: :link_collection
 
   def global_navigation_links
     acting_as? ? [] : global_link_collection.links

--- a/app/controllers/concerns/nav_tab.rb
+++ b/app/controllers/concerns/nav_tab.rb
@@ -12,7 +12,7 @@ module NavTab
     helper_method(:admin_tab?)
     helper_method(:global_navigation_links)
     helper_method(:navigation_links)
-    helper_method(:use_button)
+    helper_method(:home_button)
   end
 
   module ClassMethods
@@ -46,8 +46,8 @@ module NavTab
       link_collection.default
     end
   end
-  def use_button
-    link_collection.use_button
+  def home_button
+    link_collection.home_button
   end
 
   def global_navigation_links

--- a/app/controllers/concerns/nav_tab.rb
+++ b/app/controllers/concerns/nav_tab.rb
@@ -12,7 +12,7 @@ module NavTab
     helper_method(:admin_tab?)
     helper_method(:global_navigation_links)
     helper_method(:navigation_links)
-    helper_method(:use_button)
+    helper_method(:home_button)
   end
 
   module ClassMethods
@@ -47,8 +47,8 @@ module NavTab
     end
   end
   
-  def use_button
-    link_collection.use_button
+  def home_button
+    link_collection.home_button
   end
 
   def global_navigation_links

--- a/app/controllers/concerns/nav_tab.rb
+++ b/app/controllers/concerns/nav_tab.rb
@@ -12,6 +12,7 @@ module NavTab
     helper_method(:admin_tab?)
     helper_method(:global_navigation_links)
     helper_method(:navigation_links)
+    helper_method(:use_button)
   end
 
   module ClassMethods
@@ -35,7 +36,7 @@ module NavTab
 
   def navigation_links
     case
-    when customer_tab? && acting_user.present? && !current_facility.present?
+    when customer_tab? && acting_user.present?
       link_collection.customer.compact
     when customer_tab? && acting_user.present? && current_facility.present? && current_facility != Facility.cross_facility
       link_collection.manager
@@ -44,6 +45,9 @@ module NavTab
     else
       link_collection.default
     end
+  end
+  def use_button
+    link_collection.use_button
   end
 
   def global_navigation_links

--- a/app/controllers/concerns/nav_tab.rb
+++ b/app/controllers/concerns/nav_tab.rb
@@ -35,8 +35,10 @@ module NavTab
 
   def navigation_links
     case
-    when customer_tab? && acting_user.present?
+    when customer_tab? && acting_user.present? && !current_facility.present?
       link_collection.customer.compact
+    when customer_tab? && acting_user.present? && current_facility.present? && current_facility != Facility.cross_facility
+      link_collection.manager
     when admin_tab? && current_facility.present? && current_facility != Facility.cross_facility
       link_collection.admin
     else

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -46,8 +46,8 @@ class FacilitiesController < ApplicationController
     raise ActiveRecord::RecordNotFound unless current_facility.try(:is_active?)
     @order_form = nil
     @order_form = Order.new if acting_user && current_facility.accepts_multi_add?
-    @active_tab = "home"
     set_column_class
+    @active_tab = "use"
     render layout: "application"
   end
 

--- a/app/models/serializable_facility.rb
+++ b/app/models/serializable_facility.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SerializableFacility < SimpleDelegator
 
   include GlobalID::Identification

--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -43,9 +43,9 @@ class NavTab::LinkCollection
   end
 
   def home_button
-    if SettingsHelper.feature_on?(:use_manage) 
+    if SettingsHelper.feature_on?(:use_manage)
       use_button
-    else 
+    else
       home
     end
   end

--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -27,7 +27,7 @@ class NavTab::LinkCollection
   end
 
   def admin
-    use_button + admin_only
+    [use_button] + admin_only
   end
 
   def customer

--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -27,7 +27,11 @@ class NavTab::LinkCollection
   end
 
   def admin
-    [home_button] + [manage] + admin_only
+    if SettingsHelper.feature_on?(:use_manage)
+      [home_button] + [manage] + admin_only
+    else
+      [home_button] + admin_only
+    end
   end
 
   def customer

--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -145,8 +145,6 @@ class NavTab::LinkCollection
   end
 
   def manage
-    # url = facility ? dashboard_facility_path(facility) : root_path
-    # model = facility
     NavTab::Link.new(text: I18n.t("pages.manage", model: Facility.model_name.human(count: 2)), url: list_facilities_url)
   end
 

--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -27,11 +27,11 @@ class NavTab::LinkCollection
   end
 
   def admin
-    default + admin_only
+    use_button + admin_only
   end
 
   def customer
-    default + [orders, reservations, payment_sources, files]
+    default
   end
 
   def default
@@ -39,7 +39,12 @@ class NavTab::LinkCollection
   end
 
   def use_button
-    [use]
+    [use] + [manage]
+  end
+
+  def home_button
+    return use_button if SettingsHelper.feature_on?(:use_manage)
+    return [home]
   end
 
   private
@@ -136,11 +141,15 @@ class NavTab::LinkCollection
   end
 
   def use
-    NavTab::Link.new(tab: :use, url: root_path)
+    # Do we want use to go to current facility or list of all?
+    #url = facility ? facility_path(facility) : root_path
+    url = root_path
+    NavTab::Link.new(tab: :use, url: url)
   end
 
   def manage
-    NavTab::Link.new(text: I18n.t("pages.manage", model: facility), url: manage_facility_path(facility))
+    url = facility ? dashboard_facility_path(facility) : root_path
+    NavTab::Link.new(text: I18n.t("pages.manage", model: facility), url: url)
   end
 
   def instrument_utilization_reports
@@ -160,6 +169,10 @@ class NavTab::LinkCollection
       text: t_my(Reservation),
       url: reservations_path,
     )
+  end
+
+  def home
+    NavTab::Link.new(tab: :home, url: root_path)
   end
 
 end

--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -43,8 +43,10 @@ class NavTab::LinkCollection
   end
 
   def home_button
-    if SettingsHelper.feature_on?(:use_manage) then use_button
-    else home
+    if SettingsHelper.feature_on?(:use_manage) 
+      use_button
+    else 
+      home
     end
   end
 

--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -141,9 +141,7 @@ class NavTab::LinkCollection
   end
 
   def use
-    # Do we want use to go to current facility or list of all?
-    #url = facility ? facility_path(facility) : root_path
-    url = root_path
+    url = facility ? facility_path(facility) : root_path
     NavTab::Link.new(tab: :use, url: url)
   end
 

--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -35,11 +35,11 @@ class NavTab::LinkCollection
   end
 
   def default
-    [home]
+    [orders, reservations, payment_sources, files]
   end
 
-  def manager
-    [use,manage] + [orders, reservations, payment_sources, files]
+  def use_button
+    [use]
   end
 
   private
@@ -133,10 +133,6 @@ class NavTab::LinkCollection
       text: I18n.t("pages.general_reports"),
       url: facility_general_reports_path(facility, report_by: :product),
     )
-  end
-
-  def home
-    NavTab::Link.new(tab: :home, url: root_path)
   end
 
   def use

--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -38,6 +38,10 @@ class NavTab::LinkCollection
     [home]
   end
 
+  def manager
+    [use,manage] + [orders, reservations, payment_sources, files]
+  end
+
   private
 
   def payment_sources
@@ -133,6 +137,14 @@ class NavTab::LinkCollection
 
   def home
     NavTab::Link.new(tab: :home, url: root_path)
+  end
+
+  def use
+    NavTab::Link.new(tab: :use, url: root_path)
+  end
+
+  def manage
+    NavTab::Link.new(text: I18n.t("pages.manage", model: facility), url: manage_facility_path(facility))
   end
 
   def instrument_utilization_reports

--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -39,12 +39,13 @@ class NavTab::LinkCollection
   end
 
   def use_button
-    [use] + [manage]
+    use
   end
 
   def home_button
-    return use_button if SettingsHelper.feature_on?(:use_manage)
-    return [home]
+    if SettingsHelper.feature_on?(:use_manage) then use_button
+    else home
+    end
   end
 
   private

--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -27,7 +27,7 @@ class NavTab::LinkCollection
   end
 
   def admin
-    [use_button] + admin_only
+    [home_button] + [manage] + admin_only
   end
 
   def customer
@@ -38,13 +38,9 @@ class NavTab::LinkCollection
     [orders, reservations, payment_sources, files]
   end
 
-  def use_button
-    use
-  end
-
   def home_button
     if SettingsHelper.feature_on?(:use_manage)
-      use_button
+      use
     else
       home
     end
@@ -149,8 +145,9 @@ class NavTab::LinkCollection
   end
 
   def manage
-    url = facility ? dashboard_facility_path(facility) : root_path
-    NavTab::Link.new(text: I18n.t("pages.manage", model: facility), url: url)
+    # url = facility ? dashboard_facility_path(facility) : root_path
+    # model = facility
+    NavTab::Link.new(text: I18n.t("pages.manage", model: Facility.model_name.human(count: 2)), url: list_facilities_url)
   end
 
   def instrument_utilization_reports

--- a/app/views/shared/nav/_nav_links.html.haml
+++ b/app/views/shared/nav/_nav_links.html.haml
@@ -2,6 +2,9 @@
   - if responsive?
     -# .hidden-with-nav is hidden > 979px
     %li.hidden-with-nav= link_to t('pages.cart') + " (#{current_cart.order_details.count})", :cart
+    %li{class: [use_button[0].tab_class(controller), "useButton"], id: use_button[0].tab_id }
+      = use_button[0].to_html
+    = render "shared/nav/manage_facilities"
   - navigation_links.each do |link|
     %li{class: link.tab_class(controller), id: link.tab_id }
       - if link.subnav.present?
@@ -14,6 +17,7 @@
               %li= subnav_link.to_html
       - else
         = link.to_html
+  
 
 -# .visible-with-nav is visible > 979px
 = form_tag global_search_path, class: "navbar-search pull-right visible-with-nav" do
@@ -21,6 +25,6 @@
 
 -# trailing "<" enables use of .nav-collapse .nav:empty in boostrap-responsive-overrides.scss
 %ul.nav.pull-right<
-  -#= render "shared/nav/manage_facilities"
+  
   - global_navigation_links.each do |link|
     %li{class: link.tab_class(controller)}= link.to_html

--- a/app/views/shared/nav/_nav_links.html.haml
+++ b/app/views/shared/nav/_nav_links.html.haml
@@ -2,8 +2,8 @@
   - if responsive?
     -# .hidden-with-nav is hidden > 979px
     %li.hidden-with-nav= link_to t('pages.cart') + " (#{current_cart.order_details.count})", :cart
-    %li{class: [use_button.tab_class(controller), "useButton"], id: use_button.tab_id }
-      = use_button.to_html
+    %li{class: [home_button.tab_class(controller), "useButton"], id: home_button.tab_id }
+      = home_button.to_html
     = render "shared/nav/manage_facilities"
   - navigation_links.each do |link|
     %li{class: link.tab_class(controller), id: link.tab_id }
@@ -25,6 +25,7 @@
 
 -# trailing "<" enables use of .nav-collapse .nav:empty in boostrap-responsive-overrides.scss
 %ul.nav.pull-right<
-  
+  - if not SettingsHelper.feature_on?(:use_manage)
+    = render "shared/nav/manage_facilities"
   - global_navigation_links.each do |link|
     %li{class: link.tab_class(controller)}= link.to_html

--- a/app/views/shared/nav/_nav_links.html.haml
+++ b/app/views/shared/nav/_nav_links.html.haml
@@ -21,6 +21,6 @@
 
 -# trailing "<" enables use of .nav-collapse .nav:empty in boostrap-responsive-overrides.scss
 %ul.nav.pull-right<
-  = render "shared/nav/manage_facilities"
+  -#= render "shared/nav/manage_facilities"
   - global_navigation_links.each do |link|
     %li{class: link.tab_class(controller)}= link.to_html

--- a/app/views/shared/nav/_nav_links.html.haml
+++ b/app/views/shared/nav/_nav_links.html.haml
@@ -27,7 +27,7 @@
 
 -# trailing "<" enables use of .nav-collapse .nav:empty in boostrap-responsive-overrides.scss
 %ul.nav.pull-right<
-  - if not SettingsHelper.feature_on?(:use_manage)
+  - if !SettingsHelper.feature_on?(:use_manage)
     = render "shared/nav/manage_facilities"
   - global_navigation_links.each do |link|
     %li{class: link.tab_class(controller)}= link.to_html

--- a/app/views/shared/nav/_nav_links.html.haml
+++ b/app/views/shared/nav/_nav_links.html.haml
@@ -4,7 +4,8 @@
     %li.hidden-with-nav= link_to t('pages.cart') + " (#{current_cart.order_details.count})", :cart
     %li{class: [home_button.tab_class(controller), "useButton"], id: home_button.tab_id }  
       = home_button.to_html
-    = render "shared/nav/manage_facilities"
+    - if SettingsHelper.feature_on?(:use_manage)
+      = render "shared/nav/manage_facilities"
 
   - navigation_links.each do |link|
     %li{class: link.tab_class(controller), id: link.tab_id }

--- a/app/views/shared/nav/_nav_links.html.haml
+++ b/app/views/shared/nav/_nav_links.html.haml
@@ -2,9 +2,10 @@
   - if responsive?
     -# .hidden-with-nav is hidden > 979px
     %li.hidden-with-nav= link_to t('pages.cart') + " (#{current_cart.order_details.count})", :cart
-    %li{class: [home_button.tab_class(controller), "useButton"], id: home_button.tab_id }
+    %li{class: [home_button.tab_class(controller), "useButton"], id: home_button.tab_id }  
       = home_button.to_html
     = render "shared/nav/manage_facilities"
+
   - navigation_links.each do |link|
     %li{class: link.tab_class(controller), id: link.tab_id }
       - if link.subnav.present?

--- a/app/views/shared/nav/_nav_links.html.haml
+++ b/app/views/shared/nav/_nav_links.html.haml
@@ -2,8 +2,8 @@
   - if responsive?
     -# .hidden-with-nav is hidden > 979px
     %li.hidden-with-nav= link_to t('pages.cart') + " (#{current_cart.order_details.count})", :cart
-    %li{class: [use_button[0].tab_class(controller), "useButton"], id: use_button[0].tab_id }
-      = use_button[0].to_html
+    %li{class: [home_button[0].tab_class(controller), "useButton"], id: home_button[0].tab_id }
+      = home_button[0].to_html
     = render "shared/nav/manage_facilities"
   - navigation_links.each do |link|
     %li{class: link.tab_class(controller), id: link.tab_id }

--- a/app/views/shared/nav/_nav_links.html.haml
+++ b/app/views/shared/nav/_nav_links.html.haml
@@ -2,8 +2,8 @@
   - if responsive?
     -# .hidden-with-nav is hidden > 979px
     %li.hidden-with-nav= link_to t('pages.cart') + " (#{current_cart.order_details.count})", :cart
-    %li{class: [home_button[0].tab_class(controller), "useButton"], id: home_button[0].tab_id }
-      = home_button[0].to_html
+    %li{class: [use_button.tab_class(controller), "useButton"], id: use_button.tab_id }
+      = use_button.to_html
     = render "shared/nav/manage_facilities"
   - navigation_links.each do |link|
     %li{class: link.tab_class(controller), id: link.tab_id }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,8 @@ en:
         statements: Statements
 
   pages:
+    home: Home
+    use: Use
     admin_billing: Billing
     admin_facility: Admin
     admin_orders: Orders
@@ -62,7 +64,6 @@ en:
     global_billing: Billing
     global_settings: Global Settings
     global_user_roles: Global User Roles
-    home: Home
     instrument_utilization_reports: Instrument Utilization
     login: Login
     logout: Logout

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,7 +122,7 @@ en:
 
     purchase: Purchase
     sidenav_admin:
-      overhome: "Overhome"
+      overview: "Overview"
     tabnav_account:
       details: "Payment Source Details"
       transact: "Transactions"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,7 +122,7 @@ en:
 
     purchase: Purchase
     sidenav_admin:
-      overview: "Overview"
+      overhome: "Overhome"
     tabnav_account:
       details: "Payment Source Details"
       transact: "Transactions"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -122,6 +122,7 @@ feature:
   cross_facility_reports_on: false
   product_list_columns_on: false
   azlist_on: false
+  use_manage_on: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts


### PR DESCRIPTION
# Release Notes

Implementation of our Use/Manage design separation. Currently, "Use" will bring the user back to the facility list home page unless they are managing a facility. If they are an admin and managing a facility, then they will be taken to the facility-specific homepage with the product list.

Manage mode will take the user to the manageable facility list, however it could also be a dropdown such as in our original design.

# Screenshot
![screen shot 2018-09-06 at 9 47 16 am](https://user-images.githubusercontent.com/5000430/45161460-e68f0980-b1b9-11e8-91c8-60cfca6bc0fd.png)
