### PR TITLE
Refactor ability.rb class

### DIFF
--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -34,7 +34,7 @@ class Ability
       account_administrator_abilities(user, resource)
     end
 
-    ability_extender.extend(user, resource)    #!!!!!!!!!!!!!!!!!!!  skipped for account_manager & billing_administrator
+    ability_extender.extend(user, resource)
   end
 
 

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -104,8 +104,11 @@ class Ability
   def common_abilities(user, resource, controller)
     can :list, Facility if user.facilities.size > 0 && controller.is_a?(FacilitiesController)
     can :read, Notification if user.notifications.active.any?
-    can :complete, ExternalService if resource.is_a?(Facility)
-    can :create, TrainingRequest if resource.is_a?(Facility)
+
+    if resource.is_a?(Facility)
+      can :complete, ExternalService
+      can :create, TrainingRequest
+    end
 
     if resource.is_a?(OrderDetail)
       can [:add_accessories, :sample_results, :sample_results_zip, :show, :update, :cancel, :template_results,

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -166,7 +166,7 @@ class Ability
     ], Reservation
 
     can(:destroy, Reservation, &:admin?)
-    cannot :manage, OfflineReservation
+    cannot :manage, OfflineReservation  # ideally we don't use `cannot` as it adds a dependency on the order of assigning abilities for multiple roles
 
     can [
       :administer,
@@ -229,6 +229,8 @@ class Ability
     ]
 
     can :manage, User if controller.is_a?(FacilityUsersController)
+
+    # ideally we don't use `cannot` as it adds a dependency on the order of assigning abilities for multiple roles
     cannot([:edit, :update], User)
     cannot [:manage_accounts, :manage_billing, :manage_users], Facility.cross_facility
 
@@ -329,6 +331,7 @@ class Ability
       ]
 
       # they can get to reports controller, but they're not allowed to export all
+      # ideally we don't use `cannot` as it adds a dependency on the order of assigning abilities for multiple roles
       can :manage, Reports::ReportsController
       cannot :export_all, Reports::ReportsController
     end

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -22,12 +22,13 @@ class Ability
 
     else
       all_role_abilities(user, resource, controller)
+      facility_staff_abilities(user, resource, controller)
+      facility_senior_staff_abilities(user, resource, controller)
+      facility_administrator_abilities(user, resource, controller)
+      facility_director_abilities(user, resource, controller)
       account_manager_abilities(user, resource)
       billing_administrator_abilities(user, resource)
-      facility_director_abilities(user, resource, controller)
-      facility_administrator_abilities(user, resource, controller)
-      facility_senior_staff_abilities(user, resource, controller)
-      facility_staff_abilities(user, resource, controller)
+
       account_administrator_abilities(user, resource, controller)
     end
 

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -17,254 +17,30 @@ class Ability
   def initialize(user, resource, controller = nil)
     return unless user
 
-    if user.administrator?
-      if resource.is_a?(PriceGroup)
-        can :manage, UserPriceGroupMember if resource.admin_editable?
-        can :manage, AccountPriceGroupMember
-      else
-        can :manage, :all
-        unless user.billing_administrator?
-          cannot [:manage_accounts, :manage_billing], Facility.cross_facility
-        end
-        unless user.account_manager?
-          cannot :manage, User unless resource.is_a?(Facility)
-          if SettingsHelper.feature_off?(:create_users)
-            cannot([:edit, :update], User)
-          end
-        end
-      end
+    # common abilities
+    non_administrator_abilities(user, resource, controller) unless user.administrator?
 
-      cannot(:switch_to, User) { |target_user| !target_user.active? }
+    # global abilities
+    if user.administrator?
+      administrator_abilities(user, resource)
       ability_extender.extend(user, resource)
       return
     end
+    account_manager_abilities(user, resource) if user.account_manager?
+    billing_administrator_abilities(user, resource) if user.billing_administrator?
 
