### PR TITLE
[#137154] Email user when an order goes into problem queue

### DIFF
--- a/app/controllers/offline_reservations_controller.rb
+++ b/app/controllers/offline_reservations_controller.rb
@@ -58,7 +58,10 @@ class OfflineReservationsController < ApplicationController
 
   def move_ongoing_reservations_to_problem_queue
     OrderDetail.where(id: @instrument.reservations.ongoing.select(:order_detail_id)).find_each do |order_detail|
-      MoveToProblemQueue.move!(order_detail)
+      # We need to force completion because a default completion requirement is that
+      # the current time is after the reserve_end_at. In this offline case, the reservation
+      # might not be over yet.
+      MoveToProblemQueue.move!(order_detail, force: true)
     end
   end
 

--- a/app/controllers/offline_reservations_controller.rb
+++ b/app/controllers/offline_reservations_controller.rb
@@ -58,7 +58,6 @@ class OfflineReservationsController < ApplicationController
 
   def move_ongoing_reservations_to_problem_queue
     OrderDetail.where(id: @instrument.reservations.ongoing.select(:order_detail_id)).find_each do |order_detail|
-      order_detail.reservation.force_completable = true
       MoveToProblemQueue.move!(order_detail)
     end
   end

--- a/app/controllers/offline_reservations_controller.rb
+++ b/app/controllers/offline_reservations_controller.rb
@@ -58,6 +58,7 @@ class OfflineReservationsController < ApplicationController
 
   def move_ongoing_reservations_to_problem_queue
     OrderDetail.where(id: @instrument.reservations.ongoing.select(:order_detail_id)).find_each do |order_detail|
+      order_detail.reservation.force_completable = true
       MoveToProblemQueue.move!(order_detail)
     end
   end

--- a/app/mailers/problem_order_mailer.rb
+++ b/app/mailers/problem_order_mailer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ProblemOrderMailer < BaseMailer
+
+  def notify_user(order_detail)
+    @order_detail = order_detail
+    @user = @order_detail.user
+    mail(to: @user.email, subject: text("notify_user.subject", facility: @order_detail.facility.abbreviation))
+  end
+
+  protected
+
+  def translation_scope
+    "views.problem_order_mailer"
+  end
+
+end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -443,10 +443,6 @@ class OrderDetail < ApplicationRecord
     change_status!(OrderStatus.complete)
   end
 
-  def force_complete!
-    update(state: "complete", order_status: OrderStatus.complete)
-  end
-
   def backdate_to_complete!(event_time = Time.zone.now)
     # if we're setting it to compete, automatically set the actuals for a reservation
     if reservation

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -32,7 +32,7 @@ class Reservation < ApplicationRecord
 
   # Used when we want to force the order to complete even if it doesn't meet the
   # requirements of order_completeable?, e.g. the reservation time isn't over yet.
-  attr_accessor :force_completable
+  attr_accessor :force_completion
 
   # Delegations
   #####
@@ -151,7 +151,7 @@ class Reservation < ApplicationRecord
 
   # Is there enough information to move an associated order to complete/problem?
   def order_completable?
-    force_completable || actual_end_at || reserve_end_at < Time.current
+    force_completion || actual_end_at || reserve_end_at < Time.current
   end
 
   def start_reservation!

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -155,8 +155,11 @@ class Reservation < ApplicationRecord
   end
 
   def start_reservation!
-    # Mark running reservations as complete, which will move them to problem orders
-    product.schedule.products.flat_map(&:started_reservations).each(&:complete!)
+    # If there are any reservations running over their time on the shared schedule,
+    # kick them over to the problem queue.
+    product.schedule.products.flat_map(&:started_reservations).each do |reservation|
+      MoveToProblemQueue.move!(reservation.order_detail)
+    end
     update!(actual_start_at: Time.current)
   end
 

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -30,6 +30,10 @@ class Reservation < ApplicationRecord
   # used for overriding certain restrictions
   attr_accessor :reserved_by_admin
 
+  # Used when we want to force the order to complete even if it doesn't meet the
+  # requirements of order_completeable?, e.g. the reservation time isn't over yet.
+  attr_accessor :force_completable
+
   # Delegations
   #####
   delegate :note, :note=, :ordered_on_behalf_of?, :complete?, :account, :order,
@@ -147,7 +151,7 @@ class Reservation < ApplicationRecord
 
   # Is there enough information to move an associated order to complete/problem?
   def order_completable?
-    actual_end_at || reserve_end_at < Time.current
+    force_completable || actual_end_at || reserve_end_at < Time.current
   end
 
   def start_reservation!

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -158,6 +158,9 @@ class Reservation < ApplicationRecord
     # If there are any reservations running over their time on the shared schedule,
     # kick them over to the problem queue.
     product.schedule.products.flat_map(&:started_reservations).each do |reservation|
+      # If we're in the grace period for this reservation, but the other reservation
+      # has not finished its reserved time, this will fail and this reservation will
+      # not start.
       MoveToProblemQueue.move!(reservation.order_detail)
     end
     update!(actual_start_at: Time.current)

--- a/app/models/serializable_facility.rb
+++ b/app/models/serializable_facility.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SerializableFacility < SimpleDelegator
 
   include GlobalID::Identification

--- a/app/services/move_to_problem_queue.rb
+++ b/app/services/move_to_problem_queue.rb
@@ -2,16 +2,17 @@
 
 class MoveToProblemQueue
 
-  def self.move!(order_detail)
-    new(order_detail).move!
+  def self.move!(order_detail, force: false)
+    new(order_detail, force: force).move!
   end
 
-  def initialize(order_detail)
+  def initialize(order_detail, force: false)
     @order_detail = order_detail
+    @force = force
   end
 
   def move!
-    @order_detail.time_data.force_completion = true
+    @order_detail.time_data.force_completion = @force
     @order_detail.complete!
     # TODO: Can probably remove this at some point, but it's a safety check for now
     raise "Trying to move Order ##{@order_detail} to problem queue, but it's not a problem" unless @order_detail.problem?

--- a/app/services/move_to_problem_queue.rb
+++ b/app/services/move_to_problem_queue.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class MoveToProblemQueue
+
+  def self.move!(order_detail)
+    new(order_detail).move!
+  end
+
+  def initialize(order_detail)
+    @order_detail = order_detail
+  end
+
+  def move!
+    @order_detail.force_complete!
+    raise "It's not a problem!" unless @order_detail.problem? # TODO: Remove me
+  end
+
+end

--- a/app/services/move_to_problem_queue.rb
+++ b/app/services/move_to_problem_queue.rb
@@ -11,8 +11,10 @@ class MoveToProblemQueue
   end
 
   def move!
-    @order_detail.force_complete!
-    raise "It's not a problem!" unless @order_detail.problem? # TODO: Remove me
+    @order_detail.complete!
+    # TODO: Can probably remove this at some point, but it's a safety check for now
+    raise "Trying to move Order ##{@order_detail} to problem queue, but it's not a problem" unless @order_detail.problem?
+    ProblemOrderMailer.notify_user(@order_detail).deliver_later
   end
 
 end

--- a/app/services/move_to_problem_queue.rb
+++ b/app/services/move_to_problem_queue.rb
@@ -11,6 +11,7 @@ class MoveToProblemQueue
   end
 
   def move!
+    @order_detail.time_data.force_completion = true
     @order_detail.complete!
     # TODO: Can probably remove this at some point, but it's a safety check for now
     raise "Trying to move Order ##{@order_detail} to problem queue, but it's not a problem" unless @order_detail.problem?

--- a/app/support/auto_expire_reservation.rb
+++ b/app/support/auto_expire_reservation.rb
@@ -3,9 +3,9 @@
 class AutoExpireReservation
 
   def perform
-    order_details.each do |od|
-      od.transaction do
-        expire_reservation(od)
+    order_details.find_each do |order_detail|
+      order_detail.transaction do
+        expire_reservation(order_detail)
       end
     end
   end
@@ -28,16 +28,14 @@ class AutoExpireReservation
                .readonly(false)
   end
 
-  def expire_reservation(od)
-    od.complete!
+  def expire_reservation(order_detail)
+    MoveToProblemQueue.move!(order_detail)
 
-    # OrderDetail#complete! sets fulfilled_at and price policy,
-    # so we have to reset them.
-    od.fulfilled_at = od.reservation.reserve_end_at
-    od.save!
+    # fulfilled_at gets set as part of the previous process, so we have to reset them.
+    order_detail.update!(fulfilled_at: order_detail.reservation.reserve_end_at)
   rescue => e
     ActiveSupport::Notifications.instrument("background_error",
-                                            exception: e, information: "Failed expire reservation order detail with id: #{od.id}")
+                                            exception: e, information: "Failed expire reservation order detail ##{order_detail}")
     raise ActiveRecord::Rollback
   end
 

