### PR TITLE
[#144321] Prevent removing owners from accounts, and add select all to form for editing a user’s accounts

### DIFF
--- a/app/assets/stylesheets/app/tables.scss
+++ b/app/assets/stylesheets/app/tables.scss
@@ -25,6 +25,14 @@ table {
   }
 }
 
+.table-user-accounts {
+  thead {
+    th {
+      vertical-align: top;
+    }
+  }
+}
+
 tfoot.cart {
   border-top: 3px solid $navbarActiveBorderColor;
 }

--- a/app/controllers/user_accounts_controller.rb
+++ b/app/controllers/user_accounts_controller.rb
@@ -8,14 +8,7 @@ class UserAccountsController < ApplicationController
   load_resource class: "User", id_param: :user_id, instance_name: :user
   authorize_resource class: AccountUser
   before_action { @active_tab = "admin_users" }
-
-  def show
-    @accounts = @user.accounts.for_facility(current_facility)
-  end
-
-  def edit
-    @accounts = @user.accounts.for_facility(current_facility)
-  end
+  before_action :load_accounts
 
   def update
     if @user.update(user_params)
@@ -30,5 +23,9 @@ class UserAccountsController < ApplicationController
 
   def user_params
     params.require(:user).permit(accounts_attributes: [:id, :_destroy])
+  end
+
+  def load_accounts
+    @accounts = @user.accounts.includes(:owner_user).for_facility(current_facility)
   end
 end

--- a/app/views/user_accounts/edit.html.haml
+++ b/app/views/user_accounts/edit.html.haml
@@ -13,7 +13,9 @@
   %table.table.table-striped.table-user-accounts
     %thead
       %tr
-        %th.centered.table-user-accounts__remove= t('.remove')
+        %th.centered.table-user-accounts__remove
+          = t('.remove')
+          = select_all_link
         %th= Account.model_name.human
         %th.centered= Facility.model_name.human
     %tbody
@@ -23,7 +25,7 @@
             - if af.object.owner_user == @user
               = af.check_box :_destroy, disabled: true, title: t('.not_allowed')
             - else
-              = af.check_box :_destroy
+              = af.check_box :_destroy, class: "toggle"
           %td= payment_source_link_or_text(af.object)
           %td= af.object.per_facility? ? af.object.facilities.join(", ") : content_tag(:i, t("shared.all"))
 

--- a/app/views/user_accounts/edit.html.haml
+++ b/app/views/user_accounts/edit.html.haml
@@ -2,10 +2,10 @@
   = current_facility
 
 = content_for :sidebar do
-  = render :partial => 'admin/shared/sidenav_users', locals: { sidenav_tab: 'users' }
+  = render partial: 'admin/shared/sidenav_users', locals: { sidenav_tab: 'users' }
 
 = content_for :tabnav do
-  = render :partial => 'admin/shared/tabnav_users', locals: { secondary_tab: 'accounts' }
+  = render partial: 'admin/shared/tabnav_users', locals: { secondary_tab: 'accounts' }
 
 %h1= t('.h1', user_name: @user.full_name)
 
@@ -17,10 +17,14 @@
         %th= Account.model_name.human
         %th.centered= Facility.model_name.human
     %tbody
-      = f.fields_for :accounts do |f|
+      = f.fields_for :accounts do |af|
         %tr
-          %td.centered.table-user-accounts__remove= f.check_box :_destroy
-          %td= payment_source_link_or_text(f.object)
-          %td= f.object.per_facility? ? f.object.facilities.join(", ") :  content_tag(:i, t("shared.all"))
+          %td.centered.table-user-accounts__remove
+            - if af.object.owner_user == @user
+              = af.check_box :_destroy, disabled: true, title: t('.not_allowed')
+            - else
+              = af.check_box :_destroy
+          %td= payment_source_link_or_text(af.object)
+          %td= af.object.per_facility? ? af.object.facilities.join(", ") : content_tag(:i, t("shared.all"))
 
   = f.submit t(".update"), class: "btn btn-primary"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1010,6 +1010,7 @@ en:
       h1: "%{user_name} Payment Sources"
       remove: Remove?
       update: Update Payment Sources
+      not_allowed: This account is owned by the user, so they cannot be removed from it.
     update:
       updated: Successfully updated %{user_name}’s payment sources.
       could_not_update: Could not update %{user_name}’s payment sources. Please try again.


### PR DESCRIPTION
# Release Notes

Prevent removing owners from accounts, and add select all to form for editing a user’s accounts
