### PR TITLE
Tech task: Fix sporadic test failure

### DIFF
--- a/spec/controllers/product_users_controller_spec.rb
+++ b/spec/controllers/product_users_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ProductUsersController do
     it "should only return the two users" do
       sign_in admin
       do_request
-      expect(assigns[:product_users]).to eq([user_product, staff_product])
+      expect(assigns[:product_users]).to contain_exactly(user_product, staff_product)
     end
 
     it "should return empty and a flash if the product is not restricted" do


### PR DESCRIPTION
# Release Notes

Tech task: Fix sporadic test failure

# Additional Context

The users in the controller are sorted by last name, first name. The user factory
assigns last names of integers (e.g. "8", "9", "10"), so if it happens to hit where
it goes from 9 to 10, the ordering may not be what the test was expecting. We don't
really care about the ordering in this spec, so we can ignore it.

See https://circleci.com/gh/tablexi/nucore-open/7099

