### PR TITLE
[#144419] Fix account_facility_joins migration to work on Oracle

### DIFF
--- a/db/migrate/20190104011154_change_account_facility_relationship_144419.rb
+++ b/db/migrate/20190104011154_change_account_facility_relationship_144419.rb
@@ -3,8 +3,8 @@
 class ChangeAccountFacilityRelationship144419 < ActiveRecord::Migration[5.0]
   def up
     create_table :account_facility_joins do |t|
-      t.references :facility, index: true, null: false, foreign_key: true
-      t.references :account, index: true, null: false, foreign_key: true
+      t.references :facility, index: { name: "idx_afj_on_facility_id" }, null: false, foreign_key: true
+      t.references :account, index: { name: "idx_afj_on_account_id" }, null: false, foreign_key: true
       t.datetime :deleted_at
       t.timestamps
     end


### PR DESCRIPTION
# Release Notes

Fix account_facility_joins migration to work on Oracle

# Additional Context

Even though Oracle 12.2 supports long identifiers (up to 128 characters), and the migration by default tries to create index names like `index_account_facility_joins_on_account_id` (which should be fine), the [Oracle adapter for Rails hard-codes a limit of 30 characters](https://github.com/rsim/oracle-enhanced/blob/master/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb#L10), which will [only be increased with support for Rails 6.0](https://github.com/rsim/oracle-enhanced/issues/1819#issuecomment-458356560). Hence, we still have to conform to 30-character identifier limits until we can upgrade to a new enough version of the adapter after upgrading to Rails 6 😞

I will manually change the index names in Darmouth’s staging database, which is the only place where this migration has already been run.