### PR TITLE
Handle survey urls that already have a question mark in them

### DIFF
--- a/app/models/external_service/url_service.rb
+++ b/app/models/external_service/url_service.rb
@@ -14,14 +14,24 @@ class UrlService < ExternalService
   #   relationship. Useful for providing pass-thru HTTP param data
   #   to the external service.
   def new_url(receiver, request = nil)
-    "#{location}?#{query_string(receiver, request)}"
+    merge_queries(location, additional_query_params(receiver, request))
   end
 
-  def edit_url(receiver, request)
-    "#{receiver.edit_url}?#{query_string(receiver, request)}"
+  def edit_url(receiver, request = nil)
+    merge_queries(receiver.edit_url, additional_query_params(receiver, request))
   end
 
-  def query_string(receiver, request)
+  private
+
+  def merge_queries(url, additional_hash)
+    uri = URI(url)
+    query_hash = Rack::Utils.parse_query(uri.query)
+    query_hash.merge!(additional_hash)
+    uri.query = query_hash.to_query
+    uri.to_s
+  end
+
+  def additional_query_params(receiver, request)
     query = {
       success_url: success_path(receiver, request),
       referer: referer_url(request),
@@ -30,10 +40,8 @@ class UrlService < ExternalService
 
     query[:order_number] = receiver.order_number if receiver.respond_to?(:order_number)
     query[:quantity] = receiver.quantity if receiver.respond_to?(:quantity)
-    query.to_query
+    query
   end
-
-  private
 
   def referer_url(request)
     "#{request.protocol}#{request.host_with_port}#{request.fullpath}" if request

--- a/spec/models/external_service/url_service_spec.rb
+++ b/spec/models/external_service/url_service_spec.rb
@@ -60,5 +60,35 @@ RSpec.describe UrlService do
     it "returns a blank referer" do
       expect(query_hash["referer"]).to be_blank
     end
+
+    describe "when the location already has a ? in it" do
+      before { url_service.location = "http://www.survey.com/survey1?q=true&other=false" }
+
+      it "sets the currect uri" do
+        expect(uri.to_s).to start_with("http://www.survey.com/survey1?")
+        expect(query_hash).to include(
+          "q" => "true",
+          "other" => "false",
+          "receiver_id" => order_detail.id.to_s,
+        )
+      end
+    end
+  end
+
+  describe "edit_url" do
+    let(:edit_url) { url_service.edit_url(order_detail) }
+    let(:query_hash) { Rack::Utils.parse_query(URI(edit_url).query) }
+
+    describe "when the url already has a ?" do
+      before { allow(order_detail).to receive(:edit_url).and_return("http://www.survey.com/surveys/edit?id=123") }
+
+      it "sets the query string correctly if the link already has a ?" do
+        expect(edit_url).to start_with("http://www.survey.com/surveys/edit?")
+        expect(query_hash).to include(
+          "id" => "123",
+          "receiver_id" => order_detail.id.to_s,
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
# Release Notes

Handle external survey links that already contain a question mark.

# Additional Context

If a survey link has a question mark in it, we would append additional query params with our own `?`. This came up in the context of PerfectForms. Qualtrics and Surveyor don't have `?` in their URLs, so it wasn't a problem before.

`http://www.survey.com/surveys/edit?id=123` would end up as `http://www.survey.com/surveys/edit?id=123?order_id=123-456&...`. This corrects it so we only end up with a single question mark.
