### PR TITLE
[#144715] Fix Daily View Navigation Skipping in Firefox

### DIFF
--- a/app/assets/javascripts/timeline.js
+++ b/app/assets/javascripts/timeline.js
@@ -113,7 +113,7 @@ $(function() {
 
   function lastHiddenInstrumentId() {
     var hiddenInstruments = $('.timeline_instrument').filter(function() {
-      return $(window).scrollTop() > $(this).offset().top;
+      return $(window).scrollTop() + $('.timeline_header').height() > $(this).offset().top;
     });
 
     return hiddenInstruments.last().attr('id');


### PR DESCRIPTION
# Release Notes

Fix Daily View Navigation Skipping in Firefox

# Additional Context

In Firefox and Chrome, `$(window).scrollTop()` returns different pixel values when the page is scrolled down to the exact same instrument. This difference of 1.5 pixels was enough to trip up the calculation to think that a hidden element was visible, which was causing the wrong element id to be appended when switching dates. By using the date navigation header’s height in the calculation, we get a more robust value which takes into accound the element that is being covered, and this works everywhere.