### PR TITLE
[#148491] Improve performance of FacilitiesController#show page

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -44,7 +44,6 @@ class FacilitiesController < ApplicationController
   def show
     return redirect_to(facilities_path) if current_facility.try(:cross_facility?)
     raise ActiveRecord::RecordNotFound unless current_facility.try(:is_active?)
-    @order_form = Order.new if acting_user && current_facility.accepts_multi_add?
     @columns = "columns" if SettingsHelper.feature_on?(:product_list_columns)
     @active_tab = SettingsHelper.feature_on?(:use_manage) ? "use" : "home"
 

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -48,7 +48,7 @@ class FacilitiesController < ApplicationController
     @columns = "columns" if SettingsHelper.feature_on?(:product_list_columns)
     @active_tab = SettingsHelper.feature_on?(:use_manage) ? "use" : "home"
 
-    instruments_scope = current_facility.instruments.includes(:alert, :facility, :current_offline_reservations)
+    instruments_scope = current_facility.instruments.includes(:alert, :current_offline_reservations)
 
     if acting_as? || session_user.try(:operator_of?, current_facility)
       @instruments = instruments_scope.not_archived

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -51,17 +51,17 @@ class FacilitiesController < ApplicationController
     instruments_scope = current_facility.instruments.includes(:alert, :current_offline_reservations)
 
     if acting_as? || session_user.try(:operator_of?, current_facility)
-      @instruments = instruments_scope.not_archived
-      @items = current_facility.items.not_archived
-      @services = current_facility.services.not_archived
-      @timed_services = current_facility.timed_services.not_archived
-      @bundles = current_facility.bundles.not_archived
+      @instruments = instruments_scope.not_archived.alphabetized
+      @items = current_facility.items.not_archived.alphabetized
+      @services = current_facility.services.not_archived.alphabetized
+      @timed_services = current_facility.timed_services.not_archived.alphabetized
+      @bundles = current_facility.bundles.not_archived.alphabetized
     else
-      @instruments = instruments_scope.active
-      @items = current_facility.items.active
-      @services = current_facility.services.active
-      @timed_services = current_facility.timed_services.active
-      @bundles = current_facility.bundles.active.reject{|b| !b.products_active?}
+      @instruments = instruments_scope.active.alphabetized
+      @items = current_facility.items.active.alphabetized
+      @services = current_facility.services.active.alphabetized
+      @timed_services = current_facility.timed_services.active.alphabetized
+      @bundles = current_facility.bundles.active.alphabetized.reject{|b| !b.products_active?}
     end
 
     render layout: "application"

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -51,11 +51,11 @@ class FacilitiesController < ApplicationController
     instruments_scope = current_facility.instruments.includes(:alert, :facility, :current_offline_reservations)
 
     if acting_as? || session_user.try(:operator_of?, current_facility)
-      @instruments = instruments_scope.active_plus_hidden
-      @items = current_facility.items.active_plus_hidden
-      @services = current_facility.services.active_plus_hidden
-      @timed_services = current_facility.timed_services.active_plus_hidden
-      @bundles = current_facility.bundles.active_plus_hidden
+      @instruments = instruments_scope.not_archived
+      @items = current_facility.items.not_archived
+      @services = current_facility.services.not_archived
+      @timed_services = current_facility.timed_services.not_archived
+      @bundles = current_facility.bundles.not_archived
     else
       @instruments = instruments_scope.active
       @items = current_facility.items.active

--- a/app/controllers/product_accessories_controller.rb
+++ b/app/controllers/product_accessories_controller.rb
@@ -49,7 +49,7 @@ class ProductAccessoriesController < ApplicationController
   def set_available_accessories
     # Exclude already included accessories as well as the current product.
     non_available_accessories = [@product.id] + Array(@product_accessories).map(&:accessory_id)
-    @available_accessories = current_facility.products.accessorizable.active_plus_hidden.exclude(non_available_accessories).order(:name)
+    @available_accessories = current_facility.products.accessorizable.not_archived.exclude(non_available_accessories).order(:name)
   end
 
 end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -27,12 +27,10 @@ module ProductsHelper
     }
   end
 
-  def public_calendar_link(product, indent: false)
+  def public_calendar_link(product)
     if product.respond_to? :reservations
       opts = public_calendar_options(product)
       link_to "", facility_instrument_public_schedule_path(product.facility, product), opts
-    elsif indent
-      content_tag :span, "", class: "fa-lg fa-fw", style: "display: inline-block"
     end
   end
 

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -28,10 +28,15 @@ module ProductsHelper
   end
 
   def public_calendar_link(product)
