### PR TITLE
[#146050] Allow emailing purchasers on order status changes

### DIFF
--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -103,7 +103,7 @@ class ProductsCommonController < ApplicationController
   def resource_params
     params.require(:"#{singular_object_name}").permit(:name, :url_name, :contact_email, :description,
                                                       :facility_account_id, :account, :initial_order_status_id,
-                                                      :requires_approval, :allows_training_requests, :is_archived, :is_hidden,
+                                                      :requires_approval, :allows_training_requests, :is_archived, :is_hidden, :email_purchasers_on_order_status_changes,
                                                       :user_notes_field_mode, :user_notes_label, :show_details,
                                                       :schedule_id, :control_mechanism, :reserve_interval,
                                                       :min_reserve_mins, :max_reserve_mins, :min_cancel_hours,

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -53,6 +53,14 @@ class Notifier < ActionMailer::Base
     send_nucore_mail args[:user].email, text("views.notifier.statement.subject", facility: @facility)
   end
 
+  def order_detail_status_changed(order_detail_id)
+    @order_detail = OrderDetail.includes(:order, :order_status).find(order_detail_id)
+    mail(
+      to: @order_detail.order.user.email,
+      subject: "Order #{@order_detail.order_number} status changed to: #{@order_detail.order_status.name}"
+    )
+  end
+
   private
 
   def attach_statement_pdf

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -875,6 +875,12 @@ class OrderDetail < ApplicationRecord
     end
   end
 
+  def notify_purchaser_of_order_status
+    if product.email_purchasers_on_order_status_changes? && !reconciled?
+      Notifier.order_detail_status_changed(id).deliver_later
+    end
+  end
+
   private
 
   # Is there enough information to move an associated order to complete/problem?

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -74,11 +74,14 @@ class OrderDetail < ApplicationRecord
   has_many   :vestal_versions, as: :versioned
 
   delegate :edit_url, to: :external_service_receiver, allow_nil: true
+  delegate :in_cart?, :facility, :ordered_at, :user, to: :order
   delegate :invoice_number, to: :statement, prefix: true
+  delegate :journal_date, to: :journal, allow_nil: true
+  delegate :ordered_on_behalf_of?, to: :order
+  delegate :price_group, to: :price_policy, allow_nil: true
+  delegate :reference, to: :journal, prefix: true, allow_nil: true
   delegate :requires_but_missing_actuals?, to: :reservation, allow_nil: true
 
-  delegate :in_cart?, :facility, :ordered_at, :user, to: :order
-  delegate :price_group, to: :price_policy, allow_nil: true
   def estimated_price_group
     estimated_price_policy.try(:price_group)
   end
@@ -88,9 +91,6 @@ class OrderDetail < ApplicationRecord
   def current_journal_rows
     journal_rows.where(journal_id: journal_id)
   end
-
-  delegate :journal_date, to: :journal, allow_nil: true
-  delegate :reference, to: :journal, prefix: true, allow_nil: true
 
   def statement_date
     statement.try(:created_at)
@@ -462,8 +462,6 @@ class OrderDetail < ApplicationRecord
   def pending?
     order.purchased? && state.in?(%w[new inprocess])
   end
-
-  delegate :ordered_on_behalf_of?, to: :order
 
   def cost
     actual_cost || estimated_cost || 0

--- a/app/models/order_status.rb
+++ b/app/models/order_status.rb
@@ -51,10 +51,6 @@ class OrderStatus < ApplicationRecord
     root.name.downcase.delete(" ").to_sym
   end
 
-  def downcase_name
-    name.downcase.gsub(/\s+/, "_")
-  end
-
   def is_left_of?(o)
     rgt < o.lft
   end

--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -115,16 +115,13 @@ class OrderDetails::ParamUpdater
     @order_detail.assign_estimated_price unless @order_detail.price_policy && @order_detail.actual_cost
   end
 
-  def change_order_status(order_status_id, apply_cancel_fee)
-    status = OrderStatus.find(order_status_id)
-    @order_detail.update_order_status! @editing_user,
-                                       status,
-                                       admin: true,
-                                       apply_cancel_fee: apply_cancel_fee
+  def change_order_status(new_order_status_id, apply_cancel_fee)
+    new_order_status = OrderStatus.find(new_order_status_id)
+    @order_detail.update_order_status!(@editing_user, new_order_status, admin: true, apply_cancel_fee: apply_cancel_fee)
+    @order_detail.notify_purchaser_of_order_status
     true
   rescue => e
     @order_detail.errors.add(:base, :changing_status)
-    # returns nil
   end
 
   # Occupancies use accepts_nested_attributes which handles this.

--- a/app/views/admin/products/_product_fields.html.haml
+++ b/app/views/admin/products/_product_fields.html.haml
@@ -12,7 +12,8 @@
 
 = f.input :is_archived, as: :boolean, label: false, inline_label: text("hints.is_archived")
 = f.input :is_hidden, as: :boolean, label: false, inline_label: text("hints.is_hidden", field: f.object.class.model_name.human.downcase)
-
 - unless f.object.is_a?(Bundle)
   = f.input :user_notes_field_mode, collection: Products::UserNoteMode.all, include_blank: false
   = f.input :user_notes_label
+= f.input :email_purchasers_on_order_status_changes, label: false, inline_label: true
+

--- a/app/views/notifier/order_detail_status_changed.html.erb
+++ b/app/views/notifier/order_detail_status_changed.html.erb
@@ -1,0 +1,14 @@
+<p>
+  The status of your NUcore order <%= @order_detail.order_number %>
+  has changed to <b><%= @order_detail.order_status.name %></b>.
+</p>
+<p>
+  You can access your NUcore orders at any time by going to <%= link_to(orders_url, orders_url) %>.
+</p>
+<p>
+If you have any questions, please do not hesitate to contact us at <%= mail_to(@order_detail.facility.email) %>.
+</p>
+<p>
+Sincerely,<br />
+<%= @order_detail.facility.name %>
+</p>

--- a/app/views/notifier/order_detail_status_changed.text.erb
+++ b/app/views/notifier/order_detail_status_changed.text.erb
@@ -1,0 +1,9 @@
+The status of your NUcore order <%= @order_detail.order_number %>
+has changed to <b><%= @order_detail.order_status.name %></b>.
+
+You can access your NUcore orders at any time by going to <%= link_to(orders_url, orders_url) %>.
+
+If you have any questions, please do not hesitate to contact us at <%= mail_to(@order_detail.facility.email) %>.
+
+Sincerely,
+<%= @order_detail.facility.name %>

--- a/app/views/products_common/manage.html.haml
+++ b/app/views/products_common/manage.html.haml
@@ -28,6 +28,7 @@
   - unless @product.is_a?(Bundle)
     = f.input :user_notes_field_mode, value_method: :to_label
     = f.input :user_notes_label if f.object.user_notes_label? && f.object.user_notes_field_mode.visible?
+  = f.input :email_purchasers_on_order_status_changes
 
   = render_if_exists "#{@product.class.name.underscore}_manage_fields", f: f
 - if can? :edit, @product

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -263,6 +263,7 @@ en:
         is_hidden: Is Hidden?
         facility_account: Recharge Chart String
         user_notes_field_mode: Users may submit a note when purchasing?
+        email_purchasers_on_order_status_changes: Email purchasers when the status of an order changes?
         user_notes_label: Label for Notes Field
         training_request_contacts: Training Request Recipients
         order_notification_recipient: Order Notification Recipient

--- a/db/migrate/20190815101750_add_email_purchasers_on_order_status_changes_to_products.rb
+++ b/db/migrate/20190815101750_add_email_purchasers_on_order_status_changes_to_products.rb
@@ -1,0 +1,5 @@
+class AddEmailPurchasersOnOrderStatusChangesToProducts < ActiveRecord::Migration[5.0]
+  def change
+    add_column :products, :email_purchasers_on_order_status_changes, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190610112539) do
+ActiveRecord::Schema.define(version: 20190815101750) do
 
   create_table "account_facility_joins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "facility_id", null: false
@@ -472,37 +472,38 @@ ActiveRecord::Schema.define(version: 20190610112539) do
   end
 
   create_table "products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "type",                          limit: 50,                       null: false
-    t.integer  "facility_id",                                                    null: false
-    t.string   "name",                          limit: 200,                      null: false
-    t.string   "url_name",                      limit: 50,                       null: false
-    t.text     "description",                   limit: 65535
+    t.string   "type",                                     limit: 50,                       null: false
+    t.integer  "facility_id",                                                               null: false
+    t.string   "name",                                     limit: 200,                      null: false
+    t.string   "url_name",                                 limit: 50,                       null: false
+    t.text     "description",                              limit: 65535
     t.integer  "schedule_id"
-    t.boolean  "requires_approval",                           default: false,    null: false
-    t.boolean  "allows_training_requests",                    default: true,     null: false
+    t.boolean  "requires_approval",                                      default: false,    null: false
+    t.boolean  "allows_training_requests",                               default: true,     null: false
     t.integer  "initial_order_status_id"
-    t.boolean  "is_archived",                                 default: false,    null: false
-    t.boolean  "is_hidden",                                   default: false,    null: false
-    t.datetime "created_at",                                                     null: false
-    t.datetime "updated_at",                                                     null: false
+    t.boolean  "is_archived",                                            default: false,    null: false
+    t.boolean  "is_hidden",                                              default: false,    null: false
+    t.datetime "created_at",                                                                null: false
+    t.datetime "updated_at",                                                                null: false
     t.integer  "min_reserve_mins"
     t.integer  "max_reserve_mins"
     t.integer  "min_cancel_hours"
     t.integer  "facility_account_id"
-    t.string   "account",                       limit: 5
-    t.boolean  "show_details",                                default: false,    null: false
+    t.string   "account",                                  limit: 5
+    t.boolean  "show_details",                                           default: false,    null: false
     t.integer  "auto_cancel_mins"
     t.string   "contact_email"
     t.integer  "reserve_interval"
-    t.integer  "lock_window",                                 default: 0,        null: false
-    t.text     "training_request_contacts",     limit: 65535
-    t.integer  "cutoff_hours",                                default: 0,        null: false
+    t.integer  "lock_window",                                            default: 0,        null: false
+    t.text     "training_request_contacts",                limit: 65535
+    t.integer  "cutoff_hours",                                           default: 0,        null: false
     t.string   "dashboard_token"
-    t.string   "user_notes_field_mode",                       default: "hidden", null: false
+    t.string   "user_notes_field_mode",                                  default: "hidden", null: false
     t.string   "user_notes_label"
     t.string   "order_notification_recipient"
-    t.text     "cancellation_email_recipients", limit: 65535
-    t.text     "issue_report_recipients",       limit: 65535
+    t.text     "cancellation_email_recipients",            limit: 65535
+    t.text     "issue_report_recipients",                  limit: 65535
+    t.boolean  "email_purchasers_on_order_status_changes",               default: false,    null: false
     t.index ["dashboard_token"], name: "index_products_on_dashboard_token", using: :btree
     t.index ["facility_account_id"], name: "fk_facility_accounts", using: :btree
     t.index ["facility_id"], name: "fk_rails_0c9fa1afbe", using: :btree
@@ -821,6 +822,8 @@ ActiveRecord::Schema.define(version: 20190610112539) do
 
   add_foreign_key "account_facility_joins", "accounts"
   add_foreign_key "account_facility_joins", "facilities"
+  add_foreign_key "account_users", "accounts", name: "fk_accounts"
+  add_foreign_key "account_users", "users"
   add_foreign_key "accounts", "facilities", name: "fk_account_facility_id"
   add_foreign_key "bulk_email_jobs", "facilities"
   add_foreign_key "bulk_email_jobs", "users"

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -346,51 +346,6 @@ RSpec.describe FacilityJournalsController do
         expect(response.code).to eq("404")
       end
     end
-
-    # SLOW
-    # context "with over 1000 order details" do
-    #   let(:facility_account) do
-    #     FactoryBot.create(:facility_account, facility: facility)
-    #   end
-
-    #   let(:item) do
-    #     facility
-    #       .items
-    #       .create(attributes_for(:item, facility_account_id: facility_account.id))
-    #   end
-
-    #   let(:order_details) do
-    #     Array.new(1001) do
-    #       place_product_order(admin_user, facility, item, account)
-    #     end
-    #   end
-
-    #   before :each do
-    #     @params[:order_detail_ids] = order_details.map(&:id)
-    #     @order.state = "validated"
-    #     @order.purchase!
-    #     complete_status = OrderStatus.complete
-
-    #     order_details.each do |order_detail|
-    #       order_detail.update_attributes(
-    #         actual_cost: 20,
-    #         actual_subsidy: 10,
-    #         fulfilled_at: 2.days.ago,
-    #         order_status_id: complete_status.id,
-    #         price_policy_id: @item_pp.id,
-    #         reviewed_at: 1.day.ago,
-    #         state: complete_status.state_name,
-    #       )
-    #     end
-
-    #     sign_in admin_user
-    #     do_request
-    #   end
-
-    #   it "successfully creates a journal" do
-    #     expect(response).to redirect_to facility_journals_path(facility)
-    #   end
-    # end
   end
 
   describe "#show" do


### PR DESCRIPTION
# Release Notes

Allow emailing purchasers on order status changes

# Additional Context

The copy of the email is likely to change (pending feedback from NU), for which I will issue a separate pull request (and parametrize it into settings per our usual pattern).