### PR TITLE
Tech task: Clean up Account -> Facility relationship

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -15,6 +15,7 @@ class Account < ApplicationRecord
   include DateHelper
   include NUCore::Database::WhereIdsIn
 
+  belongs_to :facility, required: false
   has_many :account_users, -> { where(deleted_at: nil) }, inverse_of: :account
   has_many :deleted_account_users, -> { where.not("account_users.deleted_at" => nil) }, class_name: "AccountUser"
   # Using a basic hash doesn't work with the `owner_user` :through association. It would
@@ -102,22 +103,6 @@ class Account < ApplicationRecord
 
   def self.with_orders_for_facility(facility)
     where(id: ids_with_orders(facility))
-  end
-
-  # The subclassed Account objects will be cross facility by default; override
-  # this method with `belongs_to :facility` if the subclassed Account object is
-  # always scoped to a single facility.
-  def facility
-    nil
-  end
-
-  def facilities
-    if facility_id
-      # return a relation
-      Facility.active.where(id: facility_id)
-    else
-      Facility.active
-    end
   end
 
   def type_string

--- a/vendor/engines/c2po/app/models/credit_card_account.rb
+++ b/vendor/engines/c2po/app/models/credit_card_account.rb
@@ -5,8 +5,6 @@ class CreditCardAccount < Account
   include AffiliateAccount
   include ReconcilableAccount
 
-  belongs_to :facility
-
   attr_readonly :account_number
   before_validation :setup_false_credit_card_number
 

--- a/vendor/engines/c2po/app/models/purchase_order_account.rb
+++ b/vendor/engines/c2po/app/models/purchase_order_account.rb
@@ -5,8 +5,6 @@ class PurchaseOrderAccount < Account
   include AffiliateAccount
   include ReconcilableAccount
 
-  belongs_to :facility
-
   validates_presence_of :account_number
 
   def to_s(with_owner = false, flag_suspended = true)


### PR DESCRIPTION
# Release Notes

Tech task: clean up Account to Facility relationship

# Additional Context

A baby step towards making the relationship many to many. Turns out `Account#facilities` doesn't appear to be used anywhere.
