### PR TITLE
[#148934] Add missing index on instrument_statuses

### DIFF
--- a/db/migrate/20190416205054_add_index_to_instrument_statuses.rb
+++ b/db/migrate/20190416205054_add_index_to_instrument_statuses.rb
@@ -1,0 +1,5 @@
+class AddIndexToInstrumentStatuses < ActiveRecord::Migration[5.0]
+  def change
+    add_index :instrument_statuses, [:instrument_id, :created_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190328133218) do
+ActiveRecord::Schema.define(version: 20190416205054) do
 
   create_table "account_facility_joins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "facility_id", null: false
@@ -199,6 +199,7 @@ ActiveRecord::Schema.define(version: 20190328133218) do
     t.integer  "instrument_id", null: false
     t.boolean  "is_on",         null: false
     t.datetime "created_at",    null: false
+    t.index ["instrument_id", "created_at"], name: "index_instrument_statuses_on_instrument_id_and_created_at", using: :btree
     t.index ["instrument_id"], name: "fk_int_stats_product", using: :btree
   end
 


### PR DESCRIPTION
# Release Notes

Add missing index on instrument_statuses

# Additional Context

As identified by NUIT and Skylight, one of the most frequent requests to NUcore for NU is querying:

```
SELECT * FROM (SELECT  "INSTRUMENT_STATUSES".* FROM "INSTRUMENT_STATUSES" WHERE "INSTRUMENT_STATUSES"."INSTRUMENT_ID" = :a1 ORDER BY created_at DESC ) WHERE ROWNUM <= :a2
```

The query currently does a full table scan because there is no index to satisfy it, and this PR fixes that. Because currently NUcore is experiencing massive performance problems and you’re offline at a full-day meeting, @rolfrussell, I am merging this so I can create the index for NU immediately.