### PR TITLE
[#144524] Fix red select text in Firefox

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -379,6 +379,13 @@ textarea.wide {
   position: static;
 }
 
+/* Bootstrap turns the text options in the dropdown red in Firefox. This behavior
+ * is fine for regular inputs, but looks very strange in selects.
+ */
+select:focus:invalid {
+  color: inherit;
+}
+
 .checkboxControl {
   display: flex;
   min-height: 6em;


### PR DESCRIPTION
# Release Notes

Fix red text in `select` dropdowns in Firefox, specifically in the add product to bundle form.

# Screenshot

Before:

<img width="280" alt="screen shot 2019-02-01 at 3 21 40 pm" src="https://user-images.githubusercontent.com/1099111/52150294-1e00c580-2635-11e9-9768-ad3a035553f6.png">

# Additional Context

This would have been happening on any `required` dropdown (that's not `js--chosen`) when the blank `option` was selected. This only seems to happen in Firefox. There is still a red border while the `select` is focused, but that is similar to other inputs (e.g. type a letter into a `number` field and it gets a red border _and_ the text is red).