### PR TITLE
Make product "access control" field a dropdown

### DIFF
--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -12,7 +12,7 @@ class ProductsCommonController < ApplicationController
 
   include TranslationHelper
 
-  load_resource except: [:show, :manage, :index], instance_name: :product
+  # load_resource except: [:show, :manage, :index], instance_name: :product
   authorize_resource except: [:show, :manage], instance_name: :product
 
   layout "two_column"
@@ -57,9 +57,9 @@ class ProductsCommonController < ApplicationController
 
   # POST /services
   def create
-    @product = current_facility_products.new(resource_params)
-    @product.initial_order_status_id = OrderStatus.default_order_status.id
+    @product = current_facility_products.new(initial_order_status: OrderStatus.default_order_status)
     @product_form = EditProductForm.for(@product)
+    @product_form.assign_attributes(resource_params)
     if @product_form.save
       flash[:notice] = "#{@product.model_name.human} was successfully created."
       redirect_to([:manage, current_facility, @product])

--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -52,15 +52,16 @@ class ProductsCommonController < ApplicationController
   # GET /services/new
   def new
     @product = current_facility_products.new(account: Settings.accounts.product_default)
+    @product_form = EditProductForm.for(@product)
   end
 
   # POST /services
   def create
     @product = current_facility_products.new(resource_params)
     @product.initial_order_status_id = OrderStatus.default_order_status.id
-
-    if @product.save
-      flash[:notice] = "#{@product.class.name} was successfully created."
+    @product_form = EditProductForm.for(@product)
+    if @product_form.save
+      flash[:notice] = "#{@product.model_name.human} was successfully created."
       redirect_to([:manage, current_facility, @product])
     else
       render action: "new"
@@ -69,13 +70,16 @@ class ProductsCommonController < ApplicationController
 
   # GET /facilities/alpha/(items|services|instruments)/1/edit
   def edit
+    @product_form = EditProductForm.for(@product)
   end
 
   # PUT /services/1
   def update
+    @product_form = EditProductForm.for(@product)
+
     respond_to do |format|
-      if @product.update_attributes(resource_params)
-        flash[:notice] = "#{@product.class.name.capitalize} was successfully updated."
+      if @product_form.update(resource_params)
+        flash[:notice] = "#{@product.model_name.human} was successfully updated."
         format.html { redirect_to([:manage, current_facility, @product]) }
       else
         format.html { render action: "edit" }
@@ -95,6 +99,7 @@ class ProductsCommonController < ApplicationController
 
   def manage
     authorize! :view_details, @product
+    @product_form = EditProductForm.for(@product)
     @active_tab = "admin_products"
   end
 
@@ -103,11 +108,11 @@ class ProductsCommonController < ApplicationController
   def resource_params
     params.require(:"#{singular_object_name}").permit(:name, :url_name, :contact_email, :description,
                                                       :facility_account_id, :account, :initial_order_status_id,
-                                                      :requires_approval, :allows_training_requests, :is_archived, :is_hidden,
+                                                      :is_archived, :is_hidden,
                                                       :user_notes_field_mode, :user_notes_label, :show_details,
                                                       :schedule_id, :control_mechanism, :reserve_interval,
                                                       :min_reserve_mins, :max_reserve_mins, :min_cancel_hours,
-                                                      :auto_cancel_mins, :lock_window, :cutoff_hours,
+                                                      :auto_cancel_mins, :lock_window, :cutoff_hours, :access_control,
                                                       relay_attributes: [:ip, :port, :username, :password, :type,
                                                                          :auto_logout, :auto_logout_minutes, :id])
   end

--- a/app/forms/edit_product_form.rb
+++ b/app/forms/edit_product_form.rb
@@ -1,0 +1,34 @@
+class EditProductForm < TranslatableBaseForm
+
+  include ActiveModel::AttributeAssignment
+
+  def access_control
+    return :unrestricted unless requires_approval?
+
+    allows_training_requests? ? :restricted_and_allow_training : :restricted_and_no_training
+  end
+
+  def access_control=(control)
+    case control.to_s
+    when "restricted_and_allow_training"
+      self.requires_approval = true
+      self.allows_training_requests = true
+    when "restricted_and_no_training"
+      self.requires_approval = true
+      self.allows_training_requests = false
+    else
+      self.requires_approval = false
+      self.allows_training_requests = false
+    end
+  end
+
+  def update(args)
+    assign_attributes(args)
+    save
+  end
+
+  def access_control_values
+    [:unrestricted, :restricted_and_allow_training, :restricted_and_no_training]
+  end
+
+end

