### PR TITLE
[#149769] Prefill rows in Sanger Sequencing for the desired quantity, not always 5

### DIFF
--- a/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/submissions_controller.rb
+++ b/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/submissions_controller.rb
@@ -27,7 +27,7 @@ module SangerSequencing
     end
 
     def new
-      5.times { @submission.create_prefilled_sample } if @submission.samples.none?
+      number_of_samples.times { @submission.create_prefilled_sample } if @submission.samples.none?
       render :edit
     end
 
@@ -96,6 +96,12 @@ module SangerSequencing
 
     def prevent_after_purchase
       raise ActiveRecord::RecordNotFound if @submission.purchased?
+    end
+
+    def number_of_samples
+      Integer(params[:quantity])
+    rescue ArgumentError
+      5
     end
 
   end


### PR DESCRIPTION
# Release Notes

Prefill rows in Sanger Sequencing for the desired quantity, not always 5

# Screenshot

The number of rows we prefill on the sanger form should match the quantity that the user enters here:

![image](https://user-images.githubusercontent.com/7736/58432902-043c3000-80b5-11e9-9ab3-4477cd037e18.png)

Previously, we always pre-filled 5 samples, and even though the button to add samples worked as expected, users that would enter 17 (or whatever number they wanted) in the quantity field were confused as to why there are only 5 samples precreated.