### PR TITLE
[#149187] Eliminate constant in Statement which assumed that the order_details table exists

### DIFF
--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -27,9 +27,8 @@ class Statement < ApplicationRecord
     end
   }
 
-  RECONCILED_SQL = OrderDetail.unreconciled.where("order_details.statement_id = statements.id").select(1).to_sql
-  scope :unreconciled, -> { joins(:order_details).where("EXISTS (#{RECONCILED_SQL})").distinct }
-  scope :reconciled, -> { joins(:order_details).where("NOT EXISTS (#{RECONCILED_SQL})").distinct }
+  scope :reconciled, -> { where.not(id: OrderDetail.unreconciled.where.not(statement_id: nil).select(:statement_id)) }
+  scope :unreconciled, -> { where(id: OrderDetail.unreconciled.where.not(statement_id: nil).select(:statement_id)) }
 
   # Use this for restricting the the current facility
   scope :for_facility, ->(facility) { where(facility: facility) if facility.single_facility? }


### PR DESCRIPTION
# Release Notes

Eliminate constant in Statement which assumed that the order_details table exists

# Additional Context

#2067 introduced the constant `Statement:: RECONCILED_SQL`, which gets set by generating SQL based on a query via the `OrderDetail` model. This checks the `order_details` table, which may not yet exist at Rails loading time (such as when running automated tests, which execute `rake db:schema:load`, and this loads the environment), and so it results in failures like https://circleci.com/gh/tablexi/nucore-nu/2355.