### PR TITLE
Rubocop: Auto correct single to double quotes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -799,13 +799,6 @@ Style/Semicolon:
     - 'spec/controllers/reports/general_reports_controller_spec.rb'
     - 'spec/controllers/reports/instrument_reports_controller_spec.rb'
 
-# Offense count: 205
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiterals:
-  Enabled: false
-
 # Offense count: 1
 Style/StructInheritance:
   Exclude:

--- a/app/controllers/product_notifications_controller.rb
+++ b/app/controllers/product_notifications_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ProductNotificationsController < ApplicationController
 
   admin_tab :all

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -102,7 +102,7 @@ class ReservationsController < ApplicationController
       @reservation = creator.reservation
       authorize! :create, @reservation
       flash[:notice] = I18n.t "controllers.reservations.create.success"
-      flash[:error] = I18n.t('controllers.reservations.create.admin_hold_warning') if creator.reservation.conflicting_admin_reservation?
+      flash[:error] = I18n.t("controllers.reservations.create.admin_hold_warning") if creator.reservation.conflicting_admin_reservation?
 
       if creator.merged_order?
         redirect_to facility_order_path(@order_detail.facility, @order_detail.order.merge_order || @order_detail.order)

--- a/app/mailers/cancellation_mailer.rb
+++ b/app/mailers/cancellation_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CancellationMailer < BaseMailer
 
   def notify_facility(order_detail)

--- a/app/models/concerns/email_list_attribute.rb
+++ b/app/models/concerns/email_list_attribute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Include this module in a model to add that attribute that acts like an array
 # but is backed by a comma-separated string in the database.
 #

--- a/app/services/transaction_search/base_searcher.rb
+++ b/app/services/transaction_search/base_searcher.rb
@@ -7,7 +7,7 @@ module TransactionSearch
     attr_reader :order_details
 
     def self.key
-      to_s.sub(/\ATransactionSearch::/, '').sub(/Searcher\z/, '').pluralize.underscore
+      to_s.sub(/\ATransactionSearch::/, "").sub(/Searcher\z/, "").pluralize.underscore
     end
 
     def initialize(order_details)

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative 'boot'
+require_relative "boot"
 
-require 'rails/all'
+require "rails/all"
 require "will_paginate/array"
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,12 +15,12 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
+  if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => 'public, max-age=172800'
+      "Cache-Control" => "public, max-age=172800"
     }
   else
     config.action_controller.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => 'public, max-age=3600'
+    "Cache-Control" => "public, max-age=3600"
   }
 
   # Show full error reports and disable caching.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,7 +3,7 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path
 # Rails.application.config.assets.paths << Emoji.images_path

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -3,7 +3,7 @@
 #
 # Ensure attachments are saved with URL-friendly names
 Paperclip.interpolates :safe_filename do |attachment, style|
-  filename(attachment, style).tr('#', "-")
+  filename(attachment, style).tr("#", "-")
 end
 
 Paperclip.interpolates :rails_relative_url_root do |_, _|

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,4 +2,4 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_nucore_session'
+Rails.application.config.session_store :cookie_store, key: "_nucore_session"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,21 +8,21 @@ Nucore::Application.routes.draw do
   mount SangerSequencing::Engine => "/" if defined?(SangerSequencing)
 
   if SettingsHelper.feature_on?(:password_update)
-    match "/users/password/edit_current", to: 'user_password#edit_current', as: "edit_current_password", via: [:get, :post]
-    match "/users/password/reset", to: 'user_password#reset', as: "reset_password", via: [:get, :post]
+    match "/users/password/edit_current", to: "user_password#edit_current", as: "edit_current_password", via: [:get, :post]
+    match "/users/password/reset", to: "user_password#reset", as: "reset_password", via: [:get, :post]
   end
 
   # root route
-  root to: 'public#index'
+  root to: "public#index"
 
   # authentication
-  get "switch_back", to: 'public#switch_back'
+  get "switch_back", to: "public#switch_back"
 
   # shared searches
-  get "/user_search_results", to: 'search#user_search_results'
-  get "/#{I18n.t('facilities_downcase')}/:facility_id/price_group/:price_group_id/account_price_group_members/search_results", to: 'account_price_group_members#search_results'
+  get "/user_search_results", to: "search#user_search_results"
+  get "/#{I18n.t('facilities_downcase')}/:facility_id/price_group/:price_group_id/account_price_group_members/search_results", to: "account_price_group_members#search_results"
 
-  post "global_search" => 'global_search#index', as: "global_search"
+  post "global_search" => "global_search#index", as: "global_search"
 
   resources :users, only: [] do
     resources :user_preferences, only: [:index, :edit, :update], shallow: true
@@ -36,8 +36,8 @@ Nucore::Application.routes.draw do
     end
 
     if SettingsHelper.feature_on? :suspend_accounts
-      get "suspend", to: 'accounts#suspend', as: "suspend"
-      get "unsuspend", to: 'accounts#unsuspend', as: "unsuspend"
+      get "suspend", to: "accounts#suspend", as: "suspend"
+      get "unsuspend", to: "accounts#unsuspend", as: "unsuspend"
     end
 
     resources :account_users, only: [:new, :destroy, :create, :index] do
@@ -66,21 +66,21 @@ Nucore::Application.routes.draw do
       resources :training_requests, only: [:new, :create] if SettingsHelper.feature_on?(:training_requests)
 
       resource :product_notification, only: [:show, :edit, :update], path: "notifications", as: "notifications"
-   end
+    end
 
-    get "instrument_statuses", to: 'instruments#instrument_statuses', as: "instrument_statuses"
+    get "instrument_statuses", to: "instruments#instrument_statuses", as: "instrument_statuses"
 
     resources :training_requests, only: [:index, :destroy] if SettingsHelper.feature_on?(:training_requests)
 
     resources :instruments do
       collection do
-        get "list", to: 'instruments#public_list'
+        get "list", to: "instruments#public_list"
       end
       facility_product_routing_concern
-      get "public_schedule", to: 'instruments#public_schedule'
-      get "schedule",        to: 'instruments#schedule'
-      get "status",          to: 'instruments#instrument_status'
-      get "switch",          to: 'instruments#switch'
+      get "public_schedule", to: "instruments#public_schedule"
+      get "schedule",        to: "instruments#schedule"
+      get "status",          to: "instruments#instrument_status"
+      get "switch",          to: "instruments#switch"
 
       put "bring_online", to: "offline_reservations#bring_online"
       resources :offline_reservations, only: [:new, :create, :edit, :update]
@@ -89,8 +89,8 @@ Nucore::Application.routes.draw do
       resources :product_access_groups
       resources :price_policies, controller: "instrument_price_policies", except: [:show]
       resources :reservations, only: [:new, :create, :destroy], controller: "facility_reservations" do
-        get "edit_admin", to: 'facility_reservations#edit_admin'
-        patch "update_admin", to: 'facility_reservations#update_admin'
+        get "edit_admin", to: "facility_reservations#edit_admin"
+        patch "update_admin", to: "facility_reservations#update_admin"
       end
 
       resources :reservations, only: [:index]
