### PR TITLE
Define colors

### DIFF
--- a/app/assets/stylesheets/nucore-overrides.scss
+++ b/app/assets/stylesheets/nucore-overrides.scss
@@ -9,3 +9,19 @@ Example of this to include here:
   $headerBackgroundColor: #571963;
   $headerColor: white;
 */
+
+// Shared
+$dark-grey: #3F3B26;
+$grey: #9B9B9B;
+$light-grey: #D4D1D1;
+$lighter-grey: #F3F3F3;
+
+// Manage Mode
+$orange: #FF7126;
+$orange: #F89662;
+$light-orange: #FFAE84;
+
+// Use mode
+$dark-blue: #4A9FF7;
+$blue: #C2DCF8;
+$light-blue: #CDE4FC;


### PR DESCRIPTION
# Release Notes

In nucore overrides, define SCSS variables for all colors

