### PR TITLE
[#145520] Restore ability to have links open in new window

### DIFF
--- a/config/initializers/sanitized_allowed.rb
+++ b/config/initializers/sanitized_allowed.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-ActionView::Base.sanitized_allowed_attributes << "style"
-ActionView::Base.sanitized_allowed_tags += %w(table thead tbody th tr td)
+ActionView::Base.sanitized_allowed_attributes += %w[style target]
+ActionView::Base.sanitized_allowed_tags += %w[table thead tbody th tr td]


### PR DESCRIPTION
# Release Notes

Restore ability to allow links in product and facility descriptions to open in a new window.

# Additional Context

Users have the ability to set a `target` on their links in the facility and product descriptions through the editor to allow opening a link in a new window. We added some sanitization to `Facility#description` in #1703 which strips out that attribute. This lets it through sanitization.

