### PR TITLE
Fix InstrumentsController spec so it works across schools

### DIFF
--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe InstrumentsController do
         it "fails" do
           expect(response).to render_template("show")
           expect(assigns(:add_to_cart)).to be(false)
-          expect(flash[:notice]).to include("could not find a valid payment source")
+          expect(flash[:notice]).to be_present
         end
       end
 


### PR DESCRIPTION
# Release Notes

Fix InstrumentsController spec so it works across schools

# Additional Context

With #1881, this spec starts failing in Dartmouth, who don’t use training requests, because the error message is different since that validation fails first. This PR modifies the spec to check that a flash message is set, rather than checking the exact test, so that this works everywhere.