### PR TITLE
[#143771] Prevent error on invalid dates on Reservation#update

### DIFF
--- a/app/support/reservations/duration_change_validations.rb
+++ b/app/support/reservations/duration_change_validations.rb
@@ -10,7 +10,6 @@ class Reservations::DurationChangeValidations
   include ActiveModel::Validations::Callbacks
 
   attr_reader :reservation
-
   validate :start_time_not_changed, unless: "reservation.in_cart?"
   validate :duration_not_shortened, unless: "reservation.in_cart?"
 
@@ -37,6 +36,8 @@ class Reservations::DurationChangeValidations
   end
 
   def duration_not_shortened
+    return unless reservation.reserve_start_at && reservation.reserve_end_at
+
     duration_was = TimeRange.new(reservation.reserve_start_at_was, reservation.reserve_end_at_was).duration_mins
     duration_is = TimeRange.new(reservation.reserve_start_at, reservation.reserve_end_at).duration_mins
 

--- a/app/support/reservations/duration_change_validations.rb
+++ b/app/support/reservations/duration_change_validations.rb
@@ -36,7 +36,7 @@ class Reservations::DurationChangeValidations
   end
 
   def duration_not_shortened
-    return unless reservation.reserve_start_at && reservation.reserve_end_at
+    return unless reservation.has_reserved_times?
 
     duration_was = TimeRange.new(reservation.reserve_start_at_was, reservation.reserve_end_at_was).duration_mins
     duration_is = TimeRange.new(reservation.reserve_start_at, reservation.reserve_end_at).duration_mins

--- a/spec/app_support/reservations/duration_change_validations_spec.rb
+++ b/spec/app_support/reservations/duration_change_validations_spec.rb
@@ -280,5 +280,22 @@ RSpec.describe Reservations::DurationChangeValidations do
         it { expect(validator).to be_invalid }
       end
     end
+
+    context "with invalid data" do
+      before { allow(reservation).to receive(:in_cart?).and_return(false) }
+
+      # Validation errors will be on the reservation for being blank
+      it "does not trigger the errors on the start date" do
+        reservation.assign_times_from_params(reserve_start_at: "10/0/2018")
+        expect(reservation.reserve_start_at).to be_blank
+        expect(validator).to be_valid
+      end
+
+      it "does not trigger the errors on the end date" do
+        reservation.assign_times_from_params(reserve_end_at: "10/0/2018")
+        expect(reservation.reserve_start_at).to be_blank
+        expect(validator).to be_valid
+      end
+    end
   end
 end


### PR DESCRIPTION
# Release Notes

Prevents an error on the reservation edit form when start/end at is blank because of invalid data.

# Additional Context

Here's the error: "NoMethodError: undefined method `<' for nil:NilClass" on the `if duration_is < duration_was` line. 

The error that we originally got notified of was super weird: it was missing the `reserve_start_mins` and `reserve_end_mins` parameters. I could recreate that if I deleted the dropdown from within my browser's dev tools. But I was able to replicate it as well by putting in an invalid date like "10/0/2018" into the date fields.
