### PR TITLE
[#139335] Tool for turning all relays for a core on or off, at once

### DIFF
--- a/app/controllers/relays_activations_controller.rb
+++ b/app/controllers/relays_activations_controller.rb
@@ -10,14 +10,14 @@ class RelaysActivationsController < ApplicationController
     relays.each(&:activate)
     redirect_to facility_instruments_path(current_facility), flash: { notice: text("turned_on") }
   rescue NetBooter::Error
-    redirect_to facility_instruments_path(current_facility), flash: { notice: text("connection_error") }
+    redirect_to facility_instruments_path(current_facility), flash: { alert: text("connection_error") }
   end
 
   def destroy
     relays.each(&:deactivate)
     redirect_to facility_instruments_path(current_facility), flash: { notice: text("turned_off") }
   rescue NetBooter::Error
-    redirect_to facility_instruments_path(current_facility), flash: { notice: text("connection_error") }
+    redirect_to facility_instruments_path(current_facility), flash: { alert: text("connection_error") }
   end
 
   private

--- a/app/controllers/relays_activations_controller.rb
+++ b/app/controllers/relays_activations_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class RelaysActivationsController < ApplicationController
+
+  before_action :authenticate_user!
+  before_action :init_current_facility
+  authorize_resource :facility
+
+  def create
+    current_facility.instruments.includes(:relay).select(&:has_real_relay?).each do |instrument|
+      instrument.relay.activate
+      instrument.instrument_statuses.create(is_on: true)
+    end
+
+    redirect_to facility_instruments_path(current_facility), flash: { notice: text("turned_on") }
+  end
+
+  def destroy
+    current_facility.instruments.includes(:relay).select(&:has_real_relay?).each do |instrument|
+      instrument.relay.deactivate
+      instrument.instrument_statuses.create(is_on: false)
+    end
+
+    redirect_to facility_instruments_path(current_facility), flash: { notice: text("turned_off") }
+  end
+
+end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -44,6 +44,10 @@ module ProductsHelper
     )
   end
 
+  def show_buttons_to_control_all_relays?(products)
+    products.first.is_a?(Instrument) && products.includes(:relay).select(&:has_real_relay?).any?
+  end
+
   private
 
   def public_calendar_options(product)

--- a/app/views/admin/products/index.html.haml
+++ b/app/views/admin/products/index.html.haml
@@ -12,7 +12,10 @@
 %p= text("views.admin.#{plural_object_name}.index.description")
 
 - if current_user.manager_of?(current_facility)
-  %p= link_to text("admin.shared.add", model: product_class.model_name.human), [:new, current_facility, singular_object_name], class: "btn-add"
+  %p
+    = link_to text("admin.shared.add", model: product_class.model_name.human), [:new, current_facility, singular_object_name], class: "btn-add"
+    = link_to text("admin.shared.turn_all_relays_on"), facility_relays_activation_path(current_facility), method: :post, class: "btn btn-primary"
+    = link_to text("admin.shared.turn_all_relays_off"), facility_relays_activation_path(current_facility), method: :delete, class: "btn btn-danger"
 
 - if @products.empty?
   %p.notice= text(".none.#{active_key}", models: product_class.model_name.human(count: 2).downcase)

--- a/app/views/admin/products/index.html.haml
+++ b/app/views/admin/products/index.html.haml
@@ -14,8 +14,9 @@
 - if current_user.manager_of?(current_facility)
   %p
     = link_to text("admin.shared.add", model: product_class.model_name.human), [:new, current_facility, singular_object_name], class: "btn-add"
-    = link_to text("admin.shared.turn_all_relays_on"), facility_relays_activation_path(current_facility), method: :post, class: "btn btn-primary"
-    = link_to text("admin.shared.turn_all_relays_off"), facility_relays_activation_path(current_facility), method: :delete, class: "btn btn-danger"
+    - if show_buttons_to_control_all_relays?(@products)
+      = link_to text("admin.shared.turn_all_relays_on"), facility_relays_activation_path(current_facility), method: :post, class: "btn btn-primary", data: { confirm: t("shared.confirm_message") }
+      = link_to text("admin.shared.turn_all_relays_off"), facility_relays_activation_path(current_facility), method: :delete, class: "btn btn-danger", data: { confirm: t("shared.confirm_message") }
 
 - if @products.empty?
   %p.notice= text(".none.#{active_key}", models: product_class.model_name.human(count: 2).downcase)

--- a/app/views/admin/products/index.html.haml
+++ b/app/views/admin/products/index.html.haml
@@ -11,7 +11,7 @@
 
 %p= text("views.admin.#{plural_object_name}.index.description")
 
-- if current_user.manager_of?(current_facility)
+- if can?(:create, Product)
   %p
     = link_to text("admin.shared.add", model: product_class.model_name.human), [:new, current_facility, singular_object_name], class: "btn-add"
     - if show_buttons_to_control_all_relays?(@products)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,8 @@ en:
       add: "Add %{model}"
       add_to: "Add To %{model}"
       edit: "Edit %{model}"
