### PR TITLE
Revert "Handle survey urls that already have a question mark in them"

### DIFF
--- a/app/models/external_service/url_service.rb
+++ b/app/models/external_service/url_service.rb
@@ -14,24 +14,14 @@ class UrlService < ExternalService
   #   relationship. Useful for providing pass-thru HTTP param data
   #   to the external service.
   def new_url(receiver, request = nil)
-    merge_queries(location, additional_query_params(receiver, request))
+    "#{location}?#{query_string(receiver, request)}"
   end
 
-  def edit_url(receiver, request = nil)
-    merge_queries(receiver.edit_url, additional_query_params(receiver, request))
+  def edit_url(receiver, request)
+    "#{receiver.edit_url}?#{query_string(receiver, request)}"
   end
 
-  private
-
-  def merge_queries(url, additional_hash)
-    uri = URI(url)
-    query_hash = Rack::Utils.parse_query(uri.query)
-    query_hash.merge!(additional_hash)
-    uri.query = query_hash.to_query
-    uri.to_s
-  end
-
-  def additional_query_params(receiver, request)
+  def query_string(receiver, request)
     query = {
       success_url: success_path(receiver, request),
       referer: referer_url(request),
@@ -40,8 +30,10 @@ class UrlService < ExternalService
 
     query[:order_number] = receiver.order_number if receiver.respond_to?(:order_number)
     query[:quantity] = receiver.quantity if receiver.respond_to?(:quantity)
-    query
+    query.to_query
   end
+
+  private
 
   def referer_url(request)
     "#{request.protocol}#{request.host_with_port}#{request.fullpath}" if request

--- a/spec/models/external_service/url_service_spec.rb
+++ b/spec/models/external_service/url_service_spec.rb
@@ -60,35 +60,5 @@ RSpec.describe UrlService do
     it "returns a blank referer" do
       expect(query_hash["referer"]).to be_blank
     end
-
-    describe "when the location already has a ? in it" do
-      before { url_service.location = "http://www.survey.com/survey1?q=true&other=false" }
-
-      it "sets the currect uri" do
-        expect(uri.to_s).to start_with("http://www.survey.com/survey1?")
-        expect(query_hash).to include(
-          "q" => "true",
-          "other" => "false",
-          "receiver_id" => order_detail.id.to_s,
-        )
-      end
-    end
-  end
-
-  describe "edit_url" do
-    let(:edit_url) { url_service.edit_url(order_detail) }
-    let(:query_hash) { Rack::Utils.parse_query(URI(edit_url).query) }
-
-    describe "when the url already has a ?" do
-      before { allow(order_detail).to receive(:edit_url).and_return("http://www.survey.com/surveys/edit?id=123") }
-
-      it "sets the query string correctly if the link already has a ?" do
-        expect(edit_url).to start_with("http://www.survey.com/surveys/edit?")
-        expect(query_hash).to include(
-          "id" => "123",
-          "receiver_id" => order_detail.id.to_s,
-        )
-      end
-    end
   end
 end


### PR DESCRIPTION
Reverts tablexi/nucore-open#1771 because it seems to be causing https://rollbar.com/TableXI/nucore-nu/items/341/ and https://rollbar.com/TableXI/nucore-nu/items/342/