### PR TITLE
[#144828] Fix toggle for restricting access for non-instrument products

### DIFF
--- a/app/views/admin/products/_product_fields.html.haml
+++ b/app/views/admin/products/_product_fields.html.haml
@@ -6,7 +6,7 @@
   = f.input :initial_order_status_id, collection: OrderStatus.initial_statuses(current_facility).collect {|cf| [cf.name_with_level, cf.id] }, hint: text("hints.initial_order_status"), include_blank: false
 
   %fieldset.well
-    = f.input :requires_approval, as: :boolean, label: false, inline_label: text("hints.requires_approval"), input_html: { data: { disables: ".instrument_allows_training_requests"} }
+    = f.input :requires_approval, as: :boolean, label: false, inline_label: text("hints.requires_approval"), input_html: { data: { disables: ".#{f.object.class.model_name.human.downcase}_allows_training_requests"} }
     - if SettingsHelper.feature_on?(:training_requests)
       = f.input :allows_training_requests, as: :boolean, label: false, inline_label: text("hints.allows_training_requests")
 


### PR DESCRIPTION
# Release Notes

Fix toggle for restricting access for non-instrument products

# Additional Context

When a non-instrument product is edited, the checkbox toggle should reflect the product’s type so that the element it is supposed to toggle can be found on the page. Currently, it is hardcoded to `.instrument_allows_training_requests` and when a service (for example) is being edited, the field’s class ends up being `.service_allows_training_request`, so the toggle does nothing.