### PR TITLE
[#148102] Use change event for IE support, where input doesn’t fire on <select> elements

### DIFF
--- a/app/assets/javascripts/app/manage_orders.coffee
+++ b/app/assets/javascripts/app/manage_orders.coffee
@@ -28,7 +28,7 @@ class OrderDetailManagement
     @initResolutionNote()
     @initAccountOwnerUpdate()
     @disableForm() if @$element.hasClass('disabled')
-    @$element.find(".js--order-detail-price-change-reason-select").on "input", (event) ->
+    @$element.find(".js--order-detail-price-change-reason-select").on "change", (event) ->
       selectedOption = event.target.options[event.target.selectedIndex]
       noteTextField = $(".js--order-detail-price-change-reason")
       if selectedOption.value == "Other"

--- a/app/assets/javascripts/price_policy.js.coffee
+++ b/app/assets/javascripts/price_policy.js.coffee
@@ -56,7 +56,7 @@ $(document).ready ->
     updateAdjustmentFields($(evt.target))
   ).trigger("keyup")
 
-  $(".js--price-policy-note-select").on "input", (event) ->
+  $(".js--price-policy-note-select").on "change", (event) ->
     selectedOption = event.target.options[event.target.selectedIndex]
     noteTextField = $(".js--price-policy-note")
     if selectedOption.value == "Other"


### PR DESCRIPTION
# Release Notes

Use change event for IE support, where input doesn’t fire on <select> elements

# Additional Context

RaDar users (Kayla, in particular) use IE, which doesn’t fire `input` events on `<select>` elements, so we have to use `change` instead.