### PR TITLE
[#144321] Fix permissions so Facility Directors can manage a User’s Accounts

### DIFF
--- a/app/controllers/user_accounts_controller.rb
+++ b/app/controllers/user_accounts_controller.rb
@@ -2,22 +2,22 @@
 
 class UserAccountsController < ApplicationController
   admin_tab :all
-  before_action :init_current_facility
   layout "two_column"
-  load_and_authorize_resource class: "User", id_param: :user_id, instance_name: :user
+
+  before_action :init_current_facility
+  load_resource class: "User", id_param: :user_id, instance_name: :user
+  authorize_resource class: AccountUser
+  before_action { @active_tab = "admin_users" }
 
   def show
-    @active_tab = "admin_users"
     @accounts = @user.accounts.for_facility(current_facility)
   end
 
   def edit
-    @active_tab = "admin_users"
     @accounts = @user.accounts.for_facility(current_facility)
   end
 
   def update
-    @active_tab = "admin_users"
     if @user.update(user_params)
       redirect_to facility_user_accounts_path(current_facility, @user), flash: { notice: t(".updated", user_name: @user.full_name) }
     else

--- a/spec/controllers/user_accounts_controller_spec.rb
+++ b/spec/controllers/user_accounts_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe UserAccountsController do
       @params = { facility_id: facility.url_name, user_id: @guest.id }
     end
 
-    it_should_allow_admin_only do
+    it_should_allow_managers_only do
       expect(assigns(:user)).to eq(@guest)
       expect(assigns(:accounts)).to be_kind_of ActiveRecord::Relation
     end


### PR DESCRIPTION
# Release Notes

Fix permissions so Facility Directors can manage a User’s Accounts

# Additional Context

In #1917 I accidentally removed the ability for facility directors to see a user’s accounts (and now manage them), because the underlying resource being authorized changed as I moved the action away from `UsersController` and towards a resource-based one (not realizing the existing permissions in place). This PR fixes that.