### PR TITLE
[#144522] Fix bundle column on export raw

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -802,7 +802,7 @@ class OrderDetail < ApplicationRecord
   #
   # Returns true if this order detail is part of a bundle purchase, false otherwise
   def bundled?
-    !bundle.nil?
+    bundle.present?
   end
 
   # Useful when sorting so we don't get `nil` to number comparisons

--- a/app/models/reports/export_raw.rb
+++ b/app/models/reports/export_raw.rb
@@ -59,7 +59,7 @@ module Reports
         product_type: ->(od) { od.product.class.model_name.human },
         product: ->(od) { od.product.name },
         quantity: :quantity,
-        bundled_products: ->(od) { od.product.is_a?(Bundle) ? od.product.products.collect(&:name).join(" & ") : nil },
+        bundle: ->(od) { od.bundle.name if od.bundled? },
         account_type: ->(od) { od.account.type.underscore.humanize },
         affiliate: ->(od) { od.account.affiliate_to_s },
         account: ->(od) { od.account.account_number },

--- a/spec/models/reports/export_raw_spec.rb
+++ b/spec/models/reports/export_raw_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe Reports::ExportRaw do
         "Difference Total" => "$7.00",
         "Charge For" => "Quantity",
         "Assigned Staff" => user.full_name,
+        "Bundle" => "",
       )
     end
 
@@ -149,6 +150,21 @@ RSpec.describe Reports::ExportRaw do
       it "exports correct number of line items" do
         expect(report.to_csv.split("\n").length).to eq(2)
       end
+    end
+  end
+
+  describe "with a bundle" do
+    let(:items) { FactoryBot.create_list(:setup_item, 2, facility: facility) }
+    let(:bundle) { FactoryBot.create(:bundle, facility: facility, bundle_products: items) }
+
+    let!(:order) { FactoryBot.create(:purchased_order, product: bundle) }
+    let(:order_detail) { order.order_details.first }
+
+    it "has the bundle name" do
+      expect(report).to have_column_values(
+        "Product" => items.map(&:name),
+        "Bundle" => [bundle.name, bundle.name],
+      )
     end
   end
 end


### PR DESCRIPTION
# Release Notes

Fix bundle column in export raw to properly show the bundle name if the order was purchased as part of a bundle. The column was previously called "Bundled Product".

# Additional Context

Currently, if you place an order with a bundle and then go to find those line items on the export raw report the "Bundled Products" column is always blank. I'm guessing that at one point (way back to even before my time) that a bundle was a single line item with multiple products. That appears to be what it's trying to report on. For a long time now, when you add a bundle, each product of the bundle is a separate line item with a `bundle_id` tying back to the product. 
