### PR TITLE
Only split calculated_cost when doing export raw

### DIFF
--- a/app/models/reports/export_raw.rb
+++ b/app/models/reports/export_raw.rb
@@ -122,7 +122,7 @@ module Reports
         date_range_end: date_end,
         includes: [:reservation, :statement, :reservation, order: [:user]],
         preloads: [:created_by_user, :journal, order: [:facility], account: [:affiliate, :owner_user], price_policy: [:price_group]],
-        transformer_options: { time_data: true },
+        transformer_options: { time_data: true, reporting: true },
       ).perform
     end
 

--- a/vendor/engines/split_accounts/app/services/split_accounts/order_detail_list_transformer.rb
+++ b/vendor/engines/split_accounts/app/services/split_accounts/order_detail_list_transformer.rb
@@ -20,7 +20,11 @@ module SplitAccounts
       # See https://github.com/tablexi/nucore-open/pull/1341 for more details
       nested_map(order_details) do |order_detail|
         if order_detail.account.try(:splits).try(:present?)
-          SplitAccounts::OrderDetailSplitter.new(order_detail, split_time_data: options[:time_data]).split
+          SplitAccounts::OrderDetailSplitter.new(
+            order_detail,
+            split_time_data: options[:time_data],
+            reporting: options[:reporting],
+          ).split
         else
           order_detail
         end

--- a/vendor/engines/split_accounts/app/services/split_accounts/order_detail_splitter.rb
+++ b/vendor/engines/split_accounts/app/services/split_accounts/order_detail_splitter.rb
@@ -11,12 +11,15 @@ module SplitAccounts
 
     # By default, for performance reasons, we won't also split timedata
     # (reservations/occupancies).
-    def initialize(order_detail, split_time_data: false)
+    # We only care about calculated costs for export_raw, so we'll exclude doing
+    # that calculation by default as well.
+    def initialize(order_detail, split_time_data: false, reporting: false)
       @order_detail = order_detail
       @account = order_detail.account
       @splits = account.splits
       @split_order_details = []
       @split_time_data = split_time_data
+      @reporting = reporting
     end
 
     def split
@@ -31,15 +34,15 @@ module SplitAccounts
     private
 
     def order_detail_attribute_splitter
-      AttributeSplitter.new(
+      attributes = [
         :quantity,
         :actual_cost,
         :actual_subsidy,
         :estimated_cost,
         :estimated_subsidy,
-        :calculated_cost,
-        :calculated_subsidy,
-      )
+      ]
+      attributes += [:calculated_cost, :calculated_subsidy] if @reporting
+      AttributeSplitter.new(*attributes)
     end
 
     def time_data_splitter

--- a/vendor/engines/split_accounts/spec/services/order_detail_splitter_spec.rb
+++ b/vendor/engines/split_accounts/spec/services/order_detail_splitter_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe SplitAccounts::OrderDetailSplitter, type: :service do
                                   reserve_end_at: start_at + 30.minutes, actual_start_at: start_at,
                                   actual_end_at: start_at + 45.minutes)
     end
-    let(:order_detail_results) { described_class.new(order_detail, split_time_data: true).split }
+    let(:order_detail_results) { described_class.new(order_detail, split_time_data: true, reporting: true).split }
     let(:results) { order_detail_results.map(&:time_data) }
 
     it "splits the reservation minutes" do


### PR DESCRIPTION
# Release Notes

Only calculate `calculated_cost`/`subsidy` when splitting an order detail if we are in the context of export raw.

# Additional Context

There are a few other places like the the Journals#new (where we partition into valid/invalid accounts) that split order details. In these scenarios, the calculated_cost isn't used, so we don't need to copy it. This should add a performance improvement as well as avoiding errors like #1826.

Those columns were added in #1810. 
