### PR TITLE
Allow JS capybara finders to find upcased labels

### DIFF
--- a/spec/features/placing_an_order_on_behalf_of_spec.rb
+++ b/spec/features/placing_an_order_on_behalf_of_spec.rb
@@ -47,14 +47,14 @@ RSpec.describe "Placing an item order" do
     choose account.to_s
     click_button "Continue"
 
-    find("label", text: "More options").click
+    find("label", text: /More options/i).click
     fill_in "Order date", with: I18n.l(2.days.ago.to_date, format: :usa)
     select "Complete", from: "Order Status"
 
     click_button "Purchase"
 
     expect(page).to have_content "Order Receipt"
-    expect(page).to have_content "Ordered For\n#{user.full_name}"
+    expect(page).to have_content %r[Ordered For\n#{user.full_name}]i
     expect(page).to have_css(".currency .estimated_cost", count: 0)
     expect(page).to have_css(".currency .actual_cost", count: 2) # Cost and Total
   end

--- a/spec/features/placing_an_order_on_behalf_of_spec.rb
+++ b/spec/features/placing_an_order_on_behalf_of_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Placing an item order" do
     click_button "Purchase"
 
     expect(page).to have_content "Order Receipt"
-    expect(page).to have_content /Ordered For\n#{user.full_name}/i
+    expect(page).to have_content(/Ordered For\n#{user.full_name}/i)
     expect(page).to have_css(".currency .estimated_cost", count: 0)
     expect(page).to have_css(".currency .actual_cost", count: 2) # Cost and Total
   end

--- a/spec/features/placing_an_order_on_behalf_of_spec.rb
+++ b/spec/features/placing_an_order_on_behalf_of_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Placing an item order" do
     click_button "Purchase"
 
     expect(page).to have_content "Order Receipt"
-    expect(page).to have_content %r[Ordered For\n#{user.full_name}]i
+    expect(page).to have_content /Ordered For\n#{user.full_name}/i
     expect(page).to have_css(".currency .estimated_cost", count: 0)
     expect(page).to have_css(".currency .actual_cost", count: 2) # Cost and Total
   end


### PR DESCRIPTION
# Release Notes

Tech Task: Support finding labels that have been upcased via CSS in specs.

# Additional Context

UCONN is applying a `text-transform` to `label`s. Capybara uses exact matches, so in JS mode where the styles get applied, it can't find them. This switches to using regexes to allow case insensitivity. See #1787.
