### PR TITLE
[#148865] Allow reference param in AccountBuilder

### DIFF
--- a/app/services/account_builder.rb
+++ b/app/services/account_builder.rb
@@ -91,7 +91,7 @@ class AccountBuilder
   end
 
   # Needs to be overridable by engines
-  cattr_accessor(:common_permitted_account_params) { [:description] }
+  cattr_accessor(:common_permitted_account_params) { [:description, :reference] }
 
   # Override in subclassed builder to define additional strong_param attributes
   # for build action. Returns an array of "permitted" params.


### PR DESCRIPTION
# Release Notes

Allow reference param in AccountBuilder

# Additional Context

In the “move things around” shuffle while working on `#148865`, I forgot to include this commit, which actually allows the form to be saved with a reference field.