### PR TITLE
[#148949] If there’s no sanger sequencing form, do nothing in the JS

### DIFF
--- a/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/submission.js.coffee
+++ b/vendor/engines/sanger_sequencing/app/assets/javascripts/sanger_sequencing/submission.js.coffee
@@ -1,9 +1,10 @@
 $ ->
   $(document).on "fields_added.nested_form_fields", (event) ->
-    url = $(".edit_sanger_sequencing_submission").data("create-sample-url")
+    sangerSequencingForm = $("form.edit_sanger_sequencing_submission")
+    return unless sangerSequencingForm.length > 0
     row = $(event.target)
     customerSampleIdField = row.find(".js--customerSampleId")
     customerSampleIdField.prop("disabled", true).val("Loading...")
-    $.post(url).done (sample) ->
+    $.post(sangerSequencingForm.data("create-sample-url")).done (sample) ->
       customerSampleIdField.prop("disabled", false).val(sample.customer_sample_id)
       row.find(".js--sampleId").val(sample.id).text(sample.id)


### PR DESCRIPTION
# Release Notes

If there’s no sanger sequencing form, do nothing in the JS

# Additional Context

If there’s no sanger sequencing form (like in the ACGT engine, where we use the same view but with different contents), do nothing here. @rolfrussell, I’m going to merge this to get a staging release out today, but if you have any comments let me know!