### PR TITLE
Fixes to eye template

### DIFF
--- a/config/eye.yml.erb.template
+++ b/config/eye.yml.erb.template
@@ -1,7 +1,7 @@
-<% app_root = "/home/nucore/nucore.stage.tablexi.com/current" %>
+<% app_root = File.expand_path("..", __dir__) %>
 <% rails_env = ENV["RAILS_ENV"] %>
 ---
-name: <%= @app_name.underscore.camelize %> (<%%= rails_env %>)
+name: NUcore (<%= rails_env %>)
 
 config:
   logger: <%= app_root %>/log/eye.log


### PR DESCRIPTION
# Release Notes

Fix issues with default `eye.yml.erb template.

# Additional Context

I believe the only thing keeping the file itself (rather than the template) from being checked in is keys/secrets in the notifications (email, ses, datadog).