### PR TITLE
[#144271] Fix bulk email in IE

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,3 +16,4 @@
 //= require clockpunch
 //= require fine-uploader/jquery.fine-uploader
 //= require moment
+//= require polyfills

--- a/vendor/assets/javascripts/polyfills.js
+++ b/vendor/assets/javascripts/polyfills.js
@@ -1,0 +1,1 @@
+//= require_tree ./polyfills

--- a/vendor/assets/javascripts/polyfills/array.includes.js
+++ b/vendor/assets/javascripts/polyfills/array.includes.js
@@ -1,0 +1,34 @@
+// From https://developer.mozilla.org/it/docs/Web/JavaScript/Reference/Global_Objects/Array/includes#Polyfill
+
+if (!Array.prototype.includes) {
+  Array.prototype.includes = function(searchElement /*, fromIndex*/) {
+    'use strict';
+    if (this == null) {
+      throw new TypeError('Array.prototype.includes called on null or undefined');
+    }
+
+    var O = Object(this);
+    var len = parseInt(O.length, 10) || 0;
+    if (len === 0) {
+      return false;
+    }
+    var n = parseInt(arguments[1], 10) || 0;
+    var k;
+    if (n >= 0) {
+      k = n;
+    } else {
+      k = len + n;
+      if (k < 0) {k = 0;}
+    }
+    var currentElement;
+    while (k < len) {
+      currentElement = O[k];
+      if (searchElement === currentElement ||
+         (searchElement !== searchElement && currentElement !== currentElement)) { // NaN !== NaN
+        return true;
+      }
+      k++;
+    }
+    return false;
+  };
+}


### PR DESCRIPTION
# Release Notes

Fix issue in IE where "Compose Mail" button was triggering CSV download rather than taking you to the compose form

# Additional Context

The bulk email JS code uses `Array.includes` which is not available in IE 11 and below (it is available in Edge). This adds a polyfill for that functionality.

The email form is not particularly pretty in IE (the email list and greeting line inputs are not a good height), but I believe that is outside the scope of this PR.

![screen shot 2018-10-12 at 6 37 38 pm](https://user-images.githubusercontent.com/1099111/46898359-948f7280-ce4e-11e8-9534-404e2b0bcb0f.png)

