### PR TITLE
[#144321] Only show Edit Payment Sources button for a user from global Users nav

### DIFF
--- a/app/assets/stylesheets/app/tables.scss
+++ b/app/assets/stylesheets/app/tables.scss
@@ -47,6 +47,6 @@ tfoot.cart {
   }
 
   .table-user-accounts__remove {
-    max-width: 35px;
+    max-width: 45px;
   }
 }

--- a/app/views/user_accounts/show.html.haml
+++ b/app/views/user_accounts/show.html.haml
@@ -12,7 +12,8 @@
 - if @accounts.empty?
   %p.notice= t('.notice', user_name: @user.full_name)
 - else
-  = link_to t(".edit"), edit_facility_user_accounts_path(current_facility, @user), class: "btn btn-primary"
+  - if current_facility.cross_facility? && current_ability.can?(:manage_users, current_facility)
+    = link_to t(".edit"), edit_facility_user_accounts_path(current_facility, @user), class: "btn btn-primary"
 
   %table.table.table-striped.table-hover
     %thead


### PR DESCRIPTION
# Release Notes

Only show Edit Payment Sources button for a user from global Users nav

# Additional Context

As [agreed here by Dartmouth](https://pm.tablexi.com/issues/144321#note-15), and [detailed here](https://pm.tablexi.com/issues/147871#note-17) by Northwestern, the Edit Payment Sources button for a user should only be visible from the global Users navigation, which is restricted to a subset of users that should be able to edit a User’s accounts globally (rather than within a facility only).

Additionally, I snuck in a width change for the Remove? column so it’s got a bit more breathing room.