### PR TITLE
[#148527] Add support for Form.IO order forms

### DIFF
--- a/app/controllers/formio/submissions_controller.rb
+++ b/app/controllers/formio/submissions_controller.rb
@@ -46,7 +46,7 @@ module Formio
         orderedForEmail: order_detail.user.email,
         orderedForName: order_detail.user.full_name,
         orderedForUsernname: order_detail.user.username,
-        paymentSourceAccountNumber: order_detail.account.account_number
+        paymentSourceAccountNumber: order_detail.account.account_number,
       }.merge(extra_prefill_data)
     end
 

--- a/app/controllers/formio/submissions_controller.rb
+++ b/app/controllers/formio/submissions_controller.rb
@@ -8,6 +8,7 @@ module Formio
 
     def new
       @formio_url = params[:formio_url]
+      @prefill_data = prefill_data
       @redirect_url = redirect_url
     end
 
@@ -33,6 +34,18 @@ module Formio
         success_url_params = Rack::Utils.parse_query(success_url.query)
         success_url.query = success_url_params.merge(referer: referer_url.to_s).to_query
       end.to_s
+    end
+
+    def prefill_data
+      order_detail = OrderDetail.find(params[:receiver_id])
+      {
+        accountOwnerEmail: order_detail.account.owner_user.email,
+        accountOwnerName: order_detail.account.owner_user.full_name,
+        nucoreOrderNumber: order_detail.order_number,
+        orderedAtDate: order_detail.created_at.to_date.to_s,
+        orderedForEmail: order_detail.user.email,
+        orderedForName: order_detail.user.email,
+      }
     end
 
   end

--- a/app/controllers/formio/submissions_controller.rb
+++ b/app/controllers/formio/submissions_controller.rb
@@ -35,8 +35,11 @@ module Formio
       end.to_s
     end
 
+    def order_detail
+      @order_detail ||= OrderDetail.find(params[:receiver_id])
+    end
+
     def prefill_data
-      order_detail = OrderDetail.find(params[:receiver_id])
       {
         accountOwnerEmail: order_detail.account.owner_user.email,
         accountOwnerName: order_detail.account.owner_user.full_name,

--- a/app/controllers/formio/submissions_controller.rb
+++ b/app/controllers/formio/submissions_controller.rb
@@ -44,7 +44,7 @@ module Formio
         nucoreOrderNumber: order_detail.order_number,
         orderedAtDate: order_detail.created_at.to_date.to_s,
         orderedForEmail: order_detail.user.email,
-        orderedForName: order_detail.user.email,
+        orderedForName: order_detail.user.full_name,
       }
     end
 

--- a/app/controllers/formio/submissions_controller.rb
+++ b/app/controllers/formio/submissions_controller.rb
@@ -47,7 +47,13 @@ module Formio
         orderedForName: order_detail.user.full_name,
         orderedForUsernname: order_detail.user.username,
         paymentSourceAccountNumber: order_detail.account.account_number
-      }
+      }.merge(extra_prefill_data)
+    end
+
+    # Hook for university-specific forks to override this method and provide extra
+    # data that doesn’t come from nucore-open
+    def extra_prefill_data
+      {}
     end
 
   end

--- a/app/controllers/formio/submissions_controller.rb
+++ b/app/controllers/formio/submissions_controller.rb
@@ -1,0 +1,40 @@
+module Formio
+  class SubmissionsController < ApplicationController
+
+    before_action :authenticate_user!
+    before_action :check_acting_as
+
+    def new
+      @formio_url = params[:formio_url]
+      @redirect_url = redirect_url
+      render layout: false
+    end
+
+    def show
+      @formio_url = params[:formio_url]
+      render layout: false
+    end
+
+    def edit
+      @formio_url = params[:formio_url]
+      @redirect_url = redirect_url
+      render layout: false
+    end
+
+    private
+
+    # NUcore’s SurveysController expects a referer param, which contains the page
+    # to which NUcore should redirect after it processes a form submission. However,
+    # the success_url that we get from UrlService does not include this param. Instead,
+    # we get it as a separate pram, so we construct the full redirect_url here to
+    # avoid changing having to change code for unrelated integrations
+    def redirect_url
+      referer_url = URI(params[:referer])
+      URI(params[:success_url]).tap do |success_url|
+        success_url_params = Rack::Utils.parse_query(success_url.query)
+        success_url.query = success_url_params.merge(referer: referer_url.to_s).to_query
+      end.to_s
+    end
+
+  end
+end

