### PR TITLE
[#148527] Remove alias for OrderDetail#merge! and use standard #save!

### DIFF
--- a/app/controllers/order_detail_stored_files_controller.rb
+++ b/app/controllers/order_detail_stored_files_controller.rb
@@ -44,7 +44,7 @@ class OrderDetailStoredFilesController < ApplicationController
       flash[:notice] = text("upload_order_file.success")
 
       if @order_detail.order.to_be_merged?
-        @order_detail.merge! # trigger the OrderDetailObserver callbacks
+        @order_detail.save! # trigger the OrderDetailObserver callbacks
         redirect_to facility_order_path(@order_detail.facility, @order_detail.order.merge_order || @order_detail.order)
       else
         redirect_to(order_path(@order))

--- a/app/models/external_service/survey_response.rb
+++ b/app/models/external_service/survey_response.rb
@@ -22,7 +22,7 @@ class SurveyResponse
         od.quantity = params[:quantity].to_i
       end
       receiver.save!
-      od.merge!
+      od.save!
       receiver
     end
   end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -100,8 +100,6 @@ class OrderDetail < ApplicationRecord
     journal_date || statement_date
   end
 
-  alias merge! save!
-
   validates_presence_of :product_id, :order_id, :created_by
   validates_numericality_of :quantity, only_integer: true, greater_than_or_equal_to: 1
   validates_numericality_of :actual_cost, greater_than_or_equal_to: 0, if: ->(o) { o.actual_cost_changed? && !o.actual_cost.nil? }

--- a/spec/models/external_service/survey_response_spec.rb
+++ b/spec/models/external_service/survey_response_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe SurveyResponse do
     expect(esr.response_data).to eq deserialized_response_data.to_json
   end
 
-  it "merges the order detail" do
+  it "saves the order detail" do
     od = external_service_receiver.receiver
     expect(OrderDetail).to receive(:find).and_return od
-    expect(od).to receive :merge!
+    expect(od).to receive :save!
     survey_response.save!
   end
 


### PR DESCRIPTION
# Release Notes

Remove alias for OrderDetail#merge! and use standard #save!

# Additional Context

ActiveRecord’s `save!` has standard, well-defined semantics. `Hash#merge!` also has standard, well-defined semantics. Aliasing `OrderDetail#merge!` just to mean `OrderDetail#save!` is confusing and we should not do it — it is pure cognitive overhead.