@@ -116,7 +116,7 @@ Nucore::Application.routes.draw do
       get :manage, on: :member
       resources :bundle_products, controller: "bundle_products", except: [:show]
       resources :file_uploads, path: "files", only: [:index, :create, :destroy]
-      get "/files/:file_type/:id", to: 'file_uploads#download', as: "download_product_file"
+      get "/files/:file_type/:id", to: "file_uploads#download", as: "download_product_file"
     end
 
     resources :price_group_products, only: [:edit, :update]
@@ -127,7 +127,7 @@ Nucore::Application.routes.draw do
       collection do
         get "search"
       end
-      match "map_user", to: 'facility_users#map_user', via: [:get, :post]
+      match "map_user", to: "facility_users#map_user", via: [:get, :post]
     end
 
     users_options = if SettingsHelper.feature_on?(:create_users)
@@ -146,16 +146,16 @@ Nucore::Application.routes.draw do
         patch "unsuspend", on: :member
       end
 
-      get "switch_to",    to: 'users#switch_to'
-      get "orders",       to: 'users#orders'
+      get "switch_to",    to: "users#switch_to"
+      get "orders",       to: "users#orders"
       resources :reservations, only: [:index], param: :order_detail_id, controller: "facility_user_reservations" do
         member do
           put "cancel"
         end
       end
-      get "accounts",     to: 'users#accounts'
-      get "access_list",  to: 'users#access_list'
-      post "access_list/approvals", to: 'users#access_list_approvals'
+      get "accounts",     to: "users#accounts"
+      get "access_list",  to: "users#access_list"
+      post "access_list/approvals", to: "users#access_list_approvals"
     end
 
     if SettingsHelper.feature_on? :recharge_accounts
@@ -180,14 +180,14 @@ Nucore::Application.routes.draw do
         resources :reservations, controller: "facility_reservations", only: [:edit, :update, :show]
         resources :accessories, only: [:new, :create]
         member do
-          get "manage", to: 'order_management/order_details#edit'
+          get "manage", to: "order_management/order_details#edit"
           patch "manage", to: "order_management/order_details#update"
-          put "manage", to: 'order_management/order_details#update'
-          get "pricing", to: 'order_management/order_details#pricing'
-          get "files", to: 'order_management/order_details#files'
-          post "remove_from_journal", to: 'order_management/order_details#remove_from_journal'
-          get "sample_results/:stored_file_id", to: 'order_management/order_details#sample_results', as: "sample_results"
-          get "template_results/:stored_file_id", to: 'order_management/order_details#template_results', as: "template_results"
+          put "manage", to: "order_management/order_details#update"
+          get "pricing", to: "order_management/order_details#pricing"
+          get "files", to: "order_management/order_details#files"
+          post "remove_from_journal", to: "order_management/order_details#remove_from_journal"
+          get "sample_results/:stored_file_id", to: "order_management/order_details#sample_results", as: "sample_results"
+          get "template_results/:stored_file_id", to: "order_management/order_details#template_results", as: "template_results"
         end
       end
     end
@@ -206,8 +206,8 @@ Nucore::Application.routes.draw do
       end
     end
 
-    get "public_timeline", to: 'reservations#public_timeline', as: "public_timeline" if SettingsHelper.feature_on?(:daily_view)
-    get "accounts_receivable", to: 'facility_accounts#accounts_receivable'
+    get "public_timeline", to: "reservations#public_timeline", as: "public_timeline" if SettingsHelper.feature_on?(:daily_view)
+    get "accounts_receivable", to: "facility_accounts#accounts_receivable"
 
     ### Feature Toggle Editing Accounts ###
     if SettingsHelper.feature_on?(:edit_accounts)
@@ -227,14 +227,14 @@ Nucore::Application.routes.draw do
       get "search_results", via: [:post], on: :collection
 
       if SettingsHelper.feature_on?(:suspend_accounts)
-        get "suspend",   to: 'facility_accounts#suspend',   as: "suspend"
-        get "unsuspend", to: 'facility_accounts#unsuspend', as: "unsuspend"
+        get "suspend",   to: "facility_accounts#suspend",   as: "suspend"
+        get "unsuspend", to: "facility_accounts#unsuspend", as: "unsuspend"
       end
 
-      get "/members", to: 'facility_accounts#members', as: "members"
+      get "/members", to: "facility_accounts#members", as: "members"
 
       if Account.config.statements_enabled?
-        get "/statements", to: 'facility_accounts#statements', as: :statements
+        get "/statements", to: "facility_accounts#statements", as: :statements
         get "/statements/:statement_id", to: "facility_accounts#show_statement", as: :statement
       end
 
@@ -251,7 +251,7 @@ Nucore::Application.routes.draw do
     ######
 
     resources :journals, controller: "facility_journals", only: [:index, :new, :create, :update, :show] do
-      post "reconcile", to: 'facility_journals#reconcile'
+      post "reconcile", to: "facility_journals#reconcile"
     end
 
     resources :price_groups do
@@ -266,15 +266,15 @@ Nucore::Application.routes.draw do
     end
 
     get "disputed_orders", to: "facilities#disputed_orders"
-    get "notifications",       to: 'facility_notifications#index'
-    post "notifications/send", to: 'facility_notifications#send_notifications', as: "send_notifications"
-    get "transactions",        to: 'facilities#transactions'
-    get "in_review",           to: 'facility_notifications#in_review',          as: "notifications_in_review"
-    post "in_review/mark",     to: 'facility_notifications#mark_as_reviewed',   as: "notifications_mark_as_reviewed"
-    get "movable_transactions", to: 'facilities#movable_transactions'
-    post "movable_transactions/reassign_chart_strings", to: 'facilities#reassign_chart_strings'
-    post "movable_transactions/confirm", to: 'facilities#confirm_transactions'
-    post "movable_transactions/move", to: 'facilities#move_transactions'
+    get "notifications",       to: "facility_notifications#index"
+    post "notifications/send", to: "facility_notifications#send_notifications", as: "send_notifications"
+    get "transactions",        to: "facilities#transactions"
+    get "in_review",           to: "facility_notifications#in_review",          as: "notifications_in_review"
+    post "in_review/mark",     to: "facility_notifications#mark_as_reviewed",   as: "notifications_mark_as_reviewed"
+    get "movable_transactions", to: "facilities#movable_transactions"
+    post "movable_transactions/reassign_chart_strings", to: "facilities#reassign_chart_strings"
+    post "movable_transactions/confirm", to: "facilities#confirm_transactions"
+    post "movable_transactions/move", to: "facilities#move_transactions"
 
     resources :statements, controller: "facility_statements", only: [:index, :new, :show, :create]
 
@@ -287,7 +287,7 @@ Nucore::Application.routes.draw do
     get "instrument_unavailable_reports/:report_by",
         to: "reports/instrument_unavailable_reports#index",
         as: "instrument_unavailable_reports"
-    get "instrument_day_reports/:report_by", to: 'reports/instrument_day_reports#index', as: "instrument_day_reports"
+    get "instrument_day_reports/:report_by", to: "reports/instrument_day_reports#index", as: "instrument_day_reports"
   end
 
   # global settings
