### PR TITLE
Remove stale version lock for rollbar gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,14 +129,12 @@ group :test do
 end
 
 group :stage, :production do
-  gem "eye-patch", require: false
   gem "exception_notification"
+  gem "eye-patch", require: false
   gem "lograge"
   gem "logstash-event"
   gem "oj"
-  # 2.15.6 has a problem during cap deploy
-  # https://github.com/rollbar/rollbar-gem/issues/713
-  gem "rollbar", "2.15.5"
+  gem "rollbar"
   gem "unicorn", require: false
   gem "whenever", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -702,7 +702,7 @@ DEPENDENCIES
   rails-erd
   rails-observers
   rake
-  rollbar (= 2.15.5)
+  rollbar
   rspec-activejob
   rspec-collection_matchers
   rspec-rails


### PR DESCRIPTION
# Release Notes

Remove stale version lock for rollbar gem

# Additional Context

The current version is 2.19.4, so this PR remove the now-stale version lock, allowing dependabot to include `rollbar` in its update checks.