### PR TITLE
[#144294] Normalize whitespace in statement PDFs

### DIFF
--- a/app/services/whitespace_normalizer.rb
+++ b/app/services/whitespace_normalizer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class WhitespaceNormalizer
+
+  def self.normalize(text)
+    new(text).normalize
+  end
+
+  def initialize(text)
+    @text = text
+  end
+
+  def normalize
+    result = normalize_spaces(@text)
+    result = normalize_new_lines(result)
+    result
+  end
+
+  private
+
+  def normalize_spaces(text)
+    text.gsub(/\p{Blank}/, " ")
+  end
+
+  def normalize_new_lines(text)
+    text.gsub(/\R+/, "\n")
+  end
+
+end

--- a/app/services/whitespace_normalizer.rb
+++ b/app/services/whitespace_normalizer.rb
@@ -3,27 +3,9 @@
 class WhitespaceNormalizer
 
   def self.normalize(text)
-    new(text).normalize
-  end
-
-  def initialize(text)
-    @text = text
-  end
-
-  def normalize
-    result = normalize_spaces(@text)
-    result = normalize_new_lines(result)
-    result
-  end
-
-  private
-
-  def normalize_spaces(text)
-    text.gsub(/\p{Blank}/, " ")
-  end
-
-  def normalize_new_lines(text)
-    text.gsub(/\R+/, "\n")
+    text
+      &.gsub(/\p{Blank}/, " ") # spaces including unicode
+      &.gsub(/\R+/, "\n") # newlines
   end
 
 end

--- a/app/support/example_statement_pdf.rb
+++ b/app/support/example_statement_pdf.rb
@@ -52,7 +52,7 @@ class ExampleStatementPdf < StatementPdf
   def generate_remittance_information(pdf)
     pdf.move_down(10)
     pdf.text "Bill To:", font_style: :bold
-    pdf.text @account.remittance_information
+    pdf.text normalize_whitespace(@account.remittance_information)
   end
 
   def order_detail_headers
@@ -63,7 +63,7 @@ class ExampleStatementPdf < StatementPdf
     @statement.order_details.includes(:product).order("fulfilled_at DESC").map do |order_detail|
       [
         format_usa_datetime(order_detail.fulfilled_at),
-        "##{order_detail}: #{order_detail.product}" + (order_detail.note.blank? ? "" : "\n#{order_detail.note}"),
+        "##{order_detail}: #{order_detail.product}" + (order_detail.note.blank? ? "" : "\n#{normalize_whitespace(order_detail.note)}"),
         OrderDetailPresenter.new(order_detail).wrapped_quantity,
         number_to_currency(order_detail.actual_total),
       ]

--- a/app/support/statement_pdf.rb
+++ b/app/support/statement_pdf.rb
@@ -36,6 +36,10 @@ class StatementPdf
     @download
   end
 
+  def normalize_whitespace(text)
+    WhitespaceNormalizer.normalize(text)
+  end
+
   def filename
     date = I18n.l(@statement.created_at.to_date, format: :usa_filename_safe)
     I18n.t("statements.pdf.filename", date: date,

--- a/spec/services/whitespace_normalizer_spec.rb
+++ b/spec/services/whitespace_normalizer_spec.rb
@@ -47,4 +47,9 @@ RSpec.describe WhitespaceNormalizer do
     input = "with\u2028a line separator"
     expect(described_class.normalize(input)).to eq("with\na line separator")
   end
+
+  it "doesn't choke on nil" do
+    input = nil
+    expect(described_class.normalize(input)).to eq(nil)
+  end
 end

--- a/spec/services/whitespace_normalizer_spec.rb
+++ b/spec/services/whitespace_normalizer_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WhitespaceNormalizer do
+
+  it "changes spaces and tabs" do
+    input = "a test\tof tabs"
+    expect(described_class.normalize(input)).to eq("a test of tabs")
+  end
+
+  it "changes em and en unicode spaces" do
+    input = "enspace\u2002followed by\u2003emspace"
+    expect(described_class.normalize(input)).to eq("enspace followed by emspace")
+  end
+
+  it "changes a bunch of other characters" do
+    characters = [
+      "\u2007", # figure space
+      "\u2008", # punctuatin space
+      "\u2009", # thin space
+      "\u200A", # hair space
+      "\u2000", # zero-width space
+      "\u00A0", # non-breaking space
+    ]
+    input = characters.join
+
+    expect(described_class.normalize(input)).to eq(" " * characters.length)
+  end
+
+  it "leaves new lines alone" do
+    input = "with\nsome\nnew\nlines"
+    expect(described_class.normalize(input)).to eq(input)
+  end
+
+  it "converts carriage returns to newlines" do
+    input = "with\rsome\rcarriage\rreturns"
+    expect(described_class.normalize(input)).to eq("with\nsome\ncarriage\nreturns")
+  end
+
+  it "converts NL+CR to a single newline" do
+    input = "with\n\rsome\r\nbreaks"
+    expect(described_class.normalize(input)).to eq("with\nsome\nbreaks")
+  end
+
+  it "cleans up unicode line separator" do
+    input = "with\u2028a line separator"
+    expect(described_class.normalize(input)).to eq("with\na line separator")
+  end
+end


### PR DESCRIPTION
# Release Notes

Fix tab characters display on statement PDFs.

# Screenshot

![sans serif](https://user-images.githubusercontent.com/1099111/48507638-17229d80-e812-11e8-8330-cc7b6bf9d8a1.JPG)

# Additional Context

This started happening when we switched to using a TTF for the statements. Tab characters were displaying funkily. This should also handle if non-breaking spaces and its ilk get pasted in.