@@ -299,11 +299,11 @@ Nucore::Application.routes.draw do
   resources :log_events, only: :index
 
   # order process
-  get "/orders/cart", to: 'orders#cart', as: "cart"
-  get "/orders(\/:status)", to: 'orders#index', as: "orders_status", constraints: { status: /pending|all/ } ## emacs quoting \/
+  get "/orders/cart", to: "orders#cart", as: "cart"
+  get "/orders(\/:status)", to: "orders#index", as: "orders_status", constraints: { status: /pending|all/ } ## emacs quoting \/
 
-  put "/orders/:id/remove/:order_detail_id", to: 'orders#remove', as: "remove_order"
-  get "/order/:id/add_account", to: 'orders#add_account', as: "add_account"
+  put "/orders/:id/remove/:order_detail_id", to: "orders#remove", as: "remove_order"
+  get "/order/:id/add_account", to: "orders#add_account", as: "add_account"
 
   resources :orders do
     member do
@@ -331,9 +331,9 @@ Nucore::Application.routes.draw do
       get "template_results/:id", to: "order_detail_stored_files#template_results", as: "template_results"
 
       resources :reservations, except: [:index] do
-        get "/move",               to: 'reservations#earliest_move_possible'
-        post "/move",              to: 'reservations#move',              as: "move_reservation"
-        get "/switch_instrument",  to: 'reservations#switch_instrument', as: "switch_instrument"
+        get "/move",               to: "reservations#earliest_move_possible"
+        post "/move",              to: "reservations#move",              as: "move_reservation"
+        get "/switch_instrument",  to: "reservations#switch_instrument", as: "switch_instrument"
       end
 
       resources :accessories, only: [:new, :create]
@@ -352,18 +352,18 @@ Nucore::Application.routes.draw do
   end
 
   # reservations
-  get "reservations", to: 'reservations#list', as: "reservations"
-  get "reservations(/:status)", to: 'reservations#list', as: "reservations_status"
+  get "reservations", to: "reservations#list", as: "reservations"
+  get "reservations(/:status)", to: "reservations#list", as: "reservations_status"
 
   resources :my_files, only: [:index] if SettingsHelper.feature_on?(:my_files)
 
   # file upload routes
-  post  "/#{I18n.t('facilities_downcase')}/:facility_id/:product/:product_id/sample_results", to: 'file_uploads#upload_sample_results', as: "add_uploader_file"
-  get   "/#{I18n.t('facilities_downcase')}/:facility_id/:product/:product_id/files/product_survey", to: 'file_uploads#product_survey', as: "product_survey"
-  post  "/#{I18n.t('facilities_downcase')}/:facility_id/:product/:product_id/files/create_product_survey", to: 'file_uploads#create_product_survey', as: "create_product_survey"
+  post  "/#{I18n.t('facilities_downcase')}/:facility_id/:product/:product_id/sample_results", to: "file_uploads#upload_sample_results", as: "add_uploader_file"
+  get   "/#{I18n.t('facilities_downcase')}/:facility_id/:product/:product_id/files/product_survey", to: "file_uploads#product_survey", as: "product_survey"
+  post  "/#{I18n.t('facilities_downcase')}/:facility_id/:product/:product_id/files/create_product_survey", to: "file_uploads#create_product_survey", as: "create_product_survey"
 
-  put   "/#{I18n.t('facilities_downcase')}/:facility_id/services/:service_id/surveys/:external_service_passer_id/activate",   to: 'surveys#activate',                 as: "activate_survey"
-  put   "/#{I18n.t('facilities_downcase')}/:facility_id/services/:service_id/surveys/:external_service_passer_id/deactivate", to: 'surveys#deactivate',               as: "deactivate_survey"
+  put   "/#{I18n.t('facilities_downcase')}/:facility_id/services/:service_id/surveys/:external_service_passer_id/activate",   to: "surveys#activate",                 as: "activate_survey"
+  put   "/#{I18n.t('facilities_downcase')}/:facility_id/services/:service_id/surveys/:external_service_passer_id/deactivate", to: "surveys#deactivate",               as: "deactivate_survey"
   get "/#{I18n.t('facilities_downcase')}/:facility_id/services/:service_id/surveys/:external_service_id/complete", to: "surveys#complete", as: "complete_survey"
 
   namespace :admin do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ENV['RAILS_ENV'] = @environment
+ENV["RAILS_ENV"] = @environment
 require File.expand_path(File.dirname(__FILE__) + "/environment")
 
 # IMPORTANT!!! You should never edit this file in your custom fork.

--- a/db/migrate/20180822191538_add_cancellation_notification_to_product.rb
+++ b/db/migrate/20180822191538_add_cancellation_notification_to_product.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddCancellationNotificationToProduct < ActiveRecord::Migration[5.0]
 
   def change

--- a/db/migrate/20180907190857_fix_oracle_timestamps.rb
+++ b/db/migrate/20180907190857_fix_oracle_timestamps.rb
@@ -11,7 +11,6 @@ class FixOracleTimestamps < ActiveRecord::Migration[5.0]
       dir.up { change_all_columns_types(:date, :datetime) }
       dir.down { change_all_columns_types(:datetime, :date) }
     end
-
   end
 
   private

--- a/docker/oracle/create_databases.rb
+++ b/docker/oracle/create_databases.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'yaml'
-require 'erb'
+require "yaml"
+require "erb"
 
 puts "Loading database config"
-config_file_path = File.expand_path('../../../config/database.yml', __FILE__)
+config_file_path = File.expand_path("../../../config/database.yml", __FILE__)
 erb = ERB.new(File.read(config_file_path)).result
 # (yaml, whitelist_classes, whitelist_symbols, allow_aliases)
 config = YAML.safe_load(erb, [], [], true)

--- a/lib/facility_product_routing_concern.rb
+++ b/lib/facility_product_routing_concern.rb
@@ -6,7 +6,7 @@ module FacilityProductRoutingConcern
     get :manage, on: :member
     resources :users, controller: "product_users", except: [:show, :edit, :create]
     resources :file_uploads, path: "files", only: [:index, :create, :destroy]
-    get "/files/:file_type/:id", to: 'file_uploads#download', as: "download_product_file"
+    get "/files/:file_type/:id", to: "file_uploads#download", as: "download_product_file"
   end
 
 end

--- a/lib/patches/oracle_enhanced_adapter.rb
+++ b/lib/patches/oracle_enhanced_adapter.rb
@@ -48,7 +48,7 @@ module ActiveRecord
             # Read directly instance variable as otherwise migrations with table column default values are failing
             # as migrations pass ColumnDefinition object to this method.
             # Check if instance variable is defined to avoid warnings about accessing undefined instance variable.
-            column.instance_variable_defined?('@nchar') && column.instance_variable_get('@nchar') ? 'N' << super : super
+            column.instance_variable_defined?("@nchar") && column.instance_variable_get("@nchar") ? "N" << super : super
           else
             super
           end

