### PR TITLE
[#144524] Fix display of timed service quantities in bundle

### DIFF
--- a/app/assets/javascripts/app/bundle_products.js
+++ b/app/assets/javascripts/app/bundle_products.js
@@ -1,0 +1,30 @@
+// On bundle_products#new, switch between a regular quantity field and a time
+// quantity field based on the type of product selected.
+$(function() {
+  $productSelect = $(".js--bundleProducts__productSelect");
+
+  if ($productSelect.length) {
+    var timeQuantityTypes = $productSelect.data("timed-quantity-types").split(", ")
+    var $quantityField = $(".js--bundleProducts__quantityField");
+    var $timedQuantityField = $(".js--bundleProducts__timedQuantityField");
+
+    $productSelect.bind("change", function(evt) {
+      var selectedType = $(evt.target).find(":selected").closest("optgroup").attr("label");
+      var isTimeSelected = timeQuantityTypes.includes(selectedType);
+
+      // Show/hide and Enable/Disable the regular quantity vs time quantit fields
+      $quantityField.toggle(!isTimeSelected).find("input").prop("disabled", isTimeSelected);
+      $timedQuantityField.toggle(isTimeSelected).find("input").prop("disabled", !isTimeSelected);
+    }).trigger("change");
+
+    // Keep the two fields synchronized. In the time input field, there is a visible
+    // field, which is the formatted (H:MM) version and the hidden is a raw quantity.
+    $quantityField.on("change", function(evt) {
+      $timedQuantityField.find("input[type=hidden]").val($(evt.target).val()).trigger("change");
+    });
+
+    $timedQuantityField.on("change", "input[type=hidden]", function(evt) {
+      $quantityField.find("input").val($(evt.target).val())
+    });
+  }
+});

--- a/app/inputs/order_detail_quantity_input.rb
+++ b/app/inputs/order_detail_quantity_input.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-class OrderDetailQuantityInput < SimpleForm::Inputs::FileInput
-
-  def input(_wrapper_options)
-    input_html_options[:class] << "timeinput" if object.quantity_as_time?
-    @builder.text_field(attribute_name, input_html_options).html_safe
-  end
+class OrderDetailQuantityInput < QuantityInput
 
   def hint(_wrapper_options = nil)
     if object.scaling_type && !object.quantity_editable?

--- a/app/inputs/quantity_input.rb
+++ b/app/inputs/quantity_input.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class QuantityInput < SimpleForm::Inputs::FileInput
+
+  def input(_wrapper_options)
+    input_html_options[:class] << "timeinput" if object.quantity_as_time?
+    @builder.text_field(attribute_name, input_html_options).html_safe
+  end
+
+end

--- a/app/models/bundle.rb
+++ b/app/models/bundle.rb
@@ -9,11 +9,10 @@ class Bundle < Product
 
   def products_for_group_select
     products = facility.products.where(type: bundleable_product_types).order(:type, :name)
-    options = Hash.new { |h, k| h[k] = [] }
-    products.group_by { |product| product.class.model_name.human.pluralize }.each do |cname, ps|
-      options[cname] = ps.map { |p| [p.to_s_with_status, p.id] }
+
+    products.group_by { |product| product.class.model_name.human.pluralize }.each_with_object({}) do |(group, group_products), options|
+      options[group] = group_products.map { |product| [product.to_s_with_status, product.id] }
     end
-    options
   end
 
   def products_active?

--- a/app/models/bundle_product.rb
+++ b/app/models/bundle_product.rb
@@ -5,6 +5,8 @@ class BundleProduct < ApplicationRecord
   belongs_to :bundle, foreign_key: :bundle_product_id
   belongs_to :product
 
+  delegate :quantity_as_time?, to: :product
+
   validates_presence_of     :bundle_product_id, :product_id
   validates_numericality_of :quantity, only_integer: true, greater_than: 0
   validates_uniqueness_of   :product_id, scope: [:bundle_product_id]

--- a/app/presenters/quantity_presenter.rb
+++ b/app/presenters/quantity_presenter.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class QuantityPresenter
+
+  QuantityDisplay = Struct.new(:value) do
+    def html
+      to_s
+    end
+
+    delegate :to_s, to: :value
+
+    def csv
+      value.to_s
+    end
+  end
+
+  TimeQuantityDisplay = Struct.new(:value) do
+    include ActionView::Helpers::TagHelper
+
+    def csv
+      # equal sign and quotes prevent Excel from formatting as a date/time
+      %(="#{MinutesToTimeFormatter.new(value)}")
+    end
+
+    def to_s
+      MinutesToTimeFormatter.new(value).to_s
+    end
+
+    def html
+      to_s
+    end
+  end
+
+  delegate :to_s, :csv, :html, to: :display
+
+  def initialize(product, quantity)
+    @product = product
+    @quantity = quantity
+  end
+
+  private
+
+  def display
+    @display ||= if @product.quantity_as_time?
+                   TimeQuantityDisplay.new(@quantity)
+                 else
+                   QuantityDisplay.new(@quantity)
+                 end
+  end
+
+end

--- a/app/support/price_displayment.rb
+++ b/app/support/price_displayment.rb
@@ -57,45 +57,6 @@ module PriceDisplayment
     actual_cost.present?
   end
 
-  class QuantityDisplay < Struct.new(:value)
-
-    def html
-      value
-    end
-
-    def csv
-      value.to_s
-    end
-
-  end
-
-  class TimeQuantityDisplay < QuantityDisplay
-
-    include ActionView::Helpers::TagHelper
-
-    def csv
-      # equal sign and quotes prevent Excel from formatting as a date/time
-      %(="#{MinutesToTimeFormatter.new(value)}")
-    end
-
-    def html
-      MinutesToTimeFormatter.new(value).to_s
-    end
-
-  end
-
-  def build_quantity_presenter
-    if time_data.try(:actual_duration_mins) && time_data.actual_duration_mins.to_i > 0
-      TimeQuantityDisplay.new(time_data.actual_duration_mins)
-    elsif time_data.try(:duration_mins)
-      TimeQuantityDisplay.new(time_data.duration_mins)
-    elsif quantity_as_time?
-      TimeQuantityDisplay.new(quantity)
-    else
-      QuantityDisplay.new(quantity)
-    end
-  end
-
   def wrapped_quantity
     build_quantity_presenter.html
   end
@@ -105,6 +66,17 @@ module PriceDisplayment
   end
 
   private
+
+  def build_quantity_presenter
+    quantity_to_display = if time_data.try(:actual_duration_mins) && time_data.actual_duration_mins.to_i > 0
+                            time_data.actual_duration_mins
+                          elsif time_data.try(:duration_mins)
+                            time_data.duration_mins
+                          else
+                            quantity
+                          end
+    QuantityPresenter.new(product, quantity_to_display)
+  end
 
   def empty_display
     "Unassigned"

--- a/app/views/bundle_products/edit.html.haml
+++ b/app/views/bundle_products/edit.html.haml
@@ -11,7 +11,7 @@
 = simple_form_for([current_facility, @bundle, @bundle_product]) do |f|
   = f.error_messages
   .form-inputs
-    = f.input :quantity, required: true
+    = f.input :quantity, as: :quantity, required: true
   %ul.inline
     %li= f.submit text("shared.save"), class: "btn btn-primary"
     %li= link_to text("shared.cancel"), facility_bundle_bundle_products_path

--- a/app/views/bundle_products/index.html.haml
+++ b/app/views/bundle_products/index.html.haml
@@ -35,5 +35,6 @@
           - if product.is_a?(Instrument) or cannot? :edit, bundle_product
             %td= bundle_product.quantity
           - else
-            %td= %(#{bundle_product.quantity} (#{link_to text("shared.edit"), edit_facility_bundle_bundle_product_path(current_facility, @bundle, bundle_product)})).html_safe
+            - quantity = QuantityPresenter.new(bundle_product, bundle_product.quantity)
+            %td= %(#{quantity} (#{link_to text("shared.edit"), edit_facility_bundle_bundle_product_path(current_facility, @bundle, bundle_product)})).html_safe
           %td= price_policy_errors(product)

--- a/app/views/bundle_products/new.html.haml
+++ b/app/views/bundle_products/new.html.haml
@@ -13,11 +13,17 @@
   = f.error_messages
 
   .form-inputs
-    = f.label :product_id, nil, class: "require"
-    = f.select :product_id,
-      grouped_options_for_select(@bundle.products_for_group_select, @bundle_product.product_id, prompt: "")
+    = f.input :product_id,
+      as: :grouped_select,
+      required: true,
+      collection: @bundle.products_for_group_select,
+      group_method: :last,
+      input_html: { class: "js--bundleProducts__productSelect", data: { timed_quantity_types: TimedService.model_name.human(count: 2) } }
 
-    = f.input :quantity, required: true
+    .js--bundleProducts__quantityField
+      = f.input :quantity, required: true
+    .js--bundleProducts__timedQuantityField
+      = f.input :quantity, required: true, input_html: { class: "timeinput" }
 
   %ul.inline
     %li= f.submit t("shared.create"), class: "btn"

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -20,7 +20,7 @@
       - if order_detail.product.is_a?(Instrument)
         %td
       - elsif order_detail.bundle
-        %td.centered= order_detail.quantity
+        %td.centered= QuantityPresenter.new(order_detail.product, order_detail.quantity)
       - else
         %td.centered
           = odf.input :quantity,


### PR DESCRIPTION
# Release Notes

Fix display of quantities for Timed Services when inside of a bundle.

* In a cart
* In the admin of a bundle including the list of bundled products and the new and edit forms

# Screenshot

## Before

<img width="1207" alt="screen shot 2019-01-02 at 4 24 21 pm" src="https://user-images.githubusercontent.com/1099111/50615628-fb02ba80-0eaa-11e9-9970-a5176f2c4188.png">
<img width="914" alt="screen shot 2019-01-02 at 4 24 27 pm" src="https://user-images.githubusercontent.com/1099111/50615633-ff2ed800-0eaa-11e9-8760-e8ba35302983.png">
<img width="388" alt="screen shot 2019-01-02 at 4 25 27 pm" src="https://user-images.githubusercontent.com/1099111/50615640-07871300-0eab-11e9-889a-1e5a34b77d4e.png">

## After

<img width="1233" alt="screen shot 2019-01-02 at 4 24 08 pm" src="https://user-images.githubusercontent.com/1099111/50615648-0d7cf400-0eab-11e9-8ec5-5a13dd600acc.png">
<img width="793" alt="screen shot 2019-01-02 at 4 23 50 pm" src="https://user-images.githubusercontent.com/1099111/50615655-1077e480-0eab-11e9-92d5-e98b7dce78a6.png">
<img width="425" alt="screen shot 2019-01-02 at 4 26 02 pm" src="https://user-images.githubusercontent.com/1099111/50615667-1d94d380-0eab-11e9-937e-a10d712f83f3.png">

# Additional Context

The add product to bundle form will now switch between regular quantity and time-based based on what option has been selected from the dropdown.
