### PR TITLE
[#137479] Fix Support link when signed out, and make visible on mobile

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -7,8 +7,8 @@
         %span= app_name
       - if session_user.nil?
         %ul.nav.pull-right.hide-from-print
-          %li= link_to t("pages.login"), :new_user_session
           = render "/shared/support"
+          %li= link_to t("pages.login"), :new_user_session
       - else
         - if responsive?
           %a.btn.btn-navbar.hide-from-print{ data: { target: ".nav-collapse", toggle: "collapse" } }

--- a/app/views/shared/_support.html.haml
+++ b/app/views/shared/_support.html.haml
@@ -1,3 +1,3 @@
 - if Settings.support_email.present?
-  %li.visible-with-nav= mail_to Settings.support_email, t('pages.support')
+  %li= mail_to Settings.support_email, t('pages.support')
   %li.divider-vertical


### PR DESCRIPTION
# Release Notes

Fix Support link when signed out, and make visible on mobile

# Screenshot

## Before

<img width="141" alt="screen shot 2019-01-03 at 13 21 05" src="https://user-images.githubusercontent.com/7736/50637509-8e46f900-0f5a-11e9-9b78-4c7223ef3ca7.png">

## After

<img width="131" alt="screen shot 2019-01-03 at 13 21 10" src="https://user-images.githubusercontent.com/7736/50637514-94d57080-0f5a-11e9-95a9-be4947fbf19a.png">