--- a/lib/tasks/paperclip-nucore.rake
+++ b/lib/tasks/paperclip-nucore.rake
@@ -52,7 +52,7 @@ namespace :paperclip do
     stored_files.each do |stored_file|
       file_index += 1
       puts "File #{file_index} of #{file_count}"
-      push_to_s3(stored_file, stored_file.file_file_name.tr('#', "-"))
+      push_to_s3(stored_file, stored_file.file_file_name.tr("#", "-"))
     end
   end
 

--- a/spec/app_support/auto_expire_reservation_spec.rb
+++ b/spec/app_support/auto_expire_reservation_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AutoExpireReservation, :time_travel do
   let(:order_detail) { reservation.order_detail }
   let(:instrument) { create(:setup_instrument, min_reserve_mins: 1, relay: create(:relay_syna)) }
 
-  describe '#perform' do
+  describe "#perform" do
     context "a new reservation" do
       let!(:reservation) do
         create(:purchased_reservation, :yesterday, actual_start_at: 1.hour.ago,

--- a/spec/app_support/end_reservation_only_spec.rb
+++ b/spec/app_support/end_reservation_only_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe EndReservationOnly, :time_travel do
   let(:action) { described_class.new }
   let(:order_detail) { reservation.order_detail }
 
-  describe '#perform' do
+  describe "#perform" do
     context "an unpurchased reservation" do
       let!(:reservation) { create(:setup_reservation, :yesterday) }
 

--- a/spec/app_support/product_approver_spec.rb
+++ b/spec/app_support/product_approver_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ProductApprover do
     product_user.save
   end
 
-  context '#approve_access' do
+  context "#approve_access" do
     it "grants usage approval to a product" do
       expect { product_approver.approve_access(product) }
         .to change { product.can_be_used_by?(user) }.from(false).to(true)
@@ -33,7 +33,7 @@ RSpec.describe ProductApprover do
     end
   end
 
-  context '#revoke_access' do
+  context "#revoke_access" do
     before :each do
       product_approver.approve_access(product)
     end
@@ -44,7 +44,7 @@ RSpec.describe ProductApprover do
     end
   end
 
-  context '#update_approvals' do
+  context "#update_approvals" do
 
     def verify_approvals(approved_products)
       all_products.each do |product|

--- a/spec/app_support/reservation_instrument_switcher_spec.rb
+++ b/spec/app_support/reservation_instrument_switcher_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ReservationInstrumentSwitcher do
   let(:reservation) { FactoryBot.create(:purchased_reservation, product: instrument) }
   let(:action) { described_class.new(reservation) }
 
-  describe '#switch_on!' do
+  describe "#switch_on!" do
     def do_action
       action.switch_on!
     end

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe FacilityOrdersController do
     @params = { facility_id: @authable.url_name }
   end
 
-  context '#assign_price_policies_to_problem_orders' do
+  context "#assign_price_policies_to_problem_orders" do
     let(:order_details) do
       Array.new(3) do
         order_detail = place_and_complete_item_order(@director, facility)
@@ -79,7 +79,7 @@ RSpec.describe FacilityOrdersController do
 
   it_behaves_like "it supports order_detail POST #batch_update"
 
-  context '#index' do
+  context "#index" do
     before :each do
       @method = :get
       @action = :index
@@ -114,7 +114,7 @@ RSpec.describe FacilityOrdersController do
     end
   end
 
-  describe '#show' do
+  describe "#show" do
     before do
       maybe_grant_always_sign_in :admin
       @method = :get
@@ -131,7 +131,7 @@ RSpec.describe FacilityOrdersController do
     end
   end
 
-  context '#show_problems' do
+  context "#show_problems" do
     before :each do
       @method = :get
       @action = :show_problems
@@ -140,7 +140,7 @@ RSpec.describe FacilityOrdersController do
     it_should_allow_managers_only
   end
 
-  context '#send_receipt' do
+  context "#send_receipt" do
     before :each do
       @method = :post
       @action = :send_receipt
@@ -497,7 +497,7 @@ RSpec.describe FacilityOrdersController do
     end
   end
 
-  context '#tab_counts' do
+  context "#tab_counts" do
     before :each do
       @method = :get
       @action = :tab_counts

--- a/spec/controllers/facility_reservations_controller_spec.rb
+++ b/spec/controllers/facility_reservations_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe FacilityReservationsController do
     @params = { facility_id: @authable.url_name, order_id: @order.id, order_detail_id: @order_detail.id, id: @reservation.id }
   end
 
-  context '#assign_price_policies_to_problem_orders' do
+  context "#assign_price_policies_to_problem_orders" do
     let(:order_details) { [@order_detail] }
     let(:order_detail_ids) { order_details.map(&:id) }
 
@@ -161,7 +161,7 @@ RSpec.describe FacilityReservationsController do
     end
   end
 
-  context '#index' do
+  context "#index" do
     before :each do
       @method = :get
       @action = :index
@@ -190,7 +190,7 @@ RSpec.describe FacilityReservationsController do
     end
   end
 
-  context '#new' do
+  context "#new" do
     before :each do
       @method = :get
       @action = :new
@@ -200,7 +200,7 @@ RSpec.describe FacilityReservationsController do
     it_should_allow_operators_only
   end
 
-  context '#show' do
+  context "#show" do
     before :each do
       @method = :get
       @action = :show
@@ -209,11 +209,11 @@ RSpec.describe FacilityReservationsController do
     it_should_allow_operators_only
   end
 
-  context '#show_problems' do
+  context "#show_problems" do
     skip "TODO test exists for the FacilityOrdersController version"
   end
 
-  context '#timeline' do
+  context "#timeline" do
     context "instrument listing" do
       before :each do
         @instrument2 = FactoryBot.create(:instrument,
@@ -303,7 +303,7 @@ RSpec.describe FacilityReservationsController do
     end
   end
 
-  context '#update' do
+  context "#update" do
     let(:reserve_start_at) { FactoryBot.attributes_for(:reservation)[:reserve_start_at] }
     let(:reservation_params) do
       {
@@ -377,7 +377,7 @@ RSpec.describe FacilityReservationsController do
       @params = { facility_id: @authable.url_name, instrument_id: @product.url_name, reservation_id: @reservation.id }
     end
 
-    context '#edit_admin' do
+    context "#edit_admin" do
       before :each do
         @method = :get
         @action = :edit_admin
@@ -386,7 +386,7 @@ RSpec.describe FacilityReservationsController do
       it_should_allow_operators_only
     end
 
-    context '#update_admin' do
+    context "#update_admin" do
       let(:reserve_start_at) { FactoryBot.attributes_for(:admin_reservation)[:reserve_start_at] }
       let(:admin_reservation_params) do
         {

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -86,16 +86,16 @@ RSpec.describe OrderManagement::OrderDetailsController, feature_setting: { price
         end
 
         it "has estimated fields disabled" do
-          cost = dom.css('#order_detail_estimated_cost').first
+          cost = dom.css("#order_detail_estimated_cost").first
           expect(cost).to be_has_attribute("disabled")
           expect(cost["value"]).to_not be_blank
 
-          expect(dom.css('#order_detail_estimated_subsidy').first).to be_has_attribute("disabled")
-          expect(dom.css('#order_detail_estimated_total').first).to be_has_attribute("disabled")
+          expect(dom.css("#order_detail_estimated_subsidy").first).to be_has_attribute("disabled")
+          expect(dom.css("#order_detail_estimated_total").first).to be_has_attribute("disabled")
         end
 
         it "has assigned user enabled" do
-          expect(dom.css('#order_detail_assigned_user_id').first).to_not be_has_attribute("disabled")
+          expect(dom.css("#order_detail_assigned_user_id").first).to_not be_has_attribute("disabled")
         end
       end
 
@@ -114,13 +114,13 @@ RSpec.describe OrderManagement::OrderDetailsController, feature_setting: { price
             end
 
             it "has actual fields" do
-              cost = dom.css('#order_detail_actual_cost').first
+              cost = dom.css("#order_detail_actual_cost").first
               expect(cost).to be_present
               expect(cost["value"]).to_not be_blank
             end
 
             it "has the subsidy field enabled" do
-              subsidy = dom.css('#order_detail_actual_subsidy').first
+              subsidy = dom.css("#order_detail_actual_subsidy").first
               expect(subsidy).to be_present
               expect(subsidy["value"]).to_not be_blank
               expect(subsidy).to_not be_has_attribute("disabled")
@@ -136,7 +136,7 @@ RSpec.describe OrderManagement::OrderDetailsController, feature_setting: { price
             end
 
             it "has the subsidy field disabled" do
-              subsidy = dom.css('#order_detail_actual_subsidy').first
+              subsidy = dom.css("#order_detail_actual_subsidy").first
               expect(subsidy).to be_has_attribute("disabled")
             end
           end
@@ -157,7 +157,7 @@ RSpec.describe OrderManagement::OrderDetailsController, feature_setting: { price
           end
 
           it "has estimated fields disabled" do
-            cost = dom.css('#order_detail_estimated_cost').first
+            cost = dom.css("#order_detail_estimated_cost").first
             expect(cost).to be_has_attribute("disabled")
             expect(cost["value"]).to be_blank
           end
@@ -1071,7 +1071,7 @@ RSpec.describe OrderManagement::OrderDetailsController, feature_setting: { price
     end
   end
 
-  context '#remove_from_journal' do
+  context "#remove_from_journal" do
     let(:journal) do
       create(:journal, facility: facility, updated_by: 1, reference: "xyz")
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe UsersController do
         context "external user" do
           context "with successful parameters" do
             before :each do
-              user_params = FactoryBot.attributes_for(:user, username: 'user123').except(:password, :password_confirmation)
+              user_params = FactoryBot.attributes_for(:user, username: "user123").except(:password, :password_confirmation)
               @params.merge!(user: user_params)
             end
 

--- a/spec/features/admin/facility_orders_search_spec.rb
+++ b/spec/features/admin/facility_orders_search_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe "Facility Orders Search" do
 
       select item, from: "Products"
       click_button "Filter"
-      expect(page).to have_css('.order-detail-description', text: item.name, count: 2)
-      expect(page).not_to have_css('.order-detail-description', text: item2.name)
+      expect(page).to have_css(".order-detail-description", text: item.name, count: 2)
+      expect(page).not_to have_css(".order-detail-description", text: item2.name)
     end
   end
 
@@ -48,8 +48,8 @@ RSpec.describe "Facility Orders Search" do
 
       select item, from: "Products"
       click_button "Filter"
-      expect(page).to have_css('td', text: item.name, count: 2)
-      expect(page).not_to have_css('td', text: item2.name)
+      expect(page).to have_css("td", text: item.name, count: 2)
+      expect(page).not_to have_css("td", text: item2.name)
     end
   end
 end

--- a/spec/features/admin/facility_reservations_search_spec.rb
+++ b/spec/features/admin/facility_reservations_search_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe "Facility Orders Search" do
 
       select instrument, from: "Products"
       click_button "Filter"
-      expect(page).to have_css('.order-detail-description', text: instrument.name, count: 1)
-      expect(page).not_to have_css('.order-detail-description', text: instrument2.name)
+      expect(page).to have_css(".order-detail-description", text: instrument.name, count: 1)
+      expect(page).not_to have_css(".order-detail-description", text: instrument2.name)
     end
   end
 
@@ -42,8 +42,8 @@ RSpec.describe "Facility Orders Search" do
 
       select instrument, from: "Products"
       click_button "Filter"
-      expect(page).to have_css('td', text: instrument.name, count: 1)
-      expect(page).not_to have_css('td', text: instrument2.name)
+      expect(page).to have_css("td", text: instrument.name, count: 1)
+      expect(page).not_to have_css("td", text: instrument2.name)
     end
   end
 end

--- a/spec/features/admin/manage_order_detail_spec.rb
+++ b/spec/features/admin/manage_order_detail_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Managing an order detail" do
         click_button "Save"
 
         expect(page).to have_content("Canceled")
-        expect(page).to have_css('tfoot .currency', text: "$0.00", count: 3)
+        expect(page).to have_css("tfoot .currency", text: "$0.00", count: 3)
       end
     end
 
@@ -62,7 +62,7 @@ RSpec.describe "Managing an order detail" do
         click_button "Save"
 
         expect(page).to have_content("Canceled")
-        expect(page).to have_css('tfoot .currency', text: "$0.00", count: 3)
+        expect(page).to have_css("tfoot .currency", text: "$0.00", count: 3)
       end
 
       it "cancels with a fee" do
@@ -71,7 +71,7 @@ RSpec.describe "Managing an order detail" do
         click_button "Save"
 
         expect(page).to have_content("Complete")
-        expect(page).to have_css('tfoot .currency', text: "$5.00", count: 2)
+        expect(page).to have_css("tfoot .currency", text: "$5.00", count: 2)
       end
     end
   end

--- a/spec/features/admin/managing_user_spec.rb
+++ b/spec/features/admin/managing_user_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Managing User Details", :aggregate_failures, feature_setting: { 
   describe "edit" do
     describe "as a facility admin" do
       let(:admin) { FactoryBot.create(:user, :administrator) }
-      let(:user) { FactoryBot.create(:user, username: 'user123') }
+      let(:user) { FactoryBot.create(:user, username: "user123") }
 
       before do
         login_as admin

--- a/spec/features/admin/product_notifications_controller_spec.rb
+++ b/spec/features/admin/product_notifications_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe ProductNotificationsController, feature_setting: { training_requests: true } do

--- a/spec/features/transactions_search_spec.rb
+++ b/spec/features/transactions_search_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe "Transactions Search" do
 
       select accounts.first.description, from: "Payment Sources"
       click_button "Filter"
-      expect(page).to have_css('td', text: accounts.first.description, count: 2)
-      expect(page).not_to have_css('td', text: accounts.last.description, count: 2)
+      expect(page).to have_css("td", text: accounts.first.description, count: 2)
+      expect(page).not_to have_css("td", text: accounts.last.description, count: 2)
     end
   end
 
@@ -56,8 +56,8 @@ RSpec.describe "Transactions Search" do
 
       select accounts.first.description, from: "Payment Sources"
       click_button "Filter"
-      expect(page).to have_css('td', text: accounts.first.description, count: 2)
-      expect(page).not_to have_css('td', text: accounts.last.description, count: 2)
+      expect(page).to have_css("td", text: accounts.first.description, count: 2)
+      expect(page).not_to have_css("td", text: accounts.last.description, count: 2)
     end
   end
 

--- a/spec/lib/nucore/database/date_helper_spec.rb
+++ b/spec/lib/nucore/database/date_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe NUCore::Database::DateHelper do
 
   end
 
-  describe '#parse_2_digit_year_date' do
+  describe "#parse_2_digit_year_date" do
     def parse_date(date_string)
       DateHelperClass.parse_2_digit_year_date(date_string).strftime("%Y-%m-%d")
     end

--- a/spec/mailers/account_transaction_report_mailer_spec.rb
+++ b/spec/mailers/account_transaction_report_mailer_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe AccountTransactionReportMailer do
-  context '#csv_report_email' do
+  context "#csv_report_email" do
     let(:email) { ActionMailer::Base.deliveries.last }
     describe "mailer" do
       let(:report) { double Reports::AccountTransactionsReport, to_csv: "1,2,3\n", description: "test" }

--- a/spec/mailers/previews/cancelation_mailer_preview.rb
+++ b/spec/mailers/previews/cancelation_mailer_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CancellationMailerPreview < ActionMailer::Preview
 
   def notify_facility

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Account do
     end
   end
 
-  context '#unreconciled_total' do
+  context "#unreconciled_total" do
     context "without unreconciled order_details" do
       it "should total 0" do
         expect(account.unreconciled_total(facility)).to eq 0

--- a/spec/models/chart_string_reassignment_form_spec.rb
+++ b/spec/models/chart_string_reassignment_form_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ChartStringReassignmentForm do
   let(:product) { create(:setup_item) }
   let(:users) { create_list(:user, 9) }
 
-  describe '#available_accounts' do
+  describe "#available_accounts" do
     def grant_account_to_user(account, user)
       AccountUser.grant(user, AccountUser::ACCOUNT_PURCHASER, account, account_owner)
     end

--- a/spec/models/concerns/email_list_attribute_spec.rb
+++ b/spec/models/concerns/email_list_attribute_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe EmailListAttribute do

--- a/spec/models/instrument_price_policy_calculations_spec.rb
+++ b/spec/models/instrument_price_policy_calculations_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe InstrumentPricePolicyCalculations do
   let(:duration) { (end_at - start_at) / 60 }
   let(:reservation) { create :setup_reservation, product: policy.product }
 
-  it 'uses the given order detail to #calculate_cost_and_subsidy' do
+  it "uses the given order detail to #calculate_cost_and_subsidy" do
     fake_order_detail = double "OrderDetail", reservation: double("Reservation")
     expect(policy).to receive(:calculate_cost_and_subsidy).with fake_order_detail.reservation
     policy.calculate_cost_and_subsidy_from_order_detail fake_order_detail
   end
 
   describe "estimating cost and subsidy from an order detail" do
-    it 'uses the given order detail to #estimate_cost_and_subsidy' do
+    it "uses the given order detail to #estimate_cost_and_subsidy" do
       fake_reservation = double "Reservation", reserve_start_at: now, reserve_end_at: now + 1.hour
       fake_order_detail = double "OrderDetail", reservation: fake_reservation
       expect(policy).to receive(:estimate_cost_and_subsidy).with fake_reservation.reserve_start_at, fake_reservation.reserve_end_at
@@ -147,7 +147,7 @@ RSpec.describe InstrumentPricePolicyCalculations do
       reservation.actual_end_at = now + 1.hour
     end
 
-    it 'returns #calculate_cancellation_costs if the reservation was canceled' do
+    it "returns #calculate_cancellation_costs if the reservation was canceled" do
       expect(reservation.order_detail).to receive(:canceled_at?).and_return true
       expect(policy).to receive(:calculate_cancellation_costs).with reservation
       expect(policy).to_not receive :calculate_overage
@@ -161,7 +161,7 @@ RSpec.describe InstrumentPricePolicyCalculations do
         policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[:usage]
       end
 
-      it 'returns #calculate_usage' do
+      it "returns #calculate_usage" do
         expect(policy).to receive(:calculate_usage).with reservation
         expect(policy).to_not receive :calculate_overage
         expect(policy).to_not receive :calculate_reservation
@@ -180,7 +180,7 @@ RSpec.describe InstrumentPricePolicyCalculations do
         policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[:overage]
       end
 
-      it 'returns #calculate_overage when configured to charge for overage' do
+      it "returns #calculate_overage when configured to charge for overage" do
         expect(policy).to receive(:calculate_overage).with reservation
         expect(policy).to_not receive :calculate_usage
         expect(policy).to_not receive :calculate_reservation
@@ -204,7 +204,7 @@ RSpec.describe InstrumentPricePolicyCalculations do
         policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[:reservation]
       end
 
-      it 'returns #calculate_reservation when configured to charge for reservation' do
+      it "returns #calculate_reservation when configured to charge for reservation" do
         expect(policy).to receive(:calculate_reservation).with reservation
         expect(policy).to_not receive :calculate_overage
         expect(policy).to_not receive :calculate_usage
@@ -221,7 +221,7 @@ RSpec.describe InstrumentPricePolicyCalculations do
     describe "zero usage rate" do
       describe "with a minimum cost" do
         let(:options) { { usage_rate: 0, minimum_cost: 10 } }
-        it 'returns minimum cost if instrument is #free?' do
+        it "returns minimum cost if instrument is #free?" do
           expect(policy.calculate_cost_and_subsidy reservation).to eq(cost: 10, subsidy: 0)
         end
       end
@@ -229,7 +229,7 @@ RSpec.describe InstrumentPricePolicyCalculations do
       describe "without a minimum cost" do
         let(:options) { { usage_rate: 0, minimum_cost: 0 } }
 
-        it 'returns 0' do
+        it "returns 0" do
           expect(policy.calculate_cost_and_subsidy reservation).to eq(cost: 0, subsidy: 0)
         end
       end

--- a/spec/models/instrument_price_policy_spec.rb
+++ b/spec/models/instrument_price_policy_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe InstrumentPricePolicy do
     end
   end
 
-  describe 'validation using #subsidy_less_than_rate?' do
+  describe "validation using #subsidy_less_than_rate?" do
     it "gives an error if usage_subsidy > usage_rate" do
       expect(policy).to be_valid
       policy.usage_subsidy = 15
@@ -126,7 +126,7 @@ RSpec.describe InstrumentPricePolicy do
     expect(next_dates).to include ipp3.start_date.to_date
   end
 
-  describe '#reservation_window' do
+  describe "#reservation_window" do
     it "returns 0 if there is no PriceGroupProduct" do
       expect(policy.reservation_window).to eq 0
     end
@@ -138,7 +138,7 @@ RSpec.describe InstrumentPricePolicy do
     end
   end
 
-  describe '#has_subsidy?' do
+  describe "#has_subsidy?" do
     it "has a subsidy if the attribute is greater than 0" do
       policy.usage_subsidy = 9.0
       expect(policy).to have_subsidy

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe OrderDetail do
   context "account reassignment" do
     let(:unassociated_account) { build_stubbed(:setup_account) }
 
-    describe '#can_be_assigned_to_account?' do
+    describe "#can_be_assigned_to_account?" do
       it "may be reassigned to its current account" do
         expect(@order_detail.can_be_assigned_to_account?(@order_detail.account))
           .to be true
@@ -1255,7 +1255,7 @@ RSpec.describe OrderDetail do
     end
   end
 
-  context '#cancel_reservation' do
+  context "#cancel_reservation" do
     let(:statement) { create(:statement, facility: facility, created_by: user.id, account: account) }
 
     before :each do
@@ -1279,7 +1279,7 @@ RSpec.describe OrderDetail do
         expect(order_detail.statement).to be_blank
       end
 
-      it 'should have no #statement_date' do
+      it "should have no #statement_date" do
         expect(order_detail.statement_date).to be_blank
       end
     end
@@ -1404,7 +1404,7 @@ RSpec.describe OrderDetail do
     end
   end
 
-  context '#cancellation_fee' do
+  context "#cancellation_fee" do
     shared_examples_for "it charges a cancellation fee" do
       it "has a cancellation fee" do
         expect(order_detail.cancellation_fee).to be > 0
@@ -1567,7 +1567,7 @@ RSpec.describe OrderDetail do
     end
   end
 
-  context '#update_order_status!' do
+  context "#update_order_status!" do
     context "when setting order status to Canceled" do
 
       def cancel_order_detail(options)
@@ -1825,7 +1825,7 @@ RSpec.describe OrderDetail do
     end
   end
 
-  describe '#complete!' do
+  describe "#complete!" do
     before { order_detail.complete! }
 
     it "saved" do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Order do
     context "estimated" do
       let!(:order_detail_1) { create(:order_detail, order: order, product: item, account: account, estimated_cost: 10, estimated_subsidy: 5, price_policy: price_policy) }
       let!(:order_detail_2) { create(:order_detail, order: order, product: item, account: account, estimated_cost: 12, estimated_subsidy: 0, price_policy: price_policy) }
-      let!(:canceled_order_detail) { create(:order_detail, order: order, product: item, account: account, estimated_cost: 8, estimated_subsidy: 2, price_policy: price_policy, state: 'canceled') }
+      let!(:canceled_order_detail) { create(:order_detail, order: order, product: item, account: account, estimated_cost: 8, estimated_subsidy: 2, price_policy: price_policy, state: "canceled") }
 
       it "should have the expected estimated_cost" do
         expect(order.estimated_cost).to eq 22

--- a/spec/models/price_policy_spec.rb
+++ b/spec/models/price_policy_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe PricePolicy do
       expect(@pp.can_purchase).to be false
     end
 
-    it 'should alias #restrict with query method' do
+    it "should alias #restrict with query method" do
       expect(@pp).to be_respond_to :restrict_purchase?
       expect(@pp.restrict_purchase).to eq(@pp.restrict_purchase?)
     end
@@ -184,12 +184,12 @@ RSpec.describe PricePolicy do
         @sp = PricePolicy.new
       end
 
-      it 'should abstract #calculate_cost_and_subsidy' do
+      it "should abstract #calculate_cost_and_subsidy" do
         expect(@sp).to be_respond_to(:calculate_cost_and_subsidy)
         expect { @sp.calculate_cost_and_subsidy }.to raise_error RuntimeError
       end
 
-      it 'should abstract #estimate_cost_and_subsidy' do
+      it "should abstract #estimate_cost_and_subsidy" do
         expect(@sp).to be_respond_to(:estimate_cost_and_subsidy)
         expect { @sp.estimate_cost_and_subsidy }.to raise_error RuntimeError
       end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -399,7 +399,7 @@ RSpec.describe Product do
       end
     end
 
-    context '#access_group_for_user' do
+    context "#access_group_for_user" do
       context "with an access group" do
         before :each do
           schedule_rule.product_access_groups = [access_group]
@@ -461,7 +461,7 @@ RSpec.describe Product do
       end
     end
 
-    context '#find_product_user' do
+    context "#find_product_user" do
       context "when a user is a product user" do
         it "finds the product_user" do
           expect(product.find_product_user(user)).to eq product_user
@@ -477,7 +477,7 @@ RSpec.describe Product do
       end
     end
 
-    context '#has_access_list?' do
+    context "#has_access_list?" do
       context "when its type supports access groups" do
         context "when it has an access group" do
           before :each do

--- a/spec/models/reports/account_transaction_report_spec.rb
+++ b/spec/models/reports/account_transaction_report_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Reports::AccountTransactionsReport do
   subject(:report) { Reports::AccountTransactionsReport.new(order_details) }
 
-  describe '#to_csv' do
+  describe "#to_csv" do
     context "with no order details" do
       let(:order_details) { OrderDetail.none }
 

--- a/spec/models/reservation_relay_support_spec.rb
+++ b/spec/models/reservation_relay_support_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe Reservation do
       expect(subject.product.relay).to be_a RelayDummy
     end
 
-    describe '#actual_end_at' do
+    describe "#actual_end_at" do
       subject { super().actual_end_at }
       it { is_expected.to be_nil }
     end
 
-    describe '#actual_start_at' do
+    describe "#actual_start_at" do
       subject { super().actual_start_at }
       it { is_expected.to be }
     end
@@ -38,7 +38,7 @@ RSpec.describe Reservation do
     it { is_expected.not_to be_can_switch_instrument_off }
   end
 
-  context '#other_reservations_using_relay' do
+  context "#other_reservations_using_relay" do
     let!(:reservation_done) { create(:purchased_reservation, :yesterday, actual_start_at: 1.day.ago) }
 
     context "with no other running reservations" do

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1058,7 +1058,7 @@ RSpec.describe Reservation do
     expect(reservation).to be_can_start_early
   end
 
-  describe '#start_reservation!' do
+  describe "#start_reservation!" do
     it "sets actual start time", :time_travel do
       reservation.start_reservation!
       expect(reservation.actual_start_at).to eq(Time.current)

--- a/spec/models/reservations_validations_spec.rb
+++ b/spec/models/reservations_validations_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Reservations::Validations do
 
   it { is_expected.to validate_presence_of(:reserve_start_at) }
 
-  it 'validates with #duration_is_interval' do
+  it "validates with #duration_is_interval" do
     expect(reservation).to receive :duration_is_interval
     reservation.save
   end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Statement do
       end
     end
 
-    context '#remove_order_detail' do
+    context "#remove_order_detail" do
       it "is destroyed when it no longer has any statement_rows" do
         @order_details.each do |order_detail|
           statement.remove_order_detail(order_detail)

--- a/spec/presenters/reservation_user_action_presenter_spec.rb
+++ b/spec/presenters/reservation_user_action_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ReservationUserActionPresenter do
     allow(reservation).to receive(:ongoing?).and_return false
   end
 
-  context '#view_edit_link' do
+  context "#view_edit_link" do
     let(:link) { double "link" }
 
     context "when not in a current facility" do
@@ -60,7 +60,7 @@ RSpec.describe ReservationUserActionPresenter do
     end
   end
 
-  context '#user_actions' do
+  context "#user_actions" do
     before :each do
       allow(order_detail).to receive(:reservation).and_return reservation
     end

--- a/spec/product_shared_examples.rb
+++ b/spec/product_shared_examples.rb
@@ -25,7 +25,7 @@ RSpec.shared_examples_for "NonReservationProduct" do |product_type|
   let!(:account_price_group_member) { FactoryBot.create(:account_price_group_member, account: order.account, price_group: price_group) }
   let!(:account_price_group_member2) { FactoryBot.create(:account_price_group_member, account: order.account, price_group: price_group2) }
 
-  context '#cheapest_price_policy' do
+  context "#cheapest_price_policy" do
     context "current policies" do
       it "should find the cheapest price policy" do
         expect(product.cheapest_price_policy(order_detail)).to eq(pp_g1)
@@ -145,7 +145,7 @@ RSpec.shared_examples_for "ReservationProduct" do |product_type|
                       order_detail: order_detail)
   end
 
-  context '#cheapest_price_policy' do
+  context "#cheapest_price_policy" do
     context "current policies" do
       it "should find the cheapest price policy" do
         expect(product.cheapest_price_policy(order_detail)).to eq(pp_g1)

--- a/vendor/engines/fullcalendar/Rakefile
+++ b/vendor/engines/fullcalendar/Rakefile
@@ -1,29 +1,29 @@
 # frozen_string_literal: true
 
 begin
-  require 'bundler/setup'
+  require "bundler/setup"
 rescue LoadError
-  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+  puts "You must `gem install bundler` and `bundle install` to run rake tasks"
 end
 
-require 'rdoc/task'
+require "rdoc/task"
 
 RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'Fullcalendar'
-  rdoc.options << '--line-numbers'
-  rdoc.rdoc_files.include('README.rdoc')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+  rdoc.rdoc_dir = "rdoc"
+  rdoc.title    = "Fullcalendar"
+  rdoc.options << "--line-numbers"
+  rdoc.rdoc_files.include("README.rdoc")
+  rdoc.rdoc_files.include("lib/**/*.rb")
 end
 
 Bundler::GemHelper.install_tasks
 
-require 'rake/testtask'
+require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << 'lib'
-  t.libs << 'test'
-  t.pattern = 'test/**/*_test.rb'
+  t.libs << "lib"
+  t.libs << "test"
+  t.pattern = "test/**/*_test.rb"
   t.verbose = false
 end
 

--- a/vendor/engines/saml_authentication/lib/saml_authentication/saml_authenticatable_with_custom_error.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/saml_authenticatable_with_custom_error.rb
@@ -39,4 +39,4 @@ Devise.add_module(:saml_authenticatable_with_custom_error,
                   route: :saml_authenticatable,
                   strategy: true,
                   controller: :saml_sessions,
-                  model: 'devise_saml_authenticatable/model')
+                  model: "devise_saml_authenticatable/model")

--- a/vendor/engines/secure_rooms/Gemfile
+++ b/vendor/engines/secure_rooms/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Declare your gem's dependencies in secure_rooms.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and

--- a/vendor/engines/secure_rooms/bin/rails
+++ b/vendor/engines/secure_rooms/bin/rails
@@ -3,12 +3,12 @@
 
 # This command will automatically be run when you run "rails" with Rails 4 gems installed from the root of your application.
 
-ENGINE_ROOT = File.expand_path('../..', __FILE__)
-ENGINE_PATH = File.expand_path('../../lib/secure_rooms/engine', __FILE__)
+ENGINE_ROOT = File.expand_path("../..", __FILE__)
+ENGINE_PATH = File.expand_path("../../lib/secure_rooms/engine", __FILE__)
 
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
-require 'rails/all'
-require 'rails/engine/commands'
+require "rails/all"
+require "rails/engine/commands"

--- a/vendor/engines/secure_rooms/config/routes.rb
+++ b/vendor/engines/secure_rooms/config/routes.rb
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
   end
 
   namespace :secure_rooms_api do
-    post '/scan', to: 'scans#scan'
+    post "/scan", to: "scans#scan"
     resources :events, only: :create
   end
 end

--- a/vendor/engines/secure_rooms/spec/controllers/secure_rooms_api/events_controller_spec.rb
+++ b/vendor/engines/secure_rooms/spec/controllers/secure_rooms_api/events_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SecureRoomsApi::EventsController do
     name = Rails.application.secrets.secure_rooms_api["basic_auth_name"]
     password = Rails.application.secrets.secure_rooms_api["basic_auth_password"]
     encoded_auth_credentials = ActionController::HttpAuthentication::Basic.encode_credentials(name, password)
-    request.env['HTTP_AUTHORIZATION'] = encoded_auth_credentials
+    request.env["HTTP_AUTHORIZATION"] = encoded_auth_credentials
   end
 
   describe "create" do

--- a/vendor/engines/secure_rooms/spec/features/facility_occupancies_search_spec.rb
+++ b/vendor/engines/secure_rooms/spec/features/facility_occupancies_search_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe "Facility Orders Search" do
 
       select secure_room, from: "Products"
       click_button "Filter"
-      expect(page).to have_css('.order-detail-description', text: secure_room.name, count: 1)
-      expect(page).not_to have_css('.order-detail-description', text: secure_room2.name)
+      expect(page).to have_css(".order-detail-description", text: secure_room.name, count: 1)
+      expect(page).not_to have_css(".order-detail-description", text: secure_room2.name)
     end
   end
 
@@ -42,8 +42,8 @@ RSpec.describe "Facility Orders Search" do
 
       select secure_room, from: "Products"
       click_button "Filter"
-      expect(page).to have_css('td', text: secure_room.name, count: 1)
-      expect(page).not_to have_css('td', text: secure_room2.name)
+      expect(page).to have_css("td", text: secure_room.name, count: 1)
+      expect(page).not_to have_css("td", text: secure_room2.name)
     end
   end
 end

--- a/vendor/engines/secure_rooms/spec/support/auto_orphan_occupancy_spec.rb
+++ b/vendor/engines/secure_rooms/spec/support/auto_orphan_occupancy_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SecureRooms::AutoOrphanOccupancy, :time_travel do
 
   before { secure_room.product_users.create!(user: user, approved_by: 0) }
 
-  describe '#perform' do
+  describe "#perform" do
     context "with a very long-running occupancy" do
       let(:event) { create :event, :successful, occurred_at: 3.days.ago, card_reader: card_reader, user: user }
       let!(:occupancy) do


### PR DESCRIPTION
# Release Notes

Tech task: Apply Rubocop's single to double quote cop. Also adds a couple frozen string literals we seem to have missed elsewhere.

