### PR TITLE
Add spec for timed services in export raw

### DIFF
--- a/spec/factories/price_policies.rb
+++ b/spec/factories/price_policies.rb
@@ -42,7 +42,7 @@ FactoryBot.define do
 
   factory :timed_service_price_policy do
     charge_for { "usage" }
-    usage_rate { 15 / 60.0 }
+    usage_rate { 60.0 } # $1/minute
     usage_subsidy { 0 }
     minimum_cost { 1 }
     can_purchase { true }

--- a/spec/models/reports/export_raw_spec.rb
+++ b/spec/models/reports/export_raw_spec.rb
@@ -95,7 +95,51 @@ RSpec.describe Reports::ExportRaw do
         expect(report.to_csv.split("\n").length).to eq(2)
       end
     end
+  end
 
+  describe "for a timed service" do
+    let(:timed_service) { FactoryBot.create(:setup_timed_service, facility: facility) }
+    let(:order_detail) do
+      place_product_order(user, facility, timed_service, account).tap do |od|
+        od.complete!
+        od.manually_priced!
+        od.update_attributes!(
+          quantity: 60,
+          actual_cost: BigDecimal("199.99"),
+          actual_subsidy: BigDecimal("29.99"),
+          estimated_cost: BigDecimal("39.99"),
+          estimated_subsidy: BigDecimal("29.99"),
+          price_change_reason: "this is a reason",
+          assigned_user: user,
+        )
+      end
+    end
+
+    it "populates the report" do
+      expect(report).to have_column_values(
+        Facility.model_name.human => "My Facility (MF)",
+        "Order" => order_detail.to_s,
+        "Ordered By" => user.username,
+        "First Name" => user.first_name,
+        "Last Name" => user.last_name,
+        "Quantity" => "60",
+        "Estimated Cost" => "$39.99",
+        "Estimated Subsidy" => "$29.99",
+        "Estimated Total" => "$10.00",
+        "Calculated Cost" => "$60.00", # default is $1/minute
+        "Calculated Subsidy" => "$0.00",
+        "Calculated Total" => "$60.00",
+        "Actual Cost" => "$199.99",
+        "Actual Subsidy" => "$29.99",
+        "Actual Total" => "$170.00",
+        "Difference Cost" => "$139.99",
+        "Difference Subsidy" => "$29.99",
+        "Difference Total" => "$110.00",
+        "Charge For" => "Usage",
+        "Assigned Staff" => user.full_name,
+        "Bundle" => "",
+      )
+    end
   end
 
   describe "with a reservation", :time_travel do

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -52,7 +52,7 @@ def place_product_order(ordered_by, facility, product, account = nil, purchased 
 
   FactoryBot.create(:user_price_group_member, user: ordered_by, price_group: @price_group)
   create(:account_price_group_member, account: account, price_group: @price_group) if account.present?
-  @item_pp = product.send(:"#{product.class.name.downcase}_price_policies").create(FactoryBot.attributes_for(:"#{product.class.name.downcase}_price_policy", price_group_id: @price_group.id))
+  @item_pp = product.send(:"#{product.class.name.underscore.downcase}_price_policies").create(FactoryBot.attributes_for(:"#{product.class.name.underscore.downcase}_price_policy", price_group_id: @price_group.id))
   @item_pp.reload.restrict_purchase = false
   od_attrs = { product_id: product.id }
   od_attrs[:account_id] = account.id if account


### PR DESCRIPTION
# Release Notes

Tech task: Add spec for timed services in export raw

# Additional Context

We found an issue in Dartmouth with one of their custom columns and discovered there wasn't a base spec for timed services in the export raw.

