### PR TITLE
Revert Uglifier to 4.1.18, due to bug in Uglify 3.4.9.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "paranoia"
 ## views
 gem "sass-rails"
 gem "coffee-rails"
-gem "uglifier"
+gem "uglifier", "= 4.1.18" # 4.1.19 has an issue https://github.com/mishoo/UglifyJS2/issues/3245
 gem "therubyracer"
 gem "bootstrap-sass", "~> 2.3.2" # will not upgrade
 gem "haml"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -617,7 +617,7 @@ GEM
     ttfunk (1.5.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    uglifier (4.1.19)
+    uglifier (4.1.18)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.4.0)
     unicorn (5.4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -737,7 +737,7 @@ DEPENDENCIES
   text_helpers
   therubyracer
   thin
-  uglifier
+  uglifier (= 4.1.18)
   unicorn
   vuejs-rails (~> 1.0.26)
   web-console

--- a/config/initializers/uglifier_restriction.rb
+++ b/config/initializers/uglifier_restriction.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+unless Uglifier::VERSION == "4.1.18"
+  raise "Uglifier 4.1.19 has a bug (https://github.com/mishoo/UglifyJS2/issues/3245).
+  Please ensure it's fixed before advancing"
+end


### PR DESCRIPTION
https://github.com/mishoo/UglifyJS2/issues/3245 documents
a bug which occurs when using compression.

There does not appear to be any way to disable this particular path through the uglifier.

