### PR TITLE
[#144300] Rearrange payment source dropdown on add to order

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -388,6 +388,15 @@ textarea.wide {
   margin-right: 2.5em;
 }
 
+.inline-form-controls {
+  display: flex;
+  flex-wrap: wrap;
+
+  .control-group {
+    margin-right: 3rem;
+  }
+}
+
 .productListLine {
   display: flex;
 }

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -10,21 +10,18 @@
 
       = f.input_field :duration, class: "js--edit-order__duration"
 
-      .container
-        .row
-          .span4
-            = f.input :order_status_id,
-              collection: OrderStatus.add_to_order_statuses(current_facility),
-              label_method: :name_with_level,
-              input_html: { class: "js--chosen" },
-              include_blank: false,
-              label: OrderDetail.human_attribute_name(:order_status)
-          .span4
-            = f.input :account_id,
-              collection: @add_to_order_form.available_accounts,
-              include_blank: !@order.account.active?,
-              hint: @order.account.active? ? "" : t(".original_account_inactive", account: @order.account),
-              input_html: { class: "js--chosen" }
+      .inline-form-controls
+        = f.input :order_status_id,
+          collection: OrderStatus.add_to_order_statuses(current_facility),
+          label_method: :name_with_level,
+          input_html: { class: "js--chosen" },
+          include_blank: false,
+          label: OrderDetail.human_attribute_name(:order_status)
+        = f.input :account_id,
+          collection: @add_to_order_form.available_accounts,
+          include_blank: !@order.account.active?,
+          hint: @order.account.active? ? "" : t(".original_account_inactive", account: @order.account),
+          input_html: { class: "js--chosen" }
 
 
       = f.input_field :fulfilled_at,

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -10,18 +10,22 @@
 
       = f.input_field :duration, class: "js--edit-order__duration"
 
-      = f.input :account_id,
-        collection: @add_to_order_form.available_accounts,
-        include_blank: !@order.account.active?,
-        hint: @order.account.active? ? "" : t(".original_account_inactive", account: @order.account),
-        input_html: { class: "js--chosen" }
+      .container
+        .row
+          .span4
+            = f.input :order_status_id,
+              collection: OrderStatus.add_to_order_statuses(current_facility),
+              label_method: :name_with_level,
+              input_html: { class: "js--chosen" },
+              include_blank: false,
+              label: OrderDetail.human_attribute_name(:order_status)
+          .span4
+            = f.input :account_id,
+              collection: @add_to_order_form.available_accounts,
+              include_blank: !@order.account.active?,
+              hint: @order.account.active? ? "" : t(".original_account_inactive", account: @order.account),
+              input_html: { class: "js--chosen" }
 
-      = f.input :order_status_id,
-        collection: OrderStatus.add_to_order_statuses(current_facility),
-        label_method: :name_with_level,
-        input_html: { class: "js--chosen" },
-        include_blank: false,
-        label: OrderDetail.human_attribute_name(:order_status)
 
       = f.input_field :fulfilled_at,
         placeholder: OrderDetail.human_attribute_name(:fulfilled_at),


### PR DESCRIPTION
# Release Notes

Move the payment source dropdown to be next to the order status on the add to order form.

# Screenshot

<img width="1228" alt="screen shot 2019-02-01 at 1 16 09 pm" src="https://user-images.githubusercontent.com/1099111/52144465-040ab700-2624-11e9-8373-0260b16fe1c5.png">
<img width="384" alt="screen shot 2019-02-01 at 1 16 23 pm" src="https://user-images.githubusercontent.com/1099111/52144460-02d98a00-2624-11e9-96a5-351d0585d5b5.png">

# Additional Context

Per the client "Payment Source modification won't be super common, so we don't need this to be as prominent as the status selector."