-    if resource.is_a?(PriceGroup)
-      if !resource.global? && user.manager_of?(resource.facility)
-        can :manage, [AccountPriceGroupMember, UserPriceGroupMember]
-      end
+    # resource abilities
+    operator_abilities(user, resource, controller)
+    manager_abilities(user, resource, controller)
+    facility_director_abilities(user, resource)
+    facility_senior_staff_abilities(user, resource)
+    account_administrator_abilities(user, resource)
 
-      if user_has_facility_role?(user) && editable_global_group?(resource)
-        can :read, UserPriceGroupMember
-      end
-    end
-
-    can :list, Facility if user.facilities.size > 0 && controller.is_a?(FacilitiesController)
-    can :read, Notification if user.notifications.active.any?
-
-    if user.account_manager?
-      can [:manage_accounts, :manage_users], Facility.cross_facility
-
-      if resource.blank? || resource == Facility.cross_facility
-        can :manage, AccountUser
-        can [:create, :read, :administer, :accounts, :new_external, :search], User
-        can [:create, :read, :update, :suspend, :unsuspend], Account
-        if SettingsHelper.feature_off?(:create_users)
-          cannot([:create, :update], User)
-        end
-      end
-    end
-
-    if user.billing_administrator?
-      can :manage, [Account, Journal, OrderDetail]
-      can [:send_receipt, :show], Order
-      if resource == Facility.cross_facility
-        can [:accounts, :index, :orders, :show, :administer], User
-      end
-      can :manage_users, Facility.cross_facility if SettingsHelper.feature_on?(:billing_administrator_users_tab)
-      can :manage_billing, Facility.cross_facility
-      can [:disputed_orders, :movable_transactions, :transactions], Facility, &:cross_facility?
-    end
-
-    return unless resource
-
-    order_details_ability(user, resource) if resource.is_a?(OrderDetail)
-
-    if resource.is_a?(Facility)
-      can :manage, [Journal, Statement] if user.billing_administrator?
-      can :complete, ExternalService
-      can :create, TrainingRequest
-
-      if user.operator_of?(resource)
-        can :manage, [
-          AccountPriceGroupMember,
-          OrderDetail,
-          ProductUser,
-          TrainingRequest,
-          UserPriceGroupMember,
-        ]
-
-        can :read, Notification
-
-        can [
-          :administer,
-          :assign_price_policies_to_problem_orders,
-          :batch_update,
-          :cancel,
-          :create,
-          :edit,
-          :edit_admin,
-          :index,
-          :show,
-          :tab_counts,
-          :timeline,
-          :update,
-          :update_admin,
-        ], Reservation
-
-        if user.manager_of?(resource) || user.facility_senior_staff_of?(resource)
-          can :bring_online, OfflineReservation
-        else
-          cannot :manage, OfflineReservation
-        end
-
-        can(:destroy, Reservation, &:admin?)
-
-        can [
-          :administer,
-          :assign_price_policies_to_problem_orders,
-          :batch_update,
-          :create,
-          :index,
-          :order_in_past,
-          :send_receipt,
-          :show,
-          :tab_counts,
-          :update,
-        ], Order
-
-        can [:administer, :index, :view_details, :schedule, :show], Product
-
-        can [:index], StoredFile
-        can [:upload_sample_results, :destroy], StoredFile do |fileupload|
-          fileupload.file_type == "sample_result"
-        end
-
-        can [:administer], User
-        can(:switch_to, User, &:active?)
-
-        if controller.is_a?(UsersController)
-          can [:read, :create, :search, :access_list, :access_list_approvals, :new_external, :orders, :accounts], User
-        end
-
-        can :user_search_results, User if controller.is_a?(SearchController)
-
-        can [:list, :dashboard, :show], Facility
-        can :act_as, Facility
-        can :index, [BundleProduct, PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ScheduleRule, ServicePricePolicy, ProductAccessory, ProductAccessGroup]
-        can [:instrument_status, :instrument_statuses, :switch], Instrument
-        can :edit, [PriceGroupProduct]
-      end
-
-      if user.manager_of?(resource)
-        can :manage, [
-          AccountUser,
-          BundleProduct,
-          Facility,
-          FacilityAccount,
-          InstrumentPricePolicy,
-          ItemPricePolicy,
-          Journal,
-          OrderImport,
-          OrderStatus,
-          PriceGroup,
-          PriceGroupProduct,
-          PricePolicy,
-          Product,
-          ProductAccessGroup,
-          ProductAccessory,
-          Reports::ReportsController,
-          ScheduleRule,
-          ServicePricePolicy,
-          Statement,
-          StoredFile,
-          TrainingRequest,
-        ]
-
-        can :manage, User if controller.is_a?(FacilityUsersController)
-        cannot([:edit, :update], User)
-        cannot [:manage_accounts, :manage_billing, :manage_users], Facility.cross_facility
-
-        # A facility admin can manage an account if it is global (i.e. it's a chart string) or the account
-        # is attached to the current facility.
-        can :manage, Account do |account|
-          account.global? || account.account_facility_joins.any? { |af| af.facility_id == resource.id }
-        end
-
-        can [:show_problems], [Order, Reservation]
-        can [:activate, :deactivate], ExternalService
-      end
-
-      # Facility senior staff is based off of staff, but has a few more abilities
-      if in_role?(user, resource, UserRole::FACILITY_SENIOR_STAFF)
-        can :manage, [
-          ProductAccessGroup,
-          ProductAccessory,
-          ProductUser,
-          ScheduleRule,
-          StoredFile,
-          TrainingRequest,
-        ]
-
-        # they can get to reports controller, but they're not allowed to export all
-        can :manage, Reports::ReportsController
-        cannot :export_all, Reports::ReportsController
-      end
-
-      if user.facility_director_of?(resource) && SettingsHelper.feature_off?(:facility_directors_can_manage_price_groups)
-        cannot [:create, :edit, :update, :destroy], PriceGroup
-        cannot [:create, :edit, :update, :destroy], [PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ServicePricePolicy]
-      end
-
-    elsif resource.is_a?(Account)
-      if user.account_administrator_of?(resource)
-        can :manage, Account
-        can :manage, AccountUser
-        can [:show, :suspend, :unsuspend, :user_search, :user_accounts, :statements, :show_statement, :index], Statement
-      end
-
-    elsif resource.is_a?(Reservation)
-      # TODO: Add :accessory hash back in to hide hidden accessories from non-admin users
-      # See task #55479
-      can :read, ProductAccessory # , :accessory => { :is_hidden => false }
-
-      if user.operator_of?(resource.product.facility)
-        can :read, ProductAccessory
-        can :manage, Reservation
-      elsif resource.order.try(:user_id) == user.id
-        can [:read, :create, :update, :destroy, :start_stop, :move], Reservation
-      end
-
-    elsif resource.is_a?(TrainingRequest)
-      can :create, TrainingRequest
-
-      if user.facility_director_of?(resource.product.facility) ||
-         in_role?(user, resource.product.facility, UserRole::FACILITY_SENIOR_STAFF)
-        can :manage, TrainingRequest
-      end
-    end
-
-    ability_extender.extend(user, resource)
+    ability_extender.extend(user, resource)    #!!!!!!!!!!!!!!!!!!!  skipped for account_manager & billing_administrator
   end
 
