### PR TITLE
Localize member roles for facility accounts

### DIFF
--- a/app/presenters/account_user_presenter.rb
+++ b/app/presenters/account_user_presenter.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
 
 class AccountUserPresenter < SimpleDelegator
+
   def self.localized_role(role)
-    I18n.t(role.downcase.parameterize.underscore, scope: "accounts.role") # Move the en.yml location to be more generic than `member_table`
+    I18n.t(role.downcase.parameterize.underscore, scope: "accounts.role")
   end
 
   def self.selectable_user_roles(granting_user = nil, facility = nil)
-    # Nothing other than the collection uses `selectable_user_roles`, so it could even be pulled up into this class
-    AccountUser.selectable_user_roles(granting_user, facility).map {  |role| [localized_role(role), role] }
+    AccountUser.selectable_user_roles(granting_user, facility).map { |role| [localized_role(role), role] }
   end
 
   def localized_role
     self.class.localized_role(user_role)
   end
+
 end

--- a/app/presenters/account_user_presenter.rb
+++ b/app/presenters/account_user_presenter.rb
@@ -1,0 +1,15 @@
+
+class AccountUserPresenter < SimpleDelegator
+  def self.localized_role(role)
+    I18n.t(role.downcase.parameterize.underscore, scope: "accounts.role") # Move the en.yml location to be more generic than `member_table`
+  end
+
+  def self.selectable_user_roles(granting_user = nil, facility = nil)
+    # Nothing other than the collection uses `selectable_user_roles`, so it could even be pulled up into this class
+    AccountUser.selectable_user_roles(granting_user, facility).map {  |role| [localized_role(role), role] }
+  end
+
+  def localized_role
+    self.class.localized_role(user_role)
+  end
+end

--- a/app/views/account_users/new.html.haml
+++ b/app/views/account_users/new.html.haml
@@ -16,7 +16,7 @@
     = u.input :full_name, as: :readonly, label: Account.human_attribute_name(:user)
   = f.input :user_id, as: :hidden, input_html: { value: @user.id, name: "user_id" }
 
-  = f.input :user_role, collection: AccountUser.selectable_user_roles, selected: "Purchaser"
+  = f.input :user_role, collection: AccountUserPresenter.selectable_user_roles(current_user, current_facility), selected: "Purchaser"
 
   %ul.inline
     %li= f.submit "Create", class: "btn"

--- a/app/views/accounts/_member_table.html.haml
+++ b/app/views/accounts/_member_table.html.haml
@@ -29,5 +29,6 @@
 
         %td= Users::NamePresenter.new(au.user, username_label: true).full_name
         %td= au.user.email
-        %td= t(".role.#{au.user_role.downcase.parameterize.underscore}")
+        
+        %td= AccountUserPresenter.new(au).localized_role
         = render_view_hook("member_table_columns", account_user: au)

--- a/app/views/accounts/_member_table.html.haml
+++ b/app/views/accounts/_member_table.html.haml
@@ -29,5 +29,5 @@
 
         %td= Users::NamePresenter.new(au.user, username_label: true).full_name
         %td= au.user.email
-        %td= au.user_role
+        %td= t(".role.#{au.user_role.downcase.parameterize.underscore}")
         = render_view_hook("member_table_columns", account_user: au)

--- a/app/views/facility_account_users/new.html.haml
+++ b/app/views/facility_account_users/new.html.haml
@@ -26,7 +26,7 @@
   = f.input :user_id, as: :hidden, input_html: { value: @user.id, name: "user_id" }
 
   = f.input :user_role,
-    collection: AccountUser.selectable_user_roles(current_user, current_facility).map {|role| [text("accounts.member_table.role.#{role.downcase.parameterize.underscore}"), role]},
+    collection: AccountUserPresenter.selectable_user_roles(current_user, current_facility),
     selected: @account_user.user_role,
     disabled: current_owner?
 

--- a/app/views/facility_account_users/new.html.haml
+++ b/app/views/facility_account_users/new.html.haml
@@ -26,7 +26,7 @@
   = f.input :user_id, as: :hidden, input_html: { value: @user.id, name: "user_id" }
 
   = f.input :user_role,
-    collection: AccountUser.selectable_user_roles(current_user, current_facility),
+    collection: AccountUser.selectable_user_roles(current_user, current_facility).map {|role| [text("accounts.member_table.role.#{role.downcase.parameterize.underscore}"), role]},
     selected: @account_user.user_role,
     disabled: current_owner?
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -805,6 +805,11 @@ en:
         name: Name (username)
         email: Email
         role: Role
+      role:
+        owner: Owner
+        business_administrator: Business Administrator
+        purchaser: Purchaser
+      
     show:
       head: "Payment Source Details"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -798,6 +798,10 @@ en:
       transaction_in_review:
         one: You have one transaction in review
         other: You have %{count} transactions in review
+    role:
+        owner: Owner
+        business_administrator: Business Administrator
+        purchaser: Purchaser
     member_table:
       add_access: Add Access
       remove_access: Remove Access
@@ -805,11 +809,6 @@ en:
         name: Name (username)
         email: Email
         role: Role
-      role:
-        owner: Owner
-        business_administrator: Business Administrator
-        purchaser: Purchaser
-      
     show:
       head: "Payment Source Details"
 


### PR DESCRIPTION
# Release Notes

Resolves https://github.com/SquaredLabs/nucore-uconn/issues/37

Added localization to member roles under facility accounts.

# Screenshot

<img width="894" alt="screen shot 2018-10-09 at 9 42 00 am" src="https://user-images.githubusercontent.com/5000430/46673610-2a55a400-cba8-11e8-862c-f0688944ebcb.png">


# Additional Context

Because the roles are hard coded and in the database, there is no way to elegantly allow them to be localized. 
See: `account_user.rb`
```ruby
  ACCOUNT_PURCHASER = "Purchaser"
  ACCOUNT_OWNER = "Owner"
  ACCOUNT_ADMINISTRATOR = "Business Administrator"
```
Business administrator has a space, so it cannot be used to query i18n. My best workaround is to convert it in the view:
```haml
%td= t(".role.#{au.user_role.downcase.parameterize.underscore}")
```