### PR TITLE
[#148121] Rake tasks for converting user between internal and external

### DIFF
--- a/app/services/users/convert_external_to_internal_user.rb
+++ b/app/services/users/convert_external_to_internal_user.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Users
+
+  class ConvertExternalToInternalUser
+
+    attr_reader :logger
+
+    class DefaultLookup
+      def call(username)
+        User.new(username: username)
+      end
+    end
+
+    def initialize(email, netid, lookup: DefaultLookup.new, dryrun: false, logger: Rails.logger)
+      @netid = netid
+      @email = email
+      @lookup = lookup
+      @logger = logger
+      @dryrun = dryrun
+    end
+
+    def convert!
+      existing_user = User.find_by!(email: @email)
+      raise "Is already an internal user" unless existing_user.email_user?
+
+      existing_user.assign_attributes(find_attributes)
+
+      # Clear out password so they can no longer log in
+      existing_user.assign_attributes(encrypted_password: nil, password_salt: nil)
+      logger.info "Changing: #{existing_user.changes}"
+      if @dryrun
+        logger.info "Dry run"
+      else
+        existing_user.save!
+        logger.info "User updated!"
+      end
+    end
+
+    private
+
+    def find_attributes
+      new_user_details = @lookup.call(@netid)
+      raise "NetID/username #{@netid} not found in directory" unless new_user_details
+
+      new_user_details.attributes.select { |_k, v| v.present? }
+    end
+
+  end
+
+end

--- a/app/services/users/convert_internal_to_external_user.rb
+++ b/app/services/users/convert_internal_to_external_user.rb
@@ -15,6 +15,8 @@ module Users
     def convert!
       user = User.find_by!(username: @username)
 
+      raise "#{@username} is already an external user" if user.email_user?
+
       user.assign_attributes(
         username: user.email,
         password: SecureRandom.hex,

--- a/app/services/users/convert_internal_to_external_user.rb
+++ b/app/services/users/convert_internal_to_external_user.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Users
+
+  class ConvertInternalToExternalUser
+
+    attr_reader :logger
+
+    def initialize(username, dryrun: false, logger: Rails.logger)
+      @username = username
+      @dryrun = dryrun
+      @logger = logger
+    end
+
+    def convert!
+      user = User.find_by!(username: @username)
+
+      user.assign_attributes(
+        username: user.email,
+        password: SecureRandom.hex,
+      )
+
+      logger.info("Changing #{user.changes}")
+      if @dryrun
+        logger.info "Dry run"
+      else
+        user.save!
+        logger.info "User updated!"
+        logger.info "The user may use Forgot Password to create a new password"
+      end
+    end
+
+  end
+
+end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -6,4 +6,20 @@ namespace :users do
     finder = Users::ActiveUserFinder.new
     puts finder.active_users_csv(1.year.ago)
   end
+
+  namespace :convert do
+    desc "Convert an external user to internal"
+    task :external_to_internal, [:email, :netid, :commit] => :environment do |_t, args|
+      options = { dryrun: !args[:commit], logger: Logger.new(STDOUT) }
+      options.merge!(lookup: LdapAuthentication::UserLookup.new) if EngineManager.engine_loaded?("ldap_authentication")
+      Users::ConvertExternalToInternalUser.new(args[:email], args[:netid], **options).convert!
+    end
+
+    desc "Convert an internal user to external"
+    task :internal_to_external, [:netid, :commit] => :environment do |_t, args|
+      options = { dryrun: !args[:commit], logger: Logger.new(STDOUT) }
+      puts "args: #{args}"
+      Users::ConvertInternalToExternalUser.new(args[:netid], **options).convert!
+    end
+  end
 end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -8,6 +8,9 @@ namespace :users do
   end
 
   namespace :convert do
+    # Usage:
+    # Dry run: rake users:convert:external_to_internal[sst123@example.org,netid123]
+    # Commit: rake users:convert:external_to_internal[sst123@example.org,netid123,true]
     desc "Convert an external user to internal"
     task :external_to_internal, [:email, :netid, :commit] => :environment do |_t, args|
       options = { dryrun: !args[:commit], logger: Logger.new(STDOUT) }
@@ -15,6 +18,8 @@ namespace :users do
       Users::ConvertExternalToInternalUser.new(args[:email], args[:netid], **options).convert!
     end
 
+    # Dry run: rake users:convert:external_to_internal[netid123]
+    # Commit: rake users:convert:external_to_internal[netid123,true]
     desc "Convert an internal user to external"
     task :internal_to_external, [:netid, :commit] => :environment do |_t, args|
       options = { dryrun: !args[:commit], logger: Logger.new(STDOUT) }

--- a/spec/services/users/convert_external_to_internal_user_spec.rb
+++ b/spec/services/users/convert_external_to_internal_user_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe Users::ConvertExternalToInternalUser do
+
+  describe "successful conversion" do
+    let(:user) { create(:user, email: "external@example.org", username: "external@example.org", password: "something") }
+    let(:converter) { described_class.new(user.email, "netid") }
+
+    it "updates the username" do
+      expect { converter.convert! }.to change { user.reload.username }.to("netid")
+    end
+
+    it "clears the password" do
+      expect { converter.convert! }.to change { user.reload.encrypted_password }.to be_blank
+    end
+
+    it "does not change the first_name" do
+      expect { converter.convert! }.not_to change { user.reload.first_name }
+    end
+
+    it "does not change the last_name" do
+      expect { converter.convert! }.not_to change { user.reload.last_name }
+    end
+  end
+
+  describe "when the username already exists in the database" do
+    let(:user) { create(:user, email: "external@example.org", username: "external@example.org", password: "something") }
+    let!(:existing_user) { create(:user, username: "netid") }
+    let(:converter) { described_class.new(user.email, "netid") }
+
+    it "errors" do
+      expect { converter.convert! }.to raise_error(/Username has already been taken/)
+    end
+  end
+
+  describe "when the lookup updates the email and name" do
+    class TestUpdatingLookup
+      def call(username)
+        User.new(username: username, email: "newemail@example.org", first_name: "New")
+      end
+    end
+
+    let(:user) { create(:user, email: "external@example.org", username: "external@example.org", last_name: "Old") }
+    let(:converter) { described_class.new(user.email, "netid", lookup: TestUpdatingLookup.new) }
+
+    it "updates everything" do
+      converter.convert!
+      expect(user.reload).to have_attributes(
+        email: "newemail@example.org",
+        username: "netid",
+        first_name: "New",
+        last_name: "Old",
+      )
+    end
+  end
+
+  describe "when the lookup finds nothing" do
+    class TestEmptyLookup
+      def call(_username)
+      end
+    end
+
+    let(:user) { create(:user, email: "external@example.org", username: "external@example.org") }
+    let(:converter) { described_class.new(user.email, "notfound", lookup: TestEmptyLookup.new) }
+
+    it "raises an error" do
+      expect { converter.convert! }.to raise_error(/not found in directory/)
+    end
+  end
+
+end

--- a/spec/services/users/convert_internal_to_external_user_spec.rb
+++ b/spec/services/users/convert_internal_to_external_user_spec.rb
@@ -1,14 +1,25 @@
 require "rails_helper"
 
 RSpec.describe Users::ConvertInternalToExternalUser do
-  let(:user) { create(:user, username: "int123", email: "int@example.org") }
   let!(:converter) { described_class.new(user.username) }
 
-  it "converts the username" do
-    expect { converter.convert! }.to change { user.reload.username }.to("int@example.org")
+  describe "successfully converting" do
+    let(:user) { create(:user, username: "int123", email: "int@example.org") }
+
+    it "converts the username" do
+      expect { converter.convert! }.to change { user.reload.username }.to("int@example.org")
+    end
+
+    it "sets a random password" do
+      expect { converter.convert! }.to change { user.reload.encrypted_password }.to be_present
+    end
   end
 
-  it "sets a random password" do
-    expect { converter.convert! }.to change { user.reload.encrypted_password }.to be_present
+  describe "the user is already external" do
+    let(:user) { create(:user, username: "ext123@example.org", email: "ext123@example.org") }
+
+    it "errors" do
+      expect { converter.convert! }.to raise_error(/already an external/)
+    end
   end
 end

--- a/spec/services/users/convert_internal_to_external_user_spec.rb
+++ b/spec/services/users/convert_internal_to_external_user_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe Users::ConvertInternalToExternalUser do
+  let(:user) { create(:user, username: "int123", email: "int@example.org") }
+  let!(:converter) { described_class.new(user.username) }
+
+  it "converts the username" do
+    expect { converter.convert! }.to change { user.reload.username }.to("int@example.org")
+  end
+
+  it "sets a random password" do
+    expect { converter.convert! }.to change { user.reload.encrypted_password }.to be_present
+  end
+end

--- a/vendor/engines/ldap_authentication/lib/ldap_authentication/user_lookup.rb
+++ b/vendor/engines/ldap_authentication/lib/ldap_authentication/user_lookup.rb
@@ -1,0 +1,12 @@
+module LdapAuthentication
+
+  class UserLookup
+
+    def call(username)
+      entry = UserEntry.find(username)
+      entry.to_user if entry
+    end
+
+  end
+
+end

--- a/vendor/engines/ldap_authentication/lib/ldap_authentication/users_controller_extension.rb
+++ b/vendor/engines/ldap_authentication/lib/ldap_authentication/users_controller_extension.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
+require "ldap_authentication/user_lookup"
+
 module LdapAuthentication
 
   module UsersControllerExtension
 
     def service_username_lookup(username)
-      entry = UserEntry.find(username)
-      entry.to_user if entry
+      LdapAuthentication::UserLookup.new.call(username)
     end
 
   end


### PR DESCRIPTION
# Release Notes

Add rake tasks for converting a user between external and internal.

# Usage

```bash
# The simplest case. Changes the username to be internal and removes the ability to use a password
# Dry run, will show the changes to be made
bundle exec rake users:convert:internal_to_external[netid123]
# After checking your changes are correct
bundle exec rake users:convert:internal_to_external[netid123,true]

# Converting from external to internal does an LDAP lookup (for NU) and updates name and email based on what is in the directory.
# Dry run, will show the changes to be made
bundle exec rake users:convert:external_to_internal[email@example.org,netid123]
# After checking your changes are correct
bundle exec rake users:convert:external_to_internal[email@example.org,netid123,true]
```

