### PR TITLE
TECH TASK: Fix remove_foreign_key call for non-standard column

### DIFF
--- a/db/migrate/20170308030632_change_schedule_rule_to_belong_to_product.rb
+++ b/db/migrate/20170308030632_change_schedule_rule_to_belong_to_product.rb
@@ -5,7 +5,7 @@ class ChangeScheduleRuleToBelongToProduct < ActiveRecord::Migration
   def up
     # MySQL 5.6+ will rename the foreign key with the column, but Mariadb 5.5
     # (which Dartmouth uses) triggers contraint validation errors.
-    remove_foreign_key :schedule_rules, :instruments
+    remove_foreign_key :schedule_rules, column: :instrument_id
     rename_column :schedule_rules, :instrument_id, :product_id
     add_foreign_key :schedule_rules, :products
   end


### PR DESCRIPTION
# Release Notes

TECH TASK: Fix remove_foreign_key call for non-standard column

# Additional Context

Running `rake db:migrate` on an empty database currently fails on this call to `remove_foreign_key`, because Rails can’t find the appropriate column. When the foreign key [is added](https://github.com/tablexi/nucore-open/blob/de02a553304d013dc089ea654ba74003cdcf807a/db/migrate/20100101000000_initial_schema.rb#L127-L128), it is added against the `products` table but it is on the `instrument_id` column, so the `remove_foreign_key` needs additional information to be able to find the appropriate foreign key.