### PR TITLE
[#146050] Send order status emails from OrderDetailBatchUpdater also

### DIFF
--- a/app/services/order_detail_batch_updater.rb
+++ b/app/services/order_detail_batch_updater.rb
@@ -150,6 +150,7 @@ class OrderDetailBatchUpdater
       else
         order_detail.change_status!(order_status)
       end
+      order_detail.notify_purchaser_of_order_status
     end
   rescue => e
     msg_hash[:error] =


### PR DESCRIPTION
# Release Notes

Send order status emails from OrderDetailBatchUpdater also

# Additional Context

A follow-up to #2044, this PR makes mass updates made from the Orders tab also trigger the “order status changed” emails, that we are currently only sending when the status is changed for an individual order from its lightbox.