### PR TITLE
TECH TASK: Update gems for ed25519 SSH keys support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,12 +96,10 @@ group :development, :deployment do
   gem "capistrano-rvm",     require: false
   gem "capistrano-bundler", require: false
 
-  # net-ssh 4.2 requires the gems below to support ed25519 keys
-  # for deploying via capistrano
-  # more info at https://github.com/net-ssh/net-ssh/issues/478
+  # These gems are required to support ed25519 SSH keys for deploying via capistrano
+  # See https://github.com/net-ssh/net-ssh/issues/565 for more information
   gem "bcrypt_pbkdf", ">= 1.0", "< 2.0", require: false
-  gem "rbnacl", ">= 3.2", "< 5.0", require: false
-  gem "rbnacl-libsodium", require: false
+  gem "ed25519", ">= 1.2", "< 2.0", require: false
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,6 +273,7 @@ GEM
       dry-logic (~> 0.4, >= 0.4.0)
       dry-types (~> 0.12.0)
     dynamic_form (1.1.4)
+    ed25519 (1.2.4)
     erubis (2.7.0)
     eventmachine (1.2.5)
     exception_notification (4.2.2)
@@ -493,10 +494,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rbnacl (4.0.2)
-      ffi
-    rbnacl-libsodium (1.0.16)
-      rbnacl (>= 3.0.1)
     redcarpet (3.4.0)
     ref (2.0.0)
     regexp_parser (1.2.0)
@@ -677,6 +674,7 @@ DEPENDENCIES
   devise
   devise-encryptable
   dynamic_form
+  ed25519 (>= 1.2, < 2.0)
   exception_notification
   eye-patch
   factory_bot_rails
@@ -715,8 +713,6 @@ DEPENDENCIES
   rails-erd
   rails-observers
   rake
-  rbnacl (>= 3.2, < 5.0)
-  rbnacl-libsodium
   rollbar (= 2.15.5)
   rspec-activejob
   rspec-collection_matchers
@@ -752,4 +748,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.2
+   1.16.6


### PR DESCRIPTION
# Release Notes

TECH TASK: Update gems for ed25519 SSH keys support

# Additional Context

Merely having a `~/.ssh/id_ed25519` key on my computer causes Capistrano to raise this error:

```
NotImplementedError: unsupported key type `ssh-ed25519'
net-ssh requires the following gems for ed25519 support:
 * ed25519 (>= 1.2, < 2.0)
 * bcrypt_pbkdf (>= 1.0, < 2.0)
See https://github.com/net-ssh/net-ssh/issues/565 for more information
Gem::LoadError : "ed25519 is not part of the bundle. Add it to your Gemfile."
```

This PR adds the gems per the instructions, so that Capistrano can use ed25519 keys, or fall back gracefully to RSA keys. Without doing this, I have to move `~/.ssh/id_ed25519` out of `~/.ssh`, call `ssh-add -K` (to unregister the key), and then do SSH operations via Capistrano.