### PR TITLE
[WIP] Use manage css

### DIFF
--- a/app/assets/stylesheets/bootstrap-variables.scss
+++ b/app/assets/stylesheets/bootstrap-variables.scss
@@ -1,1 +1,25 @@
 /* Fork specific bootstrap overrides go here. This is included before bootstrap. */
+
+@font-face {
+  font-family: 'Inter UI';
+  font-style:  normal;
+  font-weight: 400;
+  src: font-url("Inter-UI-Regular.woff2") format("woff2"),
+  font-url("Inter-UI-Regular.woff") format("woff");
+}
+@font-face {
+  font-family: 'Inter UI';
+  font-style:  normal;
+  font-weight: 500;
+  src: font-url("Inter-UI-Medium.woff2") format("woff2"),
+  font-url("Inter-UI-Medium.woff") format("woff");
+}
+@font-face {
+  font-family: 'Inter UI';
+  font-style:  normal;
+  font-weight: 700;
+  src: font-url("Inter-UI-Bold.woff2") format("woff2"),
+  font-url("Inter-UI-Bold.woff") format("woff");
+}
+
+$sansFontFamily: "Inter UI";

--- a/app/assets/stylesheets/nucore-overrides.scss
+++ b/app/assets/stylesheets/nucore-overrides.scss
@@ -56,7 +56,6 @@ html,body{
   text-decoration: none;
   color: black;
   transition: ease 0.3s all;
-  margin-bottom: -1px;
 }
 .nav li.active{
   border:none !important;

--- a/app/assets/stylesheets/nucore-overrides.scss
+++ b/app/assets/stylesheets/nucore-overrides.scss
@@ -1,4 +1,7 @@
 /*
+UCONN Fork Styling
+Unfortunately, many of our overrides require !important to apply correctly.
+
 Fork-specific styling should go in this file. This is included after Bootstrap,
 so you will have access to Bootstrap's variables and mixins.
 
@@ -41,9 +44,6 @@ html,body{
   background: none;
   border: none;
 }
-.visible-with-nav .navbar-inner {
-  // border: 1px solid transparent;
-}
 .brand{
   font-family: inherit !important;
 }
@@ -61,7 +61,6 @@ html,body{
 .nav li.active{
   border:none !important;
   margin-top: 0 !important;
-  // border-top: none ;
 }
 .nav li.active a{
   border: 1px solid $orange !important;

--- a/app/assets/stylesheets/nucore-overrides.scss
+++ b/app/assets/stylesheets/nucore-overrides.scss
@@ -42,6 +42,7 @@ html,body{
 
 body nav .navbar-inner .container .nav, .nav-tabs{
   border-bottom: 1px solid $orange;
+  min-height: 40px;
 }
 
 .manage-mode nav .navbar-inner .container .nav, 

--- a/app/assets/stylesheets/nucore-overrides.scss
+++ b/app/assets/stylesheets/nucore-overrides.scss
@@ -35,7 +35,8 @@ html,body{
 body nav .navbar-inner .container .nav, .nav-tabs{
   border-bottom: 1px solid $blue;
 }
-.manage-mode nav .navbar-inner .container .nav, .nav-tabs {
+.manage-mode nav .navbar-inner .container .nav, 
+.manage-mode .nav-tabs {
   border-color: $orange;
 }
 .alert-info {

--- a/app/assets/stylesheets/nucore-overrides.scss
+++ b/app/assets/stylesheets/nucore-overrides.scss
@@ -35,8 +35,8 @@ html,body{
 body nav .navbar-inner .container .nav, .nav-tabs{
   border-bottom: 1px solid $blue;
 }
-.manage-mode .nav {
-  border-color: $orange
+.manage-mode nav .navbar-inner .container .nav, .nav-tabs {
+  border-color: $orange;
 }
 .alert-info {
   background-color: transparent;
@@ -78,6 +78,6 @@ body nav .navbar-inner .container .nav, .nav-tabs{
   box-shadow: none !important;
 }
 .manage-mode .nav li.active a{
-  border-color: $orange;
-
+  border-color: $orange !important;
+  border-bottom-color: transparent !important;
 }

--- a/app/assets/stylesheets/nucore-overrides.scss
+++ b/app/assets/stylesheets/nucore-overrides.scss
@@ -83,10 +83,19 @@ body nav .navbar-inner .container .nav, .nav-tabs{
   border-bottom-color: transparent !important;
 }
 
+#use_tab, .manage-button {
+  text-align: center;
+}
+
+#use_tab {
+  width: 44px;
+  height: 23px;
+}
+
 #use_tab a{
   border: solid $orange 1px !important;
-  border-radius: 10px;
-  padding: 4px 20px;
+  border-radius: 8px;
+  padding: 3px 8px;
   margin-top: 5px;
 }
 
@@ -105,13 +114,15 @@ body nav .navbar-inner .container .nav, .nav-tabs{
 }
 
 .manage-button {
-  margin: 0 1em;
+  margin: 0 10px;
+  width: 76px;
+  height: 23px;
 }
 
 .manage-button a{
   border: solid $orange 1px !important;
-  border-radius: 10px;
-  padding: 4px 20px !important;
+  border-radius: 8px;
+  padding: 3px 8px !important;
   margin-top: 5px;
 }
 

--- a/app/assets/stylesheets/nucore-overrides.scss
+++ b/app/assets/stylesheets/nucore-overrides.scss
@@ -29,16 +29,20 @@ body {
   background: linear-gradient(to bottom, #ffffff 53%,#e4e4e4 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#e4e4e4',GradientType=0 ); /* IE6-9 */
 }
