### PR TITLE
[#148527] Remove unnecessary metaprogramming from ExternalServiceReceiver

### DIFF
--- a/app/models/external_service/external_service_receiver.rb
+++ b/app/models/external_service/external_service_receiver.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-#
-# A polymorphic join class between an +ExternalService+
-# and a class that receives the results of that service
-# (the receiver).
 class ExternalServiceReceiver < ApplicationRecord
 
   belongs_to :external_service
@@ -11,20 +7,18 @@ class ExternalServiceReceiver < ApplicationRecord
 
   validates_presence_of :external_service_id, :receiver_id, :response_data
 
-  def respond_to?(symbol, include_private = false)
-    super || parsed_response_data.key?(symbol)
+  def show_url
+    parsed_response_data[:show_url]
+  end
+
+  def edit_url
+    parsed_response_data[:edit_url]
   end
 
   private
 
-  def method_missing(symbol, *args)
-    parsed = parsed_response_data
-    return parsed[symbol] if parsed.key? symbol
-    super
-  end
-
   def parsed_response_data
-    JSON.parse(self[:response_data]).symbolize_keys
+    JSON.parse(response_data).symbolize_keys
   rescue TypeError, JSON::ParserError
     {}
   end

--- a/spec/models/external_service/external_service_receiver_spec.rb
+++ b/spec/models/external_service/external_service_receiver_spec.rb
@@ -16,27 +16,15 @@ RSpec.describe ExternalServiceReceiver do
   it { is_expected.to validate_presence_of :external_service_id }
   it { is_expected.to validate_presence_of :response_data }
 
-  it "responds to keys in the response data" do
-    parsed_response_data.each do |key, _|
-      expect(receiver).to respond_to key
+  describe "#show_url" do
+    it "returns the show url from the response_data attribute" do
+      expect(subject.show_url).to eq "http://survey.test.local/show"
     end
   end
 
-  it "returns the values of keys in the response data when the keys are called as methods" do
-    parsed_response_data.each do |key, value|
-      expect(receiver.send(key)).to eq value
-    end
-  end
-
-  describe "error handling" do
-    it "does not raise an error when response_data is nil" do
-      receiver.response_data = nil
-      expect(receiver).to_not respond_to :foo
-    end
-
-    it "does not raise an error when response_data is not JSON" do
-      receiver.response_data = "a random string"
-      expect(receiver).to_not respond_to :foo
+  describe "#edit_url" do
+    it "returns the edit url from the response_data attribute" do
+      expect(subject.edit_url).to eq "http://survey.test.local/edit"
     end
   end
 end


### PR DESCRIPTION
# Release Notes

Remove unnecessary metaprogramming from ExternalServiceReceiver

# Additional Context

`#show_url` and `#edit_url` are the only non-ActiveRecord methods called on objects of this class, so let’s just define them and use regular Ruby semantics, instead of jumping through hoops and `method_missing` magic unnecessarily.
