### PR TITLE
[#144845] Facility Billing Administrator role

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,7 +97,7 @@ class ApplicationController < ActionController::Base
   end
 
   # return an ActiveRecord:Relation of facilities where this user has a role (ie is staff or higher)
-  # Administrator and Billing Administrator get a relation of all facilities
+  # Administrator and Global Billing Administrator get a relation of all facilities
   def operable_facilities
     @operable_facilities ||= (session_user.blank? ? [] : session_user.operable_facilities)
   end

--- a/app/controllers/facility_order_details_controller.rb
+++ b/app/controllers/facility_order_details_controller.rb
@@ -12,7 +12,6 @@ class FacilityOrderDetailsController < ApplicationController
 
   def initialize
     @active_tab = "admin_orders"
-binding.pry
     super
   end
 

--- a/app/controllers/facility_order_details_controller.rb
+++ b/app/controllers/facility_order_details_controller.rb
@@ -12,6 +12,7 @@ class FacilityOrderDetailsController < ApplicationController
 
   def initialize
     @active_tab = "admin_orders"
+binding.pry
     super
   end
 

--- a/app/models/concerns/users/roles.rb
+++ b/app/models/concerns/users/roles.rb
@@ -35,7 +35,7 @@ module Users
 
     # Returns relation of facilities for which this user is a director or admin
     def manageable_facilities
-      if administrator? || billing_administrator?
+      if administrator? || global_billing_administrator?
         Facility.alphabetized
       else
         facilities.alphabetized.where(user_roles: { role: UserRole.facility_management_roles })

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -7,7 +7,7 @@ class UserRole < ApplicationRecord
 
   ACCOUNT_MANAGER = "Account Manager"
   ADMINISTRATOR = "Administrator"
-  BILLING_ADMINISTRATOR = "Billing Administrator"
+  GLOBAL_BILLING_ADMINISTRATOR = "Global Billing Administrator"
   FACILITY_DIRECTOR = "Facility Director"
   FACILITY_ADMINISTRATOR = "Facility Administrator"
   FACILITY_STAFF = "Facility Staff"
@@ -36,8 +36,8 @@ class UserRole < ApplicationRecord
     [ADMINISTRATOR]
   end
 
-  def self.billing_administrator
-    [BILLING_ADMINISTRATOR]
+  def self.global_billing_administrator
+    [GLOBAL_BILLING_ADMINISTRATOR]
   end
 
   def self.facility_roles
@@ -50,7 +50,7 @@ class UserRole < ApplicationRecord
 
   def self.global_roles
     if SettingsHelper.feature_on?(:billing_administrator)
-      account_manager + administrator + billing_administrator
+      account_manager + administrator + global_billing_administrator
     else
       account_manager + administrator
     end
@@ -92,7 +92,7 @@ class UserRole < ApplicationRecord
   end
 
   # Supports a single item or an array of symbols (:account_manager), strings
-  # both underscored ("billing_administrator") and title cased ("Facility Staff).
+  # both underscored ("global_billing_administrator") and title cased ("Facility Staff).
   def in?(roles)
     role.in? Array(roles).map(&:to_s).map(&:titleize)
   end

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -12,6 +12,7 @@ class UserRole < ApplicationRecord
   FACILITY_ADMINISTRATOR = "Facility Administrator"
   FACILITY_STAFF = "Facility Staff"
   FACILITY_SENIOR_STAFF = "Facility Senior Staff"
+  FACILITY_BILLING_ADMINISTRATOR = "Facility Billing Administrator"
 
   scope :facility_director, -> { where(role: FACILITY_DIRECTOR) }
   scope :director_and_admins, -> { where(role: [FACILITY_DIRECTOR, FACILITY_ADMINISTRATOR]) }
@@ -40,12 +41,12 @@ class UserRole < ApplicationRecord
     [GLOBAL_BILLING_ADMINISTRATOR]
   end
 
-  def self.facility_roles
-    [FACILITY_DIRECTOR, FACILITY_ADMINISTRATOR, FACILITY_STAFF, FACILITY_SENIOR_STAFF]
+  def self.facility_management_roles
+    [FACILITY_DIRECTOR, FACILITY_ADMINISTRATOR]
   end
 
-  def self.facility_management_roles
-    facility_roles - [FACILITY_STAFF, FACILITY_SENIOR_STAFF]
+  def self.facility_roles
+    facility_management_roles + [FACILITY_STAFF, FACILITY_SENIOR_STAFF, FACILITY_BILLING_ADMINISTRATOR]
   end
 
   def self.global_roles

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -49,7 +49,7 @@ class UserRole < ApplicationRecord
   end
 
   def self.global_roles
-    if SettingsHelper.feature_on?(:billing_administrator)
+    if SettingsHelper.feature_on?(:global_billing_administrator)
       account_manager + administrator + global_billing_administrator
     else
       account_manager + administrator

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -94,8 +94,8 @@ relays:
 #
 # For these settings use SettingsHelper#feature_on?
 feature:
-  billing_administrator: true
-  billing_administrator_users_tab: true
+  global_billing_administrator: true
+  global_billing_administrator_users_tab: true
   create_users: true
   netids: true
   limit_short_description: true

--- a/db/migrate/20190227032150_add_product_specific_training_request_toggle.rb
+++ b/db/migrate/20190227032150_add_product_specific_training_request_toggle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddProductSpecificTrainingRequestToggle < ActiveRecord::Migration[5.0]
   def change
     add_column :products, :allows_training_requests, :boolean, default: true, null: false, after: :requires_approval

--- a/db/migrate/20190301022930_add_suspension_note_to_user.rb
+++ b/db/migrate/20190301022930_add_suspension_note_to_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSuspensionNoteToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :suspension_note, :string, after: :suspended_at

--- a/db/migrate/20190328133218_add_missing_indexes_for_timeline_pages.rb
+++ b/db/migrate/20190328133218_add_missing_indexes_for_timeline_pages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddMissingIndexesForTimelinePages < ActiveRecord::Migration[5.0]
   def change
     add_index :products, [:type, :is_archived, :schedule_id]

--- a/db/migrate/20190409205259_rename_billing_administrator_role.rb
+++ b/db/migrate/20190409205259_rename_billing_administrator_role.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class RenameBillingAdministratorRole < ActiveRecord::Migration[5.0]
+  def up
+  	UserRole.where(role: "Billing Administrator").each do |user|
+  		user.role = "Global Billing Administrator"
+  		user.save!
+  	end
+  end
+
+  def down
+  	UserRole.where(role: "Global Billing Administrator").each do |user|
+  		user.role = "Billing Administrator"
+  		user.save!
+  	end
+  end
+end

--- a/doc/user_roles.md
+++ b/doc/user_roles.md
@@ -85,13 +85,13 @@
     * May suspend/activate accounts
     * May suspend/activate users
     * Has no restrictions except in some cross-facility contexts
-      - They may not manage billing cross-facility (as Billing Administrators may do)
+      - They may not manage billing cross-facility (as Global Billing Administrators may do)
 
-  - Billing Administrator
+  - Global Billing Administrator
     * This role can manage billing in a cross-facility context where a user may:
       - View and manage orders, including disputed orders
       - Create and manage journals
-    * The Billing Administrator role has some incompatibilities with other user roles, and
+    * The Global Billing Administrator role has some incompatibilities with other user roles, and
       if used, should be assigned to a dedicated user login
 
   - Account Manager

--- a/doc/user_roles.md
+++ b/doc/user_roles.md
@@ -2,101 +2,105 @@
 
 ## Jargon Explained
 
-  - "facility"
+#### "facility"
 
-    At some schools, this may be refered to as a "resource", "shared resource",
-    or "core facility". Some user roles include the term "facility"
-    such as "Facility Director" or "Facility Staff", which means they are
-    specific to a specific facility.
+At some schools, this may be refered to as a "resource", "shared resource", or "core facility". Some user roles include the term "facility" such as "Facility Director" or "Facility Staff", which means they are specific to a specific facility.
 
-  - "cross-facility context"
+#### "cross-facility context"
 
-    Most NUcore functions exist in the context of a single facility, such as
-    the Core Genomics Facility. But some functions may apply across all
-    facilities, using the special facility name "ALL". This may be accessed by
-    some of the global roles.
+Most NUcore functions exist in the context of a single facility, such as the Core Genomics Facility. But some functions may apply across all facilities, using the special facility name "ALL". This may be accessed by some of the global roles.
 
-  - "account"
+#### "account"
 
-    A payment source which can be used to purchase things in NUcore. Examples include
-    chart strings and purchase orders.
+A payment source which can be used to purchase things in NUcore. Examples include chart strings and purchase orders.
+
+
+## All Roles
+* May create a training request
+* May complete an external service
+* May edit, view and cancel details about their own orders
+* May add, edit, view and remove their own reservations
+
 
 ## Facility Operator Roles
 
-  - Facility Staff
-    * May view, but not edit administrative details about products
-    * May view and update details about orders, except problem or disputed orders
-    * May view instrument schedule rules but not edit or remove them
-    * May view, but not change, product pricing rules
-    * May add, edit, view, and remove administrative reservations for instruments
-    * May view the list of product documentation files
-    * May view administrative details for facility users, but not change them
-    * May view orders and reservations for facility users
-    * May place orders on behalf of other users
-    * May grant or deny permission to use instruments
-    * May view the list of accessories for a product
+### Facility Staff
+* May view, but not edit administrative details about products
+* May view and update details about orders, except problem or disputed orders
+* May view instrument schedule rules but not edit or remove them
+* May view, but not change, product pricing rules
+* May add, edit, view, and remove administrative reservations for instruments
+* May view the list of product documentation files
+* May view administrative details for facility users, but not change them
+* May view orders and reservations for facility users
+* May place orders on behalf of other users
+* May grant or deny permission to use instruments
+* May view the list of accessories for a product
 
-  - Facility Senior Staff
-    * Has all the privileges of Facility Staff
-    * May add or remove product accessories
-    * May view product reports
-    * May add, edit, and remove instrument schedule rules and scheduling groups
-    * May upload and remove product documentation files
+### Facility Senior Staff
+* Has all the privileges of Facility Staff
+* May add or remove product accessories
+* May view product reports
+* May add, edit, and remove instrument schedule rules and scheduling groups
+* May upload and remove product documentation files
 
-  - Facility Director
-    * Has all the privileges of Facility Senior Staff
-    * May manage details about the facility (name, description, contact info, etc.)
-    * Has access to problem and disputed orders
-    * Has access to and may manage billing to:
-      - View and manage orders, including disputed orders
-      - Reassign the accounts associated with orders
-      - Create and manage journals
-    * May edit administrative details about products
-    * May bulk-import orders
-    * May create new users and assign user roles
-    * May add, edit and remove price groups, and add and remove a price group's users and accounts
-      - An exception is that no changes to the base and external rate price groups, are allowed
-      - No changes to the Cancer Center price group, aside from user membership, are allowed
+### Facility Director
+* Has all the privileges of Facility Senior Staff
+* May manage details about the facility (name, description, contact info, etc.)
+* Has access to problem and disputed orders
+* Has access to and may manage billing to:
+  - View and manage orders, including disputed orders
+  - Reassign the accounts associated with orders
+  - Create and manage journals
+* May edit administrative details about products
+* May bulk-import orders
+* May create new users and assign user roles
+* May add, edit and remove price groups, and add and remove a price group's users and accounts
+  - An exception is that no changes to the base and external rate price groups, are allowed
+  - No changes to the Cancer Center price group, aside from user membership, are allowed
 
-  - Facility Administrator
-    * Has the same privileges of Facility Directors
+### Facility Administrator
+* Has the same privileges of Facility Directors
+
 
 ## Account Roles
 
-  - Owner
-    * This is usually the PI (Primary Investigator)
-    * May purchase reservations, items, and services using their accounts
-    * May add/remove business administrators and purchasers from their accounts
-    * May view all transactions placed on their accounts regardless of who did the
-      ordering.
-    * May dispute charges placed on their accounts
-    * Each account can have one and only one owner
+### Owner
+* This is usually the PI (Primary Investigator)
+* May purchase reservations, items, and services using their accounts
+* May add/remove business administrators and purchasers from their accounts
+* May view all transactions placed on their accounts regardless of who did the
+  ordering.
+* May dispute charges placed on their accounts
+* Each account can have one and only one owner
 
-  - Business Administrator
-    * Has all of the same privaleges as the Owner
-    * An account may have as many BAs as they would like
+### Business Administrator
+* Has all of the same privaleges as the Owner
+* An account may have as many BAs as they would like
 
-  - Purchaser
-    * May purchase reservations, items, and services using their accounts
+### Purchaser
+* May purchase reservations, items, and services using their accounts
+
 
 ## Global Roles
-  - Administrator
-    * Virtually equivalent to being a Facility Administrator for all facilities
-    * May suspend/activate accounts
-    * May suspend/activate users
-    * Has no restrictions except in some cross-facility contexts
-      - They may not manage billing cross-facility (as Global Billing Administrators may do)
 
-  - Global Billing Administrator
-    * This role can manage billing in a cross-facility context where a user may:
-      - View and manage orders, including disputed orders
-      - Create and manage journals
-    * The Global Billing Administrator role has some incompatibilities with other user roles, and
-      if used, should be assigned to a dedicated user login
+### Administrator
+* Virtually equivalent to being a Facility Administrator for all facilities
+* May suspend/activate accounts
+* May suspend/activate users
+* Has no restrictions except in some cross-facility contexts
+  - They may not manage billing cross-facility (as Global Billing Administrators may do)
 
-  - Account Manager
-    * This role manages accounts and users in a cross-facility context
-    * May add or remove users to virtually any account
-    * May suspend/activate accounts
-    * May provision new users
-    * The Account Manager role has some incompatibilities with the Administrator role
+### Global Billing Administrator
+* This role can manage billing in a cross-facility context where a user may:
+  - View and manage orders, including disputed orders
+  - Create and manage journals
+* The Global Billing Administrator role has some incompatibilities with other user roles, and
+  if used, should be assigned to a dedicated user login
+
+### Account Manager
+* This role manages accounts and users in a cross-facility context
+* May add or remove users to virtually any account
+* May suspend/activate accounts
+* May provision new users
+* The Account Manager role has some incompatibilities with the Administrator role

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -27,7 +27,7 @@ class Ability
       facility_administrator_abilities(user, resource, controller)
       facility_director_abilities(user, resource, controller)
       account_manager_abilities(user, resource)
-      billing_administrator_abilities(user, resource)
+      global_billing_administrator_abilities(user, resource)
 
       account_administrator_abilities(user, resource, controller)
     end
@@ -48,7 +48,7 @@ class Ability
       can :manage, AccountPriceGroupMember
     else
       can :manage, :all
-      unless user.billing_administrator?
+      unless user.global_billing_administrator?
         cannot [:manage_accounts, :manage_billing], Facility.cross_facility
       end
       unless user.account_manager?
@@ -115,8 +115,8 @@ class Ability
   end
 
 
-  def billing_administrator_abilities(user, resource)
-    return unless user.billing_administrator?
+  def global_billing_administrator_abilities(user, resource)
+    return unless user.global_billing_administrator?
 
     can :manage, [Account, Journal, OrderDetail]
     can :manage, Statement if resource.is_a?(Facility)

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -127,7 +127,7 @@ class Ability
     end
     can :manage_users, Facility.cross_facility if SettingsHelper.feature_on?(:global_billing_administrator_users_tab)
     can :manage_billing, Facility.cross_facility
-    can [:disputed_orders, :movable_transactions, :transactions], Facility, &:cross_facility?
+    can [:disputed_orders, :movable_transactions, :transactions, :reassign_chart_strings, :confirm_transactions, :move_transactions], Facility, &:cross_facility?
   end
 
 
@@ -201,12 +201,18 @@ class Ability
       can [:show, :index], PriceGroup
       can [:show, :index], [PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ServicePricePolicy]
 
+      can :manage, AccountUser
+
+      can :index, [BundleProduct, ScheduleRule, ServicePricePolicy, ProductAccessory, ProductAccessGroup]
+      can :edit, [PriceGroupProduct]
+      can [:index], StoredFile
+
       can :manage, [Journal, Statement, OrderDetail]
       can [:send_receipt, :show], Order
       can [:accounts, :index, :orders, :show, :administer], User
       can :manage_users, resource
       can :manage_billing, resource
-      can [:disputed_orders, :movable_transactions, :transactions], Facility
+      can [:disputed_orders, :movable_transactions, :transactions, :reassign_chart_strings, :confirm_transactions, :move_transactions], Facility
 
       # Can manage an account if it is global (i.e. it's a chart string) or the account
       # is attached to the current facility.
@@ -336,6 +342,9 @@ class Ability
 
     if controller.is_a?(UsersController)
       can [:read, :create, :search, :access_list, :access_list_approvals, :new_external, :orders, :accounts], User
+    end
+    if controller.is_a?(UserAccountsController) || controller.is_a?(FacilityUserReservationsController)
+      can [:access_list], User
     end
 
     can :user_search_results, User if controller.is_a?(SearchController)

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -124,7 +124,7 @@ class Ability
     if resource == Facility.cross_facility
       can [:accounts, :index, :orders, :show, :administer], User
     end
-    can :manage_users, Facility.cross_facility if SettingsHelper.feature_on?(:billing_administrator_users_tab)
+    can :manage_users, Facility.cross_facility if SettingsHelper.feature_on?(:global_billing_administrator_users_tab)
     can :manage_billing, Facility.cross_facility
     can [:disputed_orders, :movable_transactions, :transactions], Facility, &:cross_facility?
   end

--- a/lib/tasks/demo_seed.rake
+++ b/lib/tasks/demo_seed.rake
@@ -210,12 +210,12 @@ namespace :demo do
     unless user_admin
       user_admin = User.new(username: "admin@example.com",
                             email: "admin@example.com",
-                            first_name: "Administrator",
+                            first_name: "Admin",
                             last_name: "Istrator")
       user_admin.password = "password"
       user_admin.save!
+      UserRole.grant(user_admin, UserRole::ADMINISTRATOR)
     end
-    UserRole.grant(user_admin, UserRole::ADMINISTRATOR)
 
     user_pi = User.find_by(username: "ppi123@example.com")
     unless user_pi
@@ -245,8 +245,8 @@ namespace :demo do
                             last_name: "Facility Staff")
       user_staff.password = "password"
       user_staff.save!
