### PR TITLE
[#144828] Use database for setting product boolean defaults

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -104,14 +104,6 @@ class Product < ApplicationRecord
   end
 
   ## AR Hooks
-  before_validation do
-    self.requires_approval ||= false
-    self.is_archived       ||= false
-    self.is_hidden         ||= false
-
-    # return true so validations will run
-    true
-  end
   after_create :set_default_pricing
 
   def initial_order_status

--- a/db/migrate/20190227031006_fix_product_defaults.rb
+++ b/db/migrate/20190227031006_fix_product_defaults.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class FixProductDefaults < ActiveRecord::Migration[5.0]
+
+  def up
+    change_column_default :products, :requires_approval, false
+    change_column_default :products, :is_archived, false
+    change_column_default :products, :is_hidden, false
+  end
+
+  def down
+    change_column_default :products, :requires_approval, nil
+    change_column_default :products, :is_archived, nil
+    change_column_default :products, :is_hidden, nil
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190220001838) do
+ActiveRecord::Schema.define(version: 20190227031006) do
 
   create_table "account_facility_joins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "facility_id", null: false
@@ -477,10 +477,10 @@ ActiveRecord::Schema.define(version: 20190220001838) do
     t.string   "url_name",                      limit: 50,                       null: false
     t.text     "description",                   limit: 65535
     t.integer  "schedule_id"
-    t.boolean  "requires_approval",                                              null: false
+    t.boolean  "requires_approval",                           default: false,    null: false
     t.integer  "initial_order_status_id"
-    t.boolean  "is_archived",                                                    null: false
-    t.boolean  "is_hidden",                                                      null: false
+    t.boolean  "is_archived",                                 default: false,    null: false
+    t.boolean  "is_hidden",                                   default: false,    null: false
     t.datetime "created_at",                                                     null: false
     t.datetime "updated_at",                                                     null: false
     t.integer  "min_reserve_mins"


### PR DESCRIPTION
# Release Notes

Tech task: Use database defaults instead of activerecord callbacks for setting boolean fields on Product.

# Additional Context

Encountered as I was working on #144828 and looking to add a new field. It seemed weird to be inconsistent.
