### PR TITLE
Update where_ids_in query for Rails 5

### DIFF
--- a/lib/nucore.rb
+++ b/lib/nucore.rb
@@ -60,14 +60,14 @@ module NUCore
         # Oracle has a limit of 1000 items in a WHERE IN clause. Use this in
         # place of `where(id: ids)` when there might be more than 1000 ids.
         # Example: facility.order_details.complete.where_ids_in(ids)
-        def where_ids_in(ids)
+        def where_ids_in(ids, batch_size: 999)
           if NUCore::Database.oracle?
             return none if ids.blank?
 
-            queries = ids.each_slice(999).flat_map do |id_slice|
-              unscoped.where(id: id_slice).where_values
+            clauses = ids.each_slice(batch_size).map do |id_slice|
+              "#{table_name.upcase}.ID IN (#{id_slice.join(', ')})"
             end
-            where(queries.reduce(:or))
+            where(clauses.join(" OR "))
           else
             where(id: ids)
           end

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -1880,4 +1880,19 @@ RSpec.describe OrderDetail do
       expect(OrderDetail.with_upcoming_reservation).not_to include(order_detail)
     end
   end
+
+  describe ".where_ids_in" do
+    it "finds the items" do
+      od2 = order_detail.dup.tap(&:save)
+      od3 = order_detail.dup.tap(&:save)
+      od4 = order_detail.dup.tap(&:save) # not looked up
+
+      expect(described_class.where_ids_in([order_detail.id, od2.id, od3.id], batch_size: 2))
+        .to contain_exactly(order_detail, od2, od3)
+    end
+
+    it "doesn't blow up on 1000+ entries" do
+      described_class.where_ids_in((0..1001).to_a).to_a
+    end
+  end
 end


### PR DESCRIPTION
# Release Notes

Tech task: Update `where_ids_in` scope for ActiveRecord `or` support.

# Additional Context

Pulled up from https://github.com/tablexi/nucore-nu/pull/408

I ended up using the dumb string version because I couldn't get an Arel version
working on Rails 5/`where-or`. This now works on both 4.2 and 5.0.