+      UserRole.grant(user_staff, UserRole::FACILITY_STAFF, facility)
     end
-    UserRole.grant(user_staff, UserRole::FACILITY_STAFF, facility)
 
     user_senior_staff = User.find_by(username: "jss123@example.com")
     unless user_senior_staff
@@ -256,8 +256,8 @@ namespace :demo do
                                    last_name: "Facility Senior Staff")
       user_senior_staff.password = "password"
       user_senior_staff.save!
+      UserRole.grant(user_senior_staff, UserRole::FACILITY_SENIOR_STAFF, facility)
     end
-    UserRole.grant(user_senior_staff, UserRole::FACILITY_SENIOR_STAFF, facility)
 
     user_facility_administrator = User.find_by(username: "mfa123@example.com")
     unless user_facility_administrator
@@ -267,8 +267,8 @@ namespace :demo do
                                              last_name: "Facility Administator")
       user_facility_administrator.password = "password"
       user_facility_administrator.save!
+      UserRole.grant(user_facility_administrator, UserRole::FACILITY_ADMINISTRATOR, facility)
     end
-    UserRole.grant(user_facility_administrator, UserRole::FACILITY_ADMINISTRATOR, facility)
 
     user_director = User.find_by(username: "ddi123@example.com")
     unless user_director
