### PR TITLE
[#137154] Fix problem order email issues

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -303,7 +303,7 @@ class OrdersController < ApplicationController
     @available_statuses = %w(pending all)
     case params[:status]
     when "pending"
-      @order_details = @order_details.pending
+      @order_details = @order_details.new_or_inprocess
     when "all"
       @order_details = @order_details.purchased
     else

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -168,9 +168,7 @@ class OrderDetail < ApplicationRecord
       .where("order_details.state != ?", "canceled")
   end
 
-  def self.purchased_active_reservations
-    pending.joins(:reservation).merge(Reservation.not_canceled)
-  end
+  scope :purchased_active_reservations, -> { new_or_inprocess.joins(:reservation).merge(Reservation.not_canceled) }
 
   scope :with_price_policy, -> { where.not(price_policy_id: nil) }
 
@@ -278,8 +276,6 @@ class OrderDetail < ApplicationRecord
   scope :reservations, -> { for_product_type("Instrument") }
 
   scope :purchased, -> { joins(:order).merge(Order.purchased) }
-
-  scope :pending, -> { joins(:order).where(state: %w(new inprocess)).purchased }
 
   scope :with_reservation, -> { purchased.joins(:reservation).order("reservations.reserve_start_at DESC") }
   scope :with_upcoming_reservation, lambda {
@@ -480,6 +476,10 @@ class OrderDetail < ApplicationRecord
   def cancelable?
     # can't cancel if the reservation isn't already canceled or if this OD has been added to a journal
     state_is_cancelable? && journal.nil? && !has_uncanceled_reservation?
+  end
+
+  def pending?
+    order.purchased? && state.in?(%w[new inprocess])
   end
 
   delegate :ordered_on_behalf_of?, to: :order

--- a/app/services/move_to_problem_queue.rb
+++ b/app/services/move_to_problem_queue.rb
@@ -14,7 +14,7 @@ class MoveToProblemQueue
   def move!
     # Some scopes may accidentally try send already-complete orders to the queue.
     # This protects against sending duplicate emails to things already in the queue.
-    return unless OrderDetail.pending.include?(@order_detail)
+    return unless @order_detail.pending?
 
     @order_detail.time_data.force_completion = @force
     @order_detail.complete!

--- a/app/services/move_to_problem_queue.rb
+++ b/app/services/move_to_problem_queue.rb
@@ -12,6 +12,10 @@ class MoveToProblemQueue
   end
 
   def move!
+    # Some scopes may accidentally try send already-complete orders to the queue.
+    # This protects against sending duplicate emails to things already in the queue.
+    return unless OrderDetail.pending.include?(@order_detail)
+
     @order_detail.time_data.force_completion = @force
     @order_detail.complete!
     # TODO: Can probably remove this at some point, but it's a safety check for now

--- a/spec/controllers/offline_reservations_controller_spec.rb
+++ b/spec/controllers/offline_reservations_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe OfflineReservationsController do
 
     context "when an ongoing reservation exists for the instrument" do
       let!(:reservation) do
-        FactoryBot.create(:setup_reservation, :running, product: instrument)
+        FactoryBot.create(:purchased_reservation, :running, product: instrument)
       end
 
       it "becomes a problem reservation" do
@@ -43,6 +43,26 @@ RSpec.describe OfflineReservationsController do
 
       it "triggers an email" do
         expect { post :create, params: params }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      end
+    end
+
+    context "when a canceled problem reservation exists for the instrument" do
+      let!(:reservation) do
+        FactoryBot.create(:purchased_reservation, :running, product: instrument)
+      end
+
+      before do
+        reservation.order_detail.update_order_status!(reservation.user, OrderStatus.canceled, admin: true)
+        expect(reservation.order_detail).not_to be_problem
+      end
+
+      it "does not change the reservation" do
+        expect { post :create, params: params }
+          .not_to change { reservation.order_detail.reload.problem? }
+      end
+
+      it "does not triggers an email" do
+        expect { post :create, params: params }.not_to change(ActionMailer::Base.deliveries, :count)
       end
     end
   end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -5,6 +5,11 @@ FactoryBot.define do
     account { nil }
   end
 
+  trait :purchased do
+    ordered_at { 1.week.ago }
+    state { "purchased" }
+  end
+
   # Must define product or facility
   factory :setup_order, class: Order do
     transient do
@@ -14,11 +19,6 @@ FactoryBot.define do
     association :account, factory: :setup_account
     user { account.owner.user }
     created_by { account.owner.user.id }
-
-    trait :purchased do
-      ordered_at { 1.week.ago }
-      state { "purchased" }
-    end
 
     after(:create) do |order, evaluator|
       # build().save will allow an already existing relation without raising an error

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/order_handler.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/order_handler.rb
@@ -20,7 +20,7 @@ module SecureRooms
         return if user_exempt_from_purchase?
 
         find_or_create_order
-        complete_order
+        complete_order if occupancy.order_completable?
 
         order
       end
@@ -37,7 +37,11 @@ module SecureRooms
       end
 
       def complete_order
-        order_detail.complete! if occupancy.order_completable?
+        if occupancy.orphaned_at?
+          MoveToProblemQueue.move!(order_detail)
+        else
+          order_detail.complete!
+        end
       end
 
       def create_order

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/access_handlers/occupancy_handler_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/access_handlers/occupancy_handler_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe SecureRooms::AccessHandlers::OccupancyHandler, type: :service do
     context "event was successful" do
       let(:event) { create :event, :successful, card_reader: card_reader }
 
-      context "current_occupant?" do
+      context "when there is current_occupant" do
         let(:account) { create :account, :with_account_owner, owner: event.user }
         let!(:existing_occupancy) do
           create(
@@ -140,6 +140,12 @@ RSpec.describe SecureRooms::AccessHandlers::OccupancyHandler, type: :service do
         end
 
         context "exiting" do
+          # orders need to be "purchased" but we don't care about the details
+          before do
+            allow_any_instance_of(OrderDetail).to receive(:valid_for_purchase?).and_return(true)
+            allow_any_instance_of(SecureRooms::AccessHandlers::OrderHandler).to receive(:user_exempt_from_purchase?).and_return(false)
+          end
+
           let(:card_reader) { create :card_reader, ingress: false }
 
           describe "the new occupancy" do

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/access_handlers/order_handler_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/access_handlers/order_handler_spec.rb
@@ -85,6 +85,27 @@ RSpec.describe SecureRooms::AccessHandlers::OrderHandler, type: :service do
           end
         end
       end
+
+      context "when orphaned" do
+        let(:occupancy) do
+          create(
+            :occupancy,
+            :orphan,
+            user: user,
+            secure_room: secure_room,
+            account: account,
+          )
+        end
+
+        subject(:order_detail) { described_class.process(occupancy).order_details.first }
+
+        it { is_expected.to be_complete }
+        it { is_expected.to be_problem }
+
+        it "triggers an email" do
+          expect { described_class.process(occupancy) }.to change(ActionMailer::Base.deliveries, :count).by(1)
+        end
+      end
     end
 
     context "without an occupancy account" do

--- a/vendor/engines/secure_rooms/spec/support/auto_orphan_occupancy_spec.rb
+++ b/vendor/engines/secure_rooms/spec/support/auto_orphan_occupancy_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SecureRooms::AutoOrphanOccupancy, :time_travel do
   let(:user) { create(:user, card_number: "123456") }
   let(:account) { create(:nufs_account, :with_account_owner, owner: user) }
 
-  let(:order) { create(:order, account: account, created_by_user: user, user: user, facility: secure_room.facility) }
+  let(:order) { create(:order, :purchased, account: account, created_by_user: user, user: user, facility: secure_room.facility) }
   let(:order_detail) { order.order_details.create(attributes_for(:order_detail, account: account, product: secure_room)) }
 
   before { secure_room.product_users.create!(user: user, approved_by: 0) }


### PR DESCRIPTION
# Release Notes

Fixes issues with emailing users when an order goes into the problem queue (#1685):

* Duplicate emails were being sent out
* Hard error when there was a problem order that had been canceled
* Email was not being sent when scanning out of a room without an entry scan
* Email was not being sent when double-scanning in
