### PR TITLE
Remove unused method ReconcilableAccount::ClassMethods#need_reconciling

### DIFF
--- a/app/support/reconcilable_account.rb
+++ b/app/support/reconcilable_account.rb
@@ -1,14 +1,3 @@
 module ReconcilableAccount
 
-  extend ActiveSupport::Concern
-
-  module ClassMethods
-
-    def need_reconciling(facility)
-      accounts = joins(:order_details).merge(OrderDetail.complete.statemented(facility))
-      where(id: accounts.distinct.pluck(:id))
-    end
-
-  end
-
 end


### PR DESCRIPTION
# Release Notes

TECH TASK: Remove unused method ReconcilableAccount::ClassMethods#need_reconciling
