### PR TITLE
[#142338] Update a Reservation’s billable_minutes after each save on an Order Detail

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -42,6 +42,8 @@ class OrderDetail < ApplicationRecord
     true # problem might be false; we need the callback chain to continue
   end
 
+  after_save :update_billable_minutes_on_reservation, if: :reservation
+
   belongs_to :product
   belongs_to :price_policy
   belongs_to :statement, inverse_of: :order_details
@@ -966,4 +968,7 @@ class OrderDetail < ApplicationRecord
     !actual_costs_match_calculated?
   end
 
+  def update_billable_minutes_on_reservation
+    reservation.update_billable_minutes
+  end
 end

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -1901,4 +1901,10 @@ RSpec.describe OrderDetail do
       described_class.where_ids_in((0..1001).to_a).to_a
     end
   end
+
+  it "calls #update_billable_minutes on the associated reservation after saving" do
+    order_detail.build_reservation
+    expect(order_detail.reservation).to receive(:update_billable_minutes)
+    order_detail.run_callbacks(:save) { true }
+  end
 end


### PR DESCRIPTION
# Release Notes

Update a Reservation’s billable_minutes after each save on an Order Detail

# Additional Context

Sometimes, details that affect a reservation’s billable minutes are saved on the order detail and not on the reservation itself (such as assigning a price policy for problem orders). To ensure that `billable_minutes` get set even in these cases, we need to update the column on Reservation after the OrderDetail is saved, which is what this PR does.