### PR TITLE
Add workflows: key to Circle CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 version: 2
+
 jobs:
   build:
     parallelism: 4
@@ -75,3 +76,9 @@ jobs:
               if [ "${CIRCLE_BRANCH}" == "master" ]; then
                 bundle exec cap staging deploy
               fi
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build


### PR DESCRIPTION
# Release Notes

Add workflows: key to Circle CI config

# Additional Context

Without this, Circle CI is complaining that no workflows are configured, so pages like https://circleci.com/gh/tablexi/workflows/nucore-open/tree/master are empty, and the new UI blows up completely (on URLs like https://app.circleci.com/jobs/github/tablexi/nucore-open/7887)