### PR TITLE
[#136151] Ability to charge full reservation cost for cancellation

### DIFF
--- a/app/assets/javascripts/price_policy.js.coffee
+++ b/app/assets/javascripts/price_policy.js.coffee
@@ -9,67 +9,50 @@ $(document).ready ->
     $inputElement.val(if isDisabled then "" else $inputElement.data("original-value"))
     $inputElement.prop "disabled", isDisabled
 
-  toggleGroupFields = ($checkbox) ->
+  # Triggered by "Can purchase?"
+  toggleFieldsInSameRow = ($checkbox) ->
     $cells = $checkbox.parents("tr").find("td")
     isDisabled = !$checkbox.prop "checked"
     $cells.toggleClass "disabled", isDisabled
     $cells.find("input[type=text], input[type=hidden], input[type=checkbox]").not($checkbox).each (_i, elem) ->
       hardToggleField($(elem), isDisabled)
     # If we are enabling the row, make sure the cancellation cost field gets the correct state
-    $cells.find(".js--full_cancellation_cost").trigger("change") unless isDisabled
+    $cells.find(".js--fullCancellationCost").trigger("change") unless isDisabled
 
-  getMasterUsageRate = ->
-    rate = parseFloat $("input.master_usage_cost.usage_rate").val()
-    if isFiniteAndPositive(rate) then rate else 0
+  updateAdjustmentFields = ($sourceElement) ->
+    rate = parseFloat($sourceElement.val())
+    rate = if isFiniteAndPositive(rate) then rate else 0
 
-  getUsageAdjustment = (usageAdjustmentElement) ->
-    usageAdjustment = parseFloat usageAdjustmentElement.value
-    if isFiniteAndPositive(usageAdjustment) then usageAdjustment else 0
+    $targets = $(".js--adjustmentRow").find($sourceElement.data("target"))
+    $targets.filter(":input").val(rate)
+    $targets.filter("span").html(rate)
 
-  setUsageSubsidy = (usageAdjustmentElement, usageSubsidy) ->
-    $(usageAdjustmentElement).parents("tr").find("span.minimum_cost").data("usageSubsidy", usageSubsidy)
+  toggleFullCancellationCostInCurrentCell = ($checkbox) ->
+    $container = $checkbox.parents(".js--cancellationCostContainer")
+    hardToggleField($container.find("input[type=text]"), $checkbox.is(":checked"))
 
-  refreshCosts = ->
-    $(".master_minimum_cost").each (index, element) -> setInternalCost element
-    $("input[type=hidden].usage_cost").val(getMasterUsageRate())
+  toggleFullCancellationInAdjustmentRows = (isChecked) ->
+    $adjustmentFields = $(".js--adjustmentRow .js--fullCancellationCost")
+    $adjustmentFields.val(if isChecked then "1" else "0")
+    hardToggleField($adjustmentFields.siblings(".js--cancellationCost").filter(":input"), isChecked)
+    # Show/hide the pricing spans
+    $adjustmentFields.siblings(".js--cancellationCost").filter("span").toggle(!isChecked)
 
-  updateUsageSubsidy = (usageAdjustmentElement) ->
-    usageAdjustment = getUsageAdjustment usageAdjustmentElement
-    usageRate = getMasterUsageRate()
-    setUsageSubsidy usageAdjustmentElement,
-      if usageAdjustment > 0 && usageRate > 0
-        usageAdjustment / usageRate
-      else
-        0
-    refreshCosts()
-
-  toggleFullCancellationCost = ($checkbox) ->
-    isChecked = $checkbox.prop "checked"
-    $inputElement = $checkbox.parents(".js--full_cancellation_cost_container").find("input[type=text]")
-    hardToggleField($inputElement, isChecked)
-
-  setInternalCost = (sourceElement) ->
-    if sourceElement.className.match /master_(\S+_cost)/
-      targetClass = RegExp.$1
-      $("span.#{targetClass}").each (i, targetElement) ->
-        $(targetElement).html(sourceElement.value)
-        .siblings("input[type=hidden].#{targetClass}").val(sourceElement.value)
-
-
-  $(".can_purchase").change((evt) ->
-    toggleGroupFields $(evt.target)
+  $(".js--canPurchase").change((evt) ->
+    toggleFieldsInSameRow $(evt.target)
   ).trigger("change")
 
-  $(".js--full_cancellation_cost").change((evt) ->
-    toggleFullCancellationCost($(evt.target))
+  $(".js--fullCancellationCost").change((evt) ->
+    $elem = $(evt.target)
+    toggleFullCancellationCostInCurrentCell($elem)
+    if $elem.parents(".js--masterInternalRow").length
+      toggleFullCancellationInAdjustmentRows($elem.is(":checked"))
+      # Update trigger the adjustment rows to be updated off of the value
+      $elem.parents(".js--cancellationCostContainer").find(".js--cancellationCost").trigger("keyup") unless $elem.is(":checked")
   ).trigger("change")
 
-  $("input[type=text]").keyup((evt) ->
-    setInternalCost evt.target
-    $(".usage_adjustment").each(updateUsageSubsidy)
+  $(".js--masterInternalRow input[type=text]").keyup((evt) ->
+    updateAdjustmentFields($(evt.target))
+    # setInternalCost evt.target
+    # refreshCosts()
   ).trigger("keyup")
-
-  $(".master_full_cancellation_cost").change((evt) ->
-    val = if $(evt.target).is(":checked") then "1" else "0"
-    $(".adjustment_full_cancellation_cost").val(val)
-  ).trigger("change")

--- a/app/assets/javascripts/price_policy.js.coffee
+++ b/app/assets/javascripts/price_policy.js.coffee
@@ -1,28 +1,19 @@
 $(document).ready ->
-  $interval = $("#interval")
 
-  $interval.change ->
-    int_value = $(this).val()
-    interval = "#{int_value} minute"
-    interval += "s" if int_value > 1
-    $("span.interval_replace").each -> $(this).html(interval)
+  isFiniteAndPositive = (number) -> isFinite(number) && number > 0
 
-  $interval.trigger('change')
-
-  isFiniteAndPositive = (number)-> isFinite(number) && number > 0
-
-  hardToggleField = ($inputElement, isDisabled)->
+  hardToggleField = ($inputElement, isDisabled) ->
     # If we're hiding the value, store it so we can retreive it later
     $inputElement.data "original-value", $inputElement.val() if $inputElement.val()
     $inputElement.val(if isDisabled then "" else $inputElement.data("original-value"))
     $inputElement.prop "disabled", isDisabled
 
-  toggleGroupFields = ($checkbox)->
+  toggleGroupFields = ($checkbox) ->
     $cells = $checkbox.parents("tr").find("td")
     isDisabled = !$checkbox.prop "checked"
     $cells.toggleClass "disabled", isDisabled
-    $cells.find("input[type=text], input[type=hidden], input[type=checkbox]").not($checkbox).each ->
-      hardToggleField($(this), isDisabled)
+    $cells.find("input[type=text], input[type=hidden], input[type=checkbox]").not($checkbox).each (_i, elem) ->
+      hardToggleField($(elem), isDisabled)
     # If we are enabling the row, make sure the cancellation cost field gets the correct state
     $cells.find(".js--full_cancellation_cost").trigger("change") unless isDisabled
 
@@ -30,18 +21,18 @@ $(document).ready ->
     rate = parseFloat $("input.master_usage_cost.usage_rate").val()
     if isFiniteAndPositive(rate) then rate else 0
 
-  getUsageAdjustment = (usageAdjustmentElement)->
+  getUsageAdjustment = (usageAdjustmentElement) ->
     usageAdjustment = parseFloat usageAdjustmentElement.value
     if isFiniteAndPositive(usageAdjustment) then usageAdjustment else 0
 
-  setUsageSubsidy = (usageAdjustmentElement, usageSubsidy)->
+  setUsageSubsidy = (usageAdjustmentElement, usageSubsidy) ->
     $(usageAdjustmentElement).parents("tr").find("span.minimum_cost").data("usageSubsidy", usageSubsidy)
 
   refreshCosts = ->
-    $(".master_minimum_cost").each (index, element)-> setInternalCost element
+    $(".master_minimum_cost").each (index, element) -> setInternalCost element
     $("input[type=hidden].usage_cost").val(getMasterUsageRate())
 
-  updateUsageSubsidy = (usageAdjustmentElement)->
+  updateUsageSubsidy = (usageAdjustmentElement) ->
     usageAdjustment = getUsageAdjustment usageAdjustmentElement
     usageRate = getMasterUsageRate()
     setUsageSubsidy usageAdjustmentElement,
@@ -51,29 +42,29 @@ $(document).ready ->
         0
     refreshCosts()
 
-  toggleFullCancellationCost = ($checkbox)->
+  toggleFullCancellationCost = ($checkbox) ->
     isChecked = $checkbox.prop "checked"
     $inputElement = $checkbox.parents(".js--full_cancellation_cost_container").find("input[type=text]")
     hardToggleField($inputElement, isChecked)
 
-  setInternalCost = (o)->
+  setInternalCost = (o) ->
     if o.className.match /master_(\S+_cost)/
       desiredClass = RegExp.$1
-      $("span.#{desiredClass}").each ->
-        $costElement = $(this)
+      $("span.#{desiredClass}").each (i, elem) ->
+        $costElement = $(elem)
         $costElement.html(o.value)
         $costElement.siblings("input[type=hidden].#{desiredClass}").val(o.value)
 
 
-  $(".js--full_cancellation_cost").change(->
-    toggleFullCancellationCost($(this))
+  $(".js--full_cancellation_cost").change((evt) ->
+    toggleFullCancellationCost($(evt.target))
   ).trigger("change")
 
-  $(".can_purchase").change(->
-    toggleGroupFields $(this)
+  $(".can_purchase").change((evt) ->
+    toggleGroupFields $(evt.target)
   ).trigger("change")
 
-  $("input[type=text]").keyup(->
-    setInternalCost this
-    $(".usage_adjustment").each -> updateUsageSubsidy(this)
+  $("input[type=text]").keyup((evt) ->
+    setInternalCost evt.target
+    $(".usage_adjustment").each (adjustment_elem) -> updateUsageSubsidy(adjustment_elem)
   ).trigger("keyup")

--- a/app/assets/javascripts/price_policy.js.coffee
+++ b/app/assets/javascripts/price_policy.js.coffee
@@ -2,8 +2,9 @@ $(document).ready ->
 
   isFiniteAndPositive = (number) -> isFinite(number) && number > 0
 
+  # In addition to disabling the field, also hide its value. But still store it
+  # so we can display it again if it gets renabled
   hardToggleField = ($inputElement, isDisabled) ->
-    # If we're hiding the value, store it so we can retreive it later
     $inputElement.data "original-value", $inputElement.val() if $inputElement.val()
     $inputElement.val(if isDisabled then "" else $inputElement.data("original-value"))
     $inputElement.prop "disabled", isDisabled
@@ -47,24 +48,28 @@ $(document).ready ->
     $inputElement = $checkbox.parents(".js--full_cancellation_cost_container").find("input[type=text]")
     hardToggleField($inputElement, isChecked)
 
-  setInternalCost = (o) ->
-    if o.className.match /master_(\S+_cost)/
-      desiredClass = RegExp.$1
-      $("span.#{desiredClass}").each (i, elem) ->
-        $costElement = $(elem)
-        $costElement.html(o.value)
-        $costElement.siblings("input[type=hidden].#{desiredClass}").val(o.value)
+  setInternalCost = (sourceElement) ->
+    if sourceElement.className.match /master_(\S+_cost)/
+      targetClass = RegExp.$1
+      $("span.#{targetClass}").each (i, targetElement) ->
+        $(targetElement).html(sourceElement.value)
+        .siblings("input[type=hidden].#{targetClass}").val(sourceElement.value)
 
-
-  $(".js--full_cancellation_cost").change((evt) ->
-    toggleFullCancellationCost($(evt.target))
-  ).trigger("change")
 
   $(".can_purchase").change((evt) ->
     toggleGroupFields $(evt.target)
   ).trigger("change")
 
+  $(".js--full_cancellation_cost").change((evt) ->
+    toggleFullCancellationCost($(evt.target))
+  ).trigger("change")
+
   $("input[type=text]").keyup((evt) ->
     setInternalCost evt.target
-    $(".usage_adjustment").each (adjustment_elem) -> updateUsageSubsidy(adjustment_elem)
+    $(".usage_adjustment").each(updateUsageSubsidy)
   ).trigger("keyup")
+
+  $(".master_full_cancellation_cost").change((evt) ->
+    val = if $(evt.target).is(":checked") then "1" else "0"
+    $(".adjustment_full_cancellation_cost").val(val)
+  ).trigger("change")

--- a/app/assets/javascripts/price_policy.js.coffee
+++ b/app/assets/javascripts/price_policy.js.coffee
@@ -48,11 +48,10 @@ $(document).ready ->
     if $elem.parents(".js--masterInternalRow").length
       toggleFullCancellationInAdjustmentRows($elem.is(":checked"))
       # Update trigger the adjustment rows to be updated off of the value
-      $elem.parents(".js--cancellationCostContainer").find(".js--cancellationCost").trigger("keyup") unless $elem.is(":checked")
+      $elem.parents(".js--cancellationCostContainer").find(".js--cancellationCost")
+        .trigger("keyup") unless $elem.is(":checked")
   ).trigger("change")
 
   $(".js--masterInternalRow input[type=text]").keyup((evt) ->
     updateAdjustmentFields($(evt.target))
-    # setInternalCost evt.target
-    # refreshCosts()
   ).trigger("keyup")

--- a/app/helpers/bootstrap_helper.rb
+++ b/app/helpers/bootstrap_helper.rb
@@ -25,10 +25,6 @@ module BootstrapHelper
     content_tag :span, order_detail.order_status, class: classes
   end
 
-  def tooltip_hint_icon(text)
-    tooltip_icon "fa fa-question-circle-o", text
-  end
-
   def tooltip_icon(icon_class, tooltip)
     content_tag :i, "", class: icon_class, data: { toggle: "tooltip" }, title: tooltip
   end

--- a/app/helpers/bootstrap_helper.rb
+++ b/app/helpers/bootstrap_helper.rb
@@ -25,6 +25,10 @@ module BootstrapHelper
     content_tag :span, order_detail.order_status, class: classes
   end
 
+  def tooltip_hint_icon(text)
+    tooltip_icon "fa fa-question-circle-o", text
+  end
+
   def tooltip_icon(icon_class, tooltip)
     content_tag :i, "", class: icon_class, data: { toggle: "tooltip" }, title: tooltip
   end

--- a/app/models/instrument_price_policy.rb
+++ b/app/models/instrument_price_policy.rb
@@ -21,6 +21,10 @@ class InstrumentPricePolicy < PricePolicy
     pgp.try(:reservation_window) || 0
   end
 
+  def charge_full_price_on_cancellation?
+    SettingsHelper.feature_on?(:charge_full_price_on_cancellation) && self[:charge_full_price_on_cancellation]
+  end
+
   private
 
   def ensure_reservation_window

--- a/app/models/instrument_price_policy_calculations.rb
+++ b/app/models/instrument_price_policy_calculations.rb
@@ -67,7 +67,7 @@ module InstrumentPricePolicyCalculations
 
   def calculate_cancellation_costs(reservation)
     return unless cancellation_penalty?(reservation)
-    if SettingsHelper.feature_on?(:full_cancellation_cost) && full_cancellation_cost?
+    if SettingsHelper.feature_on?(:charge_full_price_on_cancellation) && charge_full_price_on_cancellation?
       calculate_reservation(reservation)
     else
       { cost: cancellation_cost, subsidy: 0 }

--- a/app/models/instrument_price_policy_calculations.rb
+++ b/app/models/instrument_price_policy_calculations.rb
@@ -67,7 +67,7 @@ module InstrumentPricePolicyCalculations
 
   def calculate_cancellation_costs(reservation)
     return unless cancellation_penalty?(reservation)
-    if SettingsHelper.feature_on?(:charge_full_price_on_cancellation) && charge_full_price_on_cancellation?
+    if charge_full_price_on_cancellation?
       calculate_reservation(reservation)
     else
       { cost: cancellation_cost, subsidy: 0 }

--- a/app/models/instrument_price_policy_calculations.rb
+++ b/app/models/instrument_price_policy_calculations.rb
@@ -66,7 +66,10 @@ module InstrumentPricePolicyCalculations
   end
 
   def calculate_cancellation_costs(reservation)
-    if cancellation_penalty?(reservation)
+    return unless cancellation_penalty?(reservation)
+    if SettingsHelper.feature_on?(:full_cancellation_cost) && full_cancellation_cost?
+      calculate_reservation(reservation)
+    else
       { cost: cancellation_cost, subsidy: 0 }
     end
   end

--- a/app/models/instrument_price_policy_calculations.rb
+++ b/app/models/instrument_price_policy_calculations.rb
@@ -38,6 +38,15 @@ module InstrumentPricePolicyCalculations
     minutes_canceled_before.minutes <= product.min_cancel_hours.hours
   end
 
+  def calculate_cancellation_costs(reservation)
+    return unless cancellation_penalty?(reservation)
+    if charge_full_price_on_cancellation?
+      calculate_reservation(reservation)
+    else
+      { cost: cancellation_cost.to_f, subsidy: 0 }
+    end
+  end
+
   private
 
   # CHARGE_FOR[:reservation] uses reserve start and end time for calculation
@@ -63,15 +72,6 @@ module InstrumentPricePolicyCalculations
 
   def calculate_for_time(start_at, end_at)
     PricePolicies::TimeBasedPriceCalculator.new(self).calculate(start_at, end_at)
-  end
-
-  def calculate_cancellation_costs(reservation)
-    return unless cancellation_penalty?(reservation)
-    if charge_full_price_on_cancellation?
-      calculate_reservation(reservation)
-    else
-      { cost: cancellation_cost, subsidy: 0 }
-    end
   end
 
 end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -735,7 +735,7 @@ class OrderDetail < ApplicationRecord
   end
 
   def cancellation_fee
-    CancellationFeeCalculator.new(self).fee
+    CancellationFeeCalculator.new(self).total_cost
   end
 
   def has_subsidies?
@@ -907,12 +907,23 @@ class OrderDetail < ApplicationRecord
   end
 
   def cancel_with_fee(order_status)
-    fee = cancellation_fee
-    self.actual_cost = fee
-    self.actual_subsidy = 0
-    change_status!(fee > 0 ? OrderStatus.complete : order_status)
-    save! if changed? # If the cancel goes from complete => complete, change status doesn't save
-    true
+    assign_price_policy unless price_policy
+
+    calculator = CancellationFeeCalculator.new(self)
+
+    change_status!(calculator.total_cost > 0 ? OrderStatus.complete : order_status)
+
+    if calculator.costs.present?
+      assign_attributes(
+        actual_cost: calculator.costs[:cost],
+        actual_subsidy: calculator.costs[:subsidy],
+      )
+    end
+
+    # If the status did not change in change_status! (e.g. it was complete, but
+    # then changed to complete with cancellation fee), then it doesn't trigger a save,
+    # so we need to do it ourselves.
+    save!
   end
 
   def mark_dispute_resolved

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -735,18 +735,7 @@ class OrderDetail < ApplicationRecord
   end
 
   def cancellation_fee
-    assign_price_policy unless price_policy
-
-    return 0 unless reservation && price_policy && product.min_cancel_hours.to_i > 0
-    if outside_cancellation_window?
-      0
-    else
-      price_policy.cancellation_cost.to_f
-    end
-  end
-
-  def outside_cancellation_window?(time = Time.current)
-    reservation.reserve_start_at - time > product.min_cancel_hours.hours
+    CancellationFeeCalculator.new(self).fee
   end
 
   def has_subsidies?

--- a/app/presenters/reservation_user_action_presenter.rb
+++ b/app/presenters/reservation_user_action_presenter.rb
@@ -39,7 +39,7 @@ class ReservationUserActionPresenter
   end
 
   def cancel_link(path = cancel_order_order_detail_path(order, order_detail))
-    canceler = CancellationFeeCalculator.new(reservation)
+    canceler = CancellationFeeCalculator.new(order_detail)
 
     confirm_text = if canceler.fee > 0
                      I18n.t("reservations.delete.confirm_with_fee", fee: number_to_currency(canceler.fee))

--- a/app/presenters/reservation_user_action_presenter.rb
+++ b/app/presenters/reservation_user_action_presenter.rb
@@ -38,6 +38,18 @@ class ReservationUserActionPresenter
     link_to reservation, view_edit_path
   end
 
+  def cancel_link(path = cancel_order_order_detail_path(order, order_detail))
+    canceler = CancellationFeeCalculator.new(reservation)
+
+    confirm_text = if canceler.fee > 0
+                     I18n.t("reservations.delete.confirm_with_fee", fee: number_to_currency(canceler.fee))
+                   else
+                     I18n.t("reservations.delete.confirm")
+                   end
+
+    link_to I18n.t("reservations.delete.link"), path, method: :put, data: { confirm: confirm_text }
+  end
+
   private
 
   def accessories?
@@ -72,35 +84,10 @@ class ReservationUserActionPresenter
     end
   end
 
-  def cancel_link
-    fee = with_cancelation_now { order_detail.cancellation_fee }
-
-    if fee > 0
-      link_to I18n.t("reservations.delete.link"), cancel_order_order_detail_path(order, order_detail),
-              method: :put,
-              data: { confirm: I18n.t("reservations.delete.confirm_with_fee", fee: number_to_currency(fee)) }
-    else
-      link_to I18n.t("reservations.delete.link"), cancel_order_order_detail_path(order, order_detail),
-              method: :put,
-              data: { confirm: I18n.t("reservations.delete.confirm") }
-    end
-  end
-
   def move_link
     link_to I18n.t("reservations.moving_up.link"), order_order_detail_reservation_move_reservation_path(order, order_detail, reservation),
             class: "move-res",
             data: { reservation_id: reservation.id }
-  end
-
-  private
-
-  # Yields with canceled_at set to now, but returns it to the previous value
-  def with_cancelation_now
-    old_value = order_detail.canceled_at
-    order_detail.canceled_at = Time.zone.now
-    result = yield
-    order_detail.canceled_at = old_value
-    result
   end
 
 end

--- a/app/presenters/reservation_user_action_presenter.rb
+++ b/app/presenters/reservation_user_action_presenter.rb
@@ -39,19 +39,17 @@ class ReservationUserActionPresenter
   end
 
   def cancel_link(path = cancel_order_order_detail_path(order, order_detail))
-    canceler = CancellationFeeCalculator.new(order_detail)
-
-    confirm_key = if canceler.fee > 0
-                    if canceler.charge_full_price?
-                      "reservations.delete.confirm_with_full_price"
-                    else
-                      "reservations.delete.confirm_with_fee"
-                    end
-                 else
-                   "reservations.delete.confirm"
-                 end
-    confirm_text = I18n.t(confirm_key, fee: number_to_currency(canceler.fee))
+    confirm_key = if canceler.total_cost > 0
+                    canceler.charge_full_price? ? "confirm_with_full_price" : "confirm_with_fee"
+                  else
+                    "confirm"
+                  end
+    confirm_text = I18n.t(confirm_key, scope: "reservations.delete", fee: number_to_currency(canceler.total_cost))
     link_to I18n.t("reservations.delete.link"), path, method: :put, data: { confirm: confirm_text }
+  end
+
+  def canceler
+    @canceler ||= CancellationFeeCalculator.new(order_detail)
   end
 
   private

--- a/app/presenters/reservation_user_action_presenter.rb
+++ b/app/presenters/reservation_user_action_presenter.rb
@@ -41,12 +41,16 @@ class ReservationUserActionPresenter
   def cancel_link(path = cancel_order_order_detail_path(order, order_detail))
     canceler = CancellationFeeCalculator.new(order_detail)
 
-    confirm_text = if canceler.fee > 0
-                     I18n.t("reservations.delete.confirm_with_fee", fee: number_to_currency(canceler.fee))
-                   else
-                     I18n.t("reservations.delete.confirm")
-                   end
-
+    confirm_key = if canceler.fee > 0
+                    if canceler.charge_full_price?
+                      "reservations.delete.confirm_with_full_price"
+                    else
+                      "reservations.delete.confirm_with_fee"
+                    end
+                 else
+                   "reservations.delete.confirm"
+                 end
+    confirm_text = I18n.t(confirm_key, fee: number_to_currency(canceler.fee))
     link_to I18n.t("reservations.delete.link"), path, method: :put, data: { confirm: confirm_text }
   end
 

--- a/app/services/cancellation_fee_calculator.rb
+++ b/app/services/cancellation_fee_calculator.rb
@@ -20,7 +20,7 @@ class CancellationFeeCalculator
       order_detail.canceled_at = Time.current
       @calculated_fee = order_detail.cancellation_fee
       # OrderDetail#cancellation_fee updates the actual costs. Now reset everything.
-      order_detail.reload
+      order_detail.restore_attributes
     end
 
     @calculated_fee

--- a/app/services/cancellation_fee_calculator.rb
+++ b/app/services/cancellation_fee_calculator.rb
@@ -5,23 +5,31 @@ class CancellationFeeCalculator
   attr_accessor :order_detail
   delegate :reservation, :product, :price_policy, to: :order_detail, allow_nil: true
 
-  def initialize(order_detail)
+  def initialize(original_order_detail)
     # Use a dupped version so that any changes don't get applied to the original
-    @order_detail = order_detail.dup
-    @order_detail.time_data = order_detail.time_data.dup
+    @order_detail = original_order_detail.dup
+    @order_detail.time_data = original_order_detail.time_data.dup
+    @order_detail.price_policy = original_order_detail.price_policy
   end
 
-  def fee
-    return 0 unless reservation && product.min_cancel_hours.to_i > 0
+  def costs
+    return unless reservation && product.min_cancel_hours.to_i > 0
 
-    return @fee if defined?(@fee)
-    order_detail.canceled_at = Time.current
-    order_detail.assign_price_policy
-    @fee = order_detail.actual_cost.to_f
+    return @costs if defined?(@costs)
+
+    order_detail.canceled_at ||= Time.current
+    order_detail.assign_price_policy unless order_detail.price_policy
+
+    @costs = order_detail.price_policy&.calculate_cancellation_costs(reservation)
+  end
+
+  def total_cost
+    return 0 unless costs
+    costs[:cost] - costs[:subsidy]
   end
 
   def charge_full_price?
-    fee # make sure fee has been initialized in case this gets called first
+    costs # make sure costs has been initialized in case this gets called first
     order_detail.price_policy&.charge_full_price_on_cancellation?
   end
 

--- a/app/services/cancellation_fee_calculator.rb
+++ b/app/services/cancellation_fee_calculator.rb
@@ -2,22 +2,25 @@
 
 class CancellationFeeCalculator
 
+  attr_accessor :reservation
+  delegate :order_detail, to: :reservation
+
   def initialize(reservation)
     @reservation = reservation
   end
 
   def fee
-    @reservation.blank? ? 0 : calculated_fee
+    reservation.blank? ? 0 : calculated_fee
   end
 
   private
 
   def calculated_fee
     unless defined?(@calculated_fee)
-      original_canceled_at = @reservation.order_detail.canceled_at
-      @reservation.order_detail.canceled_at = Time.current
-      @calculated_fee = @reservation.order_detail.cancellation_fee
-      @reservation.order_detail.canceled_at = original_canceled_at
+      order_detail.canceled_at = Time.current
+      @calculated_fee = order_detail.cancellation_fee
+      # OrderDetail#cancellation_fee updates the actual costs. Now reset everything.
+      order_detail.reload
     end
 
     @calculated_fee

--- a/app/services/cancellation_fee_calculator.rb
+++ b/app/services/cancellation_fee_calculator.rb
@@ -20,4 +20,9 @@ class CancellationFeeCalculator
     @fee = order_detail.actual_cost.to_f
   end
 
+  def charge_full_price?
+    fee # make sure fee has been initialized in case this gets called first
+    order_detail.price_policy&.charge_full_price_on_cancellation?
+  end
+
 end

--- a/app/services/price_policy_updater.rb
+++ b/app/services/price_policy_updater.rb
@@ -65,7 +65,7 @@ class PricePolicyUpdater
       :unit_cost,
       :unit_subsidy,
     ].tap do |attributes|
-      attributes << :full_cancellation_cost if SettingsHelper.feature_on?(:full_cancellation_cost)
+      attributes << :charge_full_price_on_cancellation if SettingsHelper.feature_on?(:charge_full_price_on_cancellation)
     end
   end
 

--- a/app/services/price_policy_updater.rb
+++ b/app/services/price_policy_updater.rb
@@ -52,13 +52,21 @@ class PricePolicyUpdater
   end
 
   def initial_price_group_attributes(price_group)
-    @params["price_policy_#{price_group.id}"]&.permit(:can_purchase,
-                                                      :usage_rate,
-                                                      :usage_subsidy,
-                                                      :minimum_cost,
-                                                      :cancellation_cost,
-                                                      :unit_cost,
-                                                      :unit_subsidy) || { can_purchase: false }
+    @params["price_policy_#{price_group.id}"]&.permit(*allowed_attributes) || { can_purchase: false }
+  end
+
+  def allowed_attributes
+    [
+      :can_purchase,
+      :usage_rate,
+      :usage_subsidy,
+      :minimum_cost,
+      :cancellation_cost,
+      :unit_cost,
+      :unit_subsidy,
+    ].tap do |attributes|
+      attributes << :full_cancellation_cost if SettingsHelper.feature_on?(:full_cancellation_cost)
+    end
   end
 
 end

--- a/app/views/facility_user_reservations/index.html.haml
+++ b/app/views/facility_user_reservations/index.html.haml
@@ -30,13 +30,7 @@
 
           %td.centered
             - if order_detail.reservation.try(:can_cancel?)
-              - fee = CancellationFeeCalculator.new(order_detail.reservation).fee
-              - confirm_text = fee > 0 ? text("reservations.delete.confirm_with_fee", fee: number_to_currency(fee)) : text("reservations.delete.confirm")
-
-              = link_to text("reservations.delete.link"),
-                cancel_facility_user_reservation_path(current_facility, @user, order_detail),
-                method: :put,
-                data: { confirm: confirm_text }
+              = ReservationUserActionPresenter.new(self, order_detail.reservation).cancel_link(cancel_facility_user_reservation_path(current_facility, @user, order_detail))
 
           %td= order_detail.reservation
 

--- a/app/views/price_policies/_price_policy_fields.html.haml
+++ b/app/views/price_policies/_price_policy_fields.html.haml
@@ -16,10 +16,10 @@
     - @price_policies.each do |price_policy|
       - price_group = price_policy.price_group
       = fields_for "price_policy_#{price_group.id}", price_policy do |pp|
-        %tr
+        %tr{class: price_group.master_internal? ? "js--masterInternalRow" : ""}
           %td= price_group.name
           %td= price_group.type_string
-          %td= pp.check_box :can_purchase, class: "can_purchase"
+          %td= pp.check_box :can_purchase, class: "js--canPurchase"
           - if price_group.external?
             %td.centered
               = pp.text_field :unit_cost, value: number_to_currency(price_policy.unit_cost, unit: "", delimiter: ""),

--- a/app/views/price_policies/_price_policy_fields.html.haml
+++ b/app/views/price_policies/_price_policy_fields.html.haml
@@ -16,7 +16,10 @@
     - @price_policies.each do |price_policy|
       - price_group = price_policy.price_group
       = fields_for "price_policy_#{price_group.id}", price_policy do |pp|
-        %tr{class: price_group.master_internal? ? "js--masterInternalRow" : ""}
+        - row_class = []
+        - row_class << "js--masterInternalRow" if price_group.master_internal?
+        - row_class << "js--adjustmentRow" unless price_group.external? || price_group.master_internal?
+        %tr{class: row_class}
           %td= price_group.name
           %td= price_group.type_string
           %td= pp.check_box :can_purchase, class: "js--canPurchase"
@@ -29,14 +32,13 @@
             %td.centered
               = pp.text_field :unit_cost, value: number_to_currency(price_policy.unit_cost, unit: "", delimiter: ""),
                 size: 8,
-                class: "master_unit_cost"
+                data: { target: ".js--unitRate" }
             %td
           - else
             %td.centered
               %span.unit_cost
               = pp.hidden_field :unit_cost, value: number_to_currency(price_policy.unit_cost, unit: "", delimiter: ""),
-                class: "unit_cost"
+                class: "js--unitRate", readonly: true
             %td.centered
               = pp.text_field :unit_subsidy, value: number_to_currency(price_policy.unit_subsidy, unit: "", delimiter: ""),
-                size: 8,
-                class: "unit_subsidy"
+                size: 8

--- a/app/views/reservations/_my_table.html.haml
+++ b/app/views/reservations/_my_table.html.haml
@@ -31,7 +31,7 @@
 
         %td.centered= od.order_status.name
         %td.currency
-          = OrderDetailPresenter.new(od.reload).wrapped_total
+          = OrderDetailPresenter.new(od).wrapped_total
 
 = render "/price_display_footnote"
 = will_paginate(order_details)

--- a/app/views/time_based_price_policies/_adjustment_row.html.haml
+++ b/app/views/time_based_price_policies/_adjustment_row.html.haml
@@ -1,6 +1,6 @@
 %td
   = pp.hidden_field :usage_rate, value: display_usage_rate(price_group, price_policy),
-    class: "usage_cost"
+    class: "js--usageRate"
   = pp.label :usage_subsidy, t("price_policies.adjustment"), class: "normal-weight"
   = pp.text_field :usage_subsidy, value: display_usage_subsidy(price_group, price_policy),
     size: 8,
@@ -9,17 +9,20 @@
 - if local_assigns[:minimum_cost]
   %td
     = pp.label :minimum_cost, t("price_policies.amount"), class: "normal-weight"
-    %span.minimum_cost{ data: { usage_subsidy: price_policy.usage_subsidy } }
+    %span.js--minimumCost
     = pp.hidden_field :minimum_cost, value: number_to_currency(price_policy.minimum_cost, unit: "", delimiter: ""),
       size: 8,
-      class: "minimum_cost"
+      class: "js--minimumCost"
+
 
 - if local_assigns[:cancellation]
   %td
     = pp.label :cancellation_cost, t("price_policies.amount"), class: "normal-weight"
-    %span.cancellation_cost
+    %span.js--cancellationCost
     = pp.hidden_field :cancellation_cost, value: number_to_currency(price_policy.cancellation_cost, unit: "", delimiter: ""),
-      class: "cancellation_cost"
+      readonly: true,
+      size: 8,
+      class: "js--cancellationCost"
 
-    = pp.hidden_field :full_cancellation_cost, class: "adjustment_full_cancellation_cost"
+    = pp.hidden_field :full_cancellation_cost, class: "js--fullCancellationCost", readonly: true
 

--- a/app/views/time_based_price_policies/_adjustment_row.html.haml
+++ b/app/views/time_based_price_policies/_adjustment_row.html.haml
@@ -24,5 +24,5 @@
       size: 8,
       class: "js--cancellationCost"
 
-    = pp.hidden_field :full_cancellation_cost, class: "js--fullCancellationCost", readonly: true
+    = pp.hidden_field :charge_full_price_on_cancellation, class: "js--fullCancellationCost", readonly: true
 

--- a/app/views/time_based_price_policies/_adjustment_row.html.haml
+++ b/app/views/time_based_price_policies/_adjustment_row.html.haml
@@ -19,5 +19,7 @@
     = pp.label :cancellation_cost, t("price_policies.amount"), class: "normal-weight"
     %span.cancellation_cost
     = pp.hidden_field :cancellation_cost, value: number_to_currency(price_policy.cancellation_cost, unit: "", delimiter: ""),
-      size: 8,
       class: "cancellation_cost"
+
+    = pp.hidden_field :full_cancellation_cost, class: "adjustment_full_cancellation_cost"
+

--- a/app/views/time_based_price_policies/_amount_row.html.haml
+++ b/app/views/time_based_price_policies/_amount_row.html.haml
@@ -24,4 +24,4 @@
         = pp.check_box :charge_full_price_on_cancellation,
           class: "js--fullCancellationCost"
         = price_policy.class.human_attribute_name(:charge_full_price_on_cancellation)
-        = tooltip_hint_icon t("price_policies.charge_full_price_on_cancellation_hint")
+        = tooltip_icon "fa fa-question-circle-o", t("price_policies.charge_full_price_on_cancellation_hint")

--- a/app/views/time_based_price_policies/_amount_row.html.haml
+++ b/app/views/time_based_price_policies/_amount_row.html.haml
@@ -2,24 +2,26 @@
   = pp.label :usage_rate, t("price_policies.rate"), class: "normal-weight"
   = pp.text_field :usage_rate, value: display_usage_rate(price_group, price_policy),
     size: 8,
-    class: "#{price_group.master_internal? ? 'master_usage_cost' : ''} usage_rate"
+    class: "#{price_group.master_internal? ? 'master_usage_cost' : ''} usage_rate",
+    data: { target: ".js--usageRate" }
 
 - if local_assigns[:minimum_cost]
   %td
     = pp.label :minimum_cost, t("price_policies.amount"), class: "normal-weight"
     = pp.text_field :minimum_cost, value: number_to_currency(price_policy.minimum_cost, unit: "", delimiter: ""),
       size: 8,
-      class: price_group.master_internal? ? "master_minimum_cost" : ""
+      data: { target: ".js--minimumCost" }
 
 - if local_assigns[:cancellation]
-  %td.js--full_cancellation_cost_container
+  %td.js--cancellationCostContainer
     = pp.label :cancellation_cost, t("price_policies.amount"), class: "normal-weight"
     = pp.text_field :cancellation_cost, value: number_to_currency(price_policy.cancellation_cost, unit: "", delimiter: ""),
       size: 8,
-      class: price_group.master_internal? ? "master_cancellation_cost" : ""
+      class: "js--cancellationCost",
+      data: { target: ".js--cancellationCost" }
     - if SettingsHelper.feature_on?(:full_cancellation_cost)
       = label_tag(nil, class: "checkbox normal-weight") do
         = pp.check_box :full_cancellation_cost,
-          class: ["js--full_cancellation_cost", price_group.master_internal? ? "master_full_cancellation_cost" : ""]
+          class: "js--fullCancellationCost"
         = price_policy.class.human_attribute_name(:full_cancellation_cost)
         = tooltip_hint_icon t("price_policies.full_cancellation_cost_hint")

--- a/app/views/time_based_price_policies/_amount_row.html.haml
+++ b/app/views/time_based_price_policies/_amount_row.html.haml
@@ -19,9 +19,9 @@
       size: 8,
       class: "js--cancellationCost",
       data: { target: ".js--cancellationCost" }
-    - if SettingsHelper.feature_on?(:full_cancellation_cost)
+    - if SettingsHelper.feature_on?(:charge_full_price_on_cancellation)
       = label_tag(nil, class: "checkbox normal-weight") do
-        = pp.check_box :full_cancellation_cost,
+        = pp.check_box :charge_full_price_on_cancellation,
           class: "js--fullCancellationCost"
-        = price_policy.class.human_attribute_name(:full_cancellation_cost)
-        = tooltip_hint_icon t("price_policies.full_cancellation_cost_hint")
+        = price_policy.class.human_attribute_name(:charge_full_price_on_cancellation)
+        = tooltip_hint_icon t("price_policies.charge_full_price_on_cancellation_hint")

--- a/app/views/time_based_price_policies/_amount_row.html.haml
+++ b/app/views/time_based_price_policies/_amount_row.html.haml
@@ -17,3 +17,8 @@
     = pp.text_field :cancellation_cost, value: number_to_currency(price_policy.cancellation_cost, unit: "", delimiter: ""),
       size: 8,
       class: price_group.master_internal? ? "master_cancellation_cost" : ""
+    - if SettingsHelper.feature_on?(:full_cancellation_cost)
+      = label_tag(nil, class: "checkbox normal-weight") do
+        = pp.check_box :full_cancellation_cost, class: "js--full_cancellation_cost"
+        = price_policy.class.human_attribute_name(:full_cancellation_cost)
+        = tooltip_hint_icon t("price_policies.full_cancellation_cost_hint")

--- a/app/views/time_based_price_policies/_amount_row.html.haml
+++ b/app/views/time_based_price_policies/_amount_row.html.haml
@@ -19,6 +19,7 @@
       class: price_group.master_internal? ? "master_cancellation_cost" : ""
     - if SettingsHelper.feature_on?(:full_cancellation_cost)
       = label_tag(nil, class: "checkbox normal-weight") do
-        = pp.check_box :full_cancellation_cost, class: "js--full_cancellation_cost"
+        = pp.check_box :full_cancellation_cost,
+          class: ["js--full_cancellation_cost", price_group.master_internal? ? "master_full_cancellation_cost" : ""]
         = price_policy.class.human_attribute_name(:full_cancellation_cost)
         = tooltip_hint_icon t("price_policies.full_cancellation_cost_hint")

--- a/app/views/time_based_price_policies/_price_policy_fields.html.haml
+++ b/app/views/time_based_price_policies/_price_policy_fields.html.haml
@@ -24,10 +24,13 @@
     - @price_policies.each do |price_policy|
       - price_group = price_policy.price_group
       = fields_for "price_policy_#{price_group.id}", price_policy do |pp|
-        %tr
+        - row_class = []
+        - row_class << "js--masterInternalRow" if price_group.master_internal?
+        - row_class << "js--adjustmentRow" unless price_group.external? || price_group.master_internal?
+        %tr{class: row_class}
           %td= price_group.name
           %td= price_group.type_string
-          %td= pp.check_box :can_purchase, class: "can_purchase"
+          %td= pp.check_box :can_purchase, class: "js--canPurchase"
           - if price_group.external? || price_group.master_internal?
             = render "time_based_price_policies/amount_row", price_group: price_group, price_policy: price_policy, pp: pp, cancellation: cancellation, minimum_cost: minimum_cost
           - else

--- a/app/views/time_based_price_policies/_table.html.haml
+++ b/app/views/time_based_price_policies/_table.html.haml
@@ -50,7 +50,11 @@
                 %strong= "= #{number_to_currency price_policy.subsidized_minimum_cost}"
 
           - if local_assigns[:cancellation]
-            %td.currency= number_to_currency(price_policy.cancellation_cost)
+            %td.currency
+              - if price_policy.full_cancellation_cost?
+                = price_policy.class.human_attribute_name(:full_cancellation_cost)
+              - else
+                = number_to_currency(price_policy.cancellation_cost)
 
         - else
           %td.centered{ colspan: 5 }

--- a/app/views/time_based_price_policies/_table.html.haml
+++ b/app/views/time_based_price_policies/_table.html.haml
@@ -51,8 +51,8 @@
 
           - if local_assigns[:cancellation]
             %td.currency
-              - if price_policy.full_cancellation_cost?
-                = price_policy.class.human_attribute_name(:full_cancellation_cost)
+              - if price_policy.charge_full_price_on_cancellation?
+                = price_policy.class.human_attribute_name(:charge_full_price_on_cancellation)
               - else
                 = number_to_currency(price_policy.cancellation_cost)
 

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -269,6 +269,7 @@ en:
         minimum_cost: Minimum Cost
         hourly_usage_rate: Rate Per Hour
         cancellation_cost: Reservation Cost
+        full_cancellation_cost: Full reservation cost
         unit_cost: Unit Cost
         unit_adjustment: Unit Adjustment
         unit_net_cost: Unit Net Cost

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -269,7 +269,7 @@ en:
         minimum_cost: Minimum Cost
         hourly_usage_rate: Rate Per Hour
         cancellation_cost: Reservation Cost
-        full_cancellation_cost: Full reservation cost
+        charge_full_price_on_cancellation: Full reservation cost
         unit_cost: Unit Cost
         unit_adjustment: Unit Adjustment
         unit_net_cost: Unit Net Cost

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -846,6 +846,7 @@ en:
       missing_for_bundle: Product missing current price policies
       fewer_than_price_groups: Some price groups are missing price policies
     rate: Rate
+    full_cancellation_cost_hint: Charge the entire amount for a reservation if the user cancels within the minimum cancellation window.
 
   price_groups:
     price_group_fields:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -551,7 +551,7 @@ en:
     delete:
       confirm: Are you sure you wish to cancel this reservation?
       confirm_with_fee: "Canceling this reservation will incur a %{fee} fee.  Are you sure you wish to cancel this reservation?"
-      confirm_with_full_price: Canceling this reservation incur the full reservation cost. Are you sure you wish to cancel this reservation?
+      confirm_with_full_price: Canceling this reservation incur the full reservation cost of %{fee}. Are you sure you wish to cancel this reservation?
       link: Cancel
     finished: Reservation Ended
     moving_up:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -551,6 +551,7 @@ en:
     delete:
       confirm: Are you sure you wish to cancel this reservation?
       confirm_with_fee: "Canceling this reservation will incur a %{fee} fee.  Are you sure you wish to cancel this reservation?"
+      confirm_with_full_price: Canceling this reservation incur the full reservation cost. Are you sure you wish to cancel this reservation?
       link: Cancel
     finished: Reservation Ended
     moving_up:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -846,7 +846,7 @@ en:
       missing_for_bundle: Product missing current price policies
       fewer_than_price_groups: Some price groups are missing price policies
     rate: Rate
-    full_cancellation_cost_hint: Charge the entire amount for a reservation if the user cancels within the minimum cancellation window.
+    charge_full_price_on_cancellation_hint: Charge the entire amount for a reservation if the user cancels within the minimum cancellation window.
 
   price_groups:
     price_group_fields:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -124,6 +124,7 @@ feature:
   azlist_on: false
   use_manage_on: false
   facility_banner_notice_on: true
+  full_cancellation_cost_on: true
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -124,7 +124,7 @@ feature:
   azlist_on: false
   use_manage_on: false
   facility_banner_notice_on: true
-  full_cancellation_cost_on: true
+  charge_full_price_on_cancellation_on: true
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/db/migrate/20180919211201_add_full_cost_cancellation_to_price_policies.rb
+++ b/db/migrate/20180919211201_add_full_cost_cancellation_to_price_policies.rb
@@ -3,7 +3,7 @@
 class AddFullCostCancellationToPricePolicies < ActiveRecord::Migration[5.0]
 
   def change
-    add_column :price_policies, :full_cancellation_cost, :boolean, default: false, null: false
+    add_column :price_policies, :charge_full_price_on_cancellation, :boolean, default: false, null: false
   end
 
 end

--- a/db/migrate/20180919211201_add_full_cost_cancellation_to_price_policies.rb
+++ b/db/migrate/20180919211201_add_full_cost_cancellation_to_price_policies.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddFullCostCancellationToPricePolicies < ActiveRecord::Migration[5.0]
+
+  def change
+    add_column :price_policies, :full_cancellation_cost, :boolean, default: false, null: false
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180917224024) do
+ActiveRecord::Schema.define(version: 20180919211201) do
 
   create_table "account_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "account_id",            null: false
@@ -394,20 +394,21 @@ ActiveRecord::Schema.define(version: 20180917224024) do
   end
 
   create_table "price_policies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "type",              limit: 50,                                          null: false
+    t.string   "type",                   limit: 50,                                          null: false
     t.integer  "product_id"
-    t.integer  "price_group_id",                                                        null: false
-    t.boolean  "can_purchase",                                          default: false, null: false
-    t.datetime "start_date",                                                            null: false
-    t.decimal  "unit_cost",                    precision: 10, scale: 2
-    t.decimal  "unit_subsidy",                 precision: 10, scale: 2
-    t.decimal  "usage_rate",                   precision: 12, scale: 4
-    t.decimal  "minimum_cost",                 precision: 10, scale: 2
-    t.decimal  "cancellation_cost",            precision: 10, scale: 2
-    t.decimal  "usage_subsidy",                precision: 12, scale: 4
-    t.datetime "expire_date",                                                           null: false
+    t.integer  "price_group_id",                                                             null: false
+    t.boolean  "can_purchase",                                               default: false, null: false
+    t.datetime "start_date",                                                                 null: false
+    t.decimal  "unit_cost",                         precision: 10, scale: 2
+    t.decimal  "unit_subsidy",                      precision: 10, scale: 2
+    t.decimal  "usage_rate",                        precision: 12, scale: 4
+    t.decimal  "minimum_cost",                      precision: 10, scale: 2
+    t.decimal  "cancellation_cost",                 precision: 10, scale: 2
+    t.decimal  "usage_subsidy",                     precision: 12, scale: 4
+    t.datetime "expire_date",                                                                null: false
     t.string   "charge_for"
     t.string   "legacy_rates"
+    t.boolean  "full_cancellation_cost",                                     default: false, null: false
     t.index ["price_group_id"], name: "fk_rails_74aa223960", using: :btree
     t.index ["product_id"], name: "index_price_policies_on_product_id", using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -394,21 +394,21 @@ ActiveRecord::Schema.define(version: 20180919211201) do
   end
 
   create_table "price_policies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "type",                   limit: 50,                                          null: false
+    t.string   "type",                              limit: 50,                                          null: false
     t.integer  "product_id"
-    t.integer  "price_group_id",                                                             null: false
-    t.boolean  "can_purchase",                                               default: false, null: false
-    t.datetime "start_date",                                                                 null: false
-    t.decimal  "unit_cost",                         precision: 10, scale: 2
-    t.decimal  "unit_subsidy",                      precision: 10, scale: 2
-    t.decimal  "usage_rate",                        precision: 12, scale: 4
-    t.decimal  "minimum_cost",                      precision: 10, scale: 2
-    t.decimal  "cancellation_cost",                 precision: 10, scale: 2
-    t.decimal  "usage_subsidy",                     precision: 12, scale: 4
-    t.datetime "expire_date",                                                                null: false
+    t.integer  "price_group_id",                                                                        null: false
+    t.boolean  "can_purchase",                                                          default: false, null: false
+    t.datetime "start_date",                                                                            null: false
+    t.decimal  "unit_cost",                                    precision: 10, scale: 2
+    t.decimal  "unit_subsidy",                                 precision: 10, scale: 2
+    t.decimal  "usage_rate",                                   precision: 12, scale: 4
+    t.decimal  "minimum_cost",                                 precision: 10, scale: 2
+    t.decimal  "cancellation_cost",                            precision: 10, scale: 2
+    t.decimal  "usage_subsidy",                                precision: 12, scale: 4
+    t.datetime "expire_date",                                                                           null: false
     t.string   "charge_for"
     t.string   "legacy_rates"
-    t.boolean  "full_cancellation_cost",                                     default: false, null: false
+    t.boolean  "charge_full_price_on_cancellation",                                     default: false, null: false
     t.index ["price_group_id"], name: "fk_rails_74aa223960", using: :btree
     t.index ["product_id"], name: "index_price_policies_on_product_id", using: :btree
   end

--- a/spec/factories/price_groups.rb
+++ b/spec/factories/price_groups.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
     trait :cancer_center do
       global
       admin_editable { true }
+      sequence(:name, "AAAAAA") { |n| "Cancer Center #{n}" }
     end
   end
 

--- a/spec/features/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/features/admin/instrument_price_policies_controller_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+RSpec.describe InstrumentPricePoliciesController do
+  let(:facility) { create(:setup_facility) }
+  let!(:instrument) { create(:instrument, facility: facility) }
+  let(:director) { create(:user, :facility_director, facility: facility) }
+
+  let(:base_price_group) { PriceGroup.base }
+  let(:external_price_group) { PriceGroup.external }
+  let!(:cancer_center) { create(:price_group, :cancer_center) }
+
+  before do
+    page.driver.resize 1200, 1200
+    login_as director
+    facility.price_groups.destroy_all # get rid of the price groups created by the factories
+  end
+
+  it "can set up the price policies", :js do
+    visit facility_instruments_path(facility, instrument)
+    click_link instrument.name
+    click_link "Pricing"
+    click_link "Add Pricing Rules"
+
+    fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "60"
+    fill_in "price_policy_#{base_price_group.id}[minimum_cost]", with: "120"
+    fill_in "price_policy_#{base_price_group.id}[cancellation_cost]", with: "15"
+
+    fill_in "price_policy_#{cancer_center.id}[usage_subsidy]", with: "30"
+
+    fill_in "price_policy_#{external_price_group.id}[usage_rate]", with: "120.11"
+    fill_in "price_policy_#{external_price_group.id}[minimum_cost]", with: "122"
+    fill_in "price_policy_#{external_price_group.id}[cancellation_cost]", with: "31"
+
+    click_button "Add Pricing Rules"
+
+    expect(page).to have_content("$60.00\n- $30.00\n= $30.00") # Cancer Center Usage Rate
+    expect(page).to have_content("$120.00\n- $60.00\n= $60.00") # Cancer Center Minimum Cost
+    expect(page).to have_content("$15.00", count: 2) # Internal and Cancer Center Reservation Costs
+
+    # External price group
+    expect(page).to have_content("$120.11")
+    expect(page).to have_content("$122.00")
+    expect(page).to have_content("$31.00")
+  end
+
+  it "can only allow some to purchase", :js do
+    visit facility_instruments_path(facility, instrument)
+    click_link instrument.name
+    click_link "Pricing"
+    click_link "Add Pricing Rules"
+
+    fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "60"
+    fill_in "price_policy_#{base_price_group.id}[minimum_cost]", with: "120"
+    fill_in "price_policy_#{base_price_group.id}[cancellation_cost]", with: "15"
+
+    uncheck "price_policy_#{cancer_center.id}[can_purchase]"
+    uncheck "price_policy_#{external_price_group.id}[can_purchase]"
+
+    click_button "Add Pricing Rules"
+
+    expect(page).to have_content(base_price_group.name)
+    expect(page).not_to have_content(external_price_group.name)
+    expect(page).not_to have_content(cancer_center.name)
+  end
+
+  describe "with full cancellation cost enabled", :js, feature_setting: { full_cancellation_cost: true } do
+    it "can set up the price policies", :js do
+      visit facility_instruments_path(facility, instrument)
+      click_link instrument.name
+      click_link "Pricing"
+      click_link "Add Pricing Rules"
+
+      fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "60"
+      fill_in "price_policy_#{base_price_group.id}[minimum_cost]", with: "120"
+      fill_in "price_policy_#{base_price_group.id}[cancellation_cost]", with: "15"
+
+      check "price_policy_#{base_price_group.id}[full_cancellation_cost]"
+      expect(page).to have_field("price_policy_#{base_price_group.id}[cancellation_cost]", disabled: true)
+
+      fill_in "price_policy_#{cancer_center.id}[usage_subsidy]", with: "30"
+
+      fill_in "price_policy_#{external_price_group.id}[usage_rate]", with: "120.11"
+      fill_in "price_policy_#{external_price_group.id}[minimum_cost]", with: "122"
+      fill_in "price_policy_#{external_price_group.id}[cancellation_cost]", with: "31"
+      check "price_policy_#{external_price_group.id}[full_cancellation_cost]"
+      expect(page).to have_field("price_policy_#{external_price_group.id}[cancellation_cost]", disabled: true)
+
+      click_button "Add Pricing Rules"
+  save_and_open_screenshot
+
+      expect(page).to have_content("$60.00\n- $30.00\n= $30.00") # Cancer Center Usage Rate
+      expect(page).to have_content("$120.00\n- $60.00\n= $60.00") # Cancer Center Minimum Cost
+      expect(page).not_to have_content("$15.00")
+      expect(page).to have_content(PricePolicy.human_attribute_name(:full_cancellation_cost), count: 3)
+
+      expect
+    end
+  end
+end

--- a/spec/features/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/features/admin/instrument_price_policies_controller_spec.rb
@@ -86,14 +86,11 @@ RSpec.describe InstrumentPricePoliciesController do
       expect(page).to have_field("price_policy_#{external_price_group.id}[cancellation_cost]", disabled: true)
 
       click_button "Add Pricing Rules"
-  save_and_open_screenshot
 
       expect(page).to have_content("$60.00\n- $30.00\n= $30.00") # Cancer Center Usage Rate
       expect(page).to have_content("$120.00\n- $60.00\n= $60.00") # Cancer Center Minimum Cost
       expect(page).not_to have_content("$15.00")
       expect(page).to have_content(PricePolicy.human_attribute_name(:full_cancellation_cost), count: 3)
-
-      expect
     end
   end
 end

--- a/spec/features/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/features/admin/instrument_price_policies_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe InstrumentPricePoliciesController do

--- a/spec/features/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/features/admin/instrument_price_policies_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe InstrumentPricePoliciesController do
     expect(page).not_to have_content(cancer_center.name)
   end
 
-  describe "with full cancellation cost enabled", :js, feature_setting: { full_cancellation_cost: true } do
+  describe "with full cancellation cost enabled", :js, feature_setting: { charge_full_price_on_cancellation: true } do
     it "can set up the price policies", :js do
       visit facility_instruments_path(facility, instrument)
       click_link instrument.name
@@ -76,7 +76,7 @@ RSpec.describe InstrumentPricePoliciesController do
       fill_in "price_policy_#{base_price_group.id}[minimum_cost]", with: "120"
       fill_in "price_policy_#{base_price_group.id}[cancellation_cost]", with: "15"
 
-      check "price_policy_#{base_price_group.id}[full_cancellation_cost]"
+      check "price_policy_#{base_price_group.id}[charge_full_price_on_cancellation]"
       expect(page).to have_field("price_policy_#{base_price_group.id}[cancellation_cost]", disabled: true)
 
       fill_in "price_policy_#{cancer_center.id}[usage_subsidy]", with: "30"
@@ -84,7 +84,7 @@ RSpec.describe InstrumentPricePoliciesController do
       fill_in "price_policy_#{external_price_group.id}[usage_rate]", with: "120.11"
       fill_in "price_policy_#{external_price_group.id}[minimum_cost]", with: "122"
       fill_in "price_policy_#{external_price_group.id}[cancellation_cost]", with: "31"
-      check "price_policy_#{external_price_group.id}[full_cancellation_cost]"
+      check "price_policy_#{external_price_group.id}[charge_full_price_on_cancellation]"
       expect(page).to have_field("price_policy_#{external_price_group.id}[cancellation_cost]", disabled: true)
 
       click_button "Add Pricing Rules"
@@ -92,7 +92,7 @@ RSpec.describe InstrumentPricePoliciesController do
       expect(page).to have_content("$60.00\n- $30.00\n= $30.00") # Cancer Center Usage Rate
       expect(page).to have_content("$120.00\n- $60.00\n= $60.00") # Cancer Center Minimum Cost
       expect(page).not_to have_content("$15.00")
-      expect(page).to have_content(PricePolicy.human_attribute_name(:full_cancellation_cost), count: 3)
+      expect(page).to have_content(PricePolicy.human_attribute_name(:charge_full_price_on_cancellation), count: 3)
     end
   end
 end

--- a/spec/features/admin/item_price_policies_controller_spec.rb
+++ b/spec/features/admin/item_price_policies_controller_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe ItemPricePoliciesController, :js do
+  let(:facility) { create(:setup_facility) }
+  let!(:item) { create(:item, facility: facility) }
+  let(:director) { create(:user, :facility_director, facility: facility) }
+
+  let(:base_price_group) { PriceGroup.base }
+  let(:external_price_group) { PriceGroup.external }
+  let!(:cancer_center) { create(:price_group, :cancer_center) }
+
+    before do
+    login_as director
+    facility.price_groups.destroy_all # get rid of the price groups created by the factories
+  end
+
+  it "can set up price policies" do
+    visit facility_items_path(facility, item)
+    click_link item.name
+    click_link "Pricing"
+    click_link "Add Pricing Rules"
+
+    fill_in "price_policy_#{base_price_group.id}[unit_cost]", with: "100.00"
+    fill_in "price_policy_#{cancer_center.id}[unit_subsidy]", with: "25.25"
+    fill_in "price_policy_#{external_price_group.id}[unit_cost]", with: "125.15"
+
+    click_button "Add Pricing Rules"
+
+    expect(page).to have_content(table_row("#{base_price_group.name} (Internal)", "$100.00", "$0.00", "$100.00"))
+    expect(page).to have_content(table_row("#{cancer_center.name} (Internal)", "$100.00", "$25.25", "$74.75"))
+    expect(page).to have_content(table_row("#{external_price_group.name} (External)", "$125.15", "$0.00", "$125.15"))
+  end
+
+  it "can allow only some groups to purchase" do
+    visit facility_items_path(facility, item)
+    click_link item.name
+    click_link "Pricing"
+    click_link "Add Pricing Rules"
+
+    fill_in "price_policy_#{base_price_group.id}[unit_cost]", with: "100.00"
+    fill_in "price_policy_#{cancer_center.id}[unit_subsidy]", with: "25.25"
+    uncheck "price_policy_#{external_price_group.id}[can_purchase]"
+
+    click_button "Add Pricing Rules"
+
+    expect(page).to have_content(base_price_group.name)
+    expect(page).to have_content(cancer_center.name)
+    expect(page).not_to have_content(external_price_group.name)
+  end
+
+  def table_row(*columns)
+    columns.join("\t")
+  end
+end

--- a/spec/features/admin/item_price_policies_controller_spec.rb
+++ b/spec/features/admin/item_price_policies_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe ItemPricePoliciesController, :js do
@@ -9,7 +11,7 @@ RSpec.describe ItemPricePoliciesController, :js do
   let(:external_price_group) { PriceGroup.external }
   let!(:cancer_center) { create(:price_group, :cancer_center) }
 
-    before do
+  before do
     login_as director
     facility.price_groups.destroy_all # get rid of the price groups created by the factories
   end

--- a/spec/features/admin/timed_service_price_policies_controller_spec.rb
+++ b/spec/features/admin/timed_service_price_policies_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe TimedServicePricePoliciesController, :js do
@@ -9,7 +11,7 @@ RSpec.describe TimedServicePricePoliciesController, :js do
   let(:external_price_group) { PriceGroup.external }
   let!(:cancer_center) { create(:price_group, :cancer_center) }
 
-    before do
+  before do
     login_as director
     facility.price_groups.destroy_all # get rid of the price groups created by the factories
   end

--- a/spec/features/admin/timed_service_price_policies_controller_spec.rb
+++ b/spec/features/admin/timed_service_price_policies_controller_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe TimedServicePricePoliciesController, :js do
+  let(:facility) { create(:setup_facility) }
+  let!(:timed_service) { create(:timed_service, facility: facility) }
+  let(:director) { create(:user, :facility_director, facility: facility) }
+
+  let(:base_price_group) { PriceGroup.base }
+  let(:external_price_group) { PriceGroup.external }
+  let!(:cancer_center) { create(:price_group, :cancer_center) }
+
+    before do
+    login_as director
+    facility.price_groups.destroy_all # get rid of the price groups created by the factories
+  end
+
+  it "can set up price policies" do
+    visit facility_timed_services_path(facility, timed_service)
+    click_link timed_service.name
+    click_link "Pricing"
+    click_link "Add Pricing Rules"
+
+    fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "120.00"
+    fill_in "price_policy_#{cancer_center.id}[usage_subsidy]", with: "25.25"
+    fill_in "price_policy_#{external_price_group.id}[usage_rate]", with: "125.15"
+
+    click_button "Add Pricing Rules"
+
+    expect(page).to have_content("$2.0000 / minute") # Base rate
+    expect(page).to have_content("$120.00\n- $25.25\n= $94.75") # Cancer center
+    expect(page).to have_content("$1.5792 / minute") # Cancer center
+    expect(page).to have_content("$2.0858 / minute") # External
+  end
+
+  it "can allow only some groups to purchase" do
+    visit facility_timed_services_path(facility, timed_service)
+    click_link timed_service.name
+    click_link "Pricing"
+    click_link "Add Pricing Rules"
+
+    fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "100.00"
+    fill_in "price_policy_#{cancer_center.id}[usage_subsidy]", with: "25.25"
+    uncheck "price_policy_#{external_price_group.id}[can_purchase]"
+
+    click_button "Add Pricing Rules"
+
+    expect(page).to have_content(base_price_group.name)
+    expect(page).to have_content(cancer_center.name)
+    expect(page).not_to have_content(external_price_group.name)
+  end
+end

--- a/spec/models/instrument_price_policy_calculations_spec.rb
+++ b/spec/models/instrument_price_policy_calculations_spec.rb
@@ -147,13 +147,36 @@ RSpec.describe InstrumentPricePolicyCalculations do
       reservation.actual_end_at = now + 1.hour
     end
 
-    it "returns #calculate_cancellation_costs if the reservation was canceled" do
-      expect(reservation.order_detail).to receive(:canceled_at?).and_return true
-      expect(policy).to receive(:calculate_cancellation_costs).with reservation
-      expect(policy).to_not receive :calculate_overage
-      expect(policy).to_not receive :calculate_reservation
-      expect(policy).to_not receive :calculate_usage
-      policy.calculate_cost_and_subsidy reservation
+    describe "cancellation" do
+      let(:options) { { usage_rate: 60, cancellation_cost: 1.23 } }
+      before do
+        policy.product.min_cancel_hours = 1
+      end
+
+      it "charges nothing if canceled far enough in advance" do
+        reservation.order_detail.canceled_at = reservation.reserve_start_at - 3.hours
+        expect(policy.calculate_cost_and_subsidy(reservation)).to be_blank
+      end
+
+      it "charges the cancellation_cost if not far enough in advance" do
+        reservation.order_detail.canceled_at = reservation.reserve_start_at - 30.minutes
+        expect(policy.calculate_cost_and_subsidy(reservation)).to eq(cost: 1.23, subsidy: 0)
+      end
+
+      it "returns the full reservation costs if full_cancellation_cost is set", feature_setting: { full_cancellation_cost: true } do
+        policy.full_cancellation_cost = true
+        reservation.order_detail.canceled_at = reservation.reserve_start_at - 30.minutes
+
+        expect(policy.calculate_cost_and_subsidy(reservation)).to eq(cost: 60, subsidy: 0)
+      end
+
+      it "still returns the cancellation_cost even if full_cancellation_cost with the feature off", feature_setting: { full_cancellation_cost: false } do
+        policy.full_cancellation_cost = true
+        reservation.order_detail.canceled_at = reservation.reserve_start_at - 30.minutes
+
+        expect(policy.calculate_cost_and_subsidy(reservation)).to eq(cost: 1.23, subsidy: 0)
+      end
+>>>>>>> Charge reservation rate if enabled
     end
 
     context "when configured to charge for usage" do

--- a/spec/models/instrument_price_policy_calculations_spec.rb
+++ b/spec/models/instrument_price_policy_calculations_spec.rb
@@ -163,15 +163,15 @@ RSpec.describe InstrumentPricePolicyCalculations do
         expect(policy.calculate_cost_and_subsidy(reservation)).to eq(cost: 1.23, subsidy: 0)
       end
 
-      it "returns the full reservation costs if full_cancellation_cost is set", feature_setting: { full_cancellation_cost: true } do
-        policy.full_cancellation_cost = true
+      it "returns the full reservation costs if charge_full_price_on_cancellation is set", feature_setting: { charge_full_price_on_cancellation: true } do
+        policy.charge_full_price_on_cancellation = true
         reservation.order_detail.canceled_at = reservation.reserve_start_at - 30.minutes
 
         expect(policy.calculate_cost_and_subsidy(reservation)).to eq(cost: 60, subsidy: 0)
       end
 
-      it "still returns the cancellation_cost even if full_cancellation_cost with the feature off", feature_setting: { full_cancellation_cost: false } do
-        policy.full_cancellation_cost = true
+      it "still returns the cancellation_cost even if charge_full_price_on_cancellation with the feature off", feature_setting: { charge_full_price_on_cancellation: false } do
+        policy.charge_full_price_on_cancellation = true
         reservation.order_detail.canceled_at = reservation.reserve_start_at - 30.minutes
 
         expect(policy.calculate_cost_and_subsidy(reservation)).to eq(cost: 1.23, subsidy: 0)

--- a/spec/models/instrument_price_policy_calculations_spec.rb
+++ b/spec/models/instrument_price_policy_calculations_spec.rb
@@ -176,7 +176,6 @@ RSpec.describe InstrumentPricePolicyCalculations do
 
         expect(policy.calculate_cost_and_subsidy(reservation)).to eq(cost: 1.23, subsidy: 0)
       end
->>>>>>> Charge reservation rate if enabled
     end
 
     context "when configured to charge for usage" do

--- a/spec/presenters/reservation_user_action_presenter_spec.rb
+++ b/spec/presenters/reservation_user_action_presenter_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe ReservationUserActionPresenter do
         end
 
         before :each do
-          expect(order_detail).to receive(:cancellation_fee).and_return 10
+          allow(presenter.canceler).to receive(:total_cost).and_return 10
         end
 
         it_behaves_like "it has a cancellation link with a confirmation"
@@ -153,7 +153,7 @@ RSpec.describe ReservationUserActionPresenter do
         end
 
         before :each do
-          expect(order_detail).to receive(:cancellation_fee).and_return 0
+          allow(presenter.canceler).to receive(:total_cost).and_return 0
         end
 
         it_behaves_like "it has a cancellation link with a confirmation"

--- a/spec/services/cancellation_fee_calculator_spec.rb
+++ b/spec/services/cancellation_fee_calculator_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe CancellationFeeCalculator do
   let(:order_detail) { reservation.order_detail }
   let(:calculator) { described_class.new(order_detail) }
 
-  describe "#fee" do
-    subject { calculator.fee }
+  describe "#total_cost" do
+    subject { calculator.total_cost }
 
     context "when there is no reservation" do
       let(:order_detail) { build(:order_detail) }
@@ -61,7 +61,7 @@ RSpec.describe CancellationFeeCalculator do
 
         describe "with the feature off", feature_setting: { charge_full_price_on_cancellation: false } do
           it { is_expected.to eq(0) }
-          it "is the full price charge"  do
+          it "is the full price charge" do
             expect(calculator).not_to be_charge_full_price
           end
         end

--- a/spec/services/cancellation_fee_calculator_spec.rb
+++ b/spec/services/cancellation_fee_calculator_spec.rb
@@ -51,10 +51,19 @@ RSpec.describe CancellationFeeCalculator do
 
       context "when the price policy is set to charge for full reservation" do
         before { instrument.price_policies.update_all(usage_rate: 1, charge_full_price_on_cancellation: true) }
-        it { is_expected.to eq(60) } # usage_rate is per minute
 
-        it "is the full price charge" do
-          expect(calculator).to be_charge_full_price
+        describe "with the feature on", feature_setting: { charge_full_price_on_cancellation: true } do
+          it { is_expected.to eq(60) } # usage_rate is per minute
+          it "is the full price charge"  do
+            expect(calculator).to be_charge_full_price
+          end
+        end
+
+        describe "with the feature off", feature_setting: { charge_full_price_on_cancellation: false } do
+          it { is_expected.to eq(0) }
+          it "is the full price charge"  do
+            expect(calculator).not_to be_charge_full_price
+          end
         end
       end
     end

--- a/spec/services/cancellation_fee_calculator_spec.rb
+++ b/spec/services/cancellation_fee_calculator_spec.rb
@@ -3,27 +3,52 @@
 require "rails_helper"
 
 RSpec.describe CancellationFeeCalculator do
-  let(:calculator) { described_class.new(reservation) }
+  let(:order_detail) { reservation.order_detail }
+  let(:calculator) { described_class.new(order_detail) }
 
   describe "#fee" do
     subject { calculator.fee }
 
     context "when there is no reservation" do
-      let(:reservation) { nil }
+      let(:order_detail) { build(:order_detail) }
       it { is_expected.to eq(0) }
     end
 
-    let(:reservation) { FactoryBot.create(:purchased_reservation, product: instrument) }
-    let(:instrument) { FactoryBot.create(:setup_instrument, min_cancel_hours: 9999) }
+    let(:instrument) { FactoryBot.create(:setup_instrument, min_cancel_hours: 24) }
 
-    context "when there is no cancellation_cost" do
-      it { is_expected.to eq(0) }
+    describe "when outside the cancellation window" do
+      let(:reservation) { FactoryBot.create(:purchased_reservation, product: instrument, reserve_start_at: 48.hours.from_now, reserve_end_at: 49.hours.from_now) }
+
+      context "when there is a cancellation_cost" do
+        before { instrument.price_policies.update_all(cancellation_cost: 45.75) }
+        it { is_expected.to eq(0) }
+      end
+
+      it "does not change the canceled_at" do
+        expect { subject }.not_to change(order_detail, :canceled_at)
+      end
+
+      it "does not change the costs" do
+        expect { subject }.not_to change(order_detail, :actual_cost)
+      end
     end
 
-    context "when there is a cancellation_cost" do
-      before { instrument.price_policies.update_all(cancellation_cost: 45.75) }
-      it { is_expected.to eq(45.75) }
-    end
+    describe "when inside the reservation window" do
+      let!(:reservation) { FactoryBot.create(:purchased_reservation, product: instrument, reserve_start_at: 2.hours.from_now, reserve_end_at: 3.hours.from_now) }
 
+      context "when there is no cancellation_cost" do
+        it { is_expected.to eq(0) }
+      end
+
+      context "when there is a cancellation_cost" do
+        before { instrument.price_policies.update_all(cancellation_cost: 45.75) }
+        it { is_expected.to eq(45.75) }
+      end
+
+      context "when the price policy is set to charge for full reservation" do
+        before { instrument.price_policies.update_all(usage_rate: 1, charge_full_price_on_cancellation: true) }
+        it { is_expected.to eq(60) } # usage_rate is per minute
+      end
+    end
   end
 end

--- a/spec/services/cancellation_fee_calculator_spec.rb
+++ b/spec/services/cancellation_fee_calculator_spec.rb
@@ -43,11 +43,19 @@ RSpec.describe CancellationFeeCalculator do
       context "when there is a cancellation_cost" do
         before { instrument.price_policies.update_all(cancellation_cost: 45.75) }
         it { is_expected.to eq(45.75) }
+
+        it "is not the full price charge" do
+          expect(calculator).not_to be_charge_full_price
+        end
       end
 
       context "when the price policy is set to charge for full reservation" do
         before { instrument.price_policies.update_all(usage_rate: 1, charge_full_price_on_cancellation: true) }
         it { is_expected.to eq(60) } # usage_rate is per minute
+
+        it "is the full price charge" do
+          expect(calculator).to be_charge_full_price
+        end
       end
     end
   end

--- a/vendor/engines/secure_rooms/app/views/secure_room_price_policies/_price_policy_fields.html.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_room_price_policies/_price_policy_fields.html.haml
@@ -17,10 +17,13 @@
     - @price_policies.each do |price_policy|
       - price_group = price_policy.price_group
       = fields_for "price_policy_#{price_group.id}", price_policy do |pp|
-        %tr
+        - row_class = []
+        - row_class << "js--masterInternalRow" if price_group.master_internal?
+        - row_class << "js--adjustmentRow" unless price_group.external? || price_group.master_internal?
+        %tr{class: row_class}
           %td= price_group.name
           %td= price_group.type_string
-          %td= pp.check_box :can_purchase, class: "can_purchase"
+          %td= pp.check_box :can_purchase, class: "js--canPurchase"
           - if price_group.external? || price_group.master_internal?
             = render "time_based_price_policies/amount_row", price_group: price_group, price_policy: price_policy, cancellation: false, minimum_cost: true, pp: pp
           - else


### PR DESCRIPTION
# Release Notes

Adds the ability to charge the full reservation cost (based on reservation times) on cancellation. This take precedence over the "Reservation/Cancellation Cost"

# Screenshot

<img width="925" alt="screen shot 2018-09-20 at 4 44 42 pm" src="https://user-images.githubusercontent.com/1099111/45848547-89846f00-bcf4-11e8-84ef-4c69b5e39219.png">

# Additional Context

This could have compliance issues for NU, so that's why it's being feature flagged. Also, Dartmouth overrides the `cancellation_cost` locale from "Reservation Cost" to "Cancellation Cost" so we'll want to adjust the local for this new field to match for them.