@@ -278,8 +278,8 @@ namespace :demo do
                                last_name: "Facililty Director")
       user_director.password = "password"
       user_director.save
+      UserRole.grant(user_director, UserRole::FACILITY_DIRECTOR, facility)
     end
-    UserRole.grant(user_director, UserRole::FACILITY_DIRECTOR, facility)
 
     user_account_manager = User.find_by(username: "aam123@example.com")
     unless user_account_manager
@@ -289,8 +289,8 @@ namespace :demo do
                                       last_name: "Account Manager")
       user_account_manager.password = "password"
       user_account_manager.save!
+      UserRole.grant(user_account_manager, UserRole::ACCOUNT_MANAGER)
     end
-    UserRole.grant(user_account_manager, UserRole::ACCOUNT_MANAGER)
 
     if SettingsHelper.feature_on?(:global_billing_administrator)
       user_global_billing_administrator = User.find_by(email: "bba123@example.com")
@@ -301,8 +301,8 @@ namespace :demo do
                                                      last_name: "Global Billing Administator")
         user_global_billing_administrator.password = "password"
         user_global_billing_administrator.save
+        UserRole.grant(user_global_billing_administrator, UserRole::GLOBAL_BILLING_ADMINISTRATOR)
       end
-      UserRole.grant(user_global_billing_administrator, UserRole::GLOBAL_BILLING_ADMINISTRATOR)
     end
 
     user_facility_billing_administrator = User.find_by(username: "ffba123@example.com")