-  def in_role?(user, facility, *roles)
-    # facility_user_roles returns full objects; we just want the names
-    facility_roles = user.facility_user_roles(facility).map(&:role)
-    # do the roles the user is part of match any of the potential roles
-    (facility_roles & roles).any?
-  end
 
   private
-
-  def order_details_ability(user, resource)
-    # Purchaser
-    can [:add_accessories, :sample_results, :sample_results_zip, :show, :update, :cancel, :template_results,
-         :order_file, :upload_order_file, :remove_order_file], OrderDetail, order: { user_id: user.id }
-    # Facility managers
-    can :manage, OrderDetail, order: { facility_id: resource.order.facility_id } if user.operator_of?(resource.facility)
-    # Account owners/business admins
-    can [:show, :update, :dispute], OrderDetail, account: { id: resource.account_id } if user.account_administrator_of?(resource.account)
-  end
 
   def user_has_facility_role?(user)
     (user.user_roles.map(&:role) & UserRole.facility_roles).any?
@@ -276,6 +52,264 @@ class Ability
 
   def ability_extender
     @extender ||= AbilityExtensionManager.new(self)
+  end
+
+
+  def non_administrator_abilities(user, resource, controller)
+    can :list, Facility if user.facilities.size > 0 && controller.is_a?(FacilitiesController)
+    can :read, Notification if user.notifications.active.any?
+    can :complete, ExternalService if resource.is_a?(Facility)
+    can :create, TrainingRequest if resource.is_a?(Facility)
+
+    if resource.is_a?(OrderDetail)
+      # Purchaser
+      can [:add_accessories, :sample_results, :sample_results_zip, :show, :update, :cancel, :template_results,
+           :order_file, :upload_order_file, :remove_order_file], OrderDetail, order: { user_id: user.id }
+    end
+
+    if resource.is_a?(PriceGroup)
+      if user_has_facility_role?(user) && editable_global_group?(resource)      # !!!!!!!!!!!!!!!!!!!!!!!
+        can :read, UserPriceGroupMember
+      end
+    end
+
+    if resource.is_a?(Reservation)
+      # TODO: Add :accessory hash back in to hide hidden accessories from non-admin users
+      # See task #55479
+      can :read, ProductAccessory # , :accessory => { :is_hidden => false }
+
+      if resource.order.try(:user_id) == user.id
+        can [:read, :create, :update, :destroy, :start_stop, :move], Reservation
+      end
+    end
+
+    if resource.is_a?(TrainingRequest)
+      can :create, TrainingRequest
+    end
+  end
+
+
+  def administrator_abilities(user, resource)
+    if resource.is_a?(PriceGroup)
+      can :manage, UserPriceGroupMember if resource.admin_editable?
+      can :manage, AccountPriceGroupMember
+    else
+      can :manage, :all
+      unless user.billing_administrator?     # !!!!!!!!!!!!!!!!!!!!!!!
+        cannot [:manage_accounts, :manage_billing], Facility.cross_facility
+      end
+      unless user.account_manager?            # !!!!!!!!!!!!!!!!!!!!!!!
+        cannot :manage, User unless resource.is_a?(Facility)
+        if SettingsHelper.feature_off?(:create_users)
+          cannot([:edit, :update], User)
+        end
+      end
+    end
+
+    cannot(:switch_to, User) { |target_user| !target_user.active? }
+  end
+
+
+  def account_manager_abilities(user, resource)
+    can [:manage_accounts, :manage_users], Facility.cross_facility
+
+    if resource.blank? || resource == Facility.cross_facility
+      can :manage, AccountUser
+      can [:create, :read, :administer, :accounts, :new_external, :search], User
+      can [:create, :read, :update, :suspend, :unsuspend], Account
+      if SettingsHelper.feature_off?(:create_users)
+        cannot([:create, :update], User)
+      end
+    end
+  end
+
+
+  def billing_administrator_abilities(user, resource)
+    can :manage, [Account, Journal, OrderDetail]
+    can :manage, Statement if resource.is_a?(Facility)
+    can [:send_receipt, :show], Order
+    if resource == Facility.cross_facility
+      can [:accounts, :index, :orders, :show, :administer], User
+    end
+    can :manage_users, Facility.cross_facility if SettingsHelper.feature_on?(:billing_administrator_users_tab)
+    can :manage_billing, Facility.cross_facility
+    can [:disputed_orders, :movable_transactions, :transactions], Facility, &:cross_facility?
+  end
+
+
+  def operator_abilities(user, resource, controller)
+    if resource.is_a?(Reservation) && user.operator_of?(resource.product.facility)
+      can :read, ProductAccessory
+      can :manage, Reservation
+    end
+
+    if resource.is_a?(OrderDetail) && user.operator_of?(resource.facility)
+      can :manage, OrderDetail, order: { facility_id: resource.order.facility_id }
+    end
+
+    if resource.is_a?(Facility) && user.operator_of?(resource)
+      can :manage, [
+        AccountPriceGroupMember,
+        OrderDetail,
+        ProductUser,
+        TrainingRequest,
+        UserPriceGroupMember,
+      ]
+
+      can :read, Notification
+
+      can [
+        :administer,
+        :assign_price_policies_to_problem_orders,
+        :batch_update,
+        :cancel,
+        :create,
+        :edit,
+        :edit_admin,
+        :index,
+        :show,
+        :tab_counts,
+        :timeline,
+        :update,
+        :update_admin,
+      ], Reservation
+
+      if user.manager_of?(resource) || user.facility_senior_staff_of?(resource)   # !!!!!!!!!!!!!!!!!!!!!!!
+        can :bring_online, OfflineReservation
+      else
+        cannot :manage, OfflineReservation
+      end
+
+      can(:destroy, Reservation, &:admin?)
+
+      can [
+        :administer,
+        :assign_price_policies_to_problem_orders,
+        :batch_update,
+        :create,
+        :index,
+        :order_in_past,
+        :send_receipt,
+        :show,
+        :tab_counts,
+        :update,
+      ], Order
+
+      can [:administer, :index, :view_details, :schedule, :show], Product
+
+      can [:index], StoredFile
+      can [:upload_sample_results, :destroy], StoredFile do |fileupload|
+        fileupload.file_type == "sample_result"
+      end
+
+      can [:administer], User
+      can(:switch_to, User, &:active?)
+
+      if controller.is_a?(UsersController)
+        can [:read, :create, :search, :access_list, :access_list_approvals, :new_external, :orders, :accounts], User
+      end
+
+      can :user_search_results, User if controller.is_a?(SearchController)
+
+      can [:list, :dashboard, :show], Facility
+      can :act_as, Facility
+      can :index, [BundleProduct, PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ScheduleRule, ServicePricePolicy, ProductAccessory, ProductAccessGroup]
+      can [:instrument_status, :instrument_statuses, :switch], Instrument
+      can :edit, [PriceGroupProduct]
+    end
+  end
+
+
+  def manager_abilities(user, resource, controller)
+    if resource.is_a?(PriceGroup) && user.manager_of?(resource.facility)
+      if !resource.global?
+        can :manage, [AccountPriceGroupMember, UserPriceGroupMember]
+      end
+    end
+
+    if resource.is_a?(Facility) && user.manager_of?(resource)
+      can :manage, [
+        AccountUser,
+        BundleProduct,
+        Facility,
+        FacilityAccount,
+        InstrumentPricePolicy,
+        ItemPricePolicy,
+        Journal,
+        OrderImport,
+        OrderStatus,
+        PriceGroup,
+        PriceGroupProduct,
+        PricePolicy,
+        Product,
+        ProductAccessGroup,
+        ProductAccessory,
+        Reports::ReportsController,
+        ScheduleRule,
+        ServicePricePolicy,
+        Statement,
+        StoredFile,
+        TrainingRequest,
+      ]
+      if user.facility_director_of?(resource) && SettingsHelper.feature_off?(:facility_directors_can_manage_price_groups)   # !!!!!!!!!!!!!!!!!!!!!!!
+        cannot [:create, :edit, :update, :destroy], PriceGroup
+      end
+
+      can :manage, User if controller.is_a?(FacilityUsersController)
+      cannot([:edit, :update], User)
+      cannot [:manage_accounts, :manage_billing, :manage_users], Facility.cross_facility
+
+      # A facility admin can manage an account if it is global (i.e. it's a chart string) or the account
+      # is attached to the current facility.
+      can :manage, Account do |account|
+        account.global? || account.account_facility_joins.any? { |af| af.facility_id == resource.id }
+      end
+
+      can [:show_problems], [Order, Reservation]
+      can [:activate, :deactivate], ExternalService
+    end
+  end
+
+
+  def facility_director_abilities(user, resource)
+    if resource.is_a?(TrainingRequest) && user.facility_director_of?(resource.product.facility)
+      can :manage, TrainingRequest
+    end
+  end
+
+
+  def facility_senior_staff_abilities(user, resource)
+    if resource.is_a?(TrainingRequest) && user.facility_senior_staff_of?(resource.product.facility)
+      can :manage, TrainingRequest
+    end
+
+    if resource.is_a?(Facility) && user.facility_senior_staff_of?(resource)
+      can :manage, [
+        ProductAccessGroup,
+        ProductAccessory,
+        ProductUser,
+        ScheduleRule,
+        StoredFile,
+        TrainingRequest,
+      ]
+
+      # they can get to reports controller, but they're not allowed to export all
+      can :manage, Reports::ReportsController
+      cannot :export_all, Reports::ReportsController           # !!!!!!!!!!!!!!!!!!!!!!!
+    end
+  end
+
+
+  def account_administrator_abilities(user, resource)
+    if resource.is_a?(OrderDetail) && user.account_administrator_of?(resource.account)
+      can [:show, :update, :dispute], OrderDetail, account: { id: resource.account_id }
+    end
+
+    if resource.is_a?(Account) && user.account_administrator_of?(resource)
+      can :manage, Account
+      can :manage, AccountUser
+      can [:show, :suspend, :unsuspend, :user_search, :user_accounts, :statements, :show_statement, :index], Statement
+    end
   end
 
 end

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -113,7 +113,7 @@ class Ability
     end
 
     if resource.is_a?(PriceGroup)
