### PR TITLE
Use-Manage Buttons

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -673,7 +673,9 @@ thead {
   color: $grey;
   text-transform: uppercase;
   font-weight: bold;
-.btn-add {
+}
+
+.btn, .btn-add {
   border: solid $useColorDark 1px;
   outline: none;
   background: transparent;
@@ -683,11 +685,19 @@ thead {
   text-shadow: none;
 }
 
-.btn-add:hover {
+.btn:hover, .btn-add:hover {
   background-color: rgba(0, 0, 0, 0.05);
+  color: $useColorDark;
 }
 
-.manage-mode .btn-add {
-  border-color: $manageColorDark;
-  color: $manageColorDark;
+.manage-mode {
+  .btn, .btn-add {
+    border-color: $manageColorDark;
+    color: $manageColorDark;
+  }
+
+  .btn:hover, .btn-add:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+    color: $manageColorDark;
+  } 
 }

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -673,4 +673,21 @@ thead {
   color: $grey;
   text-transform: uppercase;
   font-weight: bold;
+.btn-add {
+  border: solid $useColorDark 1px;
+  outline: none;
+  background: transparent;
+  border-radius: 8px;
+  box-shadow: none;
+  color: $useColorDark;
+  text-shadow: none;
+}
+
+.btn-add:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.manage-mode .btn-add {
+  border-color: $manageColorDark;
+  color: $manageColorDark;
 }

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -676,6 +676,7 @@ thead {
 }
 
 .btn, .btn-add {
+  transition: ease-in-out 0.2s all;
   border: solid $useColorDark 1px;
   outline: none;
   background: transparent;

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -676,19 +676,31 @@ thead {
 }
 
 .btn, .btn-add {
-  transition: ease-in-out 0.2s all;
+  transition: ease 0.2s all;
   border: solid $useColorDark 1px;
   outline: none;
-  background: transparent;
+  background: none;
+  background-color: transparent;
   border-radius: 8px;
   box-shadow: none;
   color: $useColorDark;
   text-shadow: none;
 }
 
+.btn-primary {
+  font-weight: bold;
+  border-width: 1.5px;
+}
+
 .btn:hover, .btn-add:hover {
+  transition: ease 0.2s all;
   background-color: rgba(0, 0, 0, 0.05);
   color: $useColorDark;
+}
+
+.btn-primary:hover {
+  background-color: $useColorDark;
+  color: $headerBackgroundColor;
 }
 
 .manage-mode {
@@ -701,4 +713,9 @@ thead {
     background-color: rgba(0, 0, 0, 0.05);
     color: $manageColorDark;
   } 
+
+  .btn-primary:hover {
+    background-color: $manageColorDark;
+    color: $headerBackgroundColor;
+  }
 }


### PR DESCRIPTION
# Release Notes

Restyle buttons with the UCONN design. Buttons colored based on use/manage mode.

# Screenshot
## Add Facility in use mode
<img width="349" alt="screen shot 2018-12-04 at 8 29 32 am" src="https://user-images.githubusercontent.com/5000430/49445119-1771e100-f79f-11e8-9196-1eb7dffd0554.png">

## Add instrument in manage mode
<img width="667" alt="screen shot 2018-12-04 at 8 29 48 am" src="https://user-images.githubusercontent.com/5000430/49445123-193ba480-f79f-11e8-9fcc-2867166cafe0.png">

## Hover state
Simply adding a 15% alpha layer
<img width="141" alt="screen shot 2018-12-04 at 8 29 54 am" src="https://user-images.githubusercontent.com/5000430/49445125-1b056800-f79f-11e8-93ac-f4c729205dd7.png">
