### PR TITLE
[#148443 ] Prevent facility directors from changing price policies  (part deux)

### DIFF
--- a/app/views/price_policies/index.html.haml
+++ b/app/views/price_policies/index.html.haml
@@ -9,7 +9,7 @@
 
 %p= text("description")
 
-- if session_user.manager_of?(current_facility)
+- if can?(:create, PricePolicy)
   %ul.inline
     %li= link_to text("add"), [:new, current_facility, @product, :price_policy], class: "btn-add"
 

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -180,9 +180,6 @@ class Ability
           StoredFile,
           TrainingRequest,
         ]
-        if user.facility_director_of?(resource) && SettingsHelper.feature_off?(:facility_directors_can_manage_price_groups) 
-          cannot [:create, :edit, :update, :destroy], PriceGroup
-        end
 
         can :manage, User if controller.is_a?(FacilityUsersController)
         cannot([:edit, :update], User)
@@ -212,6 +209,11 @@ class Ability
         # they can get to reports controller, but they're not allowed to export all
         can :manage, Reports::ReportsController
         cannot :export_all, Reports::ReportsController
+      end
+
+      if user.facility_director_of?(resource) && SettingsHelper.feature_off?(:facility_directors_can_manage_price_groups)
+        cannot [:create, :edit, :update, :destroy], PriceGroup
+        cannot [:create, :edit, :update, :destroy], [PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ServicePricePolicy]
       end
 
     elsif resource.is_a?(Account)

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -296,6 +296,14 @@ RSpec.describe Ability do
     it { is_expected.not_to be_allowed_to(:manage_users, Facility.cross_facility) }
     it_behaves_like "it can destroy admistrative reservations"
     it_behaves_like "it allows switch_to on active, but not deactivated users"
+
+    context "when facility_directors_can_manage_price_groups on", feature_setting: { facility_directors_can_manage_price_groups: false } do
+      it_is_not_allowed_to([:create, :edit, :update, :destroy], PriceGroup)
+      it_is_not_allowed_to([:create, :edit, :update, :destroy], PricePolicy)
+      it_is_not_allowed_to([:create, :edit, :update, :destroy], InstrumentPricePolicy)
+      it_is_not_allowed_to([:create, :edit, :update, :destroy], ItemPricePolicy)
+      it_is_not_allowed_to([:create, :edit, :update, :destroy], ServicePricePolicy)
+    end
   end
 
   shared_examples_for "it has common staff abilities" do

--- a/spec/price_policies_controller_shared_examples.rb
+++ b/spec/price_policies_controller_shared_examples.rb
@@ -44,7 +44,13 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
       @action = :new
     end
 
-    it_should_allow_managers_only {}
+    context "when facility_directors_can_manage_price_groups on", feature_setting: { facility_directors_can_manage_price_groups: true } do
+      it_should_allow_managers_only {}
+    end
+
+    context "when facility_directors_can_manage_price_groups off", feature_setting: { facility_directors_can_manage_price_groups: false } do
+      it_should_allow_admin_only {}
+    end
 
     context "signed in" do
       before :each do
@@ -162,7 +168,13 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
       @params.merge!(id: @price_policy.start_date.to_s)
     end
 
-    it_should_allow_managers_only {}
+    context "when facility_directors_can_manage_price_groups on", feature_setting: { facility_directors_can_manage_price_groups: true } do
+      it_should_allow_managers_only {}
+    end
+
+    context "when facility_directors_can_manage_price_groups off", feature_setting: { facility_directors_can_manage_price_groups: false } do
+      it_should_allow_admin_only {}
+    end
 
     context "signed in" do
       before :each do
@@ -228,7 +240,13 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
         @params_modifier.before_create @params if @params_modifier.try :respond_to?, :before_create
       end
 
-      it_should_allow_managers_only(:redirect) {}
+      context "when facility_directors_can_manage_price_groups on", feature_setting: { facility_directors_can_manage_price_groups: true } do
+        it_should_allow_managers_only(:redirect) {}
+      end
+
+      context "when facility_directors_can_manage_price_groups off", feature_setting: { facility_directors_can_manage_price_groups: false } do
+        it_should_allow_admin_only(:redirect) {}
+      end
 
       context "signed in" do
         before :each do
@@ -332,7 +350,13 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
         end
       end
 
-      it_should_allow_managers_only(:redirect) {}
+      context "when facility_directors_can_manage_price_groups on", feature_setting: { facility_directors_can_manage_price_groups: true } do
+        it_should_allow_managers_only(:redirect) {}
+      end
+
+      context "when facility_directors_can_manage_price_groups off", feature_setting: { facility_directors_can_manage_price_groups: false } do
+        it_should_allow_admin_only(:redirect) {}
+      end
 
       context "when signed in as a director" do
         before { maybe_grant_always_sign_in(:director) }
@@ -478,7 +502,13 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
         expect(price_policy.start_date).to be > Time.zone.now
       end
 
-      it_should_allow_managers_only(:redirect) {}
+      context "when facility_directors_can_manage_price_groups on", feature_setting: { facility_directors_can_manage_price_groups: true } do
+        it_should_allow_managers_only(:redirect) {}
+      end
+
+      context "when facility_directors_can_manage_price_groups off", feature_setting: { facility_directors_can_manage_price_groups: false } do
+        it_should_allow_admin_only(:redirect) {}
+      end
 
       context "when signed in as a director" do
         let!(:price_policies) { product.price_policies.for_date(price_policy.start_date) }


### PR DESCRIPTION
# Release Notes

The original PR prevented facility directors from changing price groups.  This PR expands that to price policies.  This is based on feedback from Kayla.

# Screenshot

With `facility_directors_can_manage_price_groups: true`

![pricing_policies_allowed](https://user-images.githubusercontent.com/403241/57049313-1c976700-6c3d-11e9-8620-74e5d2155a96.png)


With `facility_directors_can_manage_price_groups: false`

![pricing_policies_not_allowed](https://user-images.githubusercontent.com/403241/57049316-1dc89400-6c3d-11e9-9b8d-f6757bfd2d0a.png)

