### PR TITLE
Update mysql2 gem to 0.5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "rails", "5.0.7.2"
 gem "config"
 
 ## database
-gem "mysql2", "~> 0.4.10"
+gem "mysql2"
 # To use Oracle, remove the mysql2 gem above and uncomment these lines
 # gem "ruby-oci8"
 # gem "activerecord-oracle_enhanced-adapter"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,7 +376,7 @@ GEM
     momentjs-rails (2.20.1)
       railties (>= 3.1)
     multi_json (1.13.1)
-    mysql2 (0.4.10)
+    mysql2 (0.5.2)
     nenv (0.3.0)
     nested_form_fields (0.8.2)
       coffee-rails (>= 3.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -675,7 +675,7 @@ DEPENDENCIES
   jquery-ui-rails
   ldap_authentication!
   letter_opener
-  mysql2 (~> 0.4.10)
+  mysql2
   nested_form_fields
   nokogiri
   oj


### PR DESCRIPTION
# Release Notes

Update mysql2 gem to 0.5.2

# Additional Context

I believe this is a part of why deployments to TXI’s staging environment (which uses MySQL) are currently failing, due to https://github.com/brianmario/mysql2/issues/938 (and recompiling the native extensions against a newer version of the MySQL client libraries).