### PR TITLE
[#147749] Add product-specific recipients for "Report an Issue"

### DIFF
--- a/app/controllers/product_notifications_controller.rb
+++ b/app/controllers/product_notifications_controller.rb
@@ -37,6 +37,7 @@ class ProductNotificationsController < ApplicationController
       :training_request_contacts,
       :order_notification_recipient,
       :cancellation_email_recipients,
+      :issue_report_recipients,
     )
   end
 

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -18,6 +18,7 @@ class Instrument < Product
   has_one :alert, dependent: :destroy, class_name: "InstrumentAlert"
 
   email_list_attribute :cancellation_email_recipients
+  email_list_attribute :issue_report_recipients
 
   # Validations
   # --------

--- a/app/models/instrument_issue.rb
+++ b/app/models/instrument_issue.rb
@@ -17,14 +17,18 @@ class InstrumentIssue
       product: product,
       user: user,
       message: message,
-      recipients: recipients,
+      recipients: recipients.to_a,
     ).deliver_later
   end
 
   def recipients
-    # Per NU, `Facility#email` is intentionally left out #137686
-    all = product.facility.director_and_admins.pluck(:email) + product.training_request_contacts
-    all.uniq
+    if product.issue_report_recipients.present?
+      product.issue_report_recipients
+    else
+      # Per NU, `Facility#email` is intentionally left out #137686
+      all = product.facility.director_and_admins.pluck(:email) + product.training_request_contacts
+      all.uniq
+    end
   end
 
 end

--- a/app/views/product_notifications/edit.html.haml
+++ b/app/views/product_notifications/edit.html.haml
@@ -15,6 +15,7 @@
     - key = current_facility.order_notification_recipient.present? ? "hints.order_notification_with_facility" : "hints.order_notification"
     = f.input :order_notification_recipient, as: :email, hint: text(key, email: current_facility.order_notification_recipient)
     = f.input :cancellation_email_recipients, as: :string, hint: text("hints.cancellation_email_recipients") if @product.is_a?(Instrument)
+    = f.input :issue_report_recipients, as: :string, hint: text("hints.issue_report_recipients") if @product.is_a?(Instrument)
 
   %ul.inline
     %li= f.submit text("shared.save"), class: ["btn", "btn-primary"]

--- a/app/views/product_notifications/show.html.haml
+++ b/app/views/product_notifications/show.html.haml
@@ -12,8 +12,12 @@
       = f.input :training_request_contacts, as: :string
     - hint = current_facility.order_notification_recipient.present? ? text("hints.already_configured", email: current_facility.order_notification_recipient) : nil
     = f.input :order_notification_recipient, as: :email, hint: hint
-    = f.input :cancellation_email_recipients, as: :string if @product.is_a?(Instrument)
-    = f.input :issue_report_recipients, as: :string if @product.is_a?(Instrument)
+    - if @product.is_a?(Instrument)
+      = f.input :cancellation_email_recipients, as: :string
+
+      - issue_report_hint = text("hints.issue_report_recipients") if f.object.issue_report_recipients.blank?
+      = f.input :issue_report_recipients, as: :string, hint: issue_report_hint
+
 
 - if can?(:edit, @product)
   = link_to text("shared.edit"), edit_facility_product_notifications_path(current_facility, @product), class: "btn"

--- a/app/views/product_notifications/show.html.haml
+++ b/app/views/product_notifications/show.html.haml
@@ -13,6 +13,7 @@
     - hint = current_facility.order_notification_recipient.present? ? text("hints.already_configured", email: current_facility.order_notification_recipient) : nil
     = f.input :order_notification_recipient, as: :email, hint: hint
     = f.input :cancellation_email_recipients, as: :string if @product.is_a?(Instrument)
+    = f.input :issue_report_recipients, as: :string if @product.is_a?(Instrument)
 
 - if can?(:edit, @product)
   = link_to text("shared.edit"), edit_facility_product_notifications_path(current_facility, @product), class: "btn"

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -264,6 +264,7 @@ en:
         training_request_contacts: Training Request Recipients
         order_notification_recipient: Order Notification Recipient
         cancellation_email_recipients: Cancellation Notification Recipients
+        issue_report_recipients: Alternate Issue Report Recipients
       product_accessory:
         scaling_type: Scaling Type
       instrument:

--- a/config/locales/views/admin/en.product_notifications.yml
+++ b/config/locales/views/admin/en.product_notifications.yml
@@ -5,6 +5,7 @@ en:
         none_entered: None
         hints:
           already_configured: "%{email} is already configured to receive all order notifications for the !facility_downcase!."
