### PR TITLE
Update LDAP documentation

### DIFF
--- a/config/ldap.yml.template
+++ b/config/ldap.yml.template
@@ -11,4 +11,4 @@ development:
   base: dc=example,dc=org
   attribute: uid
   admin_user: "cn=admin,dc=example,dc=org"
-  admin_password: secret
+  admin_password: admin

--- a/vendor/engines/ldap_authentication/lib/ldap_authentication.rb
+++ b/vendor/engines/ldap_authentication/lib/ldap_authentication.rb
@@ -37,7 +37,10 @@ module LdapAuthentication
   end
 
   def self.load_config_from_file
-    yaml = YAML.safe_load(ERB.new(File.read(Rails.root.join("config", "ldap.yml"))).result) || {}
+    config_file_path = Rails.root.join("config", "ldap.yml")
+    parsed = ERB.new(File.read(config_file_path)).result
+    # safe_load(yaml, whitelist_classes, whitelist_symbols, allow_aliases)
+    yaml = YAML.safe_load(parsed, [], [], true) || {}
     yaml.fetch(Rails.env, {})
   end
 


### PR DESCRIPTION
# Release Notes

Update documentation for developing against LDAP

# Additional Context

I did this while starting to work on the tool for auto-suspending users if they are removed from the LDAP directory.

Removes older instructions for setting up an LDAP server on your Mac OS system. We now recommend using Docker.

This also adds the ability to use YAML aliases in the configuration.

# Questions

When we get to the story about removing if they're not in LDAP, do we think it might be worth seeding an LDAP server on Circle to test against? I feel that would be nice, but would make running a local test suite harder.
