### PR TITLE
[#142338] If canceled_at is set on an OrderDetail, don’t set billable_minutes

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -353,7 +353,7 @@ class Reservation < ApplicationRecord
   end
 
   def calculated_billable_minutes
-    if order_detail&.complete? && price_policy.present?
+    if order_detail&.complete? && order_detail&.canceled_at.blank? && price_policy.present?
       case price_policy.charge_for
       when InstrumentPricePolicy::CHARGE_FOR.fetch(:reservation)
         TimeRange.new(reserve_start_at, reserve_end_at).duration_mins


### PR DESCRIPTION
# Release Notes

If canceled_at is set on an OrderDetail, don’t set billable_minutes

# Additional Context

As reported by Aaron from NU, there’s a certain class of orders that need to have a state of Complete, but have been canceled (and so they have a canceled_at timestamp). For these orders, we should not set `billable_minutes` on the corresponding reservations, and this PR does exactly that.