+          issue_report_recipients: Facility Directors, Facility Administrators, and Training Request Recipients will receive each issue report if not designated.
       edit:
         instructions: Leave blank to skip notifications for the event.
         hints:
@@ -17,8 +18,8 @@ en:
           cancellation_email_recipients: |
             Comma separated list of email addresses to be notified when a reservation is canceled.
           issue_report_recipients: |
-            Comma separated list of email addresses to be notified when an issue is reported. Facility Directors,
-            Facility Administrators, and Training Request Recipients will receive each issue report if not designated.
+            Comma separated list of email addresses to be notified when an issue is reported.
+            !views.product_notifications.show.hints.issue_report_recipients!
 
   controllers:
     product_notifications:

--- a/config/locales/views/admin/en.product_notifications.yml
+++ b/config/locales/views/admin/en.product_notifications.yml
@@ -16,7 +16,9 @@ en:
           training_request_contacts: Comma separated list of email addresses to be notified when a training request is placed.
           cancellation_email_recipients: |
             Comma separated list of email addresses to be notified when a reservation is canceled.
-
+          issue_report_recipients: |
+            Comma separated list of email addresses to be notified when an issue is reported. Facility Directors,
+            Facility Administrators, and Training Request Recipients will receive each issue report if not designated.
 
   controllers:
     product_notifications:

--- a/db/migrate/20190220001838_add_issue_report_recipients_to_product.rb
+++ b/db/migrate/20190220001838_add_issue_report_recipients_to_product.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIssueReportRecipientsToProduct < ActiveRecord::Migration[5.0]
+  def change
+    add_column :products, :issue_report_recipients, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190104011154) do
+ActiveRecord::Schema.define(version: 20190220001838) do
 
   create_table "account_facility_joins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "facility_id", null: false
@@ -500,6 +500,7 @@ ActiveRecord::Schema.define(version: 20190104011154) do
     t.string   "user_notes_label"
     t.string   "order_notification_recipient"
     t.text     "cancellation_email_recipients", limit: 65535
+    t.text     "issue_report_recipients",       limit: 65535
     t.index ["dashboard_token"], name: "index_products_on_dashboard_token", using: :btree
     t.index ["facility_account_id"], name: "fk_facility_accounts", using: :btree
     t.index ["facility_id"], name: "fk_rails_0c9fa1afbe", using: :btree

--- a/spec/models/instrument_issue_spec.rb
+++ b/spec/models/instrument_issue_spec.rb
@@ -36,8 +36,18 @@ RSpec.describe InstrumentIssue do
     let!(:facility_staff) { create(:user, :staff, facility: facility) }
     let(:instrument_issue) { described_class.new(product: instrument) }
 
-    it "returns the training request and admin without duplication" do
-      expect(instrument_issue.recipients).to contain_exactly("training@example.com", "admin@example.com")
+    describe "without product-specific recipients defined" do
+      it "returns the training request and admin without duplication" do
+        expect(instrument_issue.recipients).to contain_exactly("training@example.com", "admin@example.com")
+      end
+    end
+
+    describe "with product-specific recipients defined" do
+      before { instrument.update!(issue_report_recipients: "alt1@example.com, alt2@example.com") }
+
+      it "returns the specified recipients" do
+        expect(instrument_issue.recipients).to contain_exactly("alt1@example.com", "alt2@example.com")
+      end
     end
   end
 

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -861,4 +861,18 @@ RSpec.describe Instrument do
       expect(subject.has_alert?).to be false
     end
   end
+
+  describe "issue_report_recipients" do
+    before do
+      instrument.issue_report_recipients = "test1@example.com, test2@example.com"
+    end
+
+    it "treats it as a string" do
+      expect(instrument.issue_report_recipients).to eq("test1@example.com, test2@example.com")
+    end
+
+    it "can interpret it as an array" do
+      expect(instrument.issue_report_recipients.to_a).to eq(["test1@example.com", "test2@example.com"])
+    end
+  end
 end


### PR DESCRIPTION
# Release Notes

Add the ability for a facility to specify a list of email recipients for each instrument's "Report an Issue" feature. If no list is specified, it will continue with the current behavior of notifying the facility directors, admins, and product's training request recipients.

# Screenshot

<img width="1215" alt="screen shot 2019-02-20 at 12 00 19 pm" src="https://user-images.githubusercontent.com/1099111/53058441-24cd7a80-3507-11e9-8566-f6a5eb66992a.png">
