### PR TITLE
[#149187] Remove unnecessary calls to distinct when we’re just checking for inclusion

### DIFF
--- a/app/forms/statement_search_form.rb
+++ b/app/forms/statement_search_form.rb
@@ -8,8 +8,7 @@ class StatementSearchForm
   attr_accessor :accounts, :current_facility, :facilities, :sent_to, :status, :date_range_start, :date_range_end
 
   def available_accounts
-    # Oracle throws an error if there is an ORDER in a subquery and Statements have a default scope/order
-    Account.where(id: all_statements.unscope(:order).select(:account_id)).order(:account_number, :description)
+    Account.where(id: all_statements.select(:account_id)).order(:account_number, :description)
   end
 
   def available_sent_to
@@ -52,7 +51,8 @@ class StatementSearchForm
   end
 
   def all_statements
-    Statement.for_facility(current_facility)
+    # Oracle throws an error if there is an ORDER in a subquery and Statements have a default scope/order
+    Statement.for_facility(current_facility).unscope(:order)
   end
 
 end


### PR DESCRIPTION
# Release Notes

Remove unnecessary calls to distinct when we’re just checking for inclusion

# Additional Context

`SELECT DISTINCT` is a lot more work for the database and it performs worse than just a regular `SELECT`, which is just fine when all we’re using the subquery for is `WHERE id IN ()`.