### PR TITLE
[#144300] Add account select to Add to Order form

### DIFF
--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -81,7 +81,7 @@ class FacilityOrdersController < ApplicationController
   private
 
   def add_to_order_params
-    params.require(:add_to_order_form).permit(:quantity, :product_id, :order_status_id, :note, :fulfilled_at, :duration)
+    params.require(:add_to_order_form).permit(:quantity, :product_id, :order_status_id, :note, :fulfilled_at, :duration, :account_id)
   end
 
   def batch_updater

--- a/app/forms/add_to_order_form.rb
+++ b/app/forms/add_to_order_form.rb
@@ -6,9 +6,10 @@ class AddToOrderForm
   include TextHelpers::Translation
 
   attr_reader :original_order, :current_facility
-  attr_accessor :quantity, :product_id, :order_status_id, :note, :duration, :created_by, :fulfilled_at
+  attr_accessor :quantity, :product_id, :order_status_id, :note, :duration, :created_by, :fulfilled_at, :account_id
   attr_accessor :error_message
 
+  validates :account_id, presence: true
   validates :product_id, presence: true
   validates :order_status_id, presence: true
   validates :quantity, numericality: { greater_than: 0, only_integer: true }
@@ -16,6 +17,7 @@ class AddToOrderForm
   def initialize(original_order)
     @original_order = original_order
     @current_facility = original_order.facility
+    @account_id = original_order.account_id
     @quantity = 1
     @duration = 1
   end
@@ -81,6 +83,7 @@ class AddToOrderForm
       note: note.presence,
       duration: duration,
       created_by: created_by.id,
+      account: Account.find(account_id),
     }
   end
 
@@ -96,7 +99,7 @@ class AddToOrderForm
                      Order.create!(
                        merge_with_order_id: original_order.id,
                        facility_id: original_order.facility_id,
-                       account_id: original_order.account_id,
+                       account_id: account_id,
                        user_id: original_order.user_id,
                        created_by: created_by.id,
                      )

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -4,7 +4,7 @@ module AccountsHelper
 
   def account_input(form)
     hint = t("facility_order_details.edit.label.account_owner_html", owner: @order_detail.account.owner_user)
-    form.input :account, hint: hint do
+    form.input :account_id, hint: hint, label: OrderDetail.human_attribute_name(:account) do
       form.select :account_id, available_accounts_options, include_blank: false, disabled: edit_disabled?
     end
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -242,7 +242,7 @@ class Account < ApplicationRecord
     !account_users.where("user_id = ? AND deleted_at IS NULL", user.id).first.nil?
   end
 
-  def is_active?
+  def active?
     !expired? && !suspended?
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -93,7 +93,7 @@ class Order < ApplicationRecord
       order_details.all? { |od| od.account_id == account_id } && # order detail accounts match order account
       facility.can_pay_with_account?(account) &&               # payment is accepted by facility
       account.can_be_used_by?(user) &&                         # user can pay with account
-      account.is_active?                                       # account is active/valid
+      account.active?                                          # account is active/valid
   end
 
   def has_details?

--- a/app/views/facility_facility_accounts/index.html.haml
+++ b/app/views/facility_facility_accounts/index.html.haml
@@ -26,5 +26,5 @@
         %tr
           %td
             = link_to account, edit_facility_facility_account_path(current_facility, account)
-            - unless account.is_active?
+            - unless account.active?
               = text("inactive")

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -11,8 +11,7 @@
       = f.input_field :duration, class: "js--edit-order__duration"
 
       = f.input :account_id,
-        collection: AvailableAccountsFinder.new(@order.user, current_facility),
-        label: Account.model_name.human,
+        collection: @add_to_order_form.available_accounts,
         include_blank: !@order.account.active?,
         hint: @order.account.active? ? "" : t(".original_account_inactive", account: @order.account),
         input_html: { class: "js--chosen" }

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -10,10 +10,17 @@
 
       = f.input_field :duration, class: "js--edit-order__duration"
 
+      = f.input :account_id,
+        collection: AvailableAccountsFinder.new(@order.user, current_facility),
+        label: Account.model_name.human,
+        include_blank: !@order.account.active?,
+        hint: @order.account.active? ? "" : t(".original_account_inactive", account: @order.account),
+        input_html: { class: "js--chosen" }
+
       = f.input :order_status_id,
         collection: OrderStatus.add_to_order_statuses(current_facility),
         label_method: :name_with_level,
-        input_html: { class: "js--chosen optional" },
+        input_html: { class: "js--chosen" },
         include_blank: false,
         label: OrderDetail.human_attribute_name(:order_status)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -379,6 +379,8 @@ en:
       no_problem_orders: There are no problem orders.
     table_controls:
       update_orders: Update Orders
+    merge_order_form:
+      original_account_inactive: "The original account used for this order is suspended or expired: %{account}"
 
   facility_reservations:
     index:

--- a/config/locales/forms/en.add_to_order_form.yml
+++ b/config/locales/forms/en.add_to_order_form.yml
@@ -6,3 +6,8 @@ en:
       notices: "%{product} needs your attention before it is added to the order."
       invalid_status: |
         %{product} may not be set initially to an order status of %{status}.
+  activemodel:
+    attributes:
+      add_to_order_form:
+        account: Payment Source
+        account_id: Payment Source

--- a/spec/app_support/order_row_importer_spec.rb
+++ b/spec/app_support/order_row_importer_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe OrderRowImporter do
       end
 
       context "and the account is active" do
-        before { allow_any_instance_of(Account).to receive(:is_active?).and_return(true) }
+        before { allow_any_instance_of(Account).to receive(:active?).and_return(true) }
 
         context "and the account is invalid for the product" do
           before(:each) do

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -256,6 +256,24 @@ RSpec.describe FacilityOrdersController do
           end
         end
 
+        context "when specifying an account" do
+          let(:other_account) { create(:nufs_account, :with_account_owner, owner: order.user) }
+          before { @params[:add_to_order_form][:account_id] = other_account.id }
+
+          it_should_allow :director, "to add the item to that account" do
+            expect(order.order_details.last.account).to eq(other_account)
+          end
+
+          context "and that account is suspended" do
+            before { other_account.suspend }
+
+            it_should_allow :director, "to error on that account" do
+              expect(order.order_details).to be_empty
+              expect(flash[:error]).to be_present
+            end
+          end
+        end
+
         context "when setting the order status to 'Complete'" do
           let(:complete_status) { OrderStatus.complete }
           before { @params[:add_to_order_form][:order_status_id] = complete_status.id.to_s }

--- a/spec/features/admin/adding_to_an_order_spec.rb
+++ b/spec/features/admin/adding_to_an_order_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Adding to an existing order" do
   let(:facility) { product.facility }
   let(:order) { create(:purchased_order, product: product) }
   let(:user) { create(:user, :staff, facility: facility) }
+  let!(:other_account) { create(:nufs_account, :with_account_owner, owner: order.user, description: "Other Account") }
 
   before do
     login_as user
@@ -45,6 +46,35 @@ RSpec.describe "Adding to an existing order" do
         expect(order.reload.order_details.count).to eq(2)
         expect(order.order_details.last).to be_complete
         expect(I18n.l(order.order_details.last.fulfilled_at.to_date, format: :usa)).to eq(fulfilled_at_string)
+      end
+    end
+
+    describe "adding it to another account" do
+      describe "while the original account is still active" do
+        before do
+          select other_account, from: "Payment Source"
+          click_button "Add To Order"
+        end
+
+        it "creates the order detail with the new account" do
+          click_link(order.reload.order_details.last)
+          expect(page).to have_select("Payment Source", selected: other_account.to_s)
+        end
+      end
+
+      describe "when the original account is expired" do
+        before do
+          order.account.update!(expires_at: 1.day.ago)
+          page.refresh
+          save_and_open_page
+        end
+
+        it "is blank and cannot be added" do
+          expect(page).to have_select("Payment Source", selected: nil)
+          expect(page).to have_content("is suspended or expired")
+          click_button "Add To Order"
+          expect(page).to have_content("Account can't be blank")
+        end
       end
     end
   end

--- a/spec/features/admin/adding_to_an_order_spec.rb
+++ b/spec/features/admin/adding_to_an_order_spec.rb
@@ -66,14 +66,13 @@ RSpec.describe "Adding to an existing order" do
         before do
           order.account.update!(expires_at: 1.day.ago)
           page.refresh
-          save_and_open_page
         end
 
         it "is blank and cannot be added" do
           expect(page).to have_select("Payment Source", selected: nil)
           expect(page).to have_content("is suspended or expired")
           click_button "Add To Order"
-          expect(page).to have_content("Account can't be blank")
+          expect(page).to have_content("Payment Source can't be blank")
         end
       end
     end


### PR DESCRIPTION
# Release Notes

Allow facility staff to choose an account from a dropdown when adding to an existing order.

# Screenshots

When the "cart" payment source is valid:

![screen shot 2019-01-11 at 2 28 29 pm](https://user-images.githubusercontent.com/1099111/51058086-4012a500-15ad-11e9-9127-63443a8ab2e5.png)

When the "cart" payment source is expired or suspended:
![screen shot 2019-01-11 at 2 28 05 pm](https://user-images.githubusercontent.com/1099111/51058097-4bfe6700-15ad-11e9-8385-4e5bf3cc1dbc.png)


# Additional Context

Previously, new orders always got added to the order's (aka "cart") account. This is problematic when the account has since been suspended or expired.

This should avoid that issue as well as provide a convenience to the facility staff. 

It will default to the cart account unless it is no longer valid, and only includes valid accounts.

Includes #1837. Clean diff: https://github.com/tablexi/nucore-open/compare/add_to_order_refactor...add_account_to_add_to_order_144300?expand=1