-      if user_has_facility_role?(user) && editable_global_group?(resource)      # !!!!!!!!!!!!!!!!!!!!!!!
+      if user_has_facility_role?(user) && editable_global_group?(resource)
         can :read, UserPriceGroupMember
       end
     end
@@ -171,12 +171,7 @@ class Ability
         :update_admin,
       ], Reservation
 
-      if user.manager_of?(resource) || user.facility_senior_staff_of?(resource)   # !!!!!!!!!!!!!!!!!!!!!!!
-        can :bring_online, OfflineReservation
-      else
-        cannot :manage, OfflineReservation
-      end
-
+      cannot :manage, OfflineReservation
       can(:destroy, Reservation, &:admin?)
 
       can [
@@ -242,6 +237,7 @@ class Ability
         Statement,
         StoredFile,
         TrainingRequest,
+        OfflineReservation,
       ]
 
       can :manage, User if controller.is_a?(FacilityUsersController)
@@ -298,11 +294,12 @@ class Ability
         ScheduleRule,
         StoredFile,
         TrainingRequest,
+        OfflineReservation,
       ]
 
       # they can get to reports controller, but they're not allowed to export all
       can :manage, Reports::ReportsController
-      cannot :export_all, Reports::ReportsController           # !!!!!!!!!!!!!!!!!!!!!!!
+      cannot :export_all, Reports::ReportsController
     end
   end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -362,13 +362,12 @@ RSpec.describe Ability do
   describe "staff" do
     let(:user) { create(:user, :staff, facility: facility) }
 
