### PR TITLE
[#144074] Add debugging statements to secure_rooms engine

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -2,7 +2,7 @@
 
 unless Rails.env.test? || Rails.env.development?
   Nucore::Application.configure do
-    config.lograge.enabled = true
+    config.lograge.enabled = false
     config.lograge.formatter = Lograge::Formatters::Logstash.new
 
     # Add params to the log

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/occupancy_handler.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/occupancy_handler.rb
@@ -17,22 +17,30 @@ module SecureRooms
       end
 
       def process
+        Rails.logger.info("[SecureRooms] Entered SecureRooms::AccessHandlers::EventHandler#process")
+
         return unless event.success?
 
         if current_occupant? && exiting?
+          Rails.logger.info("[SecureRooms] Processing branch current_occupant? && exiting?")
           existing_occupancy.associate_exit!(event)
         elsif new_occupant? && entering?
+          Rails.logger.info("[SecureRooms] Processing branch new_occupant? && entering?")
           new_occupancy.associate_exit!(event) if entry_only?
           new_occupancy.associate_entry!(event)
         elsif new_occupant? && exiting?
+          Rails.logger.info("[SecureRooms] Processing branch new_occupant? && exiting?")
           new_occupancy.mark_orphaned!
           new_occupancy.associate_exit!(event)
         elsif current_occupant? && entering?
+          Rails.logger.info("[SecureRooms] Processing branch current_occupant? && entering?")
           complete_existing_occupancy!
           new_occupancy.associate_entry!(event)
         else
           raise NotImplementedError, "Encountered unexpected scan context"
         end
+
+        Rails.logger.info("[SecureRooms] Exiting SecureRooms::AccessHandlers::EventHandler#process")
       end
 
       private

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/occupancy_handler.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/occupancy_handler.rb
@@ -21,7 +21,7 @@ module SecureRooms
 
         return unless event.success?
 
-        if current_occupant? && exiting?
+        result = if current_occupant? && exiting?
           Rails.logger.info("[SecureRooms] Processing branch current_occupant? && exiting? (existing occupancy id: #{existing_occupancy.id})")
           existing_occupancy.associate_exit!(event)
         elsif new_occupant? && entering?
@@ -41,6 +41,7 @@ module SecureRooms
         end
 
         Rails.logger.info("[SecureRooms] Exiting SecureRooms::AccessHandlers::EventHandler#process")
+        result
       end
 
       private

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/occupancy_handler.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/occupancy_handler.rb
@@ -22,18 +22,18 @@ module SecureRooms
         return unless event.success?
 
         if current_occupant? && exiting?
-          Rails.logger.info("[SecureRooms] Processing branch current_occupant? && exiting?")
+          Rails.logger.info("[SecureRooms] Processing branch current_occupant? && exiting? (existing occupancy id: #{existing_occupancy.id})")
           existing_occupancy.associate_exit!(event)
         elsif new_occupant? && entering?
-          Rails.logger.info("[SecureRooms] Processing branch new_occupant? && entering?")
+          Rails.logger.info("[SecureRooms] Processing branch new_occupant? && entering? (new occupancy id: #{new_occupancy.id})")
           new_occupancy.associate_exit!(event) if entry_only?
           new_occupancy.associate_entry!(event)
         elsif new_occupant? && exiting?
-          Rails.logger.info("[SecureRooms] Processing branch new_occupant? && exiting?")
+          Rails.logger.info("[SecureRooms] Processing branch new_occupant? && exiting? (new occupancy id: #{new_occupancy.id})")
           new_occupancy.mark_orphaned!
           new_occupancy.associate_exit!(event)
         elsif current_occupant? && entering?
-          Rails.logger.info("[SecureRooms] Processing branch current_occupant? && entering?")
+          Rails.logger.info("[SecureRooms] Processing branch current_occupant? && entering? (existing occupancy id: #{existing_occupancy.id})")
           complete_existing_occupancy!
           new_occupancy.associate_entry!(event)
         else

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/order_handler.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/order_handler.rb
@@ -17,11 +17,12 @@ module SecureRooms
       end
 
       def process
-        Rails.logger.info("[SecureRooms] Entered SecureRooms::AccessHandlers::OrderHandler#process")
+        Rails.logger.info("[SecureRooms] Entered SecureRooms::AccessHandlers::OrderHandler#process (occupancy id #{occupancy.id})")
         return if user_exempt_from_purchase?
 
         find_or_create_order
-        Rails.logger.info("occupancy.order_completable? = #{occupancy.order_completable?}")
+        Rails.logger.info("[SecureRooms] order id #{order.id}; order detail id #{@order_detail.id}")
+        Rails.logger.info("[SecureRooms] occupancy.order_completable? = #{occupancy.order_completable?}")
         complete_order if occupancy.order_completable?
 
         Rails.logger.info("[SecureRooms] Exiting SecureRooms::AccessHandlers::OrderHandler#process")

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/order_handler.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/order_handler.rb
@@ -17,31 +17,42 @@ module SecureRooms
       end
 
       def process
+        Rails.logger.info("[SecureRooms] Entered SecureRooms::AccessHandlers::OrderHandler#process")
         return if user_exempt_from_purchase?
 
         find_or_create_order
+        Rails.logger.info("occupancy.order_completable? = #{occupancy.order_completable?}")
         complete_order if occupancy.order_completable?
 
+        Rails.logger.info("[SecureRooms] Exiting SecureRooms::AccessHandlers::OrderHandler#process")
         order
       end
 
       private
 
       def find_or_create_order
+        Rails.logger.info("[SecureRooms] Entered SecureRooms::AccessHandlers::OrderHandler#find_or_create_order")
         if occupancy.order_detail_id?
+          Rails.logger.info("[SecureRooms] Processing branch occupancy.order_detail_id?")
           @order_detail = occupancy.order_detail
           @order = order_detail.order
         else
+          Rails.logger.info("[SecureRooms] Processing branch else")
           create_order
         end
+        Rails.logger.info("[SecureRooms] Exiting SecureRooms::AccessHandlers::OrderHandler#find_or_create_order and returning #{result}")
       end
 
       def complete_order
+        Rails.logger.info("[SecureRooms] Entered SecureRooms::AccessHandlers::OrderHandler#complete_order")
         if occupancy.orphaned_at?
+          Rails.logger.info("Processing branch occupancy.orphaned_at?")
           MoveToProblemQueue.move!(order_detail)
         else
+          Rails.logger.info("[SecureRooms] Processing branch else")
           order_detail.complete!
         end
+        Rails.logger.info("[SecureRooms] Exiting SecureRooms::AccessHandlers::OrderHandler#complete_order")
       end
 
       def create_order
@@ -65,8 +76,11 @@ module SecureRooms
       # to find what the verdict would have been. A verdict returning accounts
       # signifies the user would have needed to select one to enter.
       def user_exempt_from_purchase?
+        Rails.logger.info("[SecureRooms] Entered SecureRooms::AccessHandlers::OrderHandler#user_exempt_from_purchase?")
         in_reader = occupancy.secure_room.card_readers.ingress.first
-        SecureRooms::CheckAccess.new.authorize(occupancy.user, in_reader).accounts.blank?
+        result = SecureRooms::CheckAccess.new.authorize(occupancy.user, in_reader).accounts.blank?
+        Rails.logger.info("[SecureRooms] Exiting SecureRooms::AccessHandlers::OrderHandler#user_exempt_from_purchase? and returning #{result}")
+        result
       end
 
       def create_order_and_detail

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/order_handler.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/order_handler.rb
@@ -41,7 +41,7 @@ module SecureRooms
           Rails.logger.info("[SecureRooms] Processing branch else")
           create_order
         end
-        Rails.logger.info("[SecureRooms] Exiting SecureRooms::AccessHandlers::OrderHandler#find_or_create_order and returning #{result}")
+        Rails.logger.info("[SecureRooms] Exiting SecureRooms::AccessHandlers::OrderHandler#find_or_create_order")
       end
 
       def complete_order

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_manager.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_manager.rb
@@ -11,10 +11,14 @@ module SecureRooms
     ].freeze
 
     def self.process(verdict)
+      Rails.logger.info("[SecureRooms] Entered SecureRooms::AccessManager.process")
+
       PROCESSING_CHAIN.inject(verdict) do |result, handler|
         result = handler.process(result)
         result || break
       end
+
+      Rails.logger.info("[SecureRooms] Exiting SecureRooms::AccessManager.process")
     end
 
   end


### PR DESCRIPTION
# Release Notes

Add debugging statements to secure_rooms engine

# Additional Context

Some occupancies of secure rooms are not updating the related order detail records when a user exits the room. However, looking at these occupancies and order details does not reveal why this happens — calling the code that the controller would call, processes these order details correctly. This PR is to add some tracing calls to see what in the processing chain may be getting skipped.