### PR TITLE
[#144530] Allow requiring a note when creating price policies

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -295,10 +295,6 @@ th.currency {
 
 /* Price policies */
 
-p.charge-for {
-  font-style: italic;
-}
-
 p.per-minute {
   font-style: italic;
   @extend .muted;

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -127,7 +127,7 @@ class PricePoliciesController < ApplicationController
       @price_policies,
       parse_usa_date(params[:start_date])&.beginning_of_day,
       parse_usa_date(params[:expire_date])&.end_of_day,
-      params,
+      params.merge(created_by_id: current_user.id),
     )
   end
 

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -14,6 +14,8 @@ class PricePolicy < ApplicationRecord
 
   validate :subsidy_less_than_rate, unless: :restrict_purchase?
 
+  validates :note, presence: true, if: -> { SettingsHelper.feature_on?(:price_policy_requires_note) }
+
   validates_each :expire_date do |record, _attr, value|
     start_date = record.start_date
     if value.present? && start_date.present?

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -19,6 +19,7 @@ class PricePolicy < ApplicationRecord
     # Length of 10 is defined by Dartmouth.
     validates :note, presence: true, length: { minimum: 10, allow_blank: true }
   end
+  validates :note, length: { maximum: 256 }
 
   validates_each :expire_date do |record, _attr, value|
     start_date = record.start_date

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -15,7 +15,10 @@ class PricePolicy < ApplicationRecord
 
   validate :subsidy_less_than_rate, unless: :restrict_purchase?
 
-  validates :note, presence: true, if: -> { SettingsHelper.feature_on?(:price_policy_requires_note) }
+  with_options if: -> { SettingsHelper.feature_on?(:price_policy_requires_note) } do
+    # Length of 10 is defined by Dartmouth.
+    validates :note, presence: true, length: { minimum: 10, allow_blank: true }
+  end
 
   validates_each :expire_date do |record, _attr, value|
     start_date = record.start_date

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -6,6 +6,7 @@ class PricePolicy < ApplicationRecord
 
   belongs_to :price_group
   belongs_to :product
+  belongs_to :created_by, class_name: "User"
   has_many :order_details
 
   validates :start_date, :expire_date, presence: true

--- a/app/services/price_policy_updater.rb
+++ b/app/services/price_policy_updater.rb
@@ -55,7 +55,7 @@ class PricePolicyUpdater
   end
 
   def permitted_common_params
-    @params.permit(:charge_for, :note)
+    @params.permit(:charge_for, :note, :created_by_id)
   end
 
   def permitted_params

--- a/app/services/price_policy_updater.rb
+++ b/app/services/price_policy_updater.rb
@@ -51,14 +51,14 @@ class PricePolicyUpdater
   end
 
   def permitted_price_group_attributes(price_group)
-    @params["price_policy_#{price_group.id}"]&.permit(*allowed_attributes) || { can_purchase: false }
+    @params["price_policy_#{price_group.id}"]&.permit(*permitted_params) || { can_purchase: false }
   end
 
   def permitted_common_params
     @params.permit(:charge_for, :note)
   end
 
-  def allowed_attributes
+  def permitted_params
     [
       :can_purchase,
       :usage_rate,

--- a/app/services/price_policy_updater.rb
+++ b/app/services/price_policy_updater.rb
@@ -26,14 +26,14 @@ class PricePolicyUpdater
   end
 
   def update_all
-    update && save
+    assign_attributes && save
   end
 
   private
 
-  def update
+  def assign_attributes
     @price_policies.each do |price_policy|
-      price_policy.attributes = price_group_attributes(price_policy.price_group)
+      price_policy.assign_attributes(price_group_attributes(price_policy.price_group))
     end
   end
 
@@ -44,15 +44,18 @@ class PricePolicyUpdater
   end
 
   def price_group_attributes(price_group)
-    initial_price_group_attributes(price_group).tap do |attributes|
-      attributes[:charge_for] = @params[:charge_for] if @params[:charge_for].present?
-      attributes[:expire_date] = @expire_date
-      attributes[:start_date] = @start_date
-    end
+    permitted_price_group_attributes(price_group).merge(
+      start_date: @start_date,
+      expire_date: @expire_date,
+    ).merge(permitted_common_params)
   end
 
-  def initial_price_group_attributes(price_group)
+  def permitted_price_group_attributes(price_group)
     @params["price_policy_#{price_group.id}"]&.permit(*allowed_attributes) || { can_purchase: false }
+  end
+
+  def permitted_common_params
+    @params.permit(:charge_for, :note)
   end
 
   def allowed_attributes

--- a/app/views/price_policies/_common_fields.html.haml
+++ b/app/views/price_policies/_common_fields.html.haml
@@ -1,2 +1,3 @@
 = f.input :start_date, input_html: { value: format_usa_date(price_policy.start_date), class: "datepicker__data" }, label: "Effective"
 = f.input :expire_date, input_html: { value: format_usa_date(price_policy.expire_date), class: "datepicker__data" }, label: "Expires"
+= f.input :note, as: :text, input_html: { value: price_policy.note }, required: SettingsHelper.feature_on?(:price_policy_requires_note)

--- a/app/views/price_policies/_price_policy_fields.html.haml
+++ b/app/views/price_policies/_price_policy_fields.html.haml
@@ -2,7 +2,7 @@
   = javascript_include_tag "price_policy"
 
 - price_policy = @price_policies.first
-= render "price_policies/dates", f: f, price_policy: price_policy
+= render "price_policies/common_fields", f: f, price_policy: price_policy
 
 %table.table.table-striped.table-hover.price-policy-table
   %thead

--- a/app/views/price_policies/index.html.haml
+++ b/app/views/price_policies/index.html.haml
@@ -21,7 +21,10 @@
   - policy = @current_price_policies.first
   %h4= text("dates", start: human_date(@current_start_date), expires: human_date(policy.expire_date))
   - if policy.charge_for.present?
-    %p.charge-for= text("charges_for", charge_for: policy.charge_for)
+    %p
+      %em= text("charges_for", charge_for: policy.charge_for)
+  %p
+    %em= text("note", note: policy.note)
   = render "table",
     price_policies: @current_price_policies,
     url_date: @current_start_date.strftime("%Y-%m-%d"),

--- a/app/views/time_based_price_policies/_price_policy_fields.html.haml
+++ b/app/views/time_based_price_policies/_price_policy_fields.html.haml
@@ -2,7 +2,7 @@
   = javascript_include_tag "price_policy"
 
 - price_policy = @price_policies.first
-= render "price_policies/dates", f: f, price_policy: price_policy
+= render "price_policies/common_fields", f: f, price_policy: price_policy
 
 - if local_assigns[:charge_for_collection]
   = f.input :charge_for,

--- a/config/locales/views/admin/en.price_policies.yml
+++ b/config/locales/views/admin/en.price_policies.yml
@@ -10,6 +10,7 @@ en:
         past: Past Pricing Rules
         dates: "Effective: %{start}, Expires: %{expires}"
         charges_for: "Charges for %{charge_for}"
+        note: "Note: %{note}"
       edit:
         instructional_text: |
           All users must be charged the same base rate. You may define adjustments

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -126,6 +126,7 @@ feature:
   use_manage_on: false
   facility_banner_notice_on: true
   charge_full_price_on_cancellation_on: true
+  price_policy_requires_note_on: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -126,7 +126,7 @@ feature:
   use_manage_on: false
   facility_banner_notice_on: true
   charge_full_price_on_cancellation_on: true
-  price_policy_requires_note_on: false
+  price_policy_requires_note_on: true
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/db/migrate/20181119211456_add_note_to_price_policies.rb
+++ b/db/migrate/20181119211456_add_note_to_price_policies.rb
@@ -3,7 +3,7 @@
 class AddNoteToPricePolicies < ActiveRecord::Migration[5.0]
   def change
     change_table :price_policies do |t|
-      t.text :note
+      t.string :note, limit: 256
       t.references :created_by, index: true, foreign_key: { to_table: :users }
     end
   end

--- a/db/migrate/20181119211456_add_note_to_price_policies.rb
+++ b/db/migrate/20181119211456_add_note_to_price_policies.rb
@@ -1,0 +1,8 @@
+class AddNoteToPricePolicies < ActiveRecord::Migration[5.0]
+  def change
+    change_table :price_policies do |t|
+      t.text :note
+      t.references :created_by, index: true, foreign_key: { to_table: :users }
+    end
+  end
+end

--- a/db/migrate/20181119211456_add_note_to_price_policies.rb
+++ b/db/migrate/20181119211456_add_note_to_price_policies.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddNoteToPricePolicies < ActiveRecord::Migration[5.0]
   def change
     change_table :price_policies do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181102173232) do
+ActiveRecord::Schema.define(version: 20181119211456) do
 
-  create_table "account_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "account_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "account_id",            null: false
     t.integer  "user_id",               null: false
     t.string   "user_role",  limit: 50, null: false
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["user_id"], name: "index_account_users_on_user_id", using: :btree
   end
 
-  create_table "accounts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "accounts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "type",                   limit: 50,    null: false
     t.string   "account_number",         limit: 50,    null: false
     t.string   "description",            limit: 50,    null: false
@@ -47,14 +47,14 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["facility_id"], name: "fk_account_facility_id", using: :btree
   end
 
-  create_table "affiliates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "affiliates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "name"
     t.datetime "created_at",                            null: false
     t.datetime "updated_at",                            null: false
     t.boolean  "subaffiliates_enabled", default: false, null: false
   end
 
-  create_table "budgeted_chart_strings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "budgeted_chart_strings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "fund",       limit: 20, null: false
     t.string   "dept",       limit: 20, null: false
     t.string   "project",    limit: 20
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.datetime "expires_at",            null: false
   end
 
-  create_table "bulk_email_jobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "bulk_email_jobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "facility_id"
     t.integer  "user_id",                       null: false
     t.string   "subject",                       null: false
@@ -77,7 +77,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["user_id"], name: "fk_rails_7cd8662ccc", using: :btree
   end
 
-  create_table "bundle_products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "bundle_products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "bundle_product_id", null: false
     t.integer "product_id",        null: false
     t.integer "quantity",          null: false
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["product_id"], name: "fk_bundle_prod_bundle", using: :btree
   end
 
-  create_table "delayed_jobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "delayed_jobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "priority",                      default: 0, null: false
     t.integer  "attempts",                      default: 0, null: false
     t.text     "handler",    limit: 4294967295,             null: false
@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
   end
 
-  create_table "email_events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "email_events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id",      null: false
     t.string   "key",          null: false
     t.datetime "last_sent_at", null: false
@@ -109,7 +109,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["user_id", "key"], name: "index_email_events_on_user_id_and_key", unique: true, using: :btree
   end
 
-  create_table "external_service_passers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "external_service_passers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "external_service_id"
     t.integer  "passer_id"
     t.string   "passer_type"
@@ -120,7 +120,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["passer_id", "passer_type"], name: "i_external_passer_id", using: :btree
   end
 
-  create_table "external_service_receivers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "external_service_receivers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "external_service_id"
     t.integer  "receiver_id"
     t.string   "receiver_type"
@@ -133,14 +133,14 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["receiver_id", "receiver_type"], name: "i_external_receiver_id", using: :btree
   end
 
-  create_table "external_services", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "external_services", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "type"
     t.string   "location"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "facilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "facilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "name",                         limit: 200,                   null: false
     t.string   "abbreviation",                 limit: 50,                    null: false
     t.string   "url_name",                     limit: 50,                    null: false
@@ -167,7 +167,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["url_name"], name: "index_facilities_on_url_name", unique: true, using: :btree
   end
 
-  create_table "facility_accounts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "facility_accounts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "facility_id",                null: false
     t.string   "account_number",  limit: 50, null: false
     t.boolean  "is_active",                  null: false
@@ -192,25 +192,25 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["instrument_id"], name: "fk_int_stats_product", using: :btree
   end
 
-  create_table "journal_cutoff_dates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "journal_cutoff_dates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.datetime "cutoff_date"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
   end
 
-  create_table "journal_rows", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "journal_rows", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "journal_id",                                          null: false
     t.integer "order_detail_id"
     t.string  "account",         limit: 5
     t.decimal "amount",                      precision: 9, scale: 2, null: false
-    t.string  "description",     limit: 512
+    t.string  "description",     limit: 400
     t.integer "account_id"
     t.index ["account_id"], name: "index_journal_rows_on_account_id", using: :btree
     t.index ["journal_id"], name: "index_journal_rows_on_journal_id", using: :btree
     t.index ["order_detail_id"], name: "index_journal_rows_on_order_detail_id", using: :btree
   end
 
-  create_table "journals", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "journals", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "facility_id"
     t.string   "reference",         limit: 50
     t.string   "description",       limit: 200
@@ -227,7 +227,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["facility_id"], name: "index_journals_on_facility_id", using: :btree
   end
 
-  create_table "log_events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "log_events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "loggable_id"
     t.string   "loggable_type"
     t.string   "event_type"
@@ -239,7 +239,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["user_id"], name: "index_log_events_on_user_id", using: :btree
   end
 
-  create_table "notifications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "notifications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "type",         null: false
     t.integer  "subject_id",   null: false
     t.string   "subject_type", null: false
@@ -252,7 +252,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["user_id"], name: "index_notifications_on_user_id", using: :btree
   end
 
-  create_table "order_details", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "order_details", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "order_id",                                                                        null: false
     t.integer  "parent_order_detail_id"
     t.integer  "product_id",                                                                      null: false
@@ -295,24 +295,24 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["account_id"], name: "fk_od_accounts", using: :btree
     t.index ["assigned_user_id"], name: "index_order_details_on_assigned_user_id", using: :btree
     t.index ["bundle_product_id"], name: "fk_bundle_prod_id", using: :btree
-    t.index ["dispute_by_id"], name: "fk_rails_14de4f1c86", using: :btree
+    t.index ["dispute_by_id"], name: "order_details_dispute_by_id_fk", using: :btree
     t.index ["group_id"], name: "index_order_details_on_group_id", using: :btree
     t.index ["journal_id"], name: "index_order_details_on_journal_id", using: :btree
-    t.index ["order_id"], name: "fk_rails_e5976611fd", using: :btree
+    t.index ["order_id"], name: "sys_c009172", using: :btree
     t.index ["order_status_id"], name: "index_order_details_on_order_status_id", using: :btree
-    t.index ["parent_order_detail_id"], name: "fk_rails_cc2adae8c3", using: :btree
+    t.index ["parent_order_detail_id"], name: "order_details_parent_order_detail_id_fk", using: :btree
     t.index ["price_changed_by_user_id"], name: "index_order_details_on_price_changed_by_user_id", using: :btree
-    t.index ["price_policy_id"], name: "fk_rails_555b721183", using: :btree
+    t.index ["price_policy_id"], name: "sys_c009175", using: :btree
     t.index ["problem"], name: "index_order_details_on_problem", using: :btree
-    t.index ["product_accessory_id"], name: "fk_rails_e4f0ef56a6", using: :btree
-    t.index ["product_id"], name: "fk_rails_4f2ac9473b", using: :btree
+    t.index ["product_accessory_id"], name: "order_details_product_accessory_id_fk", using: :btree
+    t.index ["product_id"], name: "sys_c009173", using: :btree
     t.index ["project_id"], name: "index_order_details_on_project_id", using: :btree
     t.index ["response_set_id"], name: "index_order_details_on_response_set_id", using: :btree
     t.index ["state"], name: "index_order_details_on_state", using: :btree
     t.index ["statement_id"], name: "index_order_details_on_statement_id", using: :btree
   end
 
-  create_table "order_imports", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "order_imports", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "facility_id"
     t.integer  "upload_file_id",                 null: false
     t.integer  "error_file_id"
@@ -328,7 +328,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["upload_file_id"], name: "index_order_imports_on_upload_file_id", using: :btree
   end
 
-  create_table "order_statuses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "order_statuses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string  "name",        limit: 50, null: false
     t.integer "facility_id"
     t.integer "parent_id"
@@ -338,7 +338,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["parent_id"], name: "index_order_statuses_on_parent_id", using: :btree
   end
 
-  create_table "orders", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "orders", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "account_id"
     t.integer  "user_id",                        null: false
     t.integer  "created_by",                     null: false
@@ -349,15 +349,24 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.string   "state",               limit: 50
     t.integer  "merge_with_order_id"
     t.integer  "order_import_id"
-    t.index ["account_id"], name: "fk_rails_144e25bef6", using: :btree
+    t.index ["account_id"], name: "sys_c008808", using: :btree
     t.index ["facility_id"], name: "index_orders_on_facility_id", using: :btree
+    t.index ["facility_id"], name: "orders_facility_id_fk", using: :btree
     t.index ["merge_with_order_id"], name: "index_orders_on_merge_with_order_id", using: :btree
     t.index ["order_import_id"], name: "index_orders_on_order_import_id", using: :btree
     t.index ["state"], name: "index_orders_on_state", using: :btree
     t.index ["user_id"], name: "index_orders_on_user_id", using: :btree
   end
 
-  create_table "payments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "partial_availabilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "instrument_id",             null: false
+    t.string   "note",          limit: 256, null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.index ["instrument_id"], name: "index_partial_availabilities_on_instrument_id", using: :btree
+  end
+
+  create_table "payments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "account_id",                                              null: false
     t.integer  "statement_id"
     t.string   "source",                                                  null: false
@@ -372,56 +381,59 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["statement_id"], name: "index_payments_on_statement_id", using: :btree
   end
 
-  create_table "price_group_members", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "price_group_members", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string  "type",           limit: 50, null: false
     t.integer "price_group_id",            null: false
     t.integer "user_id"
     t.integer "account_id"
     t.index ["account_id"], name: "index_price_group_members_on_account_id", using: :btree
-    t.index ["price_group_id"], name: "fk_rails_0425013e5b", using: :btree
+    t.index ["price_group_id"], name: "sys_c008583", using: :btree
     t.index ["user_id"], name: "index_price_group_members_on_user_id", using: :btree
   end
 
-  create_table "price_group_products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "price_group_products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "price_group_id",     null: false
     t.integer  "product_id",         null: false
     t.integer  "reservation_window"
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
-    t.index ["price_group_id"], name: "index_price_group_products_on_price_group_id", using: :btree
-    t.index ["product_id"], name: "index_price_group_products_on_product_id", using: :btree
+    t.index ["price_group_id"], name: "i_pri_gro_pro_pri_gro_id", using: :btree
+    t.index ["product_id"], name: "i_pri_gro_pro_pro_id", using: :btree
   end
 
-  create_table "price_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "price_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "facility_id"
     t.string  "name",           limit: 50,                null: false
     t.integer "display_order",                            null: false
     t.boolean "is_internal",                              null: false
     t.boolean "admin_editable",            default: true, null: false
-    t.index ["facility_id", "name"], name: "index_price_groups_on_facility_id_and_name", unique: true, using: :btree
+    t.index ["facility_id", "name"], name: "sys_c008577", unique: true, using: :btree
   end
 
-  create_table "price_policies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "type",                    limit: 50,                                          null: false
+  create_table "price_policies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.string   "type",                    limit: 50,                                             null: false
     t.integer  "product_id"
-    t.integer  "price_group_id",                                                              null: false
-    t.boolean  "can_purchase",                                                default: false, null: false
-    t.datetime "start_date",                                                                  null: false
-    t.decimal  "unit_cost",                          precision: 10, scale: 2
-    t.decimal  "unit_subsidy",                       precision: 10, scale: 2
-    t.decimal  "usage_rate",                         precision: 12, scale: 4
-    t.decimal  "minimum_cost",                       precision: 10, scale: 2
-    t.decimal  "cancellation_cost",                  precision: 10, scale: 2
-    t.decimal  "usage_subsidy",                      precision: 12, scale: 4
-    t.datetime "expire_date",                                                                 null: false
+    t.integer  "price_group_id",                                                                 null: false
+    t.boolean  "can_purchase",                                                   default: false, null: false
+    t.datetime "start_date",                                                                     null: false
+    t.decimal  "unit_cost",                             precision: 10, scale: 2
+    t.decimal  "unit_subsidy",                          precision: 10, scale: 2
+    t.decimal  "usage_rate",                            precision: 12, scale: 4
+    t.decimal  "minimum_cost",                          precision: 10, scale: 2
+    t.decimal  "cancellation_cost",                     precision: 10, scale: 2
+    t.decimal  "usage_subsidy",                         precision: 12, scale: 4
+    t.datetime "expire_date",                                                                    null: false
     t.string   "charge_for"
     t.string   "legacy_rates"
-    t.boolean  "full_price_cancellation",                                     default: false, null: false
-    t.index ["price_group_id"], name: "fk_rails_74aa223960", using: :btree
+    t.boolean  "full_price_cancellation",                                        default: false, null: false
+    t.text     "note",                    limit: 65535
+    t.integer  "created_by_id"
+    t.index ["created_by_id"], name: "index_price_policies_on_created_by_id", using: :btree
+    t.index ["price_group_id"], name: "sys_c008589", using: :btree
     t.index ["product_id"], name: "index_price_policies_on_product_id", using: :btree
   end
 
-  create_table "product_access_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "product_access_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "product_id", null: false
     t.string   "name"
     t.datetime "created_at", null: false
@@ -429,14 +441,14 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["product_id"], name: "index_product_access_groups_on_product_id", using: :btree
   end
 
-  create_table "product_access_schedule_rules", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "product_access_schedule_rules", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "product_access_group_id", null: false
     t.integer "schedule_rule_id",        null: false
     t.index ["product_access_group_id"], name: "index_product_access_schedule_rules_on_product_access_group_id", using: :btree
     t.index ["schedule_rule_id"], name: "index_product_access_schedule_rules_on_schedule_rule_id", using: :btree
   end
 
-  create_table "product_accessories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "product_accessories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "product_id",                        null: false
     t.integer  "accessory_id",                      null: false
     t.string   "scaling_type", default: "quantity", null: false
@@ -445,7 +457,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["product_id"], name: "index_product_accessories_on_product_id", using: :btree
   end
 
-  create_table "product_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "product_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "product_id",              null: false
     t.integer  "user_id",                 null: false
     t.integer  "approved_by",             null: false
@@ -457,7 +469,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["user_id"], name: "index_product_users_on_user_id", using: :btree
   end
 
-  create_table "products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "type",                          limit: 50,                       null: false
     t.integer  "facility_id",                                                    null: false
     t.string   "name",                          limit: 200,                      null: false
@@ -489,13 +501,13 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.text     "cancellation_email_recipients", limit: 65535
     t.index ["dashboard_token"], name: "index_products_on_dashboard_token", using: :btree
     t.index ["facility_account_id"], name: "fk_facility_accounts", using: :btree
-    t.index ["facility_id"], name: "fk_rails_0c9fa1afbe", using: :btree
+    t.index ["facility_id"], name: "sys_c008556", using: :btree
     t.index ["initial_order_status_id"], name: "index_products_on_initial_order_status_id", using: :btree
     t.index ["schedule_id"], name: "i_instruments_schedule_id", using: :btree
     t.index ["url_name"], name: "index_products_on_url_name", using: :btree
   end
 
-  create_table "projects", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "projects", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "name",                                     null: false
     t.text     "description", limit: 65535
     t.integer  "facility_id",                              null: false
@@ -506,7 +518,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["facility_id"], name: "index_projects_on_facility_id", using: :btree
   end
 
-  create_table "relays", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "relays", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "instrument_id"
     t.string   "ip",                  limit: 15
     t.integer  "port"
@@ -520,7 +532,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["instrument_id"], name: "index_relays_on_instrument_id", using: :btree
   end
 
-  create_table "reservations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "reservations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "order_detail_id"
     t.integer  "product_id",          null: false
     t.datetime "reserve_start_at",    null: false
@@ -539,10 +551,12 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["deleted_at"], name: "index_reservations_on_deleted_at", using: :btree
     t.index ["group_id"], name: "index_reservations_on_group_id", using: :btree
     t.index ["order_detail_id"], name: "res_od_uniq_fk", unique: true, using: :btree
+    t.index ["order_detail_id"], name: "res_ord_det_id_fk", using: :btree
     t.index ["product_id", "reserve_start_at"], name: "index_reservations_on_product_id_and_reserve_start_at", using: :btree
+    t.index ["product_id"], name: "reservations_instrument_id_fk", using: :btree
   end
 
-  create_table "sanger_seq_product_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "sanger_seq_product_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "product_id", null: false
     t.string   "group",      null: false
     t.datetime "created_at"
@@ -550,7 +564,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["product_id"], name: "index_sanger_seq_product_groups_on_product_id", unique: true, using: :btree
   end
 
-  create_table "sanger_sequencing_batches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "sanger_sequencing_batches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "created_by_id"
     t.text     "well_plates_raw", limit: 65535
     t.datetime "created_at"
@@ -562,24 +576,24 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["group"], name: "index_sanger_sequencing_batches_on_group", using: :btree
   end
 
-  create_table "sanger_sequencing_samples", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "sanger_sequencing_samples", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "submission_id",      null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
     t.string   "customer_sample_id"
     t.index ["submission_id"], name: "index_sanger_sequencing_samples_on_submission_id", using: :btree
   end
 
-  create_table "sanger_sequencing_submissions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "sanger_sequencing_submissions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "order_detail_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
     t.integer  "batch_id"
     t.index ["batch_id"], name: "fk_rails_24eeb2c9b4", using: :btree
     t.index ["order_detail_id"], name: "index_sanger_sequencing_submissions_on_order_detail_id", using: :btree
   end
 
-  create_table "schedule_rules", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "schedule_rules", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "product_id",                                                null: false
     t.decimal "discount_percent", precision: 10, scale: 2, default: "0.0", null: false
     t.integer "start_hour",                                                null: false
@@ -594,9 +608,10 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.boolean "on_fri",                                                    null: false
     t.boolean "on_sat",                                                    null: false
     t.index ["product_id"], name: "index_schedule_rules_on_product_id", using: :btree
+    t.index ["product_id"], name: "sys_c008573", using: :btree
   end
 
-  create_table "schedules", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "schedules", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "name"
     t.integer  "facility_id"
     t.datetime "created_at",  null: false
@@ -604,7 +619,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["facility_id"], name: "i_schedules_facility_id", using: :btree
   end
 
-  create_table "secure_rooms_alarm_events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "secure_rooms_alarm_events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.text     "additional_data",   limit: 65535
     t.string   "class_code"
     t.string   "event_code"
@@ -621,7 +636,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.datetime "updated_at",                      null: false
   end
 
-  create_table "secure_rooms_card_readers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "secure_rooms_card_readers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "product_id",                           null: false
     t.string   "card_reader_number"
     t.string   "control_device_number"
@@ -632,10 +647,9 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.string   "tablet_token"
     t.index ["card_reader_number", "control_device_number"], name: "i_secure_room_reader_ids", unique: true, using: :btree
     t.index ["product_id"], name: "index_secure_rooms_card_readers_on_product_id", using: :btree
-    t.index ["tablet_token"], name: "index_secure_rooms_card_readers_on_tablet_token", unique: true, using: :btree
   end
 
-  create_table "secure_rooms_events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "secure_rooms_events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "card_reader_id",  null: false
     t.integer  "user_id"
     t.datetime "occurred_at"
@@ -650,7 +664,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["user_id"], name: "index_secure_rooms_events_on_user_id", using: :btree
   end
 
-  create_table "secure_rooms_occupancies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "secure_rooms_occupancies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "product_id",      null: false
     t.integer  "user_id",         null: false
     t.integer  "account_id"
@@ -670,7 +684,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["user_id"], name: "index_secure_rooms_occupancies_on_user_id", using: :btree
   end
 
-  create_table "splits", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "splits", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "parent_split_account_id",                         null: false
     t.integer "subaccount_id",                                   null: false
     t.decimal "percent",                 precision: 6, scale: 3, null: false
@@ -679,16 +693,16 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["subaccount_id"], name: "index_splits_on_subaccount_id", using: :btree
   end
 
-  create_table "statement_rows", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "statement_rows", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "statement_id",    null: false
-    t.integer  "order_detail_id", null: false
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
+    t.integer  "order_detail_id", null: false
     t.index ["order_detail_id"], name: "index_statement_rows_on_order_detail_id", using: :btree
     t.index ["statement_id"], name: "index_statement_rows_on_statement_id", using: :btree
   end
 
-  create_table "statements", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "statements", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "facility_id", null: false
     t.integer  "created_by",  null: false
     t.datetime "created_at",  null: false
@@ -697,7 +711,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["facility_id"], name: "fk_statement_facilities", using: :btree
   end
 
-  create_table "stored_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "stored_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "order_detail_id"
     t.integer  "product_id"
     t.string   "name",              limit: 200, null: false
@@ -712,7 +726,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["product_id"], name: "fk_files_product", using: :btree
   end
 
-  create_table "training_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "training_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
     t.integer  "product_id"
     t.datetime "created_at", null: false
@@ -721,7 +735,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["user_id"], name: "index_training_requests_on_user_id", using: :btree
   end
 
-  create_table "user_preferences", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "user_preferences", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
     t.string   "name",       null: false
     t.string   "value",      null: false
@@ -730,15 +744,15 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["user_id", "name"], name: "index_user_preferences_on_user_id_and_name", unique: true, using: :btree
   end
 
-  create_table "user_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "user_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "user_id",     null: false
     t.integer "facility_id"
     t.string  "role",        null: false
     t.index ["facility_id"], name: "fk_rails_dca27403dd", using: :btree
-    t.index ["user_id", "facility_id", "role"], name: "index_user_roles_on_user_id_and_facility_id_and_role", using: :btree
+    t.index ["user_id", "facility_id", "role"], name: "i_use_rol_use_id_fac_id_rol", using: :btree
   end
 
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "username",                            null: false
     t.string   "first_name"
     t.string   "last_name"
@@ -766,7 +780,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["username"], name: "index_users_on_username", unique: true, using: :btree
   end
 
-  create_table "versions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "versions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "item_type",  limit: 191,        null: false
     t.integer  "item_id",                       null: false
     t.string   "event",                         null: false
@@ -776,7 +790,7 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
   end
 
-  create_table "vestal_versions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "vestal_versions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "versioned_id"
     t.string   "versioned_type"
     t.integer  "user_id"
@@ -793,10 +807,10 @@ ActiveRecord::Schema.define(version: 20181102173232) do
     t.index ["commit_label"], name: "index_vestal_versions_on_commit_label", using: :btree
     t.index ["created_at"], name: "index_vestal_versions_on_created_at", using: :btree
     t.index ["tag"], name: "index_vestal_versions_on_tag", using: :btree
-    t.index ["user_id", "user_type"], name: "index_vestal_versions_on_user_id_and_user_type", using: :btree
+    t.index ["user_id", "user_type"], name: "i_versions_user_id_user_type", using: :btree
     t.index ["user_name"], name: "index_vestal_versions_on_user_name", using: :btree
-    t.index ["version_number"], name: "index_vestal_versions_on_version_number", using: :btree
-    t.index ["versioned_id", "versioned_type"], name: "index_vestal_versions_on_versioned_id_and_versioned_type", using: :btree
+    t.index ["version_number"], name: "index_versions_on_number", using: :btree
+    t.index ["versioned_id", "versioned_type"], name: "i_ver_ver_id_ver_typ", using: :btree
   end
 
   add_foreign_key "account_users", "accounts", name: "fk_accounts"
@@ -808,52 +822,51 @@ ActiveRecord::Schema.define(version: 20181102173232) do
   add_foreign_key "bundle_products", "products", name: "fk_bundle_prod_bundle"
   add_foreign_key "email_events", "users"
   add_foreign_key "facility_accounts", "facilities", name: "fk_facilities"
-  add_foreign_key "instrument_statuses", "products", column: "instrument_id", name: "fk_int_stats_product"
   add_foreign_key "journal_rows", "accounts"
   add_foreign_key "journal_rows", "journals"
   add_foreign_key "journal_rows", "order_details"
   add_foreign_key "log_events", "users"
   add_foreign_key "order_details", "accounts", name: "fk_od_accounts"
   add_foreign_key "order_details", "journals"
-  add_foreign_key "order_details", "order_details", column: "parent_order_detail_id"
+  add_foreign_key "order_details", "order_details", column: "parent_order_detail_id", name: "order_details_parent_order_detail_id_fk"
   add_foreign_key "order_details", "order_statuses"
-  add_foreign_key "order_details", "orders"
-  add_foreign_key "order_details", "price_policies"
-  add_foreign_key "order_details", "product_accessories"
-  add_foreign_key "order_details", "products"
+  add_foreign_key "order_details", "orders", name: "sys_c009172"
+  add_foreign_key "order_details", "price_policies", name: "sys_c009175"
+  add_foreign_key "order_details", "product_accessories", name: "order_details_product_accessory_id_fk"
   add_foreign_key "order_details", "products", column: "bundle_product_id", name: "fk_bundle_prod_id"
+  add_foreign_key "order_details", "products", name: "sys_c009173"
   add_foreign_key "order_details", "statements"
   add_foreign_key "order_details", "users", column: "assigned_user_id"
-  add_foreign_key "order_details", "users", column: "dispute_by_id"
-  add_foreign_key "order_details", "users", column: "price_changed_by_user_id"
+  add_foreign_key "order_details", "users", column: "dispute_by_id", name: "order_details_dispute_by_id_fk"
   add_foreign_key "order_imports", "facilities", name: "fk_order_imports_facilities"
-  add_foreign_key "orders", "accounts"
-  add_foreign_key "orders", "facilities"
+  add_foreign_key "orders", "accounts", name: "sys_c008808"
+  add_foreign_key "orders", "facilities", name: "orders_facility_id_fk"
   add_foreign_key "orders", "order_imports"
   add_foreign_key "orders", "orders", column: "merge_with_order_id"
   add_foreign_key "orders", "users"
-  add_foreign_key "payments", "accounts"
-  add_foreign_key "payments", "statements"
-  add_foreign_key "payments", "users", column: "paid_by_id"
+  add_foreign_key "payments", "accounts", name: "payments_account_id_fk"
+  add_foreign_key "payments", "statements", name: "payments_statement_id_fk"
+  add_foreign_key "payments", "users", column: "paid_by_id", name: "payments_paid_by_id_fk"
   add_foreign_key "price_group_members", "accounts"
-  add_foreign_key "price_group_members", "price_groups"
+  add_foreign_key "price_group_members", "price_groups", name: "sys_c008583"
   add_foreign_key "price_group_members", "users"
-  add_foreign_key "price_groups", "facilities"
-  add_foreign_key "price_policies", "price_groups"
+  add_foreign_key "price_groups", "facilities", name: "sys_c008578"
+  add_foreign_key "price_policies", "price_groups", name: "sys_c008589"
+  add_foreign_key "price_policies", "users", column: "created_by_id"
   add_foreign_key "product_users", "products", name: "fk_products"
   add_foreign_key "product_users", "users"
-  add_foreign_key "products", "facilities"
+  add_foreign_key "products", "facilities", name: "sys_c008556"
   add_foreign_key "products", "facility_accounts", name: "fk_facility_accounts"
   add_foreign_key "products", "schedules", name: "fk_instruments_schedule"
-  add_foreign_key "projects", "facilities"
-  add_foreign_key "reservations", "order_details"
-  add_foreign_key "reservations", "products", name: "reservations_instrument_id_fk"
+  add_foreign_key "projects", "facilities", name: "projects_facility_id_fk"
+  add_foreign_key "reservations", "order_details", name: "res_ord_det_id_fk"
+  add_foreign_key "reservations", "products", name: "reservations_product_id_fk"
   add_foreign_key "reservations", "users", column: "created_by_id"
   add_foreign_key "sanger_seq_product_groups", "products"
   add_foreign_key "sanger_sequencing_batches", "facilities"
   add_foreign_key "sanger_sequencing_samples", "sanger_sequencing_submissions", column: "submission_id", on_delete: :cascade
   add_foreign_key "sanger_sequencing_submissions", "sanger_sequencing_batches", column: "batch_id", on_delete: :nullify
-  add_foreign_key "schedule_rules", "products"
+  add_foreign_key "schedule_rules", "products", name: "sys_c008573"
   add_foreign_key "schedules", "facilities", name: "fk_schedules_facility"
   add_foreign_key "secure_rooms_card_readers", "products"
   add_foreign_key "secure_rooms_events", "accounts"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -402,22 +402,22 @@ ActiveRecord::Schema.define(version: 20181119211456) do
   end
 
   create_table "price_policies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "type",                    limit: 50,                                             null: false
+    t.string   "type",                    limit: 50,                                           null: false
     t.integer  "product_id"
-    t.integer  "price_group_id",                                                                 null: false
-    t.boolean  "can_purchase",                                                   default: false, null: false
-    t.datetime "start_date",                                                                     null: false
-    t.decimal  "unit_cost",                             precision: 10, scale: 2
-    t.decimal  "unit_subsidy",                          precision: 10, scale: 2
-    t.decimal  "usage_rate",                            precision: 12, scale: 4
-    t.decimal  "minimum_cost",                          precision: 10, scale: 2
-    t.decimal  "cancellation_cost",                     precision: 10, scale: 2
-    t.decimal  "usage_subsidy",                         precision: 12, scale: 4
-    t.datetime "expire_date",                                                                    null: false
+    t.integer  "price_group_id",                                                               null: false
+    t.boolean  "can_purchase",                                                 default: false, null: false
+    t.datetime "start_date",                                                                   null: false
+    t.decimal  "unit_cost",                           precision: 10, scale: 2
+    t.decimal  "unit_subsidy",                        precision: 10, scale: 2
+    t.decimal  "usage_rate",                          precision: 12, scale: 4
+    t.decimal  "minimum_cost",                        precision: 10, scale: 2
+    t.decimal  "cancellation_cost",                   precision: 10, scale: 2
+    t.decimal  "usage_subsidy",                       precision: 12, scale: 4
+    t.datetime "expire_date",                                                                  null: false
     t.string   "charge_for"
     t.string   "legacy_rates"
-    t.boolean  "full_price_cancellation",                                        default: false, null: false
-    t.text     "note",                    limit: 65535
+    t.boolean  "full_price_cancellation",                                      default: false, null: false
+    t.string   "note",                    limit: 256
     t.integer  "created_by_id"
     t.index ["created_by_id"], name: "index_price_policies_on_created_by_id", using: :btree
     t.index ["price_group_id"], name: "fk_rails_74aa223960", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20181119211456) do
 
-  create_table "account_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "account_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "account_id",            null: false
     t.integer  "user_id",               null: false
     t.string   "user_role",  limit: 50, null: false
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["user_id"], name: "index_account_users_on_user_id", using: :btree
   end
 
-  create_table "accounts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "accounts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "type",                   limit: 50,    null: false
     t.string   "account_number",         limit: 50,    null: false
     t.string   "description",            limit: 50,    null: false
@@ -47,14 +47,14 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["facility_id"], name: "fk_account_facility_id", using: :btree
   end
 
-  create_table "affiliates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "affiliates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name"
     t.datetime "created_at",                            null: false
     t.datetime "updated_at",                            null: false
     t.boolean  "subaffiliates_enabled", default: false, null: false
   end
 
-  create_table "budgeted_chart_strings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "budgeted_chart_strings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "fund",       limit: 20, null: false
     t.string   "dept",       limit: 20, null: false
     t.string   "project",    limit: 20
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.datetime "expires_at",            null: false
   end
 
-  create_table "bulk_email_jobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "bulk_email_jobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "facility_id"
     t.integer  "user_id",                       null: false
     t.string   "subject",                       null: false
@@ -77,7 +77,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["user_id"], name: "fk_rails_7cd8662ccc", using: :btree
   end
 
-  create_table "bundle_products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "bundle_products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "bundle_product_id", null: false
     t.integer "product_id",        null: false
     t.integer "quantity",          null: false
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["product_id"], name: "fk_bundle_prod_bundle", using: :btree
   end
 
-  create_table "delayed_jobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "delayed_jobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "priority",                      default: 0, null: false
     t.integer  "attempts",                      default: 0, null: false
     t.text     "handler",    limit: 4294967295,             null: false
@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
   end
 
-  create_table "email_events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "email_events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id",      null: false
     t.string   "key",          null: false
     t.datetime "last_sent_at", null: false
@@ -109,7 +109,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["user_id", "key"], name: "index_email_events_on_user_id_and_key", unique: true, using: :btree
   end
 
-  create_table "external_service_passers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "external_service_passers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "external_service_id"
     t.integer  "passer_id"
     t.string   "passer_type"
@@ -120,7 +120,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["passer_id", "passer_type"], name: "i_external_passer_id", using: :btree
   end
 
-  create_table "external_service_receivers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "external_service_receivers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "external_service_id"
     t.integer  "receiver_id"
     t.string   "receiver_type"
@@ -133,14 +133,14 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["receiver_id", "receiver_type"], name: "i_external_receiver_id", using: :btree
   end
 
-  create_table "external_services", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "external_services", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "type"
     t.string   "location"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "facilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "facilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",                         limit: 200,                   null: false
     t.string   "abbreviation",                 limit: 50,                    null: false
     t.string   "url_name",                     limit: 50,                    null: false
@@ -167,7 +167,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["url_name"], name: "index_facilities_on_url_name", unique: true, using: :btree
   end
 
-  create_table "facility_accounts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "facility_accounts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "facility_id",                null: false
     t.string   "account_number",  limit: 50, null: false
     t.boolean  "is_active",                  null: false
@@ -192,25 +192,25 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["instrument_id"], name: "fk_int_stats_product", using: :btree
   end
 
-  create_table "journal_cutoff_dates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "journal_cutoff_dates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.datetime "cutoff_date"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
   end
 
-  create_table "journal_rows", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "journal_rows", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "journal_id",                                          null: false
     t.integer "order_detail_id"
     t.string  "account",         limit: 5
     t.decimal "amount",                      precision: 9, scale: 2, null: false
-    t.string  "description",     limit: 400
+    t.string  "description",     limit: 512
     t.integer "account_id"
     t.index ["account_id"], name: "index_journal_rows_on_account_id", using: :btree
     t.index ["journal_id"], name: "index_journal_rows_on_journal_id", using: :btree
     t.index ["order_detail_id"], name: "index_journal_rows_on_order_detail_id", using: :btree
   end
 
-  create_table "journals", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "journals", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "facility_id"
     t.string   "reference",         limit: 50
     t.string   "description",       limit: 200
@@ -227,7 +227,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["facility_id"], name: "index_journals_on_facility_id", using: :btree
   end
 
-  create_table "log_events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "log_events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "loggable_id"
     t.string   "loggable_type"
     t.string   "event_type"
@@ -239,7 +239,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["user_id"], name: "index_log_events_on_user_id", using: :btree
   end
 
-  create_table "notifications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "notifications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "type",         null: false
     t.integer  "subject_id",   null: false
     t.string   "subject_type", null: false
@@ -252,7 +252,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["user_id"], name: "index_notifications_on_user_id", using: :btree
   end
 
-  create_table "order_details", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "order_details", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "order_id",                                                                        null: false
     t.integer  "parent_order_detail_id"
     t.integer  "product_id",                                                                      null: false
@@ -295,24 +295,24 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["account_id"], name: "fk_od_accounts", using: :btree
     t.index ["assigned_user_id"], name: "index_order_details_on_assigned_user_id", using: :btree
     t.index ["bundle_product_id"], name: "fk_bundle_prod_id", using: :btree
-    t.index ["dispute_by_id"], name: "order_details_dispute_by_id_fk", using: :btree
+    t.index ["dispute_by_id"], name: "fk_rails_14de4f1c86", using: :btree
     t.index ["group_id"], name: "index_order_details_on_group_id", using: :btree
     t.index ["journal_id"], name: "index_order_details_on_journal_id", using: :btree
-    t.index ["order_id"], name: "sys_c009172", using: :btree
+    t.index ["order_id"], name: "fk_rails_e5976611fd", using: :btree
     t.index ["order_status_id"], name: "index_order_details_on_order_status_id", using: :btree
-    t.index ["parent_order_detail_id"], name: "order_details_parent_order_detail_id_fk", using: :btree
+    t.index ["parent_order_detail_id"], name: "fk_rails_cc2adae8c3", using: :btree
     t.index ["price_changed_by_user_id"], name: "index_order_details_on_price_changed_by_user_id", using: :btree
-    t.index ["price_policy_id"], name: "sys_c009175", using: :btree
+    t.index ["price_policy_id"], name: "fk_rails_555b721183", using: :btree
     t.index ["problem"], name: "index_order_details_on_problem", using: :btree
-    t.index ["product_accessory_id"], name: "order_details_product_accessory_id_fk", using: :btree
-    t.index ["product_id"], name: "sys_c009173", using: :btree
+    t.index ["product_accessory_id"], name: "fk_rails_e4f0ef56a6", using: :btree
+    t.index ["product_id"], name: "fk_rails_4f2ac9473b", using: :btree
     t.index ["project_id"], name: "index_order_details_on_project_id", using: :btree
     t.index ["response_set_id"], name: "index_order_details_on_response_set_id", using: :btree
     t.index ["state"], name: "index_order_details_on_state", using: :btree
     t.index ["statement_id"], name: "index_order_details_on_statement_id", using: :btree
   end
 
-  create_table "order_imports", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "order_imports", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "facility_id"
     t.integer  "upload_file_id",                 null: false
     t.integer  "error_file_id"
@@ -328,7 +328,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["upload_file_id"], name: "index_order_imports_on_upload_file_id", using: :btree
   end
 
-  create_table "order_statuses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "order_statuses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string  "name",        limit: 50, null: false
     t.integer "facility_id"
     t.integer "parent_id"
@@ -338,7 +338,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["parent_id"], name: "index_order_statuses_on_parent_id", using: :btree
   end
 
-  create_table "orders", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "orders", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "account_id"
     t.integer  "user_id",                        null: false
     t.integer  "created_by",                     null: false
@@ -349,24 +349,15 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.string   "state",               limit: 50
     t.integer  "merge_with_order_id"
     t.integer  "order_import_id"
-    t.index ["account_id"], name: "sys_c008808", using: :btree
+    t.index ["account_id"], name: "fk_rails_144e25bef6", using: :btree
     t.index ["facility_id"], name: "index_orders_on_facility_id", using: :btree
-    t.index ["facility_id"], name: "orders_facility_id_fk", using: :btree
     t.index ["merge_with_order_id"], name: "index_orders_on_merge_with_order_id", using: :btree
     t.index ["order_import_id"], name: "index_orders_on_order_import_id", using: :btree
     t.index ["state"], name: "index_orders_on_state", using: :btree
     t.index ["user_id"], name: "index_orders_on_user_id", using: :btree
   end
 
-  create_table "partial_availabilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "instrument_id",             null: false
-    t.string   "note",          limit: 256, null: false
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
-    t.index ["instrument_id"], name: "index_partial_availabilities_on_instrument_id", using: :btree
-  end
-
-  create_table "payments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "payments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "account_id",                                              null: false
     t.integer  "statement_id"
     t.string   "source",                                                  null: false
@@ -381,36 +372,36 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["statement_id"], name: "index_payments_on_statement_id", using: :btree
   end
 
-  create_table "price_group_members", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "price_group_members", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string  "type",           limit: 50, null: false
     t.integer "price_group_id",            null: false
     t.integer "user_id"
     t.integer "account_id"
     t.index ["account_id"], name: "index_price_group_members_on_account_id", using: :btree
-    t.index ["price_group_id"], name: "sys_c008583", using: :btree
+    t.index ["price_group_id"], name: "fk_rails_0425013e5b", using: :btree
     t.index ["user_id"], name: "index_price_group_members_on_user_id", using: :btree
   end
 
-  create_table "price_group_products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "price_group_products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "price_group_id",     null: false
     t.integer  "product_id",         null: false
     t.integer  "reservation_window"
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
-    t.index ["price_group_id"], name: "i_pri_gro_pro_pri_gro_id", using: :btree
-    t.index ["product_id"], name: "i_pri_gro_pro_pro_id", using: :btree
+    t.index ["price_group_id"], name: "index_price_group_products_on_price_group_id", using: :btree
+    t.index ["product_id"], name: "index_price_group_products_on_product_id", using: :btree
   end
 
-  create_table "price_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "price_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "facility_id"
     t.string  "name",           limit: 50,                null: false
     t.integer "display_order",                            null: false
     t.boolean "is_internal",                              null: false
     t.boolean "admin_editable",            default: true, null: false
-    t.index ["facility_id", "name"], name: "sys_c008577", unique: true, using: :btree
+    t.index ["facility_id", "name"], name: "index_price_groups_on_facility_id_and_name", unique: true, using: :btree
   end
 
-  create_table "price_policies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "price_policies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "type",                    limit: 50,                                             null: false
     t.integer  "product_id"
     t.integer  "price_group_id",                                                                 null: false
@@ -429,11 +420,11 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.text     "note",                    limit: 65535
     t.integer  "created_by_id"
     t.index ["created_by_id"], name: "index_price_policies_on_created_by_id", using: :btree
-    t.index ["price_group_id"], name: "sys_c008589", using: :btree
+    t.index ["price_group_id"], name: "fk_rails_74aa223960", using: :btree
     t.index ["product_id"], name: "index_price_policies_on_product_id", using: :btree
   end
 
-  create_table "product_access_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "product_access_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "product_id", null: false
     t.string   "name"
     t.datetime "created_at", null: false
@@ -441,14 +432,14 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["product_id"], name: "index_product_access_groups_on_product_id", using: :btree
   end
 
-  create_table "product_access_schedule_rules", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "product_access_schedule_rules", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "product_access_group_id", null: false
     t.integer "schedule_rule_id",        null: false
     t.index ["product_access_group_id"], name: "index_product_access_schedule_rules_on_product_access_group_id", using: :btree
     t.index ["schedule_rule_id"], name: "index_product_access_schedule_rules_on_schedule_rule_id", using: :btree
   end
 
-  create_table "product_accessories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "product_accessories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "product_id",                        null: false
     t.integer  "accessory_id",                      null: false
     t.string   "scaling_type", default: "quantity", null: false
@@ -457,7 +448,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["product_id"], name: "index_product_accessories_on_product_id", using: :btree
   end
 
-  create_table "product_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "product_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "product_id",              null: false
     t.integer  "user_id",                 null: false
     t.integer  "approved_by",             null: false
@@ -469,7 +460,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["user_id"], name: "index_product_users_on_user_id", using: :btree
   end
 
-  create_table "products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "type",                          limit: 50,                       null: false
     t.integer  "facility_id",                                                    null: false
     t.string   "name",                          limit: 200,                      null: false
@@ -501,13 +492,13 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.text     "cancellation_email_recipients", limit: 65535
     t.index ["dashboard_token"], name: "index_products_on_dashboard_token", using: :btree
     t.index ["facility_account_id"], name: "fk_facility_accounts", using: :btree
-    t.index ["facility_id"], name: "sys_c008556", using: :btree
+    t.index ["facility_id"], name: "fk_rails_0c9fa1afbe", using: :btree
     t.index ["initial_order_status_id"], name: "index_products_on_initial_order_status_id", using: :btree
     t.index ["schedule_id"], name: "i_instruments_schedule_id", using: :btree
     t.index ["url_name"], name: "index_products_on_url_name", using: :btree
   end
 
-  create_table "projects", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "projects", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",                                     null: false
     t.text     "description", limit: 65535
     t.integer  "facility_id",                              null: false
@@ -518,7 +509,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["facility_id"], name: "index_projects_on_facility_id", using: :btree
   end
 
-  create_table "relays", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "relays", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "instrument_id"
     t.string   "ip",                  limit: 15
     t.integer  "port"
@@ -532,7 +523,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["instrument_id"], name: "index_relays_on_instrument_id", using: :btree
   end
 
-  create_table "reservations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "reservations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "order_detail_id"
     t.integer  "product_id",          null: false
     t.datetime "reserve_start_at",    null: false
@@ -551,12 +542,10 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["deleted_at"], name: "index_reservations_on_deleted_at", using: :btree
     t.index ["group_id"], name: "index_reservations_on_group_id", using: :btree
     t.index ["order_detail_id"], name: "res_od_uniq_fk", unique: true, using: :btree
-    t.index ["order_detail_id"], name: "res_ord_det_id_fk", using: :btree
     t.index ["product_id", "reserve_start_at"], name: "index_reservations_on_product_id_and_reserve_start_at", using: :btree
-    t.index ["product_id"], name: "reservations_instrument_id_fk", using: :btree
   end
 
-  create_table "sanger_seq_product_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "sanger_seq_product_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "product_id", null: false
     t.string   "group",      null: false
     t.datetime "created_at"
@@ -564,7 +553,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["product_id"], name: "index_sanger_seq_product_groups_on_product_id", unique: true, using: :btree
   end
 
-  create_table "sanger_sequencing_batches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "sanger_sequencing_batches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "created_by_id"
     t.text     "well_plates_raw", limit: 65535
     t.datetime "created_at"
@@ -576,24 +565,24 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["group"], name: "index_sanger_sequencing_batches_on_group", using: :btree
   end
 
-  create_table "sanger_sequencing_samples", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "sanger_sequencing_samples", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "submission_id",      null: false
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string   "customer_sample_id"
     t.index ["submission_id"], name: "index_sanger_sequencing_samples_on_submission_id", using: :btree
   end
 
-  create_table "sanger_sequencing_submissions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "sanger_sequencing_submissions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "order_detail_id"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "batch_id"
     t.index ["batch_id"], name: "fk_rails_24eeb2c9b4", using: :btree
     t.index ["order_detail_id"], name: "index_sanger_sequencing_submissions_on_order_detail_id", using: :btree
   end
 
-  create_table "schedule_rules", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "schedule_rules", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "product_id",                                                null: false
     t.decimal "discount_percent", precision: 10, scale: 2, default: "0.0", null: false
     t.integer "start_hour",                                                null: false
@@ -608,10 +597,9 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.boolean "on_fri",                                                    null: false
     t.boolean "on_sat",                                                    null: false
     t.index ["product_id"], name: "index_schedule_rules_on_product_id", using: :btree
-    t.index ["product_id"], name: "sys_c008573", using: :btree
   end
 
-  create_table "schedules", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "schedules", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name"
     t.integer  "facility_id"
     t.datetime "created_at",  null: false
@@ -619,7 +607,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["facility_id"], name: "i_schedules_facility_id", using: :btree
   end
 
-  create_table "secure_rooms_alarm_events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "secure_rooms_alarm_events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.text     "additional_data",   limit: 65535
     t.string   "class_code"
     t.string   "event_code"
@@ -636,7 +624,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.datetime "updated_at",                      null: false
   end
 
-  create_table "secure_rooms_card_readers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "secure_rooms_card_readers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "product_id",                           null: false
     t.string   "card_reader_number"
     t.string   "control_device_number"
@@ -647,9 +635,10 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.string   "tablet_token"
     t.index ["card_reader_number", "control_device_number"], name: "i_secure_room_reader_ids", unique: true, using: :btree
     t.index ["product_id"], name: "index_secure_rooms_card_readers_on_product_id", using: :btree
+    t.index ["tablet_token"], name: "index_secure_rooms_card_readers_on_tablet_token", unique: true, using: :btree
   end
 
-  create_table "secure_rooms_events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "secure_rooms_events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "card_reader_id",  null: false
     t.integer  "user_id"
     t.datetime "occurred_at"
@@ -664,7 +653,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["user_id"], name: "index_secure_rooms_events_on_user_id", using: :btree
   end
 
-  create_table "secure_rooms_occupancies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "secure_rooms_occupancies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "product_id",      null: false
     t.integer  "user_id",         null: false
     t.integer  "account_id"
@@ -684,7 +673,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["user_id"], name: "index_secure_rooms_occupancies_on_user_id", using: :btree
   end
 
-  create_table "splits", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "splits", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "parent_split_account_id",                         null: false
     t.integer "subaccount_id",                                   null: false
     t.decimal "percent",                 precision: 6, scale: 3, null: false
@@ -693,16 +682,16 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["subaccount_id"], name: "index_splits_on_subaccount_id", using: :btree
   end
 
-  create_table "statement_rows", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "statement_rows", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "statement_id",    null: false
+    t.integer  "order_detail_id", null: false
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
-    t.integer  "order_detail_id", null: false
     t.index ["order_detail_id"], name: "index_statement_rows_on_order_detail_id", using: :btree
     t.index ["statement_id"], name: "index_statement_rows_on_statement_id", using: :btree
   end
 
-  create_table "statements", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "statements", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "facility_id", null: false
     t.integer  "created_by",  null: false
     t.datetime "created_at",  null: false
@@ -711,7 +700,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["facility_id"], name: "fk_statement_facilities", using: :btree
   end
 
-  create_table "stored_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "stored_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "order_detail_id"
     t.integer  "product_id"
     t.string   "name",              limit: 200, null: false
@@ -726,7 +715,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["product_id"], name: "fk_files_product", using: :btree
   end
 
-  create_table "training_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "training_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
     t.integer  "product_id"
     t.datetime "created_at", null: false
@@ -735,7 +724,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["user_id"], name: "index_training_requests_on_user_id", using: :btree
   end
 
-  create_table "user_preferences", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "user_preferences", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
     t.string   "name",       null: false
     t.string   "value",      null: false
@@ -744,15 +733,15 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["user_id", "name"], name: "index_user_preferences_on_user_id_and_name", unique: true, using: :btree
   end
 
-  create_table "user_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "user_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id",     null: false
     t.integer "facility_id"
     t.string  "role",        null: false
     t.index ["facility_id"], name: "fk_rails_dca27403dd", using: :btree
-    t.index ["user_id", "facility_id", "role"], name: "i_use_rol_use_id_fac_id_rol", using: :btree
+    t.index ["user_id", "facility_id", "role"], name: "index_user_roles_on_user_id_and_facility_id_and_role", using: :btree
   end
 
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "username",                            null: false
     t.string   "first_name"
     t.string   "last_name"
@@ -780,7 +769,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["username"], name: "index_users_on_username", unique: true, using: :btree
   end
 
-  create_table "versions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "versions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "item_type",  limit: 191,        null: false
     t.integer  "item_id",                       null: false
     t.string   "event",                         null: false
@@ -790,7 +779,7 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
   end
 
-  create_table "vestal_versions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "vestal_versions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "versioned_id"
     t.string   "versioned_type"
     t.integer  "user_id"
@@ -807,10 +796,10 @@ ActiveRecord::Schema.define(version: 20181119211456) do
     t.index ["commit_label"], name: "index_vestal_versions_on_commit_label", using: :btree
     t.index ["created_at"], name: "index_vestal_versions_on_created_at", using: :btree
     t.index ["tag"], name: "index_vestal_versions_on_tag", using: :btree
-    t.index ["user_id", "user_type"], name: "i_versions_user_id_user_type", using: :btree
+    t.index ["user_id", "user_type"], name: "index_vestal_versions_on_user_id_and_user_type", using: :btree
     t.index ["user_name"], name: "index_vestal_versions_on_user_name", using: :btree
-    t.index ["version_number"], name: "index_versions_on_number", using: :btree
-    t.index ["versioned_id", "versioned_type"], name: "i_ver_ver_id_ver_typ", using: :btree
+    t.index ["version_number"], name: "index_vestal_versions_on_version_number", using: :btree
+    t.index ["versioned_id", "versioned_type"], name: "index_vestal_versions_on_versioned_id_and_versioned_type", using: :btree
   end
 
   add_foreign_key "account_users", "accounts", name: "fk_accounts"
@@ -822,51 +811,53 @@ ActiveRecord::Schema.define(version: 20181119211456) do
   add_foreign_key "bundle_products", "products", name: "fk_bundle_prod_bundle"
   add_foreign_key "email_events", "users"
   add_foreign_key "facility_accounts", "facilities", name: "fk_facilities"
+  add_foreign_key "instrument_statuses", "products", column: "instrument_id", name: "fk_int_stats_product"
   add_foreign_key "journal_rows", "accounts"
   add_foreign_key "journal_rows", "journals"
   add_foreign_key "journal_rows", "order_details"
   add_foreign_key "log_events", "users"
   add_foreign_key "order_details", "accounts", name: "fk_od_accounts"
   add_foreign_key "order_details", "journals"
-  add_foreign_key "order_details", "order_details", column: "parent_order_detail_id", name: "order_details_parent_order_detail_id_fk"
+  add_foreign_key "order_details", "order_details", column: "parent_order_detail_id"
   add_foreign_key "order_details", "order_statuses"
-  add_foreign_key "order_details", "orders", name: "sys_c009172"
-  add_foreign_key "order_details", "price_policies", name: "sys_c009175"
-  add_foreign_key "order_details", "product_accessories", name: "order_details_product_accessory_id_fk"
+  add_foreign_key "order_details", "orders"
+  add_foreign_key "order_details", "price_policies"
+  add_foreign_key "order_details", "product_accessories"
+  add_foreign_key "order_details", "products"
   add_foreign_key "order_details", "products", column: "bundle_product_id", name: "fk_bundle_prod_id"
-  add_foreign_key "order_details", "products", name: "sys_c009173"
   add_foreign_key "order_details", "statements"
   add_foreign_key "order_details", "users", column: "assigned_user_id"
-  add_foreign_key "order_details", "users", column: "dispute_by_id", name: "order_details_dispute_by_id_fk"
+  add_foreign_key "order_details", "users", column: "dispute_by_id"
+  add_foreign_key "order_details", "users", column: "price_changed_by_user_id"
   add_foreign_key "order_imports", "facilities", name: "fk_order_imports_facilities"
-  add_foreign_key "orders", "accounts", name: "sys_c008808"
-  add_foreign_key "orders", "facilities", name: "orders_facility_id_fk"
+  add_foreign_key "orders", "accounts"
+  add_foreign_key "orders", "facilities"
   add_foreign_key "orders", "order_imports"
   add_foreign_key "orders", "orders", column: "merge_with_order_id"
   add_foreign_key "orders", "users"
-  add_foreign_key "payments", "accounts", name: "payments_account_id_fk"
-  add_foreign_key "payments", "statements", name: "payments_statement_id_fk"
-  add_foreign_key "payments", "users", column: "paid_by_id", name: "payments_paid_by_id_fk"
+  add_foreign_key "payments", "accounts"
+  add_foreign_key "payments", "statements"
+  add_foreign_key "payments", "users", column: "paid_by_id"
   add_foreign_key "price_group_members", "accounts"
-  add_foreign_key "price_group_members", "price_groups", name: "sys_c008583"
+  add_foreign_key "price_group_members", "price_groups"
   add_foreign_key "price_group_members", "users"
-  add_foreign_key "price_groups", "facilities", name: "sys_c008578"
-  add_foreign_key "price_policies", "price_groups", name: "sys_c008589"
+  add_foreign_key "price_groups", "facilities"
+  add_foreign_key "price_policies", "price_groups"
   add_foreign_key "price_policies", "users", column: "created_by_id"
   add_foreign_key "product_users", "products", name: "fk_products"
   add_foreign_key "product_users", "users"
-  add_foreign_key "products", "facilities", name: "sys_c008556"
+  add_foreign_key "products", "facilities"
   add_foreign_key "products", "facility_accounts", name: "fk_facility_accounts"
   add_foreign_key "products", "schedules", name: "fk_instruments_schedule"
-  add_foreign_key "projects", "facilities", name: "projects_facility_id_fk"
-  add_foreign_key "reservations", "order_details", name: "res_ord_det_id_fk"
-  add_foreign_key "reservations", "products", name: "reservations_product_id_fk"
+  add_foreign_key "projects", "facilities"
+  add_foreign_key "reservations", "order_details"
+  add_foreign_key "reservations", "products", name: "reservations_instrument_id_fk"
   add_foreign_key "reservations", "users", column: "created_by_id"
   add_foreign_key "sanger_seq_product_groups", "products"
   add_foreign_key "sanger_sequencing_batches", "facilities"
   add_foreign_key "sanger_sequencing_samples", "sanger_sequencing_submissions", column: "submission_id", on_delete: :cascade
   add_foreign_key "sanger_sequencing_submissions", "sanger_sequencing_batches", column: "batch_id", on_delete: :nullify
-  add_foreign_key "schedule_rules", "products", name: "sys_c008573"
+  add_foreign_key "schedule_rules", "products"
   add_foreign_key "schedules", "facilities", name: "fk_schedules_facility"
   add_foreign_key "secure_rooms_card_readers", "products"
   add_foreign_key "secure_rooms_events", "accounts"

--- a/lib/settings_helper.rb
+++ b/lib/settings_helper.rb
@@ -35,7 +35,7 @@ module SettingsHelper
   #   If you want to check setting 'feature.password_update_on'
   #   then this parameter would be :password_update
   def self.feature_on?(feature)
-    Settings.feature.try(:"#{feature}_on")
+    !!Settings.feature["#{feature}_on"]
   end
 
   def self.feature_off?(feature)

--- a/spec/factories/price_policies.rb
+++ b/spec/factories/price_policies.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     can_purchase { true }
     start_date { Time.zone.now.beginning_of_day }
     expire_date { PricePolicy.generate_expire_date(start_date) }
-    note { "A note" }
+    note { "This is note" }
   end
 
   factory :instrument_usage_price_policy, parent: :instrument_price_policy do
@@ -28,7 +28,7 @@ FactoryBot.define do
     unit_subsidy { 0 }
     start_date { Time.zone.now.beginning_of_day }
     expire_date { PricePolicy.generate_expire_date(start_date) }
-    note { "A note" }
+    note { "This is note" }
   end
 
   factory :service_price_policy do
@@ -37,7 +37,7 @@ FactoryBot.define do
     unit_subsidy { 0 }
     start_date { Time.zone.now.beginning_of_day }
     expire_date { PricePolicy.generate_expire_date(start_date) }
-    note { "A note" }
+    note { "This is note" }
   end
 
   factory :timed_service_price_policy do
@@ -48,6 +48,6 @@ FactoryBot.define do
     can_purchase { true }
     start_date { Time.zone.now.beginning_of_day }
     expire_date { PricePolicy.generate_expire_date(start_date) }
-    note { "A note" }
+    note { "This is note" }
   end
 end

--- a/spec/factories/price_policies.rb
+++ b/spec/factories/price_policies.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     can_purchase { true }
     start_date { Time.zone.now.beginning_of_day }
     expire_date { PricePolicy.generate_expire_date(start_date) }
+    note { "A note" }
   end
 
   factory :instrument_usage_price_policy, parent: :instrument_price_policy do
@@ -27,6 +28,7 @@ FactoryBot.define do
     unit_subsidy { 0 }
     start_date { Time.zone.now.beginning_of_day }
     expire_date { PricePolicy.generate_expire_date(start_date) }
+    note { "A note" }
   end
 
   factory :service_price_policy do
@@ -35,6 +37,7 @@ FactoryBot.define do
     unit_subsidy { 0 }
     start_date { Time.zone.now.beginning_of_day }
     expire_date { PricePolicy.generate_expire_date(start_date) }
+    note { "A note" }
   end
 
   factory :timed_service_price_policy do
@@ -45,5 +48,6 @@ FactoryBot.define do
     can_purchase { true }
     start_date { Time.zone.now.beginning_of_day }
     expire_date { PricePolicy.generate_expire_date(start_date) }
+    note { "A note" }
   end
 end

--- a/spec/features/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/features/admin/instrument_price_policies_controller_spec.rb
@@ -54,6 +54,8 @@ RSpec.describe InstrumentPricePoliciesController do
     click_link "Pricing"
     click_link "Add Pricing Rules"
 
+    fill_in "Note", with: "This is my note"
+
     fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "60"
     fill_in "price_policy_#{base_price_group.id}[minimum_cost]", with: "120"
     fill_in "price_policy_#{base_price_group.id}[cancellation_cost]", with: "15"
@@ -101,6 +103,8 @@ RSpec.describe InstrumentPricePoliciesController do
       fill_in "price_policy_#{external_price_group.id}[cancellation_cost]", with: "31"
       check "price_policy_#{external_price_group.id}[full_price_cancellation]"
       expect(page).to have_field("price_policy_#{external_price_group.id}[cancellation_cost]", disabled: true)
+
+      fill_in "Note", with: "This is my note"
 
       click_button "Add Pricing Rules"
 

--- a/spec/features/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/features/admin/instrument_price_policies_controller_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe InstrumentPricePoliciesController do
   let!(:cancer_center) { create(:price_group, :cancer_center) }
 
   before do
-    page.driver.resize 1200, 1200
     login_as director
     facility.price_groups.destroy_all # get rid of the price groups created by the factories
   end
@@ -33,6 +32,8 @@ RSpec.describe InstrumentPricePoliciesController do
     fill_in "price_policy_#{external_price_group.id}[minimum_cost]", with: "122"
     fill_in "price_policy_#{external_price_group.id}[cancellation_cost]", with: "31"
 
+    fill_in "Note", with: "This is my note"
+
     click_button "Add Pricing Rules"
 
     expect(page).to have_content("$60.00\n- $30.00\n= $30.00") # Cancer Center Usage Rate
@@ -43,6 +44,8 @@ RSpec.describe InstrumentPricePoliciesController do
     expect(page).to have_content("$120.11")
     expect(page).to have_content("$122.00")
     expect(page).to have_content("$31.00")
+
+    expect(page).to have_content("This is my note")
   end
 
   it "can only allow some to purchase", :js do
@@ -63,6 +66,18 @@ RSpec.describe InstrumentPricePoliciesController do
     expect(page).to have_content(base_price_group.name)
     expect(page).not_to have_content(external_price_group.name)
     expect(page).not_to have_content(cancer_center.name)
+  end
+
+  describe "with required note enabled", feature_setting: { price_policy_requires_note: true } do
+    it "requires the field" do
+      visit facility_instruments_path(facility, instrument)
+      click_link instrument.name
+      click_link "Pricing"
+      click_link "Add Pricing Rules"
+
+      click_button "Add Pricing Rules"
+      expect(page).to have_content("Note may not be blank")
+    end
   end
 
   describe "with full cancellation cost enabled", :js, feature_setting: { charge_full_price_on_cancellation: true } do

--- a/spec/features/admin/item_price_policies_controller_spec.rb
+++ b/spec/features/admin/item_price_policies_controller_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe ItemPricePoliciesController, :js do
     click_link "Pricing"
     click_link "Add Pricing Rules"
 
+    fill_in "Note", with: "This is my note"
+
     fill_in "price_policy_#{base_price_group.id}[unit_cost]", with: "100.00"
     fill_in "price_policy_#{cancer_center.id}[unit_subsidy]", with: "25.25"
     uncheck "price_policy_#{external_price_group.id}[can_purchase]"

--- a/spec/features/admin/item_price_policies_controller_spec.rb
+++ b/spec/features/admin/item_price_policies_controller_spec.rb
@@ -26,11 +26,15 @@ RSpec.describe ItemPricePoliciesController, :js do
     fill_in "price_policy_#{cancer_center.id}[unit_subsidy]", with: "25.25"
     fill_in "price_policy_#{external_price_group.id}[unit_cost]", with: "125.15"
 
+    fill_in "Note", with: "This is my note"
+
     click_button "Add Pricing Rules"
 
     expect(page).to have_content(table_row("#{base_price_group.name} (Internal)", "$100.00", "$0.00", "$100.00"))
     expect(page).to have_content(table_row("#{cancer_center.name} (Internal)", "$100.00", "$25.25", "$74.75"))
     expect(page).to have_content(table_row("#{external_price_group.name} (External)", "$125.15", "$0.00", "$125.15"))
+
+    expect(page).to have_content("This is my note")
   end
 
   it "can allow only some groups to purchase" do
@@ -48,6 +52,18 @@ RSpec.describe ItemPricePoliciesController, :js do
     expect(page).to have_content(base_price_group.name)
     expect(page).to have_content(cancer_center.name)
     expect(page).not_to have_content(external_price_group.name)
+  end
+
+  describe "with required note enabled", feature_setting: { price_policy_requires_note: true } do
+    it "requires the field" do
+      visit facility_items_path(facility, item)
+      click_link item.name
+      click_link "Pricing"
+      click_link "Add Pricing Rules"
+
+      click_button "Add Pricing Rules"
+      expect(page).to have_content("Note may not be blank")
+    end
   end
 
   def table_row(*columns)

--- a/spec/features/admin/timed_service_price_policies_controller_spec.rb
+++ b/spec/features/admin/timed_service_price_policies_controller_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe TimedServicePricePoliciesController, :js do
     click_link "Pricing"
     click_link "Add Pricing Rules"
 
+    fill_in "Note", with: "This is my note"
+
     fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "100.00"
     fill_in "price_policy_#{cancer_center.id}[usage_subsidy]", with: "25.25"
     uncheck "price_policy_#{external_price_group.id}[can_purchase]"

--- a/spec/features/admin/timed_service_price_policies_controller_spec.rb
+++ b/spec/features/admin/timed_service_price_policies_controller_spec.rb
@@ -26,12 +26,16 @@ RSpec.describe TimedServicePricePoliciesController, :js do
     fill_in "price_policy_#{cancer_center.id}[usage_subsidy]", with: "25.25"
     fill_in "price_policy_#{external_price_group.id}[usage_rate]", with: "125.15"
 
+    fill_in "Note", with: "This is my note"
+
     click_button "Add Pricing Rules"
 
     expect(page).to have_content("$2.0000 / minute") # Base rate
     expect(page).to have_content("$120.00\n- $25.25\n= $94.75") # Cancer center
     expect(page).to have_content("$1.5792 / minute") # Cancer center
     expect(page).to have_content("$2.0858 / minute") # External
+
+    expect(page).to have_content("This is my note")
   end
 
   it "can allow only some groups to purchase" do
@@ -49,5 +53,17 @@ RSpec.describe TimedServicePricePoliciesController, :js do
     expect(page).to have_content(base_price_group.name)
     expect(page).to have_content(cancer_center.name)
     expect(page).not_to have_content(external_price_group.name)
+  end
+
+  describe "with required note enabled", feature_setting: { price_policy_requires_note: true } do
+    it "requires the field" do
+      visit facility_timed_services_path(facility, timed_service)
+      click_link timed_service.name
+      click_link "Pricing"
+      click_link "Add Pricing Rules"
+
+      click_button "Add Pricing Rules"
+      expect(page).to have_content("Note may not be blank")
+    end
   end
 end

--- a/spec/models/item_price_policy_spec.rb
+++ b/spec/models/item_price_policy_spec.rb
@@ -53,11 +53,11 @@ RSpec.describe ItemPricePolicy do
     it "is valid for for today if no active price policy already exists" do
       is_expected.to allow_value(Date.today).for(:start_date)
       ipp = create(:item_price_policy, product: @item, start_date: Date.today - 7, expire_date: Date.today - 6,
-                                              price_group: @price_group)
+                                       price_group: @price_group)
       ipp.save(validate: false)
 
       ipp_new = build(:item_price_policy, product: @item, start_date: Date.today, expire_date: 1.day.from_now,
-                                                price_group: @price_group)
+                                          price_group: @price_group)
       expect(ipp_new).to be_valid
     end
 