-    # it_behaves_like "it has common staff abilities"
-    it_is_not_allowed_to([:bring_online, :create], OfflineReservation)
-    # it_is_not_allowed_to([:bring_online, :create, :edit, :new, :update], OfflineReservation)
-    # it { is_expected.to be_allowed_to(:create, TrainingRequest) }
-    # it_behaves_like "it can not manage training requests"
-    # it_is_not_allowed_to([:create, :update, :destroy], ScheduleRule)
-    # it_is_not_allowed_to([:create, :update, :destroy], ProductAccessGroup)
+    it_behaves_like "it has common staff abilities"
+    it_is_not_allowed_to([:bring_online, :create, :edit, :new, :update], OfflineReservation)
+    it { is_expected.to be_allowed_to(:create, TrainingRequest) }
+    it_behaves_like "it can not manage training requests"
+    it_is_not_allowed_to([:create, :update, :destroy], ScheduleRule)
+    it_is_not_allowed_to([:create, :update, :destroy], ProductAccessGroup)
   end
 
   describe "unprivileged user" do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -362,12 +362,13 @@ RSpec.describe Ability do
   describe "staff" do
     let(:user) { create(:user, :staff, facility: facility) }
 
-    it_behaves_like "it has common staff abilities"
-    it_is_not_allowed_to([:bring_online, :create, :edit, :new, :update], OfflineReservation)
-    it { is_expected.to be_allowed_to(:create, TrainingRequest) }
-    it_behaves_like "it can not manage training requests"
-    it_is_not_allowed_to([:create, :update, :destroy], ScheduleRule)
-    it_is_not_allowed_to([:create, :update, :destroy], ProductAccessGroup)
+    # it_behaves_like "it has common staff abilities"
+    it_is_not_allowed_to([:bring_online, :create], OfflineReservation)
+    # it_is_not_allowed_to([:bring_online, :create, :edit, :new, :update], OfflineReservation)
+    # it { is_expected.to be_allowed_to(:create, TrainingRequest) }
+    # it_behaves_like "it can not manage training requests"
+    # it_is_not_allowed_to([:create, :update, :destroy], ScheduleRule)
+    # it_is_not_allowed_to([:create, :update, :destroy], ProductAccessGroup)
   end
 
   describe "unprivileged user" do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe Ability do
     end
   end
 
