### PR TITLE
[#142338] Add billable minutes to reservations and automatically set them

### DIFF
--- a/app/models/admin_reservation.rb
+++ b/app/models/admin_reservation.rb
@@ -26,4 +26,10 @@ class AdminReservation < Reservation
     expires_mins_before.present?
   end
 
+  private
+
+  def set_billable_minutes
+    self.billable_minutes = nil
+  end
+
 end

--- a/app/models/offline_reservation.rb
+++ b/app/models/offline_reservation.rb
@@ -33,4 +33,10 @@ class OfflineReservation < Reservation
     end
   end
 
+  private
+
+  def set_billable_minutes
+    self.billable_minutes = nil
+  end
+
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -50,6 +50,7 @@ class Reservation < ApplicationRecord
   end
 
   ## AR Hooks
+  before_save :set_billable_minutes
   after_update :auto_save_order_detail, if: :order_detail
 
   # Scopes
@@ -341,6 +342,9 @@ class Reservation < ApplicationRecord
 
   def grace_period_duration
     SettingsHelper.setting("reservations.grace_period") || 5.minutes
+  end
+
+  def set_billable_minutes
   end
 
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -345,7 +345,7 @@ class Reservation < ApplicationRecord
   end
 
   def set_billable_minutes
-    if order_detail&.complete?
+    if order_detail&.complete? && price_policy.present?
       case price_policy.charge_for
       when InstrumentPricePolicy::CHARGE_FOR.fetch(:reservation)
         self.billable_minutes = TimeRange.new(reserve_start_at, reserve_end_at).duration_mins

--- a/db/migrate/20190610112539_add_billable_minutes_to_reservations.rb
+++ b/db/migrate/20190610112539_add_billable_minutes_to_reservations.rb
@@ -1,0 +1,5 @@
+class AddBillableMinutesToReservations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :reservations, :billable_minutes, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190416205054) do
+ActiveRecord::Schema.define(version: 20190610112539) do
 
   create_table "account_facility_joins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "facility_id", null: false
@@ -552,6 +552,7 @@ ActiveRecord::Schema.define(version: 20190416205054) do
     t.datetime "deleted_at"
     t.string   "group_id"
     t.string   "user_note"
+    t.integer  "billable_minutes"
     t.index ["created_by_id"], name: "index_reservations_on_created_by_id", using: :btree
     t.index ["deleted_at"], name: "index_reservations_on_deleted_at", using: :btree
     t.index ["group_id"], name: "index_reservations_on_group_id", using: :btree
@@ -820,6 +821,8 @@ ActiveRecord::Schema.define(version: 20190416205054) do
 
   add_foreign_key "account_facility_joins", "accounts"
   add_foreign_key "account_facility_joins", "facilities"
+  add_foreign_key "account_users", "accounts", name: "fk_accounts"
+  add_foreign_key "account_users", "users"
   add_foreign_key "accounts", "facilities", name: "fk_account_facility_id"
   add_foreign_key "bulk_email_jobs", "facilities"
   add_foreign_key "bulk_email_jobs", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -821,8 +821,6 @@ ActiveRecord::Schema.define(version: 20190610112539) do
 
   add_foreign_key "account_facility_joins", "accounts"
   add_foreign_key "account_facility_joins", "facilities"
-  add_foreign_key "account_users", "accounts", name: "fk_accounts"
-  add_foreign_key "account_users", "users"
   add_foreign_key "accounts", "facilities", name: "fk_account_facility_id"
   add_foreign_key "bulk_email_jobs", "facilities"
   add_foreign_key "bulk_email_jobs", "users"

--- a/spec/models/admin_reservation_spec.rb
+++ b/spec/models/admin_reservation_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AdminReservation do
+  it "sets billable_minutes to nil before saving" do
+    expect(subject).to receive(:billable_minutes=).with(nil)
+    subject.run_callbacks(:save) { false }
+  end
+end

--- a/spec/models/offline_reservation_spec.rb
+++ b/spec/models/offline_reservation_spec.rb
@@ -56,4 +56,9 @@ RSpec.describe OfflineReservation do
       end
     end
   end
+
+  it "sets billable_minutes to nil before saving" do
+    expect(subject).to receive(:billable_minutes=).with(nil)
+    subject.run_callbacks(:save) { false }
+  end
 end


### PR DESCRIPTION
# Release Notes

Add billable minutes to reservations and automatically set them

# Additional Context

Adds the column and code for automatically calculating and setting it.