### PR TITLE
[#148949] Restore defaulting in sanger sequencing form and allow overriding in ACGT

### DIFF
--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/submission.js.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/submission.js.coffee
@@ -1,5 +1,9 @@
 $ ->
   $(document).on "fields_added.nested_form_fields", (event) ->
-    lastCustomerSampleId = $(".js--customerSampleId").last().val() || Date.now().valueOf()
-    newCustomerSampleId = (lastCustomerSampleId + 1) % 10000
-    $(event.target).find(".js--customerSampleId").val(newCustomerSampleId)
+    url = $(".edit_sanger_sequencing_submission").data("create-sample-url")
+    row = $(event.target)
+    customerSampleIdField = row.find(".js--customerSampleId")
+    customerSampleIdField.prop("disabled", true).val("Loading...")
+    $.post(url).done (sample) ->
+      customerSampleIdField.prop("disabled", false).val(sample.customer_sample_id)
+      row.find(".js--sampleId").val(sample.id).text(sample.id)

--- a/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/submissions_controller.rb
+++ b/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/submissions_controller.rb
@@ -27,13 +27,7 @@ module SangerSequencing
     end
 
     def new
-      if @submission.samples.empty?
-        starting_customer_sample_id = Time.now.to_i
-        params[:quantity].to_i.times do |n|
-          sample_id = ("%04d" % (starting_customer_sample_id + n)).last(4)
-          @submission.samples.new(customer_sample_id: sample_id)
-        end
-      end
+      5.times { @submission.create_prefilled_sample } if @submission.samples.none?
       render :edit
     end
 
@@ -41,7 +35,6 @@ module SangerSequencing
     end
 
     def edit
-      @submission.samples.new if @submission.samples.empty?
     end
 
     def update
@@ -50,6 +43,11 @@ module SangerSequencing
       else
         render :edit
       end
+    end
+
+    def create_sample
+      sample = @submission.create_prefilled_sample
+      render json: sample.slice(:id, :customer_sample_id)
     end
 
     def current_ability

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/ability.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/ability.rb
@@ -9,7 +9,7 @@ module SangerSequencing
     def initialize(user, facility = nil)
       return unless user
 
-      can [:show, :create, :update], Submission, user: user
+      can [:show, :create, :update, :create_sample], Submission, user: user
 
       if facility && user.operator_of?(facility)
         can [:index, :show], Submission

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/sample.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/sample.rb
@@ -11,23 +11,12 @@ module SangerSequencing
 
     default_scope { order(:id) }
 
-    def form_customer_sample_id
-      customer_sample_id || default_customer_sample_id
-    end
-
     def reserved?
       false
     end
 
     def results_files
       submission.order_detail.sample_results_files.select { |file| file.name.start_with?("#{id}_") }
-    end
-
-    private
-
-    def default_customer_sample_id
-      number = id || Time.now.to_i
-      ("%04d" % number).last(4)
     end
 
   end

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
@@ -49,6 +49,16 @@ module SangerSequencing
       order_detail.bundle.blank?
     end
 
+    def create_prefilled_sample
+      transaction do
+        sample = samples.new
+        sample.save(validate: false)
+        customer_sample_id = ("%04d" % sample.id).last(4)
+        sample.update_column(:customer_sample_id, customer_sample_id)
+        sample
+      end
+    end
+
     private
 
     def savable_samples

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/submissions/_form.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/submissions/_form.html.haml
@@ -1,4 +1,4 @@
-= simple_form_for @submission do |f|
+= simple_form_for @submission, html: { data: { create_sample_url: create_sample_sanger_sequencing_submission_path(@submission) } } do |f|
   = hidden_field_tag :referer, params[:referer]
   = hidden_field_tag :success_url, params[:success_url]
   %table.table.table-striped.table-tight
@@ -9,7 +9,7 @@
     %tbody
       = f.nested_fields_for :samples, wrapper: false, class_name: "SangerSequencing::Sample", wrapper_tag: :tr do |sf|
         %td
-          = sf.input :customer_sample_id, label: false, input_html: { value: sf.object.form_customer_sample_id, class: "js--customerSampleId" }
+          = sf.input :customer_sample_id, label: false, input_html: { class: "js--customerSampleId" }
           = sf.input :id, as: :hidden, input_html: { class: "js--sampleId" }
         %td.js--sampleId= sf.object.id
         - if @submission.quantity_editable?

--- a/vendor/engines/sanger_sequencing/config/routes.rb
+++ b/vendor/engines/sanger_sequencing/config/routes.rb
@@ -4,7 +4,9 @@
 # /sanger_sequencing/submissions/new and the back end /facilities/xxx/sanger_sequencing/submissions
 Rails.application.routes.draw do
   namespace :sanger_sequencing, path: I18n.t("sanger_sequencing.route") do
-    resources :submissions, only: [:new, :show, :edit, :update]
+    resources :submissions, only: [:new, :show, :edit, :update] do
+      post :create_sample, on: :member
+    end
   end
 
   resources :facilities, only: [] do

--- a/vendor/engines/sanger_sequencing/spec/factories/samples.rb
+++ b/vendor/engines/sanger_sequencing/spec/factories/samples.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :sanger_sequencing_sample, class: SangerSequencing::Sample do
-    after(:stub) do |sample, _evaluator|
-      sample.customer_sample_id = sample.form_customer_sample_id
-    end
-  end
+  factory :sanger_sequencing_sample, class: SangerSequencing::Sample
 end

--- a/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/sample_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/sample_spec.rb
@@ -8,38 +8,4 @@ RSpec.describe SangerSequencing::Sample do
     sample = described_class.create!(submission: submission, customer_sample_id: "1234")
     expect(sample.submission).to eq(submission)
   end
-
-  describe "#form_customer_sample_id" do
-    let(:sample) { described_class.new.tap { |s| s.id = id } }
-    subject(:customer_sample_id) { sample.form_customer_sample_id }
-
-    describe "when I've set the customer_sample_id myself" do
-      let(:id) { 123 }
-      before { sample.customer_sample_id = "TESTING" }
-      it { is_expected.to eq("TESTING") }
-    end
-
-    describe "when ID is nil (before being persisted)" do
-      let(:id) { nil }
-
-      it "returns a 4-digit number" do
-        expect(subject.length).to eq 4
-      end
-    end
-
-    describe "when the ID is large" do
-      let(:id) { 121_234 }
-      it { is_expected.to eq("1234") }
-    end
-
-    describe "when the ID is less than 4 characters" do
-      let(:id) { 12 }
-      it { is_expected.to eq("0012") }
-    end
-
-    describe "when the ID has a zero in the thousands" do
-      let(:id) { 120_123 }
-      it { is_expected.to eq("0123") }
-    end
-  end
 end

--- a/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/submission_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/submission_spec.rb
@@ -3,9 +3,21 @@
 require "rails_helper"
 
 RSpec.describe SangerSequencing::Submission do
-  it "can have a submission" do
-    order_detail = FactoryBot.build(:order_detail)
-    submission = described_class.create!(order_detail: order_detail)
-    expect(submission.order_detail).to eq(order_detail)
+  let(:order_detail) { FactoryBot.build(:order_detail) }
+  let(:subject) { described_class.create!(order_detail: order_detail) }
+
+  it "can be created" do
+    expect(subject.order_detail).to eq(order_detail)
+  end
+
+  describe "#create_prefilled_sample" do
+    it "returns a sample" do
+      expect(subject.create_prefilled_sample).to be_kind_of(SangerSequencing::Sample)
+    end
+
+    it "sets customer_sample_id to the id of the sample padded and limitedto 4 places" do
+      sample = subject.create_prefilled_sample
+      expect(sample.customer_sample_id).to eq(("%04d" % sample.id).last(4))
+    end
   end
 end

--- a/vendor/engines/sanger_sequencing/spec/presenters/sanger_sequencing/well_plate_presenter_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/presenters/sanger_sequencing/well_plate_presenter_spec.rb
@@ -32,14 +32,14 @@ RSpec.describe SangerSequencing::WellPlatePresenter do
 
       it "renders" do
         expect(sample_rows[0]).to match(["A01", "", "", expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
-        expect(sample_rows[1]).to match(["B01", samples[0].id.to_s, samples[0].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
-        expect(sample_rows[2]).to match(["C01", samples[1].id.to_s, samples[1].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
-        expect(sample_rows[3]).to match(["D01", samples[2].id.to_s, samples[2].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
-        expect(sample_rows[4]).to match(["E01", samples[3].id.to_s, samples[3].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
-        expect(sample_rows[5]).to match(["F01", samples[4].id.to_s, samples[4].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
-        expect(sample_rows[6]).to match(["G01", samples[5].id.to_s, samples[5].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
-        expect(sample_rows[7]).to match(["H01", samples[6].id.to_s, samples[6].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
-        expect(sample_rows[8]).to match(["A03", samples[7].id.to_s, samples[7].customer_sample_id, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
+        expect(sample_rows[1]).to match(["B01", samples[0].id.to_s, samples[0].customer_sample_id.to_s, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
+        expect(sample_rows[2]).to match(["C01", samples[1].id.to_s, samples[1].customer_sample_id.to_s, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
+        expect(sample_rows[3]).to match(["D01", samples[2].id.to_s, samples[2].customer_sample_id.to_s, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
+        expect(sample_rows[4]).to match(["E01", samples[3].id.to_s, samples[3].customer_sample_id.to_s, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
+        expect(sample_rows[5]).to match(["F01", samples[4].id.to_s, samples[4].customer_sample_id.to_s, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
+        expect(sample_rows[6]).to match(["G01", samples[5].id.to_s, samples[5].customer_sample_id.to_s, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
+        expect(sample_rows[7]).to match(["H01", samples[6].id.to_s, samples[6].customer_sample_id.to_s, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
+        expect(sample_rows[8]).to match(["A03", samples[7].id.to_s, samples[7].customer_sample_id.to_s, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
       end
     end
 
@@ -49,14 +49,14 @@ RSpec.describe SangerSequencing::WellPlatePresenter do
 
       it "renders" do
         expect(sample_rows[0]).to match(["A01", "", ""] + extra_columns)
-        expect(sample_rows[1]).to match(["B01", samples[0].id.to_s, samples[0].customer_sample_id] + extra_columns)
-        expect(sample_rows[2]).to match(["C01", samples[1].id.to_s, samples[1].customer_sample_id] + extra_columns)
-        expect(sample_rows[3]).to match(["D01", samples[2].id.to_s, samples[2].customer_sample_id] + extra_columns)
-        expect(sample_rows[4]).to match(["E01", samples[3].id.to_s, samples[3].customer_sample_id] + extra_columns)
-        expect(sample_rows[5]).to match(["F01", samples[4].id.to_s, samples[4].customer_sample_id] + extra_columns)
-        expect(sample_rows[6]).to match(["G01", samples[5].id.to_s, samples[5].customer_sample_id] + extra_columns)
-        expect(sample_rows[7]).to match(["H01", samples[6].id.to_s, samples[6].customer_sample_id] + extra_columns)
-        expect(sample_rows[8]).to match(["A03", samples[7].id.to_s, samples[7].customer_sample_id] + extra_columns)
+        expect(sample_rows[1]).to match(["B01", samples[0].id.to_s, samples[0].customer_sample_id.to_s] + extra_columns)
+        expect(sample_rows[2]).to match(["C01", samples[1].id.to_s, samples[1].customer_sample_id.to_s] + extra_columns)
+        expect(sample_rows[3]).to match(["D01", samples[2].id.to_s, samples[2].customer_sample_id.to_s] + extra_columns)
+        expect(sample_rows[4]).to match(["E01", samples[3].id.to_s, samples[3].customer_sample_id.to_s] + extra_columns)
+        expect(sample_rows[5]).to match(["F01", samples[4].id.to_s, samples[4].customer_sample_id.to_s] + extra_columns)
+        expect(sample_rows[6]).to match(["G01", samples[5].id.to_s, samples[5].customer_sample_id.to_s] + extra_columns)
+        expect(sample_rows[7]).to match(["H01", samples[6].id.to_s, samples[6].customer_sample_id.to_s] + extra_columns)
+        expect(sample_rows[8]).to match(["A03", samples[7].id.to_s, samples[7].customer_sample_id.to_s] + extra_columns)
       end
     end
   end


### PR DESCRIPTION
# Release Notes

Restore defaulting in sanger sequencing form and allow overriding in ACGT

# Additional Context

The tight coupling between a sanger sequencing form and the ACGT form (despite them being very different) made #1947 change the prefilling behavior in ACGT (which NU does not want) and altered the prefiling behavior for sanger sequencing in a way that is different from what Dartmouth currently uses.

This PR restores the behavior in Sanger sequencing and allows us to override only the prefilling aspect of the form for ACGT, which is the combination that will work for NU and Dartmouth both.

Unfortunately, I had to restore some of the “create invalid samples and then make them valid” behavior, because for sanger sequencing forms, we default the customer sample id form field to a 4-digit-padded version of the record’s database id, which we can only get if we save a record without the customer id.