### PR TITLE
Fix oracle types in Rails 5

### DIFF
--- a/db/migrate/20180907190857_fix_oracle_timestamps.rb
+++ b/db/migrate/20180907190857_fix_oracle_timestamps.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# In Rails <= 4.2, Rails mapped the Oracle `DATE` to Ruby's `DateTime`. As of Rails 5
+# `DATE` maps to `Date`. We need to change it
+class FixOracleTimestamps < ActiveRecord::Migration[5.0]
+
+  def change
+    return unless NUCore::Database.oracle?
+
+    reversible do |dir|
+      dir.up { change_all_columns_types(:date, :datetime) }
+      dir.down { change_all_columns_types(:datetime, :date) }
+    end
+
+  end
+
+  private
+
+  def change_all_columns_types(from_type, to_type)
+    ActiveRecord::Base.connection.tables.sort.each do |table_name|
+      columns = ActiveRecord::Base.connection.columns(table_name).select { |c| c.type.to_s == from_type.to_s }
+
+      next if columns.blank?
+
+      columns.each do |c|
+        change_column table_name, c.name, to_type
+      end
+    end
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180907155501) do
+ActiveRecord::Schema.define(version: 20180907190857) do
 
   create_table "account_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "account_id",            null: false


### PR DESCRIPTION
# Release Notes

Tech task: Update Oracle database DATE column types to TIMESTAMP.

# Additional Context

Pulled up from https://github.com/tablexi/nucore-nu/pull/405

# Tech Notes

In rails 4.2, ruby `DateTime` maps to an oracle `DATE` column (which supports seconds, but not subseconds). Now it's assocated to ruby `Date`. So In rails 5, it's only grabbing the date portion of those columns. And the schema dumper writes them as  `t.date` rather than `t.datetime` https://github.com/rsim/oracle-enhanced/pull/875

Looks like they're going to be using TIMESTAMP for the rails datetime. https://github.com/rsim/oracle-enhanced/pull/739

This ends up being a no-op when applied to MySQL.

For additional reference, we go from 1.6.9 -> 1.7.11 of the oracle adapter https://github.com/rsim/oracle-enhanced/blob/master/History.md

I kind of like changing the columns in that it gives us fractional sections, which isn't important on its own, but does give closer parity to mysql.

Also, I ran this against a production backup. It was super fast; I was worried this would be slow on the really big tables.