### PR TITLE
Fix calculated_cost when missing reservation

### DIFF
--- a/app/models/instrument_price_policy_calculations.rb
+++ b/app/models/instrument_price_policy_calculations.rb
@@ -20,6 +20,7 @@ module InstrumentPricePolicyCalculations
   end
 
   def calculate_cost_and_subsidy(reservation)
+    return if reservation.blank?
     return calculate_cancellation_costs(reservation) if reservation.canceled?
 
     case charge_for


### PR DESCRIPTION
# Release Notes

Fix `calculated_cost` errors for orders that are missing reservations due to a previous bug.

# Additional Context

There was a bug introduced in the Rails 5.0 upgrade that caused some reservations on split accounts to get deleted. We managed to recover most of the data from backups, but there are still some orders out there that were not recovered. This will prevent exceptions when reports and other views include those orders.

On split accounts, the calculated cost will show up as `$0.00`, but it should still be clear there's a problem since the reservation and actual times will be gone.

See https://github.com/tablexi/nucore-open/pull/949

