### PR TITLE
[#144419] Interface for managing an Account's facilities

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -208,6 +208,13 @@ ul.unstyled {
 
 form.compact { margin: 0 }
 
+.checkbox-group {
+  .checkbox {
+    display: block;
+    margin-bottom: 0.5rem;
+  }
+}
+
 .modal form,
 .well form {
   margin-bottom: 0;

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -208,13 +208,6 @@ ul.unstyled {
 
 form.compact { margin: 0 }
 
-.checkbox-group {
-  .checkbox {
-    display: block;
-    margin-bottom: 0.5rem;
-  }
-}
-
 .modal form,
 .well form {
   margin-bottom: 0;
@@ -308,7 +301,8 @@ th.currency {
   }
 }
 
-.price-policy-table input[type=text] {
+.price-policy-table input[type=text],
+.half-width {
   width: 50%;
 }
 

--- a/app/controllers/account_facility_joins_controller.rb
+++ b/app/controllers/account_facility_joins_controller.rb
@@ -6,6 +6,7 @@ class AccountFacilityJoinsController < ApplicationController
   before_action :authenticate_user!
   before_action :check_acting_as
   before_action :init_account
+  authorize_resource # Only global admins should have access
 
   layout "two_column"
 
@@ -16,8 +17,9 @@ class AccountFacilityJoinsController < ApplicationController
     update_params = params.require(:account_facility_joins_form).permit(facility_ids: [])
     @account_facility_joins_form.assign_attributes(update_params)
     if @account_facility_joins_form.save
-      redirect_to({ action: :edit }, notice: "Success")
+      redirect_to({ action: :edit }, notice: text("update.success"))
     else
+      flash.now[:error] = text("update.error")
       render :edit
     end
   end
@@ -26,7 +28,7 @@ class AccountFacilityJoinsController < ApplicationController
 
   def init_account
     @account = Account.for_facility(current_facility).per_facility.find(params[:account_id])
-    @account_facility_joins_form = AccountFacilityJoinsForm.new(account: @account)
+    @account_facility_joins_form = AccountFacilityJoinsForm.new(account: @account, current_facility: current_facility)
   end
 
 end

--- a/app/controllers/account_facility_joins_controller.rb
+++ b/app/controllers/account_facility_joins_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class AccountFacilityJoinsController < ApplicationController
+
+  admin_tab     :all
+  before_action :authenticate_user!
+  before_action :check_acting_as
+  before_action :init_account
+
+  layout "two_column"
+
+  def edit
+  end
+
+  def update
+    update_params = params.require(:account_facility_joins_form).permit(facility_ids: [])
+    @account_facility_joins_form.assign_attributes(update_params)
+    if @account_facility_joins_form.save
+      redirect_to({ action: :edit }, notice: "Success")
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def init_account
+    @account = Account.for_facility(current_facility).per_facility.find(params[:account_id])
+    @account_facility_joins_form = AccountFacilityJoinsForm.new(account: @account)
+  end
+
+end

--- a/app/forms/account_facility_joins_form.rb
+++ b/app/forms/account_facility_joins_form.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class AccountFacilityJoinsForm
+
+  include ActiveModel::Model
+
+  attr_accessor :account
+
+  validates :facility_ids, presence: true
+  validates :account, presence: true
+
+  def facility_ids
+    @facility_ids || account.facilities.pluck(:id)
+  end
+
+  def facility_ids=(facility_ids)
+    @facility_ids = Array(facility_ids).select(&:present?)
+  end
+
+  def save
+    return unless valid?
+
+    account.facilities = Facility.find(facility_ids)
+    true
+  end
+
+end

--- a/app/forms/account_facility_joins_form.rb
+++ b/app/forms/account_facility_joins_form.rb
@@ -4,10 +4,11 @@ class AccountFacilityJoinsForm
 
   include ActiveModel::Model
 
-  attr_accessor :account
+  attr_accessor :account, :current_facility
 
   validates :facility_ids, presence: true
   validates :account, presence: true
+  validate :must_include_current_facility
 
   def facility_ids
     @facility_ids || account.facilities.pluck(:id)
@@ -22,6 +23,14 @@ class AccountFacilityJoinsForm
 
     account.facilities = Facility.find(facility_ids)
     true
+  end
+
+  private
+
+  def must_include_current_facility
+    return if current_facility.cross_facility? || facility_ids.map(&:to_s).include?(current_facility.id.to_s)
+
+    errors.add(:facility_ids, :missing_current_facility)
   end
 
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -64,6 +64,7 @@ class Account < ApplicationRecord
   validate { errors.add(:base, :missing_owner) if missing_owner? }
 
   delegate :administrators, to: :account_users
+  delegate :global?, :per_facility?, to: :class
 
   # The @@config class variable stores account configuration details via a
   # seperate `AccountConfig` class. This way downstream repositories can use

--- a/app/services/account_builder.rb
+++ b/app/services/account_builder.rb
@@ -175,7 +175,7 @@ class AccountBuilder
 
   # Set the facility if the account type is scoped to facility.
   def set_facility
-    account.facility_id = account.class.per_facility? ? facility.try(:id) : nil
+    account.facility_id = account.per_facility? ? facility.try(:id) : nil
     account
   end
 

--- a/app/views/account_facility_joins/edit.html.haml
+++ b/app/views/account_facility_joins/edit.html.haml
@@ -9,5 +9,6 @@
 %h2= @account
 
 = simple_form_for @account_facility_joins_form, url: facility_account_account_facility_joins_path, method: :patch do |f|
-  = f.input :facility_ids, collection: Facility.alphabetized, as: :check_boxes, label: false, wrapper_html: { class: "checkbox-group" }
-  = f.submit "Submit", class: "btn btn-primary"
+
+  = f.input :facility_ids, collection: Facility.alphabetized, input_html: { multiple: true, class: "js--chosen half-width" }, label_method: :to_s
+  = f.submit text("shared.save"), class: "btn btn-primary"

--- a/app/views/account_facility_joins/edit.html.haml
+++ b/app/views/account_facility_joins/edit.html.haml
@@ -1,0 +1,13 @@
+= content_for :tabnav do
+  = render "admin/shared/tabnav_payment_method", secondary_tab: "facilities"
+
+= content_for :h1 do
+  = current_facility
+
+= render "facility_accounts/sidebar"
+
+%h2= @account
+
+= simple_form_for @account_facility_joins_form, url: facility_account_account_facility_joins_path, method: :patch do |f|
+  = f.input :facility_ids, collection: Facility.alphabetized, as: :check_boxes, label: false, wrapper_html: { class: "checkbox-group" }
+  = f.submit "Submit", class: "btn btn-primary"

--- a/app/views/accounts/index.html.haml
+++ b/app/views/accounts/index.html.haml
@@ -2,12 +2,11 @@
   = t_my(Account)
 
 - if @account_users.empty?
-  %p.notice= "You do not have any #{Account.model_name.human.pluralize.downcase}."
+  %p.notice= text("empty", models: Account.model_name.human.pluralize.downcase)
 - else
   - if @administered_order_details_in_review.any?
-    = link_to t(".transaction_in_review", count: @administered_order_details_in_review.count),
+    = link_to text("transaction_in_review", count: @administered_order_details_in_review.count),
       in_review_transactions_path
-
   %table.table.table-striped.table-hover.js--responsive_table
     %thead
       %tr
@@ -30,11 +29,11 @@
           %td= account.description_to_s
           %td= account.type_string
           %td= human_date(account.expires_at)
-          %td= account.facilities.alphabetized.join(", ") || '<i>All</i>'.html_safe
+          %td= account.per_facility? ? account.facilities.alphabetized.join(", ") : html("all", inline: true)
           - if au.can_administer? || session_user.administrator?
-            - show_th=true
-            %td= link_to "Transactions", transactions_path(search: { accounts: [account] })
-            %td= link_to "Members", account_account_users_path(account)
+            - show_th = true
+            %td= link_to text("transactions"), transactions_path(search: { accounts: [account] })
+            %td= link_to text("members"), account_account_users_path(account)
 
     - if show_th
       = javascript_tag "$(function(){ $('th.hidden').show(); });"

--- a/app/views/accounts/index.html.haml
+++ b/app/views/accounts/index.html.haml
@@ -30,7 +30,7 @@
           %td= account.description_to_s
           %td= account.type_string
           %td= human_date(account.expires_at)
-          %td= account.facility || '<i>All</i>'.html_safe
+          %td= account.facilities.alphabetized.join(", ") || '<i>All</i>'.html_safe
           - if au.can_administer? || session_user.administrator?
             - show_th=true
             %td= link_to "Transactions", transactions_path(search: { accounts: [account] })

--- a/app/views/admin/shared/_tabnav_payment_method.html.haml
+++ b/app/views/admin/shared/_tabnav_payment_method.html.haml
@@ -6,3 +6,4 @@
   = tab t(".members"), facility_account_members_path(current_facility, @account), (secondary_tab == "members")
   - if current_ability.can?(:orders, @account)
     = tab t(".orders"), facility_account_orders_path(current_facility, @account), (secondary_tab == "orders")
+  = tab Facility.model_name.human(count: :other), edit_facility_account_account_facility_joins_path(current_facility, @account), (secondary_tab == "facilities")

--- a/app/views/admin/shared/_tabnav_payment_method.html.haml
+++ b/app/views/admin/shared/_tabnav_payment_method.html.haml
@@ -6,4 +6,5 @@
   = tab t(".members"), facility_account_members_path(current_facility, @account), (secondary_tab == "members")
   - if current_ability.can?(:orders, @account)
     = tab t(".orders"), facility_account_orders_path(current_facility, @account), (secondary_tab == "orders")
-  = tab Facility.model_name.human(count: :other), edit_facility_account_account_facility_joins_path(current_facility, @account), (secondary_tab == "facilities")
+  - if @account.per_facility? && current_ability.can?(:edit, AccountFacilityJoinsForm.new(account: @account))
+    = tab Facility.model_name.human(count: :other), edit_facility_account_account_facility_joins_path(current_facility, @account), (secondary_tab == "facilities")

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -6,6 +6,11 @@ en:
       create:
         success: "%{accessories} added"
 
+    account_facility_joins:
+      update:
+        success: Payment source was successfully updated.
+        error: There was a problem updating the payment source
+
     account_price_group_members:
       create:
         notice: "%{account_number} was added to the %{price_group_name} Price Group"

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -11,6 +11,9 @@ en:
         expires?: Release In Advance
         expires_mins_before: "Release hh:mm Prior To Start"
         user_note: Note for users
+      account_facility_joins_form:
+        facility_ids: Facilities
+
     errors:
       models:
         order_details/reconciler:
@@ -30,6 +33,8 @@ en:
               blank: must be a valid date
               too_far_in_future: Cannot be dated more than %{time} in the future
               must_be_after_initial_reservation: must occur after initial reservation
+        account_facility_joins_form:
+          missing_current_facility: can't remove the current facility
 
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -797,10 +797,6 @@ en:
         search: "Search by name, NetID, or username"
 
   accounts:
-    index:
-      transaction_in_review:
-        one: You have one transaction in review
-        other: You have %{count} transactions in review
     role:
         owner: Owner
         business_administrator: Business Administrator

--- a/config/locales/views/en.accounts.yml
+++ b/config/locales/views/en.accounts.yml
@@ -1,0 +1,11 @@
+en:
+  views:
+    accounts:
+      index:
+        empty: You do not have any %{models}
+        all: "*All*"
+        transaction_in_review:
+          one: You have one transaction in review
+          other: You have %{count} transactions in review
+        transactions: Transactions
+        members: Members

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,6 +225,8 @@ Nucore::Application.routes.draw do
             get "user_search"
           end
         end
+
+        resource :account_facility_joins, only: [:edit, :update], path: "facilities" if SettingsHelper.feature_on?(:multi_facility_accounts)
       end
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -129,6 +129,7 @@ feature:
   facility_banner_notice: true
   charge_full_price_on_cancellation: true
   price_policy_requires_note: true
+  multi_facility_accounts: true
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/spec/features/admin/account_facility_joins_controller_spec.rb
+++ b/spec/features/admin/account_facility_joins_controller_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AccountFacilityJoinsController do
+
+  # Not all implementations have facility-specific account types, so build our own for this
+  # set of specs.
+  class PerFacilityTestAccount < Account
+  end
+
+  before do
+    allow(Account.config).to receive(:facility_account_types).and_return(["PerFacilityTestAccount"])
+    facility_specific_account.update!(type: "PerFacilityTestAccount")
+  end
+
+  let(:facility) { create(:facility) }
+  let(:facility_specific_account) { create(:account, :with_account_owner, facility: facility) }
+  let(:global_account) { create(:nufs_account, :with_account_owner) }
+
+  describe "as a global admin" do
+    let!(:facility2) { create(:facility) }
+    before { login_as create(:user, :administrator) }
+
+    it "can update the facilities" do
+      visit edit_facility_account_account_facility_joins_path(facility, facility_specific_account)
+      select facility2.to_s, from: "Facilities"
+      click_button "Save"
+      expect(page).to have_content("updated")
+      expect(page).to have_select("Facilities", selected: [facility.to_s, facility2.to_s])
+    end
+
+    it "has an error if nothing is selected" do
+      visit edit_facility_account_account_facility_joins_path(facility, facility_specific_account)
+      unselect facility.to_s, from: "Facilities"
+      click_button "Save"
+      expect(page).to have_content "can't be blank"
+    end
+
+    it "errors if you're trying to remove it from the current facility" do
+      visit edit_facility_account_account_facility_joins_path(facility, facility_specific_account)
+      select facility2.to_s, from: "Facilities"
+      unselect facility.to_s, from: "Facilities"
+      click_button "Save"
+      expect(page).to have_content "can't remove"
+    end
+
+    it "cannot visit a global account" do
+      visit edit_facility_account_account_facility_joins_path(facility, global_account)
+      expect(page).to have_content("Not Found")
+    end
+  end
+
+  describe "as a facility admin" do
+    before { login_as create(:user, :facility_administrator, facility: facility) }
+
+    it "cannot access the page" do
+      visit edit_facility_account_account_facility_joins_path(facility, facility_specific_account)
+      expect(page).to have_content("Permission Denied")
+    end
+  end
+
+  describe "as an account manager" do
+    before { login_as create(:user, :account_manager) }
+
+    it "cannot access the page" do
+      visit edit_facility_account_account_facility_joins_path(facility, facility_specific_account)
+      expect(page).to have_content("Permission Denied")
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

Add an interface for global admins to manage which facilities an account is valid for. This applies to non-global accounts (e.g. Credit Cards and POs).

# Screenshot

![screen shot 2019-01-16 at 4 14 13 pm](https://user-images.githubusercontent.com/1099111/51282192-12ad6900-19aa-11e9-808e-df8b69bc11ff.png)


# Additional context

I considered using checkboxes, but this seemed better for when there are lots of facilities.

We will probably want to disable this for NU for a little while until they can get BI to update their queries.