--- a/spec/models/item_price_policy_spec.rb
+++ b/spec/models/item_price_policy_spec.rb
@@ -52,11 +52,11 @@ RSpec.describe ItemPricePolicy do
 
     it "is valid for for today if no active price policy already exists" do
       is_expected.to allow_value(Date.today).for(:start_date)
-      ipp = @item.item_price_policies.create!(unit_cost: 1, unit_subsidy: 0, start_date: Date.today - 7, expire_date: Date.today - 6,
+      ipp = create(:item_price_policy, product: @item, start_date: Date.today - 7, expire_date: Date.today - 6,
                                               price_group: @price_group)
       ipp.save(validate: false)
 
-      ipp_new = @item.item_price_policies.build(unit_cost: 1, unit_subsidy: 0, start_date: Date.today, expire_date: 1.day.from_now,
+      ipp_new = build(:item_price_policy, product: @item, start_date: Date.today, expire_date: 1.day.from_now,
                                                 price_group: @price_group)
       expect(ipp_new).to be_valid
     end

--- a/spec/models/price_policy_spec.rb
+++ b/spec/models/price_policy_spec.rb
@@ -245,6 +245,12 @@ RSpec.describe PricePolicy do
         note.valid?
         expect(note.errors).not_to include(:note)
       end
+
+      it "requires it be short enough" do
+        note = described_class.new(note: "x" * 257)
+        expect(note).to be_invalid
+        expect(note.errors).to be_added(:note, :too_long, count: 256)
+      end
     end
 
     context "when the required note feature is disabled", feature_setting: { price_policy_requires_note: false } do
@@ -252,6 +258,12 @@ RSpec.describe PricePolicy do
         note = described_class.new(note: "")
         note.valid?
         expect(note.errors).not_to include(:note)
+      end
+
+      it "requires it be short enough" do
+        note = described_class.new(note: "x" * 257)
+        expect(note).to be_invalid
+        expect(note.errors).to be_added(:note, :too_long, count: 256)
       end
     end
   end

--- a/spec/models/price_policy_spec.rb
+++ b/spec/models/price_policy_spec.rb
@@ -224,4 +224,36 @@ RSpec.describe PricePolicy do
 
   end
 
+  describe "note" do
+    context "when the required note feature is enabled", feature_setting: { price_policy_requires_note: true } do
+      it "requires the note" do
+        note = described_class.new(note: "")
+        expect(note).to be_invalid
+        expect(note.errors).to be_added(:note, :blank)
+        expect(note.errors).not_to be_added(:note, :too_short, count: 10)
+      end
+
+      it "requires the note be long enough" do
+        note = described_class.new(note: "a")
+        expect(note).to be_invalid
+        expect(note.errors).not_to be_added(:note, :blank)
+        expect(note.errors).to be_added(:note, :too_short, count: 10)
+      end
+
+      it "is fine when it is present and long enough" do
+        note = described_class.new(note: "12345678910")
+        note.valid?
+        expect(note.errors).not_to include(:note)
+      end
+    end
+
+    context "when the required note feature is disabled", feature_setting: { price_policy_requires_note: false } do
+      it "is fine with a blank value" do
+        note = described_class.new(note: "")
+        note.valid?
+        expect(note.errors).not_to include(:note)
+      end
+    end
+  end
+
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -217,6 +217,10 @@ RSpec.describe Product do
           :unit_cost
         end
 
+        def note
+          "present"
+        end
+
       end
 
       before :each do

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe Product do
         end
 
         def note
-          "present"
+          "I am a note and I am present"
         end
 
       end

--- a/spec/models/service_price_policy_spec.rb
+++ b/spec/models/service_price_policy_spec.rb
@@ -52,10 +52,10 @@ RSpec.describe ServicePricePolicy do
 
     it "is valid for today if no active price policy already exists" do
       is_expected.to allow_value(Date.today).for(:start_date)
-      ipp = @service.service_price_policies.create!(unit_cost: 1, unit_subsidy: 0, start_date: Date.today - 7, expire_date: Date.today - 6,
+      ipp = create(:service_price_policy, product: @service, start_date: Date.today - 7, expire_date: Date.today - 6,
                                                     price_group: @price_group)
       ipp.save(validate: false)
-      ipp_new = @service.service_price_policies.build(unit_cost: 1, unit_subsidy: 0, start_date: Date.today, expire_date: 1.day.from_now,
+      ipp_new = build(:service_price_policy, product: @service, start_date: Date.today, expire_date: 1.day.from_now,
                                                       price_group: @price_group)
       expect(ipp_new).to be_valid
       expect(ipp_new.errors_on(:start_date)).not_to be_nil

--- a/spec/models/service_price_policy_spec.rb
+++ b/spec/models/service_price_policy_spec.rb
@@ -53,10 +53,10 @@ RSpec.describe ServicePricePolicy do
     it "is valid for today if no active price policy already exists" do
       is_expected.to allow_value(Date.today).for(:start_date)
       ipp = create(:service_price_policy, product: @service, start_date: Date.today - 7, expire_date: Date.today - 6,
-                                                    price_group: @price_group)
+                                          price_group: @price_group)
       ipp.save(validate: false)
       ipp_new = build(:service_price_policy, product: @service, start_date: Date.today, expire_date: 1.day.from_now,
-                                                      price_group: @price_group)
+                                             price_group: @price_group)
       expect(ipp_new).to be_valid
       expect(ipp_new.errors_on(:start_date)).not_to be_nil
     end

--- a/spec/price_policies_controller_shared_examples.rb
+++ b/spec/price_policies_controller_shared_examples.rb
@@ -207,8 +207,6 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
 
   context "with policy params" do
     before :each do
-      @params[:interval] = 5
-
       facility.price_groups.map(&:id).each do |id|
         @params.merge!(
           :"price_policy_#{id}" =>
@@ -225,6 +223,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
         @expire_date = PricePolicy.generate_expire_date(@start_date)
         @params[:start_date] = @start_date.to_s
         @params[:expire_date] = @expire_date.to_s
+        @params[:note] = "A note"
 
         @params_modifier.before_create @params if @params_modifier.try :respond_to?, :before_create
       end
@@ -325,6 +324,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
           id: price_policy.start_date.to_s,
           start_date: price_policy.start_date.to_s,
           expire_date: price_policy.expire_date.to_s,
+          note: "A note",
         )
 
         if @params_modifier.respond_to?(:before_update)

--- a/spec/price_policies_controller_shared_examples.rb
+++ b/spec/price_policies_controller_shared_examples.rb
@@ -223,7 +223,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
         @expire_date = PricePolicy.generate_expire_date(@start_date)
         @params[:start_date] = @start_date.to_s
         @params[:expire_date] = @expire_date.to_s
-        @params[:note] = "A note"
+        @params[:note] = "This is a note"
 
         @params_modifier.before_create @params if @params_modifier.try :respond_to?, :before_create
       end
@@ -324,7 +324,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
           id: price_policy.start_date.to_s,
           start_date: price_policy.start_date.to_s,
           expire_date: price_policy.expire_date.to_s,
-          note: "A note",
+          note: "This is a note",
         )
 
         if @params_modifier.respond_to?(:before_update)

--- a/spec/price_policies_controller_shared_examples.rb
+++ b/spec/price_policies_controller_shared_examples.rb
@@ -84,6 +84,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
         price_groups = assigns[:price_policies].map(&:price_group)
         expect(price_groups).to contain_all PriceGroup.all
       end
+
       it "sets the policies in the correct order" do
         @price_group.update_attributes(display_order: 2)
         @price_group2.update_attributes(display_order: 1)
@@ -306,6 +307,11 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
           expect(assigns[:expire_date]).to be_blank
           expect(assigns[:price_policies].first.errors).to be_added(:expire_date, :blank)
           expect(assigns[:price_policies]).to all(be_new_record)
+        end
+
+        it "sets the created_by" do
+          do_request
+          expect(assigns[:price_policies].map(&:created_by)).to all eq(@director)
         end
       end
     end

--- a/vendor/engines/secure_rooms/app/views/secure_room_price_policies/_price_policy_fields.html.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_room_price_policies/_price_policy_fields.html.haml
@@ -3,7 +3,7 @@
 
 - price_policy = @price_policies.first
 
-= render "price_policies/dates", f: f, price_policy: price_policy
+= render "price_policies/common_fields", f: f, price_policy: price_policy
 
 %table.table.table-striped.table-hover.price-policy-table
   %thead

--- a/vendor/engines/secure_rooms/spec/factories/secure_rooms_price_policies.rb
+++ b/vendor/engines/secure_rooms/spec/factories/secure_rooms_price_policies.rb
@@ -9,5 +9,6 @@ FactoryBot.define do
     can_purchase { true }
     start_date { Time.zone.now.beginning_of_day }
     expire_date { PricePolicy.generate_expire_date(Time.zone.now.beginning_of_day) }
+    note { "A note" }
   end
 end

--- a/vendor/engines/secure_rooms/spec/factories/secure_rooms_price_policies.rb
+++ b/vendor/engines/secure_rooms/spec/factories/secure_rooms_price_policies.rb
@@ -9,6 +9,6 @@ FactoryBot.define do
     can_purchase { true }
     start_date { Time.zone.now.beginning_of_day }
     expire_date { PricePolicy.generate_expire_date(Time.zone.now.beginning_of_day) }
-    note { "A note" }
+    note { "This is note" }
   end
 end

--- a/vendor/engines/secure_rooms/spec/features/create_a_secure_room_spec.rb
+++ b/vendor/engines/secure_rooms/spec/features/create_a_secure_room_spec.rb
@@ -47,6 +47,9 @@ RSpec.describe "Creating a SecureRoom" do
       uncheck "price_policy_#{external_price_group.id}[can_purchase]"
       uncheck "price_policy_#{facility_price_group.id}[can_purchase]"
       fill_in "price_policy_#{global_price_group.id}[usage_subsidy]", with: "60"
+
+      fill_in "Note", with: "My note"
+
       click_button "Add Pricing Rules"
     end
 
@@ -55,6 +58,8 @@ RSpec.describe "Creating a SecureRoom" do
       expect(page).not_to have_content(external_price_group.name)
       expect(page).to have_content("$120.00")
       expect(page).to have_content("$22.50") # minimum cost, subsidized
+
+      expect(page).to have_content("My note")
     end
   end
 end

--- a/vendor/engines/secure_rooms/spec/features/create_a_secure_room_spec.rb
+++ b/vendor/engines/secure_rooms/spec/features/create_a_secure_room_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Creating a SecureRoom" do
       uncheck "price_policy_#{facility_price_group.id}[can_purchase]"
       fill_in "price_policy_#{global_price_group.id}[usage_subsidy]", with: "60"
 
-      fill_in "Note", with: "My note"
+      fill_in "Note", with: "This is a note"
 
       click_button "Add Pricing Rules"
     end
@@ -59,7 +59,7 @@ RSpec.describe "Creating a SecureRoom" do
       expect(page).to have_content("$120.00")
       expect(page).to have_content("$22.50") # minimum cost, subsidized
 
-      expect(page).to have_content("My note")
+      expect(page).to have_content("This is a note")
     end
   end
 end


### PR DESCRIPTION
# Release Notes

Add a note field to price policies and optionally make it required.

# Additional Context

Dartmouth wants to make it required. NU is fine adding the field, but does not want to require it being filled out.