--- a/app/controllers/formio/submissions_controller.rb
+++ b/app/controllers/formio/submissions_controller.rb
@@ -4,21 +4,20 @@ module Formio
     before_action :authenticate_user!
     before_action :check_acting_as
 
+    layout "formio"
+
     def new
       @formio_url = params[:formio_url]
       @redirect_url = redirect_url
-      render layout: false
     end
 
     def show
       @formio_url = params[:formio_url]
-      render layout: false
     end
 
     def edit
       @formio_url = params[:formio_url]
       @redirect_url = redirect_url
-      render layout: false
     end
 
     private

--- a/app/controllers/formio/submissions_controller.rb
+++ b/app/controllers/formio/submissions_controller.rb
@@ -40,10 +40,13 @@ module Formio
       {
         accountOwnerEmail: order_detail.account.owner_user.email,
         accountOwnerName: order_detail.account.owner_user.full_name,
+        accountOwnerUsername: order_detail.account.owner_user.username,
         nucoreOrderNumber: order_detail.order_number,
         orderedAtDate: order_detail.created_at.to_date.to_s,
         orderedForEmail: order_detail.user.email,
         orderedForName: order_detail.user.full_name,
+        orderedForUsernname: order_detail.user.username,
+        paymentSourceAccountNumber: order_detail.account.account_number
       }
     end
 

--- a/app/controllers/formio/submissions_controller.rb
+++ b/app/controllers/formio/submissions_controller.rb
@@ -2,7 +2,6 @@ module Formio
   class SubmissionsController < ApplicationController
 
     before_action :authenticate_user!
-    before_action :check_acting_as
 
     layout "formio"
 

--- a/app/models/external_service/external_service_receiver.rb
+++ b/app/models/external_service/external_service_receiver.rb
@@ -8,14 +8,28 @@ class ExternalServiceReceiver < ApplicationRecord
   validates_presence_of :external_service_id, :receiver_id, :response_data
 
   def show_url
-    parsed_response_data[:show_url]
+    url = parsed_response_data[:show_url]
+    if formio_submission?(url)
+      Rails.application.routes.url_helpers.formio_submission_path(formio_url: url)
+    else
+      url
+    end
   end
 
   def edit_url
-    parsed_response_data[:edit_url]
+    url = parsed_response_data[:edit_url]
+    if formio_submission?(url)
+      Rails.application.routes.url_helpers.edit_formio_submission_path(formio_url: url)
+    else
+      url
+    end
   end
 
   private
+
+  def formio_submission?(url)
+    URI(url).host.try(:include?, "form.io")
+  end
 
   def parsed_response_data
     JSON.parse(response_data).symbolize_keys

--- a/app/models/external_service/external_service_receiver.rb
+++ b/app/models/external_service/external_service_receiver.rb
@@ -28,7 +28,7 @@ class ExternalServiceReceiver < ApplicationRecord
   private
 
   def formio_submission?(url)
-    URI(url).host.try(:include?, "form.io")
+    URI(url).host.try(:ends_with?, "form.io")
   end
 
   def parsed_response_data

--- a/app/models/external_service/url_service.rb
+++ b/app/models/external_service/url_service.rb
@@ -14,7 +14,11 @@ class UrlService < ExternalService
   #   relationship. Useful for providing pass-thru HTTP param data
   #   to the external service.
   def new_url(receiver, request = nil)
-    merge_queries(location, additional_query_params(receiver, request))
+    if formio_form?
+      new_formio_submission_path({ formio_url: location }.merge(additional_query_params(receiver, request)))
+    else
+      merge_queries(location, additional_query_params(receiver, request))
+    end
   end
 
   def edit_url(receiver, request = nil)
@@ -22,6 +26,10 @@ class UrlService < ExternalService
   end
 
   private
+
+  def formio_form?
+    URI(location).host.ends_with?("form.io")
+  end
 
   def merge_queries(url, additional_hash)
     uri = URI(url.to_s.strip)

--- a/app/models/external_service/url_service.rb
+++ b/app/models/external_service/url_service.rb
@@ -28,7 +28,7 @@ class UrlService < ExternalService
   private
 
   def formio_form?
-    URI(location).host.ends_with?("form.io")
+    URI(location).host.try(:ends_with?, "form.io")
   end
 
   def merge_queries(url, additional_hash)

