### PR TITLE
Remove thin server from development and test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,7 +106,6 @@ group :development, :test do
   gem "spring"
   gem "spring-commands-rspec"
   gem "teaspoon-jasmine"
-  gem "thin"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,6 @@ GEM
     dynamic_form (1.1.4)
     ed25519 (1.2.4)
     erubis (2.7.0)
-    eventmachine (1.2.5)
     exception_notification (4.3.0)
       actionmailer (>= 4.0, < 6)
       activesupport (>= 4.0, < 6)
@@ -588,10 +587,6 @@ GEM
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
-    thin (1.7.2)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -717,7 +712,6 @@ DEPENDENCIES
   teaspoon-jasmine
   text_helpers
   therubyracer
-  thin
   uglifier (= 4.1.18)
   unicorn
   vuejs-rails (~> 1.0.26)


### PR DESCRIPTION
# Release Notes

Remove thin server from development and test

# Additional Context

NUcore is deployed using unicorn, which is a vastly different server from thin. This PR removes thin, because there is no good reason to have it for development and test only.