### PR TITLE
[#144674] Add calculated cost fields to export raw

### DIFF
--- a/app/models/reports/export_raw.rb
+++ b/app/models/reports/export_raw.rb
@@ -39,7 +39,7 @@ module Reports
 
     private
 
-    def default_report_hash
+    def default_report_hash # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       hash = {
         facility: :facility,
         order: :to_s,
@@ -74,9 +74,15 @@ module Reports
         estimated_cost: ->(od) { as_currency(od.estimated_cost) },
         estimated_subsidy: ->(od) { as_currency(od.estimated_subsidy) },
         estimated_total: ->(od) { as_currency(od.estimated_total) },
+        calculated_cost: ->(od) { as_currency(od.calculated_cost) },
+        calculated_subsidy: ->(od) { as_currency(od.calculated_subsidy) },
+        calculated_total: ->(od) { as_currency(od.calculated_total) },
         actual_cost: ->(od) { as_currency(od.actual_cost) },
         actual_subsidy: ->(od) { as_currency(od.actual_subsidy) },
         actual_total: ->(od) { as_currency(od.actual_total) },
+        difference_cost: ->(od) { as_currency_difference(od.actual_cost, od.calculated_cost) },
+        difference_subsidy: ->(od) { as_currency_difference(od.actual_subsidy, od.calculated_subsidy) },
+        difference_total: ->(od) { as_currency_difference(od.actual_total, od.calculated_total) },
         reservation_start_time: ->(od) { od.reservation.reserve_start_at if od.reservation },
         reservation_end_time: ->(od) { od.reservation.reserve_end_at if od.reservation },
         reservation_minutes: ->(od) { od.time_data.try(:duration_mins) },
@@ -118,6 +124,12 @@ module Reports
         preloads: [:created_by_user, :journal, order: [:facility], account: [:affiliate, :owner_user], price_policy: [:price_group]],
         transformer_options: { time_data: true },
       ).perform
+    end
+
+    def as_currency_difference(minuend, subtrahend)
+      return "" unless minuend && subtrahend
+
+      as_currency(minuend - subtrahend)
     end
 
     def as_currency(number)

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
   factory :setup_order, class: Order do
     transient do
       product { nil }
+      quantity { 1 }
     end
     facility { product.facility }
     association :account, factory: :setup_account
@@ -24,7 +25,7 @@ FactoryBot.define do
       # build().save will allow an already existing relation without raising an error
       build(:account_price_group_member, account: order.account, price_group: evaluator.product.facility.price_groups.last).save
       build(:user_price_group_member, user: evaluator.user, price_group: evaluator.product.facility.price_groups.last).save
-      order.add(evaluator.product)
+      order.add(evaluator.product, evaluator.quantity)
     end
 
     factory :purchased_order do

--- a/spec/models/reports/export_raw_spec.rb
+++ b/spec/models/reports/export_raw_spec.rb
@@ -54,9 +54,15 @@ RSpec.describe Reports::ExportRaw do
         "Estimated Cost" => "$39.99",
         "Estimated Subsidy" => "$29.99",
         "Estimated Total" => "$10.00",
+        "Calculated Cost" => "$3.00", # Default price policy is $1/each
+        "Calculated Subsidy" => "$0.00",
+        "Calculated Total" => "$3.00",
         "Actual Cost" => "$19.99",
         "Actual Subsidy" => "$9.99",
         "Actual Total" => "$10.00",
+        "Difference Cost" => "$16.99",
+        "Difference Subsidy" => "$9.99",
+        "Difference Total" => "$7.00",
         "Charge For" => "Quantity",
         "Assigned Staff" => user.full_name,
       )

--- a/vendor/engines/split_accounts/app/services/split_accounts/order_detail_splitter.rb
+++ b/vendor/engines/split_accounts/app/services/split_accounts/order_detail_splitter.rb
@@ -37,6 +37,8 @@ module SplitAccounts
         :actual_subsidy,
         :estimated_cost,
         :estimated_subsidy,
+        :calculated_cost,
+        :calculated_subsidy,
       )
     end
 


### PR DESCRIPTION
# Release Notes

Adds the following fields to export raw: 

* Calculated Cost
* Calculated Subsidy
* Calculated Total
* Difference Cost
* Difference Subsidy
* Difference Total

The difference fields are the difference between the actual assigned price and the price as it would have been if it were automatically priced. This is to tell when a price was manually adjusted.

# Additional Context

DC already had the "calculated" columns, so this pulls them up into the main app and adds the difference columns.

Extracted from https://github.com/tablexi/nucore-dartmouth/pull/245
