### PR TITLE
[#146242] Fix for split accounts when cancelled with a fee

### DIFF
--- a/app/models/instrument_price_policy_calculations.rb
+++ b/app/models/instrument_price_policy_calculations.rb
@@ -43,7 +43,7 @@ module InstrumentPricePolicyCalculations
     if charge_full_price_on_cancellation?
       calculate_reservation(reservation)
     else
-      { cost: cancellation_cost.to_f, subsidy: 0 }
+      { cost: cancellation_cost, subsidy: 0 }
     end
   end
 

--- a/app/models/instrument_price_policy_calculations.rb
+++ b/app/models/instrument_price_policy_calculations.rb
@@ -43,7 +43,9 @@ module InstrumentPricePolicyCalculations
     if charge_full_price_on_cancellation?
       calculate_reservation(reservation)
     else
-      { cost: cancellation_cost.to_d, subsidy: 0 }
+      # To be consistent with to other calculations, we should return BigDecimals
+      # or Integers.
+      { cost: cancellation_cost&.to_d || 0, subsidy: 0 }
     end
   end
 

--- a/app/models/instrument_price_policy_calculations.rb
+++ b/app/models/instrument_price_policy_calculations.rb
@@ -43,7 +43,7 @@ module InstrumentPricePolicyCalculations
     if charge_full_price_on_cancellation?
       calculate_reservation(reservation)
     else
-      { cost: cancellation_cost, subsidy: 0 }
+      { cost: cancellation_cost.to_d, subsidy: 0 }
     end
   end
 

--- a/vendor/engines/split_accounts/app/services/split_accounts/attribute_splitter.rb
+++ b/vendor/engines/split_accounts/app/services/split_accounts/attribute_splitter.rb
@@ -25,7 +25,7 @@ module SplitAccounts
 
     def floored_amount(percent, value)
       return BigDecimal(0) if percent == 0 || value.blank?
-      amount = BigDecimal(value) * BigDecimal(percent) / 100
+      amount = value.to_d * percent.to_d / 100
       amount.floor(2)
     end
 

--- a/vendor/engines/split_accounts/spec/services/order_detail_splitter_spec.rb
+++ b/vendor/engines/split_accounts/spec/services/order_detail_splitter_spec.rb
@@ -139,6 +139,16 @@ RSpec.describe SplitAccounts::OrderDetailSplitter, type: :service do
       expect(results.map(&:actual_start_at)).to all(eq(start_at))
       expect(results.map(&:actual_end_at)).to all(eq(start_at + 45.minutes))
     end
+
+    it "splits calculated cost" do
+      allow(order_detail).to receive(:calculated_cost).and_return(BigDecimal("6.66"))
+      expect(order_detail_results.map(&:calculated_cost)).to eq([2.24, 2.21, 2.21])
+    end
+
+    it "splits the calculated cost if it's a Float" do
+      allow(order_detail).to receive(:calculated_cost).and_return(6.66)
+      expect(order_detail_results.map(&:calculated_cost)).to eq([2.24, 2.21, 2.21])
+    end
   end
 
   # Fix for #135513 - Reservations were getting deleted when Export Raw was run.


### PR DESCRIPTION
# Release Notes

Fix errors on Create Journal and report when there is a canceled with cost reservation on a split account.

# Additional Context

This is a side effect of the new calculated cost fields in #1810. All of the other cost calculations return an integer or BigDecimal, but cancelation fee was returning a Float, which can't be converted to a BigDecimal w/o a precision (`can't omit precision for a Float`).
