### PR TITLE
[#142338] Handle billable minutes for split accounts

### DIFF
--- a/app/models/reports/export_raw.rb
+++ b/app/models/reports/export_raw.rb
@@ -105,7 +105,7 @@ module Reports
         price_change_reason: :price_change_reason,
         price_changed_by_user: ->(od) { od.price_changed_by_user&.full_name(suspended_label: false) },
         assigned_staff: ->(od) { od.assigned_user&.full_name(suspended_label: false) },
-        billable_minutes: ->(od) { od.reservation&.billable_minutes }
+        billable_minutes: ->(od) { od.time_data.try(:billable_minutes) }
       }
       if SettingsHelper.has_review_period?
         hash

--- a/vendor/engines/split_accounts/app/services/split_accounts/order_detail_splitter.rb
+++ b/vendor/engines/split_accounts/app/services/split_accounts/order_detail_splitter.rb
@@ -50,6 +50,7 @@ module SplitAccounts
         :duration_mins,
         :actual_duration_mins,
         :quantity,
+        :billable_minutes,
       )
     end
 

--- a/vendor/engines/split_accounts/spec/services/order_detail_splitter_spec.rb
+++ b/vendor/engines/split_accounts/spec/services/order_detail_splitter_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe SplitAccounts::OrderDetailSplitter, type: :service do
     let(:reservation) do
       build_stubbed(:reservation, reserve_start_at: start_at,
                                   reserve_end_at: start_at + 30.minutes, actual_start_at: start_at,
-                                  actual_end_at: start_at + 45.minutes)
+                                  actual_end_at: start_at + 45.minutes, billable_minutes: 45)
     end
     let(:order_detail_results) { described_class.new(order_detail, split_time_data: true, reporting: true).split }
     let(:results) { order_detail_results.map(&:time_data) }
@@ -120,6 +120,10 @@ RSpec.describe SplitAccounts::OrderDetailSplitter, type: :service do
 
     it "splits the actual minutes" do
       expect(results.map(&:actual_duration_mins)).to eq([15.02, 14.99, 14.99])
+    end
+
+    it "splits the billable minutes" do
+      expect(results.map(&:billable_minutes)).to eq([17, 14, 14])
     end
 
     it "splits the order detail's accounts" do


### PR DESCRIPTION
# Release Notes

Handle billable minutes for split accounts

# Additional Context

Splits the billable minutes for a reservation, shown in the raw export, the same way that the reserved and actual minutes are split.