+  shared_examples_for "it can manage training requests" do
+    let(:subject_resource) { create(:training_request, product: instrument) }
+
+    it { is_expected.to be_allowed_to(:manage, TrainingRequest) }
+  end
+
   shared_examples_for "it can destroy admistrative reservations" do
     let(:order) { build_stubbed(:order) }
     let(:order_detail) { build_stubbed(:order_detail, order: order) }
@@ -219,6 +225,7 @@ RSpec.describe Ability do
       it { is_expected.to be_allowed_to(:show, Order) }
       it_is_not_allowed_to([:edit, :update], Reservation)
       it { is_expected.not_to be_allowed_to(:administer, Product) }
+      it_is_allowed_to(:manage, Statement)
     end
 
     context "in no facility" do
@@ -234,6 +241,7 @@ RSpec.describe Ability do
 
       it { is_expected.to be_allowed_to(:manage_billing, Facility.cross_facility) }
       it_is_not_allowed_to([:create, :switch_to], User)
+      it_is_not_allowed_to(:manage, Statement)
     end
   end
 
@@ -296,14 +304,7 @@ RSpec.describe Ability do
     it { is_expected.not_to be_allowed_to(:manage_users, Facility.cross_facility) }
     it_behaves_like "it can destroy admistrative reservations"
     it_behaves_like "it allows switch_to on active, but not deactivated users"
