### PR TITLE
[#148491] Improve performance of FacilitiesController#show (Part 2)

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -51,16 +51,11 @@ class FacilitiesController < ApplicationController
 
     if acting_as? || session_user.try(:operator_of?, current_facility)
       @instruments = instruments_scope.not_archived.alphabetized
-      @items = current_facility.items.not_archived.alphabetized
-      @services = current_facility.services.not_archived.alphabetized
-      @timed_services = current_facility.timed_services.not_archived.alphabetized
-      @bundles = current_facility.bundles.not_archived.alphabetized
+      @non_instrument_products_by_type = current_facility.non_instrument_products.not_archived.group_by(&:type)
     else
       @instruments = instruments_scope.active.alphabetized
-      @items = current_facility.items.active.alphabetized
-      @services = current_facility.services.active.alphabetized
-      @timed_services = current_facility.timed_services.active.alphabetized
-      @bundles = current_facility.bundles.active.alphabetized.reject{|b| !b.products_active?}
+      @non_instrument_products_by_type = current_facility.non_instrument_products.active.group_by(&:type)
+      @non_instrument_products_by_type["Bundle"].select!(&:products_active?)
     end
 
     render layout: "application"

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -55,7 +55,7 @@ class FacilitiesController < ApplicationController
     else
       @instruments = instruments_scope.active.alphabetized
       @non_instrument_products_by_type = current_facility.non_instrument_products.active.group_by(&:type)
-      @non_instrument_products_by_type["Bundle"].select!(&:products_active?)
+      @non_instrument_products_by_type["Bundle"].try(:select!, &:products_active?)
     end
 
     render layout: "application"

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -11,6 +11,7 @@ class Facility < ApplicationRecord
   has_many :instruments, inverse_of: :facility
   has_many :items, inverse_of: :facility
   has_many :journals
+  has_many :non_instrument_products, -> { where.not(type: "Instrument").alphabetized }, class_name: "Product", inverse_of: :facility
   has_many :order_details, through: :products
   has_many :order_imports, dependent: :destroy
   has_many :orders, -> { where.not(ordered_at: nil) }

--- a/app/views/facilities/_product_list.html.haml
+++ b/app/views/facilities/_product_list.html.haml
@@ -1,4 +1,4 @@
-- if products.any?
+- if products.present?
   .product_list{ class: @columns }
     %h3= product_list_title products, local_assigns[:title_extra]
 

--- a/app/views/facilities/show.html.haml
+++ b/app/views/facilities/show.html.haml
@@ -17,16 +17,12 @@
     .button_row
       = f.submit class: ['btn', 'btn-primary']
     = render partial: 'product_list', locals: { products: @instruments, f: f, title_extra: daily_view_link }
-    = render partial: 'product_list', locals: { products: @services, f: f }
-    = render partial: 'product_list', locals: { products: @timed_services, f: f }
-    = render partial: 'product_list', locals: { products: @items, f: f }
-    = render partial: 'product_list', locals: { products: @bundles, f: f }
+    - ["Service", "TimedService", "Item", "Bundle"].each do |type|
+      = render partial: 'product_list', locals: { products: @non_instrument_products_by_type[type], f: f }
     .button_row
       = f.submit class: ['btn', 'btn-primary']
 - else
   .product_list_container{class: @columns}
     = render partial: 'product_list', locals: { products: @instruments, title_extra: daily_view_link }
-    = render partial: 'product_list', locals: { products: @services }
-    = render partial: 'product_list', locals: { products: @timed_services }
-    = render partial: 'product_list', locals: { products: @items }
-    = render partial: 'product_list', locals: { products: @bundles }
+    - ["Service", "TimedService", "Item", "Bundle"].each do |type|
+      = render partial: 'product_list', locals: { products: @non_instrument_products_by_type[type], f: f }

--- a/app/views/facilities/show.html.haml
+++ b/app/views/facilities/show.html.haml
@@ -18,11 +18,11 @@
       = f.submit class: ['btn', 'btn-primary']
     = render partial: 'product_list', locals: { products: @instruments, f: f, title_extra: daily_view_link }
     - ["Service", "TimedService", "Item", "Bundle"].each do |type|
-      = render partial: 'product_list', locals: { products: @non_instrument_products_by_type[type], f: f }
+      = render partial: 'product_list', locals: { products: @non_instrument_products_by_type.fetch(type, []), f: f }
     .button_row
       = f.submit class: ['btn', 'btn-primary']
 - else
   .product_list_container{class: @columns}
     = render partial: 'product_list', locals: { products: @instruments, title_extra: daily_view_link }
     - ["Service", "TimedService", "Item", "Bundle"].each do |type|
-      = render partial: 'product_list', locals: { products: @non_instrument_products_by_type[type], f: f }
+      = render partial: 'product_list', locals: { products: @non_instrument_products_by_type.fetch(type, []) }


### PR DESCRIPTION
# Release Notes

Improve performance of FacilitiesController#show (Part 2)

# Additional Context

## Rendering all non-instruments before

```
   (0.4ms)  SELECT COUNT(*) FROM `products` WHERE `products`.`type` IN ('Service') AND `products`.`facility_id` = 1 AND `products`.`is_archived` = 0 AND `products`.`is_hidden` = 0
  Service Load (0.3ms)  SELECT  `products`.* FROM `products` WHERE `products`.`type` IN ('Service') AND `products`.`facility_id` = 1 AND `products`.`is_archived` = 0 AND `products`.`is_hidden` = 0 ORDER BY lower(products.name) LIMIT 1
  Service Load (0.3ms)  SELECT `products`.* FROM `products` WHERE `products`.`type` IN ('Service') AND `products`.`facility_id` = 1 AND `products`.`is_archived` = 0 AND `products`.`is_hidden` = 0 ORDER BY lower(products.name)
  Rendered collection of facilities/_product.html.haml [2 times] (2.3ms)
  Rendered facilities/_product_list.html.haml (11.0ms)
   (0.4ms)  SELECT COUNT(*) FROM `products` WHERE `products`.`type` IN ('TimedService') AND `products`.`facility_id` = 1 AND `products`.`is_archived` = 0 AND `products`.`is_hidden` = 0
  Rendered facilities/_product_list.html.haml (1.0ms)
   (0.3ms)  SELECT COUNT(*) FROM `products` WHERE `products`.`type` IN ('Item') AND `products`.`facility_id` = 1 AND `products`.`is_archived` = 0 AND `products`.`is_hidden` = 0
  Item Load (0.3ms)  SELECT  `products`.* FROM `products` WHERE `products`.`type` IN ('Item') AND `products`.`facility_id` = 1 AND `products`.`is_archived` = 0 AND `products`.`is_hidden` = 0 ORDER BY lower(products.name) LIMIT 1
  Item Load (0.3ms)  SELECT `products`.* FROM `products` WHERE `products`.`type` IN ('Item') AND `products`.`facility_id` = 1 AND `products`.`is_archived` = 0 AND `products`.`is_hidden` = 0 ORDER BY lower(products.name)
  Rendered collection of facilities/_product.html.haml [1 times] (1.1ms)
  Rendered facilities/_product_list.html.haml (6.2ms)
  Rendered collection of facilities/_product.html.haml [1 times] (1.1ms)
  Rendered facilities/_product_list.html.haml (4.1ms)
```

## Rendering all non-instruments after

```
  Rendered collection of facilities/_product.html.haml [2 times] (1.9ms)
  Rendered facilities/_product_list.html.haml (6.9ms)
  Rendered facilities/_product_list.html.haml (0.0ms)
  Rendered collection of facilities/_product.html.haml [1 times] (1.2ms)
  Rendered facilities/_product_list.html.haml (4.2ms)
  Rendered collection of facilities/_product.html.haml [1 times] (1.2ms)
  Rendered facilities/_product_list.html.haml (4.3ms)
```

Skylight reports [the SQL queries to load from `products` to be a large part of the response time](https://www.skylight.io/app/applications/Oj0TmDuSN-3Y/1557320400/1d/endpoints/FacilitiesController%23show?responseType=html), so this should help improve performance by executing fewer queries against that table.