### PR TITLE
Show all facilities for account in user listing

### DIFF
--- a/app/views/shared/_accounts_table.html.haml
+++ b/app/views/shared/_accounts_table.html.haml
@@ -7,5 +7,4 @@
     - @accounts.each do |account|
       %tr
         %td= payment_source_link_or_text(account)
-        %td{style: "padding-left: 50px"}
-          = account.facility || "<i>All</i>".html_safe
+        %td= account.per_facility? ? account.facilities.join(", ") :  content_tag(:i, t("shared.all"))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,6 +95,7 @@ en:
     training_requests: Training Requests
 
   shared:
+    all: All
     cancel: Cancel
     create: Create
     confirm_message: Are you sure?


### PR DESCRIPTION
# Release Notes

Fix display of multi-facility accounts in the Manage Facilities > Users > User > Payment Sources tab.

# Additional Context

I thought I had done this already, but it might have gotten lost in one of my branches. I'm surprised this doesn't error on #1863. I may try to add a spec over there to catch this.

This could get unwieldy if they start adding too many facilities, but I think we can address it if it becomes a problem. I was thinking maybe truncating after a certain number, so "Facility 1, Facility 2, Facility 3, and X more..." or something like that.