--- a/app/forms/translatable_base_form.rb
+++ b/app/forms/translatable_base_form.rb
@@ -1,0 +1,40 @@
+class TranslatableBaseForm < SimpleDelegator
+
+  extend ActiveModel::Translation
+
+  def self.for(instance)
+    instance_class = instance.class
+    # Dynamically create a subclass where the model_name is based off the original
+    # instance's type so that `human_attribute_name` can work off the same translations
+    # as the original object.
+    Class.new(self) do
+      # This will be a class method, i.e. def self.model_name
+      define_singleton_method(:model_name) do
+        ActiveModel::Name.new(instance_class)
+      end
+
+      define_singleton_method(:i18n_scope) do
+        instance_class.i18n_scope
+      end
+
+      # So I18n looks upwards in the class hierarchy
+      define_singleton_method(:ancestors) do
+        instance_class.ancestors
+      end
+
+      # SimpleForm needs to recognize this method
+      define_singleton_method(:reflect_on_association) do |*args|
+        instance_class.reflect_on_association(*args)
+      end
+    end.new(instance)
+  end
+
+    def model_name
+      ActiveModel::Name.new(__getobj__.class)
+    end
+
+    def to_model
+      self
+    end
+
+end

--- a/app/views/admin/products/_product_fields.html.haml
+++ b/app/views/admin/products/_product_fields.html.haml
@@ -4,13 +4,11 @@
   = render "admin/products/account_fields", f: f
 
   = f.input :initial_order_status_id, collection: OrderStatus.initial_statuses(current_facility).collect {|cf| [cf.name_with_level, cf.id] }, hint: text("hints.initial_order_status"), include_blank: false
-  -# TODO: Either make this a dropdown or add JS to disable training request checkbox
-  %fieldset.well
-    = f.input :requires_approval, as: :boolean, label: false, inline_label: text("hints.requires_approval")
-    = f.input :allows_training_requests, as: :boolean, label: false, inline_label: text("hints.allows_training_requests")
+
+  = f.input :access_control, collection: f.object.access_control_values, label_method: ->(v) { v.to_s.titleize }, include_blank: false
 
 = f.input :is_archived, as: :boolean, label: false, inline_label: text("hints.is_archived")
-= f.input :is_hidden, as: :boolean, label: false, inline_label: text("hints.is_hidden", field: f.object.class.model_name.human.downcase)
+= f.input :is_hidden, as: :boolean, label: false, inline_label: text("hints.is_hidden", field: f.object.model_name.human.downcase)
 
 - unless f.object.is_a?(Bundle)
   = f.input :user_notes_field_mode, collection: Products::UserNoteMode.all, include_blank: false

--- a/app/views/products_common/_form.html.haml
+++ b/app/views/products_common/_form.html.haml
@@ -1,4 +1,4 @@
-= simple_form_for([current_facility, @product]) do |f|
+= simple_form_for([current_facility, @product_form]) do |f|
   = f.error_messages
   .form-inputs
     = render "product_fields", f: f

--- a/app/views/products_common/manage.html.haml
+++ b/app/views/products_common/manage.html.haml
@@ -6,7 +6,7 @@
   = render "admin/shared/tabnav_product", secondary_tab: "details"
 
 %h2= @product
-= readonly_form_for @product.class.name.underscore, @product do |f|
+= readonly_form_for @product_form.model_name.singular, @product_form do |f|
   = f.input :url_name, input_html: { value: link_to(polymorphic_url([current_facility, @product]), [current_facility, @product]) }
 
   - if SettingsHelper::feature_on? :product_specific_contacts
@@ -20,9 +20,7 @@
         input_html: { value: @product.facility_account.account_number + (@product.facility_account.is_active? ? "" : " (inactive)") }
 
     = f.input :initial_order_status
-    = f.input :requires_approval
-    - if f.object.requires_approval?
-      = f.input :allows_training_requests
+    = f.input :access_control, input_html: { value: f.object.access_control.to_s.titleize }
   = f.input :is_archived
   = f.input :is_hidden
   - unless @product.is_a?(Bundle)


### PR DESCRIPTION
# Release Notes

Make the access control option for products a dropdown rather than two checkboxes.

# Additional Context

Into #1881, but I wanted to keep it as a separate PR to get feedback on this approach.

