### PR TITLE
[#136546] Allow account membership changes after expiration

### DIFF
--- a/app/controllers/account_users_controller.rb
+++ b/app/controllers/account_users_controller.rb
@@ -28,16 +28,14 @@ class AccountUsersController < ApplicationController
   def create
     ## TODO add security
     @user = User.find(params[:user_id])
-    @account_user = @account.account_users.new(create_params)
-    @account_user.user = @user
-    @account_user.created_by = session_user.id
+    @account_user = AccountUser.grant(@user, create_params[:user_role], @account, by: session_user)
 
-    if @account_user.save
+    if @account_user.errors.none?
       LogEvent.log(@account_user, :create, current_user)
-      flash[:notice] = "#{@user.full_name} was added to the #{@account.type_string} Account"
+      flash[:notice] = text("create.success", user: @user.full_name, account_type: @account.type_string)
       redirect_to account_account_users_path(@account)
     else
-      flash.now[:error] = "An error was encountered while trying to add #{@user.full_name} to the #{@account.type_string} Account"
+      flash.now[:error] = text("create.error", user: @user.full_name, account_type: @account.type_string)
       render :new
     end
   end
@@ -51,9 +49,9 @@ class AccountUsersController < ApplicationController
 
     if @account_user.save
       LogEvent.log(@account_user, :delete, current_user)
-      flash[:notice] = "The user was successfully removed from the payment method"
+      flash[:notice] = text("destroy.success")
     else
-      flash[:error] = "An error was encountered while attempting to remove the user from the payment method"
+      flash[:error] = text("destroy.error")
     end
     redirect_to account_account_users_path(@account)
   end

--- a/app/controllers/account_users_controller.rb
+++ b/app/controllers/account_users_controller.rb
@@ -30,7 +30,7 @@ class AccountUsersController < ApplicationController
     @user = User.find(params[:user_id])
     @account_user = AccountUser.grant(@user, create_params[:user_role], @account, by: session_user)
 
-    if @account_user.errors.none?
+    if @account_user.persisted?
       LogEvent.log(@account_user, :create, current_user)
       flash[:notice] = text("create.success", user: @user.full_name, account_type: @account.type_string)
       redirect_to account_account_users_path(@account)

--- a/app/controllers/facility_account_users_controller.rb
+++ b/app/controllers/facility_account_users_controller.rb
@@ -41,7 +41,7 @@ class FacilityAccountUsersController < ApplicationController
     # account owner might've changed by earlier operation... reload it
     @account.reload
 
-    if @account.errors.any?
+    if @account_user.errors.any?
       flash.now[:error] = "An error was encountered while trying to add #{@user.full_name} to the #{@account.type_string} Account"
       render(action: "new")
     else

--- a/app/controllers/facility_account_users_controller.rb
+++ b/app/controllers/facility_account_users_controller.rb
@@ -26,7 +26,7 @@ class FacilityAccountUsersController < ApplicationController
 
   # GET /facilities/:facility_id/accounts/:account_id/account_users/new
   def new
-    @user         = User.find(params[:user_id])
+    @user = User.find(params[:user_id])
     role = current_owner? ? AccountUser::ACCOUNT_OWNER : AccountUser::ACCOUNT_PURCHASER
     @account_user = AccountUser.new(user_role: role)
   end

--- a/app/controllers/facility_account_users_controller.rb
+++ b/app/controllers/facility_account_users_controller.rb
@@ -37,7 +37,7 @@ class FacilityAccountUsersController < ApplicationController
     @user = User.find(params[:user_id])
     role = create_params[:user_role]
 
-    @account_user = @account.add_or_update_member(@user, role, session_user)
+    @account_user = AccountUser.grant(@user, role, @account, by: session_user)
     # account owner might've changed by earlier operation... reload it
     @account.reload
 

--- a/app/controllers/facility_account_users_controller.rb
+++ b/app/controllers/facility_account_users_controller.rb
@@ -6,6 +6,7 @@ class FacilityAccountUsersController < ApplicationController
   before_action :authenticate_user!
   before_action :check_acting_as
   before_action :init_current_facility
+  before_action :init_account
 
   load_and_authorize_resource class: AccountUser
 
@@ -25,7 +26,6 @@ class FacilityAccountUsersController < ApplicationController
 
   # GET /facilities/:facility_id/accounts/:account_id/account_users/new
   def new
-    @account      = Account.find(params[:account_id])
     @user         = User.find(params[:user_id])
     role = current_owner? ? AccountUser::ACCOUNT_OWNER : AccountUser::ACCOUNT_PURCHASER
     @account_user = AccountUser.new(user_role: role)
@@ -33,22 +33,20 @@ class FacilityAccountUsersController < ApplicationController
 
   # POST /facilities/:facility_id/accounts/:account_id/account_users
   def create
-    @account = Account.find(params[:account_id])
     @user = User.find(params[:user_id])
-    role = create_params[:user_role]
 
-    @account_user = AccountUser.grant(@user, role, @account, by: session_user)
+    @account_user = AccountUser.grant(@user, create_params[:user_role], @account, by: session_user)
     # account owner might've changed by earlier operation... reload it
     @account.reload
 
-    if @account_user.errors.any?
-      flash.now[:error] = "An error was encountered while trying to add #{@user.full_name} to the #{@account.type_string} Account"
-      render(action: "new")
-    else
-      flash[:notice] = "#{@user.full_name} was added to the #{@account.type_string} Account"
+    if @account_user.errors.none? && @account.errors.none?
+      flash[:notice] = text("create.success", user: @user.full_name, account_type: @account.type_string)
       LogEvent.log(@account_user, :create, current_user)
       Notifier.user_update(account: @account, user: @user, created_by: session_user).deliver_now
       redirect_to facility_account_members_path(current_facility, @account)
+    else
+      flash.now[:error] = text("create.error", user: @user.full_name, account_type: @account.type_string)
+      render(action: "new")
     end
   end
 
@@ -61,14 +59,18 @@ class FacilityAccountUsersController < ApplicationController
 
     if @account_user.save
       LogEvent.log(@account_user, :delete, current_user)
-      flash[:notice] = "The user was successfully removed from the payment method"
+      flash[:notice] = text("destroy.success")
     else
-      flash[:error] = "An error was encountered while attempting to remove the user from the payment method"
+      flash[:error] = text("destroy.error")
     end
     redirect_to facility_account_members_path(current_facility, @account)
   end
 
   private
+
+  def init_account
+    @account = Account.find(params[:account_id])
+  end
 
   def create_params
     params.require(:account_user).permit(:user_role)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -285,35 +285,6 @@ class Account < ApplicationRecord
     end
   end
 
-  def add_or_update_member(user, new_role, session_user)
-    Account.transaction do
-      # expire old owner if new
-      if new_role == AccountUser::ACCOUNT_OWNER
-        # expire old owner record
-        @old_owner = owner
-        if @old_owner
-          @old_owner.deleted_at = Time.zone.now
-          @old_owner.deleted_by = session_user.id
-          @old_owner.save!
-        end
-      end
-
-      # find non-deleted record for this user and account or init new one
-      # deleted_at MUST be nil to preserve existing audit trail
-      @account_user = AccountUser.find_or_initialize_by(account_id: id, user_id: user.id, deleted_at: nil)
-      # set (new?) role
-      @account_user.user_role = new_role
-      # set creation information
-      @account_user.created_by = session_user.id
-
-      account_users << @account_user
-
-      raise ActiveRecord::Rollback unless save
-    end
-
-    @account_user
-  end
-
   # Optionally override this method for models that inherit from Account.
   # Forces journal rows to be destroyed and recreated when an order detail is
   # updated.

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -41,7 +41,7 @@ class Account < ApplicationRecord
   validates_presence_of :account_number, :description, :expires_at, :created_by, :type
   validates_length_of :description, maximum: 50
 
-  validate :require_owner
+  validate { errors.add(:base, "Must have an account owner") if missing_owner? }
 
   delegate :administrators, to: :account_users
 
@@ -286,12 +286,9 @@ class Account < ApplicationRecord
     false
   end
 
-  def require_owner
-    # a current account owner if required
+  def missing_owner?
     # don't use a scope so we can validate on nested attributes
-    if account_users.none? { |au| au.active? && au.owner? }
-      errors.add(:base, "Must have an account owner")
-    end
+    account_users.none? { |au| au.active? && au.owner? }
   end
 
   private

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -41,7 +41,7 @@ class Account < ApplicationRecord
   validates_presence_of :account_number, :description, :expires_at, :created_by, :type
   validates_length_of :description, maximum: 50
 
-  validate { errors.add(:base, "Must have an account owner") if missing_owner? }
+  validate { errors.add(:base, :missing_owner) if missing_owner? }
 
   delegate :administrators, to: :account_users
 
@@ -287,7 +287,6 @@ class Account < ApplicationRecord
   end
 
   def missing_owner?
-    # don't use a scope so we can validate on nested attributes
     account_users.none? { |au| au.active? && au.owner? }
   end
 

--- a/app/models/account_user.rb
+++ b/app/models/account_user.rb
@@ -91,4 +91,8 @@ class AccountUser < ApplicationRecord
     user_role == ACCOUNT_OWNER
   end
 
+  def active?
+    deleted_at.blank?
+  end
+
 end

--- a/app/models/account_user.rb
+++ b/app/models/account_user.rb
@@ -11,6 +11,7 @@ class AccountUser < ApplicationRecord
   validates :user_role, inclusion: { in: ->(record) { record.class.user_roles }, message: "is invalid" }
   validates :user_id, uniqueness: { scope: [:account_id, :deleted_at] }, unless: :deleted_at?
   validates :user_role, uniqueness: { scope: [:account_id, :deleted_at] }, if: -> { owner? && !deleted_at? }
+  validate :validate_account_has_owner
 
   ACCOUNT_PURCHASER = "Purchaser"
   ACCOUNT_OWNER = "Owner"
@@ -93,6 +94,10 @@ class AccountUser < ApplicationRecord
 
   def active?
     deleted_at.blank?
+  end
+
+  def validate_account_has_owner
+    errors.add(:base, :account_missing_owner) if account&.missing_owner?
   end
 
 end

--- a/app/models/account_user.rb
+++ b/app/models/account_user.rb
@@ -2,9 +2,15 @@
 
 class AccountUser < ApplicationRecord
 
-  belongs_to :user
-  belongs_to :account, inverse_of: :account_users
+  belongs_to :user, required: true
+  belongs_to :account, inverse_of: :account_users, required: true
+  belongs_to :created_by_user, class_name: "User", foreign_key: :created_by
   has_many :log_events, as: :loggable
+
+  validates :created_by, presence: true
+  validates :user_role, inclusion: { in: ->(record) { record.class.user_roles }, message: "is invalid" }
+  validates :user_id, uniqueness: { scope: [:account_id, :deleted_at] }, unless: :deleted_at?
+  validates :user_role, uniqueness: { scope: [:account_id, :deleted_at] }, if: -> { owner? && !deleted_at? }
 
   ACCOUNT_PURCHASER = "Purchaser"
   ACCOUNT_OWNER = "Owner"
@@ -71,19 +77,38 @@ class AccountUser < ApplicationRecord
   #   one of this class' constants
   # [_account_]
   #   the account that you want to grant permissions on.
-  # [_granting_user_]
+  # [_by_]
   #   the user who is granting the privilege
-  def self.grant(user, role, account, granting_user)
-    create!(user: user, user_role: role, account: account, created_by: granting_user.id)
+  def self.grant(user, role, account, by:)
+    transaction do
+      # expire old owner if new
+      if role == AccountUser::ACCOUNT_OWNER
+        # Soft-delete the old owner record
+        account.owner&.update!(
+          deleted_at: Time.current,
+          deleted_by: by.id,
+        )
+      end
+
+      # find non-deleted record for this user and account or init new one
+      # deleted_at MUST be nil to preserve existing audit trail
+      account_user = find_or_initialize_by(account: account, user: user, deleted_at: nil)
+      account_user.update!(
+        user_role: role,
+        created_by_user: by
+      )
+      account_user
+    end
+  rescue ActiveRecord::RecordInvalid
+    # return nothing
   end
 
   def can_administer?
     deleted_at.nil? && AccountUser.admin_user_roles.any? { |r| r == user_role }
   end
 
-  validates_presence_of :created_by
-  validates_inclusion_of :user_role, in: user_roles, message: "is invalid"
-  validates_uniqueness_of :user_id, scope: [:account_id, :deleted_at]
-  validates_uniqueness_of :user_role, scope: [:account_id, :deleted_at], if: ->(o) { o.user_role == ACCOUNT_OWNER }
+  def owner?
+    user_role == ACCOUNT_OWNER
+  end
 
 end

--- a/app/services/account_role_grantor.rb
+++ b/app/services/account_role_grantor.rb
@@ -1,0 +1,58 @@
+class AccountRoleGrantor
+
+  attr_reader :account, :by
+
+  def initialize(account, by:)
+    @account = account
+    @by = by
+  end
+
+  def grant(user, role)
+    account_user = nil
+
+    within_transaction do
+        # expire old owner if it's a new user
+      remove_old_user if role == AccountUser::ACCOUNT_OWNER
+
+      account_user = create_or_update_user_role(user, role)
+
+      unless account.reload.owner.present?
+        account_user.errors.add(:base, "Must have an account owner")
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    account_user
+  end
+
+  private
+
+  def remove_old_user
+    # Soft-delete the old owner record
+    account.owner&.update!(
+      deleted_at: Time.current,
+      deleted_by: by.id,
+    )
+  end
+
+  def create_or_update_user_role(user, role)
+    # find non-deleted record for this user and account or init new one
+    # deleted_at MUST be nil to preserve existing audit trail
+    account_user = AccountUser.find_or_initialize_by(account: account, user: user, deleted_at: nil)
+    account_user.update!(
+      user_role: role,
+      created_by_user: by
+    )
+    account_user
+  end
+
+  def within_transaction
+    account.transaction do
+      yield
+    end
+  rescue ActiveRecord::RecordInvalid
+
+    # do nothing
+  end
+
+end

--- a/app/services/account_role_grantor.rb
+++ b/app/services/account_role_grantor.rb
@@ -54,7 +54,7 @@ class AccountRoleGrantor
     account.transaction do
       yield
     end
-  rescue ActiveRecord::RecordInvalid
+  rescue ActiveRecord::RecordInvalid # rubocop:disable Lint/HandleExceptions
     # do nothing
   end
 

--- a/app/services/account_role_grantor.rb
+++ b/app/services/account_role_grantor.rb
@@ -21,8 +21,9 @@ class AccountRoleGrantor
 
       # In order to allow changes once an account is closed (i.e. becomes invalid
       # per the Validator) we cannot run the validations directly on the account.
-      account.require_owner
-      raise ActiveRecord::Rollback if account.errors.any?
+      account_user.errors.add(:base, "Must have an account owner") if account.missing_owner?
+
+      raise ActiveRecord::Rollback if account_user.errors.any?
     end
 
     account_user

--- a/app/views/account_users/new.html.haml
+++ b/app/views/account_users/new.html.haml
@@ -19,5 +19,5 @@
   = f.input :user_role, collection: AccountUserPresenter.selectable_user_roles(current_user, current_facility), selected: "Purchaser"
 
   %ul.inline
-    %li= f.submit "Create", class: "btn"
-    %li= link_to "Cancel", account_account_users_path(@account)
+    %li= f.submit t("shared.create"), class: "btn btn-primary"
+    %li= link_to t("shared.cancel"), account_account_users_path(@account)

--- a/app/views/facility_account_users/new.html.haml
+++ b/app/views/facility_account_users/new.html.haml
@@ -12,7 +12,7 @@
   = f.error_messages
 
   - if current_owner?
-    %p.error= t(".messages.current_user")
+    %p.alert.alert-danger= t(".messages.current_user")
 
   = f.simple_fields_for @account do |account|
     = account.input :type_string, as: :readonly
@@ -31,5 +31,6 @@
     disabled: current_owner?
 
   %ul.inline
-    %li= f.submit "Create", class: "btn" unless current_owner?
-    %li= link_to "Cancel", facility_account_path(current_facility, @account)
+    - unless current_owner?
+      %li= f.submit t("shared.create"), class: "btn btn-primary"
+    %li= link_to t("shared.cancel"), facility_account_path(current_facility, @account)

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -110,9 +110,11 @@ en:
             name:
               taken: "Filename already exists for this order"
         account_user:
+          account_missing_owner: Must have an account owner
           attributes:
             user_id:
               taken: "is already a member of this payment source"
+
         journal:
           attributes:
             journal_date:

--- a/config/locales/models/en.account.yml
+++ b/config/locales/models/en.account.yml
@@ -4,3 +4,4 @@ en:
       models:
         account:
           not_open: "The %{model} is not open for the required account"
+          missing_owner: Must have an account owner

--- a/config/locales/views/admin/en.facility_account_users.yml
+++ b/config/locales/views/admin/en.facility_account_users.yml
@@ -1,0 +1,9 @@
+en:
+  controllers:
+    facility_account_users:
+      create:
+        success: "%{user} was added to the %{account_type} Account"
+        error: An error was encountered while trying to add %{user} to the %{account_type} Account
+      destroy:
+        success: The user was successfully removed from the payment method
+        error: An error was encountered while attempting to remove the user from the payment method

--- a/config/locales/views/en.account_users.yml
+++ b/config/locales/views/en.account_users.yml
@@ -1,0 +1,9 @@
+en:
+  controllers:
+    account_users:
+      create:
+        success: "%{user} was added to the %{account_type} Account"
+        error: An error was encountered while trying to add %{user} to the %{account_type} Account
+      destroy:
+        success: The user was successfully removed from the payment method
+        error: An error was encountered while attempting to remove the user from the payment method

--- a/spec/controller_spec_helper.rb
+++ b/spec/controller_spec_helper.rb
@@ -226,13 +226,13 @@ def grant_role(user, authable = nil)
     # Creating a NufsAccount requires an owner to be present, and some pre-Rails3 tests try to add the same user
     # to the same account with the same role of owner. That's a uniqueness error on AccountUser. Avoid it.
     existing = AccountUser.find_by(user_id: user.id, account_id: authable.id, user_role: AccountUser::ACCOUNT_OWNER)
-    AccountUser.grant(user, AccountUser::ACCOUNT_OWNER, authable, @admin) unless existing
+    AccountUser.grant(user, AccountUser::ACCOUNT_OWNER, authable, by: @admin) unless existing
     expect(user.reload).to be_owner_of(authable)
   when "purchaser"
-    AccountUser.grant(user, AccountUser::ACCOUNT_PURCHASER, authable, @admin)
+    AccountUser.grant(user, AccountUser::ACCOUNT_PURCHASER, authable, by: @admin)
     expect(user.reload).to be_purchaser_of(authable)
   when "business_admin"
-    AccountUser.grant(user, AccountUser::ACCOUNT_ADMINISTRATOR, authable, @admin)
+    AccountUser.grant(user, AccountUser::ACCOUNT_ADMINISTRATOR, authable, by: @admin)
     expect(user.reload).to be_business_administrator_of(authable)
   when "senior_staff"
     UserRole.grant(user, UserRole::FACILITY_SENIOR_STAFF, authable)

--- a/spec/controllers/facility_account_users_controller_spec.rb
+++ b/spec/controllers/facility_account_users_controller_spec.rb
@@ -161,6 +161,11 @@ RSpec.describe FacilityAccountUsersController, if: SettingsHelper.feature_on?(:e
             expect(@account.account_users.purchasers).not_to be_any
           end
 
+          it "has the correct error" do
+            do_request
+            expect(assigns(:account_user).errors).to be_added(:base, "Must have an account owner")
+          end
+
           it "should be prevented" do
             do_request
             expect(assigns(:account)).to eq(@account)

--- a/spec/controllers/facility_account_users_controller_spec.rb
+++ b/spec/controllers/facility_account_users_controller_spec.rb
@@ -179,6 +179,17 @@ RSpec.describe FacilityAccountUsersController, if: SettingsHelper.feature_on?(:e
         end
       end
     end
+
+    describe "adding to an account that does not pass validation" do
+      before do
+        allow_any_instance_of(ValidatorFactory.validator_class)
+          .to receive(:account_is_open!).and_raise(ValidatorError)
+      end
+
+      it_should_allow(:director) do
+        expect(assigns(:account_user)).to be_persisted
+      end
+    end
   end
 
   context "destroy" do

--- a/spec/controllers/facility_account_users_controller_spec.rb
+++ b/spec/controllers/facility_account_users_controller_spec.rb
@@ -113,16 +113,16 @@ RSpec.describe FacilityAccountUsersController, if: SettingsHelper.feature_on?(:e
 
         before :each do
           @account_user = @account.owner
-          AccountUser.delete(@account_user.id)
+          @account_user.destroy!
 
           @params[:account_user][:user_role] = AccountUser::ACCOUNT_OWNER
-          expect(@account.account_users.owners).not_to be_any
+          expect(@account.account_users.owners).to be_empty
           do_request
         end
 
         it "adds the owner" do
           expect(assigns(:account)).to eq(@account)
-          expect(@account.account_users.owners.count).to eq(1)
+          expect(@account.reload.owner_user).to eq(@purchaser)
           is_expected.to set_flash
           assert_redirected_to facility_account_members_path(@authable, @account)
         end
@@ -215,6 +215,17 @@ RSpec.describe FacilityAccountUsersController, if: SettingsHelper.feature_on?(:e
       expect(assigns(:account_user).deleted_by).to eq(user.id)
       is_expected.to set_flash
       assert_redirected_to facility_account_members_path(@authable, @account)
+    end
+
+    describe "adding to an account that does not pass validation" do
+      before do
+        allow_any_instance_of(ValidatorFactory.validator_class)
+          .to receive(:account_is_open!).and_raise(ValidatorError)
+      end
+
+      it_should_allow(:director) do
+        expect(@account_user.reload.deleted_at).to be_present
+      end
     end
 
   end

--- a/spec/controllers/global_search_controller_spec.rb
+++ b/spec/controllers/global_search_controller_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe GlobalSearchController do
       context "when signed in as a business admin" do
         before :each do
           sign_in @staff
-          AccountUser.grant(@staff, AccountUser::ACCOUNT_ADMINISTRATOR, account, @admin)
+          AccountUser.grant(@staff, AccountUser::ACCOUNT_ADMINISTRATOR, account, by: @admin)
         end
 
         it_should_find_the_order
@@ -160,7 +160,7 @@ RSpec.describe GlobalSearchController do
       context "when signed in as a purchaser" do
         before :each do
           sign_in @staff
-          AccountUser.grant(@staff, AccountUser::ACCOUNT_PURCHASER, account, @admin)
+          AccountUser.grant(@staff, AccountUser::ACCOUNT_PURCHASER, account, by: @admin)
         end
 
         it_should_not_find_the_order
@@ -169,7 +169,7 @@ RSpec.describe GlobalSearchController do
       context "when signed in as an account owner" do
         before :each do
           sign_in @staff
-          account.add_or_update_member(@staff, AccountUser::ACCOUNT_OWNER, @admin)
+          AccountUser.grant(@staff, AccountUser::ACCOUNT_OWNER, account, by: @admin)
         end
 
         it_should_find_the_order

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -50,7 +50,24 @@ FactoryBot.define do
           user,
           AccountUser::ACCOUNT_ADMINISTRATOR,
           evaluator.account,
-          evaluator.administrator || user,
+          by: evaluator.administrator || user,
+        )
+      end
+    end
+
+
+    trait :purchaser do
+      transient do
+        account { nil }
+        administrator { nil }
+      end
+
+      after(:create) do |user, evaluator|
+        AccountUser.grant(
+          user,
+          AccountUser::ACCOUNT_PURCHASER,
+          evaluator.account,
+          by: evaluator.administrator,
         )
       end
     end
@@ -75,22 +92,6 @@ FactoryBot.define do
           user: user,
           role: UserRole::FACILITY_DIRECTOR,
           facility: evaluator.facility,
-        )
-      end
-    end
-
-    trait :purchaser do
-      transient do
-        account { nil }
-        administrator { nil }
-      end
-
-      after(:create) do |user, evaluator|
-        AccountUser.grant(
-          user,
-          AccountUser::ACCOUNT_PURCHASER,
-          evaluator.account,
-          evaluator.administrator,
         )
       end
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -55,7 +55,6 @@ FactoryBot.define do
       end
     end
 
-
     trait :purchaser do
       transient do
         account { nil }

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -209,6 +209,15 @@ RSpec.describe Account do
       expect(@account.errors[:base]).to eq(["Must have an account owner"])
     end
 
+    it "autosaves the association to the account owner" do
+      user = FactoryBot.create(:user)
+      account = FactoryBot.build(:account)
+      account_user = account.account_users.build(user: user, user_role: AccountUser::ACCOUNT_OWNER, created_by_user: user)
+
+      expect(account.save).to be_truthy
+      expect(account_user).to be_persisted
+    end
+
     it "should find the non-deleted account owner" do
       @user1   = FactoryBot.create(:user)
       @user2   = FactoryBot.create(:user)

--- a/spec/models/account_user_spec.rb
+++ b/spec/models/account_user_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe AccountUser do
       )
     end
 
-    it "will still create the purchaser if the account is invalid" do
+    it "will still create the purchaser if the account is invalid per the validator" do
       allow_any_instance_of(ValidatorFactory.validator_class)
         .to receive(:account_is_open!).and_raise(ValidatorError)
 
@@ -201,6 +201,14 @@ RSpec.describe AccountUser do
       result = described_class.grant(nil, AccountUser::ACCOUNT_OWNER, account, by: account_manager)
       expect(result).to be_new_record
       expect(old_owner_role.reload.deleted_at).to be_blank
+    end
+
+    it "creates a new row and deletes the old one when changing the role" do
+      purchaser_account_user = described_class.grant(new_purchaser, AccountUser::ACCOUNT_PURCHASER, account, by: account_manager)
+      ba_account_user = described_class.grant(new_purchaser, AccountUser::ACCOUNT_ADMINISTRATOR, account, by: account_manager)
+
+      expect(purchaser_account_user).not_to eq(ba_account_user)
+      expect(purchaser_account_user.reload.deleted_at).to be_present
     end
   end
 end

--- a/spec/models/account_user_spec.rb
+++ b/spec/models/account_user_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe AccountUser do
     it "does not persist if there's something wrong with it" do
       old_owner_role = account.owner
       result = described_class.grant(nil, AccountUser::ACCOUNT_OWNER, account, by: account_manager)
-      expect(result).to be_blank
+      expect(result).to be_new_record
       expect(old_owner_role.reload.deleted_at).to be_blank
     end
   end

--- a/spec/models/account_user_spec.rb
+++ b/spec/models/account_user_spec.rb
@@ -15,7 +15,10 @@ RSpec.describe AccountUser do
       context role do
         subject { build(:account_user, user_role: role) }
 
-        it { is_expected.to be_valid }
+        it "does not have an error on the role" do
+          subject.valid?
+          expect(subject.errors).not_to include(:user_role)
+        end
       end
     end
   end
@@ -25,8 +28,7 @@ RSpec.describe AccountUser do
 
     it "is invalid" do
       is_expected.not_to be_valid
-      expect(account_user.errors[:user_role])
-        .to include(a_string_matching("invalid"))
+      expect(account_user.errors).to be_added(:user_role, "is invalid")
     end
   end
 
@@ -35,8 +37,7 @@ RSpec.describe AccountUser do
 
     it "is invalid" do
       is_expected.not_to be_valid
-      expect(account_user.errors[:user_role])
-        .to include(a_string_matching("invalid"))
+      expect(account_user.errors).to be_added(:user_role, "is invalid")
     end
   end
 
@@ -74,6 +75,17 @@ RSpec.describe AccountUser do
     end
   end
 
+  describe "when there is already an inactive role" do
+    let(:account) { create(:nufs_account, :with_account_owner) }
+    let(:user) { create(:user) }
+
+    it "can have multiple inactive roles for an account" do
+      create(:account_user, :purchaser, :inactive, account: account, user: user)
+      old = build(:account_user, :purchaser, :inactive, account: account, user: user)
+      expect(old).to be_valid
+    end
+  end
+
   context "when an account has an active owner" do
     let!(:account) { create(:nufs_account, :with_account_owner) }
 
@@ -88,6 +100,17 @@ RSpec.describe AccountUser do
         expect(account_user.errors[:user_role])
           .to include(a_string_matching("already been taken"))
       end
+    end
+  end
+
+  describe "can have multiple old owners" do
+    let!(:account) { create(:nufs_account, :with_account_owner) }
+
+    it "in valid" do
+      create(:account_user, :owner, :inactive, account: account, user: create(:user))
+      old = build(:account_user, :owner, :inactive, account: account, user: create(:user))
+
+      expect(old).to be_valid
     end
   end
 
@@ -133,6 +156,51 @@ RSpec.describe AccountUser do
 
         it { is_expected.not_to include(AccountUser::ACCOUNT_OWNER) }
       end
+    end
+  end
+
+  describe ".grant" do
+    let(:account_manager) { create(:user, :administrator) }
+    let!(:account) { create(:nufs_account, :with_account_owner) }
+    let(:new_purchaser) { create(:user) }
+
+    it "creates a new UserRole when adding a purchaser" do
+      result = described_class.grant(new_purchaser, AccountUser::ACCOUNT_PURCHASER, account, by: account_manager)
+      expect(result).to be_persisted
+      expect(result).to have_attributes(
+        user: new_purchaser,
+        account: account,
+        user_role: AccountUser::ACCOUNT_PURCHASER,
+        created_by_user: account_manager,
+      )
+    end
+
+    it "will still create the purchaser if the account is invalid" do
+      allow_any_instance_of(ValidatorFactory.validator_class)
+          .to receive(:account_is_open!).and_raise(ValidatorError)
+
+      result = described_class.grant(new_purchaser, AccountUser::ACCOUNT_PURCHASER, account, by: account_manager)
+      expect(result).to be_persisted
+    end
+
+    it "replaces the owner if you add a new one" do
+      old_owner = account.owner_user
+
+      expect { described_class.grant(new_purchaser, AccountUser::ACCOUNT_OWNER, account, by: account_manager) }
+        .to change { account.reload.owner_user }.from(old_owner).to(new_purchaser)
+    end
+
+    it "soft deletes the old owner" do
+      old_owner_role = account.owner
+      expect { described_class.grant(new_purchaser, AccountUser::ACCOUNT_OWNER, account, by: account_manager) }
+        .to change(old_owner_role, :deleted_at).to be_present
+    end
+
+    it "does not persist if there's something wrong with it" do
+      old_owner_role = account.owner
+      result = described_class.grant(nil, AccountUser::ACCOUNT_OWNER, account, by: account_manager)
+      expect(result).to be_blank
+      expect(old_owner_role.reload.deleted_at).to be_blank
     end
   end
 end

--- a/spec/models/account_user_spec.rb
+++ b/spec/models/account_user_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe AccountUser do
 
     it "will still create the purchaser if the account is invalid" do
       allow_any_instance_of(ValidatorFactory.validator_class)
-          .to receive(:account_is_open!).and_raise(ValidatorError)
+        .to receive(:account_is_open!).and_raise(ValidatorError)
 
       result = described_class.grant(new_purchaser, AccountUser::ACCOUNT_PURCHASER, account, by: account_manager)
       expect(result).to be_persisted

--- a/spec/models/chart_string_reassignment_form_spec.rb
+++ b/spec/models/chart_string_reassignment_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ChartStringReassignmentForm do
 
   describe "#available_accounts" do
     def grant_account_to_user(account, user)
-      AccountUser.grant(user, AccountUser::ACCOUNT_PURCHASER, account, account_owner)
+      AccountUser.grant(user, AccountUser::ACCOUNT_PURCHASER, account, by: account_owner)
     end
 
     def grant_accounts_to_user(accounts, user)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -132,7 +132,7 @@ RSpec.configure do |config|
 
   require "rspec/active_job"
   config.include(RSpec::ActiveJob)
-
+  config.filter_gems_from_backtrace("activesupport", "activemodel", "activerecord", "spring")
 end
 
 FactoryBot::SyntaxRunner.class_eval do


### PR DESCRIPTION
# Release Notes

Allow changes to account membership even if the chartstring becomes invalid.

# Screenshot

Before:

![](https://pm.tablexi.com/attachments/download/86702/Screen%20Shot%202017-06-05%20at%2012.10.01%20PM.png)

# Additional Context

The major issue was that `NufsAccount` runs the `ValidatorFactory`'s validations on `update`. The way this was being done before was triggering those validations, and if the validator raised a validation error, we couldn't add another user to the payment source.

This sidesteps that issue by doing the work from the `AccountUser` model and doing an ownership check on the `Account` just to make sure.

I also tried to standardize `AccountUser` creation so it's always going through the `grant` method. That accounts for a chunk of noise in the specs.