### PR TITLE
TECH TASK: Rename cancellation_notification_recipients to cancellation_email_recipients

### DIFF
--- a/app/controllers/product_notifications_controller.rb
+++ b/app/controllers/product_notifications_controller.rb
@@ -34,7 +34,7 @@ class ProductNotificationsController < ApplicationController
     params.require(:product).permit(
       :training_request_contacts,
       :order_notification_recipient,
-      :cancellation_notification_recipients,
+      :cancellation_email_recipients,
     )
   end
 

--- a/app/mailers/cancellation_mailer.rb
+++ b/app/mailers/cancellation_mailer.rb
@@ -3,9 +3,9 @@ class CancellationMailer < BaseMailer
   def notify_facility(order_detail)
     @order_detail = order_detail
     @product = order_detail.product
-    if @product.cancellation_notification_recipients.any?
+    if @product.cancellation_email_recipients.any?
       mail(
-        to: @product.cancellation_notification_recipients,
+        to: @product.cancellation_email_recipients,
         subject: text("views.cancellation_mailer.notify_facility.subject", facility: @order_detail.facility, order_detail: @order_detail),
       )
     end

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -16,7 +16,7 @@ class Instrument < Product
   has_many :admin_reservations, foreign_key: "product_id"
   has_many :offline_reservations, foreign_key: "product_id"
 
-  email_list_attribute :cancellation_notification_recipients
+  email_list_attribute :cancellation_email_recipients
 
   # Validations
   # --------

--- a/app/views/product_notifications/edit.html.haml
+++ b/app/views/product_notifications/edit.html.haml
@@ -14,7 +14,7 @@
       = f.input :training_request_contacts, as: :string, hint: text("hints.training_request_contacts")
     - key = current_facility.order_notification_recipient.present? ? "hints.order_notification_with_facility" : "hints.order_notification"
     = f.input :order_notification_recipient, as: :email, hint: text(key, email: current_facility.order_notification_recipient)
-    = f.input :cancellation_notification_recipients, as: :string, hint: text("hints.cancellation_notification_recipients") if @product.is_a?(Instrument)
+    = f.input :cancellation_email_recipients, as: :string, hint: text("hints.cancellation_email_recipients") if @product.is_a?(Instrument)
 
   %ul.inline
     %li= f.submit text("shared.save"), class: ["btn", "btn-primary"]

--- a/app/views/product_notifications/show.html.haml
+++ b/app/views/product_notifications/show.html.haml
@@ -12,7 +12,7 @@
       = f.input :training_request_contacts, as: :string
     - hint = current_facility.order_notification_recipient.present? ? text("hints.already_configured", email: current_facility.order_notification_recipient) : nil
     = f.input :order_notification_recipient, as: :email, hint: hint
-    = f.input :cancellation_notification_recipients, as: :string if @product.is_a?(Instrument)
+    = f.input :cancellation_email_recipients, as: :string if @product.is_a?(Instrument)
 
 - if can?(:edit, @product)
   = link_to text("shared.edit"), edit_facility_product_notifications_path(current_facility, @product), class: "btn"

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -252,7 +252,7 @@ en:
         user_notes_label: Label for Notes Field
         training_request_contacts: Training Request Recipients
         order_notification_recipient: Order Notification Recipient
-        cancellation_notification_recipients: Cancellation Notification Recipients
+        cancellation_email_recipients: Cancellation Notification Recipients
       product_accessory:
         scaling_type: Scaling Type
       instrument:

--- a/config/locales/views/admin/en.product_notifications.yml
+++ b/config/locales/views/admin/en.product_notifications.yml
@@ -14,7 +14,7 @@ en:
             !views.product_notifications.edit.hints.order_notification!
             !views.product_notifications.show.hints.already_configured!
           training_request_contacts: Comma separated list of email addresses to be notified when a training request is placed.
-          cancellation_notification_recipients: |
+          cancellation_email_recipients: |
             Comma separated list of email addresses to be notified when a reservation is canceled.
 
 

--- a/db/migrate/20180822191538_add_cancellation_notification_to_product.rb
+++ b/db/migrate/20180822191538_add_cancellation_notification_to_product.rb
@@ -2,7 +2,7 @@ class AddCancellationNotificationToProduct < ActiveRecord::Migration[5.0]
 
   def change
     change_table :products do |t|
-      t.text :cancellation_notification_recipients
+      t.text :cancellation_email_recipients
     end
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -476,7 +476,7 @@ ActiveRecord::Schema.define(version: 20180822191538) do
     t.string   "user_notes_field_mode",                              default: "hidden", null: false
     t.string   "user_notes_label"
     t.string   "order_notification_recipient"
-    t.text     "cancellation_notification_recipients", limit: 65535
+    t.text     "cancellation_email_recipients", limit: 65535
     t.index ["dashboard_token"], name: "index_products_on_dashboard_token", using: :btree
     t.index ["facility_account_id"], name: "fk_facility_accounts", using: :btree
     t.index ["facility_id"], name: "fk_rails_0c9fa1afbe", using: :btree

--- a/spec/controllers/order_details_controller_spec.rb
+++ b/spec/controllers/order_details_controller_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe OrderDetailsController do
         end
 
         context "and the cancellation notification recipients is set" do
-          before { reservation.product.update(cancellation_notification_recipients: "cancel@example.com") }
+          before { reservation.product.update(cancellation_email_recipients: "cancel@example.com") }
 
           it "triggers an email" do
             expect { put :cancel, params: { order_id: order.id, id: order_detail.id } }.to change(ActionMailer::Base.deliveries, :count).by(1)

--- a/spec/mailers/previews/cancelation_mailer_preview.rb
+++ b/spec/mailers/previews/cancelation_mailer_preview.rb
@@ -1,7 +1,7 @@
 class CancellationMailerPreview < ActionMailer::Preview
 
   def notify_facility
-    products_with_contacts = Product.where("LENGTH(cancellation_notification_recipients) > 0")
+    products_with_contacts = Product.where("LENGTH(cancellation_email_recipients) > 0")
     product = NUCore::Database.random(products_with_contacts)
     CancellationMailer.notify_facility(NUCore::Database.random(product.order_details.canceled))
   end


### PR DESCRIPTION
# Release Notes

TECH TASK: Rename cancellation_notification_recipients to cancellation_email_recipients

# Additional Context

On Oracle, and identifier can’t be longer than 30 characters, and the column name `cancellation_notification_recipients` is 36 characters. Hence, running the migration which adds this column results in the error:

```
OCIError: ORA-00972: identifier is too long: ALTER TABLE "PRODUCTS" ADD "CANCELLATION_NOTIFICATION_RECIPIENTS" CLOB
```

so the feature from #1666 will not work on Oracle as-is.