-
-    context "when facility_directors_can_manage_price_groups on", feature_setting: { facility_directors_can_manage_price_groups: false } do
-      it_is_not_allowed_to([:create, :edit, :update, :destroy], PriceGroup)
-      it_is_not_allowed_to([:create, :edit, :update, :destroy], PricePolicy)
-      it_is_not_allowed_to([:create, :edit, :update, :destroy], InstrumentPricePolicy)
-      it_is_not_allowed_to([:create, :edit, :update, :destroy], ItemPricePolicy)
-      it_is_not_allowed_to([:create, :edit, :update, :destroy], ServicePricePolicy)
-    end
+    it_behaves_like "it can manage training requests"
   end
 
   shared_examples_for "it has common staff abilities" do
@@ -321,6 +322,22 @@ RSpec.describe Ability do
 
     it_behaves_like "it can destroy admistrative reservations"
     it_behaves_like "it allows switch_to on active, but not deactivated users"
+
+    it { is_expected.not_to be_allowed_to(:manage, Reservation) }
+    context "when managing reservations" do
+      let(:instrument) { create(:instrument, facility: facility) }
+      let(:subject_resource) { create(:reservation, product: instrument) }
+
+      it { is_expected.to be_allowed_to(:read, ProductAccessory) }
+      it { is_expected.to be_allowed_to(:manage, Reservation) }
+    end
+
+    context "when managing order details" do
+      let(:order) { build_stubbed(:order, facility: facility) }
+      let(:subject_resource) { build_stubbed(:order_detail, order: order) }
+
+      it { is_expected.to be_allowed_to(:manage, OrderDetail) }
+    end
   end
 
   describe "senior staff" do
