### PR TITLE
[#148527] Gracefully handle space characters in the location of UrlService

### DIFF
--- a/app/models/external_service/url_service.rb
+++ b/app/models/external_service/url_service.rb
@@ -14,8 +14,9 @@ class UrlService < ExternalService
   #   relationship. Useful for providing pass-thru HTTP param data
   #   to the external service.
   def new_url(receiver, request = nil)
-    if formio_form?
-      new_formio_submission_path({ formio_url: location }.merge(additional_query_params(receiver, request)))
+    sanitized_location = location.strip
+    if formio_form?(sanitized_location)
+      new_formio_submission_path({ formio_url: sanitized_location }.merge(additional_query_params(receiver, request)))
     else
       merge_queries(location, additional_query_params(receiver, request))
     end
@@ -27,8 +28,8 @@ class UrlService < ExternalService
 
   private
 
-  def formio_form?
-    URI(location).host.try(:ends_with?, "form.io")
+  def formio_form?(url_string)
+    URI(url_string).host.try(:ends_with?, "form.io")
   end
 
   def merge_queries(url, additional_hash)

--- a/spec/models/external_service/url_service_spec.rb
+++ b/spec/models/external_service/url_service_spec.rb
@@ -126,4 +126,16 @@ RSpec.describe UrlService do
       end
     end
   end
+
+  describe "#new_url" do
+    context "when the location contains invalid space characters" do
+      before do
+        url_service.location = " \thttps://nucore-staging.northwestern.edu/acgt/submissions/new"
+      end
+
+      it "does not raise an error" do
+        expect(url_service.new_url(order_detail)).to be_a(String)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Release Notes

Gracefully handle space characters in the location of UrlService

# Additional Context

Some URLs for Order Forms contain ` \t` characters at the beginning of their URLs, and #2089 caused the check on `location` to blow up when being parsed with URI (see errors at https://rollbar.com/TableXI/nucore-nu/items/489/). This PR fixes that by stripping out the characters, and adding a test to ensure that these URLs are handled gracefully.