### PR TITLE
Tech task: Fix feature-flag dependent specs

### DIFF
--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -157,14 +157,14 @@ RSpec.describe InstrumentsController do
           do_request
         end
 
-        context "if the training request feature is enabled", feature_setting: { training_requests: true } do
+        context "if the training request feature is enabled", feature_setting: { training_requests: true, reload_routes: true } do
           it "gives the user the option to submit a request for approval" do
             expect(assigns[:add_to_cart]).to be_blank
             assert_redirected_to(new_facility_product_training_request_path(facility, instrument))
           end
         end
 
-        context "if the training request feature is disabled", feature_setting: { training_requests: false } do
+        context "if the training request feature is disabled", feature_setting: { training_requests: false, reload_routes: true } do
           it "denies access to the user" do
             expect(assigns[:add_to_cart]).to be_blank
             expect(flash[:notice]).to include("instrument requires approval")

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -1377,7 +1377,7 @@ RSpec.describe ReservationsController do
     end
   end
 
-  describe "timeline as guest", feature_setting: { daily_view: true } do
+  describe "timeline as guest", feature_setting: { daily_view: true, reload_routes: true } do
     let!(:hidden_instrument) do
       create(
         :instrument,

--- a/spec/features/admin/account_facility_joins_controller_spec.rb
+++ b/spec/features/admin/account_facility_joins_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AccountFacilityJoinsController do
+RSpec.describe AccountFacilityJoinsController, feature_setting: { edit_accounts: true, multi_facility_accounts: true, reload_routes: true } do
 
   # Not all implementations have facility-specific account types, so build our own for this
   # set of specs.

--- a/spec/features/admin/managing_training_requests_spec.rb
+++ b/spec/features/admin/managing_training_requests_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Managing training a request", feature_setting: { training_requests: true } do
+RSpec.describe "Managing training a request", feature_setting: { training_requests: true, reload_routes: true } do
   let(:director) { create(:user, :facility_director, facility: facility) }
   let!(:training_request) { create(:training_request) }
   let(:facility) { training_request.product.facility }

--- a/spec/features/admin/managing_user_spec.rb
+++ b/spec/features/admin/managing_user_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Managing User Details", :aggregate_failures, feature_setting: { create_users: true, user_based_price_groups: true } do
+RSpec.describe "Managing User Details", :aggregate_failures, feature_setting: { create_users: true, user_based_price_groups: true, reload_routes: true } do
 
   let(:facility) { FactoryBot.create(:facility) }
 

--- a/spec/features/admin/product_notifications_controller_spec.rb
+++ b/spec/features/admin/product_notifications_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ProductNotificationsController, feature_setting: { training_requests: true } do
+RSpec.describe ProductNotificationsController, feature_setting: { training_requests: true, reload_routes: true } do
   let(:facility) { create(:setup_facility) }
   let!(:instrument) { create(:instrument, facility: facility) }
 

--- a/spec/features/admin/suspending_a_user_spec.rb
+++ b/spec/features/admin/suspending_a_user_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "User suspension", feature_setting: { create_users: true } do
+RSpec.describe "User suspension", feature_setting: { create_users: true, reload_routes: true } do
   let(:facility) { create(:facility) }
   let(:user) { create(:user, email: "todelete@example.com", first_name: "Del", last_name: "User") }
 

--- a/spec/features/my_files_spec.rb
+++ b/spec/features/my_files_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Visiting my files", feature_setting: { my_files: true } do
+RSpec.describe "Visiting my files", feature_setting: { my_files: true, reload_routes: true } do
   let(:facility) { FactoryBot.create(:setup_facility) }
   let!(:service) { FactoryBot.create(:setup_service, facility: facility) }
   let!(:account) { FactoryBot.create(:nufs_account, :with_account_owner, owner: user) }

--- a/spec/features/passwords_spec.rb
+++ b/spec/features/passwords_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Passwords", :aggregate_failures, feature_setting: { password_update: true } do
+RSpec.describe "Passwords", :aggregate_failures, feature_setting: { password_update: true, reload_routes: true } do
   let(:external_user) { FactoryBot.create(:user, :external, password: "originalpassword") }
   let(:internal_user) { FactoryBot.create(:user, password: "originalpassword") }
 

--- a/spec/models/product_for_cart_spec.rb
+++ b/spec/models/product_for_cart_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe ProductForCart do
         allow(user).to receive(:can_override_restrictions?).and_return(false)
       end
 
-      context "and training requests are turned on", feature_setting: { training_requests: true } do
+      context "and training requests are turned on", feature_setting: { training_requests: true, reload_routes: true } do
         context "and the user has already submitted a training request" do
           before(:each) { allow(TrainingRequest).to receive(:submitted?).and_return(true) }
 
@@ -95,7 +95,7 @@ RSpec.describe ProductForCart do
         end
       end
 
-      context "and training requests are turned off", feature_setting: { training_requests: false } do
+      context "and training requests are turned off", feature_setting: { training_requests: false, reload_routes: true } do
         it "sets error_message explaining that the product requires approval" do
           product_for_cart.purchasable_by?(user, user)
           expect(product_for_cart.error_message).to match(/requires approval to purchase/)

--- a/spec/services/results_file_notifier_spec.rb
+++ b/spec/services/results_file_notifier_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ResultsFileNotifier do
   let(:stored_file) { FactoryBot.create(:stored_file, :results, order_detail: order.order_details.first) }
   let(:notifier) { described_class.new(stored_file) }
 
-  describe "with notifications enabled", feature_setting: { results_file_notifications: true, my_files: true } do
+  describe "with notifications enabled", feature_setting: { results_file_notifications: true, my_files: true, reload_routes: true } do
     it "sends a notification" do
       expect { notifier.notify }.to change(ActionMailer::Base.deliveries, :count).by(1)
     end

--- a/vendor/engines/bulk_email/spec/features/bulk_emailer_searching_spec.rb
+++ b/vendor/engines/bulk_email/spec/features/bulk_emailer_searching_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Bulk email search", feature_setting: { training_requests: true } do
+RSpec.describe "Bulk email search", feature_setting: { training_requests: true, reload_routes: true } do
   let!(:training_request) { create(:training_request) }
   let(:facility) { training_request.product.facility }
   let(:instrument) { training_request.product }


### PR DESCRIPTION
# Release Notes

Tech task: Fix specs that are dependent on feature flagged routes.

# Screenshot

Optional.

# Additional Context

These all pass with the default `nucore-open` settings, but were failing in UIC where some of the flags are disabled.

See https://github.com/tablexi/nucore-uic/pull/223 for status
