### PR TITLE
[#148865] Support account reference field in c2po engine

### DIFF
--- a/app/views/facility_accounts/show.html.haml
+++ b/app/views/facility_accounts/show.html.haml
@@ -13,6 +13,8 @@
   = f.input :owner_user
   = f.input :type_string
   = f.input :description
+  - if SettingsHelper.feature_on?(:account_reference_field)
+    = f.input :reference
   = f.input :expires_at, date_only: true
 
   - if @account.suspended?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -131,6 +131,7 @@ feature:
   price_policy_requires_note: true
   multi_facility_accounts: true
   facility_directors_can_manage_price_groups: true
+  account_reference_field: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/vendor/engines/c2po/app/views/facility_accounts/account_fields/_credit_card_account.html.haml
+++ b/vendor/engines/c2po/app/views/facility_accounts/account_fields/_credit_card_account.html.haml
@@ -4,5 +4,7 @@
   = f.input :expiration_year, required: true, collection: (Time.zone.now.year..(Time.zone.now.year + 10)).to_a
 
 = f.input :description, required: true, hint: t('facility_accounts.account_fields.label.all_instruct'), hint_html: { class: 'help-inline' }
+- if SettingsHelper.feature_on?(:account_reference_field)
+  = f.input :reference
 = render partial: 'facility_accounts/account_fields/affiliate', locals: { f: f }
 = render partial: 'facility_accounts/account_fields/remittance_information', locals: { f: f }

--- a/vendor/engines/c2po/app/views/facility_accounts/account_fields/_purchase_order_account.html.haml
+++ b/vendor/engines/c2po/app/views/facility_accounts/account_fields/_purchase_order_account.html.haml
@@ -6,6 +6,9 @@
 
 = f.input :description, required: true
 
+- if SettingsHelper.feature_on?(:account_reference_field)
+  = f.input :reference
+
 = render partial: 'facility_accounts/account_fields/affiliate', locals: { f: f }
 
 = render partial: 'facility_accounts/account_fields/remittance_information', locals: { f: f }

--- a/vendor/engines/c2po/config/locales/en.yml
+++ b/vendor/engines/c2po/config/locales/en.yml
@@ -49,3 +49,10 @@ en:
       credit_card_account:
         account_number: Payment Source
         name_on_card: Name On Card
+
+  simple_form:
+    labels:
+      purchase_order_account:
+        reference: Reference (optional)
+      credit_card_account:
+        reference: Reference (optional)


### PR DESCRIPTION
# Release Notes

Support account reference field in c2po engine

# Additional Context

The c2po engine adds support for purchase orders and credit cards, and it is used by both NU and Dartmouth. This PR adds support for Dartmouth’s account reference field to this engine, and keeps the setting turned off in master (so the field is visible only for Dartmouth).