### PR TITLE
[#141852] Allow admins to add note when suspending a user

### DIFF
--- a/app/controllers/user_suspension_controller.rb
+++ b/app/controllers/user_suspension_controller.rb
@@ -10,14 +10,20 @@ class UserSuspensionController < ApplicationController
   # POST /facilities/facility_id/users/:id/suspension
   def create
     @user.suspended_at ||= Time.current
-    @user.save!
+    @user.update!(suspension_params)
     redirect_to facility_user_path(current_facility, @user), notice: text("create.success")
   end
 
   # DELETE /facilities/facility_id/users/:id/suspension
   def destroy
-    @user.update!(suspended_at: nil)
+    @user.update!(suspended_at: nil, suspension_note: nil)
     redirect_to facility_user_path(current_facility, @user), notice: text("destroy.success")
+  end
+
+  private
+
+  def suspension_params
+    params.require(:user).permit(:suspension_note)
   end
 
 end

--- a/app/controllers/user_suspension_controller.rb
+++ b/app/controllers/user_suspension_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class UserSuspensionController < ApplicationController
+
+  admin_tab     :all
+  before_action :init_current_facility
+  before_action :authenticate_user!
+  load_and_authorize_resource :user, id_param: :user_id
+
+  # POST /facilities/facility_id/users/:id/suspension
+  def create
+    @user.suspended_at ||= Time.current
+    @user.save!
+    redirect_to facility_user_path(current_facility, @user), notice: text("create.success")
+  end
+
+  # DELETE /facilities/facility_id/users/:id/suspension
+  def destroy
+    @user.update!(suspended_at: nil)
+    redirect_to facility_user_path(current_facility, @user), notice: text("destroy.success")
+  end
+
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -133,19 +133,6 @@ class UsersController < ApplicationController
     end
   end
 
-  # PATCH /facilities/:facility_id/users/:id/suspend
-  def suspend
-    @user.suspended_at ||= Time.current
-    @user.save!
-    redirect_to facility_user_path(current_facility, @user), notice: text("suspend.success")
-  end
-
-  # PATCH /facilities/:facility_id/users/:id/unsuspend
-  def unsuspend
-    @user.update!(suspended_at: nil)
-    redirect_to facility_user_path(current_facility, @user), notice: text("unsuspend.success")
-  end
-
   def unexpire
     @user.update!(expired_at: nil, expired_note: nil)
     redirect_to facility_user_path(current_facility, @user), notice: text("unexpire.success")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,7 @@ class User < ApplicationRecord
   validates_presence_of :username, :first_name, :last_name
   validates :email, presence: true, email_format: true
   validates_uniqueness_of :username, :email
+  validates :suspension_note, length: { maximum: 255 }
 
   #
   # Gem ldap_authenticatable expects User to respond_to? :login. For us that's #username.

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -16,9 +16,10 @@
   = f.input :last_sign_in_at, default_value: "none"
   = f.input :internal?, label: text("views.users.edit.internal") if SettingsHelper.feature_on?(:user_based_price_groups)
   = f.input :suspended_at if f.object.suspended?
+  = f.input :suspension_note if f.object.suspended? && current_user.administrator?
   = f.input :expired_at if f.object.expired?
-  -# Only show to global admins per future ticket for suspended note #141852
   = f.input :expired_note if f.object.expired? && current_user.administrator?
+
   = render_view_hook "additional_user_fields", f: f
 
 - if can? :edit, @user
@@ -27,11 +28,13 @@
 
     - if can?(:unexpire, @user) && @user.expired?
       %li= link_to text("unexpire"), unexpire_facility_user_path(current_facility, @user), class: "btn", method: :patch
-    - elsif can? :deactivate, @user
-      - if @user.suspended?
-        %li= link_to t("shared.activate"), facility_user_suspension_path(current_facility, @user), class: "btn", method: :delete
-      - else
-        %li= link_to t("shared.suspend"), facility_user_suspension_path(current_facility, @user), class: "btn", method: :post
+    - elsif can?(:deactivate, @user) && @user.suspended?
+      = link_to t("shared.activate"), facility_user_suspension_path(current_facility, @user), class: "btn", method: :delete
+  - if can?(:deactivate, @user) && !@user.suspended? && !@user.expired?
+    %fieldset.well
+      = simple_form_for @user, url: facility_user_suspension_path(current_facility, @user), method: :post do |f|
+        = f.input :suspension_note
+        = f.submit t("shared.suspend"), class: "btn btn-danger"
 
 
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -29,9 +29,9 @@
       %li= link_to text("unexpire"), unexpire_facility_user_path(current_facility, @user), class: "btn", method: :patch
     - elsif can? :deactivate, @user
       - if @user.suspended?
-        %li= link_to t("shared.activate"), unsuspend_facility_user_path(current_facility, @user), class: "btn", method: :patch
+        %li= link_to t("shared.activate"), facility_user_suspension_path(current_facility, @user), class: "btn", method: :delete
       - else
-        %li= link_to t("shared.suspend"), suspend_facility_user_path(current_facility, @user), class: "btn", method: :patch
+        %li= link_to t("shared.suspend"), facility_user_suspension_path(current_facility, @user), class: "btn", method: :post
 
 
 

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -235,6 +235,8 @@ en:
         current_password: Current password
         last_sign_in_at: Last Login
         full_name: Full Name
+        suspended_at: Suspended
+        suspension_note: Suspension Note
         suspended: SUSPENDED
         expired: EXPIRED
       facility:

--- a/config/locales/views/admin/en.user_suspension.yml
+++ b/config/locales/views/admin/en.user_suspension.yml
@@ -1,0 +1,7 @@
+en:
+  controllers:
+    user_suspension:
+      create:
+        success: User suspended
+      destroy:
+        success: User reactivated

--- a/config/locales/views/admin/en.users.yml
+++ b/config/locales/views/admin/en.users.yml
@@ -25,9 +25,5 @@ en:
       update:
         error: There was an error updating the user. %{message}
         success: The user has been updated successfully.
-      suspend:
-        success: User suspended
-      unsuspend:
-        success: User reactivated
       unexpire:
         success: Expiration removed from user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,9 +146,8 @@ Nucore::Application.routes.draw do
           get "new_external"
           post "search"
         end
-        patch "suspend", on: :member
-        patch "unsuspend", on: :member
         patch "unexpire", on: :member
+        resource :suspension, controller: :user_suspension, only: [:create, :destroy]
       end
 
       get "switch_to",    to: "users#switch_to"

--- a/db/migrate/20190301022930_add_suspension_note_to_user.rb
+++ b/db/migrate/20190301022930_add_suspension_note_to_user.rb
@@ -1,0 +1,5 @@
+class AddSuspensionNoteToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :suspension_note, :string, after: :suspended_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190227031006) do
+ActiveRecord::Schema.define(version: 20190301022930) do
 
   create_table "account_facility_joins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "facility_id", null: false
