### PR TITLE
Add globstar option when running specs on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - checkout
 
+      - run: shopt -u globstar
+
       # Bundle
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - checkout
 
-      - run: shopt -u globstar
-
       # Bundle
       - restore_cache:
           keys:
@@ -44,6 +42,7 @@ jobs:
       - run: bundle exec rake db:schema:load
 
       - run:
+          shell: /bin/bash -eo pipefail -O globstar
           command: |
             bundle exec rspec --profile 10 \
                               --format RspecJunitFormatter \


### PR DESCRIPTION
# Release Notes

Tech task: Ensure we are running all specs on CI.

# Additional Context

This ended up being fine on open, but we're not running specs in Dartmouth which are more than one level nested. So we're running `vendor/engines/dc_chartstrings/spec/models/facility_spec.rb`, but not `vendor/engines/dc_chartstrings/spec/models/dc_chartstrings/general_ledger_account_spec.rb`. I'm also going to try this out on NU.
