### PR TITLE
[#136151] Fix test failure when charge_full_price_on_cancellation is turned off

### DIFF
--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -1612,7 +1612,7 @@ RSpec.describe OrderDetail do
             end
           end
 
-          context "has full cost cancellation fee", feature_setting: { charge_full_price_on_cancellation_on: true } do
+          context "has full cost cancellation fee", feature_setting: { charge_full_price_on_cancellation: true } do
             before do
               PricePolicy.update_all(charge_full_price_on_cancellation: true, usage_rate: 3, usage_subsidy: 1)
               order_detail.price_policy.reload


### PR DESCRIPTION
# Release Notes

Tech task: Fix test failure when `charge_full_price_on_cancellation` feature is turned off.

# Additional Context

See test failure on https://github.com/tablexi/nucore-open/compare/disable_full_cancellation_cost?expand=1