### PR TITLE
[#1884] Provide instructions for SQLite but no hope

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Open source version of Northwestern University Core Facility Management Software
 Welcome to NUcore! This guide will help you get a development environment up and running. It makes a few assumptions:
 
 1. You write code on a Mac.
-2. You have a running Oracle or MySQL instance with two brand new databases. (Oracle setup instructions [here](doc/HOWTO_oracle.txt).)
+2. You have a running Oracle or MySQL instance with two brand new databases. (Oracle setup instructions [here](doc/HOWTO_oracle.txt).) . Installation with a SQLite database is [possible](doc/HOWTO_sqlite.md) but not supported.
 3. You have the following installed:
     * [Ruby 2.4.1](http://www.ruby-lang.org/en)
     * [Bundler](http://gembundler.com)

--- a/doc/HOWTO_sqlite.md
+++ b/doc/HOWTO_sqlite.md
@@ -1,0 +1,57 @@
+# Running SQLite in Development
+
+If you really want, you can use nucore with a SQLite database.  The procedere requires a couple of manual changes and thus is (besides performance considerations) **not a good idea for your production environment**.  Note that this guide **might be out of date** and aimed at users of UNIX-like systems. For installation, you still need to follow the `README`, this guide is meant for an audience that are somewhat familiar with setting up Ruby on Rails applications.
+
+## Require the SQLite gem
+
+Add the following line to your `Gemfile`
+
+    gem 'sqlite3', '~> 1.3.6'
+
+. The version restriction might be out of date - it stems from a 'bug' in rails or ActiveRecord (one example related issue is https://github.com/rails/rails/issues/35153 ).
+
+Run
+
+    bundle install
+
+to install the sqlite3 gem once you made the changes to the `Gemfile`.
+
+## Remove MySQLisms from schema file
+
+Run this command to remove the MySQL-specific part of `db/schema.rb` (from which the database initialization is derived):
+
+    sed -i 's|, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8"||g' db/schema.rb
+
+## Configure the database to be used
+
+Instead of using the provided `config/database.yml.mysql.template`, create the file `config/database.yml` with following content:
+
+    default: &default
+      adapter: sqlite3
+      pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+      timeout: 5000
+    
+    development:
+      <<: *default
+      database: db/development.sqlite3
+    
+    # Warning: The database defined as "test" will be erased and
+    # re-generated from your development database when you run "rake".
+    # Do not set this db to the same as development or production.
+    test:
+      <<: *default
+      database: db/test.sqlite3
+
+Note that you also **could** define production settings, but since its a bad idea, we leave this exercise to the reader.
+
+### Initialize and populate the database
+
+Run
+
+    rails db:schema:load
+
+to create the necessary tables. If you wish, populate the database with demo data by calling
+
+    rails demo:seed
+
+.


### PR DESCRIPTION
# Release Notes

Added a file under doc/ with instructions on how to use nucore with a sqlite-database. For some developers (me ...) this might be the prefered way over using a MySQL or Oracle setup. However it has to be made clear that this is necessarily a good idea for production use.

To be fair I should note that I did not run tests and used ruby 2.5.1 .

# Screenshot

Optional.

# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".