-    if product.respond_to? :reservations
-      opts = public_calendar_options(product)
-      link_to "", facility_instrument_public_schedule_path(product.facility, product), opts
+    return unless product.respond_to? :reservations
+
+    opts = if product.facility.show_instrument_availability?
+      public_calendar_availability_options(product)
+    else
+      { class: ["fa fa-calendar fa-lg fa-fw"], title: t("instruments.public_schedule.icon") }
     end
+
+    link_to "", facility_instrument_public_schedule_path(product.facility, product), opts
   end
 
   def show_buttons_to_control_all_relays?(products)
@@ -39,15 +44,6 @@ module ProductsHelper
   end
 
   private
-
-  def public_calendar_options(product)
-    if current_facility&.show_instrument_availability? || !current_facility && product.facility.show_instrument_availability?
-      public_calendar_availability_options(product)
-    else
-      { class: ["fa fa-calendar fa-lg fa-fw"],
-        title: t("instruments.public_schedule.icon") }
-    end
-  end
 
   def public_calendar_availability_options(product)
     if product.offline?

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -4,21 +4,21 @@ class Facility < ApplicationRecord
 
   before_validation :set_journal_mask, on: :create
 
-  has_many :bundles
+  has_many :bundles, inverse_of: :facility
   has_many :director_and_admin_roles, -> { merge(UserRole.director_and_admins) }, class_name: "UserRole"
   has_many :director_and_admins, -> { distinct }, through: :director_and_admin_roles, source: :user
   has_many :facility_accounts
-  has_many :instruments
-  has_many :items
+  has_many :instruments, inverse_of: :facility
+  has_many :items, inverse_of: :facility
   has_many :journals
   has_many :order_details, through: :products
   has_many :order_imports, dependent: :destroy
   has_many :orders, -> { where.not(ordered_at: nil) }
   has_many :products
   has_many :schedules
-  has_many :services
+  has_many :services, inverse_of: :facility
   has_many :statements
-  has_many :timed_services
+  has_many :timed_services, inverse_of: :facility
   has_many :training_requests, through: :products
   has_many :user_roles, dependent: :destroy
   has_many :users, -> { distinct }, through: :user_roles

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -55,7 +55,6 @@ class Product < ApplicationRecord
   end
 
   scope :active, -> { where(is_archived: false, is_hidden: false) }
-  scope :active_plus_hidden, -> { where(is_archived: false) } # TODO: phase out in favor of the .not_archived scope
   scope :alphabetized, -> { order("lower(products.name)") }
   scope :archived, -> { where(is_archived: true) }
   scope :not_archived, -> { where(is_archived: false) }

--- a/app/support/order_row_importer.rb
+++ b/app/support/order_row_importer.rb
@@ -155,7 +155,7 @@ class OrderRowImporter
       @order_import
       .facility
       .products
-      .active_plus_hidden
+      .not_archived
       .find_by(name: product_field)
   end
 

--- a/app/views/facilities/_product.html.haml
+++ b/app/views/facilities/_product.html.haml
@@ -1,0 +1,13 @@
+%li{ class: product.model_name.singular }
+  - if local_assigns[:f]
+    = f.fields_for :order_details do |builder|
+      - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
+        = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
+        = builder.hidden_field :product_id, value: product.id, index: nil
+  = public_calendar_link(product)
+  = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(product.facility, product)
+  - if acting_user.present? && !product.can_be_used_by?(acting_user)
+    %i.fa.fa-lock
+    = " (#{product.class.human_attribute_name(:requires_approval_show)})"
+
+  = warning_if_instrument_is_offline_or_partially_available(product)

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -9,7 +9,6 @@
       - if products.first.class.model_name == "TimedService"
         %p= t("facilities.show.timed_services_note")
     %ul
-      - indent_for_icon = products.any? { |p| p.respond_to? :reservations }
       - products.sort.each do |product|
         %li{ class: product.class.model_name.to_s.downcase }
           - if local_assigns[:f]
@@ -17,8 +16,8 @@
               - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
                 = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
                 = builder.hidden_field :product_id, value: product.id, index: nil
-          = public_calendar_link(product, indent: indent_for_icon)
-          = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(current_facility || product.facility, product)
+          = public_calendar_link(product)
+          = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(product.facility, product)
           - if acting_user.present? && !product.can_be_used_by?(acting_user)
             %i.fa.fa-lock
             = " (#{product.class.human_attribute_name(:requires_approval_show)})"

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -1,25 +1,9 @@
 - if products.any?
-  - if local_assigns[:title]
-    %h4= local_assigns[:title]
-
   .product_list{ class: @columns }
-    - if current_facility.present?
-      %h3= product_list_title products, local_assigns[:title_extra]
+    %h3= product_list_title products, local_assigns[:title_extra]
 
-      - if products.first.is_a?(TimedService)
-        %p= t("facilities.show.timed_services_note")
+    - if products.first.is_a?(TimedService)
+      %p= t("facilities.show.timed_services_note")
+
     %ul
