### PR TITLE
[#149820] Only show relay toggles on today’s facility timeline

### DIFF
--- a/app/views/facility_reservations/_instrument.html.haml
+++ b/app/views/facility_reservations/_instrument.html.haml
@@ -7,13 +7,12 @@
     .unit_container
       = render partial: "reservation",
         collection: (@reservations_by_instrument.fetch(instrument, []) + instrument.blackout_reservations(@display_datetime)),
-        as: :reservation,
         locals: { product: instrument }
 
-      - if @display_datetime.beginning_of_day == Time.current.beginning_of_day
+      - if @display_datetime.today?
         .current_time{style: "left: #{datetime_left_position(@display_datetime, Time.current)}"}
 
-    - if instrument.has_real_relay?
+    - if @display_datetime.today? && instrument.has_real_relay?
       .relay_checkbox
         = check_box_tag "relay[#{instrument.id}]", 1, false, :disabled => true, :"data-relay-url" => facility_instrument_switch_path(instrument.facility, instrument)
         .loading_box

--- a/app/views/reservations/_instrument.html.haml
+++ b/app/views/reservations/_instrument.html.haml
@@ -7,8 +7,7 @@
     .unit_container
       = render partial: "reservation",
         collection: (@reservations_by_instrument.fetch(instrument, []) + instrument.blackout_reservations(@display_datetime)),
-        as: :reservation,
         locals: { product: instrument }
 
-      - if @display_datetime.beginning_of_day == Time.current.beginning_of_day
+      - if @display_datetime.today?
         .current_time{style: "left: #{datetime_left_position(@display_datetime, Time.current)}"}

--- a/spec/controllers/facility_reservations_controller_spec.rb
+++ b/spec/controllers/facility_reservations_controller_spec.rb
@@ -241,6 +241,19 @@ RSpec.describe FacilityReservationsController do
         do_request
         expect(assigns[:display_datetime]).to eq(Time.zone.parse("2015-06-14T00:00"))
       end
+
+      it "shows relay status toggles when the date is today" do
+        allow_any_instance_of(Instrument).to receive(:has_real_relay?).and_return(true)
+        do_request
+        expect(response.body).to include("relay_checkbox")
+      end
+
+      it "does not show relay status toggles when the date is not today" do
+        @params[:date] = "6/14/2015"
+        allow_any_instance_of(Instrument).to receive(:has_real_relay?).and_return(true)
+        do_request
+        expect(response.body).not_to include("relay_checkbox")
+      end
     end
 
     context "orders" do


### PR DESCRIPTION
# Release Notes

Only show relay toggles on today’s facility timeline

# Additional Context

These toggles always reflect the current status (and they are quite slow to populate), so we will only show them on today’s page going forward.