### PR TITLE
[#144151] Add ability to override login form

### DIFF
--- a/app/helpers/view_hook_helper.rb
+++ b/app/helpers/view_hook_helper.rb
@@ -14,7 +14,7 @@ module ViewHookHelper
 
   def view_hook_exists?(placement)
     path = @virtual_path.gsub(%r{/_?}, ".")
-    ViewHook.exists?(path, placement)
+    ViewHook.find(path, placement).any?
   end
 
 end

--- a/app/helpers/view_hook_helper.rb
+++ b/app/helpers/view_hook_helper.rb
@@ -12,4 +12,9 @@ module ViewHookHelper
     ViewHook.render_view_hook(path, placement, self, args)
   end
 
+  def view_hook_exists?(placement)
+    path = @virtual_path.gsub(%r{/_?}, ".")
+    ViewHook.exists?(path, placement)
+  end
+
 end

--- a/app/presenters/view_hook.rb
+++ b/app/presenters/view_hook.rb
@@ -8,7 +8,7 @@ class ViewHook
       @instance ||= new
     end
 
-    delegate :add_hook, :remove_hook, :render_view_hook, to: :instance
+    delegate :add_hook, :remove_hook, :render_view_hook, :exists?, to: :instance
 
   end
 
@@ -25,6 +25,10 @@ class ViewHook
 
   def remove_hook(view, placement, partial)
     _view_hooks[view.to_s][placement.to_s].delete partial.to_s
+  end
+
+  def exists?(view, placement)
+    find(view, placement).any?
   end
 
   def find(view, placement)

--- a/app/presenters/view_hook.rb
+++ b/app/presenters/view_hook.rb
@@ -8,7 +8,7 @@ class ViewHook
       @instance ||= new
     end
 
-    delegate :add_hook, :remove_hook, :render_view_hook, :exists?, to: :instance
+    delegate :add_hook, :remove_hook, :render_view_hook, :find, to: :instance
 
   end
 
@@ -25,10 +25,6 @@ class ViewHook
 
   def remove_hook(view, placement, partial)
     _view_hooks[view.to_s][placement.to_s].delete partial.to_s
-  end
-
-  def exists?(view, placement)
-    find(view, placement).any?
   end
 
   def find(view, placement)

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,5 +1,5 @@
 = content_for :h1 do
-  = t("pages.login")
+  = text("title")
 
 = render_view_hook "before_login_form"
 
@@ -12,9 +12,9 @@
       = f.input :password, required: false
       = f.input :remember_me, as: :boolean if devise_mapping.rememberable?
 
-      = f.button :submit, t("pages.login"), class: ["btn", "btn-primary"]
+      = f.button :submit, text("submit"), class: ["btn", "btn-primary"]
 
   - if SettingsHelper.feature_on? :password_update
-    %p= link_to "Forgot password?", :reset_password
+    %p= link_to text("forgot_password"), :reset_password
 
 = render_view_hook("login_screen_announcement")

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -3,15 +3,18 @@
 
 = render_view_hook "before_login_form"
 
-= simple_form_for resource, as: resource_name, url: session_path(resource_name) do |f|
-  .form-inputs
-    = f.input :username, required: false, autofocus: true
-    = f.input :password, required: false
-    = f.input :remember_me, as: :boolean if devise_mapping.rememberable?
+- if view_hook_exists?("login_form")
+  = render_view_hook("login_form")
+- else
+  = simple_form_for resource, as: resource_name, url: session_path(resource_name) do |f|
+    .form-inputs
+      = f.input :username, required: false, autofocus: true
+      = f.input :password, required: false
+      = f.input :remember_me, as: :boolean if devise_mapping.rememberable?
 
-    = f.button :submit, t("pages.login"), class: ["btn", "btn-primary"]
+      = f.button :submit, t("pages.login"), class: ["btn", "btn-primary"]
 
-- if SettingsHelper.feature_on? :password_update
-  = link_to "Forgot password?", :reset_password
+  - if SettingsHelper.feature_on? :password_update
+    %p= link_to "Forgot password?", :reset_password
 
 = render_view_hook("login_screen_announcement")

--- a/config/locales/views/en.devise.yml
+++ b/config/locales/views/en.devise.yml
@@ -1,0 +1,8 @@
+en:
+  views:
+    devise:
+      sessions:
+        new:
+          title: "!pages.login!"
+          submit: "!pages.login!"
+          forgot_password: Forgot password?

--- a/vendor/engines/saml_authentication/app/views/saml_authentication/sessions/_new.html.haml
+++ b/vendor/engines/saml_authentication/app/views/saml_authentication/sessions/_new.html.haml
@@ -1,2 +1,2 @@
-%p= link_to text("sso_button"), new_saml_user_session_path, class: "btn btn-primary"
+%p= link_to text("sso_button"), new_saml_user_session_path, class: "btn btn-primary btn-large"
 %hr


### PR DESCRIPTION
# Release Notes

Tech task: Add a view hook to enable downstream forks to override the login form.

# Additional Context

Extracted from https://github.com/tablexi/nucore-dartmouth/pull/233 so we can collapse the login form via javascript to direct people to login via SSO instead.
