### PR TITLE
[#147636] Only require note for newly-created Price Policies

### DIFF
--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -17,7 +17,7 @@ class PricePolicy < ApplicationRecord
 
   with_options if: -> { SettingsHelper.feature_on?(:price_policy_requires_note) } do
     # Length of 10 is defined by Dartmouth.
-    validates :note, presence: true, length: { minimum: 10, allow_blank: true }
+    validates :note, presence: true, length: { minimum: 10, allow_blank: true }, on: :create
   end
   validates :note, length: { maximum: 256 }
 

--- a/spec/models/price_policy_spec.rb
+++ b/spec/models/price_policy_spec.rb
@@ -247,6 +247,12 @@ RSpec.describe PricePolicy do
         expect(note).to be_invalid
         expect(note.errors).to be_added(:note, :too_long, count: 256)
       end
+
+      it "does not require the note for existing records" do
+        price_policy = FactoryBot.create(:item_price_policy, product: @item, price_group: @price_group)
+        price_policy.note = ""
+        expect(price_policy).to be_valid
+      end
     end
 
     context "when the required note feature is disabled", feature_setting: { price_policy_requires_note: false } do


### PR DESCRIPTION
# Release Notes

Only require note for newly-created Price Policies

# Additional Context

I did this work in `nucore-dartmouth` to expedite getting a hotfix released, so this PR just pulls up the code into `nucore-open` so that there’s not a conflict on the next regular release.