### PR TITLE
Fix manage mode to work on other pages

### DIFF
--- a/app/controllers/concerns/nav_tab.rb
+++ b/app/controllers/concerns/nav_tab.rb
@@ -36,7 +36,7 @@ module NavTab
   end
 
   def manage_mode?
-    admin_tab? && current_facility.present? && current_facility != Facility.cross_facility
+    admin_tab?
   end
 
   def navigation_links

--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -10,7 +10,7 @@ class NavTab::LinkCollection
   delegate :single_facility?, to: :facility
 
   def initialize(facility, ability)
-    @facility = facility
+    @facility = facility || Facility.cross_facility
     @ability = ability
   end
 

--- a/app/views/layouts/plain.html.haml
+++ b/app/views/layouts/plain.html.haml
@@ -2,7 +2,7 @@
 %html
   %head
     = render "/shared/head"
-  %body
+  %body{ class: SettingsHelper.feature_on?(:use_manage) && manage_mode? ? "manage-mode" : "" }
     #content
       .container
         .row

--- a/app/views/layouts/two_column.html.haml
+++ b/app/views/layouts/two_column.html.haml
@@ -2,7 +2,7 @@
 %html
   %head
     = render :partial => '/shared/head'
-  %body
+  %body{ class: SettingsHelper.feature_on?(:use_manage) && manage_mode? ? "manage-mode" : "" }
     %header
       = render :partial => '/shared/header'
     %nav

--- a/app/views/layouts/two_column_head.html.haml
+++ b/app/views/layouts/two_column_head.html.haml
@@ -2,7 +2,7 @@
 %html
   %head
     = render :partial => '/shared/head'
-  %body
+  %body{ class: SettingsHelper.feature_on?(:use_manage) && manage_mode? ? "manage-mode" : "" }
     %header
       = render :partial => '/shared/header'
     %nav


### PR DESCRIPTION
# Release Notes

* Update the logic to check which mode the page is in.

* Add manage mode class to other pages.

# Additional Context
It seems like the issue was not necessarily that the use/manage class was not correct in the helper. The fix ended up being that some views don't use `application.html.haml`, there are also two-column layouts that it needed to be added to.
