### PR TITLE
update README to specify ruby 2.4.1 to match the .ruby-version file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Welcome to NUcore! This guide will help you get a development environment up and
 1. You write code on a Mac.
 2. You have a running Oracle or MySQL instance with two brand new databases. (Oracle setup instructions [here](doc/HOWTO_oracle.txt).)
 3. You have the following installed:
-    * [Ruby 2.2](http://www.ruby-lang.org/en)
+    * [Ruby 2.4.1](http://www.ruby-lang.org/en)
     * [Bundler](http://gembundler.com)
     * [Git](http://git-scm.com)
     * [PhantomJS](http://phantomjs.org/)


### PR DESCRIPTION
# Release Notes

Updates the README to show the correct ruby version (2.4.1) which matches the `.ruby-version` file.

When I was following the setup guide, the `bundle install` step failed due to having installed ruby `2.2` instead of `2.4.1`
