### PR TITLE
Changes from UMass to support new user changes

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -48,6 +48,7 @@ class UsersController < ApplicationController
 
   # GET /facilities/:facility_id/users/new
   def new
+    redirect_to action: :new_external if SettingsHelper.feature_off?(:lookup_netids)
   end
 
   # GET /facilities/:facility_id/users/new_external
@@ -140,7 +141,7 @@ class UsersController < ApplicationController
   helper_method :training_requested_for?
 
   def create_params
-    params.require(:user).permit(:email, :first_name, :last_name, :username)
+    params.require(:user).permit(*user_form_class.permitted_params)
   end
 
   def edit_user_params
@@ -152,8 +153,9 @@ class UsersController < ApplicationController
   end
 
   def create_external
-    @user = User.new(create_params)
+    @user = User.new
     @user_form = user_form_class.new(@user)
+    @user_form.assign_attributes(create_params)
 
     authorize! :create, @user_form.user
 

--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -12,6 +12,10 @@ class UserForm < SimpleDelegator
     self
   end
 
+  def self.permitted_params
+    [:email, :first_name, :last_name, :username]
+  end
+
   def user
     __getobj__
   end

--- a/app/views/search/_create_new_user.html.haml
+++ b/app/views/search/_create_new_user.html.haml
@@ -1,7 +1,7 @@
 - if params[:create_link] == "true" && SettingsHelper.feature_on?(:create_users)
   %p
     = t(".prompt")
-    - if SettingsHelper.feature_on?(:netids)
+    - if SettingsHelper.feature_on?(:lookup_netids)
       = link_to t(".link"), new_facility_user_path(@facility)
     - else
       = link_to t(".link"), new_external_facility_users_path(@facility)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -79,7 +79,7 @@ feature:
   global_billing_administrator: true
   global_billing_administrator_users_tab: true
   create_users: true
-  netids: true
+  lookup_netids: true
   limit_short_description: true
   manage_payment_sources_with_users: true
   order_assignment_notifications: true

--- a/lib/engine_manager.rb
+++ b/lib/engine_manager.rb
@@ -18,4 +18,12 @@ class EngineManager
     loaded_engines.map(&:name).include?(class_name)
   end
 
+  # Allow the engine's views to take precedence over the application's views
+  def self.allow_view_overrides!(engine_name)
+    paths = ActionController::Base.view_paths.to_a
+    index = paths.find_index { |p| p.to_s.include?(engine_name) }
+    paths.unshift paths.delete_at(index)
+    ActionController::Base.view_paths = paths
+  end
+
 end

--- a/vendor/engines/c2po/lib/c2po.rb
+++ b/vendor/engines/c2po/lib/c2po.rb
@@ -22,11 +22,7 @@ module C2po
       # Permit engine-specific params
       FacilitiesController.permitted_facility_params.concat [:accepts_po, :accepts_cc]
 
-      # Make this engine's views override the main app's views
-      paths = ActionController::Base.view_paths.to_a
-      index = paths.find_index { |p| p.to_s.include? "c2po" }
-      paths.unshift paths.delete_at(index)
-      ActionController::Base.view_paths = paths
+      EngineManager.allow_view_overrides!("c2po")
 
       # Register view hooks
       ViewHook.add_hook "facilities.manage", "before_is_active", "c2po/facilities/manage"


### PR DESCRIPTION
# Release Notes

Adds support for some changes made in UMass around user creation. Also extracts some code from the C2PO engine into a helper for allowing the engine's views to take precedence over the main app's code.

I also renamed one of the settings so it's more in line with what it actually means: we are using netids in Dartmouth and UMass, however, the lookup feature (which NU has for looking up in their LDAP directory) does not exist.

Extracted from https://github.com/tablexi/nucore-umass/pull/18

