### PR TITLE
[#145115] Add minimum price change reason length for order details

### DIFF
--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "controller_spec_helper"
 
-RSpec.describe OrderManagement::OrderDetailsController, feature_setting: { price_change_reason_required: false } do
+RSpec.describe OrderManagement::OrderDetailsController do
   def reservation_params(reserve_start_at, actual_start_at = nil)
     params = {
       reserve_start_date: I18n.l(reserve_start_at.to_date, format: :usa),
@@ -504,7 +504,7 @@ RSpec.describe OrderManagement::OrderDetailsController, feature_setting: { price
           describe "price change reason" do
             # the expected price (calculated from the price policy) is 1
 
-            context "with reason required off" do
+            context "with reason required off", feature_setting: { price_change_reason_required: false } do
               it "does not require a reason when the price is changed" do
                 @params[:order_detail] = {
                   actual_cost: "10",
@@ -515,6 +515,7 @@ RSpec.describe OrderManagement::OrderDetailsController, feature_setting: { price
                 expect(assigns[:order_detail].errors).not_to include :price_change_reason
               end
             end
+
             context "with reason required on", feature_setting: { price_change_reason_required: true } do
               it "requires a reason when the price is changed from the expected price" do
                 @params[:order_detail] = {
@@ -652,6 +653,7 @@ RSpec.describe OrderManagement::OrderDetailsController, feature_setting: { price
             @params[:order_detail] = {
               actual_cost: "20.00",
               actual_subsidy: "4.00",
+              price_change_reason: "i am a reason",
             }
             do_request
             expect(order_detail.reload.actual_total).to eq(16.00)
@@ -662,6 +664,7 @@ RSpec.describe OrderManagement::OrderDetailsController, feature_setting: { price
               actual_cost: "20.00",
               actual_subsidy: "4.00",
               account_id: new_account.id,
+              price_change_reason: "changing the account",
             }
             do_request
             expect(order_detail.reload.actual_total).to eq(16.00)
@@ -715,6 +718,7 @@ RSpec.describe OrderManagement::OrderDetailsController, feature_setting: { price
               actual_cost: "20.00",
               actual_subsidy: "4.00",
               quantity: 36,
+              price_change_reason: "i am a reason",
             }
             do_request
             expect(order_detail.reload.actual_total).to eq(16.00)

--- a/spec/models/reports/export_raw_spec.rb
+++ b/spec/models/reports/export_raw_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Reports::ExportRaw do
           actual_subsidy: BigDecimal("9.99"),
           estimated_cost: BigDecimal("39.99"),
           estimated_subsidy: BigDecimal("29.99"),
-          price_change_reason: "note",
+          price_change_reason: "this is a reason",
           assigned_user: user,
         )
       end


### PR DESCRIPTION
# Release Notes

Require that the price change reason for an order be at least 10 characters. This validation only applies when an order is being manually adjusted from its calculated cost.

# Additional Context

I debated if it was worth the effort of moving the specs over to the model, but they were already in the controller spec and the model spec is already almost 2000 lines long.

Also, by moving the `feature_setting` tag, I was able to drop the time that file takes to run from about 2:40 to 1:30 (flipping the feature settings is slow because we also end up reloading the routes).

UIC is the only school with this feature disabled, so we might be able to remove the feature flag at some point in the future.
