### PR TITLE
[#142011] Allow global admins to unreconcile orders

### DIFF
--- a/app/controllers/reconcilliations_controller.rb
+++ b/app/controllers/reconcilliations_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ReconcilliationsController < ApplicationController
+
+  load_resource :order
+  load_resource :order_detail, through: :order
+
+  def destroy
+    if current_user.administrator?
+      @order_detail.update!(state: "complete", order_status: OrderStatus.complete, reconciled_at: nil)
+      redirect_to facility_transactions_path(current_facility)
+    else
+      raise CanCan::AccessDenied
+    end
+  end
+
+end

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -28,7 +28,9 @@
         - else
           = f.label :order_status
           = @order_detail.order_status
-          = l(@order_detail.reconciled_at.to_date, format: :usa) if @order_detail.reconciled_at
+          - if f.object.reconciled? && current_user.administrator?
+            = l(@order_detail.reconciled_at.to_date, format: :usa)
+            = link_to t("facility_order_details.edit.label.unreconcile"), facility_order_order_detail_reconcilliation_path(current_facility, @order, @order_detail), method: :delete
 
         - if @order_detail.reservation
           .cancel-fee-option

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -475,6 +475,7 @@ en:
         reconcile: "Reconciliation Note:"
         with_cancel_fee: Add reservation cost
         updating: Calculating Price
+        unreconcile: Unreconcile
       instruct:
         dispute: "To resolve the dispute, please make the necessary changes and click \"Resolve Dispute\"."
         bundle: "This order is part of a bundle.  Below is a summary of related bundle order line items."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -179,6 +179,7 @@ Nucore::Application.routes.draw do
       resources :order_details, controller: "facility_order_details", only: [:show, :destroy] do
         resources :reservations, controller: "facility_reservations", only: [:edit, :update, :show]
         resources :accessories, only: [:new, :create]
+        resource :reconcilliation, only: [:destroy]
         member do
           get "manage", to: "order_management/order_details#edit"
           patch "manage", to: "order_management/order_details#update"

--- a/spec/controllers/reconcilliations_controller_spec.rb
+++ b/spec/controllers/reconcilliations_controller_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "controller_spec_helper"
+
+RSpec.describe ReconcilliationsController do
+  before(:all) { create_users }
+
+  let(:user) { FactoryBot.create(:user) }
+  let(:facility) { FactoryBot.create(:setup_facility) }
+  let(:item) { FactoryBot.create(:item, facility: facility) }
+  let(:account) do
+    FactoryBot.create(:nufs_account, account_users_attributes: [FactoryBot.attributes_for(:account_user, user: user)]).tap do |account|
+      define_open_account item.account, account.account_number
+    end
+  end
+  let(:order_detail) { place_and_complete_item_order(user, facility, account) }
+
+  before :each do
+    order_detail.change_status! OrderStatus.reconciled
+  end
+
+  describe "DELETE to :destroy" do
+    context "for an administrator" do
+      before :each do
+        sign_in @admin
+        delete :destroy, params: { facility_id: facility.url_name, order_id: order_detail.order.id, order_detail_id: order_detail.id }
+      end
+
+      it "changes the order detail’s status to complete" do
+        expect(order_detail.reload.state).to eq "complete"
+      end
+
+      it "redirects the user to the facility transactions page" do
+        expect(response).to redirect_to facility_transactions_path(facility)
+      end
+    end
+
+    context "for a user that is not an administrator" do
+      before :each do
+        sign_in @director
+        delete :destroy, params: { facility_id: facility.url_name, order_id: order_detail.order.id, order_detail_id: order_detail.id }
+      end
+
+      it "does not allow the action" do
+        expect(response.code).to eq("403")
+      end
+    end
+  end
+end

--- a/spec/controllers/reconcilliations_controller_spec.rb
+++ b/spec/controllers/reconcilliations_controller_spec.rb
@@ -4,16 +4,10 @@ require "rails_helper"
 require "controller_spec_helper"
 
 RSpec.describe ReconcilliationsController do
-  before(:all) { create_users }
-
   let(:user) { FactoryBot.create(:user) }
   let(:facility) { FactoryBot.create(:setup_facility) }
   let(:item) { FactoryBot.create(:item, facility: facility) }
-  let(:account) do
-    FactoryBot.create(:nufs_account, account_users_attributes: [FactoryBot.attributes_for(:account_user, user: user)]).tap do |account|
-      define_open_account item.account, account.account_number
-    end
-  end
+  let(:account) { FactoryBot.create(:setup_account, owner: user) }
   let(:order_detail) { place_and_complete_item_order(user, facility, account) }
 
   before :each do
@@ -22,8 +16,10 @@ RSpec.describe ReconcilliationsController do
 
   describe "DELETE to :destroy" do
     context "for an administrator" do
+      let(:admin) { FactoryBot.create(:user, :administrator) }
+
       before :each do
-        sign_in @admin
+        sign_in admin
         delete :destroy, params: { facility_id: facility.url_name, order_id: order_detail.order.id, order_detail_id: order_detail.id }
       end
 
@@ -37,8 +33,10 @@ RSpec.describe ReconcilliationsController do
     end
 
     context "for a user that is not an administrator" do
+      let(:director) { create(:user, :facility_director, facility: facility) }
+
       before :each do
-        sign_in @director
+        sign_in director
         delete :destroy, params: { facility_id: facility.url_name, order_id: order_detail.order.id, order_detail_id: order_detail.id }
       end
 


### PR DESCRIPTION
# Release Notes

Allow global admins to unreconcile orders

# Screenshot

<img width="1012" alt="screen shot 2018-10-01 at 15 04 02" src="https://user-images.githubusercontent.com/7736/46290239-92dec880-c58b-11e8-9cbe-9496b35f28c5.png">
