### PR TITLE
Update CODEOWNERS so all three are used

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-* @vandrijevik
-* @rolfrussell
-* @jhanggi
+* @vandrijevik @rolfrussell @jhanggi


### PR DESCRIPTION
# Release Notes

Update CODEOWNERS so all three are used

# Additional Context

After #2069, only the last match (in this case, @jhanggi) is used, and so PRs like https://github.com/tablexi/nucore-open/pull/2074 don’t get the other users as reviewers automatically.