### PR TITLE
Tech task: Fix spec for export raw price calculation.

### DIFF
--- a/spec/models/reports/export_raw_spec.rb
+++ b/spec/models/reports/export_raw_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Reports::ExportRaw do
     describe "with a broken reservation" do
       before do
         instrument.price_policies.each { |pp| pp.update(start_date: 3.days.ago, usage_rate: 60) }
-        order_detail.update_attributes!(account: account)
+        order_detail.reassign_price && order_detail.save!
         reservation.really_destroy!
       end
 


### PR DESCRIPTION
# Release Notes

Tech task: Fix spec for export raw price calculation.

# Screenshot

Optional.

# Additional Context

Cherry-picked from https://github.com/tablexi/nucore-dartmouth/pull/253

This will trigger pricing w/o changing the account. The account change was causing price group issues in Dartmouth. I'm pretty sure this change will also fix a spec in UIC.

