### PR TITLE
[#149187] Statement filtering feedback

### DIFF
--- a/app/controllers/facility_statements_controller.rb
+++ b/app/controllers/facility_statements_controller.rb
@@ -22,7 +22,9 @@ class FacilityStatementsController < ApplicationController
 
   # GET /facilities/:facility_id/statements
   def index
-    @search_form = StatementSearchForm.new(permitted_search_params.merge(current_facility: current_facility))
+    search_params = permitted_search_params.merge(current_facility: current_facility)
+
+    @search_form = StatementSearchForm.new(search_params)
     @statements = @search_form.search.order(created_at: :desc)
 
     respond_to do |format|

--- a/app/views/facility_statements/index.html.haml
+++ b/app/views/facility_statements/index.html.haml
@@ -1,10 +1,9 @@
 = content_for :h1 do
   = current_facility
-
+- content_for :h2 do
+  = text("head")
 = content_for :sidebar do
   = render "admin/shared/sidenav_billing", sidenav_tab: "statement_history"
-
-%h2= text("head")
 
 = simple_form_for @search_form, url: url_for, method: :get, html: { class: "search_form" }, defaults: { required: false } do |f|
   .row
@@ -14,9 +13,9 @@
       = f.input :accounts, collection: @search_form.available_accounts, as: :transaction_chosen, input_html: { class: "js--chosen" }, label_method: :account_list_item
       = f.input :sent_to, collection: @search_form.available_sent_to, as: :transaction_chosen, input_html: { class: "js--chosen" }, label: Statement.human_attribute_name(:sent_to)
     %fieldset.span2
+      = f.input :status, collection: @search_form.available_statuses
       = f.input :date_range_start, input_html: { class: "datepicker__data" }
       = f.input :date_range_end, input_html: { class: "datepicker__data" }
-      = f.input :status, collection: @search_form.available_statuses
 
     .submit_button.span12
       = hidden_field_tag :email, current_user.email, disabled: true

--- a/config/locales/forms/en.statement_search_form.yml
+++ b/config/locales/forms/en.statement_search_form.yml
@@ -2,5 +2,5 @@ en:
   activemodel:
     attributes:
       statement_search_form:
-        date_range_start: Created At Start
-        date_range_end: Created At End
+        date_range_start: Start Date
+        date_range_end: End Date

--- a/spec/features/admin/facility_statements_spec.rb
+++ b/spec/features/admin/facility_statements_spec.rb
@@ -77,14 +77,14 @@ RSpec.describe "Facility Statement Admin" do
     end
 
     it "can filter by dates" do
-      fill_in "Created At Start", with: I18n.l(4.days.ago.to_date, format: :usa)
+      fill_in "Start Date", with: I18n.l(4.days.ago.to_date, format: :usa)
       click_button "Filter"
 
       expect(page).to have_content(statement1.invoice_number)
       expect(page).not_to have_content(statement2.invoice_number)
 
-      fill_in "Created At Start", with: ""
-      fill_in "Created At End", with: I18n.l(4.days.ago.to_date, format: :usa)
+      fill_in "Start Date", with: ""
+      fill_in "End Date", with: I18n.l(4.days.ago.to_date, format: :usa)
 
       click_button "Filter"
       expect(page).not_to have_content(statement1.invoice_number)

--- a/spec/features/admin/facility_statements_spec.rb
+++ b/spec/features/admin/facility_statements_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe "Facility Statement Admin" do
       select accounts.first.account_list_item, from: "Payment Sources"
       click_button "Filter"
 
-      expect(page).to have_link(order_details.first.id, href: manage_facility_order_order_detail_path(facility, orders.first, order_details.first))
-      expect(page).not_to have_link(order_details.second.id, href: manage_facility_order_order_detail_path(facility, orders.second, order_details.second))
+      expect(page).to have_link(order_details.first.id.to_s, href: manage_facility_order_order_detail_path(facility, orders.first, order_details.first))
+      expect(page).not_to have_link(order_details.second.id.to_s, href: manage_facility_order_order_detail_path(facility, orders.second, order_details.second))
     end
   end
 

--- a/spec/features/admin/facility_statements_spec.rb
+++ b/spec/features/admin/facility_statements_spec.rb
@@ -90,5 +90,9 @@ RSpec.describe "Facility Statement Admin" do
       expect(page).not_to have_content(statement1.invoice_number)
       expect(page).to have_content(statement2.invoice_number)
     end
+
+    it "sends a csv in an email" do
+      expect { click_link "Export as CSV" }.to change(ActionMailer::Base.deliveries, :count)
+    end
   end
 end


### PR DESCRIPTION
# Release Notes

Fix statement searching CSV export and adjust the form layout to be more consistent with transaction search.

# Additional Context

Based on client feedback to #2067 

> * Move the "Statement History" header to the space above left-hand navigation box
> * Move the "Status" drop down to the top right corner of the filtering selection area (to the right of the "Payment Sources" selection box)
> * Relabel the Date Range fields to "Start Date" and "End Date" to be consistent with other date filters

Rollbar error of the CSV export: https://rollbar.com/TableXI/nucore-nu/items/471/

```
NameError: undefined local variable or method `search_params' for #<FacilityStatementsController:0x000000000d0d2c00> (Most recent call first)
File /home/nucore/nucore-staging.northwestern.edu/releases/20190909125311/app/controllers/facility_statements_controller.rb line 32 in block (3 levels) in index
```