### PR TITLE
[#141856] Fix sort by order an product columns on New/In Process

### DIFF
--- a/app/controllers/concerns/new_inprocess_controller.rb
+++ b/app/controllers/concerns/new_inprocess_controller.rb
@@ -28,6 +28,7 @@ module NewInprocessController
 
   def sort_lookup_hash
     {
+      "order_number" => ["order_details.order_id", "order_details.id"],
       "assigned_to" => ["assigned_users.last_name", "assigned_users.first_name", "order_statuses.name", "orders.ordered_at"],
       "ordered_at" => "orders.ordered_at",
       "ordered_for" => ["#{User.table_name}.last_name", "#{User.table_name}.first_name"],

--- a/app/views/facility_orders/index.html.haml
+++ b/app/views/facility_orders/index.html.haml
@@ -21,9 +21,9 @@
             %th.nowrap= sortable "order_number", Order.model_name.human
             %th.nowrap= OrderDetail.model_name.human
             %th.nowrap= sortable "ordered_for", Order.human_attribute_name(:user)
-            %th.nowrap= sortable "date", Order.human_attribute_name(:ordered_at)
+            %th.nowrap= sortable "ordered_at", Order.human_attribute_name(:ordered_at)
             %th.nowrap= OrderDetail.human_attribute_name(:quantity)
-            %th.nowrap.order-note= sortable "product"
+            %th.nowrap.order-note= sortable "product_name", OrderDetail.human_attribute_name(:product)
             %th.nowrap= sortable "assigned_to", OrderDetail.human_attribute_name(:assigned_user)
             %th.nowrap= sortable "status"
             %th.nowrap.currency= OrderDetail.human_attribute_name(:actual_cost)


### PR DESCRIPTION
# Release Notes

Fix broken sortable columns on New/In Process reservations, orders, and occupancies pages.

# Additional Context

Broken by a refactor in #1790.
