### PR TITLE
Update readme about known issue of running db:setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,12 @@ Welcome to NUcore! This guide will help you get a development environment up and
 5. Set up databases
 
     ```
-    rake db:setup
+    rake db:create
+    rake db:schema:load
+    rake db:seed
     ```
+
+_Known issue: if you run `db:setup` or all three in one rake command, the next time you run `db:migrate`, you will receive a `Table 'splits' already exists` error. Use the separate commands instead._
 
 6. Seed your development database
 


### PR DESCRIPTION
# Release Notes

Update readme about an issue if you run `rake db:setup` when setting up your local dev environment. I don't really know why this is the case--I think it has something to do with the engine loading. But it does work if you run the `db:create` and `db:schema:load` as separate commands.

