### PR TITLE
[#144525] Alphabetize homepage case insensitively

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -36,7 +36,7 @@ class FacilitiesController < ApplicationController
     @recently_used_facilities = MostRecentlyUsedSearcher.new(acting_user).recently_used_facilities.alphabetized
     @active_tab = SettingsHelper.feature_on?(:use_manage) ? "use" : "home"
     @recent_products = MostRecentlyUsedSearcher.new(acting_user).recently_used_products.includes(:facility).alphabetized
-    @azlist = get_az_list(@facilities)
+    @azlist = build_az_list(@facilities)
     render layout: "application"
   end
 

--- a/app/helpers/a_z_helper.rb
+++ b/app/helpers/a_z_helper.rb
@@ -4,8 +4,8 @@ module AZHelper
 
   # Generates empty hash with keys for each letter
   ALPHABET = ("A".."Z").to_a.map { |x| [x, []] }.to_h
-  def get_az_list(facilities)
-    ALPHABET.merge(facilities.group_by { |row| row.name[0] })
+  def build_az_list(facilities)
+    ALPHABET.merge(facilities.group_by { |row| row.name[0].upcase })
   end
 
   def az_classname_for_facility(index, _letter)

--- a/spec/helpers/a_z_helper_spec.rb
+++ b/spec/helpers/a_z_helper_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AZHelper do
         FactoryBot.build(:facility, name: "Alpha"),
         FactoryBot.build(:facility, name: "Alpha2"),
         FactoryBot.build(:facility, name: "Delta"),
-        FactoryBot.build(:facility, name: "delta2")
+        FactoryBot.build(:facility, name: "delta2"),
       ]
     end
 

--- a/spec/helpers/a_z_helper_spec.rb
+++ b/spec/helpers/a_z_helper_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AZHelper do
+
+  describe "build_az_list" do
+    let(:facilities) do
+      [
+        FactoryBot.build(:facility, name: "Alpha"),
+        FactoryBot.build(:facility, name: "Alpha2"),
+        FactoryBot.build(:facility, name: "Delta"),
+        FactoryBot.build(:facility, name: "delta2")
+      ]
+    end
+
+    let(:az_list) { helper.build_az_list(facilities) }
+
+    it "puts all the A's together" do
+      expect(az_list["A"].map(&:name)).to contain_exactly("Alpha", "Alpha2")
+    end
+
+    it "has an empty array for not-found letters" do
+      expect(az_list["B"]).to eq([])
+    end
+
+    it "groups lowercase and uppercase together" do
+      expect(az_list["D"].map(&:name)).to contain_exactly("Delta", "delta2")
+    end
+  end
+
+end


### PR DESCRIPTION
# Release Notes

Fix issue where facilities beginning with lowercase letters were shifted to the end of the list.

# Additional Context

Dartmouth has a lab called "bioMT" which was hard to find because it was pulled down to the bottom. 

This also fixes an issue with the A-Z list where it treats "b" and "B" as separate letters.