-      - products.each do |product|
-        %li{ class: product.class.model_name.to_s.downcase }
-          - if local_assigns[:f]
-            = f.fields_for :order_details do |builder|
-              - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
-                = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
-                = builder.hidden_field :product_id, value: product.id, index: nil
-          = public_calendar_link(product)
-          = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(product.facility, product)
-          - if acting_user.present? && !product.can_be_used_by?(acting_user)
-            %i.fa.fa-lock
-            = " (#{product.class.human_attribute_name(:requires_approval_show)})"
-
-          = warning_if_instrument_is_offline_or_partially_available(product)
+      = render partial: "product", collection: products, locals: { f: f }

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -6,4 +6,4 @@
       %p= t("facilities.show.timed_services_note")
 
     %ul
-      = render partial: "product", collection: products, locals: { f: f }
+      = render partial: "product", collection: products, locals: { f: local_assigns[:f] }

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -2,7 +2,7 @@
   - if local_assigns[:title]
     %h4= local_assigns[:title]
 
-  .product_list{ class: [products.first.class.model_name.to_s.pluralize.downcase, @columns] }
+  .product_list{ class: @columns }
     - if current_facility.present?
       %h3= product_list_title products, local_assigns[:title_extra]
 

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -6,7 +6,7 @@
     - if current_facility.present?
       %h3= product_list_title products, local_assigns[:title_extra]
 
-      - if products.first.class.model_name == "TimedService"
+      - if products.first.is_a?(TimedService)
         %p= t("facilities.show.timed_services_note")
     %ul
       - products.each do |product|

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -9,7 +9,7 @@
       - if products.first.class.model_name == "TimedService"
         %p= t("facilities.show.timed_services_note")
     %ul
-      - products.sort.each do |product|
+      - products.each do |product|
         %li{ class: product.class.model_name.to_s.downcase }
           - if local_assigns[:f]
             = f.fields_for :order_details do |builder|

--- a/app/views/facilities/_recently_used_products.html.haml
+++ b/app/views/facilities/_recently_used_products.html.haml
@@ -1,0 +1,5 @@
+- if products.any?
+  %h4= text("title")
+  .product_list
+    %ul
+      = render partial: "product", collection: products

--- a/app/views/facilities/index.html.haml
+++ b/app/views/facilities/index.html.haml
@@ -6,13 +6,13 @@
 - if azlist_on?
   .az_list_container
     = render "azlist"
-  = render "product_list", products: @recent_products, title: text("recently_purchased")
+  = render "recently_used_products", products: @recent_products
   = render "recently_used_facilities"
   = render "facilities_list"
 
 - else
   = render "recently_used_facilities"
   %hr
-  = render "product_list", products: @recent_products, title: text("recently_purchased")
+  = render "recently_used_products", products: @recent_products
   %hr
   = render "facilities_list"

--- a/app/views/facilities/show.html.haml
+++ b/app/views/facilities/show.html.haml
@@ -4,19 +4,6 @@
   = content_for :banner do
     .global-alert-banner= sanitize current_facility.banner_notice
 
-- if acting_as? || session_user.try(:operator_of?, current_facility)
-  - instruments = current_facility.instruments.active_plus_hidden
-  - items = current_facility.items.active_plus_hidden
-  - services = current_facility.services.active_plus_hidden
-  - timed_services = current_facility.timed_services.active_plus_hidden
-  - bundles = current_facility.bundles.active_plus_hidden
-- else
-  - instruments = current_facility.instruments.active
-  - items = current_facility.items.active
-  - services = current_facility.services.active
-  - timed_services = current_facility.timed_services.active
-  - bundles = current_facility.bundles.active.reject{|b| !b.products_active?}
-
 = content_for :breadcrumb do
   %ul.breadcrumb
     %li= link_to 'Home', :root
@@ -30,17 +17,17 @@
   = form_for @order_form, url: add_order_path(acting_user.cart(session_user)), html: {method: :put, class:['product_list_container', @columns]} do |f|
     .button_row
       = f.submit class: ['btn', 'btn-primary']
-    = render partial: 'product_list', locals: {products: instruments, f: f, title_extra: daily_view_link }
-    = render partial: 'product_list', locals: {products: services, f: f}
-    = render partial: 'product_list', locals: {products: timed_services, f: f}
-    = render partial: 'product_list', locals: {products: items, f: f}
-    = render partial: 'product_list', locals: {products: bundles, f: f}
+    = render partial: 'product_list', locals: { products: @instruments, f: f, title_extra: daily_view_link }
+    = render partial: 'product_list', locals: { products: @services, f: f }
+    = render partial: 'product_list', locals: { products: @timed_services, f: f }
+    = render partial: 'product_list', locals: { products: @items, f: f }
+    = render partial: 'product_list', locals: { products: @bundles, f: f }
     .button_row
       = f.submit class: ['btn', 'btn-primary']
 - else
   .product_list_container{class: @columns}
