### PR TITLE
Reformat and alphabetize Capistrano deployment config

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
-# config valid only for current version of Capistrano
 lock "~> 3.11.0"
 
 set :application, "nucore"
-
+set :eye_config, "config/eye.yml.erb"
+set :eye_env, -> { { rails_env: fetch(:rails_env) } }
 set :repo_url, "git@github.com:tablexi/nucore-open.git"
-
-set :bundle_without, "#{fetch(:bundle_without)} oracle"
+set :rollbar_env, Proc.new { fetch :rails_env }
+set :rollbar_role, Proc.new { :app }
+set :rollbar_token, ENV["ROLLBAR_ACCESS_TOKEN"]
 
 set :linked_files, fetch(:linked_files, []).concat(
   %w(config/database.yml config/secrets.yml config/eye.yml.erb),
@@ -15,10 +16,3 @@ set :linked_files, fetch(:linked_files, []).concat(
 set :linked_dirs, fetch(:linked_dirs, []).concat(
   %w(bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/files),
 )
-
-set :eye_config, "config/eye.yml.erb"
-set :eye_env, -> { { rails_env: fetch(:rails_env) } }
-
-set :rollbar_token, ENV["ROLLBAR_ACCESS_TOKEN"]
-set :rollbar_env, Proc.new { fetch :rails_env }
-set :rollbar_role, Proc.new { :app }

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
+set :branch, ENV["CIRCLE_SHA1"] || ENV["REVISION"] || ENV["BRANCH_NAME"] || "master"
+set :rails_env, "stage"
+
 server "tablexi-shared02.txihosting.com", user: "nucore", roles: %w(web app db)
 set :deploy_to, "/home/nucore/nucore.stage.tablexi.com"
-set :rails_env, "stage"
-set :branch, ENV["CIRCLE_SHA1"] || ENV["REVISION"] || ENV["BRANCH_NAME"] || "master"


### PR DESCRIPTION
# Release Notes

Reformat and alphabetize Capistrano deployment config

# Additional Context

This format is meant to make it trivial to only add the things that are different for each school at the end, making conflicts easier to resolve, and reading these files more straightforward. I will do the same in nucore-nu and nucore-dartmouth for their staging and production deployments.