### PR TITLE
[#150534] Fix reference to LogEventSearcher, it is not in LogEvent

### DIFF
--- a/app/views/log_events/index.html.haml
+++ b/app/views/log_events/index.html.haml
@@ -20,7 +20,7 @@
   .row
     .span3
       = label_tag(text(:event_filter))
-      - option_list = LogEvent::LogEventSearcher::ALLOWED_EVENTS.map { |event| [text(event), event] }
+      - option_list = LogEventSearcher::ALLOWED_EVENTS.map { |event| [text(event), event] }
       = select_tag(:events,
         options_for_select(option_list, params[:events]),
         multiple: true,


### PR DESCRIPTION
# Release Notes

Fix reference to LogEventSearcher, it is not in LogEvent
