### PR TITLE
Run rubocop on OccupancyHandler file

### DIFF
--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/occupancy_handler.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_handlers/occupancy_handler.rb
@@ -22,22 +22,22 @@ module SecureRooms
         return unless event.success?
 
         result = if current_occupant? && exiting?
-          Rails.logger.info("[SecureRooms] Processing branch current_occupant? && exiting? (existing occupancy id: #{existing_occupancy.id})")
-          existing_occupancy.associate_exit!(event)
-        elsif new_occupant? && entering?
-          Rails.logger.info("[SecureRooms] Processing branch new_occupant? && entering? (new occupancy id: #{new_occupancy.id})")
-          new_occupancy.associate_exit!(event) if entry_only?
-          new_occupancy.associate_entry!(event)
-        elsif new_occupant? && exiting?
-          Rails.logger.info("[SecureRooms] Processing branch new_occupant? && exiting? (new occupancy id: #{new_occupancy.id})")
-          new_occupancy.mark_orphaned!
-          new_occupancy.associate_exit!(event)
-        elsif current_occupant? && entering?
-          Rails.logger.info("[SecureRooms] Processing branch current_occupant? && entering? (existing occupancy id: #{existing_occupancy.id})")
-          complete_existing_occupancy!
-          new_occupancy.associate_entry!(event)
-        else
-          raise NotImplementedError, "Encountered unexpected scan context"
+                   Rails.logger.info("[SecureRooms] Processing branch current_occupant? && exiting? (existing occupancy id: #{existing_occupancy.id})")
+                   existing_occupancy.associate_exit!(event)
+                 elsif new_occupant? && entering?
+                   Rails.logger.info("[SecureRooms] Processing branch new_occupant? && entering? (new occupancy id: #{new_occupancy.id})")
+                   new_occupancy.associate_exit!(event) if entry_only?
+                   new_occupancy.associate_entry!(event)
+                 elsif new_occupant? && exiting?
+                   Rails.logger.info("[SecureRooms] Processing branch new_occupant? && exiting? (new occupancy id: #{new_occupancy.id})")
+                   new_occupancy.mark_orphaned!
+                   new_occupancy.associate_exit!(event)
+                 elsif current_occupant? && entering?
+                   Rails.logger.info("[SecureRooms] Processing branch current_occupant? && entering? (existing occupancy id: #{existing_occupancy.id})")
+                   complete_existing_occupancy!
+                   new_occupancy.associate_entry!(event)
+                 else
+                   raise NotImplementedError, "Encountered unexpected scan context"
         end
 
         Rails.logger.info("[SecureRooms] Exiting SecureRooms::AccessHandlers::EventHandler#process")


### PR DESCRIPTION
# Release Notes

Tech task: Run rubocop on OccupancyHandler file

# Additional Context

This was showing up when running rubocop across the whole app. This should clean up some of the noise.
