### PR TITLE
Add instructions for running LDAP in docker-compose

### DIFF
--- a/config/ldap.yml.template
+++ b/config/ldap.yml.template
@@ -6,8 +6,8 @@
 #   'base' => Base Distinguished Name (Base DN)
 #
 development:
-  host: localhost
-  port: 389
+  host: <%= ENV.fetch("LDAP_HOST", "localhost") %>
+  port: <%= ENV.fetch("LDAP_PORT", 389) %>
   base: dc=example,dc=org
   attribute: uid
   admin_user: "cn=admin,dc=example,dc=org"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,22 +29,24 @@ services:
       - db-data:/var/lib/mysql
     logging:
       driver: none
-  # ldap:
-  #   image: osixia/openldap
-  #   command: "--copy-service"
-  #   volumes:
-  #     - "ldap-data:/var/lib/ldap"
-  #     # Loads some default users into the database
-  #     - "./vendor/engines/ldap_authentication/spec/fixtures:/container/service/slapd/assets/config/bootstrap/ldif/custom"
-  # ldap-admin:
-  #   image: osixia/phpldapadmin
-  #   ports:
-  #     - "8081:80"
-  #   depends_on:
-  #     - ldap
-  #   environment:
-  #     - PHPLDAPADMIN_LDAP_HOSTS=ldap
-  #     - PHPLDAPADMIN_HTTPS=false
+  ldap:
+    image: osixia/openldap
+    command: "--copy-service"
+    ports:
+      - "389:389"
+    volumes:
+      - "ldap-data:/var/lib/ldap"
+      # Loads some default users into the database
+      - "./vendor/engines/ldap_authentication/spec/fixtures:/container/service/slapd/assets/config/bootstrap/ldif/custom"
+  ldap-admin:
+    image: osixia/phpldapadmin
+    ports:
+      - "8081:80"
+    depends_on:
+      - ldap
+    environment:
+      - PHPLDAPADMIN_LDAP_HOSTS=ldap
+      - PHPLDAPADMIN_HTTPS=false
 
 volumes:
   db-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
       - MYSQL_HOST=db
       - MYSQL_USER=root
       - MYSQL_PASSWORD=root
+      - LDAP_HOST=ldap
     tty: true
     stdin_open: true
   db:
@@ -28,8 +29,26 @@ services:
       - db-data:/var/lib/mysql
     logging:
       driver: none
+  # ldap:
+  #   image: osixia/openldap
+  #   command: "--copy-service"
+  #   volumes:
+  #     - "ldap-data:/var/lib/ldap"
+  #     # Loads some default users into the database
+  #     - "./vendor/engines/ldap_authentication/spec/fixtures:/container/service/slapd/assets/config/bootstrap/ldif/custom"
+  # ldap-admin:
+  #   image: osixia/phpldapadmin
+  #   ports:
+  #     - "8081:80"
+  #   depends_on:
+  #     - ldap
+  #   environment:
+  #     - PHPLDAPADMIN_LDAP_HOSTS=ldap
+  #     - PHPLDAPADMIN_HTTPS=false
 
 volumes:
   db-data:
+    driver: local
+  ldap-data:
     driver: local
   gem_cache: {}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,6 @@ services:
       - MYSQL_HOST=db
       - MYSQL_USER=root
       - MYSQL_PASSWORD=root
-      - LDAP_HOST=ldap
     tty: true
     stdin_open: true
   db:
@@ -29,28 +28,8 @@ services:
       - db-data:/var/lib/mysql
     logging:
       driver: none
-  ldap:
-    image: osixia/openldap
-    command: "--copy-service"
-    ports:
-      - "389:389"
-    volumes:
-      - "ldap-data:/var/lib/ldap"
-      # Loads some default users into the database
-      - "./vendor/engines/ldap_authentication/spec/fixtures:/container/service/slapd/assets/config/bootstrap/ldif/custom"
-  ldap-admin:
-    image: osixia/phpldapadmin
-    ports:
-      - "8081:80"
-    depends_on:
-      - ldap
-    environment:
-      - PHPLDAPADMIN_LDAP_HOSTS=ldap
-      - PHPLDAPADMIN_HTTPS=false
 
 volumes:
   db-data:
-    driver: local
-  ldap-data:
     driver: local
   gem_cache: {}

--- a/vendor/engines/ldap_authentication/README.md
+++ b/vendor/engines/ldap_authentication/README.md
@@ -43,6 +43,10 @@ be the value of the `base: key`.
 
 ### Using Docker
 
+The easiest thing to do is enable LDAP in `docker-compose`.
+
+You may also run it standalone:
+
 ```
 docker run --name ldap-service --hostname ldap-service -p 389:389 -p 636:636 --detach osixia/openldap
 ```

--- a/vendor/engines/ldap_authentication/spec/fixtures/chico.user.ldif
+++ b/vendor/engines/ldap_authentication/spec/fixtures/chico.user.ldif
@@ -1,0 +1,10 @@
+dn: uid=cgreen,dc=example,dc=org
+uid: cgreen
+cn: Chico Green
+gn: Chico
+sn: Green
+mail: cgreen@example.org
+userPassword: secret
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson


### PR DESCRIPTION
# Release Notes

Update instructions for running a dev LDAP server within `docker-compose`.

# Additional Context

I did this as I was working on #2108 converting external to internal users. I initially left it in the `docker-compose.yml` file commented out, but I figured it won't be used enough it's not worth giving it such a prominent spot.