### PR TITLE
Fixes for settings not being reset properly in tests

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -92,41 +92,41 @@ relays:
 #
 # For these settings use SettingsHelper#feature_on?
 feature:
-  billing_administrator_on: true
-  billing_administrator_users_tab_on: true
-  create_users_on: true
-  netids_on: true
-  limit_short_description_on: true
-  manage_payment_sources_with_users_on: true
-  order_assignment_notifications_on: true
-  password_update_on: true
-  recharge_accounts_on: true
-  expense_accounts_on: true
-  edit_accounts_on: true
-  suspend_accounts_on: true
-  product_specific_contacts_on: true
-  training_requests_on: true
-  daily_view_on: true
-  split_accounts_on: true
-  print_order_detail_on: false
-  user_based_price_groups_on: true
-  my_files_on: true
+  billing_administrator: true
+  billing_administrator_users_tab: true
+  create_users: true
+  netids: true
+  limit_short_description: true
+  manage_payment_sources_with_users: true
+  order_assignment_notifications: true
+  password_update: true
+  recharge_accounts: true
+  expense_accounts: true
+  edit_accounts: true
+  suspend_accounts: true
+  product_specific_contacts: true
+  training_requests: true
+  daily_view: true
+  split_accounts: true
+  print_order_detail: false
+  user_based_price_groups: true
+  my_files: true
   # results file notifications requires that my_files be on as well
-  results_file_notifications_on: true
-  set_statement_search_start_date_on: false
-  send_statement_emails_on: true
-  ready_for_journal_notice_on: true
-  journals_may_span_fiscal_years_on: false
-  equipment_list_on: true
-  price_change_reason_required_on: true
-  can_manage_global_price_groups_on: true
-  cross_facility_reports_on: false
-  product_list_columns_on: false
-  azlist_on: false
-  use_manage_on: false
-  facility_banner_notice_on: true
-  charge_full_price_on_cancellation_on: true
-  price_policy_requires_note_on: true
+  results_file_notifications: true
+  set_statement_search_start_date: false
+  send_statement_emails: true
+  ready_for_journal_notice: true
+  journals_may_span_fiscal_years: false
+  equipment_list: true
+  price_change_reason_required: true
+  can_manage_global_price_groups: true
+  cross_facility_reports: false
+  product_list_columns: false
+  azlist: false
+  use_manage: false
+  facility_banner_notice: true
+  charge_full_price_on_cancellation: true
+  price_policy_requires_note: true
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/lib/settings_helper.rb
+++ b/lib/settings_helper.rb
@@ -43,17 +43,6 @@ module SettingsHelper
   end
 
   #
-  # Used to turn on an off a feature. Most useful for tests:
-  # [_feature_]
-  #   If you want to change 'feature.password_update_on'
-  #   then this parameter would be :password_update
-  # [_value_]
-  #   If set to false, it will disable the feature
-  def self.enable_feature(feature, value = true)
-    Settings.feature.send(:"#{feature}_on=", !!value) # !! forces to boolean
-  end
-
-  #
   # Used for looking up a setting where parts of the chain might not be there.
   # Setting is accessed like "reservations.grace_period"
   def self.setting(setting)

--- a/lib/settings_helper.rb
+++ b/lib/settings_helper.rb
@@ -32,10 +32,10 @@ module SettingsHelper
   #
   # Used to query the +Settings+ under feature:
   # [_feature_]
-  #   If you want to check setting 'feature.password_update_on'
-  #   then this parameter would be :password_update
+  #   If you want to check setting 'feature.password_update' then this parameter
+  #.  would be :password_update. Will raise an error if the setting does not exist.
   def self.feature_on?(feature)
-    !!Settings.feature["#{feature}_on"]
+    !!Settings.feature.to_h.fetch(feature)
   end
 
   def self.feature_off?(feature)

--- a/lib/settings_helper.rb
+++ b/lib/settings_helper.rb
@@ -33,7 +33,7 @@ module SettingsHelper
   # Used to query the +Settings+ under feature:
   # [_feature_]
   #   If you want to check setting 'feature.password_update' then this parameter
