### PR TITLE
Fixes for Rails 5 issues discovered in testing by NU

### DIFF
--- a/app/services/admin_reservation_expirer.rb
+++ b/app/services/admin_reservation_expirer.rb
@@ -10,7 +10,7 @@ class AdminReservationExpirer
 
   def expired_reservations
     if NUCore::Database.oracle?
-      AdminReservation.where("reserve_start_at - expires_mins_before / (60*24) < ?", Time.current)
+      AdminReservation.where("reserve_start_at - expires_mins_before / (60*24) < TO_TIMESTAMP(?)", Time.current)
     else
       AdminReservation.where("SUBTIME(reserve_start_at, MAKETIME(expires_mins_before DIV 60, expires_mins_before MOD 60, 0)) < ?", Time.current)
     end

--- a/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_results.html.haml
+++ b/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_results.html.haml
@@ -12,11 +12,11 @@
         = safe_join(@searcher.search_params_as_hidden_fields)
 
         = submit_tag t("bulk_email.compose_mail"),
-          data: { format: :html },
+          data: { format: :html, disable_with: false },
           class: "btn btn-primary js--bulk-email-submit-button js--bulk-email-compose-button"
 
       = submit_tag t("bulk_email.export"),
-        data: { format: :csv },
+        data: { format: :csv, disable_with: false },
         class: "btn btn-primary js--bulk-email-submit-button js--bulk-email-download-csv-button"
 
     .clear


### PR DESCRIPTION
# Release Notes

Fixes for Rails 5 issues discovered in testing

# Additional Context

1. Due to the datetime column changes, a `TO_TIMESTAMP` type cast is necessary to make the query in Oracle comparisons
2. Rails 5 automatically disables form submit buttons when they are clicked. On the bulk email form, this is undesirable for the Export button, since clicking the button doesn’t leave the page (the file is just downloaded).
