### PR TITLE
[#144321] Fix width of Remove? column for editing accounts for a User

### DIFF
--- a/app/assets/stylesheets/app/tables.scss
+++ b/app/assets/stylesheets/app/tables.scss
@@ -39,6 +39,6 @@ tfoot.cart {
   }
 
   .table-user-accounts__remove {
-    max-width: 25px;
+    max-width: 35px;
   }
 }


### PR DESCRIPTION
# Release Notes

Fix width of Remove? column for editing accounts for a User

# Screenshot

## Before

<img width="348" alt="Screen Shot 2019-04-04 at 14 30 38" src="https://user-images.githubusercontent.com/7736/55555767-4d3fbb80-56e6-11e9-8b51-87fe43ddb23c.png">

## After

<img width="320" alt="Screen Shot 2019-04-04 at 14 30 31" src="https://user-images.githubusercontent.com/7736/55555773-50d34280-56e6-11e9-9fc4-bc6d9ca25a9e.png">
