### PR TITLE
[#144419] Use INSERT INTO that works on Oracle in migration

### DIFF
--- a/db/migrate/20190104011154_change_account_facility_relationship_144419.rb
+++ b/db/migrate/20190104011154_change_account_facility_relationship_144419.rb
@@ -9,13 +9,24 @@ class ChangeAccountFacilityRelationship144419 < ActiveRecord::Migration[5.0]
       t.timestamps
     end
 
-    execute <<~SQL
-      INSERT INTO account_facility_joins
-      (account_id, facility_id, created_at, updated_at)
-      SELECT id, facility_id, created_at, updated_at
-      FROM accounts
-      WHERE facility_id IS NOT NULL
-    SQL
+    if NUCore::Database.oracle?
+      execute <<~SQL
+        INSERT INTO account_facility_joins (id, account_id, facility_id, created_at, updated_at)
+        SELECT ACCOUNT_FACILITY_JOINS_SEQ.NEXTVAL, account_id, facility_id, created_at, updated_at
+        FROM (
+          SELECT id account_id, facility_id, created_at, updated_at
+          FROM accounts
+          WHERE facility_id IS NOT NULL
+        )
+      SQL
+    else
+      execute <<~SQL
+        INSERT INTO account_facility_joins (account_id, facility_id, created_at, updated_at)
+        SELECT id, facility_id, created_at, updated_at
+        FROM accounts
+        WHERE facility_id IS NOT NULL
+      SQL
+    end
   end
 
   def down


### PR DESCRIPTION
# Release Notes

Use INSERT INTO that works on Oracle in migration

# Additional Context

As-is, the migration fails in Oracle because [when a column is marked as not null, it must be specified in the `INSERT INTO` clause](https://asktom.oracle.com/pls/apex/asktom.search?tag=cannot-insert-null-values-to-a-column-defined-not-null-with-default-constraint). Therefore, we use the next value of the sequence for `account_facility_joins.id` to insert the correct value, and we leave the migration as-is for other databases.