-  #.  would be :password_update. Will raise an error if the setting does not exist.
+  # .  would be :password_update. Will raise an error if the setting does not exist.
   def self.feature_on?(feature)
     !!Settings.feature.to_h.fetch(feature)
   end

--- a/spec/controllers/facilities_controller_spec.rb
+++ b/spec/controllers/facilities_controller_spec.rb
@@ -199,12 +199,12 @@ RSpec.describe FacilitiesController do
     describe "daily view link" do
       let!(:instrument) { create(:instrument, facility: facility, facility_account: facility_account) }
 
-      it "includes link to daily view", feature_setting: { daily_view: true } do
+      it "includes link to daily view", feature_setting: { daily_view: true, reload_routes: true } do
         do_request
         expect(response.body).to include("daily view")
       end
 
-      it "does not include a link to the daily view when disabled", feature_setting: { daily_view: false } do
+      it "does not include a link to the daily view when disabled", feature_setting: { daily_view: false, reload_routes: true } do
         do_request
         expect(response.body).not_to include("daily view")
       end

--- a/spec/controllers/facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_accounts_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "controller_spec_helper"
 
-RSpec.describe FacilityAccountsController, feature_setting: { recharge_accounts: true, reload_routes: true } do
+RSpec.describe FacilityAccountsController, feature_setting: { edit_accounts: true, suspend_accounts: true, reload_routes: true } do
 
   let(:facility) { FactoryBot.create(:facility) }
   let(:account) { create_nufs_account_with_owner }

--- a/spec/controllers/facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_accounts_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "controller_spec_helper"
 
-RSpec.describe FacilityAccountsController, feature_setting: { edit_accounts: true } do
+RSpec.describe FacilityAccountsController, feature_setting: { recharge_accounts: true, reload_routes: true } do
 
   let(:facility) { FactoryBot.create(:facility) }
   let(:account) { create_nufs_account_with_owner }
