### PR TITLE
Make "Reservation Interval" appear as required on instrument edit form

### DIFF
--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -24,7 +24,7 @@ class Instrument < Product
   # --------
 
   validates :initial_order_status_id, presence: true
-  validates :reserve_interval, inclusion: { in: RESERVE_INTERVALS }
+  validates :reserve_interval, presence: true, inclusion: { in: RESERVE_INTERVALS, allow_blank: true }
   validates :min_reserve_mins,
             :max_reserve_mins,
             :auto_cancel_mins,


### PR DESCRIPTION
# Release Notes

Mark "Reservation Interval" as a required field when creating or editing an instrument.

# Additional Context

It is required by virtue of the inclusion validation, but because it didn't have the presence validation, it didn't get the `*` to mark it as required.

This was just something I noticed as I was setting up a new instrument for testing on another story.
