### PR TITLE
Use master as default base for merge_describer

### DIFF
--- a/bin/merge_describer
+++ b/bin/merge_describer
@@ -1,11 +1,11 @@
 #!/bin/sh
 # Usage:
-# Compare your current branch to develop:
+# Compare your current branch to master:
 # bin/merge_describer
 #
 # Compare your current branch to master:
 # bin/merge_describer master
-target_branch=${1:-develop}
+target_branch=${1:-master}
 git log $target_branch.. | egrep '\(#\d+\)$' | while read LINE; do
   pr=$(echo $LINE | sed -E 's/^.+\(#//' | sed -E 's/\)$//')
   desc=$(echo $LINE | sed -E 's/ *\(#[0-9]+\)$//')


### PR DESCRIPTION
# Release Notes

Tech task: Use `master` as default base for merge_describer

# Additional Context

Now that we're switching our downstreams to use `master` as the default branch and getting rid of `develop`, this changes the default base for our merge describer utility.