@@ -64,7 +64,7 @@ RSpec.describe FacilityAccountsController, feature_setting: { edit_accounts: tru
 
   end
 
-  context "edit accounts", if: SettingsHelper.feature_on?(:edit_accounts) do
+  context "edit accounts" do
     context "new" do
 
       before(:each) do
@@ -315,7 +315,7 @@ RSpec.describe FacilityAccountsController, feature_setting: { edit_accounts: tru
     end
   end
 
-  context "suspension", if: SettingsHelper.feature_on?(:suspend_accounts) do
+  context "suspension" do
     context "suspend" do
 
       before :each do

--- a/spec/controllers/facility_facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_facility_accounts_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "controller_spec_helper"
 
-RSpec.describe FacilityFacilityAccountsController, if: SettingsHelper.feature_on?(:recharge_accounts) do
+RSpec.describe FacilityFacilityAccountsController, feature_setting: { recharge_accounts: true, reload_routes: true } do
   render_views
 
   around(:each) do |example|

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe SearchController do
       let(:params) { { account_id: account.id } }
     end
 
-    describe "facility_account_account_user", feature_setting: { edit_accounts: true } do
+    describe "facility_account_account_user", feature_setting: { edit_accounts: true, reload_routes: true } do
       it_behaves_like "searching", "facility_account_account_user" do
         let(:account) { FactoryBot.create(:setup_account) }
         let(:params) { { account_id: account.id } }
@@ -58,7 +58,7 @@ RSpec.describe SearchController do
 
     it_behaves_like "searching", "map_user"
 
-    describe "user_new_account", feature_setting: { edit_accounts: true } do
+    describe "user_new_account", feature_setting: { edit_accounts: true, reload_routes: true } do
       it_behaves_like "searching", "user_new_account"
     end
 

--- a/spec/controllers/training_requests_controller_spec.rb
+++ b/spec/controllers/training_requests_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe TrainingRequestsController, feature_setting: { training_requests: true } do
+RSpec.describe TrainingRequestsController, feature_setting: { training_requests: true, reload_routes: true } do
   let(:facility) { FactoryBot.create(:setup_facility) }
   let(:product) do
     FactoryBot.create(:setup_item, facility: facility,

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe UsersController do
 
   end
 
-  describe "GET #edit", feature_setting: { create_users: true } do
+  describe "GET #edit", feature_setting: { create_users: true, reload_routes: true } do
     let(:user) { FactoryBot.create(:user, :external) }
 
     before(:each) do
@@ -60,7 +60,7 @@ RSpec.describe UsersController do
     it_should_allow_admin_only { expect(assigns[:user]).to eq(user) }
   end
 
-  describe "PUT #update", feature_setting: { create_users: true } do
+  describe "PUT #update", feature_setting: { create_users: true, reload_routes: true } do
     let(:user) { FactoryBot.create(:user, :external, first_name: "Old", uid: 22) }
 
     before(:each) do
@@ -109,7 +109,7 @@ RSpec.describe UsersController do
   end
 
   context "creating users" do
-    context "enabled", feature_setting: { create_users: true } do
+    context "enabled", feature_setting: { create_users: true, reload_routes: true } do
 
       it "routes", :aggregate_failures do
         expect(get: "/#{facilities_route}/url_name/users/new").to route_to(controller: "users", action: "new", facility_id: "url_name")
@@ -280,7 +280,7 @@ RSpec.describe UsersController do
       end
     end
 
-    context "disabled", feature_setting: { create_users: false } do
+    context "disabled", feature_setting: { create_users: false, reload_routes: true } do
       it "doesn't route route", :aggregate_failures do
         expect(get: "/#{facilities_route}/url_name/users/new").not_to be_routable
         expect(get: "/#{facilities_route}/url_name/users/edit").not_to be_routable
@@ -315,7 +315,7 @@ RSpec.describe UsersController do
 
   end
 
-  describe "unexpire", feature_setting: { create_users: true } do
+  describe "unexpire", feature_setting: { create_users: true, reload_routes: true } do
     let(:expired_user) { create(:user, :expired) }
     let(:facility) { create(:facility) }
 

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -33,4 +33,10 @@ RSpec.describe SettingsHelper do
     end
   end
 
+  describe "feature_on" do
+    it "raises an error if the feature does not exist" do
+      expect { SettingsHelper.feature_on?(:nonexistent_feature) }.to raise_error(KeyError)
+    end
+  end
+
 end

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -3,31 +3,31 @@
 require "rails_helper"
 
 RSpec.describe SettingsHelper do
-  # Make sure we return the Settings to the default state after each test
-  after :each do
-    Settings.reload!
-  end
-
   context "fiscal year" do
     before :each do
-      Settings.financial.fiscal_year_begins = "03-01"
+      allow(Settings.financial).to receive(:fiscal_year_begins).and_return("03-01")
     end
+
     it "should get the right fiscal year for a year" do
       expect(SettingsHelper.fiscal_year(2020)).to eq(Time.zone.parse("2020-03-01").beginning_of_day)
       # Make sure our parsing is happening correctly (i.e. it's not mixing up the month and day)
       expect(SettingsHelper.fiscal_year(2020).strftime("%b %-d %Y")).to eq("Mar 1 2020")
     end
+
     it "should get the previous year for dates before the start" do
       expect(SettingsHelper.fiscal_year_beginning(Time.zone.local(2010, 2, 5))).to eq(Time.zone.parse("2009-03-01").beginning_of_day)
       # Make sure we can compare either DateTime or Time
       expect(SettingsHelper.fiscal_year_beginning(Time.zone.parse("2010-02-05"))).to eq(Time.zone.parse("2009-03-01").beginning_of_day)
     end
+
     it "should the the next year for dates after the start" do
       expect(SettingsHelper.fiscal_year_beginning(Time.zone.local(2010, 5, 5))).to eq(Time.zone.parse("2010-03-01").beginning_of_day)
     end
+
     it "should set the end of the fiscal year for dates before the start" do
       expect(SettingsHelper.fiscal_year_end(Time.zone.local(2014, 2, 5))).to eq(Time.zone.parse("2014-02-28").end_of_day)
     end
+
     it "should set the end of the fiscal year for dates after the start" do
       expect(SettingsHelper.fiscal_year_end(Time.zone.local(2014, 5, 14))).to eq(Time.zone.parse("2015-02-28").end_of_day)
     end

--- a/spec/lib/status_change_notifications_spec.rb
+++ b/spec/lib/status_change_notifications_spec.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-RSpec.describe StatusChangeNotifications do
+RSpec.describe StatusChangeNotifications, feature_setting: { product_specific_contacts: true } do
   before :each do
     @order_status = FactoryBot.create(:order_status)
-    Settings.order_details ||= {}
-    Settings.order_details.status_change_hooks = {
+    allow(Settings).to receive_message_chain(:order_details, :status_change_hooks).and_return(
       :"#{@order_status.downcase_name}" => "StatusChangeNotifications::#{self.class.description}",
-    }
-    SettingsHelper.enable_feature(:product_specific_contacts)
+    )
     @user = FactoryBot.create(:user)
     @facility = FactoryBot.create(:facility, email: "notify-facility@example.org")
     @order_detail = place_and_complete_item_order(@user, @facility)

--- a/spec/models/budgeted_chart_string_spec.rb
+++ b/spec/models/budgeted_chart_string_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe BudgetedChartString do
   # year setting anyways. -Jason
   context "import" do
     before :each do
-      Settings.financial.fiscal_year_begins = "04-01"
+      allow(Settings.financial).to receive(:fiscal_year_begins).and_return("04-01")
       filename = "#{Rails.root}/spec/files/budgeted_chart_strings1.txt"
       BudgetedChartString.delete_all
       BudgetedChartString.import(filename)
@@ -33,9 +33,6 @@ RSpec.describe BudgetedChartString do
       # should properly parse account fields and dates
       @bcs1 = BudgetedChartString.all[4]
       @bcs2 = BudgetedChartString.last
-    end
-    after :each do
-      Settings.reload!
     end
 
     it "should set fields correctly" do

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe Journal do
 
   context "order_details_span_fiscal_years?" do
     before :each do
-      Settings.financial.fiscal_year_begins = "06-01"
+      allow(Settings.financial).to receive(:fiscal_year_begins).and_return("06-01")
       @owner = FactoryBot.create(:user)
       @account = FactoryBot.create(:nufs_account, :with_account_owner, owner: @owner)
       @facility_account = FactoryBot.create(:facility_account, facility: facility)

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe OrderDetail do
   let(:user) { @user }
 
   before(:each) do
-    Settings.order_details.status_change_hooks = nil
+    allow(Settings).to receive_message_chain(:order_details, :status_change_hooks).and_return(nil)
     @facility = create(:facility)
     @facility_account = create(:facility_account, facility: @facility)
     @user = create(:user)

--- a/spec/models/price_policy_spec.rb
+++ b/spec/models/price_policy_spec.rb
@@ -3,12 +3,8 @@
 require "rails_helper"
 
 RSpec.describe PricePolicy do
-  before :all do
-    # Settings should be 09-01 or 08-01
-    Settings.financial.fiscal_year_begins = "10-01"
-  end
-  after :all do
-    Settings.reload!
+  before(:each) do
+    allow(Settings.financial).to receive(:fiscal_year_begins).and_return("10-01")
   end
 
   let(:facility) { @facility }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ RSpec.configure do |config|
 
   config.around(:each, :feature_setting) do |example|
     example.metadata[:feature_setting].except(:reload_routes).each do |feature, value|
-      Settings.feature.public_send("#{feature}_on=", value)
+      Settings.feature[feature] = value
     end
 
     Nucore::Application.reload_routes! if example.metadata[:feature_setting][:reload_routes]


### PR DESCRIPTION
# Release Notes

Tech task: Fix tests that don't properly clean up `Settings` after themselves. This also makes it explicit which tests need to reload their routes, which should speed up overall suite speed.

# Additional Context

The critical ones that caused https://github.com/tablexi/nucore-dartmouth/pull/244 to fail are related to the fiscal year. Using `allow(Settings.financial).to receive(: fiscal_year_begins)` makes it so rspec will un-stub it after the test is over so changes don't bleed across specs.

I could be convinced the `reload_routes` option isn't worth it.