--- a/app/support/auto_expire_reservation.rb
+++ b/app/support/auto_expire_reservation.rb
@@ -31,7 +31,7 @@ class AutoExpireReservation
   def expire_reservation(order_detail)
     MoveToProblemQueue.move!(order_detail)
 
-    # fulfilled_at gets set as part of the previous process, so we have to reset them.
+    # fulfilled_at gets set to Time.current but we want it to be the end of the reservation
     order_detail.update!(fulfilled_at: order_detail.reservation.reserve_end_at)
   rescue => e
     ActiveSupport::Notifications.instrument("background_error",

--- a/app/views/problem_order_mailer/notify_user.html.haml
+++ b/app/views/problem_order_mailer/notify_user.html.haml
@@ -1,0 +1,8 @@
+= html("body",
+  user: @user,
+  facility: @order_detail.facility.name,
+  facility_email: @order_detail.facility.email,
+  product: @order_detail.product.name,
+  order_detail: @order_detail,
+  order_detail_link: order_order_detail_url(@order_detail.order, @order_detail),
+  fulfillment_date: l(@order_detail.fulfilled_at.to_date, format: :usa))

--- a/app/views/problem_order_mailer/notify_user.text.erb
+++ b/app/views/problem_order_mailer/notify_user.text.erb
@@ -1,0 +1,10 @@
+<%= text("body",
+  user: @user,
+  facility: @order_detail.facility.name,
+  facility_email: @order_detail.facility.email,
+  product: @order_detail.product.name,
+  order_detail: @order_detail,
+  order_detail_link: order_order_detail_url(@order_detail.order, @order_detail),
+  fulfillment_date: l(@order_detail.fulfilled_at.to_date, format: :usa),
+  smart: false)
+%>

--- a/config/locales/views/en.problem_order_mailer.yml
+++ b/config/locales/views/en.problem_order_mailer.yml
@@ -1,0 +1,19 @@
+en:
+  views:
+    problem_order_mailer:
+      notify_user:
+        subject: "!app_name! Problem Order Alert: %{facility}"
+        body: |
+          Dear %{user},
+
+          !app_name! is missing information regarding your recent use of the %{product}
+          at the %{facility} on %{fulfillment_date}. Please [contact the facility](mailto:%{facility_email})
+          to let them know your reservation's actual start time and total duration,
+          or your entry and exit times through the facility's secure door, referencing
+          the following !app_name! Order Number:
+
+          [#%{order_detail}](%{order_detail_link})
+
+          Thank you,
+
+          %{facility}

--- a/spec/app_support/auto_expire_reservation_spec.rb
+++ b/spec/app_support/auto_expire_reservation_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe AutoExpireReservation, :time_travel do
       it "sets the reservation fulfilled at time" do
         expect { action.perform }.to change { order_detail.reload.fulfilled_at }.to(reservation.reserve_end_at)
       end
+
+      it "triggers an email" do
+        expect { action.perform }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      end
     end
 
     context "an unpurchased reservation" do

--- a/spec/app_support/auto_logout_spec.rb
+++ b/spec/app_support/auto_logout_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe AutoLogout, :time_travel do
       # see before block for deactivate expectation
       action.perform
     end
+
+    it "triggers an email" do
+      expect { action.perform }.to change(ActionMailer::Base.deliveries, :count).by(1)
+    end
   end
 
   describe "a new reservation prior to log out time" do

--- a/spec/controllers/offline_reservations_controller_spec.rb
+++ b/spec/controllers/offline_reservations_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe OfflineReservationsController do
   let(:administrator) { FactoryBot.create(:user, :administrator) }
   let(:facility) { instrument.facility }
-  let(:instrument) { FactoryBot.create(:setup_instrument) }
+  let(:instrument) { FactoryBot.create(:setup_instrument, :timer) }
 
   describe "POST #create" do
     before { sign_in administrator }
@@ -37,6 +37,12 @@ RSpec.describe OfflineReservationsController do
           .to change { reservation.order_detail.reload.problem? }
           .from(false)
           .to(true)
+        # And it's for the right reason
+        expect(reservation.order_detail.problem_description_key).to eq(:missing_actuals)
+      end
+
+      it "triggers an email" do
+        expect { post :create, params: params }.to change(ActionMailer::Base.deliveries, :count).by(1)
       end
     end
   end

--- a/spec/mailers/previews/problem_order_mailer_preview.rb
+++ b/spec/mailers/previews/problem_order_mailer_preview.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ProblemOrderMailerPreview < ActionMailer::Preview
+
+  def notify_user
+    order_detail = NUCore::Database.random(Reservation.user.joins(:order_detail).merge(OrderDetail.complete)).order_detail
+    ProblemOrderMailer.notify_user(order_detail)
+  end
+
+end

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -1841,13 +1841,6 @@ RSpec.describe OrderDetail do
     end
   end
 
-  describe "#force_complete!" do
-    it "forces a transition from new to complete" do
-      expect { order_detail.force_complete! }
-        .to change { order_detail.reload.state }.from("new").to("complete")
-    end
-  end
-
   def set_cancellation_cost_for_all_policies(cost)
     PricePolicy.all.each do |price_policy|
       price_policy.update_attribute :cancellation_cost, cost

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1073,7 +1073,7 @@ RSpec.describe Reservation do
                           actual_start_at: start_time)
       end
 
-      before do
+      def perform
         order = running.order_detail.order
         order.state = "validated"
         order.purchase!
@@ -1082,15 +1082,20 @@ RSpec.describe Reservation do
       end
 
       it "completes the running reservation" do
-        expect(running.reload).to be_complete
+        expect { perform }.to change { running.reload.complete? }.to be(true)
       end
 
       it "sets the orders as a problem order" do
-        expect(running.reload.order_detail).to be_problem
+        expect { perform }.to change { running.order_detail.reload.problem? }.to be(true)
       end
 
       it "does not set actual_end_at" do
+        perform
         expect(running.reload.actual_end_at).to be_nil
+      end
+
+      it "triggers an email" do
+        expect { perform }.to change(ActionMailer::Base.deliveries, :count).by(1)
       end
     end
 
@@ -1098,7 +1103,7 @@ RSpec.describe Reservation do
       let(:running_instrument) { create(:setup_instrument, schedule: reservation.product.schedule, min_reserve_mins: 1) }
       let!(:running) { create :setup_reservation, product: running_instrument, reserve_start_at: 30.minutes.ago, reserve_end_at: 1.minute.ago, actual_start_at: 30.minutes.ago }
 
-      before do
+      def perform
         order = running.order_detail.order
         order.state = "validated"
         order.purchase!
@@ -1110,15 +1115,20 @@ RSpec.describe Reservation do
       end
 
       it "completes the running reservation" do
-        expect(running.reload).to be_complete
+        expect { perform }.to change { running.reload.complete? }.to be(true)
       end
 
       it "sets the orders as a problem order" do
-        expect(running.reload.order_detail).to be_problem
+        expect { perform }.to change { running.order_detail.reload.problem? }.to be(true)
       end
 
       it "does not set actual_end_at" do
+        perform
         expect(running.reload.actual_end_at).to be_nil
+      end
+
+      it "triggers an email" do
+        expect { perform }.to change(ActionMailer::Base.deliveries, :count).by(1)
       end
     end
 

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
@@ -26,6 +26,9 @@ module SecureRooms
     validates :secure_room, :user, presence: true
     validate :entry_and_exit_are_valid, if: :editing_time_data
 
+    # Not used internally, but implemented for API compatibility with Reservation
+    attr_writer :force_completion
+
     def self.valid
       where(orphaned_at: nil)
     end

--- a/vendor/engines/secure_rooms/app/support/secure_rooms/auto_orphan_occupancy.rb
+++ b/vendor/engines/secure_rooms/app/support/secure_rooms/auto_orphan_occupancy.rb
@@ -27,7 +27,6 @@ module SecureRooms
       SecureRooms::AccessHandlers::OrderHandler.process(occupancy)
       MoveToProblemQueue.move!(occupancy.order_detail) if occupancy.order_detail
     rescue => e
-      binding.pry
       ActiveSupport::Notifications.instrument("background_error",
                                               exception: e, information: "Failed orphan occupancy #{occupancy.id}")
       raise ActiveRecord::Rollback

--- a/vendor/engines/secure_rooms/app/support/secure_rooms/auto_orphan_occupancy.rb
+++ b/vendor/engines/secure_rooms/app/support/secure_rooms/auto_orphan_occupancy.rb
@@ -25,6 +25,7 @@ module SecureRooms
     def orphan_occupancy(occupancy)
       occupancy.mark_orphaned!
       SecureRooms::AccessHandlers::OrderHandler.process(occupancy)
+      MoveToProblemQueue.move!(occupancy.order_detail) if occupancy.order_detail
     rescue => e
       ActiveSupport::Notifications.instrument("background_error",
                                               exception: e, information: "Failed orphan occupancy order detail with id: #{od.id}")

--- a/vendor/engines/secure_rooms/app/support/secure_rooms/auto_orphan_occupancy.rb
+++ b/vendor/engines/secure_rooms/app/support/secure_rooms/auto_orphan_occupancy.rb
@@ -27,8 +27,9 @@ module SecureRooms
       SecureRooms::AccessHandlers::OrderHandler.process(occupancy)
       MoveToProblemQueue.move!(occupancy.order_detail) if occupancy.order_detail
     rescue => e
+      binding.pry
       ActiveSupport::Notifications.instrument("background_error",
-                                              exception: e, information: "Failed orphan occupancy order detail with id: #{od.id}")
+                                              exception: e, information: "Failed orphan occupancy #{occupancy.id}")
       raise ActiveRecord::Rollback
     end
 


### PR DESCRIPTION
# Release Notes

Notify the user via email if their reservation/occupancy enters into the problem queue. 

# Additional Context

We do not trigger the email for missing price policies as that is something the facility needs to address.

For reservations, this only applies to timer and relay based instruments.

* Reservation never started, 12 hours after it was scheduled to end
* Reservation started, but never ended, 12 hours after it was scheduled to end
* Reservation started, but never ended and another reservation is started. Applies across a shared scheduled.
* Logged out via the Auto Logout setting (relays only)
* Reservation started and not yet ended and instrument is marked offline. Applies across a shared schedule.

For occupancies, this only applies to normal users. Facility staff does not get orders associated with their occupancies so they will never go to the problem queue.

* Scan into a room, do not scan out, 12 hours after the scan in
* Scan into a room, scan in again. First scan's order goes into the problem queue
* Scan out without an associated scan in



