### PR TITLE
[#141855] Product Search on Mobile Interface

### DIFF
--- a/app/assets/stylesheets/app/tables.scss
+++ b/app/assets/stylesheets/app/tables.scss
@@ -24,3 +24,15 @@ table {
 tfoot.cart {
   border-top: 3px solid $navbarActiveBorderColor;
 }
+
+@media screen and (min-width: 980px) {
+  .table-product-results {
+    .name, .type, .facility {
+      max-width: 124px;
+    }
+
+    .description {
+      max-width: 444px;
+    }
+  }
+}

--- a/app/views/global_search/_products.html.haml
+++ b/app/views/global_search/_products.html.haml
@@ -10,13 +10,13 @@
   %tbody
     - results.take(20).each do |product|
       %tr
-        %td.nowrap.span2
+        %td.nowrap
           = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(product.facility, product)
-        %td.span2
+        %td
           = product.model_name.human
-        %td.span2
+        %td
           = link_to product.facility, facility_path(product.facility)
-        %td.span6
+        %td
           = truncate(strip_tags(product.description), length: 300)
 
 - if results.count >= 20

--- a/app/views/global_search/_products.html.haml
+++ b/app/views/global_search/_products.html.haml
@@ -1,22 +1,22 @@
 %h3= Product.model_name.human(count: 2)
 
-%table.table.table-striped.table-hover.js--responsive_table
+%table.table.table-striped.table-hover.js--responsive_table.table-product-results
   %thead
     %tr
-      %th= Product.model_name.human
-      %th= Product.human_attribute_name("type")
-      %th= Facility.model_name.human
-      %th= Product.human_attribute_name("description")
+      %th.name= Product.model_name.human
+      %th.type= Product.human_attribute_name("type")
+      %th.facility= Facility.model_name.human
+      %th.description= Product.human_attribute_name("description")
   %tbody
     - results.take(20).each do |product|
       %tr
-        %td.nowrap
+        %td.name
           = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(product.facility, product)
-        %td
+        %td.type
           = product.model_name.human
-        %td
+        %td.facility
           = link_to product.facility, facility_path(product.facility)
-        %td
+        %td.description
           = truncate(strip_tags(product.description), length: 300)
 
 - if results.count >= 20


### PR DESCRIPTION
# Release Notes

Fix display of product search results on narrow screens

# Screenshot

## Old

![old](https://user-images.githubusercontent.com/7736/49949948-24a57300-fef7-11e8-84d4-a972d728ca66.png)

## New

![new](https://user-images.githubusercontent.com/7736/49949960-2838fa00-fef7-11e8-9dd7-ec6a9c3306b7.png)

# Additional Context

The `span2` and `span6` styles coming from Bootstrap do not work with our CSS implementation of `js--responsive_table`. Hence, I removed those styles and reigned in the column widths of this table separately, so it now works both on narrow and wide screens.