### PR TITLE
[#143406] facility senior staff can see problem queues

### DIFF
--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -250,6 +250,8 @@ class Ability
         OfflineReservation,
       ]
 
+      can :show_problems, [Reservation, Order]
+
       # they can get to reports controller, but they're not allowed to export all
       # ideally we don't use `cannot` as it adds a dependency on the order of assigning abilities for multiple roles
       can :manage, Reports::ReportsController

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe FacilityOrdersController do
       @action = :show_problems
     end
 
-    it_should_allow_managers_only
+    it_should_allow_managers_and_senior_staff_only
   end
 
   context "#send_receipt" do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -393,7 +393,6 @@ RSpec.describe Ability do
   shared_examples_for "it has common staff abilities" do
     it { is_expected.not_to be_allowed_to(:disputed, Order) }
     it { is_expected.not_to be_allowed_to(:manage, Account) }
-    it { is_expected.not_to be_allowed_to(:show_problems, Reservation) }
     it { is_expected.to be_allowed_to(:batch_update, Order) }
     it_is_allowed_to([:batch_update, :cancel, :index], Reservation)
     it { is_expected.to be_allowed_to(:read, Notification) }
@@ -427,6 +426,8 @@ RSpec.describe Ability do
     let(:user) { create(:user, :senior_staff, facility: facility) }
 
     it_behaves_like "it has common staff abilities"
+    it { is_expected.to be_allowed_to(:show_problems, Reservation) }
+    it { is_expected.to be_allowed_to(:show_problems, Order) }
     it_is_allowed_to([:bring_online, :create, :edit, :new, :update], OfflineReservation)
     it { is_expected.to be_allowed_to(:manage, TrainingRequest) }
     it { is_expected.to be_allowed_to(:manage, ScheduleRule) }
@@ -438,6 +439,7 @@ RSpec.describe Ability do
     let(:user) { create(:user, :staff, facility: facility) }
 
     it_behaves_like "it has common staff abilities"
+    it { is_expected.not_to be_allowed_to(:show_problems, Reservation) }
     it_is_not_allowed_to([:bring_online, :create, :edit, :new, :update], OfflineReservation)
     it { is_expected.to be_allowed_to(:create, TrainingRequest) }
     it_behaves_like "it can not manage training requests"

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/ability_extension.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/ability_extension.rb
@@ -11,8 +11,6 @@ module SecureRooms
     end
 
     def extend(user, resource)
-      ability.can :manage, CardReader if user.manager_of?(resource) || user.facility_senior_staff_of?(resource)
-
       if user.operator_of?(resource)
         ability.can [
           :index,
@@ -23,9 +21,13 @@ module SecureRooms
 
       if user.manager_of?(resource)
         ability.can [
-          :show_problems,
           :assign_price_policies_to_problem_orders,
         ], Occupancy
+      end
+
+      if user.manager_of?(resource) || user.facility_senior_staff_of?(resource)
+        ability.can :manage, CardReader
+        ability.can :show_problems, Occupancy
       end
     end
 

--- a/vendor/engines/secure_rooms/spec/models/ability_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/ability_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Ability do
     let(:user) { FactoryBot.create(:user, :senior_staff, facility: facility) }
 
     it_is_allowed_to([:index, :dashboard, :tab_counts], SecureRooms::Occupancy)
-    it_is_not_allowed_to([:show_problems, :assign_price_policies_to_problem_orders], SecureRooms::Occupancy)
+    it_is_not_allowed_to(:assign_price_policies_to_problem_orders, SecureRooms::Occupancy)
+    it_is_allowed_to(:show_problems, SecureRooms::Occupancy)
   end
 
   describe "facility billing administrator" do


### PR DESCRIPTION
# Release Notes

Facility senior staff have the ability to see problem queues for Orders, Reservations, and Occupancies.