@@ -331,6 +348,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:manage, TrainingRequest) }
     it { is_expected.to be_allowed_to(:manage, ScheduleRule) }
     it { is_expected.to be_allowed_to(:manage, ProductAccessGroup) }
+    it_behaves_like "it can manage training requests"
   end
 
   describe "staff" do
@@ -409,5 +427,25 @@ RSpec.describe Ability do
     it { is_expected.not_to be_allowed_to(:show_problems, Reservation) }
     it { is_expected.not_to be_allowed_to(:disputed, Order) }
     it { is_expected.not_to be_allowed_to(:manage, User) }
+  end
+
+  describe "account administrator" do
+    let(:user) { create(:user) }
+    let(:account) { create(:setup_account, owner: user) }
+
+    context "managing accounts" do
+      let(:subject_resource) { account }
+
+      it_is_allowed_to([:manage], Account)
+      it_is_allowed_to([:manage], AccountUser)
+      it_is_allowed_to [:show, :suspend, :unsuspend, :user_search, :user_accounts, :statements, :show_statement, :index], Statement
+    end
+
+    context "when managing order details of own account" do
+      let(:order) { build_stubbed(:order, facility: facility) }
+      let(:subject_resource) { build_stubbed(:order_detail, order: order, account: account) }
+
+      it_is_allowed_to([:show, :update, :dispute], OrderDetail)
+    end
   end
 end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -305,6 +305,14 @@ RSpec.describe Ability do
     it_behaves_like "it can destroy admistrative reservations"
     it_behaves_like "it allows switch_to on active, but not deactivated users"
     it_behaves_like "it can manage training requests"
+
+    context "when facility_directors_can_manage_price_groups on", feature_setting: { facility_directors_can_manage_price_groups: false } do
+      it_is_not_allowed_to([:create, :edit, :update, :destroy], PriceGroup)
+      it_is_not_allowed_to([:create, :edit, :update, :destroy], PricePolicy)
+      it_is_not_allowed_to([:create, :edit, :update, :destroy], InstrumentPricePolicy)
+      it_is_not_allowed_to([:create, :edit, :update, :destroy], ItemPricePolicy)
+      it_is_not_allowed_to([:create, :edit, :update, :destroy], ServicePricePolicy)
+    end
   end
 
   shared_examples_for "it has common staff abilities" do


### PR DESCRIPTION
# Release Notes

Refactor the ability.rb class into role based methods to make it easier to manage.  Specifically this is being done in preparation for introducing a facility_billing_administrator role.

# Additional Context

This refactoring leaves the logic of ability.rb intact but some differences:  
* It attempts to group abilities by role and not have them bleed into one another.  (It doesn't succeed 100%).
* It attempts to make it more likely that users with multiple roles will end up with the right set of abilities.  For example by reducing the number of `cannot` ability revocations.
* Originally `ability_extender.extend(user, resource)` was not reached for account_manager & billing_administrator.  In this version it is reached.  It wasn't clear to me why it shouldn't be reached.

Note that users with the `administrator` role and another role only run `administrator_abilities()`.  This is because `can :manage, :all` is granted to `administrators` and running the ability method from another role would either not change the abilities or revoke abilities.  This is also why `administrator_abilities()` does have some logic for users with other additional roles