+      turn_all_relays_on: Turn All Relays ON
+      turn_all_relays_off: Turn All Relays OFF
       tabnav_users:
         details: "Details"
         orders: "Orders"

--- a/config/locales/views/en.relays_activations.yml
+++ b/config/locales/views/en.relays_activations.yml
@@ -1,0 +1,5 @@
+en:
+  controllers:
+    relays_activations:
+      turned_on: Turned on!!!
+      turned_off: Turned off!!!

--- a/config/locales/views/en.relays_activations.yml
+++ b/config/locales/views/en.relays_activations.yml
@@ -1,5 +1,6 @@
 en:
   controllers:
     relays_activations:
-      turned_on: Turned on!!!
-      turned_off: Turned off!!!
+      turned_on: Successfully turned on all relays.
+      turned_off: Successfully turned off all relays.
+      connection_error: There was an error connecting to one or more relays. Please try again.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,8 @@ Nucore::Application.routes.draw do
       resource :alert, controller: "instrument_alerts", only: [:new, :create, :destroy]
     end
 
+    resource :relays_activation, only: [:create, :destroy]
+
     resources :services do
       facility_product_routing_concern
       resources :price_policies, controller: "service_price_policies", except: [:show]

--- a/spec/controllers/relays_activations_controller_spec.rb
+++ b/spec/controllers/relays_activations_controller_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RelaysActivationsController do
+  let(:user) { FactoryBot.create(:user, :administrator) }
+  let(:instrument) { FactoryBot.create(:setup_instrument) }
+  let(:relay) { build_stubbed(:relay) }
+
+  before do
+    allow_any_instance_of(Instrument).to receive(:has_real_relay?).and_return true
+    allow_any_instance_of(Instrument).to receive(:relay).and_return relay
+    allow(relay).to receive(:activate)
+    allow(relay).to receive(:deactivate)
+    sign_in user
+  end
+
+  describe "POST to #create" do
+    it "activates all real relays for the facility’s instruments" do
+      expect(relay).to receive(:activate)
+      post :create, params: { facility_id: instrument.facility.url_name }
+    end
+
+    it "redirects back to the instruments page" do
+      post :create, params: { facility_id: instrument.facility.url_name }
+      expect(response).to redirect_to facility_instruments_path(instrument.facility)
+    end
+
+    it "sets a notice in the flash" do
+      post :create, params: { facility_id: instrument.facility.url_name }
+      expect(flash[:notice]).to be_present
+    end
+
+    it "sets an alert in the flash when an error is encountered" do
+      allow(relay).to receive(:activate).and_raise(NetBooter::Error)
+      post :create, params: { facility_id: instrument.facility.url_name }
+      expect(flash[:alert]).to be_present
+    end
+  end
+
+  context "DELETE to :destroy" do
+    it "deactivates all real relays for the facility’s instruments" do
+      expect(relay).to receive(:deactivate)
+      delete :destroy, params: { facility_id: instrument.facility.url_name }
+    end
+
+    it "redirects back to the instruments page" do
+      delete :destroy, params: { facility_id: instrument.facility.url_name }
+      expect(response).to redirect_to facility_instruments_path(instrument.facility)
+    end
+
+    it "sets a notice in the flash" do
+      delete :destroy, params: { facility_id: instrument.facility.url_name }
+      expect(flash[:notice]).to be_present
+    end
+
+    it "sets an alert in the flash when an error is encountered" do
+      allow(relay).to receive(:deactivate).and_raise(NetBooter::Error)
+      delete :destroy, params: { facility_id: instrument.facility.url_name }
+      expect(flash[:alert]).to be_present
+    end
+  end
+end

--- a/spec/controllers/relays_activations_controller_spec.rb
+++ b/spec/controllers/relays_activations_controller_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe RelaysActivationsController do
-  let(:user) { FactoryBot.create(:user, :administrator) }
   let(:instrument) { FactoryBot.create(:setup_instrument) }
+  let(:user) { FactoryBot.create(:user, :facility_director, facility: instrument.facility) }
   let(:relay) { build_stubbed(:relay) }
 
   before do


### PR DESCRIPTION
# Release Notes

Tool for turning all relays for a core on or off, at once

# Screenshot

<img width="641" alt="screen shot 2019-01-25 at 13 51 11" src="https://user-images.githubusercontent.com/7736/51746970-4ffbb000-20a8-11e9-81eb-05bef603f5b2.png">

# Additional Context

Since these actions call activate/deactivate on all relays regardless of their current status, I am not creating InstrumentStatus records on the instruments to signify that there was a change (because perhaps there was not one). This should be okay, because https://github.com/tablexi/nucore-open/blob/master/app/controllers/instruments_controller.rb#L72-L77 reconciles a relay’s actual status by creating (or skipping) an InstrumentStatus record on view.