### PR TITLE
[#149698] Add inverse_of to sanger submission/sample relationship

### DIFF
--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/sample.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/sample.rb
@@ -5,7 +5,7 @@ module SangerSequencing
   class Sample < ApplicationRecord
 
     self.table_name = "sanger_sequencing_samples"
-    belongs_to :submission
+    belongs_to :submission, inverse_of: :samples
 
     validates :customer_sample_id, presence: true
 

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
@@ -13,7 +13,7 @@ module SangerSequencing
     has_one :order, through: :order_detail
     has_one :user, through: :order
     has_one :facility, through: :order
-    has_many :samples
+    has_many :samples, inverse_of: :submission
 
     accepts_nested_attributes_for :samples, allow_destroy: true
 


### PR DESCRIPTION
# Release Notes

Tech Task: Add `inverse_of` to SangerSequencing Submission/Sample relationship. This ensures that some validations we add in NU will run properly.

# Additional Context

I thought that this was something that Rails was supposed to have taken care of automatically, but in this case it did not, so we need to explicitly add it.

Extracted from https://github.com/tablexi/nucore-nu/pull/518