### PR TITLE
[#144828] Use timed_service rather than timed service in UI toggle to target correct element

### DIFF
--- a/app/views/admin/products/_product_fields.html.haml
+++ b/app/views/admin/products/_product_fields.html.haml
@@ -6,7 +6,7 @@
   = f.input :initial_order_status_id, collection: OrderStatus.initial_statuses(current_facility).collect {|cf| [cf.name_with_level, cf.id] }, hint: text("hints.initial_order_status"), include_blank: false
 
   %fieldset.well
-    = f.input :requires_approval, as: :boolean, label: false, inline_label: text("hints.requires_approval"), input_html: { data: { disables: ".#{f.object.class.model_name.human.downcase}_allows_training_requests"} }
+    = f.input :requires_approval, as: :boolean, label: false, inline_label: text("hints.requires_approval"), input_html: { data: { disables: ".#{f.object.class.model_name.to_s.underscore}_allows_training_requests"} }
     - if SettingsHelper.feature_on?(:training_requests)
       = f.input :allows_training_requests, as: :boolean, label: false, inline_label: text("hints.allows_training_requests")
 


### PR DESCRIPTION
# Release Notes

Use timed_service rather than timed service in UI toggle to target correct element

# Additional Context

Fixes #1897 for timed services as well (for these, `human` returned `timed service` instead of `timed_service`)