### PR TITLE
Add `manage-mode` body class when in manage mode

### DIFF
--- a/app/controllers/concerns/nav_tab.rb
+++ b/app/controllers/concerns/nav_tab.rb
@@ -13,6 +13,7 @@ module NavTab
     helper_method(:global_navigation_links)
     helper_method(:navigation_links)
     helper_method(:home_button)
+    helper_method(:manage_mode?)
   end
 
   module ClassMethods
@@ -34,13 +35,15 @@ module NavTab
     ((self.class.admin_actions || []) & [action_name.to_sym, :all]).any?
   end
 
+  def manage_mode?
+    admin_tab? && current_facility.present? && current_facility != Facility.cross_facility
+  end
+
   def navigation_links
     case
-    when customer_tab? && acting_user.present?
+    when customer_tab? && !acting_as?
       link_collection.customer.compact
-    when customer_tab? && acting_user.present? && current_facility.present? && current_facility != Facility.cross_facility
-      link_collection.manager
-    when admin_tab? && current_facility.present? && current_facility != Facility.cross_facility
+    when manage_mode?
       link_collection.admin
     else
       link_collection.default

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,7 +2,7 @@
 %html
   %head
     = render "/shared/head"
-  %body
+  %body{ class: SettingsHelper.feature_on?(:use_manage) && manage_mode? ? "manage-mode" : "" }
     %header
       = render "/shared/acting_as"
       = render_view_hook("banner")


### PR DESCRIPTION
# Release Notes

Tech task: Add `manage-mode` body class when in manage mode.

# Additional Context

This will allow us to target the CSS of the page based on if we are in use or manage mode.