@@ -313,9 +313,8 @@ namespace :demo do
                                                      last_name: "Facility Billing Administator")
       user_facility_billing_administrator.password = "password"
       user_facility_billing_administrator.save!
+      UserRole.grant(user_facility_billing_administrator, UserRole::FACILITY_BILLING_ADMINISTRATOR, facility)
     end
-    UserRole.grant(user_facility_billing_administrator, UserRole::FACILITY_BILLING_ADMINISTRATOR, facility)
-
 
     UserPriceGroupMember.find_or_create_by!(user_id: user_pi.id, price_group_id: pgnu.id)
     UserPriceGroupMember.find_or_create_by!(user_id: user_student.id, price_group_id: pgnu.id)

--- a/lib/tasks/demo_seed.rake
+++ b/lib/tasks/demo_seed.rake
@@ -210,7 +210,7 @@ namespace :demo do
     unless user_admin
       user_admin = User.new(username: "admin@example.com",
                             email: "admin@example.com",
-                            first_name: "Admin",
+                            first_name: "Administrator",
                             last_name: "Istrator")
       user_admin.password = "password"
       user_admin.save!
@@ -242,7 +242,7 @@ namespace :demo do
       user_staff = User.new(username: "ast123@example.com",
                             email: "ast123@example.com",
                             first_name: "Alice",
-                            last_name: "Staff")
+                            last_name: "Facility Staff")
       user_staff.password = "password"
       user_staff.save!
     end
@@ -253,7 +253,7 @@ namespace :demo do
       user_senior_staff = User.new(username: "jss123@example.com",
                                    email: "jss123@example.com",
                                    first_name: "Jennifer",
-                                   last_name: "Senior Staff")
+                                   last_name: "Facility Senior Staff")
       user_senior_staff.password = "password"
       user_senior_staff.save!
     end
@@ -275,7 +275,7 @@ namespace :demo do
       user_director = User.new(username: "ddi123@example.com",
                                email: "ddi123@example.com",
                                first_name: "Dave",
-                               last_name: "Director")
+                               last_name: "Facililty Director")
       user_director.password = "password"
       user_director.save
     end
@@ -294,21 +294,28 @@ namespace :demo do
 
     if SettingsHelper.feature_on?(:global_billing_administrator)
       user_global_billing_administrator = User.find_by(email: "bba123@example.com")
-
       if user_global_billing_administrator.blank?
-        user_global_billing_administrator =
-          User.new(
-            username: "bba123@example.com",
-            email: "bba123@example.com",
-            first_name: "Billy",
-            last_name: "Billing",
-          )
+        user_global_billing_administrator = User.new(username: "bba123@example.com",
+                                                     email: "bba123@example.com",
+                                                     first_name: "Billy",
+                                                     last_name: "Global Billing Administator")
         user_global_billing_administrator.password = "password"
         user_global_billing_administrator.save
       end
-
       UserRole.grant(user_global_billing_administrator, UserRole::GLOBAL_BILLING_ADMINISTRATOR)
     end
+
+    user_facility_billing_administrator = User.find_by(username: "ffba123@example.com")
+    unless user_facility_billing_administrator
+      user_facility_billing_administrator = User.new(username: "ffba123@example.com",
+                                                     email: "ffba123@example.com",
+                                                     first_name: "Felix",
+                                                     last_name: "Facility Billing Administator")
+      user_facility_billing_administrator.password = "password"
+      user_facility_billing_administrator.save!
+    end
+    UserRole.grant(user_facility_billing_administrator, UserRole::FACILITY_BILLING_ADMINISTRATOR, facility)
+
 
     UserPriceGroupMember.find_or_create_by!(user_id: user_pi.id, price_group_id: pgnu.id)
     UserPriceGroupMember.find_or_create_by!(user_id: user_student.id, price_group_id: pgnu.id)

--- a/lib/tasks/demo_seed.rake
+++ b/lib/tasks/demo_seed.rake
@@ -292,7 +292,7 @@ namespace :demo do
     end
     UserRole.grant(user_account_manager, UserRole::ACCOUNT_MANAGER)
 
-    if SettingsHelper.feature_on?(:billing_administrator)
+    if SettingsHelper.feature_on?(:global_billing_administrator)
       user_global_billing_administrator = User.find_by(email: "bba123@example.com")
 
       if user_global_billing_administrator.blank?

--- a/lib/tasks/demo_seed.rake
+++ b/lib/tasks/demo_seed.rake
@@ -293,21 +293,21 @@ namespace :demo do
     UserRole.grant(user_account_manager, UserRole::ACCOUNT_MANAGER)
 
     if SettingsHelper.feature_on?(:billing_administrator)
-      user_billing_administrator = User.find_by(email: "bba123@example.com")
+      user_global_billing_administrator = User.find_by(email: "bba123@example.com")
 
-      if user_billing_administrator.blank?
-        user_billing_administrator =
+      if user_global_billing_administrator.blank?
+        user_global_billing_administrator =
           User.new(
             username: "bba123@example.com",
             email: "bba123@example.com",
             first_name: "Billy",
             last_name: "Billing",
           )
-        user_billing_administrator.password = "password"
-        user_billing_administrator.save
+        user_global_billing_administrator.password = "password"
+        user_global_billing_administrator.save
       end
 
-      UserRole.grant(user_billing_administrator, UserRole::BILLING_ADMINISTRATOR)
+      UserRole.grant(user_global_billing_administrator, UserRole::GLOBAL_BILLING_ADMINISTRATOR)
     end
 
     UserPriceGroupMember.find_or_create_by!(user_id: user_pi.id, price_group_id: pgnu.id)

