### PR TITLE
[#141855] Ensure mobile menu appears above other content on page

### DIFF
--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -25,6 +25,7 @@ $navbarActiveBorderColor: #aaa;
     background-color: $navCollapseBackgroundColor;
     position: relative;
     width: 100%;
+    z-index: 1;
   }
   .nav-collapse .nav {
     margin: 0;


### PR DESCRIPTION
# Release Notes

Ensure mobile menu appears above other content on page

# Screenshot

## Before

<img width="646" alt="screen shot 2019-01-04 at 14 28 56" src="https://user-images.githubusercontent.com/7736/50690341-2d3c2580-102d-11e9-87eb-3e9bd68175a5.png">

## After

<img width="647" alt="screen shot 2019-01-04 at 14 28 39" src="https://user-images.githubusercontent.com/7736/50690349-30cfac80-102d-11e9-96dc-e72eefbe904a.png">
