### PR TITLE
[#142338] Backfill task for setting billable_minutes on past reservations

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -352,8 +352,9 @@ class Reservation < ApplicationRecord
     self.billable_minutes = calculated_billable_minutes
   end
 
+  # FIXME: Temporary override to include reconciled orders, so we can backfill them
   def calculated_billable_minutes
-    if order_detail&.complete? && order_detail&.canceled_at.blank? && price_policy.present?
+    if (order_detail&.complete? || order_detail&.reconciled?) && order_detail&.canceled_at.blank? && price_policy.present?
       case price_policy.charge_for
       when InstrumentPricePolicy::CHARGE_FOR.fetch(:reservation)
         TimeRange.new(reserve_start_at, reserve_end_at).duration_mins

--- a/lib/tasks/backfill_billable_minutes.rake
+++ b/lib/tasks/backfill_billable_minutes.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+desc "Backfills billable_minutes on existing Reservations"
+task backfill_billable_minutes: :environment do
+  Reservation.
+    joins(order_detail: :price_policy).
+    where(order_details: { state: ["complete", "reconciled"], canceled_at: nil }, price_policies: { charge_for: "reservation" }).
+    where(reservations: { billable_minutes: nil }).
+    find_each { |reservation| reservation.update_billable_minutes }
+
+  Reservation.
+    joins(order_detail: :price_policy).
+    where(order_details: { state: ["complete", "reconciled"], canceled_at: nil }, price_policies: { charge_for: ["usage", "overage"] }).
+    where(reservations: { billable_minutes: nil }).
+    where.not(reservations: { actual_start_at: nil, actual_end_at: nil }).
+    find_each { |reservation| reservation.update_billable_minutes }
+end


### PR DESCRIPTION
# Release Notes

Backfill task for setting billable_minutes on past reservations
