### PR TITLE
Account facility rename single cross methods

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -74,13 +74,13 @@ class Account < ApplicationRecord
   end
 
   # Returns true if this account type is limited to a single facility.
-  def self.single_facility?
-    config.single_facility?(name)
+  def self.per_facility?
+    config.per_facility?(name)
   end
 
   # Returns true if this account type can cross multiple facilities.
-  def self.cross_facility?
-    config.cross_facility?(name)
+  def self.global?
+    config.global?(name)
   end
 
   # Returns true if this account type supports affiliate.

--- a/app/models/account_config.rb
+++ b/app/models/account_config.rb
@@ -71,7 +71,7 @@ class AccountConfig
   # and the NullObject always returns `true` for cross_facility?.
   def account_types_for_facility(facility, action)
     types = account_types
-    types = types.select { |type| type.constantize.cross_facility? } if facility.try(:cross_facility?)
+    types = types.select { |type| type.constantize.global? } if facility.try(:cross_facility?)
     types -= creation_disabled_types if action == :create
     types
   end
@@ -94,12 +94,12 @@ class AccountConfig
   end
 
   # Returns true if this account type is limited to a single facility.
-  def single_facility?(account_type)
+  def per_facility?(account_type)
     facility_account_types.include?(account_type.to_s.classify)
   end
 
   # Returns true if this account type can cross multiple facilities.
-  def cross_facility?(account_type)
+  def global?(account_type)
     global_account_types.include?(account_type.to_s.classify)
   end
 

--- a/app/services/account_builder.rb
+++ b/app/services/account_builder.rb
@@ -175,7 +175,7 @@ class AccountBuilder
 
   # Set the facility if the account type is scoped to facility.
   def set_facility
-    account.facility_id = account.class.single_facility? ? facility.try(:id) : nil
+    account.facility_id = account.class.per_facility? ? facility.try(:id) : nil
     account
   end
 

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -9,7 +9,7 @@
         %th= Statement.human_attribute_name(:sent_to)
         - unless @account
           %th= Account.model_name.human
-        - unless current_facility.try(:single_facility?)
+        - if current_facility&.cross_facility?
           %th= Facility.model_name.human
         %th.currency # of #{Order.model_name.human.pluralize}
         %th.currency= Statement.human_attribute_name(:total_cost)
@@ -26,7 +26,7 @@
           %td= s.account.notify_users.map(&:full_name).join(', ')
           - unless @account
             %td= link_to s.account, facility_account_path(current_facility, s.account)
-          - unless current_facility.try(:single_facility?)
+          - if current_facility&.cross_facility?
             %td= s.facility.name
           %td.currency= s.order_details.count
           %td.currency= number_to_currency(s.total_cost)

--- a/spec/models/account_config_spec.rb
+++ b/spec/models/account_config_spec.rb
@@ -118,20 +118,20 @@ RSpec.describe AccountConfig, type: :model do
     end
   end
 
-  describe "#single_facility?" do
+  describe "#per_facility?" do
     context "when account_type is included in facility_account_types" do
       it "returns true" do
         allow(instance).to receive(:facility_account_types).and_return(["FooAccount"])
-        expect(instance.single_facility?("FooAccount")).to eq(true)
+        expect(instance.per_facility?("FooAccount")).to eq(true)
       end
     end
   end
 
-  describe "#cross_facility?" do
+  describe "#global?" do
     context "when account_type is included in global_account_types" do
       it "returns true" do
         allow(instance).to receive(:global_account_types).and_return(["FooAccount"])
-        expect(instance.cross_facility?("FooAccount")).to eq(true)
+        expect(instance.global?("FooAccount")).to eq(true)
       end
     end
   end

--- a/spec/models/nufs_account_spec.rb
+++ b/spec/models/nufs_account_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe NufsAccount do
     end
 
     it "should not be limited to a single facility" do
-      expect(NufsAccount.single_facility?).to be false
+      expect(NufsAccount.per_facility?).to be false
     end
 
   end

--- a/vendor/engines/c2po/spec/models/credit_card_account_spec.rb
+++ b/vendor/engines/c2po/spec/models/credit_card_account_spec.rb
@@ -9,8 +9,12 @@ RSpec.describe CreditCardAccount do
   include_examples "AffiliateAccount"
   include_examples "an Account"
 
-  it "should be limited to a single facility" do
-    expect(described_class).to be_single_facility
+  it "is a per-facility account" do
+    expect(described_class).to be_per_facility
+  end
+
+  it "is not a global account" do
+    expect(described_class).not_to be_global
   end
 
   it "has the facility association" do

--- a/vendor/engines/c2po/spec/models/purchase_order_account_spec.rb
+++ b/vendor/engines/c2po/spec/models/purchase_order_account_spec.rb
@@ -9,8 +9,12 @@ RSpec.describe PurchaseOrderAccount do
   include_examples "AffiliateAccount"
   include_examples "an Account"
 
-  it "is limited to a single facility" do
-    expect(described_class).to be_single_facility
+  it "is a per-facility account" do
+    expect(described_class).to be_per_facility
+  end
+
+  it "is not a global account" do
+    expect(described_class).not_to be_global
   end
 
   it "includes the facility in the description" do


### PR DESCRIPTION
# Release Notes

Tech task: Rename Account `single_facility?` and `cross_facility?` methods to better describe their new behavior.

# Additional Context

Extends from #1829 
