### PR TITLE
[#141856] Make "Ordered For" column sortable on New/In Process orders page

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -1,3 +1,7 @@
+.nowrap {
+  white-space: nowrap;
+}
+
 .highlighted {
   @include gradient-vertical($sidebarActiveBackgroundColorHighlight, $sidebarActiveBackgroundColor);
   color: $sidebarActiveColor;

--- a/app/controllers/concerns/new_inprocess_controller.rb
+++ b/app/controllers/concerns/new_inprocess_controller.rb
@@ -26,4 +26,15 @@ module NewInprocessController
     raise NotImplementedError
   end
 
+  def sort_lookup_hash
+    {
+      "assigned_to" => ["assigned_users.last_name", "assigned_users.first_name", "order_statuses.name", "orders.ordered_at"],
+      "ordered_at" => "orders.ordered_at",
+      "ordered_for" => ["#{User.table_name}.last_name", "#{User.table_name}.first_name"],
+      "product_name" => ["products.name", "order_details.state", "orders.ordered_at"],
+      "reserve_range" => ["reservations.reserve_start_at", "reservations.reserve_end_at"],
+      "status" => "order_statuses.name",
+    }
+  end
+
 end

--- a/app/controllers/concerns/new_inprocess_controller.rb
+++ b/app/controllers/concerns/new_inprocess_controller.rb
@@ -34,6 +34,7 @@ module NewInprocessController
       "product_name" => ["products.name", "order_details.state", "orders.ordered_at"],
       "reserve_range" => ["reservations.reserve_start_at", "reservations.reserve_end_at"],
       "status" => "order_statuses.name",
+      "payment_source" => "accounts.description",
     }
   end
 

--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -130,6 +130,7 @@ class FacilityOrdersController < ApplicationController
       "product" => ["products.name", "order_details.state", "orders.ordered_at"],
       "assigned_to" => ["assigned_users.last_name", "assigned_users.first_name", "order_statuses.name", "orders.ordered_at"],
       "status" => ["order_statuses.name", "orders.ordered_at"],
+      "ordered_for" => ["#{User.table_name}.first_name", "#{User.table_name}.last_name"],
     }
   end
 

--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -2,8 +2,8 @@
 
 class FacilityOrdersController < ApplicationController
 
-  include NewInprocessController
   include SortableColumnController
+  include NewInprocessController
   include ProblemOrderDetailsController
   include TabCountHelper
 
@@ -121,17 +121,6 @@ class FacilityOrdersController < ApplicationController
 
   def problem_order_details
     current_facility.problem_plain_order_details
-  end
-
-  def sort_lookup_hash
-    {
-      "order_number" => ["order_details.order_id", "order_details.id"],
-      "date" => "orders.ordered_at",
-      "product" => ["products.name", "order_details.state", "orders.ordered_at"],
-      "assigned_to" => ["assigned_users.last_name", "assigned_users.first_name", "order_statuses.name", "orders.ordered_at"],
-      "status" => ["order_statuses.name", "orders.ordered_at"],
-      "ordered_for" => ["#{User.table_name}.first_name", "#{User.table_name}.last_name"],
-    }
   end
 
 end

--- a/app/controllers/facility_reservations_controller.rb
+++ b/app/controllers/facility_reservations_controller.rb
@@ -2,8 +2,8 @@
 
 class FacilityReservationsController < ApplicationController
 
-  include NewInprocessController
   include SortableColumnController
+  include NewInprocessController
   include ProblemOrderDetailsController
   include TabCountHelper
   include Timelineable
@@ -218,17 +218,6 @@ class FacilityReservationsController < ApplicationController
   def new_or_in_process_orders
     current_facility.order_details.new_or_inprocess.reservations
                     .includes(:reservation)
-  end
-
-  def sort_lookup_hash
-    {
-      "date" => "orders.ordered_at",
-      "reserve_range" => ["reservations.reserve_start_at", "reservations.reserve_end_at"],
-      "product_name"  => "products.name",
-      "status"        => "order_statuses.name",
-      "assigned_to"   => ["assigned_users.last_name", "assigned_users.first_name"],
-      "reserved_by"   => ["#{User.table_name}.first_name", "#{User.table_name}.last_name"],
-    }
   end
 
   def set_windows

--- a/app/views/facility_orders/index.html.haml
+++ b/app/views/facility_orders/index.html.haml
@@ -18,23 +18,23 @@
         %thead
           %tr
             %th
-            %th.order_num_width.centered= sortable "order_number", Order.model_name.human
-            %th.order_num_width.centered= OrderDetail.model_name.human
-            %th.ordered_on_width= sortable "date", Order.human_attribute_name(:ordered_at)
-            %th= sortable "ordered_for", Order.human_attribute_name(:user)
-            %th= OrderDetail.human_attribute_name(:quantity)
-            %th.order-note= sortable "product"
-            %th= sortable "assigned_to"
-            %th= sortable "status"
-            %th.currency= OrderDetail.human_attribute_name(:actual_cost)
+            %th.nowrap= sortable "order_number", Order.model_name.human
+            %th.nowrap= OrderDetail.model_name.human
+            %th.nowrap= sortable "ordered_for", Order.human_attribute_name(:user)
+            %th.nowrap= sortable "date", Order.human_attribute_name(:ordered_at)
+            %th.nowrap= OrderDetail.human_attribute_name(:quantity)
+            %th.nowrap.order-note= sortable "product"
+            %th.nowrap= sortable "assigned_to", OrderDetail.human_attribute_name(:assigned_user)
+            %th.nowrap= sortable "status"
+            %th.nowrap.currency= OrderDetail.human_attribute_name(:actual_cost)
         %tbody
           - @order_details.each do |od|
             %tr
               %td.centered= check_box_tag("order_detail_ids[]", od.id, false, {class: "toggle", id: nil })
               %td.centered= link_to od.order_id, facility_order_path(current_facility, od.order)
               %td.centered= link_to od.id, manage_order_detail_path(od), class: "manage-order-detail"
