### PR TITLE
Refactor ability class - some tests broke in Dartmouth build

### DIFF
--- a/spec/controllers/price_groups_controller_spec.rb
+++ b/spec/controllers/price_groups_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe PriceGroupsController do
         @action = :users
       end
 
-      context "when user-based price groups are enabled", feature_setting: { user_based_price_groups: true } do
+      context "when user-based price groups are enabled", feature_setting: { user_based_price_groups: true, facility_directors_can_manage_price_groups: true } do
         let(:user) { FactoryBot.create(:user) }
         let!(:user_member) { FactoryBot.create(:user_price_group_member, price_group: price_group, user: user) }
 
@@ -64,7 +64,7 @@ RSpec.describe PriceGroupsController do
         end
       end
 
-      context "when user-based price groups are disabled", feature_setting: { user_based_price_groups: false } do
+      context "when user-based price groups are disabled", feature_setting: { user_based_price_groups: false, facility_directors_can_manage_price_groups: true } do
         before(:each) do
           maybe_grant_always_sign_in(user)
           do_request
@@ -106,10 +106,20 @@ RSpec.describe PriceGroupsController do
         @action = :accounts
       end
 
-      it_should_allow_managers_only do
-        expect(assigns(:account_members)).to include(account_member)
-        expect(assigns(:tab)).to eq(:accounts)
-        is_expected.to render_template("show")
+      context "when facility_directors_can_manage_price_groups on", feature_setting: { facility_directors_can_manage_price_groups: true } do
+        it_should_allow_managers_only do
+          expect(assigns(:account_members)).to include(account_member)
+          expect(assigns(:tab)).to eq(:accounts)
+          is_expected.to render_template("show")
+        end
+      end
+
+      context "when facility_directors_can_manage_price_groups off", feature_setting: { facility_directors_can_manage_price_groups: false } do
+        it_should_allow_admin_only do
+          expect(assigns(:account_members)).to include(account_member)
+          expect(assigns(:tab)).to eq(:accounts)
+          is_expected.to render_template("show")
+        end
       end
     end
 
@@ -120,14 +130,14 @@ RSpec.describe PriceGroupsController do
       end
 
       context "when facility_directors_can_manage_price_groups on", feature_setting: { facility_directors_can_manage_price_groups: true } do
-        it_should_allow_managers_only do 
+        it_should_allow_managers_only do
           expect(assigns(:price_group)).to be_kind_of(PriceGroup).and eq(price_group)
           is_expected.to render_template("edit")
         end
       end
 
       context "when facility_directors_can_manage_price_groups off", feature_setting: { facility_directors_can_manage_price_groups: false } do
-        it_should_allow_admin_only do 
+        it_should_allow_admin_only do
           expect(assigns(:price_group)).to be_kind_of(PriceGroup).and eq(price_group)
           is_expected.to render_template("edit")
         end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -294,7 +294,6 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:read, Notification) }
     it { is_expected.to be_allowed_to(:show_problems, Reservation) }
     it { is_expected.to be_allowed_to(:batch_update, Order) }
-    it { is_expected.to be_allowed_to(:manage, PriceGroup) }
     it_is_allowed_to([:batch_update, :cancel, :index], Reservation)
     it { is_expected.to be_allowed_to(:manage, ScheduleRule) }
     it { is_expected.to be_allowed_to(:manage, ProductAccessGroup) }
@@ -306,11 +305,24 @@ RSpec.describe Ability do
     it_behaves_like "it allows switch_to on active, but not deactivated users"
     it_behaves_like "it can manage training requests"
 
-    context "when facility_directors_can_manage_price_groups on", feature_setting: { facility_directors_can_manage_price_groups: false } do
+    context "when facility_directors_can_manage_price_groups enabled", feature_setting: { facility_directors_can_manage_price_groups: true } do
+      it_is_allowed_to(:manage, PriceGroup)
+      it_is_allowed_to(:manage, PricePolicy)
+      it_is_allowed_to(:manage, InstrumentPricePolicy)
+      it_is_allowed_to(:manage, ItemPricePolicy)
+      it_is_allowed_to(:manage, ServicePricePolicy)
+    end
+
+    context "when facility_directors_can_manage_price_groups disabled", feature_setting: { facility_directors_can_manage_price_groups: false } do
+      it_is_allowed_to([:show, :index], PriceGroup)
       it_is_not_allowed_to([:create, :edit, :update, :destroy], PriceGroup)
+      it_is_allowed_to([:show, :index], PricePolicy)
       it_is_not_allowed_to([:create, :edit, :update, :destroy], PricePolicy)
+      it_is_allowed_to([:show, :index], InstrumentPricePolicy)
       it_is_not_allowed_to([:create, :edit, :update, :destroy], InstrumentPricePolicy)
+      it_is_allowed_to([:show, :index], ItemPricePolicy)
       it_is_not_allowed_to([:create, :edit, :update, :destroy], ItemPricePolicy)
+      it_is_allowed_to([:show, :index], ServicePricePolicy)
       it_is_not_allowed_to([:create, :edit, :update, :destroy], ServicePricePolicy)
     end
   end


### PR DESCRIPTION
because of the `facility_directors_can_manage_price_groups` feature

@vandrijevik I'm going to merge this because you are out tomorrow and it is just spec fixes.  I'd like to get the refactoring out to Dartmouth stage today if possible so they can test.