### PR TITLE
[#136151] Rename column to full_price_cancellation so it fits into Oracle <= 30 limit

### DIFF
--- a/app/models/instrument_price_policy.rb
+++ b/app/models/instrument_price_policy.rb
@@ -22,7 +22,7 @@ class InstrumentPricePolicy < PricePolicy
   end
 
   def charge_full_price_on_cancellation?
-    SettingsHelper.feature_on?(:charge_full_price_on_cancellation) && self[:charge_full_price_on_cancellation]
+    SettingsHelper.feature_on?(:charge_full_price_on_cancellation) && full_price_cancellation?
   end
 
   private

--- a/app/services/price_policy_updater.rb
+++ b/app/services/price_policy_updater.rb
@@ -65,7 +65,7 @@ class PricePolicyUpdater
       :unit_cost,
       :unit_subsidy,
     ].tap do |attributes|
-      attributes << :charge_full_price_on_cancellation if SettingsHelper.feature_on?(:charge_full_price_on_cancellation)
+      attributes << :full_price_cancellation if SettingsHelper.feature_on?(:charge_full_price_on_cancellation)
     end
   end
 

--- a/app/views/time_based_price_policies/_adjustment_row.html.haml
+++ b/app/views/time_based_price_policies/_adjustment_row.html.haml
@@ -24,5 +24,5 @@
       size: 8,
       class: "js--cancellationCost"
 
-    = pp.hidden_field :charge_full_price_on_cancellation, class: "js--fullCancellationCost", readonly: true
+    = pp.hidden_field :full_price_cancellation, class: "js--fullCancellationCost", readonly: true
 

--- a/app/views/time_based_price_policies/_amount_row.html.haml
+++ b/app/views/time_based_price_policies/_amount_row.html.haml
@@ -21,7 +21,7 @@
       data: { target: ".js--cancellationCost" }
     - if SettingsHelper.feature_on?(:charge_full_price_on_cancellation)
       = label_tag(nil, class: "checkbox normal-weight") do
-        = pp.check_box :charge_full_price_on_cancellation,
+        = pp.check_box :full_price_cancellation,
           class: "js--fullCancellationCost"
-        = price_policy.class.human_attribute_name(:charge_full_price_on_cancellation)
+        = price_policy.class.human_attribute_name(:full_price_cancellation)
         = tooltip_icon "fa fa-question-circle-o", t("price_policies.charge_full_price_on_cancellation_hint")

--- a/app/views/time_based_price_policies/_table.html.haml
+++ b/app/views/time_based_price_policies/_table.html.haml
@@ -52,7 +52,7 @@
           - if local_assigns[:cancellation]
             %td.currency
               - if price_policy.charge_full_price_on_cancellation?
-                = price_policy.class.human_attribute_name(:charge_full_price_on_cancellation)
+                = price_policy.class.human_attribute_name(:full_price_cancellation)
               - else
                 = number_to_currency(price_policy.cancellation_cost)
 

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -269,7 +269,7 @@ en:
         minimum_cost: Minimum Cost
         hourly_usage_rate: Rate Per Hour
         cancellation_cost: Reservation Cost
-        charge_full_price_on_cancellation: Full reservation cost
+        full_price_cancellation: Full reservation cost
         unit_cost: Unit Cost
         unit_adjustment: Unit Adjustment
         unit_net_cost: Unit Net Cost

--- a/db/migrate/20180919211201_add_full_cost_cancellation_to_price_policies.rb
+++ b/db/migrate/20180919211201_add_full_cost_cancellation_to_price_policies.rb
@@ -3,7 +3,7 @@
 class AddFullCostCancellationToPricePolicies < ActiveRecord::Migration[5.0]
 
   def change
-    add_column :price_policies, :charge_full_price_on_cancellation, :boolean, default: false, null: false
+    add_column :price_policies, :full_price_cancellation, :boolean, default: false, null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -408,7 +408,7 @@ ActiveRecord::Schema.define(version: 20180919211201) do
     t.datetime "expire_date",                                                                           null: false
     t.string   "charge_for"
     t.string   "legacy_rates"
-    t.boolean  "charge_full_price_on_cancellation",                                     default: false, null: false
+    t.boolean  "full_price_cancellation",                                               default: false, null: false
     t.index ["price_group_id"], name: "fk_rails_74aa223960", using: :btree
     t.index ["product_id"], name: "index_price_policies_on_product_id", using: :btree
   end

--- a/spec/features/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/features/admin/instrument_price_policies_controller_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe InstrumentPricePoliciesController do
       fill_in "price_policy_#{base_price_group.id}[minimum_cost]", with: "120"
       fill_in "price_policy_#{base_price_group.id}[cancellation_cost]", with: "15"
 
