### PR TITLE
[#143728] Allow searching users by card number

### DIFF
--- a/app/services/user_finder.rb
+++ b/app/services/user_finder.rb
@@ -4,6 +4,16 @@ class UserFinder
 
   include SearchHelper
 
+  class_attribute :searchable_columns
+
+  self.searchable_columns = [
+    "first_name",
+    "last_name",
+    "username",
+    "CONCAT(first_name, last_name)",
+    "email",
+  ]
+
   def self.search(search_term, limit)
     if search_term.present?
       new(search_term, limit).result
@@ -23,23 +33,11 @@ class UserFinder
 
   private
 
-  def condition_sql
-    <<-SQL
-      (
-          LOWER(first_name) LIKE :search_term
-        OR
-          LOWER(last_name) LIKE :search_term
-        OR
-          LOWER(username) LIKE :search_term
-        OR
-          LOWER(CONCAT(first_name, last_name)) LIKE :search_term
-        OR
-          LOWER(email) LIKE :search_term
-      )
-    SQL
-  end
-
   def relation
+    condition_sql = searchable_columns
+                    .map { |column| "LOWER(#{column}) LIKE :search_term" }
+                    .join(" OR ")
+
     @relation ||= User.where(condition_sql, search_term: @search_term)
   end
 

--- a/app/views/search/_results_table.html.haml
+++ b/app/views/search/_results_table.html.haml
@@ -10,6 +10,7 @@
       %th= t(".name")
       %th= t(".username")
       %th= t(".email")
+      = render_view_hook "extra_headers"
   %tbody
     - users.each do |user|
       %tr
@@ -22,3 +23,4 @@
           = render "search/#{search_type}_link", user: UserPresenter.new(user)
         %td= user.username
         %td= user.email
+        = render_view_hook "extra_columns", user: user

--- a/spec/services/user_finder_spec.rb
+++ b/spec/services/user_finder_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserFinder do
+  describe ".search" do
+    it "finds users by first_name" do
+      first_name = SecureRandom.hex(8)
+      user = FactoryBot.create(:user, first_name: first_name)
+      found_users = UserFinder.search(first_name, nil).first
+      expect(found_users).to include(user)
+    end
+
+    it "finds users by last_name" do
+      last_name = SecureRandom.hex(8)
+      user = FactoryBot.create(:user, last_name: last_name)
+      found_users = UserFinder.search(last_name, nil).first
+      expect(found_users).to include(user)
+    end
+
+    it "finds users by username" do
+      username = SecureRandom.hex(8)
+      user = FactoryBot.create(:user, username: username)
+      found_users = UserFinder.search(username, nil).first
+      expect(found_users).to include(user)
+    end
+
+    it "finds users by their first_name and last_name joined together" do
+      first_name = SecureRandom.hex(8)
+      last_name = SecureRandom.hex(8)
+      user = FactoryBot.create(:user, first_name: first_name, last_name: last_name)
+      found_users = UserFinder.search([first_name, last_name].join, nil).first
+      expect(found_users).to include(user)
+    end
+
+    it "finds users by email" do
+      email = "#{SecureRandom.hex(8)}@example.com"
+      user = FactoryBot.create(:user, email: email)
+      found_users = UserFinder.search(email, nil).first
+      expect(found_users).to include(user)
+    end
+  end
+end

--- a/vendor/engines/secure_rooms/app/views/search/_extra_columns.html.haml
+++ b/vendor/engines/secure_rooms/app/views/search/_extra_columns.html.haml
@@ -1,0 +1,1 @@
+%td= user.card_number

--- a/vendor/engines/secure_rooms/app/views/search/_extra_headers.html.haml
+++ b/vendor/engines/secure_rooms/app/views/search/_extra_headers.html.haml
@@ -1,0 +1,1 @@
+%th= t(".card_number")

--- a/vendor/engines/secure_rooms/config/locales/en.yml
+++ b/vendor/engines/secure_rooms/config/locales/en.yml
@@ -28,6 +28,10 @@ en:
         badge: Missing Exit
         alert: This order's occupancy does not have an exit time. Please ensure that all times are set and there is a price policy for the date this order was fulfilled.
 
+  search:
+    extra_headers:
+      card_number: Card Number
+
   secure_rooms:
     facility_occupancies:
       table_controls:

--- a/vendor/engines/secure_rooms/lib/secure_rooms/engine.rb
+++ b/vendor/engines/secure_rooms/lib/secure_rooms/engine.rb
@@ -39,6 +39,9 @@ module SecureRooms
       ViewHook.add_hook "admin.shared.tabnav_users",
                         "after",
                         "secure_rooms/shared/tabnav_users"
+
+      ViewHook.add_hook "search.results_table", "extra_headers", "search/extra_headers"
+      ViewHook.add_hook "search.results_table", "extra_columns", "search/extra_columns"
     end
 
     initializer "secure_rooms.action_controller" do

--- a/vendor/engines/secure_rooms/lib/secure_rooms/engine.rb
+++ b/vendor/engines/secure_rooms/lib/secure_rooms/engine.rb
@@ -26,6 +26,8 @@ module SecureRooms
 
       Admin::ServicesController.five_minute_tasks << SecureRooms::AutoOrphanOccupancy
 
+      UserFinder.searchable_columns << "card_number"
+
       ViewHook.add_hook "users.show",
                         "additional_user_fields",
                         "secure_rooms/shared/card_number_form_field"

--- a/vendor/engines/secure_rooms/spec/services/user_finder_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/user_finder_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserFinder do
+  describe ".search" do
+    it "finds users by card_number" do
+      card_number = SecureRandom.hex(8)
+      user = FactoryBot.create(:user, card_number: card_number)
+      found_users = UserFinder.search(card_number, nil).first
+      expect(found_users).to include(user)
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

Allows searching users by card number when secure rooms are used

# Screenshot

![screen shot 2018-11-01 at 21 20 19](https://user-images.githubusercontent.com/7736/47877341-f6267980-de1b-11e8-835a-596bc28f8bc7.png)

# Additional Context

To make it obvious why a particular user matched, I added `Card Number` as a column to the results table when the secure rooms engine is required.