### PR TITLE
Remove unused and unusable InstrumentsController#instrument_status

### DIFF
--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -55,22 +55,6 @@ class InstrumentsController < ProductsCommonController
     end
   end
 
-  # GET /facilities/:facility_id/instruments/:instrument_id/status
-  def instrument_status
-    begin
-      @relay = @product.relay
-      status = SettingsHelper.relays_enabled_for_admin? ? instrument.relay.get_status : true
-      @status = @product.instrument_statuses.create!(is_on: status)
-    rescue => e
-      logger.error e
-      raise ActiveRecord::RecordNotFound
-    end
-    respond_to do |format|
-      format.html  { render layout: false }
-      format.json  { render json: @status }
-    end
-  end
-
   def instrument_statuses
     @instrument_statuses = []
     current_facility.instruments.order(:id).includes(:relay).each do |instrument|
@@ -117,10 +101,7 @@ class InstrumentsController < ProductsCommonController
       @status = InstrumentStatus.new(instrument: @product, error_message: e.message)
       # raise ActiveRecord::RecordNotFound
     end
-    respond_to do |format|
-      format.html { render action: :instrument_status, layout: false }
-      format.json { render json: @status }
-    end
+    render json: @status
   end
 
 end

--- a/app/views/instruments/instrument_status.html.haml
+++ b/app/views/instruments/instrument_status.html.haml
@@ -1,3 +1,0 @@
-%ul
-  %li= "#{@status.status_string} (#{link_to("Refresh", facility_instrument_status_path(current_facility, @product), :id => "instrument_status_link_#{@product.id}", :class => 'instrument_status_link')})".html_safe
-  %li= format_usa_datetime(@status.created_at)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,7 +79,6 @@ Nucore::Application.routes.draw do
       facility_product_routing_concern
       get "public_schedule", to: "instruments#public_schedule"
       get "schedule",        to: "instruments#schedule"
-      get "status",          to: "instruments#instrument_status"
       get "switch",          to: "instruments#switch"
       resources :issues, only: [:new, :create], controller: "instrument_issues"
 

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -545,17 +545,6 @@ RSpec.describe InstrumentsController do
 
     end
 
-    context "status" do
-
-      before :each do
-        @method = :get
-        @action = :instrument_status
-      end
-
-      it_should_allow_operators_only
-
-    end
-
     context "instrument statuses" do
       before :each do
         # So it doesn't try to actually connect


### PR DESCRIPTION
# Release Notes

TECH TASK: Remove unused and unusable InstrumentsController#instrument_status

# Additional Context

I was scratching my head with the `InstrumentStatus` records while working on `#139335`, and this action is unused and unusable (because there is no local variable or method called `instrument`, it always raises `ActiveRecord::RecordNotFound`, which results in a 404).