### PR TITLE
[#148443] Prevent facility directors from creating, editing or deleting price groups

### DIFF
--- a/app/views/admin/shared/_tabnav_price_group.html.haml
+++ b/app/views/admin/shared/_tabnav_price_group.html.haml
@@ -2,5 +2,5 @@
   = tab t('shared.tabnav_price_group.accounts'), accounts_facility_price_group_path(current_facility, @price_group), (secondary_tab == 'accounts')
   - if SettingsHelper.feature_on?(:user_based_price_groups) && @price_group_ability.can?(:read, UserPriceGroupMember)
     = tab t('shared.tabnav_price_group.users'), users_facility_price_group_path(current_facility, @price_group), (secondary_tab == 'users')
-  - unless @price_group.global?
+  - if @price_group.is_not_global? && current_ability.can?(:edit, PriceGroup)
     = tab t('shared.tabnav_price_group.edit'), edit_facility_price_group_path(current_facility, @price_group), (secondary_tab == 'edit')

--- a/app/views/price_groups/index.html.haml
+++ b/app/views/price_groups/index.html.haml
@@ -8,7 +8,8 @@
 %p= t('.intro')
 
 %ul.inline
-  %li= link_to t('.link.add'), new_facility_price_group_path, :class => 'btn-add'
+  - if current_ability.can?(:create, PriceGroup)
+    %li= link_to t('.link.add'), new_facility_price_group_path, :class => 'btn-add'
 
 - if @price_groups.empty?
   %p.alert.alert-info= t(".notice")
@@ -25,7 +26,7 @@
       - @price_groups.each do |price_group|
         %tr
           %td
-            - if price_group.can_delete?
+            - if price_group.can_delete? && current_ability.can?(:destroy, PriceGroup)
               = link_to t("shared.remove"),
                 [current_facility, price_group],
                 data: { confirm: t("shared.confirm_message") },

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -130,6 +130,7 @@ feature:
   charge_full_price_on_cancellation: true
   price_policy_requires_note: true
   multi_facility_accounts: true
+  facility_directors_can_manage_price_groups: true
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -180,6 +180,9 @@ class Ability
           StoredFile,
           TrainingRequest,
         ]
+        if user.facility_director_of?(resource) && SettingsHelper.feature_off?(:facility_directors_can_manage_price_groups) 
+          cannot [:create, :edit, :update, :destroy], PriceGroup
+        end
 
         can :manage, User if controller.is_a?(FacilityUsersController)
         cannot([:edit, :update], User)

--- a/spec/controllers/price_groups_controller_spec.rb
+++ b/spec/controllers/price_groups_controller_spec.rb
@@ -119,9 +119,18 @@ RSpec.describe PriceGroupsController do
         @action = :edit
       end
 
-      it_should_allow_managers_only do
-        expect(assigns(:price_group)).to be_kind_of(PriceGroup).and eq(price_group)
-        is_expected.to render_template("edit")
+      context "when facility_directors_can_manage_price_groups on", feature_setting: { facility_directors_can_manage_price_groups: true } do
+        it_should_allow_managers_only do 
+          expect(assigns(:price_group)).to be_kind_of(PriceGroup).and eq(price_group)
+          is_expected.to render_template("edit")
+        end
+      end
+
+      context "when facility_directors_can_manage_price_groups off", feature_setting: { facility_directors_can_manage_price_groups: false } do
+        it_should_allow_admin_only do 
+          expect(assigns(:price_group)).to be_kind_of(PriceGroup).and eq(price_group)
+          is_expected.to render_template("edit")
+        end
       end
     end
 
@@ -132,10 +141,20 @@ RSpec.describe PriceGroupsController do
         @params.merge!(price_group: attributes_for(:price_group, facility_id: facility.id))
       end
 
-      it_should_allow_managers_only :redirect do
-        expect(assigns(:price_group)).to be_kind_of(PriceGroup).and eq(price_group)
-        expect(flash[:notice]).to include("successfully updated")
-        is_expected.to redirect_to([facility, price_group])
+      context "when facility_directors_can_manage_price_groups on", feature_setting: { facility_directors_can_manage_price_groups: true } do
+        it_should_allow_managers_only :redirect do
+          expect(assigns(:price_group)).to be_kind_of(PriceGroup).and eq(price_group)
+          expect(flash[:notice]).to include("successfully updated")
+          is_expected.to redirect_to([facility, price_group])
+        end
+      end
+
+      context "when facility_directors_can_manage_price_groups off", feature_setting: { facility_directors_can_manage_price_groups: false } do
+        it_should_allow_admin_only :redirect do
+          expect(assigns(:price_group)).to be_kind_of(PriceGroup).and eq(price_group)
+          expect(flash[:notice]).to include("successfully updated")
+          is_expected.to redirect_to([facility, price_group])
+        end
       end
     end
 
@@ -145,10 +164,20 @@ RSpec.describe PriceGroupsController do
         @action = :destroy
       end
 
-      it_should_allow_managers_only :redirect do
-        expect(assigns(:price_group)).to be_kind_of(PriceGroup).and eq(price_group)
-        should_be_destroyed price_group
-        is_expected.to redirect_to(facility_price_groups_url)
+      context "when facility_directors_can_manage_price_groups on", feature_setting: { facility_directors_can_manage_price_groups: true } do
+        it_should_allow_managers_only :redirect do
+          expect(assigns(:price_group)).to be_kind_of(PriceGroup).and eq(price_group)
+          should_be_destroyed price_group
+          is_expected.to redirect_to(facility_price_groups_url)
+        end
+      end
+
+      context "when facility_directors_can_manage_price_groups off", feature_setting: { facility_directors_can_manage_price_groups: false } do
+        it_should_allow_admin_only :redirect do
+          expect(assigns(:price_group)).to be_kind_of(PriceGroup).and eq(price_group)
+          should_be_destroyed price_group
+          is_expected.to redirect_to(facility_price_groups_url)
+        end
       end
     end
   end

--- a/spec/features/admin/price_group_management_spec.rb
+++ b/spec/features/admin/price_group_management_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Managing Price Groups", :aggregate_failures do
   let(:facility) { FactoryBot.create(:facility) }
 
   describe "create" do
-    describe "as a facility admin" do
+    describe "as a facility admin", feature_setting: { facility_directors_can_manage_price_groups: true } do
       let(:user) { FactoryBot.create(:user, :facility_director, facility: facility) }
 
       before do


### PR DESCRIPTION
# Release Notes

Prevent facility directors from creating, editing or deleting price groups.

Adds `facility_directors_can_manage_price_groups` feature flag


# Screenshot - as admin

![Screen Shot 2019-04-03 at 12 59 57 PM](https://user-images.githubusercontent.com/403241/55501730-a50bf300-5610-11e9-9e7e-e1e55450fe4f.png)

![Screen Shot 2019-04-03 at 1 00 06 PM](https://user-images.githubusercontent.com/403241/55501869-fa480480-5610-11e9-8178-11650644a232.png)


# Screenshot - as facility director without privileges

![Screen Shot 2019-04-03 at 1 00 27 PM](https://user-images.githubusercontent.com/403241/55501843-ea302500-5610-11e9-88d4-c3e51fc5f153.png)

![Screen Shot 2019-04-03 at 1 00 34 PM](https://user-images.githubusercontent.com/403241/55501701-9e7d7b80-5610-11e9-853a-638cab9af854.png)