--- a/app/views/formio/submissions/edit.html.haml
+++ b/app/views/formio/submissions/edit.html.haml
@@ -4,7 +4,7 @@
       .createForm(document.getElementById('formio'), '#{@formio_url}')
       .then(function(form) {
         form.on('submitDone', function(submission) {
-          var surveyUrl = '#{@formio_url}';
+          var surveyUrl = encodeURIComponent('#{@formio_url}');
           window.location = '#{raw @redirect_url}&survey_url=' + surveyUrl + '&survey_edit_url=' + surveyUrl;
         });
       });

--- a/app/views/formio/submissions/edit.html.haml
+++ b/app/views/formio/submissions/edit.html.haml
@@ -1,15 +1,3 @@
-:plain
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://unpkg.com/formiojs@latest/dist/formio.full.min.css">
-  <style>
-    #formio {
-      margin: 2em auto;
-      max-width: 960px;
-    }
-  </style>
-  <script src="https://unpkg.com/formiojs@latest/dist/formio.full.min.js"></script>
-  <div id="formio"></div>
-
 :javascript
   window.onload = function() {
     Formio

--- a/app/views/formio/submissions/edit.html.haml
+++ b/app/views/formio/submissions/edit.html.haml
@@ -1,0 +1,23 @@
+:plain
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/formiojs@latest/dist/formio.full.min.css">
+  <style>
+    #formio {
+      margin: 2em auto;
+      max-width: 960px;
+    }
+  </style>
+  <script src="https://unpkg.com/formiojs@latest/dist/formio.full.min.js"></script>
+  <div id="formio"></div>
+
+:javascript
+  window.onload = function() {
+    Formio
+      .createForm(document.getElementById('formio'), '#{@formio_url}')
+      .then(function(form) {
+        form.on('submitDone', function(submission) {
+          var surveyUrl = '#{@formio_url}';
+          window.location = '#{raw @redirect_url}&survey_url=' + surveyUrl + '&survey_edit_url=' + surveyUrl;
+        });
+      });
+  };

--- a/app/views/formio/submissions/new.html.haml
+++ b/app/views/formio/submissions/new.html.haml
@@ -1,0 +1,23 @@
+:plain
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/formiojs@latest/dist/formio.full.min.css">
+  <style>
+    #formio {
+      margin: 2em auto;
+      max-width: 960px;
+    }
+  </style>
+  <script src="https://unpkg.com/formiojs@latest/dist/formio.full.min.js"></script>
+  <div id="formio"></div>
+
+:javascript
+  window.onload = function() {
+    Formio
+      .createForm(document.getElementById('formio'), '#{@formio_url}')
+      .then(function(form) {
+        form.on('submitDone', function(submission) {
+          var surveyUrl = encodeURIComponent('#{@formio_url}/submission/' + submission._id);
+          window.location = '#{raw @redirect_url}&survey_url=' + surveyUrl + '&survey_edit_url=' + surveyUrl;
+        });
+      });
+  };

