### PR TITLE
[#137479] Allow configuring a support email for top-level link

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -8,6 +8,7 @@
       - if session_user.nil?
         %ul.nav.pull-right.hide-from-print
           %li= link_to t("pages.login"), :new_user_session
+          = render "/shared/support"
       - else
         - if responsive?
           %a.btn.btn-navbar.hide-from-print{ data: { target: ".nav-collapse", toggle: "collapse" } }
@@ -21,6 +22,7 @@
           %ul.nav.pull-right.hide-from-print
             - if acting_as?
               %li.navbar-text= "#{acting_user.full_name} (#{acting_user.username})"
+              = render "/shared/support"
               %li= link_to "#{t('pages.cart')} (#{current_cart.order_details.count})", :cart
             - else
               - if UserPreference.options_for(current_user).any?
@@ -32,6 +34,7 @@
                 %li= link_to t("user_password.edit.head"), :edit_current_password
                 %li.divider-vertical
               -# .visible-with-nav is visible > 979px
+              = render "/shared/support"
               %li.visible-with-nav= link_to t('pages.cart') + " (#{current_cart.order_details.count})", :cart
               %li.divider-vertical
               = render "shared/message_summary"

--- a/app/views/shared/_support.html.haml
+++ b/app/views/shared/_support.html.haml
@@ -1,0 +1,3 @@
+- if Settings.support_email.present?
+  %li.visible-with-nav= mail_to Settings.support_email, t('pages.support')
+  %li.divider-vertical

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,7 @@ en:
     my_tab: My %{model}
     transactions: My Transactions
     notices: Notices
+    support: Support
 
   affiliates:
     add: Add Affiliate

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,6 +44,8 @@ email:
     sender: 'noreply@example.com'
     recipients: [ 'warn@example.com', 'error@example.com' ]
 
+support_email: ~
+
 order_details:
   # These hooks are triggered when an order detail enters into the status
   # The hooks can be configured with settings. Here are several formats you can use:


### PR DESCRIPTION
# Release Notes

Allow configuring a support email for top-level link

# Additional Context

Shows a Support link in the top-level navigation if a support email has been configured. This way, we can configure per-school support emails, and this link is only displayed if such an email is configured.