-      check "price_policy_#{base_price_group.id}[charge_full_price_on_cancellation]"
+      check "price_policy_#{base_price_group.id}[full_price_cancellation]"
       expect(page).to have_field("price_policy_#{base_price_group.id}[cancellation_cost]", disabled: true)
 
       fill_in "price_policy_#{cancer_center.id}[usage_subsidy]", with: "30"
@@ -84,7 +84,7 @@ RSpec.describe InstrumentPricePoliciesController do
       fill_in "price_policy_#{external_price_group.id}[usage_rate]", with: "120.11"
       fill_in "price_policy_#{external_price_group.id}[minimum_cost]", with: "122"
       fill_in "price_policy_#{external_price_group.id}[cancellation_cost]", with: "31"
-      check "price_policy_#{external_price_group.id}[charge_full_price_on_cancellation]"
+      check "price_policy_#{external_price_group.id}[full_price_cancellation]"
       expect(page).to have_field("price_policy_#{external_price_group.id}[cancellation_cost]", disabled: true)
 
       click_button "Add Pricing Rules"
@@ -92,7 +92,7 @@ RSpec.describe InstrumentPricePoliciesController do
       expect(page).to have_content("$60.00\n- $30.00\n= $30.00") # Cancer Center Usage Rate
       expect(page).to have_content("$120.00\n- $60.00\n= $60.00") # Cancer Center Minimum Cost
       expect(page).not_to have_content("$15.00")
-      expect(page).to have_content(PricePolicy.human_attribute_name(:charge_full_price_on_cancellation), count: 3)
+      expect(page).to have_content(PricePolicy.human_attribute_name(:full_price_cancellation), count: 3)
     end
   end
 end

--- a/spec/models/instrument_price_policy_calculations_spec.rb
+++ b/spec/models/instrument_price_policy_calculations_spec.rb
@@ -164,14 +164,14 @@ RSpec.describe InstrumentPricePolicyCalculations do
       end
 
       it "returns the full reservation costs if charge_full_price_on_cancellation is set", feature_setting: { charge_full_price_on_cancellation: true } do
-        policy.charge_full_price_on_cancellation = true
+        policy.full_price_cancellation = true
         reservation.order_detail.canceled_at = reservation.reserve_start_at - 30.minutes
 
         expect(policy.calculate_cost_and_subsidy(reservation)).to eq(cost: 60, subsidy: 0)
       end
 
       it "still returns the cancellation_cost even if charge_full_price_on_cancellation with the feature off", feature_setting: { charge_full_price_on_cancellation: false } do
-        policy.charge_full_price_on_cancellation = true
+        policy.full_price_cancellation = true
         reservation.order_detail.canceled_at = reservation.reserve_start_at - 30.minutes
 
         expect(policy.calculate_cost_and_subsidy(reservation)).to eq(cost: 1.23, subsidy: 0)

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -1614,7 +1614,7 @@ RSpec.describe OrderDetail do
 
           context "has full cost cancellation fee", feature_setting: { charge_full_price_on_cancellation: true } do
             before do
-              PricePolicy.update_all(charge_full_price_on_cancellation: true, usage_rate: 3, usage_subsidy: 1)
+              PricePolicy.update_all(full_price_cancellation: true, usage_rate: 3, usage_subsidy: 1)
               order_detail.price_policy.reload
             end
 

--- a/spec/services/cancellation_fee_calculator_spec.rb
+++ b/spec/services/cancellation_fee_calculator_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe CancellationFeeCalculator do
       end
 
       context "when the price policy is set to charge for full reservation" do
-        before { instrument.price_policies.update_all(usage_rate: 1, charge_full_price_on_cancellation: true) }
+        before { instrument.price_policies.update_all(usage_rate: 1, full_price_cancellation: true) }
 
         describe "with the feature on", feature_setting: { charge_full_price_on_cancellation: true } do
           it { is_expected.to eq(60) } # usage_rate is per minute


### PR DESCRIPTION
# Release Notes

TECH TASK: Rename column to full_price_cancellation so it fits into Oracle <= 30 limit

# Additional Context

When deploying to NU, whose DB server runs Oracle 12.1, the migration fails:

```
== 20180919211201 AddFullCostCancellationToPricePolicies: migrating ===========
-- add_column(:price_policies, :charge_full_price_on_cancellation, :boolean, {:default=>false, :null=>false})
rake stderr: rake aborted!
StandardError: An error has occurred, all later migrations canceled:

OCIError: ORA-00972: identifier is too long: ALTER TABLE "PRICE_POLICIES" ADD "CHARGE_FULL_PRICE_ON_CANCELLATION" NUMBER(1) DEFAULT 0 NOT NULL
stmt.c:243:in oci8lib_240.so
```

Therefore, I am renaming the DB column only, from `charge_full_price_on_cancellation` to `full_price_cancellation`, so it is less than 30 characters and can be applied. Earlier, we thought that the database server runs Oracle 12.2, but that was only the version of client tools that NU provides on the servers (which is different than the server version).