### PR TITLE
[#141977] Prevent double icon in dropdown searches

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,7 +4,7 @@ $baseFontSize: 12px;
 @import "bootstrap";
 @import "bootstrap-responsive";
 @import "font-awesome";
-@import "chosen";
+@import "chosen-base";
 
 @import "nucore-variables";
 @import "nucore-overrides";


### PR DESCRIPTION
# Release Notes

Fix double search icon appearing in dropdowns that include searches.

# Screenshot

Before and after:
![screen shot 2018-12-11 at 1 07 43 pm](https://user-images.githubusercontent.com/1099111/49823732-fcc2dd80-fd45-11e8-9565-52a11162b7d7.png)
![screen shot 2018-12-11 at 1 06 11 pm](https://user-images.githubusercontent.com/1099111/49823733-fcc2dd80-fd45-11e8-9d3a-0010e7c10a37.png)

# Additional Context

We used this same fix on another project. Reference: https://github.com/tsechingho/chosen-rails/issues/103