@@ -770,6 +770,7 @@ ActiveRecord::Schema.define(version: 20190227031006) do
     t.datetime "reset_password_sent_at"
     t.integer  "uid"
     t.datetime "suspended_at"
+    t.string   "suspension_note"
     t.string   "card_number"
     t.datetime "expired_at"
     t.string   "expired_note"

--- a/spec/features/admin/suspending_a_user_spec.rb
+++ b/spec/features/admin/suspending_a_user_spec.rb
@@ -14,11 +14,14 @@ RSpec.describe "User suspension", feature_setting: { create_users: true, reload_
       visit facility_user_path(facility, user)
 
       expect(page).to have_content("todelete@example.com")
-      click_link "Suspend"
+      fill_in "Suspension Note", with: "User was naughty"
+      click_button "Suspend"
       expect(page).to have_content("Del User (SUSPENDED)")
+      expect(page).to have_content("Suspension Note\nUser was naughty")
 
       click_link "Activate"
       expect(page).not_to have_content("(SUSPENDED)")
+      expect(page).not_to have_content("naughty")
     end
   end
 
@@ -30,7 +33,7 @@ RSpec.describe "User suspension", feature_setting: { create_users: true, reload_
       visit facility_user_path(facility, user)
 
       expect(page).to have_content("todelete@example.com")
-      expect(page).not_to have_link("Suspend")
+      expect(page).not_to have_button("Suspend")
       expect(page).not_to have_link("Activate")
     end
   end


### PR DESCRIPTION
# Release Notes

Add the ability for global admins to add a note when suspending a user.

# Screenshot

<img width="916" alt="screen shot 2019-03-01 at 2 21 15 pm" src="https://user-images.githubusercontent.com/1099111/53614225-4debba80-3c2d-11e9-8d9b-1885bbf01866.png">

# Additional Context

I decided not to add a new page (`user_suspension/new`) just because it seemed like an extra click. It might have made the user show view a little complex, though. I didn't spend much time on the interface, so feel free to give it additional love.

I also left the field optional. I suspect that you would run into problems if we added a validation on there (since all existing suspended users would not have a note).

I also went back and forth between `suspended_note` and `suspension_note`. I eventually just settled on `suspension_note`: I thought it read better on the form.
