### PR TITLE
[#133770] Facility Notification Banner

### DIFF
--- a/app/assets/javascripts/ckeditor/editor.js
+++ b/app/assets/javascripts/ckeditor/editor.js
@@ -1,8 +1,8 @@
 $(document).ready(function() {
   if (! CKEDITOR) return;
   $('textarea.editor').each(function(){
-    CKEDITOR.replace(this.id, { 
-      toolbar: 
+    CKEDITOR.replace(this.id, {
+      toolbar:
         [
           ['Source','-','Preview'],
           ['Cut','Copy','Paste','PasteText','PasteFromWord','SpellChecker','Scayt'],
@@ -17,6 +17,20 @@ $(document).ready(function() {
           ['TextColor']
         ],
       resize_enabled: true
+    });
+  });
+
+  $('textarea.editor__simple').each(function(){
+    CKEDITOR.replace(this.id, {
+      toolbar:
+        [
+          ['Bold','Italic','Underline'],
+          ['Link','Unlink'],
+          ['Cut','Copy','Paste','PasteText','PasteFromWord',],
+          ['Undo','Redo','-','SelectAll','RemoveFormat'],
+          ['ShowBlocks'],
+        ],
+      resize_enabled: false
     });
   });
 });

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -198,6 +198,7 @@ class FacilitiesController < ApplicationController
         abbreviation
         accepts_multi_add
         address
+        banner_notice
         description
         email
         fax_number

--- a/app/inputs/readonly_input.rb
+++ b/app/inputs/readonly_input.rb
@@ -3,6 +3,7 @@
 class ReadonlyInput < SimpleForm::Inputs::Base
 
   include DateHelper
+  include ActionView::Helpers::SanitizeHelper
 
   disable :required
 
@@ -14,6 +15,7 @@ class ReadonlyInput < SimpleForm::Inputs::Base
       value = process_boolean(value)  if !!value == value # is it a boolean
       value = options.delete(:value_method).call(value) if options[:value_method].is_a?(Proc)
       value = value.send(options[:value_method] || :to_s)
+      value = sanitize(value)
       value.to_s.presence || options[:default_value] # extra to_s is in case value is integer 0
     end
   end

--- a/app/inputs/readonly_input.rb
+++ b/app/inputs/readonly_input.rb
@@ -15,8 +15,8 @@ class ReadonlyInput < SimpleForm::Inputs::Base
       value = process_boolean(value)  if !!value == value # is it a boolean
       value = options.delete(:value_method).call(value) if options[:value_method].is_a?(Proc)
       value = value.send(options[:value_method] || :to_s)
-      value = sanitize(value)
-      value.to_s.presence || options[:default_value] # extra to_s is in case value is integer 0
+      value = sanitize(value.to_s)
+      value.presence || options[:default_value]
     end
   end
 

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -63,10 +63,6 @@ class Facility < ApplicationRecord
     # super
   end
 
-  def description
-    self[:description]&.html_safe
-  end
-
   def order_statuses
     OrderStatus.for_facility(self)
   end

--- a/app/views/facilities/_facility_fields.html.haml
+++ b/app/views/facilities/_facility_fields.html.haml
@@ -1,10 +1,16 @@
-= f.input :name, hint: text(".hints.name")
-= f.input :abbreviation, hint: text(".hints.abbreviation")
-= f.input :url_name, hint: facility_url(f.object.url_name || "url-name"), as: :string
-= f.input :short_description, input_html: { class: "wide" }, hint: text(".hints.short_description")
-= f.input :description, input_html: { class: "editor" }, hint: text(".hints.description")
+%fieldset.well
+  = f.input :name, hint: text(".hints.name")
+  = f.input :abbreviation, hint: text(".hints.abbreviation")
+  = f.input :url_name, hint: facility_url(f.object.url_name || "url-name"), as: :string
+  = f.input :short_description, input_html: { class: "wide" }, hint: text(".hints.short_description")
+  = f.input :description, input_html: { class: "editor" }, hint: text(".hints.description")
 
-.well
+- if SettingsHelper.feature_on?(:facility_banner_notice)
+  %fieldset.well.collapsable{ class: f.object.banner_notice.blank? ? "collapsed" : "" }
+    %label.legend= f.label :banner_notice
+    = f.input :banner_notice, input_html: { class: "editor__simple" }, hint: text(".hints.banner_notice"), label: false
+
+%fieldset.well
   %p
     = f.input :accepts_multi_add,
       as: :boolean, label: false, inline_label: text(".labels.accepts_multi_add")

--- a/app/views/facilities/manage.html.haml
+++ b/app/views/facilities/manage.html.haml
@@ -9,6 +9,7 @@
   = f.input :url_name
   = f.input :short_description
   = f.input :description
+  = f.input :banner_notice if SettingsHelper.feature_on?(:facility_banner_notice)
   = f.input :accepts_multi_add, label: text("views.facilities.facility_fields.labels.accepts_multi_add")
   = f.input :show_instrument_availability, label: text("views.facilities.facility_fields.labels.show_instrument_availability")
   = render_view_hook("before_is_active", f: f)

--- a/app/views/facilities/show.html.haml
+++ b/app/views/facilities/show.html.haml
@@ -1,5 +1,8 @@
 = content_for :h1 do
   = current_facility
+- if SettingsHelper.feature_on?(:facility_banner_notice) && strip_tags(current_facility.banner_notice).present?
+  = content_for :banner do
+    .global-alert-banner= sanitize current_facility.banner_notice
 
 - if acting_as? || session_user.try(:operator_of?, current_facility)
   - instruments = current_facility.instruments.active_plus_hidden
@@ -20,7 +23,7 @@
     %li== &raquo;
     %li= current_facility
 
-.wysiwyg= current_facility.description
+.wysiwyg= sanitize current_facility.description
 
 .product_list_container{class: @columns}
   - if @order_form

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,6 +6,7 @@
     %header
       = render "/shared/acting_as"
       = render_view_hook("banner")
+      = yield(:banner)
       = render "/shared/header"
     %nav
       = render "/shared/nav"

--- a/config/initializers/sanitized_allowed.rb
+++ b/config/initializers/sanitized_allowed.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 ActionView::Base.sanitized_allowed_attributes << "style"
+ActionView::Base.sanitized_allowed_tags += %w(table thead tbody th tr td)

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -228,6 +228,7 @@ en:
         full_name: Full Name
         suspended: SUSPENDED
       facility:
+        banner_notice: Banner Notice
         fax_number: Fax Number
         is_active: Is Active?
         journal_mask: CoreID

--- a/config/locales/views/admin/en.facilities.yml
+++ b/config/locales/views/admin/en.facilities.yml
@@ -7,6 +7,7 @@ en:
           abbreviation: "Abbreviated name or acronym for the !facility_downcase!"
           short_description: "Description as it will appear on the home page"
           description: "Description as it will appear on the !facility_downcase! main page"
+          banner_notice: Highly visible banner that will display when a user visits your homepage. Banner will be hidden if blank.
           show_instrument_availability: Public schedule icon on !facility_downcase! page will show current availability.
         labels:
           is_active: "Is Active?"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -123,6 +123,7 @@ feature:
   product_list_columns_on: false
   azlist_on: false
   use_manage_on: false
+  facility_banner_notice_on: true
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/db/migrate/20180917224024_add_facility_notice.rb
+++ b/db/migrate/20180917224024_add_facility_notice.rb
@@ -1,0 +1,7 @@
+class AddFacilityNotice < ActiveRecord::Migration[5.0]
+
+  def change
+    add_column :facilities, :banner_notice, :text
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180907190857) do
+ActiveRecord::Schema.define(version: 20180917224024) do
 
   create_table "account_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "account_id",            null: false
@@ -160,6 +160,7 @@ ActiveRecord::Schema.define(version: 20180907190857) do
     t.boolean  "show_instrument_availability",               default: false, null: false
     t.string   "order_notification_recipient"
     t.boolean  "sanger_sequencing_enabled",                  default: false, null: false
+    t.text     "banner_notice",                limit: 65535
     t.index ["abbreviation"], name: "index_facilities_on_abbreviation", unique: true, using: :btree
     t.index ["is_active", "name"], name: "index_facilities_on_is_active_and_name", using: :btree
     t.index ["name"], name: "index_facilities_on_name", unique: true, using: :btree
@@ -448,32 +449,32 @@ ActiveRecord::Schema.define(version: 20180907190857) do
   end
 
   create_table "products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "type",                                 limit: 50,                       null: false
-    t.integer  "facility_id",                                                           null: false
-    t.string   "name",                                 limit: 200,                      null: false
-    t.string   "url_name",                             limit: 50,                       null: false
-    t.text     "description",                          limit: 65535
+    t.string   "type",                          limit: 50,                       null: false
+    t.integer  "facility_id",                                                    null: false
+    t.string   "name",                          limit: 200,                      null: false
+    t.string   "url_name",                      limit: 50,                       null: false
+    t.text     "description",                   limit: 65535
     t.integer  "schedule_id"
-    t.boolean  "requires_approval",                                                     null: false
+    t.boolean  "requires_approval",                                              null: false
     t.integer  "initial_order_status_id"
-    t.boolean  "is_archived",                                                           null: false
-    t.boolean  "is_hidden",                                                             null: false
-    t.datetime "created_at",                                                            null: false
-    t.datetime "updated_at",                                                            null: false
+    t.boolean  "is_archived",                                                    null: false
+    t.boolean  "is_hidden",                                                      null: false
+    t.datetime "created_at",                                                     null: false
+    t.datetime "updated_at",                                                     null: false
     t.integer  "min_reserve_mins"
     t.integer  "max_reserve_mins"
     t.integer  "min_cancel_hours"
     t.integer  "facility_account_id"
-    t.string   "account",                              limit: 5
-    t.boolean  "show_details",                                       default: false,    null: false
+    t.string   "account",                       limit: 5
+    t.boolean  "show_details",                                default: false,    null: false
     t.integer  "auto_cancel_mins"
     t.string   "contact_email"
     t.integer  "reserve_interval"
-    t.integer  "lock_window",                                        default: 0,        null: false
-    t.text     "training_request_contacts",            limit: 65535
-    t.integer  "cutoff_hours",                                       default: 0,        null: false
+    t.integer  "lock_window",                                 default: 0,        null: false
+    t.text     "training_request_contacts",     limit: 65535
+    t.integer  "cutoff_hours",                                default: 0,        null: false
     t.string   "dashboard_token"
-    t.string   "user_notes_field_mode",                              default: "hidden", null: false
+    t.string   "user_notes_field_mode",                       default: "hidden", null: false
     t.string   "user_notes_label"
     t.string   "order_notification_recipient"
     t.text     "cancellation_email_recipients", limit: 65535


### PR DESCRIPTION
# Release Notes

Adds a per-facility optional banner notification that can be configured by the facility. The banner appears on the facility's home page (the instrument listing).

# Screenshot

![screen shot 2018-09-17 at 7 06 28 pm](https://user-images.githubusercontent.com/1099111/45657150-b3e4eb00-baae-11e8-9c4d-ad91b9ab8469.png)

In Dartmouth when combined with the SSO warning notice (hopefully will be going away in the next little bit).

![screen shot 2018-09-17 at 7 19 57 pm](https://user-images.githubusercontent.com/1099111/45657152-b6474500-baae-11e8-97a6-082b4591b0be.png)

Combined with the order on behalf of banner. This doesn't look great, but that banner could definitely use some love in the future. We could also hide the notification banner if the order on behalf banner.

# Additional Context

I gave this a feature flag because I could see NU not being interested.
