### PR TITLE
Easy attribute update skipping in SAML

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -137,6 +137,8 @@ paperclip:
 #   # certificate_file: path/to/file.p12 # Optional. Do not check in to version control.
 #   # driver: # Optional. Useful to override inferred SAML settings if need be.
 #   #   "idp_sso_target_url": "https://websso.example.com/idp/profile/SAML2/Redirect/SSO"
+#   # metadata_parse_options: # Optional. See RubySaml::IdpMetadataParser
+#   #   sso_binding: ["urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"]
 #   attribute_map:
 #     "PersonImmutableID": "username"
 #     "User.email": "email"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -144,7 +144,8 @@ paperclip:
 #     "User.email": "email"
 #     "User.FirstName": "first_name"
 #     "User.LastName": "last_name"
-#  # user_updater_class_name: SamlAuthentication::UserUpdater
+#   # user_updating:
+#   #  skip_attributes: email
 
 price_policy_note_options: ~
 order_detail_price_change_reason_options: ~

--- a/vendor/engines/saml_authentication/lib/saml_authentication/devise_configurator.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/devise_configurator.rb
@@ -14,7 +14,7 @@ module SamlAuthentication
         config.saml_create_user = saml_create_user?
         config.saml_update_user = true
         config.saml_resource_locator = SamlAuthentication::UserLocator.new
-        config.saml_update_resource_hook = saml_updater
+        config.saml_update_resource_hook = SamlAuthentication::UserUpdater.new(**Settings.saml.user_updating)
         config.saml_sign_out_success_url = Rails.application.routes.url_helpers.root_url
         config.idp_entity_id_reader = SamlAuthentication::IdpEntityIdReader
 
@@ -34,10 +34,6 @@ module SamlAuthentication
     end
 
     private
-
-    def saml_updater
-      Settings.saml.user_updater_class_name.presence.try(:constantize).try(:new) || SamlAuthentication::UserUpdater.new
-    end
 
     def saml_create_user?
       if Settings.saml.create_user.nil?

--- a/vendor/engines/saml_authentication/lib/saml_authentication/devise_configurator.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/devise_configurator.rb
@@ -14,7 +14,7 @@ module SamlAuthentication
         config.saml_create_user = saml_create_user?
         config.saml_update_user = true
         config.saml_resource_locator = SamlAuthentication::UserLocator.new
-        config.saml_update_resource_hook = SamlAuthentication::UserUpdater.new(**Settings.saml.user_updating)
+        config.saml_update_resource_hook = SamlAuthentication::UserUpdater.new(**Hash(Settings.saml.user_updating))
         config.saml_sign_out_success_url = Rails.application.routes.url_helpers.root_url
         config.idp_entity_id_reader = SamlAuthentication::IdpEntityIdReader
 

--- a/vendor/engines/saml_authentication/lib/saml_authentication/devise_configurator.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/devise_configurator.rb
@@ -18,8 +18,8 @@ module SamlAuthentication
         config.saml_sign_out_success_url = Rails.application.routes.url_helpers.root_url
         config.idp_entity_id_reader = SamlAuthentication::IdpEntityIdReader
 
-        config.saml_config = fetch_metadata_config
-
+        config.saml_config = fetch_metadata_config(Hash(Settings.saml.metadata_parse_options))
+        Rails.logger.debug(config.saml_config)
         config.saml_configure do |settings|
           settings.assertion_consumer_service_url = Rails.application.routes.url_helpers.auth_saml_user_session_url
           settings.issuer = Rails.application.routes.url_helpers.metadata_saml_user_session_url
@@ -47,13 +47,14 @@ module SamlAuthentication
       end
     end
 
-    def fetch_metadata_config
+    def fetch_metadata_config(options)
+      Rails.logger.debug("Fetching metadata config with #{options}")
       idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
       # Can be either remote or local
       if Settings.saml.idp_metadata.start_with?("https://")
-        idp_metadata_parser.parse_remote(Settings.saml.idp_metadata, true)
+        idp_metadata_parser.parse_remote(Settings.saml.idp_metadata, true, options)
       else
-        idp_metadata_parser.parse(File.open(File.expand_path(Settings.saml.idp_metadata)))
+        idp_metadata_parser.parse(File.open(File.expand_path(Settings.saml.idp_metadata)), options)
       end
     end
 

--- a/vendor/engines/saml_authentication/lib/saml_authentication/saml_attributes.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/saml_attributes.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module SamlAuthentication
+
+  class SamlAttributes
+
+    delegate :[], :except, to: :to_h
+
+    def initialize(saml_response)
+      @saml_response = saml_response
+    end
+
+    def to_h
+      @saml_response.attributes.resource_keys.each_with_object({}) do |key, memo|
+        memo[key] = @saml_response.attribute_value_by_resource_key(key)
+      end.with_indifferent_access
+    end
+
+  end
+
+end

--- a/vendor/engines/saml_authentication/lib/saml_authentication/user_locator.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/user_locator.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
+require "saml_authentication/saml_attributes"
+
 module SamlAuthentication
 
   class UserLocator
 
     def call(model, saml_response, _auth_value)
-      username = saml_response.attribute_value_by_resource_key(:username)
-      email = saml_response.attribute_value_by_resource_key(:email)
+      attributes = SamlAttributes.new(saml_response)
+      username = attributes[:username]
+      email = attributes[:email]
 
       model.find_by(username: username) || model.find_by(email: email)
     end


### PR DESCRIPTION
# Release Notes

Allow SAML configuration to specify attributes that should not be updated upon login.

# Additional Context

This is a refactor in UMass extracted from https://github.com/tablexi/nucore-umass/pull/10

This will allow some cleanup in Dartmouth as well.