### PR TITLE
[#148443 ] Prevent facility directors from changing price policies (part quatre) 

### DIFF
--- a/spec/features/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/features/admin/instrument_price_policies_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe InstrumentPricePoliciesController do
     facility.price_groups.destroy_all # get rid of the price groups created by the factories
   end
 
-  it "can set up the price policies", :js do
+  it "can set up the price policies", :js, feature_setting: { facility_directors_can_manage_price_groups: true } do
     visit facility_instruments_path(facility, instrument)
     click_link instrument.name
     click_link "Pricing"
@@ -48,7 +48,7 @@ RSpec.describe InstrumentPricePoliciesController do
     expect(page).to have_content("This is my note")
   end
 
-  it "can only allow some to purchase", :js do
+  it "can only allow some to purchase", :js, feature_setting: { facility_directors_can_manage_price_groups: true } do
     visit facility_instruments_path(facility, instrument)
     click_link instrument.name
     click_link "Pricing"
@@ -70,7 +70,7 @@ RSpec.describe InstrumentPricePoliciesController do
     expect(page).not_to have_content(cancer_center.name)
   end
 
-  describe "with required note enabled", feature_setting: { price_policy_requires_note: true } do
+  describe "with required note enabled", feature_setting: { price_policy_requires_note: true, facility_directors_can_manage_price_groups: true } do
     it "requires the field" do
       visit facility_instruments_path(facility, instrument)
       click_link instrument.name
@@ -82,7 +82,7 @@ RSpec.describe InstrumentPricePoliciesController do
     end
   end
 
-  describe "with full cancellation cost enabled", :js, feature_setting: { charge_full_price_on_cancellation: true } do
+  describe "with full cancellation cost enabled", :js, feature_setting: { charge_full_price_on_cancellation: true, facility_directors_can_manage_price_groups: true } do
     it "can set up the price policies", :js do
       visit facility_instruments_path(facility, instrument)
       click_link instrument.name

--- a/spec/features/admin/item_price_policies_controller_spec.rb
+++ b/spec/features/admin/item_price_policies_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ItemPricePoliciesController, :js do
     facility.price_groups.destroy_all # get rid of the price groups created by the factories
   end
 
-  it "can set up price policies" do
+  it "can set up price policies", feature_setting: { facility_directors_can_manage_price_groups: true }  do
     visit facility_items_path(facility, item)
     click_link item.name
     click_link "Pricing"
@@ -37,7 +37,7 @@ RSpec.describe ItemPricePoliciesController, :js do
     expect(page).to have_content("This is my note")
   end
 
-  it "can allow only some groups to purchase" do
+  it "can allow only some groups to purchase", feature_setting: { facility_directors_can_manage_price_groups: true }  do
     visit facility_items_path(facility, item)
     click_link item.name
     click_link "Pricing"
@@ -56,7 +56,7 @@ RSpec.describe ItemPricePoliciesController, :js do
     expect(page).not_to have_content(external_price_group.name)
   end
 
-  describe "with required note enabled", feature_setting: { price_policy_requires_note: true } do
+  describe "with required note enabled", feature_setting: { price_policy_requires_note: true, facility_directors_can_manage_price_groups: true } do
     it "requires the field" do
       visit facility_items_path(facility, item)
       click_link item.name

--- a/spec/features/admin/timed_service_price_policies_controller_spec.rb
+++ b/spec/features/admin/timed_service_price_policies_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe TimedServicePricePoliciesController, :js do
     facility.price_groups.destroy_all # get rid of the price groups created by the factories
   end
 
-  it "can set up price policies" do
+  it "can set up price policies", feature_setting: { facility_directors_can_manage_price_groups: true }  do
     visit facility_timed_services_path(facility, timed_service)
     click_link timed_service.name
     click_link "Pricing"
@@ -38,7 +38,7 @@ RSpec.describe TimedServicePricePoliciesController, :js do
     expect(page).to have_content("This is my note")
   end
 
-  it "can allow only some groups to purchase" do
+  it "can allow only some groups to purchase", feature_setting: { facility_directors_can_manage_price_groups: true }  do
     visit facility_timed_services_path(facility, timed_service)
     click_link timed_service.name
     click_link "Pricing"
@@ -57,7 +57,7 @@ RSpec.describe TimedServicePricePoliciesController, :js do
     expect(page).not_to have_content(external_price_group.name)
   end
 
-  describe "with required note enabled", feature_setting: { price_policy_requires_note: true } do
+  describe "with required note enabled", feature_setting: { price_policy_requires_note: true, facility_directors_can_manage_price_groups: true } do
     it "requires the field" do
       visit facility_timed_services_path(facility, timed_service)
       click_link timed_service.name


### PR DESCRIPTION
Force feature specs to have 'facility_directors_can_manage_price_groups: true' so dartmouth tests pass
