### PR TITLE
[#143399] Add another column to current rooms dashboard

### DIFF
--- a/vendor/engines/secure_rooms/app/views/secure_rooms/shared/_dashboard_column.html.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_rooms/shared/_dashboard_column.html.haml
@@ -1,0 +1,12 @@
+- unless local_assigns[:hide]
+  %h4= header
+  %table.table.table-striped.table-hover.current_occupants
+    %thead
+      %tr
+        %th= User.human_attribute_name(:full_name)
+        %th= SecureRooms::Occupancy.human_attribute_name(timestamp)
+    %tbody
+      - occupancies.each do |occupancy|
+        %tr
+          %td= occupancy.user.full_name(suspended_label: false)
+          %td= format_usa_datetime(occupancy.public_send(timestamp))

--- a/vendor/engines/secure_rooms/app/views/secure_rooms/shared/_dashboard_column.html.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_rooms/shared/_dashboard_column.html.haml
@@ -1,12 +1,11 @@
-- unless local_assigns[:hide]
-  %h4= header
-  %table.table.table-striped.table-hover.current_occupants
-    %thead
+%h4= header
+%table.table.table-striped.table-hover.current_occupants
+  %thead
+    %tr
+      %th= User.human_attribute_name(:full_name)
+      %th= SecureRooms::Occupancy.human_attribute_name(timestamp)
+  %tbody
+    - occupancies.each do |occupancy|
       %tr
-        %th= User.human_attribute_name(:full_name)
-        %th= SecureRooms::Occupancy.human_attribute_name(timestamp)
-    %tbody
-      - occupancies.each do |occupancy|
-        %tr
-          %td= occupancy.user.full_name(suspended_label: false)
-          %td= format_usa_datetime(occupancy.public_send(timestamp))
+        %td= occupancy.user.full_name(suspended_label: false)
+        %td= format_usa_datetime(occupancy.public_send(timestamp))

--- a/vendor/engines/secure_rooms/app/views/secure_rooms/shared/_secure_rooms_dashboard.html.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_rooms/shared/_secure_rooms_dashboard.html.haml
@@ -1,27 +1,9 @@
 %label= text(:time_label)
 .refreshed_at= format_usa_datetime(Time.current)
+- current_occupancies = room.occupancies.current
 .row
-  .span6
-    %h4= text(:current)
-    %table.table.table-striped.table-hover.current_occupants
-      %thead
-        %tr
-          %th= User.human_attribute_name(:full_name)
-          %th= SecureRooms::Occupancy.human_attribute_name(:entry_at)
-      %tbody
-        - room.occupancies.current.each do |occupancy|
-          %tr
-            %td= occupancy.user.full_name(suspended_label: false)
-            %td= format_usa_datetime(occupancy.entry_at)
-  .span6
-    %h4= text(:recent)
-    %table.table.table-striped.table-hover.recent_occupants
-      %thead
-        %tr
-          %th= User.human_attribute_name(:full_name)
-          %th= SecureRooms::Occupancy.human_attribute_name(:exit_at)
-      %tbody
-        - room.occupancies.recent.each do |occupancy|
-          %tr
-            %td= occupancy.user.full_name(suspended_label: false)
-            %td= format_usa_datetime(occupancy.exit_at)
+  .span4= render "secure_rooms/shared/dashboard_column", occupancies: current_occupancies.limit(10), header: text(:current), timestamp: :entry_at
+  - second_column_occupancies = current_occupancies.offset(10)
+  .span4= render "secure_rooms/shared/dashboard_column", occupancies: second_column_occupancies, header: text(:current_continued), timestamp: :entry_at, hide: second_column_occupancies.none?
+
+  .span4= render "secure_rooms/shared/dashboard_column", occupancies: room.occupancies.recent, header: text(:recent), timestamp: :exit_at

--- a/vendor/engines/secure_rooms/app/views/secure_rooms/shared/_secure_rooms_dashboard.html.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_rooms/shared/_secure_rooms_dashboard.html.haml
@@ -4,6 +4,7 @@
 .row
   .span4= render "secure_rooms/shared/dashboard_column", occupancies: current_occupancies.limit(10), header: text(:current), timestamp: :entry_at
   - second_column_occupancies = current_occupancies.offset(10)
-  .span4= render "secure_rooms/shared/dashboard_column", occupancies: second_column_occupancies, header: text(:current_continued), timestamp: :entry_at, hide: second_column_occupancies.none?
+  .span4
+    = render "secure_rooms/shared/dashboard_column", occupancies: second_column_occupancies, header: text(:current_continued), timestamp: :entry_at if second_column_occupancies.any?
 
   .span4= render "secure_rooms/shared/dashboard_column", occupancies: room.occupancies.recent, header: text(:recent), timestamp: :exit_at

--- a/vendor/engines/secure_rooms/config/locales/en.yml
+++ b/vendor/engines/secure_rooms/config/locales/en.yml
@@ -137,6 +137,7 @@ en:
         secure_rooms_dashboard:
           time_label: Occupancy Data Taken At
           current: Current Occupants
+          current_continued: Current Occupants (Continued)
           recent: Recent Occupants
 
   simple_form:


### PR DESCRIPTION
# Release Notes

Adds another "Current Occupancies" column to the secure rooms dashboard so that a high occupancy (more than 10) does not overflow the screen.

# Screenshot

<img width="1252" alt="screen shot 2018-09-10 at 4 09 11 pm" src="https://user-images.githubusercontent.com/1099111/45324608-3cdeae00-b514-11e8-8793-53a14c7a9fdc.png">

# Additional Context

I chatted with Aaron and showed him a couple options. This maintains the current behavior of always showing the "Current Occupancies" header and table header of the first column for empty rooms. We hide the second column header if there is nothing there.

The facilities occupancies shows all of the rooms for a facility, but shared the same code with the public dashboard so this change applies to both places.
