### PR TITLE
Tech task: Use dynamic attribute for factory (missed from earlier)

### DIFF
--- a/spec/factories/nufs_accounts.rb
+++ b/spec/factories/nufs_accounts.rb
@@ -7,7 +7,7 @@ overridable_factory :nufs_account do
 
   sequence(:description, "aaaaaaaa") { |n| "nufs account #{n}" }
   expires_at { Time.zone.now + 1.month }
-  created_by 0
+  created_by { 0 }
 end
 
 FactoryBot.modify do


### PR DESCRIPTION
# Release Notes

Tech task: Use dynamic attribute for FactoryBot factory that we missed earlier.

# Additional Context

Missed this in #1656 and #1657