-              %td= format_usa_datetime(od.order.ordered_at)
               %td= od.order.user.full_name
+              %td= format_usa_datetime(od.order.ordered_at)
               %td.centered= OrderDetailPresenter.new(od).wrapped_quantity
               = render partial: "shared/order_detail_cell", locals: { od: od }
               %td= od.assigned_user

--- a/app/views/facility_orders/index.html.haml
+++ b/app/views/facility_orders/index.html.haml
@@ -21,7 +21,7 @@
             %th.order_num_width.centered= sortable "order_number", Order.model_name.human
             %th.order_num_width.centered= OrderDetail.model_name.human
             %th.ordered_on_width= sortable "date", Order.human_attribute_name(:ordered_at)
-            %th= Order.human_attribute_name(:user)
+            %th= sortable "ordered_for", Order.human_attribute_name(:user)
             %th= OrderDetail.human_attribute_name(:quantity)
             %th.order-note= sortable "product"
             %th= sortable "assigned_to"

--- a/app/views/facility_reservations/index.html.haml
+++ b/app/views/facility_reservations/index.html.haml
@@ -19,14 +19,14 @@
         %thead
           %tr
             %th
-            %th= Order.model_name.human
-            %th= OrderDetail.model_name.human
-            %th= sortable "reserved_by"
-            %th{colspan: 2}= sortable "date", Order.human_attribute_name(:ordered_at)
-            %th{colspan: 2}= sortable "reserve_range", Reservation.human_attribute_name(:reserve_range)
-            %th.order-note= sortable "product_name", OrderDetail.human_attribute_name(:product)
-            %th= sortable "assigned_to", OrderDetail.human_attribute_name(:assigned_user)
-            %th= sortable "status"
+            %th.nowrap= sortable "order_number", Order.model_name.human
+            %th.nowrap= OrderDetail.model_name.human
+            %th.nowrap= sortable "ordered_for", Order.human_attribute_name(:user)
+            %th.nowrap{colspan: 2}= sortable "ordered_at", Order.human_attribute_name(:ordered_at)
+            %th.nowrap{colspan: 2}= sortable "reserve_range", Reservation.human_attribute_name(:reserve_range)
+            %th.nowrap.order-note= sortable "product_name", OrderDetail.human_attribute_name(:product)
+            %th.nowrap= sortable "assigned_to", OrderDetail.human_attribute_name(:assigned_user)
+            %th.nowrap= sortable "status"
             %th.currency= OrderDetail.human_attribute_name(:actual_cost)
         %tbody
           - @order_details.each do |od|

--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms/facility_occupancies_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms/facility_occupancies_controller.rb
@@ -6,6 +6,7 @@ module SecureRooms
 
     include OrderDetailsCsvExport
     include SortableColumnController
+    include NewInprocessController
     include ProblemOrderDetailsController
     include TabCountHelper
 
@@ -62,12 +63,9 @@ module SecureRooms
     end
 
     def sort_lookup_hash
-      {
+      super.merge(
         "entry_at" => "secure_rooms_occupancies.entry_at",
-        "user_name" => ["users.last_name", "users.first_name"],
-        "product_name" => "products.name",
-        "payment_source" => "accounts.description",
-      }
+      )
     end
 
   end

--- a/vendor/engines/secure_rooms/app/views/secure_rooms/facility_occupancies/index.html.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_rooms/facility_occupancies/index.html.haml
@@ -19,12 +19,12 @@
         = render "table_controls"
         %thead
           %tr
-            %th= Order.model_name.human
-            %th= OrderDetail.model_name.human
-            %th= sortable "entry_at", SecureRooms::Occupancy.human_attribute_name(:entry_at)
-            %th= sortable "user_name", User.model_name.human
-            %th.order-note= sortable "product_name", SecureRoom.model_name.human
-            %th= sortable "payment_source", Account.model_name.human
+            %th.nowrap= sortable "order_number", Order.model_name.human
+            %th.nowrap= OrderDetail.model_name.human
+            %th.nowrap= sortable "ordered_for", User.model_name.human
+            %th.nowrap= sortable "entry_at", SecureRooms::Occupancy.human_attribute_name(:entry_at)
+            %th.nowrap.order-note= sortable "product_name", SecureRoom.model_name.human
+            %th.nowrap= sortable "payment_source", Account.model_name.human
         %tbody
           - @order_details.each do |od|
             - order = od.order
@@ -32,8 +32,8 @@
             %tr
               %td.centered= link_to od.order_id, facility_order_path(current_facility, order)
               %td.centered= link_to od.id, manage_order_detail_path(od), class: "manage-order-detail"
-              %td= format_usa_datetime(occ.entry_at)
               %td= od.user&.full_name
+              %td= format_usa_datetime(occ.entry_at)
               = render partial: "shared/order_detail_cell", locals: { od: od, show_occupancy: false }
               %td= od.account
 


### PR DESCRIPTION
# Release Notes

Make "Ordered For" column sortable on New/In Process orders page. Make the ordering of columns on the New/In process orders and reservations pages more consistent with each other.

# Additional Context

Per NU, sorting on last, first made the most sense so we made this consistent across the columns.
