### PR TITLE
[#144828] Toggle training requests per product

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -135,6 +135,10 @@ li.nav-spacer {
   @extend .alert-info;
 }
 
+.alert p:last-child {
+  margin-bottom: 0;
+}
+
 /*
   Product List
 */

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -24,14 +24,16 @@ class InstrumentsController < ProductsCommonController
   def show
     instrument_for_cart = InstrumentForCart.new(@product)
     @add_to_cart = instrument_for_cart.purchasable_by?(acting_user, session_user)
-
     if @add_to_cart
       redirect_to add_order_path(
         acting_user.cart(session_user),
         order: { order_details: [{ product_id: @product.id, quantity: 1 }] },
       )
-    else
+    elsif instrument_for_cart.error_path
       redirect_to instrument_for_cart.error_path, notice: instrument_for_cart.error_message
+    else
+      flash.now[:error] = instrument_for_cart.error_message if instrument_for_cart.error_message
+      render layout: "application"
     end
   end
 

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -32,7 +32,7 @@ class InstrumentsController < ProductsCommonController
     elsif instrument_for_cart.error_path
       redirect_to instrument_for_cart.error_path, notice: instrument_for_cart.error_message
     else
-      flash.now[:error] = instrument_for_cart.error_message if instrument_for_cart.error_message
+      flash.now[:notice] = instrument_for_cart.error_message if instrument_for_cart.error_message
       render layout: "application"
     end
   end

--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -103,7 +103,7 @@ class ProductsCommonController < ApplicationController
   def resource_params
     params.require(:"#{singular_object_name}").permit(:name, :url_name, :contact_email, :description,
                                                       :facility_account_id, :account, :initial_order_status_id,
-                                                      :requires_approval, :is_archived, :is_hidden,
+                                                      :requires_approval, :allows_training_requests, :is_archived, :is_hidden,
                                                       :user_notes_field_mode, :user_notes_label, :show_details,
                                                       :schedule_id, :control_mechanism, :reserve_interval,
                                                       :min_reserve_mins, :max_reserve_mins, :min_cancel_hours,

--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -44,7 +44,7 @@ class ProductsCommonController < ApplicationController
     if product_for_cart.error_path
       redirect_to product_for_cart.error_path, notice: product_for_cart.error_message
     else
-      flash.now[:notice] = product_for_cart.error_message if product_for_cart.error_message
+      flash.now[:error] = product_for_cart.error_message if product_for_cart.error_message
       render layout: "application"
     end
   end

--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -44,7 +44,7 @@ class ProductsCommonController < ApplicationController
     if product_for_cart.error_path
       redirect_to product_for_cart.error_path, notice: product_for_cart.error_message
     else
-      flash.now[:error] = product_for_cart.error_message if product_for_cart.error_message
+      flash.now[:notice] = product_for_cart.error_message if product_for_cart.error_message
       render layout: "application"
     end
   end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -36,14 +36,6 @@ module ProductsHelper
     end
   end
 
-  def product_url_hint(product)
-    public_send(
-      "facility_#{product.class.name.underscore}_url",
-      current_facility.url_name,
-      "URL_NAME".html_safe,
-    )
-  end
-
   def show_buttons_to_control_all_relays?(products)
     products.first.is_a?(Instrument) && products.includes(:relay).select(&:has_real_relay?).any?
   end

--- a/app/models/instrument_for_cart.rb
+++ b/app/models/instrument_for_cart.rb
@@ -2,15 +2,6 @@
 
 class InstrumentForCart < ProductForCart
 
-  def purchasable_by?(acting_user, session_user)
-    # If an instrument is not purchasable, we always redirect. Hence, if super
-    # doesn't set an error path due to some specific error, we set the error path
-    # to the facility path.
-    super.tap do |is_purchasable|
-      @error_path ||= url_helpers.facility_path(product.facility) unless is_purchasable
-    end
-  end
-
   private
 
   def checks(acting_user, session_user)

--- a/app/models/product_for_cart.rb
+++ b/app/models/product_for_cart.rb
@@ -60,7 +60,7 @@ class ProductForCart
   def check_that_product_can_be_used(acting_user, session_user)
     proc do
       if !product.can_be_used_by?(acting_user) && !(session_user.present? && session_user.can_override_restrictions?(product))
-        if SettingsHelper.feature_on?(:training_requests)
+        if SettingsHelper.feature_on?(:training_requests) && product.allows_training_requests?
           if TrainingRequest.submitted?(session_user, product)
             @error_message = text("models.product_for_cart.already_requested_access", i18n_params)
             @error_path = url_helpers.facility_path(product.facility)
@@ -68,7 +68,7 @@ class ProductForCart
             @error_path = url_helpers.new_facility_product_training_request_path(product.facility, product)
           end
         else
-          @error_message = html(".requires_approval", i18n_params)
+          @error_message = html("requires_approval", i18n_params)
         end
       end
     end

--- a/app/views/admin/products/_meta_fields.html.haml
+++ b/app/views/admin/products/_meta_fields.html.haml
@@ -1,6 +1,6 @@
-= f.input :name, hint: text("hints.name", field: f.object.class.model_name.human.downcase)
+= f.input :name, hint: text("hints.name", field: f.object.model_name.human.downcase)
 
-= f.input :url_name, hint: product_url_hint(f.object), as: :string
+= f.input :url_name, hint: url_for([current_facility, f.object.model_name.singular, id: "URL_NAME"]), as: :string
 
 - if SettingsHelper.feature_on? :product_specific_contacts
   = f.input :contact_email,

--- a/app/views/admin/products/_product_fields.html.haml
+++ b/app/views/admin/products/_product_fields.html.haml
@@ -4,7 +4,10 @@
   = render "admin/products/account_fields", f: f
 
   = f.input :initial_order_status_id, collection: OrderStatus.initial_statuses(current_facility).collect {|cf| [cf.name_with_level, cf.id] }, hint: text("hints.initial_order_status"), include_blank: false
-  = f.input :requires_approval, as: :boolean, label: false, inline_label: text("hints.requires_approval")
+  -# TODO: Either make this a dropdown or add JS to disable training request checkbox
+  %fieldset.well
+    = f.input :requires_approval, as: :boolean, label: false, inline_label: text("hints.requires_approval")
+    = f.input :allows_training_requests, as: :boolean, label: false, inline_label: text("hints.allows_training_requests")
 
 = f.input :is_archived, as: :boolean, label: false, inline_label: text("hints.is_archived")
 = f.input :is_hidden, as: :boolean, label: false, inline_label: text("hints.is_hidden", field: f.object.class.model_name.human.downcase)

--- a/app/views/admin/products/_product_fields.html.haml
+++ b/app/views/admin/products/_product_fields.html.haml
@@ -4,10 +4,11 @@
   = render "admin/products/account_fields", f: f
 
   = f.input :initial_order_status_id, collection: OrderStatus.initial_statuses(current_facility).collect {|cf| [cf.name_with_level, cf.id] }, hint: text("hints.initial_order_status"), include_blank: false
-  -# TODO: Either make this a dropdown or add JS to disable training request checkbox
+
   %fieldset.well
-    = f.input :requires_approval, as: :boolean, label: false, inline_label: text("hints.requires_approval")
-    = f.input :allows_training_requests, as: :boolean, label: false, inline_label: text("hints.allows_training_requests")
+    = f.input :requires_approval, as: :boolean, label: false, inline_label: text("hints.requires_approval"), input_html: { data: { disables: ".instrument_allows_training_requests"} }
+    - if SettingsHelper.feature_on?(:training_requests)
+      = f.input :allows_training_requests, as: :boolean, label: false, inline_label: text("hints.allows_training_requests")
 
 = f.input :is_archived, as: :boolean, label: false, inline_label: text("hints.is_archived")
 = f.input :is_hidden, as: :boolean, label: false, inline_label: text("hints.is_hidden", field: f.object.class.model_name.human.downcase)

--- a/app/views/products_common/manage.html.haml
+++ b/app/views/products_common/manage.html.haml
@@ -21,6 +21,8 @@
 
     = f.input :initial_order_status
     = f.input :requires_approval
+    - if f.object.requires_approval?
+      = f.input :allows_training_requests
   = f.input :is_archived
   = f.input :is_hidden
   - unless @product.is_a?(Bundle)

--- a/app/views/products_common/show.html.haml
+++ b/app/views/products_common/show.html.haml
@@ -7,7 +7,9 @@
     %li= @product.name
 
 = content_for :h1 do
-  = @product.name
+  = current_facility
+
+%h2= @product
 
 = render "description", product: @product
 
@@ -15,5 +17,3 @@
   = link_to "Login", new_user_session_path, class: "btn"
 - elsif @add_to_cart
   = link_to "Add to cart", add_order_path(acting_user.cart(session_user), order: {order_details: [{product_id: @product.id, quantity: 1}] }), method: :put, class: "btn btn-primary"
-
-

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -254,6 +254,7 @@ en:
         url: URL
         url_name: URL Name
         requires_approval: Requires Approval?
+        allows_training_requests: Allows Training Requests?
         requires_approval_show: Requires Approval
         initial_order_status: Initial Order Status
         is_archived: Is Inactive?

--- a/config/locales/models/en.instrument_for_cart.yml
+++ b/config/locales/models/en.instrument_for_cart.yml
@@ -1,13 +1,7 @@
 en:
   models:
     instrument_for_cart:
-      requires_approval: |
-        The %{product_name} instrument requires approval to reserve;
-        please contact the !facility_downcase! for further information:
-
-        %{facility}
-
-        [%{email}](mailto:%{email})
+      requires_approval: "!models.product_for_cart.requires_approval!"
       not_available: |
         The %{product_name} instrument is currently unavailable for reservation online.
       no_accounts: Sorry, but we could not find a valid payment source that you can use to reserve this instrument

--- a/config/locales/models/en.product_for_cart.yml
+++ b/config/locales/models/en.product_for_cart.yml
@@ -15,7 +15,7 @@ en:
         You are not in a price group that may purchase this %{product_type}; please contact
         the !facility_downcase!.
       requires_approval: |
-        This %{product_type} requires approval to purchase; please contact the !facility_downcase!.
+        <i class="fa fa-lock"></i> Please [contact the !facility_downcase!](mailto:%{email}) to request access to this %{product_type}.
       pricing_not_available: |
         Pricing for this %{product_type} is currently unavailable. Please contact the facility manager for assistance.
 

--- a/config/locales/models/en.product_for_cart.yml
+++ b/config/locales/models/en.product_for_cart.yml
@@ -15,7 +15,7 @@ en:
         You are not in a price group that may purchase this %{product_type}; please contact
         the !facility_downcase!.
       requires_approval: |
-        <i class="fa fa-lock"></i> Please [contact the !facility_downcase!](mailto:%{email}) to request access to this %{product_type}.
+        <i class="fa fa-lock"></i> This %{product_type} requires approval to purchase. Please [contact the !facility_downcase!](mailto:%{email}) to request access to this %{product_type}.
       pricing_not_available: |
         Pricing for this %{product_type} is currently unavailable. Please contact the facility manager for assistance.
 

--- a/config/locales/views/admin/en.products.yml
+++ b/config/locales/views/admin/en.products.yml
@@ -25,6 +25,7 @@ en:
         product_fields:
           hints:
             requires_approval: "Restrict access to approved users"
+            allows_training_requests: "Allow users to request training (only relevant if approval is required)"
             initial_order_status: "Default status for new orders"
             is_archived: "Inactivate the product, disallowing purchase and viewing"
             is_hidden: "Hide %{field} from end users; visible to staff when \"ordering on behalf\" of another user"

--- a/config/locales/views/admin/en.products.yml
+++ b/config/locales/views/admin/en.products.yml
@@ -25,7 +25,7 @@ en:
         product_fields:
           hints:
             requires_approval: "Restrict access to approved users"
-            allows_training_requests: "Allow users to request training (only relevant if approval is required)"
+            allows_training_requests: "Allow users to request training"
             initial_order_status: "Default status for new orders"
             is_archived: "Inactivate the product, disallowing purchase and viewing"
             is_hidden: "Hide %{field} from end users; visible to staff when \"ordering on behalf\" of another user"

--- a/db/migrate/20190227032150_add_product_specific_training_request_toggle.rb
+++ b/db/migrate/20190227032150_add_product_specific_training_request_toggle.rb
@@ -1,0 +1,5 @@
+class AddProductSpecificTrainingRequestToggle < ActiveRecord::Migration[5.0]
+  def change
+    add_column :products, :allows_training_requests, :boolean, default: true, null: false, after: :requires_approval
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190227031006) do
+ActiveRecord::Schema.define(version: 20190227032150) do
 
   create_table "account_facility_joins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "facility_id", null: false
@@ -478,6 +478,7 @@ ActiveRecord::Schema.define(version: 20190227031006) do
     t.text     "description",                   limit: 65535
     t.integer  "schedule_id"
     t.boolean  "requires_approval",                           default: false,    null: false
+    t.boolean  "allows_training_requests",                    default: true,     null: false
     t.integer  "initial_order_status_id"
     t.boolean  "is_archived",                                 default: false,    null: false
     t.boolean  "is_hidden",                                   default: false,    null: false

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -173,6 +173,10 @@ FactoryBot.define do
 
   factory :instrument_requiring_approval, parent: :setup_instrument do
     requires_approval { true }
+
+    trait :disallowing_training_request do
+      allows_training_requests { false }
+    end
   end
 
 end

--- a/spec/features/training_requests_spec.rb
+++ b/spec/features/training_requests_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe "Training Requests" do
     let!(:item) { create(:setup_item, requires_approval: true, allows_training_requests: false, facility: facility) }
 
     it "just has a link if requests are disabled" do
-      pending "to implement"
       visit facility_path(facility.url_name)
       click_link item.name
       expect(page).not_to have_link("Add to cart")
@@ -79,7 +78,6 @@ RSpec.describe "Training Requests" do
     let!(:instrument) { create(:setup_instrument, requires_approval: true, allows_training_requests: false, facility: facility) }
 
     it "just has a link if requests are disabled" do
-      pending "to implement"
       visit facility_path(facility.url_name)
       click_link instrument.name
       expect(page).not_to have_field("Reserve Start")

--- a/spec/features/training_requests_spec.rb
+++ b/spec/features/training_requests_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe "Training Requests" do
+  let(:facility) { create(:setup_facility) }
+
+  let(:user) { create(:user) }
+  let!(:account) { FactoryBot.create(:nufs_account, :with_account_owner, owner: user) }
+
+  before do
+    login_as user
+  end
+
+  describe "with an unrestricted item" do
+    let!(:item) { create(:setup_item, facility: facility) }
+    before do
+      create(:item_price_policy, product: item, price_group: PriceGroup.base)
+    end
+
+    it "can add the unrestricted item to the cart" do
+      visit facility_path(facility.url_name)
+      click_link item.name
+      expect(page).to have_link "Add to cart"
+    end
+  end
+
+  describe "with a restricted item" do
+    let!(:item) { create(:setup_item, requires_approval: true, facility: facility) }
+
+    it "can submit a training request" do
+      visit facility_path(facility.url_name)
+      click_link item.name
+      expect(page).not_to have_link("Add to cart")
+      expect(page).to have_content("Would you like to be contacted by the facility for access")
+      click_button "Yes"
+      expect(page).to have_content("has been submitted")
+    end
+  end
+
+  describe "with a restricted item, but requests are disabled" do
+    let!(:item) { create(:setup_item, requires_approval: true, allows_training_requests: false, facility: facility) }
+
+    it "just has a link if requests are disabled" do
+      pending "to implement"
+      visit facility_path(facility.url_name)
+      click_link item.name
+      expect(page).not_to have_link("Add to cart")
+      expect(page).to have_content("Please contact the facility to request access")
+    end
+  end
+
+  describe "with an unrestricted instrument" do
+    let!(:instrument) { create(:setup_instrument, facility: facility) }
+    before do
+      create(:instrument_price_policy, product: instrument, price_group: PriceGroup.base)
+    end
+
+    it "can add the unrestricted instrument to the cart" do
+      visit facility_path(facility.url_name)
+      click_link instrument.name
+      # i.e. we're on the new reservation page
+      expect(page).to have_field("Reserve Start")
+    end
+  end
+
+  describe "with a restricted instrument" do
+    let!(:instrument) { create(:setup_instrument, requires_approval: true, facility: facility) }
+
+    it "can submit a training request" do
+      visit facility_path(facility.url_name)
+      click_link instrument.name
+      expect(page).not_to have_field("Reserve Start")
+      expect(page).to have_content("Would you like to be contacted by the facility for access")
+      click_button "Yes"
+      expect(page).to have_content("has been submitted")
+    end
+  end
+
+  describe "with a restricted instrument, but requests are disabled" do
+    let!(:instrument) { create(:setup_instrument, requires_approval: true, allows_training_requests: false, facility: facility) }
+
+    it "just has a link if requests are disabled" do
+      pending "to implement"
+      visit facility_path(facility.url_name)
+      click_link instrument.name
+      expect(page).not_to have_field("Reserve Start")
+      expect(page).to have_content("Please contact the facility to request access")
+    end
+  end
+end

--- a/spec/features/training_requests_spec.rb
+++ b/spec/features/training_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Training Requests" do
+RSpec.describe "Training Requests", feature_setting: { training_requests: true, reload_routes: true } do
   let(:facility) { create(:setup_facility) }
 
   let(:user) { create(:user) }

--- a/spec/models/instrument_for_cart_spec.rb
+++ b/spec/models/instrument_for_cart_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe InstrumentForCart do
         expect(instrument_for_cart.error_message).to match(/A schedule for this instrument is currently unavailable/)
       end
 
-      it "sets error_path to the facility’s page" do
+      it "does not set an error_path" do
         instrument_for_cart.purchasable_by?(user, user)
-        expect(instrument_for_cart.error_path).to eq Rails.application.routes.url_helpers.facility_path(facility)
+        expect(instrument_for_cart.error_path).to be_blank
       end
     end
 


### PR DESCRIPTION
# Release Notes

Adds the ability to toggle the training requests feature per product.

# Additional Context

One of the things I've done here is bring the instrument show and product show behavior closer together. Before, if there was an error such as missing schedule rules, or user not having accounts that can be used for the product, for instruments it would redirect back to the facility homepage and display an error, while for items and services it would show the product description with the error message. NU gave us the thumbs up for this change of behavior.

There's also some improvements to the admin interface to still do. The client would like a dropdown, which I agree would probably be a more efficient and intuitive interface, but it probably warrants a form object, which makes that page more complicated. Thoughts on that?
