### PR TITLE
[#139203] Add product description to training request page

### DIFF
--- a/app/controllers/training_requests_controller.rb
+++ b/app/controllers/training_requests_controller.rb
@@ -4,6 +4,7 @@ class TrainingRequestsController < ApplicationController
 
   include SortableColumnController
 
+  customer_tab :new, :create
   admin_tab :index
 
   before_action :authenticate_user!

--- a/app/views/products_common/_description.html.haml
+++ b/app/views/products_common/_description.html.haml
@@ -1,0 +1,14 @@
+- docs = product.stored_files.info
+.container
+  .row
+    - if docs.any?
+      .wysiwyg.span8= product.description
+      .span4
+        .well
+          %h3= text("documentation")
+          %ul.unstyled
+            - docs.each do |stored_file|
+              %li.document
+                = link_to stored_file.name, product_file_path(stored_file)
+    - else
+      .wysiwyg.span12= product.description

--- a/app/views/products_common/show.html.haml
+++ b/app/views/products_common/show.html.haml
@@ -9,19 +9,11 @@
 = content_for :h1 do
   = @product.name
 
-.wysiwyg.pull-left
-  = @product.description
-  - if acting_user.blank?
-    = link_to "Login", new_user_session_path, class: "btn"
-  - elsif @add_to_cart
-    = link_to "Add to cart", add_order_path(acting_user.cart(session_user), order: {order_details: [{product_id: @product.id, quantity: 1}] }), method: :put, class: "btn"
+= render "description", product: @product
 
-- docs = @product.stored_files.info
-- unless docs.empty?
-  .well.pull-right.span4
-    %h3 Documentation
-    %ul.unstyled
-      - docs.each do |stored_file|
-        %li.document
-          = link_to stored_file.name, product_file_path(stored_file)
+- if acting_user.blank?
+  = link_to "Login", new_user_session_path, class: "btn"
+- elsif @add_to_cart
+  = link_to "Add to cart", add_order_path(acting_user.cart(session_user), order: {order_details: [{product_id: @product.id, quantity: 1}] }), method: :put, class: "btn btn-primary"
+
 

--- a/app/views/reservations/_documentation.html.haml
+++ b/app/views/reservations/_documentation.html.haml
@@ -1,9 +1,0 @@
-- docs = @instrument.stored_files.info
-- if docs.any?
-  .row
-    .well.span4
-      %h3= t('reservations.new.documentation')
-      %ul.unstyled
-        - docs.each do |stored_file|
-          %li.document
-            = link_to stored_file.name, product_file_path(stored_file)

--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -19,12 +19,10 @@
 
 %h2= @instrument
 
-.wysiwyg= @instrument.description
-
 - if @instrument.offline?
   %p.alert.alert-danger= text("instruments.offline.notice")
 
-= render "documentation"
+= render "products_common/description", product: @instrument
 
 = simple_form_for [@order, @order_detail, @reservation], html: { class: "js--reservationForm js--reservationUpdateCreateAndStart" } do |f|
   = f.error_messages

--- a/app/views/training_requests/new.html.haml
+++ b/app/views/training_requests/new.html.haml
@@ -1,8 +1,26 @@
+= content_for :breadcrumb do
+  %ul.breadcrumb
+    %li= link_to t("pages.home"), facilities_path
+    %li &raquo;
+    %li= link_to @product.facility, facility_path(@product.facility)
+    %li &raquo;
+    %li= @product
+    %li &raquo;
+    %li= TrainingRequest.model_name.human
+
 = content_for :h1 do
   = current_facility
 
-= text(".requires_approval", product: @product)
+%h2= @product
 
-= form_tag facility_product_training_requests_path do
-  = submit_tag t("boolean.true"), class: "btn"
-  = link_to t("boolean.false"), facility_path(current_facility), class: "btn"
+= render "products_common/description", product: @product
+
+.well
+  %p
+    %i.fa.fa-lock
+    = text("requires_approval", product: @product)
+
+  = form_tag facility_product_training_requests_path do
+    %p
+      = submit_tag t("boolean.true"), class: "btn btn-primary"
+      = link_to t("boolean.false"), facility_path(current_facility), class: "btn"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -536,7 +536,6 @@ en:
       cancel: "Stay logged in"
     new:
       label: "Payment source"
-      documentation: "Documentation"
       crumb: "Create Reservation"
       notify: Send Notification
     list:

--- a/config/locales/views/en.products.yml
+++ b/config/locales/views/en.products.yml
@@ -1,5 +1,7 @@
 en:
   views:
     products_common:
+      description:
+        documentation: "Documentation"
       manage:
         none_entered: None Entered


### PR DESCRIPTION
# Release Notes

Add product description and documentation to training request page. Before, users weren't able to see any details about the product before requesting training. Now they can.

# Screenshot

Before:
<img width="1211" alt="training-request-current" src="https://user-images.githubusercontent.com/1099111/46898446-5e9ebe00-ce4f-11e8-876c-d3ff6fbf2340.png">

After:
<img width="1199" alt="training-request-proposed" src="https://user-images.githubusercontent.com/1099111/46898457-69f1e980-ce4f-11e8-9fc5-b12efd8ad790.png">

The same instrument's reservation page:
<img width="1211" alt="reservation-page" src="https://user-images.githubusercontent.com/1099111/46898468-770ed880-ce4f-11e8-89c4-577567227f9f.png">