+
 html,body{
   min-height: 100%;
 }
+
 body nav .navbar-inner .container .nav, .nav-tabs{
   border-bottom: 1px solid $orange;
 }
+
 .manage-mode nav .navbar-inner .container .nav, 
 .manage-mode .nav-tabs {
   border-color: $blue;
 }
+
 .alert-info {
   background-color: transparent;
   border-color: transparent;
@@ -56,10 +60,12 @@ body nav .navbar-inner .container .nav, .nav-tabs{
 .brand{
   font-family: inherit !important;
 }
+
 .nav li:hover{
   border: none !important;
   margin-top: 0 !important;
 }
+
 .nav li a{
   padding: 13px;
   text-decoration: none;
@@ -71,6 +77,7 @@ body nav .navbar-inner .container .nav, .nav-tabs{
   margin-top: 0 !important;
   margin-bottom: -1px;
 }
+
 .nav li.active a{
   border: 1px solid $orange !important;
   border-radius: 4px 4px 0 0;
@@ -78,6 +85,7 @@ body nav .navbar-inner .container .nav, .nav-tabs{
   background-color: white !important;
   box-shadow: none !important;
 }
+
 .manage-mode .nav li.active a{
   border-color: $blue !important;
   border-bottom-color: transparent !important;
@@ -95,8 +103,8 @@ body nav .navbar-inner .container .nav, .nav-tabs{
 #use_tab a{
   border: solid $orange 1px !important;
   border-radius: 8px;
-  padding: 3px 8px;
-  margin-top: 5px;
+  padding: 1px 1px;
+  margin-top: 9px;
 }
 
 .manage-mode #use_tab a{
@@ -122,8 +130,8 @@ body nav .navbar-inner .container .nav, .nav-tabs{
 .manage-button a{
   border: solid $orange 1px !important;
   border-radius: 8px;
-  padding: 3px 8px !important;
-  margin-top: 5px;
+  padding: 1px 1px !important;
+  margin-top: 9px;
 }
 
 .manage-mode .manage-button a{

--- a/app/assets/stylesheets/nucore-overrides.scss
+++ b/app/assets/stylesheets/nucore-overrides.scss
@@ -33,16 +33,16 @@ html,body{
   min-height: 100%;
 }
 body nav .navbar-inner .container .nav, .nav-tabs{
-  border-bottom: 1px solid $blue;
+  border-bottom: 1px solid $orange;
 }
 .manage-mode nav .navbar-inner .container .nav, 
 .manage-mode .nav-tabs {
-  border-color: $orange;
+  border-color: $blue;
 }
 .alert-info {
   background-color: transparent;
   border-color: transparent;
-  color: $orange;
+  color: $blue;
   font-size: 24px;
   line-height: 1em;
 }
@@ -72,36 +72,36 @@ body nav .navbar-inner .container .nav, .nav-tabs{
   margin-bottom: -1px;
 }
 .nav li.active a{
-  border: 1px solid $blue !important;
+  border: 1px solid $orange !important;
   border-radius: 4px 4px 0 0;
   border-bottom-color: transparent !important;
   background-color: white !important;
   box-shadow: none !important;
 }
 .manage-mode .nav li.active a{
-  border-color: $orange !important;
+  border-color: $blue !important;
   border-bottom-color: transparent !important;
 }
 
 #use_tab a{
-  border: solid $blue 1px !important;
+  border: solid $orange 1px !important;
   border-radius: 10px;
   padding: 4px 20px;
   margin-top: 5px;
 }
 
 .manage-mode #use_tab a{
-  border-color: $orange !important;
+  border-color: $blue !important;
 }
 
 #use_tab.active a{
   text-shadow: none;
-  background-color: $blue !important;
+  background-color: $orange !important;
   color: white;
 }
 
 .manage-mode #use_tab.active a{
-  background-color: $orange !important;
+  background-color: $blue !important;
 }
 
 .manage-button {
@@ -109,19 +109,19 @@ body nav .navbar-inner .container .nav, .nav-tabs{
 }
 
 .manage-button a{
-  border: solid $blue 1px !important;
+  border: solid $orange 1px !important;
   border-radius: 10px;
   padding: 4px 20px !important;
   margin-top: 5px;
 }
 
 .manage-mode .manage-button a{
-  border-color: $orange !important;
-  background-color: $orange !important;
+  border-color: $blue !important;
+  background-color: $blue !important;
   text-shadow: none !important;
   color: white !important;
 }
 
 .manage-mode .manage-button.active a{
-  background-color: $orange !important;
+  background-color: $blue !important;
 }

--- a/app/assets/stylesheets/nucore-overrides.scss
+++ b/app/assets/stylesheets/nucore-overrides.scss
@@ -12,13 +12,17 @@ Example of this to include here:
   $headerBackgroundColor: #571963;
   $headerColor: white;
 */
+// Shared
 $dark-grey: #3F3B26;
 $grey: #9B9B9B;
+// Manage Mode
 $light-orange: #FFAE84;
 $orange: #FF7126;
+// Use mode
+$light-blue: #CDE4FC;
+$blue: #4A9FF7;
 
 body {
-  
   background: #ffffff; /* Old browsers */
   background: -moz-linear-gradient(top, #ffffff 53%, #e4e4e4 100%); /* FF3.6-15 */
   background: -webkit-linear-gradient(top, #ffffff 53%,#e4e4e4 100%); /* Chrome10-25,Safari5.1-6 */
@@ -28,8 +32,11 @@ body {
 html,body{
   min-height: 100%;
 }
-.nav{
-  border-bottom: 1px solid $orange;
+body nav .navbar-inner .container .nav, .nav-tabs{
+  border-bottom: 1px solid $blue;
+}
+.manage-mode .nav {
+  border-color: $orange
 }
 .alert-info {
   background-color: transparent;
@@ -44,6 +51,7 @@ html,body{
   background: none;
   border: none;
 }
+
 .brand{
   font-family: inherit !important;
 }
@@ -60,11 +68,16 @@ html,body{
 .nav li.active{
   border:none !important;
   margin-top: 0 !important;
+  margin-bottom: -1px;
 }
 .nav li.active a{
-  border: 1px solid $orange !important;
+  border: 1px solid $blue !important;
   border-radius: 4px 4px 0 0;
   border-bottom-color: transparent !important;
   background-color: white !important;
   box-shadow: none !important;
+}
+.manage-mode .nav li.active a{
+  border-color: $orange;
+
 }

--- a/app/assets/stylesheets/nucore-overrides.scss
+++ b/app/assets/stylesheets/nucore-overrides.scss
@@ -84,7 +84,7 @@ body nav .navbar-inner .container .nav, .nav-tabs{
 
 #use_tab a{
   border: solid $blue 1px !important;
-  border-radius: 6px;
+  border-radius: 10px;
   padding: 4px 20px;
   margin-top: 5px;
 }
@@ -100,5 +100,27 @@ body nav .navbar-inner .container .nav, .nav-tabs{
 }
 
 .manage-mode #use_tab.active a{
+  background-color: $orange !important;
+}
+
+.manage-button {
+  margin: 0 1em;
+}
+
+.manage-button a{
+  border: solid $blue 1px !important;
+  border-radius: 10px;
+  padding: 4px 20px !important;
+  margin-top: 5px;
+}
+
+.manage-mode .manage-button a{
+  border-color: $orange !important;
+  background-color: $orange !important;
+  text-shadow: none !important;
+  color: white !important;
+}
+
+.manage-mode .manage-button.active a{
   background-color: $orange !important;
 }

--- a/app/assets/stylesheets/nucore-overrides.scss
+++ b/app/assets/stylesheets/nucore-overrides.scss
@@ -9,3 +9,64 @@ Example of this to include here:
   $headerBackgroundColor: #571963;
   $headerColor: white;
 */
+$dark-grey: #3F3B26;
+$grey: #9B9B9B;
+$light-orange: #FFAE84;
+$orange: #FF7126;
+
+body {
+  
+  background: #ffffff; /* Old browsers */
+  background: -moz-linear-gradient(top, #ffffff 53%, #e4e4e4 100%); /* FF3.6-15 */
+  background: -webkit-linear-gradient(top, #ffffff 53%,#e4e4e4 100%); /* Chrome10-25,Safari5.1-6 */
+  background: linear-gradient(to bottom, #ffffff 53%,#e4e4e4 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#e4e4e4',GradientType=0 ); /* IE6-9 */
+}
+html,body{
+  min-height: 100%;
+}
+.nav{
+  border-bottom: 1px solid $orange;
+}
+.alert-info {
+  background-color: transparent;
+  border-color: transparent;
+  color: $orange;
+  font-size: 24px;
+  line-height: 1em;
+}
+
+.navbar-inner {
+  box-shadow: none !important;
+  background: none;
+  border: none;
+}
+.visible-with-nav .navbar-inner {
+  // border: 1px solid transparent;
+}
+.brand{
+  font-family: inherit !important;
+}
+.nav li:hover{
+  border: none !important;
+  margin-top: 0 !important;
+}
+.nav li a{
+  padding: 13px;
+  text-decoration: none;
+  color: black;
+  transition: ease 0.3s all;
+  margin-bottom: -1px;
+}
+.nav li.active{
+  border:none !important;
+  margin-top: 0 !important;
+  // border-top: none ;
+}
+.nav li.active a{
+  border: 1px solid $orange !important;
+  border-radius: 4px 4px 0 0;
+  border-bottom-color: transparent !important;
+  background-color: white !important;
+  box-shadow: none !important;
+}

--- a/app/assets/stylesheets/nucore-overrides.scss
+++ b/app/assets/stylesheets/nucore-overrides.scss
@@ -114,7 +114,7 @@ body nav .navbar-inner .container .nav, .nav-tabs{
 }
 
 .manage-mode #use_tab a{
-  border-color: $blue !important;
+  border-color: $grey !important;
 }
 
 #use_tab.active a{
@@ -134,7 +134,7 @@ body nav .navbar-inner .container .nav, .nav-tabs{
 }
 
 .manage-button a{
-  border: solid $orange 1px !important;
+  border: solid $grey 1px !important;
   border-radius: 8px;
   padding: 1px 1px !important;
   margin-top: 9px;

--- a/app/assets/stylesheets/nucore-overrides.scss
+++ b/app/assets/stylesheets/nucore-overrides.scss
@@ -29,7 +29,13 @@ body {
   background: linear-gradient(to bottom, #ffffff 53%,#e4e4e4 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#e4e4e4',GradientType=0 ); /* IE6-9 */
 }
-
+.manage-mode {
+  background: #ffffff; /* Old browsers */
+  background: -moz-linear-gradient(top, #ffffff 53%, $light-blue 100%); /* FF3.6-15 */
+  background: -webkit-linear-gradient(top, #ffffff 53%,$light-blue 100%); /* Chrome10-25,Safari5.1-6 */
+  background: linear-gradient(to bottom, #ffffff 53%, $light-blue 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='$light-blue',GradientType=0 ); /* IE6-9 */
+}
 html,body{
   min-height: 100%;
 }

--- a/app/assets/stylesheets/nucore-overrides.scss
+++ b/app/assets/stylesheets/nucore-overrides.scss
@@ -81,3 +81,24 @@ body nav .navbar-inner .container .nav, .nav-tabs{
   border-color: $orange !important;
   border-bottom-color: transparent !important;
 }
+
+#use_tab a{
+  border: solid $blue 1px !important;
+  border-radius: 6px;
+  padding: 4px 20px;
+  margin-top: 5px;
+}
+
+.manage-mode #use_tab a{
+  border-color: $orange !important;
+}
+
+#use_tab.active a{
+  text-shadow: none;
+  background-color: $blue !important;
+  color: white;
+}
+
+.manage-mode #use_tab.active a{
+  background-color: $orange !important;
+}

--- a/app/views/shared/nav/_manage_facilities.html.haml
+++ b/app/views/shared/nav/_manage_facilities.html.haml
@@ -1,8 +1,8 @@
 - if !acting_as? && current_user.try(:administrator?)
-  %li= link_to text("pages.manage", model: Facility.model_name.human(count: 2)), :list_facilities
+  %li.manage-button= link_to text("pages.manage", model: Facility.model_name.human(count: 2)), :list_facilities
 
 - elsif !acting_as? && menu_facilities.any?
-  %li.dropdown.pull-right{class: controller.active_tab == "manage_facilites" ? "active" : ""}
+  %li.manage-button.dropdown.pull-right{class: controller.active_tab == "manage_facilites" ? "active" : ""}
     = link_to "#", class: "dropdown-toggle", data: { toggle: :dropdown, target: "#" } do
       = t("pages.manage", model: t("activerecord.models.facility", count: 2))
       %b.caret

--- a/app/views/shared/nav/_manage_facilities.html.haml
+++ b/app/views/shared/nav/_manage_facilities.html.haml
@@ -1,10 +1,10 @@
 - if !acting_as? && current_user.try(:administrator?)
-  %li.manage-button= link_to text("pages.manage", model: Facility.model_name.human(count: 2)), :list_facilities
+  %li.manage-button= link_to text("pages.manage_short"), :list_facilities
 
 - elsif !acting_as? && menu_facilities.any?
   %li.manage-button.dropdown.pull-right{class: controller.active_tab == "manage_facilites" ? "active" : ""}
     = link_to "#", class: "dropdown-toggle", data: { toggle: :dropdown, target: "#" } do
-      = t("pages.manage", model: t("activerecord.models.facility", count: 2))
+      = t("pages.manage_short")
       %b.caret
     %ul.dropdown-menu
       - menu_facilities.each do |facility|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,6 +68,7 @@ en:
     login: Login
     logout: Logout
     manage: Manage %{model}
+    manage_short: Manage
     my_tab: My %{model}
     transactions: My Transactions
     notices: Notices

--- a/config/locales/override/en.yml
+++ b/config/locales/override/en.yml
@@ -1,6 +1,6 @@
 # Put any locale overrides specific to your fork in this file
 en:
-  # app_name: NUcore
+  app_name: CIDER
   # institution_name: Northwestern
 
   # shared:

--- a/config/locales/override/en.yml
+++ b/config/locales/override/en.yml
@@ -3,10 +3,10 @@ en:
   app_name: CIDER
   institution_name: UConn
 
-  # shared:
-  #   footer:
-  #     copyright_html: "&copy; Copyright 2011%{to_date} Northwestern University"
-  #     logo_alt: "Northwestern University Logo"
+  shared:
+    footer:
+      copyright_html: "&copy; Copyright 2018&ndash;%{to_date} University of Connecticut"
+      logo_alt: "UConn Logo"
 
   testing: # DO NOT DELETE: these are used to verify proper file loading in the specs
     locale_loading: This is here to verify the file is loaded in the specs

--- a/config/locales/override/en.yml
+++ b/config/locales/override/en.yml
@@ -1,7 +1,7 @@
 # Put any locale overrides specific to your fork in this file
 en:
   app_name: CIDER
-  # institution_name: Northwestern
+  institution_name: UConn
 
   # shared:
   #   footer:


### PR DESCRIPTION
# Release Notes

Implement the design changes associated with the Use/Manage layout. This includes:
* New navbar
* New use/manage buttons
* Gradient background
* Small fix to prevent the app logo background from contrasting with the gradient
* Color changes depending on which mode the user is in

# Screenshot

## Use
<img width="1280" alt="screen shot 2018-09-28 at 12 23 56 pm" src="https://user-images.githubusercontent.com/5000430/46221012-ddf1a500-c319-11e8-9b44-da8e6393fc54.png">

## Manage
<img width="1280" alt="screen shot 2018-09-28 at 12 24 08 pm" src="https://user-images.githubusercontent.com/5000430/46221038-f366cf00-c319-11e8-85e2-2532f309969d.png">

## Logo before/after
<img width="784" alt="screen shot 2018-09-28 at 9 55 43 am" src="https://user-images.githubusercontent.com/5000430/46221047-f95cb000-c319-11e8-8c69-784d27b8b03f.png">
<img width="809" alt="screen shot 2018-09-28 at 9 54 54 am" src="https://user-images.githubusercontent.com/5000430/46221058-fe216400-c319-11e8-98de-2362948b9fd7.png">

# Additional Context

This is a WIP. The buttons sizing and spacing will likely be tweaked slightly.