### PR TITLE
[#146388] Fix confirmation popups that used to exist

### DIFF
--- a/app/views/instruments/schedule.html.haml
+++ b/app/views/instruments/schedule.html.haml
@@ -67,7 +67,7 @@
             %td
               = link_to t("shared.remove"),
                 facility_instrument_reservation_path(current_facility, @product, reservation),
-                confirm: t("shared.confirm_message"),
+                data: { confirm: t("shared.confirm_message") },
                 method: :delete
 
             %td= reservation.class.model_name.human

--- a/app/views/journal_cutoff_dates/edit.html.haml
+++ b/app/views/journal_cutoff_dates/edit.html.haml
@@ -6,7 +6,7 @@
 
 %h2= t(".header")
 
-= link_to t(".delete"), journal_cutoff_date_path(@journal_cutoff_date), confirm: t(".delete_confirm"), class: "btn btn-danger pull-right", method: :delete
+= link_to t(".delete"), journal_cutoff_date_path(@journal_cutoff_date), data: { confirm: t(".delete_confirm") }, class: "btn btn-danger pull-right", method: :delete
 
 = render "form"
 

--- a/app/views/price_groups/_accounts.html.haml
+++ b/app/views/price_groups/_accounts.html.haml
@@ -15,7 +15,7 @@
       - @account_members.each do |account_price_group_member|
         %tr
           - if @price_group_ability.can?(:destroy, AccountPriceGroupMember) && price_group.can_manage_price_group_members?
-            %td= link_to "Remove", [current_facility, @price_group, account_price_group_member], confirm: "Are you sure?", method: :delete
+            %td= link_to "Remove", [current_facility, @price_group, account_price_group_member], data: { confirm: "Are you sure?" }, method: :delete
           %td= account_price_group_member.account.account_number
           - owner=account_price_group_member.account.owner_user
           %td= owner.full_name if owner

--- a/app/views/price_groups/_users.html.haml
+++ b/app/views/price_groups/_users.html.haml
@@ -17,7 +17,7 @@
       - @user_members.each do |user_price_group_member|
         %tr{class: cycle(:odd, :even)}
           - if @price_group_ability.can?(:destroy, UserPriceGroupMember) && price_group.can_manage_price_group_members?
-            %td= link_to "Remove", [current_facility, @price_group, user_price_group_member], confirm: "Are you sure?", method: :delete
+            %td= link_to "Remove", [current_facility, @price_group, user_price_group_member], data: { confirm: "Are you sure?" }, method: :delete
           %td= user_price_group_member.user.full_name
           %td= user_price_group_member.user.username
           %td= user_price_group_member.user.email


### PR DESCRIPTION
# Release Notes

Fix confirmation popups that used to exist.

The pages affected:
- Journal Cutoff Dates #edit
- Instruments #Schedule
- Price Groups #show > Accounts
- Price Groups #show > Users

## Additional Context

This likely was broken during the rails 4 upgrade, a long time ago. Adds data:{} wrappers around the confirm actions