--- a/spec/controllers/facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_accounts_controller_spec.rb
@@ -290,8 +290,8 @@ RSpec.describe FacilityAccountsController, feature_setting: { edit_accounts: tru
         expect(response.code).to eq("403")
       end
 
-      it "allows billing administrator to access the statement" do
-        user = create(:user, :billing_administrator)
+      it "allows global billing administrator to access the statement" do
+        user = create(:user, :global_billing_administrator)
         sign_in user
         do_request
         expect(response).to be_success

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -335,7 +335,7 @@ RSpec.describe FacilityJournalsController do
       end
     end
 
-    context "in cross facility", feature_setting: { billing_administrator: true } do
+    context "in cross facility", feature_setting: { global_billing_administrator: true } do
       before :each do
         @params[:facility_id] = "all"
         sign_in create(:user, :global_billing_administrator)
@@ -445,7 +445,7 @@ RSpec.describe FacilityJournalsController do
       expect(assigns(:order_detail_action)).to be_nil
     end
 
-    context "in cross facility", feature_setting: { billing_administrator: true } do
+    context "in cross facility", feature_setting: { global_billing_administrator: true } do
       before :each do
         @params[:facility_id] = "all"
         sign_in create(:user, :global_billing_administrator)

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe FacilityJournalsController do
     context "in cross facility", feature_setting: { billing_administrator: true } do
       before :each do
         @params[:facility_id] = "all"
-        sign_in create(:user, :billing_administrator)
+        sign_in create(:user, :global_billing_administrator)
         do_request
       end
 
@@ -448,7 +448,7 @@ RSpec.describe FacilityJournalsController do
     context "in cross facility", feature_setting: { billing_administrator: true } do
       before :each do
         @params[:facility_id] = "all"
-        sign_in create(:user, :billing_administrator)
+        sign_in create(:user, :global_billing_administrator)
         do_request
       end
 

--- a/spec/controllers/facility_statements_controller_spec.rb
+++ b/spec/controllers/facility_statements_controller_spec.rb
@@ -75,7 +75,7 @@ if Account.config.statements_enabled?
         let(:billing_admin) { create(:user) }
 
         before do
-          UserRole.grant(billing_admin, UserRole::BILLING_ADMINISTRATOR)
+          UserRole.grant(billing_admin, UserRole::GLOBAL_BILLING_ADMINISTRATOR)
           sign_in billing_admin
           get :index, params: { facility_id: "all" }
         end

--- a/spec/controllers/global_search_controller_spec.rb
+++ b/spec/controllers/global_search_controller_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe GlobalSearchController do
       it_should_have_customer_paths
     end
 
-    context "when signed in as a global billing administrator", feature_setting: { billing_administrator: true } do
+    context "when signed in as a global billing administrator", feature_setting: { global_billing_administrator: true } do
       before { sign_in create(:user, :global_billing_administrator) }
 
       it_should_find_the_order

--- a/spec/controllers/global_search_controller_spec.rb
+++ b/spec/controllers/global_search_controller_spec.rb
@@ -138,8 +138,8 @@ RSpec.describe GlobalSearchController do
       it_should_have_customer_paths
     end
 
-    context "when signed in as a billing administrator", feature_setting: { billing_administrator: true } do
-      before { sign_in create(:user, :billing_administrator) }
+    context "when signed in as a global billing administrator", feature_setting: { billing_administrator: true } do
+      before { sign_in create(:user, :global_billing_administrator) }
 
       it_should_find_the_order
       it_should_have_admin_edit_paths

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -38,9 +38,9 @@ FactoryBot.define do
       end
     end
 
-    trait :billing_administrator do
+    trait :global_billing_administrator do
       after(:create) do |user, _|
-        UserRole.create!(user: user, role: UserRole::BILLING_ADMINISTRATOR)
+        UserRole.create!(user: user, role: UserRole::GLOBAL_BILLING_ADMINISTRATOR)
       end
     end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -123,5 +123,17 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :facility_billing_administrator do
+      transient { facility { nil } }
+
+      after(:create) do |user, evaluator|
+        UserRole.create!(
+          user: user,
+          role: UserRole::FACILITY_BILLING_ADMINISTRATOR,
+          facility: evaluator.facility,
+        )
+      end
+    end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ApplicationHelper do
       it_behaves_like "it returns only facilities with a role"
     end
 
-    context "when the user is a global billing_admin", feature_setting: { billing_administrator: true } do
+    context "when the user is a global billing_admin", feature_setting: { global_billing_administrator: true } do
       let(:user) { create(:user, :global_billing_administrator) }
       it_behaves_like "it returns only facilities with a role"
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe ApplicationHelper do
       it_behaves_like "it returns only facilities with a role"
     end
 
-    context "when the user is a billing_admin", feature_setting: { billing_administrator: true } do
-      let(:user) { create(:user, :billing_administrator) }
+    context "when the user is a global billing_admin", feature_setting: { billing_administrator: true } do
+      let(:user) { create(:user, :global_billing_administrator) }
       it_behaves_like "it returns only facilities with a role"
     end
   end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe Ability do
       it_is_allowed_to([:accounts, :index, :show], User)
       it_is_not_allowed_to([:create, :orders, :switch_to], User)
       it_is_allowed_to([:send_receipt, :show], Order)
-      it_is_not_allowed_to([:send_receipt, :show], Order)
+      it_is_not_allowed_to([:update, :edit, :new, :destroy], Order)
       it_is_allowed_to([:show], Reservation)
       it_is_not_allowed_to([:edit, :update, :destroy], Reservation)
       it { is_expected.to be_allowed_to(:administer, :index, :show, Product) }

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Ability do
         it { is_expected.not_to be_allowed_to(:manage_users, facility) }
       end
 
-      %i(disputed_orders manage_billing movable_transactions transactions).each do |action|
+      %i(disputed_orders manage_billing movable_transactions transactions reassign_chart_strings confirm_transactions move_transactions).each do |action|
         it { is_expected.to be_allowed_to(action, facility) }
       end
       it_is_allowed_to([:accounts, :index, :orders, :show], User)
@@ -350,6 +350,15 @@ RSpec.describe Ability do
       it_is_allowed_to([:show, :index], PricePolicy)
       it_is_not_allowed_to([:create, :edit, :update, :destroy], PricePolicy)
 
+      it { is_expected.to be_allowed_to(:index, BundleProduct) }
+      it { is_expected.to be_allowed_to(:index, ScheduleRule) }
+      it { is_expected.to be_allowed_to(:index, ServicePricePolicy) }
+      it { is_expected.to be_allowed_to(:index, ProductAccessory) }
+      it { is_expected.to be_allowed_to(:index, ProductAccessGroup) }
+      it { is_expected.to be_allowed_to(:edit, PriceGroupProduct) }
+      it { is_expected.to be_allowed_to(:index, StoredFile) }
+
+      it { is_expected.to be_allowed_to(:manage, AccountUser) }
 
       it { is_expected.to be_allowed_to(:manage_users, subject_resource) }
       it { is_expected.to be_allowed_to(:manage_billing, subject_resource) }
@@ -358,8 +367,8 @@ RSpec.describe Ability do
       it_is_allowed_to([:send_receipt, :show], Order)
       it_is_not_allowed_to([:update, :edit, :new, :destroy], Order)
 
-      %i(disputed_orders manage_billing movable_transactions transactions).each do |action|
-        it { is_expected.to be_allowed_to(action, facility) }
+      %i(disputed_orders movable_transactions transactions reassign_chart_strings confirm_transactions move_transactions).each do |action|
+        it { is_expected.to be_allowed_to(action, subject_resource) }
       end
     end
 
@@ -375,7 +384,7 @@ RSpec.describe Ability do
       it_is_not_allowed_to([:accounts, :index, :orders, :show, :create, :switch_to], User)
       it_is_not_allowed_to([:send_receipt, :show], Order)
 
-      %i(disputed_orders manage_billing movable_transactions transactions).each do |action|
+      %i(disputed_orders manage_billing movable_transactions transactions reassign_chart_strings confirm_transactions move_transactions).each do |action|
         it { is_expected.not_to be_allowed_to(action, facility) }
       end
     end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -245,49 +245,6 @@ RSpec.describe Ability do
     end
   end
 
-  describe "facility billing administrator" do
-    let(:user) { create(:user, :facility_billing_administrator, facility: facility) }
-
-    it { is_expected.to be_allowed_to(:manage, Account) }
-    it { is_expected.to be_allowed_to(:manage, Journal) }
-    it { is_expected.to be_allowed_to(:manage, Statement) }
-    it { is_expected.to be_allowed_to(:manage, OrderDetail) }
-    it_is_not_allowed_to([:edit, :update]) { FactoryBot.create(:user) }
-    it_is_not_allowed_to([:accounts, :index, :orders, :show, :create, :switch_to], User)
-
-    context "in a single facility" do
-      let(:subject_resource) { facility }
-
-      %i(disputed_orders movable_transactions transactions).each do |action|
-        it { is_expected.to be_allowed_to(action, subject_resource) }
-      end
-      it { is_expected.to be_allowed_to(:manage_billing, subject_resource) }
-      it { is_expected.to be_allowed_to(:manage_users, subject_resource) }
-      it_is_allowed_to([:accounts, :index, :show], User)
-      it_is_not_allowed_to([:create, :orders, :switch_to], User)
-      it_is_allowed_to([:send_receipt, :show], Order)
-      it_is_not_allowed_to([:update, :edit, :new, :destroy], Order)
-      it_is_allowed_to([:show], Reservation)
-      it_is_not_allowed_to([:edit, :update, :destroy], Reservation)
-      it { is_expected.to be_allowed_to(:administer, :index, :show, Product) }
-      it { is_expected.not_to be_allowed_to(:edit, :update, :destroy, Product) }
-    end
-
-    context "in cross-facility" do
-      let(:subject_resource) { Facility.cross_facility }
-
-      %i(disputed_orders movable_transactions transactions).each do |action|
-        it { is_expected.to_not be_allowed_to(action, subject_resource) }
-      end
-      it { is_expected.to_not be_allowed_to(:manage_billing, subject_resource) }
-      it { is_expected.to_not be_allowed_to(:manage_users, subject_resource) }
-      it_is_not_allowed_to([:accounts, :index, :orders, :show, :create, :switch_to], User)
-      it { is_expected.not_to be_allowed_to(:show, Order) }
-      it { is_expected.not_to be_allowed_to(:manage, Reservation) }
-      it { is_expected.not_to be_allowed_to(:administer, Product) }
-    end
-  end
-
   describe "facility administrator" do
     let(:user) { create(:user, :facility_administrator, facility: facility) }
 
@@ -367,6 +324,60 @@ RSpec.describe Ability do
       it_is_not_allowed_to([:create, :edit, :update, :destroy], ItemPricePolicy)
       it_is_allowed_to([:show, :index], ServicePricePolicy)
       it_is_not_allowed_to([:create, :edit, :update, :destroy], ServicePricePolicy)
+    end
+  end
+
+  describe "facility billing administrator" do
+    let(:user) { create(:user, :facility_billing_administrator, facility: facility) }
+
+    it_is_allowed_to(:manage, Journal)
+    it_is_allowed_to(:manage, Statement)
+    it_is_allowed_to(:manage, OrderDetail)
+    it_is_allowed_to(:manage, Account)
+    it_is_not_allowed_to([:create, :edit, :update, :suspend, :switch_to], User)
+    it_is_allowed_to([:accounts, :index, :orders, :show, :administer], User)
+
+    context "in a single facility" do
+      let(:subject_resource) { facility }
+
+      it_is_allowed_to([:list, :dashboard, :show], Facility)
+      it_is_allowed_to([:index, :show, :timeline], Reservation)
+      it_is_not_allowed_to([:edit, :update, :destroy], Reservation)
+      it_is_allowed_to([:administer, :index, :view_details, :schedule, :show], Product)
+      it_is_not_allowed_to([:edit, :update, :destroy], Product)
+      it_is_allowed_to([:show, :index], PriceGroup)
+      it_is_not_allowed_to([:create, :edit, :update, :destroy], PriceGroup)
+      it_is_allowed_to([:show, :index], PricePolicy)
+      it_is_not_allowed_to([:create, :edit, :update, :destroy], PricePolicy)
+
+
+      it { is_expected.to be_allowed_to(:manage_users, subject_resource) }
+      it { is_expected.to be_allowed_to(:manage_billing, subject_resource) }
+      it_is_allowed_to([:accounts, :index, :orders, :show, :administer], User)
+      it_is_not_allowed_to([:create, :edit, :update, :switch_to], User)
+      it_is_allowed_to([:send_receipt, :show], Order)
+      it_is_not_allowed_to([:update, :edit, :new, :destroy], Order)
+
+      %i(disputed_orders manage_billing movable_transactions transactions).each do |action|
+        it { is_expected.to be_allowed_to(action, facility) }
+      end
+    end
+
+    context "in cross-facility" do
+      let(:subject_resource) { Facility.cross_facility }
+
+      it_is_not_allowed_to(:show, Reservation)
+      it_is_not_allowed_to([:administer, :index, :show], Product)
+      it_is_not_allowed_to([:show, :index], PriceGroup)
+
+      it { is_expected.not_to be_allowed_to(:manage_users, subject_resource) }
+      it { is_expected.not_to be_allowed_to(:manage_billing, subject_resource) }
+      it_is_not_allowed_to([:accounts, :index, :orders, :show, :create, :switch_to], User)
+      it_is_not_allowed_to([:send_receipt, :show], Order)
+
+      %i(disputed_orders manage_billing movable_transactions transactions).each do |action|
+        it { is_expected.not_to be_allowed_to(action, facility) }
+      end
     end
   end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -245,6 +245,49 @@ RSpec.describe Ability do
     end
   end
 
+  describe "facility billing administrator" do
+    let(:user) { create(:user, :facility_billing_administrator, facility: facility) }
+
+    it { is_expected.to be_allowed_to(:manage, Account) }
+    it { is_expected.to be_allowed_to(:manage, Journal) }
+    it { is_expected.to be_allowed_to(:manage, Statement) }
+    it { is_expected.to be_allowed_to(:manage, OrderDetail) }
+    it_is_not_allowed_to([:edit, :update]) { FactoryBot.create(:user) }
+    it_is_not_allowed_to([:accounts, :index, :orders, :show, :create, :switch_to], User)
+
+    context "in a single facility" do
+      let(:subject_resource) { facility }
+
+      %i(disputed_orders movable_transactions transactions).each do |action|
+        it { is_expected.to be_allowed_to(action, subject_resource) }
+      end
+      it { is_expected.to be_allowed_to(:manage_billing, subject_resource) }
+      it { is_expected.to be_allowed_to(:manage_users, subject_resource) }
+      it_is_allowed_to([:accounts, :index, :show], User)
+      it_is_not_allowed_to([:create, :orders, :switch_to], User)
+      it_is_allowed_to([:send_receipt, :show], Order)
+      it_is_not_allowed_to([:send_receipt, :show], Order)
+      it_is_allowed_to([:show], Reservation)
+      it_is_not_allowed_to([:edit, :update, :destroy], Reservation)
+      it { is_expected.to be_allowed_to(:administer, :index, :show, Product) }
+      it { is_expected.not_to be_allowed_to(:edit, :update, :destroy, Product) }
+    end
+
+    context "in cross-facility" do
+      let(:subject_resource) { Facility.cross_facility }
+
+      %i(disputed_orders movable_transactions transactions).each do |action|
+        it { is_expected.to_not be_allowed_to(action, subject_resource) }
+      end
+      it { is_expected.to_not be_allowed_to(:manage_billing, subject_resource) }
+      it { is_expected.to_not be_allowed_to(:manage_users, subject_resource) }
+      it_is_not_allowed_to([:accounts, :index, :orders, :show, :create, :switch_to], User)
+      it { is_expected.not_to be_allowed_to(:show, Order) }
+      it { is_expected.not_to be_allowed_to(:manage, Reservation) }
+      it { is_expected.not_to be_allowed_to(:administer, Product) }
+    end
+  end
+
   describe "facility administrator" do
     let(:user) { create(:user, :facility_administrator, facility: facility) }
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -190,8 +190,8 @@ RSpec.describe Ability do
     end
   end
 
-  describe "billing administrator", feature_setting: { billing_administrator: true } do
-    let(:user) { create(:user, :billing_administrator) }
+  describe "global billing administrator", feature_setting: { billing_administrator: true } do
+    let(:user) { create(:user, :global_billing_administrator) }
 
     it { is_expected.to be_allowed_to(:manage, Account) }
     it { is_expected.to be_allowed_to(:manage, Journal) }

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe Ability do
     end
   end
 
-  describe "global billing administrator", feature_setting: { billing_administrator: true } do
+  describe "global billing administrator", feature_setting: { global_billing_administrator: true } do
     let(:user) { create(:user, :global_billing_administrator) }
 
     it { is_expected.to be_allowed_to(:manage, Account) }
@@ -209,11 +209,11 @@ RSpec.describe Ability do
     context "in cross-facility" do
       let(:facility) { Facility.cross_facility }
 
-      context "with the users tab active", feature_setting: { billing_administrator_users_tab: true } do
+      context "with the users tab active", feature_setting: { global_billing_administrator_users_tab: true } do
         it { is_expected.to be_allowed_to(:manage_users, facility) }
       end
 
-      context "with the users tab inactive", feature_setting: { billing_administrator_users_tab: false } do
+      context "with the users tab inactive", feature_setting: { global_billing_administrator_users_tab: false } do
         it { is_expected.not_to be_allowed_to(:manage_users, facility) }
       end
 
@@ -231,11 +231,11 @@ RSpec.describe Ability do
     context "in no facility" do
       let(:facility) { nil }
 
-      context "with the users tab active", feature_setting: { billing_administrator_users_tab: true } do
+      context "with the users tab active", feature_setting: { global_billing_administrator_users_tab: true } do
         it { is_expected.to be_allowed_to(:manage_users, Facility.cross_facility) }
       end
 
-      context "with the users tab inactive", feature_setting: { billing_administrator_users_tab: false } do
+      context "with the users tab inactive", feature_setting: { global_billing_administrator_users_tab: false } do
         it { is_expected.not_to be_allowed_to(:manage_users, Facility.cross_facility) }
       end
 

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe UserRole do
     subject(:user_role) { described_class.new(user: user, role: role, facility: facility) }
     let(:user) { create(:user) }
 
-    context "when the role is Billing Administrator" do
+    context "when the role is Global Billing Administrator" do
       let(:facility) { nil }
-      let(:role) { described_class::BILLING_ADMINISTRATOR }
+      let(:role) { described_class::GLOBAL_BILLING_ADMINISTRATOR }
 
       context "and the billing_administrator feature is enabled", feature_setting: { billing_administrator: true } do
         it { is_expected.to be_valid }

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe UserRole do
       let(:facility) { nil }
       let(:role) { described_class::GLOBAL_BILLING_ADMINISTRATOR }
 
-      context "and the billing_administrator feature is enabled", feature_setting: { billing_administrator: true } do
+      context "and the global_billing_administrator feature is enabled", feature_setting: { global_billing_administrator: true } do
         it { is_expected.to be_valid }
       end
 
-      context "and the billing_administrator feature is disabled", feature_setting: { billing_administrator: false } do
+      context "and the global_billing_administrator feature is disabled", feature_setting: { global_billing_administrator: false } do
         it "is invalid" do
           is_expected.not_to be_valid
           expect(user_role.errors[:role])

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe User do
       it { is_expected.to match_array(privileged_users) }
     end
 
-    context "when users have the global billing administrator role", feature_setting: { billing_administrator: true } do
+    context "when users have the global billing administrator role", feature_setting: { global_billing_administrator: true } do
       let!(:privileged_users) { create_list(:user, 2, :global_billing_administrator) }
 
       it { is_expected.to match_array(privileged_users) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -119,8 +119,8 @@ RSpec.describe User do
       it { is_expected.to match_array(privileged_users) }
     end
 
-    context "when users have the billing administrator role", feature_setting: { billing_administrator: true } do
-      let!(:privileged_users) { create_list(:user, 2, :billing_administrator) }
+    context "when users have the global billing administrator role", feature_setting: { billing_administrator: true } do
+      let!(:privileged_users) { create_list(:user, 2, :global_billing_administrator) }
 
       it { is_expected.to match_array(privileged_users) }
     end

--- a/spec/presenters/user_presenter_spec.rb
+++ b/spec/presenters/user_presenter_spec.rb
@@ -26,16 +26,16 @@ RSpec.describe UserPresenter, feature_setting: { billing_administrator: true } d
         expect(global_role_select_options)
           .to include('selected="selected" value="Administrator">Administrator')
         expect(global_role_select_options)
-          .not_to include('selected="selected" value="Billing Administrator">Billing Administrator')
+          .not_to include('selected="selected" value="Global Billing Administrator">Global Billing Administrator')
       end
     end
   end
 
   context "when the user has multiple global roles" do
-    let(:user) { create(:user, :administrator, :billing_administrator) }
+    let(:user) { create(:user, :administrator, :global_billing_administrator) }
 
     describe "#global_role_list" do
-      it { expect(global_role_list).to eq("Administrator, Billing Administrator") }
+      it { expect(global_role_list).to eq("Administrator, Global Billing Administrator") }
     end
 
     describe "#global_role_select_options" do
@@ -43,7 +43,7 @@ RSpec.describe UserPresenter, feature_setting: { billing_administrator: true } d
         expect(global_role_select_options)
           .to include('selected="selected" value="Administrator">Administrator')
         expect(global_role_select_options)
-          .to include('selected="selected" value="Billing Administrator">Billing Administrator')
+          .to include('selected="selected" value="Global Billing Administrator">Global Billing Administrator')
       end
     end
   end

--- a/spec/presenters/user_presenter_spec.rb
+++ b/spec/presenters/user_presenter_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UserPresenter, feature_setting: { billing_administrator: true } do
+RSpec.describe UserPresenter, feature_setting: { global_billing_administrator: true } do
   subject { described_class.new(user) }
   let(:global_role_list) { subject.global_role_list }
   let(:global_role_select_options) { subject.global_role_select_options }

--- a/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
+++ b/vendor/engines/bulk_email/spec/controllers/bulk_email/bulk_email_controller_spec.rb
@@ -131,8 +131,8 @@ RSpec.describe BulkEmail::BulkEmailController do
         it_behaves_like "it can search for recipients"
       end
 
-      context "when logged in as a billing administrator" do
-        let(:user) { FactoryBot.create(:user, :billing_administrator) }
+      context "when logged in as a global billing administrator" do
+        let(:user) { FactoryBot.create(:user, :global_billing_administrator) }
 
         context "in a cross-facility context" do
           let(:facility) { Facility.cross_facility }

--- a/vendor/engines/bulk_email/spec/models/bulk_email/ability_extension_spec.rb
+++ b/vendor/engines/bulk_email/spec/models/bulk_email/ability_extension_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe BulkEmail::AbilityExtension do
     it_behaves_like "it may send bulk email"
   end
 
-  describe "billing administrator", feature_setting: { billing_administrator: true } do
-    let(:user) { FactoryBot.create(:user, :billing_administrator) }
+  describe "global billing administrator", feature_setting: { billing_administrator: true } do
+    let(:user) { FactoryBot.create(:user, :global_billing_administrator) }
 
     context "when in a cross-facility context" do
       let(:facility) { Facility.cross_facility }

--- a/vendor/engines/bulk_email/spec/models/bulk_email/ability_extension_spec.rb
+++ b/vendor/engines/bulk_email/spec/models/bulk_email/ability_extension_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe BulkEmail::AbilityExtension do
     it_behaves_like "it may send bulk email"
   end
 
-  describe "global billing administrator", feature_setting: { billing_administrator: true } do
+  describe "global billing administrator", feature_setting: { global_billing_administrator: true } do
     let(:user) { FactoryBot.create(:user, :global_billing_administrator) }
 
     context "when in a cross-facility context" do

--- a/vendor/engines/projects/app/models/projects/ability_extension.rb
+++ b/vendor/engines/projects/app/models/projects/ability_extension.rb
@@ -11,7 +11,7 @@ module Projects
     end
 
     def extend(user, resource)
-      if user.operator_of?(resource)
+      if user.operator_of?(resource) && !user.facility_billing_administrator_of?(resource)
         ability.can([:create, :edit, :inactive, :index, :new, :show, :update], Projects::Project)
       end
     end

--- a/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
+++ b/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
@@ -50,6 +50,11 @@ RSpec.describe Projects::AbilityExtension do
     it_behaves_like "it has full access"
   end
 
+  describe "facility billing administrator" do
+    let(:user) { FactoryBot.create(:user, :facility_billing_administrator, facility: facility) }
+    it_behaves_like "it has no access"
+  end
+
   describe "senior staff" do
     let(:user) { FactoryBot.create(:user, :senior_staff, facility: facility) }
     it_behaves_like "it has full access"

--- a/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
+++ b/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe Projects::AbilityExtension do
     it_behaves_like "it has full access"
   end
 
-  describe "billing administrator", feature_setting: { billing_administrator: true } do
-    let(:user) { FactoryBot.create(:user, :billing_administrator) }
+  describe "global billing administrator", feature_setting: { billing_administrator: true } do
+    let(:user) { FactoryBot.create(:user, :global_billing_administrator) }
     it_behaves_like "it has no access"
   end
 

--- a/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
+++ b/vendor/engines/projects/spec/models/projects/ability_extension_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Projects::AbilityExtension do
     it_behaves_like "it has full access"
   end
 
-  describe "global billing administrator", feature_setting: { billing_administrator: true } do
+  describe "global billing administrator", feature_setting: { global_billing_administrator: true } do
     let(:user) { FactoryBot.create(:user, :global_billing_administrator) }
     it_behaves_like "it has no access"
   end

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/ability_extension.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/ability_extension.rb
@@ -12,6 +12,7 @@ module SecureRooms
 
     def extend(user, resource)
       ability.can :manage, CardReader if user.manager_of?(resource) || user.facility_senior_staff_of?(resource)
+
       if user.operator_of?(resource)
         ability.can [
           :index,

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/card_number_ability.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/card_number_ability.rb
@@ -9,7 +9,10 @@ module SecureRooms
     def initialize(user, facility)
       return unless user && facility
 
-      can :edit, User if user.administrator? || user.operator_of?(facility)
+      if user.administrator? || user.facility_director_of?(facility) || user.facility_administrator_of?(facility) ||
+      	 user.facility_senior_staff_of?(facility) || user.facility_staff_of?(facility)
+      	can :edit, User
+      end
     end
 
   end

--- a/vendor/engines/secure_rooms/spec/models/ability_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/ability_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe Ability do
     it_is_not_allowed_to([:show_problems, :assign_price_policies_to_problem_orders], SecureRooms::Occupancy)
   end
 
+  describe "facility billing administrator" do
+    let(:user) { FactoryBot.create(:user, :facility_billing_administrator, facility: facility) }
+
+    it_is_allowed_to([:index, :dashboard, :tab_counts], SecureRooms::Occupancy)
+    it_is_not_allowed_to([:show_problems, :assign_price_policies_to_problem_orders], SecureRooms::Occupancy)
+  end
+
   describe "facility administrator" do
     let(:user) { FactoryBot.create(:user, :facility_administrator, facility: facility) }
 

--- a/vendor/engines/secure_rooms/spec/models/ability_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/ability_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe Ability do
                           :assign_price_policies_to_problem_orders], SecureRooms::Occupancy)
   end
 
-  describe "billing admin" do
-    let(:user) { FactoryBot.create(:user, :billing_administrator) }
+  describe "global billing administrator" do
+    let(:user) { FactoryBot.create(:user, :global_billing_administrator) }
 
     it_is_not_allowed_to([:index, :dashboard, :tab_counts, :show_problems,
                           :assign_price_policies_to_problem_orders], SecureRooms::Occupancy)

--- a/vendor/engines/secure_rooms/spec/models/secure_rooms/card_number_ability_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/secure_rooms/card_number_ability_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe SecureRooms::CardNumberAbility do
     it { is_expected.to be_allowed_to(:edit, card_user) }
   end
 
+  describe "facility billing administrator" do
+    let(:current_user) { FactoryBot.create(:user, :facility_billing_administrator, facility: facility) }
+    it { is_expected.not_to be_allowed_to(:edit, card_user) }
+  end
+
   describe "senior staff" do
     let(:current_user) { FactoryBot.create(:user, :senior_staff, facility: facility) }
     it { is_expected.to be_allowed_to(:edit, card_user) }


### PR DESCRIPTION
# Release Notes

Create a Facility Billing Administrator role similar to the Billing Administrator role but limited to specific facilities.

# Screenshot

Optional.

# Notes for merging into other repos

Two feature flags have been renamed.   Make sure they merge correctly:
-   `billing_administrator`  -->  `global_billing_administrator`
-   `billing_administrator_users_tab`  -->  `global_billing_administrator_users_tab`


# Additional Context

https://pm.tablexi.com/issues/144845

This PR renames the role `Billing Administrator` to `Global Billing Administrator`.

Kayla specified the following permissions:

- Has access to and may manage billing to:
  - View and manage orders, including disputed orders
  - Reassign the accounts associated with orders
  - Create and manage journals * May create new users and assign user roles
- May add, edit, and suspend accounts
- May view, but not change, product pricing rules
- May view orders and reservations for resource users
- MAYBE: add and remove account memberships (what is account membership?)