### PR TITLE
Use published version of shoulda-matchers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,15 +118,15 @@ group :development, :test do
 end
 
 group :test do
-  gem "rspec_junit_formatter"
-  gem "ci_reporter_rspec"
-  gem "codeclimate_circle_ci_coverage"
   gem "capybara"
   gem "capybara-email"
+  gem "ci_reporter_rspec"
+  gem "codeclimate_circle_ci_coverage"
   gem "poltergeist"
   gem "rails-controller-testing"
   gem "rspec-collection_matchers"
-  gem "shoulda-matchers", github: "thoughtbot/shoulda-matchers" # https://github.com/thoughtbot/shoulda-matchers/issues/913
+  gem "rspec_junit_formatter"
+  gem "shoulda-matchers"
   gem "single_test"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ source "https://rubygems.org"
 
 ruby File.open(File.expand_path(".ruby-version", File.dirname(__FILE__))) { |f| f.read.chomp }
 
-git_source(:github) { |repo_name| "git@github.com:#{repo_name}.git" }
-
 ## base
 gem "rails", "5.0.7.1"
 gem "config"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: git@github.com:thoughtbot/shoulda-matchers.git
-  revision: 5ce00eb9757cd22a6554821a15efdbb0cfa402bd
-  specs:
-    shoulda-matchers (4.0.1)
-      activesupport (>= 4.2.0)
-
 PATH
   remote: vendor/engines/bulk_email
   specs:
@@ -555,6 +548,8 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     shellany (0.0.1)
+    shoulda-matchers (4.0.1)
+      activesupport (>= 4.2.0)
     simple_form (4.1.0)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -719,7 +714,7 @@ DEPENDENCIES
   sanger_sequencing!
   sass-rails
   secure_rooms!
-  shoulda-matchers!
+  shoulda-matchers
   simple_form
   single_test
   split_accounts!
@@ -742,4 +737,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.6
+   1.17.3


### PR DESCRIPTION
# Release Notes

Use published version of shoulda-matchers gem

# Additional Context

With version 4.0.1 being published, the linked-to issue that required us to use a GitHub-backed version of the gem has been fixed, so this PR gets us back to using a published version of the gem.