### PR TITLE
[#142635] Keep date navigation on timeline pages always visible

### DIFF
--- a/app/assets/javascripts/timeline.js
+++ b/app/assets/javascripts/timeline.js
@@ -20,7 +20,10 @@ $(function() {
     showOn: "button",
     buttonText: "<i class='fa fa-calendar icon-large'>",
   }).change(function() {
-    $(this).parents("form").submit();
+    var form = $(this).parents('form');
+    var formUrl = form.attr('action');
+    form.attr('action', formUrl + '#' + lastHiddenInstrumentId());
+    form.submit();
   });
 
   //Get the Current Hour, create a class and add it the time div
@@ -108,13 +111,16 @@ $(function() {
   // Only try to load relay statuses if there are relays to check
   if ($('.relay_checkbox :checkbox').length > 0) loadRelayStatuses();
 
-  $('#reservation_left, #reservation_right').on('click', function(event) {
-    var heightOfDateNav = $('.timeline_header').outerHeight();
+  function lastHiddenInstrumentId() {
     var hiddenInstruments = $('.timeline_instrument').filter(function() {
       return $(window).scrollTop() > $(this).offset().top;
-    })
-    var urlFragment = hiddenInstruments.last().attr('id');
+    });
+
+    return hiddenInstruments.last().attr('id');
+  }
+
+  $('#reservation_left, #reservation_right').on('click', function(event) {
     var urlWithoutFragment = this.href.split('#')[0]
-    this.href = urlWithoutFragment + '#' + urlFragment
+    this.href = urlWithoutFragment + '#' + lastHiddenInstrumentId()
   });
 });

--- a/app/assets/javascripts/timeline.js
+++ b/app/assets/javascripts/timeline.js
@@ -52,26 +52,27 @@ $(function() {
   // no animation when first loading
   $('.status_canceled').toggle($('#show_canceled').is(':checked'));
 
-
-  $('.relay_checkbox :checkbox')
-  .bind('click', function(e) {
-    if (confirm("Are you sure you want to toggle the relay?")) {
-      $(this).parent().addClass("loading");
-      $.ajax({
-        url: $(this).data("relay-url"),
-        success: function(data) {
-          updateRelayStatus(data.instrument_status);
-        },
-        data: {
-          switch: $(this).is(":checked") ? "on" : "off"
-        },
-        dataType: 'json'
-      });
-    } else {
-      return false;
-    }
-  })
-  .toggleSwitch();
+  relayCheckboxes = $('.relay_checkbox :checkbox')
+  if (relayCheckboxes.length > 0) {
+    relayCheckboxes.bind('click', function(e) {
+      if (confirm("Are you sure you want to toggle the relay?")) {
+        $(this).parent().addClass("loading");
+        $.ajax({
+          url: $(this).data("relay-url"),
+          success: function(data) {
+            updateRelayStatus(data.instrument_status);
+          },
+          data: {
+            switch: $(this).is(":checked") ? "on" : "off"
+          },
+          dataType: 'json'
+        });
+      } else {
+        return false;
+      }
+    })
+    .toggleSwitch();
+  }
 
   function loadRelayStatuses() {
     $.ajax({

--- a/app/assets/javascripts/timeline.js
+++ b/app/assets/javascripts/timeline.js
@@ -106,4 +106,14 @@ $(function() {
   $('.relay_checkbox').addClass('loading');
   // Only try to load relay statuses if there are relays to check
   if ($('.relay_checkbox :checkbox').length > 0) loadRelayStatuses();
+
+  $('#reservation_left, #reservation_right').on('click', function(event) {
+    var heightOfDateNav = $('.timeline_header').outerHeight();
+    var instrumentsBelowScroll = $('.timeline_instrument').filter(function() {
+      return $(window).scrollTop() < heightOfDateNav + $(this).offset().top;
+    })
+    var instrumentToScrollTo = instrumentsBelowScroll[0]
+    var urlWithoutFragment = this.href.split('#')[0]
+    this.href = urlWithoutFragment + '#' + instrumentToScrollTo.id
+  });
 });

--- a/app/assets/javascripts/timeline.js
+++ b/app/assets/javascripts/timeline.js
@@ -110,11 +110,11 @@ $(function() {
 
   $('#reservation_left, #reservation_right').on('click', function(event) {
     var heightOfDateNav = $('.timeline_header').outerHeight();
-    var instrumentsBelowScroll = $('.timeline_instrument').filter(function() {
-      return $(window).scrollTop() < heightOfDateNav + $(this).offset().top;
+    var hiddenInstruments = $('.timeline_instrument').filter(function() {
+      return $(window).scrollTop() > $(this).offset().top;
     })
-    var instrumentToScrollTo = instrumentsBelowScroll[0]
+    var urlFragment = hiddenInstruments.last().attr('id');
     var urlWithoutFragment = this.href.split('#')[0]
-    this.href = urlWithoutFragment + '#' + instrumentToScrollTo.id
+    this.href = urlWithoutFragment + '#' + urlFragment
   });
 });

--- a/app/assets/stylesheets/app/timeline.scss
+++ b/app/assets/stylesheets/app/timeline.scss
@@ -160,16 +160,25 @@ body .unit {
 }
 
 .timeline_header {
+  background-color: white;
+  padding: 10px 0;
+  position: sticky;
   text-align: center;
-}
+  top: 0;
+  z-index: 100;
 
-/* Center the text excluding the calendar icon. The margin-left should be the width of the icon */
-.timeline_header h3 {
-  margin-left: 16px;
-}
+  form {
+    margin-bottom: 0
+  }
 
-.timeline_header i {
-  vertical-align: top;
+  /* Center the text excluding the calendar icon. The margin-left should be the width of the icon */
+  h3 {
+    margin-left: 16px;
+  }
+
+  i {
+    vertical-align: top;
+  }
 }
 
 .timeline_instrument {

--- a/app/views/shared/timeline/_instrument.html.haml
+++ b/app/views/shared/timeline/_instrument.html.haml
@@ -1,4 +1,4 @@
-.timeline_instrument
+.timeline_instrument[instrument]
   %h4
     - if public_timeline?
       = link_to instrument,


### PR DESCRIPTION
# Release Notes

Keep date navigation on timeline pages always visible

# Additional Context

This makes the date navigation always visible on the public timeline, and manage timeline pages for a facility. I tried to make the datepicker scroll along with the date navigation, but after a few attempts, including a fix [like this one](https://stackoverflow.com/a/22038827), I was unable to get this working. Since closing and reopening the date picker positions it correctly, I don’t think this is worth pursuing further.

A note about the instrument ids: because the date navigation is always visible, the JS code takes its height into account when determining which instrument is the first visible one. Therefore, the URL fragment when clicking next and previous gets set to the element which is partially covered by the date navigation, thus maintaining the first visible element between clicks. This doesn’t maintain the exact vertical pixel position, which would be more complicated since we’d have to scroll the viewport in JS (which I don’t think we should do), but I think that it is good enough for maintaining position on a long page.