### PR TITLE
[#137738] Total cost on pages

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -272,6 +272,14 @@ th.currency {
   tr.reconcile-warning td {
     background-color: $errorBackground !important;
   }
+
+  tfoot {
+    font-weight: bold;
+
+    .total {
+      text-align: right;
+    }
+  }
 }
 
 .table tr.row-warning {

--- a/app/support/price_displayment.rb
+++ b/app/support/price_displayment.rb
@@ -27,8 +27,12 @@ module PriceDisplayment
     format(actual_subsidy) || format(estimated_subsidy) || empty_display
   end
 
+  def actual_or_estimated_total
+    actual_total || estimated_total
+  end
+
   def display_total
-    format(actual_total) || format(estimated_total) || empty_display
+    format(actual_or_estimated_total) || empty_display
   end
 
   def wrapped_cost

--- a/app/views/facilities/disputed_orders.html.haml
+++ b/app/views/facilities/disputed_orders.html.haml
@@ -9,4 +9,4 @@
 = content_for :top_block do
   = render "shared/transactions/top", tab: "disputed_orders"
 
-= render "shared/transactions/table" if @order_details.present?
+= render "shared/transactions/table", order_details: @order_details if @order_details.present?

--- a/app/views/facilities/movable_transactions.html.haml
+++ b/app/views/facilities/movable_transactions.html.haml
@@ -10,7 +10,7 @@
   = render "shared/transactions/top", tab: "movable_transactions"
 
 - if @order_details.present?
-  = render "shared/transactions/table"
+  = render "shared/transactions/table", order_details: @order_details
   = render "shared/reconcile_footnote"
 - else
   %p.alert.alert-info= text("facilities.movable_transactions.no_orders")

--- a/app/views/facilities/transactions.html.haml
+++ b/app/views/facilities/transactions.html.haml
@@ -8,6 +8,6 @@
 = content_for :top_block do
   = render "shared/transactions/top", tab: "transactions"
 - if @order_details.any?
-  = render "shared/transactions/table"
+  = render "shared/transactions/table", order_details: @order_details
 - else
   %p.alert.alert-info= text("facilities.transactions.no_orders")

--- a/app/views/facility_notifications/in_review.html.haml
+++ b/app/views/facility_notifications/in_review.html.haml
@@ -11,7 +11,7 @@
   = content_for :action_instructions do
     %p.alert.alert-info= t(".instructions")
 
-  = render "shared/transactions/table"
+  = render "shared/transactions/table", order_details: @order_details
   = render "shared/reconcile_footnote"
 - else
   %p.alert.alert-info= text("facility_notifications.in_review.no_orders")

--- a/app/views/facility_notifications/index.html.haml
+++ b/app/views/facility_notifications/index.html.haml
@@ -10,7 +10,7 @@
   = render "shared/transactions/top", tab: "notifications"
 
 - if @order_details.any?
-  = render "shared/transactions/table"
+  = render "shared/transactions/table", order_details: @order_details
   = render "shared/reconcile_footnote"
 - else
   %p.alert.alert-info= text("facility_notifications.index.no_orders")

--- a/app/views/facility_statements/new.html.haml
+++ b/app/views/facility_statements/new.html.haml
@@ -16,7 +16,7 @@
     - else
       %p.notice.notice-info= text("instructions_without_email")
 
-  = render "shared/transactions/table"
+  = render "shared/transactions/table", order_details: @order_details
   = render "shared/reconcile_footnote"
 - else
   %p.alert.alert-info= t(".no_transactions")

--- a/app/views/shared/transactions/_table.html.haml
+++ b/app/views/shared/transactions/_table.html.haml
@@ -1,4 +1,3 @@
-- order_details = local_assigns.key?(:order_details) ? order_details : @order_details
 #table_billing
   - if @export_enabled
     = link_to t('reports.account_transactions.export'), url_for(format: :csv), class: 'js--exportSearchResults pull-right', data: { form: '.search_form' }

--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -21,12 +21,18 @@
       - if local_assigns[:show_statements]
         %th= Statement.model_name.human
   %tbody
+    / We need to keep track of how many columns there are to the left of the Cost column,
+    / so we can position the Total correctly.
+    - colspan_for_total = 5
     - order_details.each do |order_detail|
+      - colspan_for_total = 5
       %tr{ class: row_class(order_detail) }
         - if @order_detail_action
           %td= check_box_tag "order_detail_ids[]", order_detail.id, false, {:class => 'toggle'}
+          - colspan_for_total += 1
         - if @order_detail_link
           %td.nowrap= link_to @order_detail_link[:text], @order_detail_link[:proc].call(order_detail) if @order_detail_link[:display?].call(order_detail)
+          - colspan_for_total += 1
         - if backend?
           %td.nowrap= link_to order_detail.order.id, facility_order_path(order_detail.order.facility, order_detail.order)
           %td.nowrap= link_to order_detail.id, manage_order_detail_path(order_detail), :class => 'manage-order-detail'
@@ -36,9 +42,10 @@
         %td= order_detail.send(:"#{@date_range_field}").try(:strftime, "%m/%d/%Y")
         - if @extra_date_column and order_detail.send(@extra_date_column)
           %td= order_detail.send(@extra_date_column).strftime("%m/%d/%Y")
+          - colspan_for_total += 1
         - if current_facility.blank? || cross_facility?
-
           %td= order_detail.order.facility
+          - colspan_for_total += 1
         %td.user-order-detail.order-note
           .order-detail-description
             = OrderDetailPresenter.new(order_detail).description_as_html
@@ -50,12 +57,11 @@
           - if order_detail.note.present?
             .order-detail-extra.order-detail-note
               = render "shared/order_detail_note", order_detail: order_detail
-
-
         %td= order_detail.order.user.full_name
         - unless @account
           %td= order_detail.account
           %td= order_detail.account.owner_user
+          - colspan_for_total += 2
         %td.currency
           = OrderDetailPresenter.new(order_detail).wrapped_total
         %td.nowrap
@@ -63,4 +69,9 @@
           = order_detail_status_badges(order_detail)
         - if local_assigns[:show_statements]
           %td= link_to "Download", account_statement_path(order_detail.account, order_detail.statement_id, format: :pdf) if order_detail.statement
+  - unless order_details.respond_to? :total_pages
+    %tfoot
+      %th.total{colspan: colspan_for_total, scope: "row"}= t(".total")
+      %td.currency= number_to_currency(order_details.sum(&:actual_or_estimated_total))
+      %td{colspan: local_assigns[:show_statements] ? 2 : 1}
 = will_paginate(order_details) if order_details.respond_to? :total_pages

--- a/app/views/transactions/index.html.haml
+++ b/app/views/transactions/index.html.haml
@@ -5,6 +5,6 @@
 = render "shared/transactions/search"
 
 - if @order_details.any?
-  = render "shared/transactions/table", show_statements: true
+  = render "shared/transactions/table", order_details: @order_details, show_statements: true
 - else
   %p.alert.alert-info= t(".no_transactions")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,6 +138,9 @@ en:
         admin_reservation: Administrative Hold
         offline_reservation: Instrument Offline
         expiration: Expires %{time} prior
+    transactions:
+      table_inside:
+        total: Total
     update: Update
 
   global_search:

--- a/spec/features/admin/review_period_spec.rb
+++ b/spec/features/admin/review_period_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe "Review period - Sending notifications and marking as reviewed", 
     expect(page).to have_content("OD ##{order_details.second.order_number}")
   end
 
+  it "shows a total cost at the bottom of the table" do
+    login_as director
+    visit facility_notifications_path(facility)
+
+    within(".old-table tfoot") do
+      expect(page).to have_selector("th", text: "Total")
+      expect(page).to have_selector("td", text: "$2.0")
+    end
+  end
+
   describe "marking as reviewed" do
     before do
       order_details.each { |od| od.update!(reviewed_at: 1.week.from_now) }


### PR DESCRIPTION
# Release Notes

Add total cost on unpaginated lists of transactions

# Screenshot

<img width="1215" alt="screen shot 2019-01-08 at 21 48 09" src="https://user-images.githubusercontent.com/7736/50857859-27c53f00-138f-11e9-856d-4ccb2507daf8.png">

# Additional Context

I am not a fan of the way I keep track of how many columns this table has, so that I can position the `Total` correctly. I’m open to suggestions on how to make this better!