--- a/app/views/formio/submissions/new.html.haml
+++ b/app/views/formio/submissions/new.html.haml
@@ -1,15 +1,3 @@
-:plain
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://unpkg.com/formiojs@latest/dist/formio.full.min.css">
-  <style>
-    #formio {
-      margin: 2em auto;
-      max-width: 960px;
-    }
-  </style>
-  <script src="https://unpkg.com/formiojs@latest/dist/formio.full.min.js"></script>
-  <div id="formio"></div>
-
 :javascript
   window.onload = function() {
     Formio

--- a/app/views/formio/submissions/new.html.haml
+++ b/app/views/formio/submissions/new.html.haml
@@ -3,6 +3,8 @@
     Formio
       .createForm(document.getElementById('formio'), '#{@formio_url}')
       .then(function(form) {
+        form.submission = { data: #{raw @prefill_data.to_json} };
+
         form.on('submitDone', function(submission) {
           var surveyUrl = encodeURIComponent('#{@formio_url}/submission/' + submission._id);
           window.location = '#{raw @redirect_url}&survey_url=' + surveyUrl + '&survey_edit_url=' + surveyUrl;

--- a/app/views/formio/submissions/show.html.haml
+++ b/app/views/formio/submissions/show.html.haml
@@ -1,19 +1,6 @@
-:plain
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://unpkg.com/formiojs@latest/dist/formio.full.min.css">
-  <style>
-    #formio {
-      margin: 2em auto;
-      max-width: 960px;
-    }
-  </style>
-  <script src="https://unpkg.com/formiojs@latest/dist/formio.full.min.js"></script>
-  <div id="formio"></div>
-
 :javascript
   window.onload = function() {
     Formio.createForm(document.getElementById('formio'), '#{@formio_url}', {
       readOnly: true,
-      viewAsHtml: true
     });
   };

--- a/app/views/formio/submissions/show.html.haml
+++ b/app/views/formio/submissions/show.html.haml
@@ -1,0 +1,19 @@
+:plain
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/formiojs@latest/dist/formio.full.min.css">
+  <style>
+    #formio {
+      margin: 2em auto;
+      max-width: 960px;
+    }
+  </style>
+  <script src="https://unpkg.com/formiojs@latest/dist/formio.full.min.js"></script>
+  <div id="formio"></div>
+
+:javascript
+  window.onload = function() {
+    Formio.createForm(document.getElementById('formio'), '#{@formio_url}', {
+      readOnly: true,
+      viewAsHtml: true
+    });
+  };

--- a/app/views/layouts/formio.html.haml
+++ b/app/views/layouts/formio.html.haml
@@ -13,5 +13,6 @@
       </style>
       <script src="https://unpkg.com/formiojs@latest/dist/formio.full.min.js"></script>
   %body
-    #formio
+    / Prevent dragged files from being opened, so that Form.IO’s file component can accept drag & drop
+    #formio{ "ondragover" => "event.preventDefault();" }
     = yield

--- a/app/views/layouts/formio.html.haml
+++ b/app/views/layouts/formio.html.haml
@@ -4,14 +4,14 @@
     %meta{ "http-equiv" => "content-type", "content" => "text/html; charset=UTF-8" }
     :plain
       <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-      <link rel="stylesheet" href="https://unpkg.com/formiojs@latest/dist/formio.full.min.css">
+      <link rel="stylesheet" href="https://unpkg.com/formiojs@3.28.0/dist/formio.full.min.css">
       <style>
         #formio {
           margin: 2em auto;
           max-width: 960px;
         }
       </style>
-      <script src="https://unpkg.com/formiojs@latest/dist/formio.full.min.js"></script>
+      <script src="https://unpkg.com/formiojs@3.28.0/dist/formio.full.min.js"></script>
   %body
     / Prevent dragged files from being opened, so that Form.IO’s file component can accept drag & drop
     #formio{ "ondragover" => "event.preventDefault();" }

--- a/app/views/layouts/formio.html.haml
+++ b/app/views/layouts/formio.html.haml
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+%html
+  %head
+    %meta{ "http-equiv" => "content-type", "content" => "text/html; charset=UTF-8" }
+    :plain
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+      <link rel="stylesheet" href="https://unpkg.com/formiojs@latest/dist/formio.full.min.css">
+      <style>
+        #formio {
+          margin: 2em auto;
+          max-width: 960px;
+        }
+      </style>
+      <script src="https://unpkg.com/formiojs@latest/dist/formio.full.min.js"></script>
+  %body
+    #formio
+    = yield

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -385,4 +385,8 @@ Nucore::Application.routes.draw do
   namespace :api do
     resources :order_details, only: [:show, :index]
   end
+
+  namespace :formio do
+    resource :submission, only: [:new, :show, :edit]
+  end
 end

--- a/spec/models/external_service/url_service_spec.rb
+++ b/spec/models/external_service/url_service_spec.rb
@@ -73,6 +73,18 @@ RSpec.describe UrlService do
         )
       end
     end
+
+    context "for a Form.IO form" do
+      before { url_service.location = "https://nucore-development-12ea0e74.form.io/labitsupport" }
+
+      it "returns a URL for a new formio submission" do
+        expect(uri.to_s).to start_with("/formio/submission/new")
+      end
+
+      it "includes the location as a formio_url parameter" do
+        expect(query_hash).to include("formio_url" => url_service.location)
+      end
+    end
   end
 
   describe "edit_url" do


### PR DESCRIPTION
# Release Notes

Add support for Form.IO order forms

# Additional Context

Form.IO’s forms have a prominently featured “Embed URL”. For each form, I wanted this to be the URL that the users can copy and enter into NUcore. However, the integration is done via JavaScript (instead of us redirecting to a different domain and then back to NUcore), and we’re serving up a NUcore page with JS that embeds the Form.IO form.

In order to make this all work, I’ve extended the existing classes to check whether the order form’s URL is a Form.IO one, and we do some special behavior. This is a short-term solution, because NU will be looking to replace Qualtrics and Surveyor forms with Form.IO-backed ones, at which point we can clean up all of this code and simplify it.

I’m still working on tests for the new controller, but I wanted to get this PR out because all of the behavior has been tested and accepted on staging from this branch, so this is ready for production.