### PR TITLE
[#140549] Retry LDAP queries up to 3 times

### DIFF
--- a/vendor/engines/ldap_authentication/lib/ldap_authentication/user_entry.rb
+++ b/vendor/engines/ldap_authentication/lib/ldap_authentication/user_entry.rb
@@ -10,7 +10,7 @@ module LdapAuthentication
 
       ldap_entries = nil
       ActiveSupport::Notifications.instrument "search.ldap_authentication" do |payload|
-        ldap_entries = admin_ldap.search(filter: Net::LDAP::Filter.eq(LdapAuthentication.attribute_field, uid))
+        ldap_entries = with_retry { admin_ldap.search(filter: Net::LDAP::Filter.eq(LdapAuthentication.attribute_field, uid)) }
         payload[:uid] = uid
         payload[:results] = ldap_entries
       end
@@ -50,6 +50,16 @@ module LdapAuthentication
 
     def to_user
       UserConverter.new(self).to_user
+    end
+
+    def self.with_retry(errors = [Net::LDAP::Error], max_attempts: 3)
+      tries = 0
+      begin
+        yield
+      rescue *errors => e
+        tries += 1
+        tries >= max_attempts ? raise : retry
+      end
     end
 
   end

--- a/vendor/engines/ldap_authentication/lib/ldap_authentication/user_entry.rb
+++ b/vendor/engines/ldap_authentication/lib/ldap_authentication/user_entry.rb
@@ -52,11 +52,11 @@ module LdapAuthentication
       UserConverter.new(self).to_user
     end
 
-    def self.with_retry(errors = [Net::LDAP::Error], max_attempts: 3)
+    def self.with_retry(max_attempts = 3)
       tries = 0
       begin
         yield
-      rescue *errors => e
+      rescue Net::LDAP::Error => e
         tries += 1
         tries >= max_attempts ? raise : retry
       end

--- a/vendor/engines/ldap_authentication/spec/ldap_authentication/user_entry_spec.rb
+++ b/vendor/engines/ldap_authentication/spec/ldap_authentication/user_entry_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe LdapAuthentication::UserEntry do
 
     describe "retrying" do
       it "raise an error if it fails 3 times" do
-        expect(admin_ldap).to receive(:search).exactly(3).times { raise(Net::LDAP::Error, "Connection timed out") }
+        expect(admin_ldap).to(receive(:search).exactly(3).times { raise(Net::LDAP::Error, "Connection timed out") })
 
         expect { described_class.find("uname") }.to raise_error(Net::LDAP::Error, "Connection timed out")
       end
 
       it "succeeds if it succeeds the third time" do
-        expect(admin_ldap).to receive(:search).twice { raise(Net::LDAP::Error, "Connection timed out") }
-        expect(admin_ldap).to receive(:search).once { [net_ldap_entry] }
+        expect(admin_ldap).to(receive(:search).twice { raise(Net::LDAP::Error, "Connection timed out") })
+        expect(admin_ldap).to(receive(:search).once { [net_ldap_entry] })
 
         entry = described_class.find("uname")
         expect(entry).to be_an_instance_of(described_class)

--- a/vendor/engines/ldap_authentication/spec/ldap_authentication/user_entry_spec.rb
+++ b/vendor/engines/ldap_authentication/spec/ldap_authentication/user_entry_spec.rb
@@ -22,6 +22,22 @@ RSpec.describe LdapAuthentication::UserEntry do
       expect(entry).to be_an_instance_of(described_class)
       expect(admin_ldap).to have_received(:search).with(filter: Net::LDAP::Filter.eq("uid", "uname"))
     end
+
+    describe "retrying" do
+      it "raise an error if it fails 3 times" do
+        expect(admin_ldap).to receive(:search).exactly(3).times { raise(Net::LDAP::Error, "Connection timed out") }
+
+        expect { described_class.find("uname") }.to raise_error(Net::LDAP::Error, "Connection timed out")
+      end
+
+      it "succeeds if it succeeds the third time" do
+        expect(admin_ldap).to receive(:search).twice { raise(Net::LDAP::Error, "Connection timed out") }
+        expect(admin_ldap).to receive(:search).once { [net_ldap_entry] }
+
+        entry = described_class.find("uname")
+        expect(entry).to be_an_instance_of(described_class)
+      end
+    end
   end
 
   describe "fields" do


### PR DESCRIPTION

# Release Notes

Tech task: Retry, up to three times, LDAP queries that time out.

# Additional Context

This should help with the LDAP deactivation job getting occasional timeouts which
was causing the entire job to fail. It'll still end up crashing if there's a serious issue with LDAP, but hopefully, this will handle most of the cases.