-    = render partial: 'product_list', locals: {products: instruments, title_extra: daily_view_link }
-    = render partial: 'product_list', locals: {products: services}
-    = render partial: 'product_list', locals: {products: timed_services}
-    = render partial: 'product_list', locals: {products: items}
-    = render partial: 'product_list', locals: {products: bundles}
+    = render partial: 'product_list', locals: { products: @instruments, title_extra: daily_view_link }
+    = render partial: 'product_list', locals: { products: @services }
+    = render partial: 'product_list', locals: { products: @timed_services }
+    = render partial: 'product_list', locals: { products: @items }
+    = render partial: 'product_list', locals: { products: @bundles }

--- a/app/views/facilities/show.html.haml
+++ b/app/views/facilities/show.html.haml
@@ -12,7 +12,6 @@
 
 .wysiwyg= sanitize current_facility.description
 
-
 - if @order_form
   = form_for @order_form, url: add_order_path(acting_user.cart(session_user)), html: {method: :put, class:['product_list_container', @columns]} do |f|
     .button_row

--- a/app/views/facilities/show.html.haml
+++ b/app/views/facilities/show.html.haml
@@ -12,8 +12,8 @@
 
 .wysiwyg= sanitize current_facility.description
 
-- if @order_form
-  = form_for @order_form, url: add_order_path(acting_user.cart(session_user)), html: {method: :put, class:['product_list_container', @columns]} do |f|
+- if acting_user && current_facility.accepts_multi_add?
+  = form_for Order.new, url: add_order_path(acting_user.cart(session_user)), html: {method: :put, class:['product_list_container', @columns]} do |f|
     .button_row
       = f.submit class: ['btn', 'btn-primary']
     = render partial: 'product_list', locals: { products: @instruments, f: f, title_extra: daily_view_link }

--- a/config/locales/views/en.facilities.yml
+++ b/config/locales/views/en.facilities.yml
@@ -2,13 +2,14 @@ en:
   views:
     facilities:
       index:
-        recently_purchased: Recently Purchased Products
         welcome: |
           Welcome to !app_name!, the centralized ordering system for shared !facilities_downcase!.
           Please select the shared !facility_downcase! below to view and purchase services
           and products offered by the !facility_downcase!
       recently_used_facilities:
         title: Recently Used !Facilities!
+      recently_used_products:
+        title: Recently Purchased Products
       facilities_list:
         all: All !Facilities!
         none: "No !facilities_downcase! are available at this time."

--- a/lib/tasks/price_policies.rake
+++ b/lib/tasks/price_policies.rake
@@ -6,7 +6,7 @@ namespace :price_policies do
   task :duplicate_to_current_fiscal_year, [:url_name] => :environment do |_t, args|
     facility = Facility.find_by!(url_name: args[:url_name])
 
-    facility.services.active_plus_hidden.each do |service|
+    facility.services.not_archived.each do |service|
       service.price_policies.newest.each do |price_policy|
         next unless price_policy.expired? # Don't duplicate a current policy
 

--- a/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
+++ b/vendor/engines/bulk_email/app/controllers/bulk_email/bulk_email_controller.rb
@@ -106,7 +106,7 @@ module BulkEmail
     end
 
     def init_search_options
-      products = Product.for_facility(current_facility).active_plus_hidden.alphabetized.includes(:facility)
+      products = Product.for_facility(current_facility).not_archived.alphabetized.includes(:facility)
       facilities = Facility.active.alphabetized if current_facility.cross_facility?
       @search_options = { products: products, facilities: facilities }
       @search_fields = params

--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms/facility_occupancies_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms/facility_occupancies_controller.rb
@@ -37,7 +37,7 @@ module SecureRooms
     end
 
     def dashboard
-      @secure_rooms = current_facility.secure_rooms.active_plus_hidden.alphabetized
+      @secure_rooms = current_facility.secure_rooms.not_archived.alphabetized
     end
 
     protected

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/facility_extension.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/facility_extension.rb
@@ -7,7 +7,7 @@ module SecureRooms
     extend ActiveSupport::Concern
 
     included do
-      has_many :secure_rooms
+      has_many :secure_rooms, inverse_of: :facility
     end
 
   end


### PR DESCRIPTION
# Release Notes

Improve performance of FacilitiesController#show page

# Additional Context

This PR removes N+1 database queries for displaying instruments (per Skylight, we spend about 55% of the response time in the database), and rearranges the partials and attempts to optimize them so we have fewer object allocations (another performance hotspot per Skylight).