### PR TITLE
Add delayed_job to docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ To do this:
 
 If you seeded the demo data, you can log in with admin@example.com/password
 
+#### Email
+
+We use [mailcatcher](https://mailcatcher.me/) as an SMTP server and web client. Visit <http://localhost:1080>.
+
 #### Useful Commands
 
 * **Rails Console:** `docker-compose exec app bundle exec rails c`

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,7 +29,14 @@ Rails.application.configure do
   end
 
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :letter_opener
+  if ENV["SMTP_HOST"]
+    # letter_opener doesn't work well with docker, so use mailcatcher instead when
+    # using docker.
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = { address: ENV["SMTP_HOST"], port: ENV.fetch("SMTP_PORT", 1025) }
+  else
+    config.action_mailer.delivery_method = :letter_opener
+  end
   config.action_mailer.perform_deliveries = true
   Rails.application.routes.default_url_options =
     config.action_mailer.default_url_options = { host: "localhost", port: 3000 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,8 +16,24 @@ services:
       - MYSQL_HOST=db
       - MYSQL_USER=root
       - MYSQL_PASSWORD=root
+      - SMTP_HOST=mailcatcher
     tty: true
     stdin_open: true
+  delayed_job:
+    build: .
+    command: bundle exec rake jobs:work
+    depends_on:
+      - app
+    volumes:
+      - .:/app
+      - gem_cache:/gems
+    environment:
+      - MYSQL_HOST=db
+      - MYSQL_USER=root
+      - MYSQL_PASSWORD=root
+      - SMTP_HOST=mailcatcher
+    stdin_open: true
+    tty: true
   db:
     image: mysql:5.7.22
     environment:
@@ -28,7 +44,16 @@ services:
       - db-data:/var/lib/mysql
     logging:
       driver: none
-
+  mailcatcher:
+    build: .
+    command: bash -c "gem install mailcatcher && mailcatcher --ip 0.0.0.0 --no-quit -f"
+    ports:
+      - "1080:1080"
+    volumes:
+      - .:/app
+      - gem_cache:/gems
+    tty: true
+    stdin_open: true
 volumes:
   db-data:
     driver: local


### PR DESCRIPTION
# Release Notes

Add delayed_job to our docker setup for development. This also adds `mailcatcher` so you can view emails.

# Additional Context

In docker, `letter_opener`/`launchy` (which opens emails in the browser as soon as they get sent) won't work since they're inside a container and can't talk to the host machine.