### PR TITLE
Move timezone configuration to settings

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,7 @@ module Nucore
 
     config.active_job.queue_adapter = :delayed_job
 
-    config.time_zone = "Central Time (US & Canada)" # move to settings
+    config.time_zone = Settings.time_zone
 
     config.active_record.observers = :order_detail_observer
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -149,3 +149,5 @@ paperclip:
 
 price_policy_note_options: ~
 order_detail_price_change_reason_options: ~
+
+time_zone: "Central Time (US & Canada)"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,6 +6,8 @@ price_group:
     external: 'External Rate'
     cancer_center: 'Cancer Center Rate'
 
+time_zone: "Central Time (US & Canada)"
+
 accounts:
   # Most frequently used account by NU
   product_default: 75340
@@ -149,5 +151,3 @@ paperclip:
 
 price_policy_note_options: ~
 order_detail_price_change_reason_options: ~
-
-time_zone: "Central Time (US & Canada)"


### PR DESCRIPTION
I'm assuming that by changing `application.rb` here, we only need to add the changes to the `settings.yml` file downstream in order for these changes to take effect. Let me know if I'm mistaken.