### PR TITLE
Add health_check gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem "prawn-table"
 ## other
 gem "delayed_job_active_record"
 gem "fog-aws"
+gem "health_check"
 gem "rake"
 gem "spreadsheet"
 gem "daemons"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,6 +326,8 @@ GEM
       rainbow
       rubocop (>= 0.50.0)
       sysexits (~> 1.1)
+    health_check (3.0.0)
+      railties (>= 5.0)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     icalendar (2.5.3)
@@ -653,6 +655,7 @@ DEPENDENCIES
   guard-teaspoon
   haml
   haml_lint
+  health_check
   icalendar
   ice_cube
   jquery-rails

--- a/config/initializers/health_check.rb
+++ b/config/initializers/health_check.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# See https://github.com/ianheggie/health_check for more options
+HealthCheck.setup do |config|
+  config.uri = "healthz"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -390,5 +390,6 @@ Nucore::Application.routes.draw do
     resource :submission, only: [:new, :show, :edit]
   end
 
+  # See config/initializers/health_check.rb for more information
   health_check_routes
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -389,4 +389,6 @@ Nucore::Application.routes.draw do
   namespace :formio do
     resource :submission, only: [:new, :show, :edit]
   end
+
+  health_check_routes
 end


### PR DESCRIPTION
# Release Notes

Adds a health check endpoint at `/healthz`.

# Additional Context

We're adding this for UMass, but I believe we had been thinking of this for NU as well so their load balancers are hitting something a little more lightweight than the homepage.