### PR TITLE
[#144419] Improve PO description if it's part of more than one facility

### DIFF
--- a/vendor/engines/c2po/app/models/purchase_order_account.rb
+++ b/vendor/engines/c2po/app/models/purchase_order_account.rb
@@ -9,7 +9,7 @@ class PurchaseOrderAccount < Account
 
   def to_s(with_owner = false, flag_suspended = true)
     desc = super(with_owner, false)
-    desc += " / #{facility_description}"
+    desc += " / #{facility_description}" if facilities.present?
     desc += " (#{display_status.upcase})" if flag_suspended && suspended?
     desc
   end

--- a/vendor/engines/c2po/app/models/purchase_order_account.rb
+++ b/vendor/engines/c2po/app/models/purchase_order_account.rb
@@ -9,9 +9,23 @@ class PurchaseOrderAccount < Account
 
   def to_s(with_owner = false, flag_suspended = true)
     desc = super(with_owner, false)
-    desc += " / #{facility.name}" if facility
+    desc += " / #{facility_description}"
     desc += " (#{display_status.upcase})" if flag_suspended && suspended?
     desc
+  end
+
+  private
+
+  def facility_description
+    if facilities.length > 1
+      I18n.t(
+        "purchase_order_account.shared_facility_description",
+        count: facilities.length,
+        facilities: Facility.model_name.human(count: facilities.length)
+      )
+    else
+      facilities.first.name
+    end
   end
 
 end

--- a/vendor/engines/c2po/config/locales/en.yml
+++ b/vendor/engines/c2po/config/locales/en.yml
@@ -32,6 +32,9 @@ en:
     credit_card: Credit Card
     po: Purchase Order
 
+  purchase_order_account:
+    shared_facility_description: Shared (%{count} %{facilities})
+
   activerecord:
     models:
       credit_card_account:

--- a/vendor/engines/c2po/spec/models/purchase_order_account_spec.rb
+++ b/vendor/engines/c2po/spec/models/purchase_order_account_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe PurchaseOrderAccount do
+  include TextHelpers
+
   let(:facility) { FactoryBot.create(:facility) }
   subject(:account) { FactoryBot.create(:purchase_order_account, :with_account_owner, facility: facility) }
 
@@ -24,4 +26,11 @@ RSpec.describe PurchaseOrderAccount do
   it "has the facility association" do
     expect(account.facility).to eq facility
   end
+
+  it "rolls the facilities up in the description of there are more than one" do
+    facility2 = FactoryBot.create(:facility)
+    account.facilities << facility2
+    expect(account.to_s).to include "2 #{Facility.model_name.human.pluralize}"
+  end
+
 end


### PR DESCRIPTION
# Release Notes

Improve PO description if it's part of more than one facility. If it's part of more than one facility, it will now include "Shared (X Facilities)" as part of the description rather than the original facility it was created under.

# Additional Context

This should support Dartmouth's "Resources" naming override, so they should see "Shared (X Resources)"
