### PR TITLE
Only execute multi_facility test if the c2po engine is enabled

### DIFF
--- a/spec/controllers/facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_accounts_controller_spec.rb
@@ -79,17 +79,19 @@ RSpec.describe FacilityAccountsController, feature_setting: { edit_accounts: tru
       end
     end
 
-    context "when the multi_facility_accounts feature is turned off", feature_setting: { multi_facility_accounts: false, reload_routes: true } do
-      let(:purchase_order) { FactoryBot.create(:purchase_order_account, :with_account_owner, facility: facility) }
+    if EngineManager.engine_loaded?(:c2po)
+      context "when the multi_facility_accounts feature is turned off", feature_setting: { multi_facility_accounts: false, reload_routes: true } do
+        let(:purchase_order) { FactoryBot.create(:purchase_order_account, :with_account_owner, facility: facility) }
 
-      before do
-        sign_in admin
-      end
+        before do
+          sign_in admin
+        end
 
-      it "does not show the facilities tab for a per-facility account to global admins" do
-        get :show, params: { facility_id: facility.to_param, id: purchase_order.to_param }
-        expect(response).to have_http_status(:ok)
-        expect(response.body).not_to include("/accounts/#{purchase_order.id}/facilities/edit")
+        it "does not show the facilities tab for a per-facility account to global admins" do
+          get :show, params: { facility_id: facility.to_param, id: purchase_order.to_param }
+          expect(response).to have_http_status(:ok)
+          expect(response.body).not_to include("/accounts/#{purchase_order.id}/facilities/edit")
+        end
       end
     end
 

--- a/spec/controllers/facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_accounts_controller_spec.rb
@@ -78,23 +78,6 @@ RSpec.describe FacilityAccountsController, feature_setting: { edit_accounts: tru
         is_expected.to render_template("show")
       end
     end
-
-    if EngineManager.engine_loaded?(:c2po)
-      context "when the multi_facility_accounts feature is turned off", feature_setting: { multi_facility_accounts: false, reload_routes: true } do
-        let(:purchase_order) { FactoryBot.create(:purchase_order_account, :with_account_owner, facility: facility) }
-
-        before do
-          sign_in admin
-        end
-
-        it "does not show the facilities tab for a per-facility account to global admins" do
-          get :show, params: { facility_id: facility.to_param, id: purchase_order.to_param }
-          expect(response).to have_http_status(:ok)
-          expect(response.body).not_to include("/accounts/#{purchase_order.id}/facilities/edit")
-        end
-      end
-    end
-
   end
 
   context "edit accounts" do

--- a/vendor/engines/c2po/spec/controllers/facility_accounts_controller_spec.rb
+++ b/vendor/engines/c2po/spec/controllers/facility_accounts_controller_spec.rb
@@ -49,8 +49,6 @@ RSpec.describe FacilityAccountsController do
         it_should_deny :director
       end
     end
-
-
   end
 
   context "PUT #update" do
@@ -222,6 +220,23 @@ RSpec.describe FacilityAccountsController do
           .to be_within(1.second).of(Time.zone.parse("#{expiration_year}-5-1").end_of_month.end_of_day)
         expect(assigns(:account).facilities).to eq([facility])
         expect(assigns(:account).facility_id).to eq(facility.id)
+      end
+    end
+  end
+
+  context "GET #show" do
+    context "when the multi_facility_accounts feature is turned off", feature_setting: { multi_facility_accounts: false, reload_routes: true } do
+      let(:admin) { @admin }
+      let(:purchase_order) { FactoryBot.create(:purchase_order_account, :with_account_owner, facility: facility) }
+
+      before do
+        sign_in admin
+      end
+
+      it "does not show the facilities tab for a per-facility account to global admins" do
+        get :show, params: { facility_id: facility.to_param, id: purchase_order.to_param }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("/accounts/#{purchase_order.id}/facilities/edit")
       end
     end
   end


### PR DESCRIPTION
# Release Notes

Only execute multi_facility test if the c2po engine is enabled

# Additional Context

The c2po engine adds the ability to accept credit cards and purchase orders. When this engine is not turned on (like the case is with UIC), the test modified in this PR can’t run because the code it tests is not loaded. Hence, this PR adds a guard for executing the test only when the engine is turned on.
