### PR TITLE
[#147850] Move ordered_at field from Order to OrderDetail

### DIFF
--- a/app/controllers/concerns/new_inprocess_controller.rb
+++ b/app/controllers/concerns/new_inprocess_controller.rb
@@ -29,10 +29,10 @@ module NewInprocessController
   def sort_lookup_hash
     {
       "order_number" => ["order_details.order_id", "order_details.id"],
-      "assigned_to" => ["assigned_users.last_name", "assigned_users.first_name", "order_statuses.name", "orders.ordered_at"],
-      "ordered_at" => "orders.ordered_at",
+      "assigned_to" => ["assigned_users.last_name", "assigned_users.first_name", "order_statuses.name", "order_details.ordered_at"],
+      "ordered_at" => "order_details.ordered_at",
       "ordered_for" => ["#{User.table_name}.last_name", "#{User.table_name}.first_name"],
-      "product_name" => ["products.name", "order_details.state", "orders.ordered_at"],
+      "product_name" => ["products.name", "order_details.state", "order_details.ordered_at"],
       "reserve_range" => ["reservations.reserve_start_at", "reservations.reserve_end_at"],
       "status" => "order_statuses.name",
       "payment_source" => "accounts.description",

--- a/app/controllers/facility_account_orders_controller.rb
+++ b/app/controllers/facility_account_orders_controller.rb
@@ -18,7 +18,7 @@ class FacilityAccountOrdersController < ApplicationController
       .order_details
       .for_facility(current_facility)
       .purchased
-      .by_ordered_at
+      .order(ordered_at: :desc)
       .paginate(page: params[:page])
   end
 

--- a/app/controllers/facility_account_orders_controller.rb
+++ b/app/controllers/facility_account_orders_controller.rb
@@ -18,7 +18,7 @@ class FacilityAccountOrdersController < ApplicationController
       .order_details
       .for_facility(current_facility)
       .purchased
-      .order("orders.ordered_at DESC")
+      .by_ordered_at
       .paginate(page: params[:page])
   end
 

--- a/app/controllers/facility_user_reservations_controller.rb
+++ b/app/controllers/facility_user_reservations_controller.rb
@@ -17,7 +17,7 @@ class FacilityUserReservationsController < ApplicationController
   def index
     @order_details = user_order_details
                      .purchased
-                     .by_ordered_at
+                     .order(ordered_at: :desc)
                      .paginate(page: params[:page])
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -84,7 +84,7 @@ class UsersController < ApplicationController
                           .item_and_service_orders
                           .for_facility(current_facility)
                           .purchased
-                          .order("orders.ordered_at DESC")
+                          .by_ordered_at
                           .paginate(page: params[:page])
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -84,7 +84,7 @@ class UsersController < ApplicationController
                           .item_and_service_orders
                           .for_facility(current_facility)
                           .purchased
-                          .by_ordered_at
+                          .order(ordered_at: :desc)
                           .paginate(page: params[:page])
   end
 

--- a/app/helpers/problem_order_details_helper.rb
+++ b/app/helpers/problem_order_details_helper.rb
@@ -15,7 +15,7 @@ module ProblemOrderDetailsHelper
       if show_reservation_start_at
         order_detail.reservation.actual_start_at
       else
-        order_detail.order.ordered_at
+        order_detail.ordered_at
       end
 
     format_usa_datetime(date)

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -14,7 +14,7 @@ class Facility < ApplicationRecord
   has_many :non_instrument_products, -> { where.not(type: "Instrument").alphabetized }, class_name: "Product", inverse_of: :facility
   has_many :order_details, through: :products
   has_many :order_imports, dependent: :destroy
-  has_many :orders, -> { where.not(ordered_at: nil) }
+  has_many :orders, -> { purchased }
   has_many :products
   has_many :schedules
   has_many :services, inverse_of: :facility

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -23,15 +23,11 @@ class Order < ApplicationRecord
   end
 
   def self.carts
-    where(ordered_at: nil, merge_with_order_id: nil)
+    where.not(state: :purchased).where(merge_with_order_id: nil)
   end
 
   def self.for_facility(facility)
     facility.cross_facility? ? all : where(facility_id: facility.id)
-  end
-
-  def self.recent
-    where("orders.ordered_at > ?", Time.zone.now - 1.year)
   end
 
   attr_accessor :being_purchased_by_admin
@@ -41,7 +37,7 @@ class Order < ApplicationRecord
   aasm column: :state do
     state :new, initial: true
     state :validated
-    state :purchased, before_enter: :set_ordered_at
+    state :purchased, before_enter: :set_order_details_ordered_at
 
     event :invalidate do
       transitions to: :new, from: [:new, :validated]
@@ -77,7 +73,7 @@ class Order < ApplicationRecord
   end
 
   def in_cart?
-    !ordered_at?
+    !purchased?
   end
 
   def move_order_details_to_default_status
@@ -111,8 +107,8 @@ class Order < ApplicationRecord
     save
   end
 
-  def set_ordered_at
-    self.ordered_at ||= Time.zone.now
+  def set_order_details_ordered_at
+    self.ordered_at = Time.current
   end
   #####
   # END acts_as_state_machine
@@ -123,6 +119,15 @@ class Order < ApplicationRecord
 
     ods.each(&:assign_estimated_price!)
     ods
+  end
+
+  def ordered_at=(datetime)
+    raise "Cannot assign ordered_at after purchase" if purchased?
+    order_details.each { |od| od.ordered_at ||= datetime }
+  end
+
+  def initial_ordered_at
+    order_details.map(&:ordered_at).min
   end
 
   ## TODO: this doesn't pass errors up to the caller.. does it need to?

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -108,7 +108,7 @@ class Order < ApplicationRecord
   end
 
   def set_order_details_ordered_at
-    self.ordered_at = Time.current
+    self.order_details_ordered_at = Time.current
   end
   #####
   # END acts_as_state_machine
@@ -121,8 +121,7 @@ class Order < ApplicationRecord
     ods
   end
 
-  def ordered_at=(datetime)
-    raise "Cannot assign ordered_at after purchase" if purchased?
+  def order_details_ordered_at=(datetime)
     order_details.each { |od| od.ordered_at ||= datetime }
   end
 

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -126,7 +126,6 @@ class OrderDetail < ApplicationRecord
   ## TODO validate order status is global or a member of the product's facility
   ## TODO validate which fields can be edited for which states
 
-  scope :by_ordered_at, -> { order(ordered_at: :desc) }
   scope :batch_updatable, -> { where(dispute_at: nil, state: %w(new inprocess)) }
   scope :new_or_inprocess, -> { purchased.where(state: %w(new inprocess)) }
   scope :non_canceled, -> { where.not(state: "canceled") }

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -74,7 +74,7 @@ class OrderDetail < ApplicationRecord
   has_many   :vestal_versions, as: :versioned
 
   delegate :edit_url, to: :external_service_receiver, allow_nil: true
-  delegate :in_cart?, :facility, :ordered_at, :user, to: :order
+  delegate :in_cart?, :facility, :user, to: :order
   delegate :invoice_number, to: :statement, prefix: true
   delegate :journal_date, to: :journal, allow_nil: true
   delegate :ordered_on_behalf_of?, to: :order
@@ -109,7 +109,7 @@ class OrderDetail < ApplicationRecord
   validates_presence_of :dispute_resolved_at, :dispute_resolved_reason, if: proc { dispute_resolved_reason.present? || dispute_resolved_at.present? }
   # only do this validation if it hasn't been ordered yet. Update errors caused by notification sending
   # were being triggered on orders where the orderer had been removed from the account.
-  validate :account_usable_by_order_owner?, if: ->(o) { o.account_id_changed? || o.order.nil? || o.order.ordered_at.nil? }
+  validate :account_usable_by_order_owner?, if: ->(o) { o.account_id_changed? || o.order.nil? || o.ordered_at.blank? }
   validates_length_of :note, maximum: 1000, allow_blank: true, allow_nil: true
   validate :valid_manual_fulfilled_at
   validates :price_change_reason, presence: true, length: { minimum: 10, allow_blank: true }, if: :pricing_note_required?
@@ -126,7 +126,7 @@ class OrderDetail < ApplicationRecord
   ## TODO validate order status is global or a member of the product's facility
   ## TODO validate which fields can be edited for which states
 
-  scope :by_ordered_at, -> { joins(:order).order("orders.ordered_at DESC") }
+  scope :by_ordered_at, -> { order(ordered_at: :desc) }
   scope :batch_updatable, -> { where(dispute_at: nil, state: %w(new inprocess)) }
   scope :new_or_inprocess, -> { purchased.where(state: %w(new inprocess)) }
   scope :non_canceled, -> { where.not(state: "canceled") }
@@ -142,6 +142,8 @@ class OrderDetail < ApplicationRecord
       all
     end
   end
+
+  scope :recent, -> { where("ordered_at > ?", 1.year.ago) }
 
   def self.in_dispute
     where("dispute_at IS NOT NULL")
@@ -257,6 +259,7 @@ class OrderDetail < ApplicationRecord
   scope :reservations, -> { for_product_type("Instrument") }
 
   scope :purchased, -> { joins(:order).merge(Order.purchased) }
+  scope :ordered_at, -> { where.not(ordered_at: nil) }
 
   scope :with_reservation, -> { purchased.joins(:reservation).order("reservations.reserve_start_at DESC") }
   scope :with_upcoming_reservation, lambda {
@@ -280,6 +283,7 @@ class OrderDetail < ApplicationRecord
   scope :for_order_statuses, ->(statuses) { where("order_details.order_status_id in (?)", statuses) unless statuses.nil? || statuses.empty? }
   scope :joins_assigned_users, -> { joins("LEFT OUTER JOIN users assigned_users ON assigned_users.id = order_details.assigned_user_id") }
 
+  # TODO: Target for removal
   scope :in_date_range, lambda { |start_date, end_date|
     search = all
     search = search.where("orders.ordered_at > ?", start_date.beginning_of_day) if start_date
@@ -336,15 +340,15 @@ class OrderDetail < ApplicationRecord
     start_date = start_date.beginning_of_day if start_date
     end_date = end_date.end_of_day if end_date
 
-    query = joins(:order).joins("LEFT JOIN reservations ON reservations.order_detail_id = order_details.id")
+    query = joins("LEFT JOIN reservations ON reservations.order_detail_id = order_details.id")
     # If there is a reservation, query on the reservation time, if there's not a reservation (i.e. the left join ends up with a null reservation)
     # use the ordered at time
     if start_date && end_date
-      sql = "(reservations.id IS NULL AND orders.ordered_at > :start AND orders.ordered_at < :end) OR (reservations.id IS NOT NULL AND reservations.reserve_start_at > :start AND reservations.reserve_start_at < :end)"
+      sql = "(reservations.id IS NULL AND order_details.ordered_at > :start AND order_details.ordered_at < :end) OR (reservations.id IS NOT NULL AND reservations.reserve_start_at > :start AND reservations.reserve_start_at < :end)"
     elsif start_date
-      sql = "(reservations.id IS NULL AND orders.ordered_at > :start) OR (reservations.id IS NOT NULL AND reservations.reserve_start_at > :start)"
+      sql = "(reservations.id IS NULL AND order_details.ordered_at > :start) OR (reservations.id IS NOT NULL AND reservations.reserve_start_at > :start)"
     elsif end_date
-      sql = "(reservations.id IS NULL AND orders.ordered_at < :end) OR (reservations.id IS NOT NULL AND reservations.reserve_start_at < :end)"
+      sql = "(reservations.id IS NULL AND order_details.ordered_at < :end) OR (reservations.id IS NOT NULL AND reservations.reserve_start_at < :end)"
     end
 
     query.where(sql, start: start_date, end: end_date)

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -283,14 +283,6 @@ class OrderDetail < ApplicationRecord
   scope :for_order_statuses, ->(statuses) { where("order_details.order_status_id in (?)", statuses) unless statuses.nil? || statuses.empty? }
   scope :joins_assigned_users, -> { joins("LEFT OUTER JOIN users assigned_users ON assigned_users.id = order_details.assigned_user_id") }
 
-  # TODO: Target for removal
-  scope :in_date_range, lambda { |start_date, end_date|
-    search = all
-    search = search.where("orders.ordered_at > ?", start_date.beginning_of_day) if start_date
-    search = search.where("orders.ordered_at < ?", end_date.end_of_day) if end_date
-    search
-  }
-
   scope :fulfilled_in_date_range, lambda { |start_date, end_date|
     action_in_date_range :fulfilled_at, start_date, end_date
   }

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -109,7 +109,7 @@ class OrderDetail < ApplicationRecord
   validates_presence_of :dispute_resolved_at, :dispute_resolved_reason, if: proc { dispute_resolved_reason.present? || dispute_resolved_at.present? }
   # only do this validation if it hasn't been ordered yet. Update errors caused by notification sending
   # were being triggered on orders where the orderer had been removed from the account.
-  validate :account_usable_by_order_owner?, if: ->(o) { o.account_id_changed? || o.order.nil? || o.ordered_at.blank? }
+  validate :account_usable_by_order_owner?, if: ->(order_detail) { order_detail.account_id_changed? || order_detail.order.nil? || order_detail.ordered_at.blank? }
   validates_length_of :note, maximum: 1000, allow_blank: true, allow_nil: true
   validate :valid_manual_fulfilled_at
   validates :price_change_reason, presence: true, length: { minimum: 10, allow_blank: true }, if: :pricing_note_required?

--- a/app/models/order_import.rb
+++ b/app/models/order_import.rb
@@ -76,7 +76,6 @@ class OrderImport < ApplicationRecord
       account: row_importer.account,
       user: row_importer.user,
       created_by_user: creator,
-      ordered_at: row_importer.order_date,
       order_import_id: id,
     )
   end

--- a/app/models/reports/export_raw.rb
+++ b/app/models/reports/export_raw.rb
@@ -43,7 +43,7 @@ module Reports
       hash = {
         facility: :facility,
         order: :to_s,
-        ordered_at: ->(od) { od.order.ordered_at },
+        ordered_at: :ordered_at,
         fulfilled_at: ->(od) { od.fulfilled_at },
         order_status: ->(od) { od.order_status.name },
         order_state: :state,

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -35,12 +35,6 @@ class Statement < ApplicationRecord
   # Use this for restricting based on search parameters
   scope :for_facilities, ->(facilities) { where(facility: facilities) if facilities.present? }
 
-  # Used in NU branch
-  def first_order_detail_date
-    min_order = order_details.min { |a, b| a.order.ordered_at <=> b.order.ordered_at }
-    min_order.order.ordered_at
-  end
-
   def total_cost
     statement_rows.inject(0) { |sum, row| sum += row.amount }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,7 +49,7 @@ class User < ApplicationRecord
   scope :unexpired, -> { where(expired_at: nil) }
 
   scope :with_global_roles, -> { where(id: UserRole.global.select("distinct user_id")) }
-  scope :with_recent_orders, ->(facility) { distinct.joins(:orders).merge(Order.recent.for_facility(facility)) }
+  scope :with_recent_orders, ->(facility) { distinct.joins(:order_details).merge(OrderDetail.recent.for_facility(facility)) }
   scope :sort_last_first, -> { order("LOWER(users.last_name), LOWER(users.first_name)") }
 
   # finds all user role mappings for a this user in a facility

--- a/app/services/most_recently_used_searcher.rb
+++ b/app/services/most_recently_used_searcher.rb
@@ -11,15 +11,21 @@ class MostRecentlyUsedSearcher
   def recently_used_facilities(limit = 5)
     return Facility.none unless user
 
-    facility_ids = user.orders.purchased.order("MAX(ordered_at) DESC").limit(limit).group(:facility_id).pluck(:facility_id)
+    facility_ids = recent_order_details.limit(limit).group(:facility_id).pluck(:facility_id)
     Facility.where(id: facility_ids)
   end
 
   def recently_used_products(limit = 10)
     return Product.none unless user
 
-    product_ids = user.orders.joins(order_details: :product).merge(Product.active.in_active_facility).purchased.order("MAX(orders.ordered_at) DESC").limit(limit).group(:product_id).pluck(:product_id)
+    product_ids = recent_order_details.limit(limit).joins(:product).merge(Product.active.in_active_facility).group(:product_id).pluck(:product_id)
     Product.where(id: product_ids)
+  end
+
+  private
+
+  def recent_order_details
+    user.order_details.ordered_at.order("MAX(ordered_at) DESC")
   end
 
 end

--- a/app/services/order_purchaser.rb
+++ b/app/services/order_purchaser.rb
@@ -69,7 +69,7 @@ class OrderPurchaser
   end
 
   def can_backdate_order_details?
-    order.ordered_at <= Time.zone.now
+    order.initial_ordered_at <= Time.zone.now
   end
 
   def backdate_order_details!(update_by, order_status)
@@ -77,7 +77,7 @@ class OrderPurchaser
       next if od.reservation # reservations should always have order_status dictated by their dates
 
       if order_status.root == OrderStatus.complete
-        od.backdate_to_complete!(order.ordered_at)
+        od.backdate_to_complete!(od.ordered_at)
       else
         od.update_order_status!(update_by, order_status, admin: true)
       end

--- a/app/services/order_purchaser.rb
+++ b/app/services/order_purchaser.rb
@@ -27,7 +27,7 @@ class OrderPurchaser
       return
     end
 
-    order.ordered_at = backdate_to if backdate_to
+    order.order_details_ordered_at = backdate_to if backdate_to
 
     validate_order!
     return unless do_additional_validations

--- a/app/support/order_row_importer.rb
+++ b/app/support/order_row_importer.rb
@@ -112,6 +112,7 @@ class OrderRowImporter
 
   def backdate_order_details_to_complete!
     @order_details.each do |order_detail|
+      order_detail.ordered_at = order_date
       order_detail.backdate_to_complete!(fulfillment_date)
     end
   end

--- a/app/views/facility_journals/show.csv.erb
+++ b/app/views/facility_journals/show.csv.erb
@@ -50,7 +50,7 @@ output = CSV.generate do |csv|
 
     row = [od.facility,
            od.to_s,
-           format_usa_datetime(order.ordered_at),
+           format_usa_datetime(od.ordered_at),
            format_usa_datetime(od.fulfilled_at)]
 
            # Who placed the order

--- a/app/views/facility_orders/index.html.haml
+++ b/app/views/facility_orders/index.html.haml
@@ -34,7 +34,7 @@
               %td.centered= link_to od.order_id, facility_order_path(current_facility, od.order)
               %td.centered= link_to od.id, manage_order_detail_path(od), class: "manage-order-detail"
               %td= od.order.user.full_name
-              %td= format_usa_datetime(od.order.ordered_at)
+              %td= format_usa_datetime(od.ordered_at)
               %td.centered= OrderDetailPresenter.new(od).wrapped_quantity
               = render partial: "shared/order_detail_cell", locals: { od: od }
               %td= od.assigned_user

--- a/app/views/facility_reservations/index.html.haml
+++ b/app/views/facility_reservations/index.html.haml
@@ -39,7 +39,7 @@
               %td.centered= link_to od.id, manage_order_detail_path(od), class: "manage-order-detail"
               %td= order.user.full_name
               %td{colspan: 2}
-                = format_usa_datetime(order.ordered_at)
+                = format_usa_datetime(od.ordered_at)
               %td{colspan: 2}
                 - if res.admin_editable?
                   = link_to res, edit_facility_order_order_detail_reservation_path(current_facility, order, od, res)

--- a/app/views/order_details/show.html.haml
+++ b/app/views/order_details/show.html.haml
@@ -21,7 +21,7 @@
           = link_to t(".link.change_account"), [:edit, @order, @order_detail], class: "normal-weight" if order_editable?
         .controls= @order_detail.account
 
-      = f.input :ordered_at
+      = f.input :ordered_at, input_html: { value: @order_detail.ordered_at }
       = f.input :user
       = f.input :created_by_user
 

--- a/app/views/orders/receipt.html.haml
+++ b/app/views/orders/receipt.html.haml
@@ -16,7 +16,7 @@
   = f.input :facility, label: Facility.model_name.human
 
   = f.input :account, :input_html => { :value => @accounts.join(', ') }
-  = f.input :ordered_at
+  = f.input :initial_ordered_at
   = f.input :user
   = f.input :created_by_user
 

--- a/app/views/purchase_notifier/order_receipt.html.haml
+++ b/app/views/purchase_notifier/order_receipt.html.haml
@@ -5,7 +5,7 @@
   %tr
     %td
       %strong= Order.human_attribute_name(:ordered_at)
-    %td= l(@order.ordered_at, format: :receipt)
+    %td= l(@order.initial_ordered_at, format: :receipt)
 
   %tr
     %td

--- a/app/views/purchase_notifier/order_receipt.text.haml
+++ b/app/views/purchase_notifier/order_receipt.text.haml
@@ -2,7 +2,7 @@
   #{@greeting}
 ==
 
-#{Order.human_attribute_name(:ordered_at)}: #{l(@order.ordered_at, format: :receipt)}
+#{Order.human_attribute_name(:ordered_at)}: #{l(@order.initial_ordered_at, format: :receipt)}
 #{Facility.model_name.human}: #{@order.facility}
 #{OrderDetail.human_attribute_name(:ordered_by)}: #{@order.created_by_user.full_name}
 #{Account.model_name.human}: #{@order.account}

--- a/app/views/purchase_notifier/product_order_notification.html.haml
+++ b/app/views/purchase_notifier/product_order_notification.html.haml
@@ -2,7 +2,7 @@
   %tr
     %td
       %strong= Order.human_attribute_name(:ordered_at)
-    %td= l(@order.ordered_at, format: :receipt)
+    %td= l(@order_detail.ordered_at, format: :receipt)
 
   %tr
     %td

--- a/app/views/purchase_notifier/product_order_notification.text.haml
+++ b/app/views/purchase_notifier/product_order_notification.text.haml
@@ -1,4 +1,4 @@
-#{Order.human_attribute_name(:ordered_at)}: #{l(@order.ordered_at, format: :receipt)}
+#{Order.human_attribute_name(:ordered_at)}: #{l(@order_detail.ordered_at, format: :receipt)}
 #{Facility.model_name.human}: #{@order.facility}
 #{OrderDetail.human_attribute_name(:ordered_by)}: #{@order.created_by_user.full_name}
 #{Account.model_name.human}: #{@order.account}

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -293,7 +293,7 @@ en:
       order:
         user: Ordered For
         created_by_user: Ordered By
-        ordered_at: Ordered Date
+        initial_ordered_at: Ordered Date
         account: Payment Source
       order_detail:
         account: Payment Source

--- a/db/migrate/20191114122118_move_ordered_at_to_order_detail.rb
+++ b/db/migrate/20191114122118_move_ordered_at_to_order_detail.rb
@@ -1,9 +1,13 @@
+# frozen_string_literal: true
+
 class MoveOrderedAtToOrderDetail < ActiveRecord::Migration[5.0]
   def up
     change_table :order_details do |t|
       t.datetime :ordered_at
     end
-    execute "UPDATE order_details JOIN orders ON orders.id = order_details.order_id SET order_details.ordered_at = orders.ordered_at"
+
+    execute NUCore::Database.oracle? ? oracle_up : mysql_up
+
     change_table :orders do |t|
       t.remove :ordered_at
     end
@@ -13,10 +17,39 @@ class MoveOrderedAtToOrderDetail < ActiveRecord::Migration[5.0]
     change_table :orders do |t|
       t.datetime :ordered_at, after: :updated_at
     end
-    # This will lose data if the ordered_at of a detail is ever changed
-    execute "UPDATE orders SET orders.ordered_at = (SELECT MAX(order_details.ordered_at) from order_details where order_details.order_id = orders.id)"
+
+    execute <<-SQL
+        UPDATE orders
+        SET orders.ordered_at = (
+          SELECT MAX(order_details.ordered_at)
+          FROM order_details
+          WHERE order_details.order_id = orders.id
+        )
+      SQL
+
     change_table :order_details do |t|
       t.remove :ordered_at
     end
+  end
+
+  def mysql_up
+    <<-SQL
+      UPDATE order_details
+      JOIN orders
+      ON orders.id = order_details.order_id
+      SET order_details.ordered_at = orders.ordered_at
+    SQL
+  end
+
+  def oracle_up
+    <<-SQL
+      UPDATE
+      (SELECT orders.ordered_at as orders_ordered_at, order_details.ordered_at as order_details_ordered_at
+       FROM order_details
+       INNER JOIN orders
+       ON order_details.order_id = orders.id
+      ) t
+      SET t.order_details_ordered_at = t.orders_ordered_at
+    SQL
   end
 end

--- a/db/migrate/20191114122118_move_ordered_at_to_order_detail.rb
+++ b/db/migrate/20191114122118_move_ordered_at_to_order_detail.rb
@@ -1,0 +1,22 @@
+class MoveOrderedAtToOrderDetail < ActiveRecord::Migration[5.0]
+  def up
+    change_table :order_details do |t|
+      t.datetime :ordered_at
+    end
+    execute "UPDATE order_details JOIN orders ON orders.id = order_details.order_id SET order_details.ordered_at = orders.ordered_at"
+    change_table :orders do |t|
+      t.remove :ordered_at
+    end
+  end
+
+  def down
+    change_table :orders do |t|
+      t.datetime :ordered_at, after: :updated_at
+    end
+    # This will lose data if the ordered_at of a detail is ever changed
+    execute "UPDATE orders SET orders.ordered_at = (SELECT MAX(order_details.ordered_at) from order_details where order_details.order_id = orders.id)"
+    change_table :order_details do |t|
+      t.remove :ordered_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190815101750) do
+ActiveRecord::Schema.define(version: 20191114122118) do
 
   create_table "account_facility_joins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "facility_id", null: false
@@ -303,6 +303,7 @@ ActiveRecord::Schema.define(version: 20190815101750) do
     t.string   "canceled_reason"
     t.string   "price_change_reason"
     t.integer  "price_changed_by_user_id"
+    t.datetime "ordered_at"
     t.index ["account_id"], name: "fk_od_accounts", using: :btree
     t.index ["assigned_user_id"], name: "index_order_details_on_assigned_user_id", using: :btree
     t.index ["bundle_product_id"], name: "fk_bundle_prod_id", using: :btree
@@ -355,7 +356,6 @@ ActiveRecord::Schema.define(version: 20190815101750) do
     t.integer  "created_by",                     null: false
     t.datetime "created_at",                     null: false
     t.datetime "updated_at",                     null: false
-    t.datetime "ordered_at"
     t.integer  "facility_id"
     t.string   "state",               limit: 50
     t.integer  "merge_with_order_id"

--- a/lib/tasks/demo_seed.rake
+++ b/lib/tasks/demo_seed.rake
@@ -536,6 +536,7 @@ namespace :demo do
             bundle_product_id: product.id,
             group_id: group_id,
             order_status_id: bp.product.initial_order_status.id,
+            ordered_at: ordered_at,
           )
           od.account = account
           od.save!
@@ -552,6 +553,7 @@ namespace :demo do
           quantity: product.is_a?(Item) ? (rand(3) + 1) : 1,
           created_at: (ordered_at - (60 * rand(60) + 1)),
           order_status_id: product.initial_order_status.id,
+          ordered_at: ordered_at,
         )
 
         # create a reservation
@@ -581,7 +583,6 @@ namespace :demo do
       o.state = "validated"
       o.save(validate: false)
       o.purchase!
-      o.update_attributes!(ordered_at: ordered_at)
     end
     o.validate_order! if args[:validate]
     o

--- a/spec/app_support/order_row_importer_spec.rb
+++ b/spec/app_support/order_row_importer_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe OrderRowImporter do
         before { subject.import }
 
         it "has the expected ordered_at" do
-          expect(order.ordered_at).to eq parse_usa_date(order_date)
+          expect(order.order_details.map(&:ordered_at)).to all(eq parse_usa_date(order_date))
         end
 
         it "has the expected creator" do

--- a/spec/controllers/facility_account_orders_controller_spec.rb
+++ b/spec/controllers/facility_account_orders_controller_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FacilityAccountOrdersController do
+  render_views
+
+  let(:facility) { create(:setup_facility) }
+  let(:product) { create(:setup_item, facility: facility) }
+  let(:account) { create(:account, :with_account_owner) }
+  let(:admin) { create(:user, :administrator) }
+  let!(:purchased_order) { create(:purchased_order, product: product, account: account) }
+
+  it "renders" do
+    sign_in admin
+    get :index, params: { facility_id: facility.url_name, account_id: account.id }
+    expect(response.status).to eq(200)
+  end
+end

--- a/spec/controllers/facility_order_details_controller_spec.rb
+++ b/spec/controllers/facility_order_details_controller_spec.rb
@@ -21,12 +21,11 @@ RSpec.describe FacilityOrderDetailsController do
                                user: @director,
                                created_by: @director.id,
                                account: @account,
-                               ordered_at: Time.zone.now,
                                state: "purchased",
                               )
     @price_group = FactoryBot.create(:price_group, facility: @authable)
     @price_policy = FactoryBot.create(:item_price_policy, product: @product, price_group: @price_group)
-    @order_detail = FactoryBot.create(:order_detail, order: @order, product: @product, price_policy: @price_policy)
+    @order_detail = FactoryBot.create(:order_detail, order: @order, product: @product, price_policy: @price_policy, ordered_at: Time.current)
     @order_detail.set_default_status!
     @params = { facility_id: @authable.url_name, order_id: @order.id, id: @order_detail.id }
   end

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -508,7 +508,7 @@ RSpec.describe FacilityOrdersController do
       expect(merge_order.account_id).to eq(original_order.account_id)
       expect(merge_order.user_id).to eq(original_order.user_id)
       expect(merge_order.created_by).to eq(@director.id)
-      expect(merge_order.ordered_at).to be_blank
+      expect(merge_order.order_details).to be { |od| od.ordered_at.blank? }
       expect(merge_order.order_details.size).to eq(detail_count)
       expect(MergeNotification.count).to eq(detail_count)
       assert_update_success merge_order, product

--- a/spec/controllers/facility_reservations_controller_spec.rb
+++ b/spec/controllers/facility_reservations_controller_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe FacilityReservationsController do
                                user: @director,
                                created_by: @director.id,
                                account: @account,
-                               ordered_at: Time.zone.now,
                                state: "purchased",
                               )
 
@@ -264,7 +263,6 @@ RSpec.describe FacilityReservationsController do
                                     user: @director,
                                     created_by: @director.id,
                                     account: @account,
-                                    ordered_at: nil,
                                     state: "new",
                                    )
         # make sure the reservations are happening today

--- a/spec/controllers/file_uploads_controller_spec.rb
+++ b/spec/controllers/file_uploads_controller_spec.rb
@@ -225,7 +225,6 @@ RSpec.describe FileUploadsController do
                                user: @director,
                                created_by: @director.id,
                                account: @account,
-                               ordered_at: Time.zone.now,
                               )
     @price_group = FactoryBot.create(:price_group, facility: @authable)
     @price_policy = FactoryBot.create(:item_price_policy, product: @product, price_group: @price_group)

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe OrdersController do
 
   class DummyNotifier
 
-    def deliver
+    def deliver_later
     end
 
   end
@@ -543,14 +543,14 @@ RSpec.describe OrdersController do
         @params[:order_date] = format_usa_date(1.day.ago)
         @params[:order_time] = { hour: "10", minute: "12", ampm: "AM" }
         do_request
-        expect(assigns[:order].reload.ordered_at).to match_date 1.day.ago.change(hour: 10, min: 12)
+        expect(assigns[:order].order_details.map(&:ordered_at)).to all(match_date 1.day.ago.change(hour: 10, min: 12))
       end
 
       it "sets ordered_at to now if not acting_as" do
         maybe_grant_always_sign_in :director
         @params[:order_date] = format_usa_date(1.day.ago)
         do_request
-        expect(assigns[:order].reload.ordered_at).to match_date Time.zone.now
+        expect(assigns[:order].order_details.map(&:ordered_at)).to all(match_date Time.current)
       end
 
       it "does not set ordered_at when quantities change" do
@@ -566,7 +566,7 @@ RSpec.describe OrdersController do
         do_request
 
         expect(@order.reload.state).not_to eq("purchased")
-        expect(@order.ordered_at).to be_blank
+        expect(@order.order_details.map(&:ordered_at)).to all(be_blank)
       end
 
       context "setting status of order details" do

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -510,7 +510,7 @@ RSpec.describe OrdersController do
     context "backdating" do
       before :each do
         @order_detail = place_product_order(@staff, @authable, @item, @account, false)
-        @order.update_attribute(:ordered_at, nil)
+        @order_detail.update_attribute(:ordered_at, nil)
         @params.merge!(id: @order.id)
       end
 

--- a/spec/controllers/reports/general_reports_controller_spec.rb
+++ b/spec/controllers/reports/general_reports_controller_spec.rb
@@ -64,10 +64,10 @@ RSpec.describe Reports::GeneralReportsController do
       @order_detail_ordered_today_unfulfilled = place_product_order(@user, @authable, @item, @account)
 
       @order_detail_ordered_yesterday_unfulfilled = place_product_order(@user, @authable, @item, @account)
-      @order_detail_ordered_yesterday_unfulfilled.order.update_attributes(ordered_at: 1.day.ago)
+      @order_detail_ordered_yesterday_unfulfilled.update_attributes!(ordered_at: 1.day.ago)
 
       @order_detail_ordered_yesterday_fulfilled_today_unreconciled = place_and_complete_item_order(@user, @authable, @account)
-      @order_detail_ordered_yesterday_fulfilled_today_unreconciled.order.update_attributes(ordered_at: 1.day.ago)
+      @order_detail_ordered_yesterday_fulfilled_today_unreconciled.update_attributes!(ordered_at: 1.day.ago)
 
       @order_detail_ordered_today_fulfilled_today_unreconciled = place_and_complete_item_order(@user, @authable, @account)
 
@@ -75,15 +75,13 @@ RSpec.describe Reports::GeneralReportsController do
       @order_detail_ordered_today_fulfilled_next_month_unreconciled.update_attributes(fulfilled_at: 1.month.from_now)
 
       @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today = place_and_complete_item_order(@user, @authable, @account)
-      @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today.order.update_attributes(ordered_at: 1.day.ago)
-      @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today.update_attributes(fulfilled_at: 1.day.ago)
+      @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today.update_attributes!(ordered_at: 1.day.ago, fulfilled_at: 1.day.ago)
       @journal_today = FactoryBot.create(:journal, facility: @authable, created_by: @admin.id, journal_date: Time.zone.now)
       @journal_today.create_journal_rows!([@order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today])
       @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today.change_status!(OrderStatus.reconciled)
 
       @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_yesterday = place_and_complete_item_order(@user, @authable, @account)
-      @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_yesterday.order.update_attributes(ordered_at: 1.day.ago)
-      @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_yesterday.update_attributes(fulfilled_at: 1.day.ago)
+      @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_yesterday.update_attributes(ordered_at: 1.day.ago, fulfilled_at: 1.day.ago)
       @journal_yesterday = FactoryBot.create(:journal, facility: @authable, created_by: @admin.id, journal_date: 1.day.ago)
       @journal_yesterday.create_journal_rows!([@order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_yesterday])
       @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_yesterday.change_status!(OrderStatus.reconciled)

--- a/spec/controllers/surveys_controller_spec.rb
+++ b/spec/controllers/surveys_controller_spec.rb
@@ -130,7 +130,6 @@ RSpec.describe SurveysController do
                     user: @director,
                     created_by: @director.id,
                     account: @account,
-                    ordered_at: Time.zone.now,
                    )
     @price_group = FactoryBot.create(:price_group, facility: authable)
     @price_policy = FactoryBot.create(:item_price_policy, product: @product, price_group: @price_group)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe UsersController do
 
       @lapsed_user = FactoryBot.create(:user, first_name: "Lapsed")
       @old_order_detail = place_and_complete_item_order(@lapsed_user, @authable)
-      @old_order_detail.order.update_attributes(ordered_at: 400.days.ago)
+      @old_order_detail.update_attributes!(ordered_at: 400.days.ago)
     end
 
     it_should_allow_operators_only :success, "include the right users" do

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -34,8 +34,13 @@ FactoryBot.define do
     end
 
     factory :purchased_order do
-      after(:create) do |order|
+      transient do
+        ordered_at { Time.current }
+      end
+
+      after(:create) do |order, evaluator|
         allow(order).to receive(:cart_valid?).and_return(true) # so we don't have to worry about defining price groups, etc
+        order.order_details_ordered_at = evaluator.ordered_at
         order.validate_order!
         order.purchase!
       end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -6,8 +6,13 @@ FactoryBot.define do
   end
 
   trait :purchased do
-    ordered_at { 1.week.ago }
+    transient do
+      ordered_at { 1.week.ago }
+    end
     state { "purchased" }
+    after(:create) do |order, evaluator|
+      order.order_details.update_all(ordered_at: evaluator.ordered_at)
+    end
   end
 
   # Must define product or facility

--- a/spec/features/placing_an_order_on_behalf_of_spec.rb
+++ b/spec/features/placing_an_order_on_behalf_of_spec.rb
@@ -57,5 +57,7 @@ RSpec.describe "Placing an item order" do
     expect(page).to have_content(/Ordered For\n#{user.full_name}/i)
     expect(page).to have_css(".currency .estimated_cost", count: 0)
     expect(page).to have_css(".currency .actual_cost", count: 2) # Cost and Total
+
+    expect(page).to have_content("Ordered Date\n#{I18n.l(2.days.ago.to_date, format: :usa)}")
   end
 end

--- a/spec/helpers/reservations_helper_spec.rb
+++ b/spec/helpers/reservations_helper_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe ReservationsHelper do
         subject(:reservation) { create(:setup_reservation, :yesterday) }
 
         context "and the reservation is in a cart" do
-          before { reservation.order.ordered_at = nil }
+          before { reservation.order.state = :new }
 
           it { expect(end_time_editing_disabled?(reservation)).to be false }
         end
 
         context "and the reservation has been ordered" do
-          before { reservation.order.ordered_at = Time.zone.now }
+          before { reservation.order.state = :purchased }
 
           it { expect(end_time_editing_disabled?(reservation)).to be true }
         end
@@ -51,13 +51,13 @@ RSpec.describe ReservationsHelper do
         subject(:reservation) { create(:setup_reservation, :yesterday) }
 
         context "and the reservation is in a cart" do
-          before { reservation.order.ordered_at = false }
+          before { reservation.order.state = :new }
 
           it { expect(start_time_editing_disabled?(reservation)).to be false }
         end
 
         context "and the reservation has been ordered" do
-          before { reservation.order.ordered_at = Time.zone.now }
+          before { reservation.order.state = :purchased }
 
           it { expect(start_time_editing_disabled?(reservation)).to be true }
         end

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -425,7 +425,6 @@ RSpec.describe OrderDetail do
                user: user,
                created_by: user.id,
                account: account,
-               ordered_at: Time.zone.now,
               )
       end
 

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -1218,10 +1218,10 @@ RSpec.describe OrderDetail do
       ignore_order_detail_account_validations
       @user = create(:user)
       @od_yesterday = place_product_order(@user, @facility, @item, @account)
-      @od_yesterday.order.update_attributes(ordered_at: (Time.zone.now - 1.day))
+      @od_yesterday.update_attributes!(ordered_at: 1.day.ago)
 
       @od_tomorrow = place_product_order(@user, @facility, @item, @account)
-      @od_tomorrow.order.update_attributes(ordered_at: (Time.zone.now + 1.day))
+      @od_tomorrow.update_attributes!(ordered_at: 1.day.from_now)
 
       @od_today = place_product_order(@user, @facility, @item, @account)
 
@@ -1232,10 +1232,10 @@ RSpec.describe OrderDetail do
                            min_reserve_mins: 60,
                            max_reserve_mins: 60)
 
-      # all reservations get placed in today
-      @reservation_yesterday = place_reservation_for_instrument(@user, @instrument, @account, Time.zone.now - 1.day)
-      @reservation_tomorrow = place_reservation_for_instrument(@user, @instrument, @account, Time.zone.now + 1.day)
-      @reservation_today = place_reservation_for_instrument(@user, @instrument, @account, Time.zone.now)
+      # all reservations get purchased today
+      @reservation_yesterday = place_reservation_for_instrument(@user, @instrument, @account, Time.zone.now - 1.day, purchased: true)
+      @reservation_tomorrow = place_reservation_for_instrument(@user, @instrument, @account, Time.zone.now + 1.day, purchased: true)
+      @reservation_today = place_reservation_for_instrument(@user, @instrument, @account, Time.zone.now, purchased: true)
     end
 
     it "should only return the reservations and the orders from today and tomorrow" do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -152,9 +152,9 @@ RSpec.describe Order do
       it "should start off with an empty order status" do
         @order.order_details.all? { |od| expect(od.order_status).to be_nil }
       end
-      it "should set the ordered_at" do
+      it "should set the ordered_at of all the details" do
         expect(@order.purchase!).to be true
-        expect(@order.ordered_at).not_to be_nil
+        expect(@order.order_details).to all(be_ordered_at)
       end
       it "should add to facility.orders collection" do
         expect(@order.purchase!).to be true
@@ -471,14 +471,20 @@ RSpec.describe Order do
   end
 
   describe "#in_cart?" do
-    context "when ordered_at is set" do
-      subject(:order) { build(:order, ordered_at: Time.zone.now) }
+    context "when it is purchased" do
+      subject(:order) { build(:order, state: :purchased) }
 
       it { expect(order).not_to be_in_cart }
     end
 
-    context "when ordered_at is not set" do
-      subject(:order) { build(:order, ordered_at: nil) }
+    context "when it is new" do
+      subject(:order) { build(:order, state: :new) }
+
+      it { expect(order).to be_in_cart }
+    end
+
+    context "when it is validated" do
+      subject(:order) { build(:order, state: :validated) }
 
       it { expect(order).to be_in_cart }
     end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -48,18 +48,6 @@ RSpec.describe Statement do
       @order_details.each { |od| statement.add_order_detail(od) }
     end
 
-    context "with the ordered_at switched up" do
-      before :each do
-        @order_details[0].order.update_attributes(ordered_at: 2.days.ago)
-        @order_details[1].order.update_attributes(ordered_at: 3.days.ago)
-        @order_details[2].order.update_attributes(ordered_at: 1.day.ago)
-      end
-
-      it "should return the first date" do
-        expect(statement.first_order_detail_date).to eq @order_details[1].ordered_at
-      end
-    end
-
     it "should set the statement_id of each order detail" do
       @order_details.each do |order_detail|
         expect(order_detail.statement_id).to be_present

--- a/spec/report_spec_helper.rb
+++ b/spec/report_spec_helper.rb
@@ -36,7 +36,7 @@ module ReportSpecHelper
             [:owner, :staff, :purchaser].each do |user|
               acct = create_nufs_account_with_owner user
               place_and_complete_item_order(instance_variable_get("@#{user}"), @authable, acct)
-              @order.ordered_at = parse_usa_date(@params[:date_start]) + 15.days
+              @order_detail.ordered_at = parse_usa_date(@params[:date_start]) + 15.days
               assert @order.save
               setup_extra_test_data(user)
             end

--- a/spec/services/transaction_search/date_range_searcher_spec.rb
+++ b/spec/services/transaction_search/date_range_searcher_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe TransactionSearch::DateRangeSearcher do
 
   describe "ordered_at" do
     before do
-      orders[0].update!(ordered_at: 2.days.ago)
-      orders[1].update!(ordered_at: 1.day.ago)
+      order_details[0].update!(ordered_at: 2.days.ago)
+      order_details[1].update!(ordered_at: 1.day.ago)
     end
 
     it "finds only the right ones when starting a day ago" do

--- a/spec/services/transaction_search/searcher_spec.rb
+++ b/spec/services/transaction_search/searcher_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TransactionSearch::Searcher, type: :service do
     let(:scope) { OrderDetail.all.joins(:order) }
     before do
       order_detail.to_complete!
-      order.update(ordered_at: 3.days.ago)
+      order_detail.update(ordered_at: 3.days.ago)
     end
 
     it "can find the order detail with empty params" do

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -45,7 +45,7 @@ end
 def place_product_order(ordered_by, facility, product, account = nil, purchased = true)
   @price_group = FactoryBot.create(:price_group, facility: facility)
 
-  o_attrs = { created_by: ordered_by.id, facility: facility, ordered_at: Time.zone.now }
+  o_attrs = { created_by: ordered_by.id, facility: facility }
   o_attrs[:account_id] = account.id if account
   o_attrs[:state] = "purchased" if purchased
   @order = ordered_by.orders.create(FactoryBot.attributes_for(:order, o_attrs))
@@ -56,6 +56,7 @@ def place_product_order(ordered_by, facility, product, account = nil, purchased 
   @item_pp.reload.restrict_purchase = false
   od_attrs = { product_id: product.id }
   od_attrs[:account_id] = account.id if account
+  od_attrs[:ordered_at] = Time.current if purchased
   od_attrs[:created_by] = @order.created_by
   @order_detail = @order.order_details.create(FactoryBot.attributes_for(:order_detail).update(od_attrs))
 
@@ -112,8 +113,8 @@ end
 #   Other parameters for the reservation; will override the defaults defined below
 #
 # and_return the reservation
-def place_reservation_for_instrument(ordered_by, instrument, account, reserve_start, extra_reservation_attrs = nil)
-  order_detail = place_product_order(ordered_by, instrument.facility, instrument, account, false)
+def place_reservation_for_instrument(ordered_by, instrument, account, reserve_start, extra_reservation_attrs = nil, purchased: false)
+  order_detail = place_product_order(ordered_by, instrument.facility, instrument, account, purchased)
 
   instrument.schedule_rules.create(FactoryBot.attributes_for(:schedule_rule)) if instrument.schedule_rules.empty?
   res_attrs = {

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -203,7 +203,7 @@ def setup_reservation(facility, account, user)
   # create price policy with default window of 1 day
   @instrument.instrument_price_policies.create(FactoryBot.attributes_for(:instrument_price_policy).update(price_group_id: @price_group.id))
   # create order, order detail
-  @order = user.orders.create(FactoryBot.attributes_for(:order, created_by: user.id, account: account, ordered_at: Time.zone.now))
+  @order = user.orders.create(FactoryBot.attributes_for(:order, created_by: user.id, account: account))
   @order.add(@instrument, 1)
   @order_detail = @order.order_details.first
 end

--- a/vendor/engines/projects/app/controllers/projects/projects_controller.rb
+++ b/vendor/engines/projects/app/controllers/projects/projects_controller.rb
@@ -36,6 +36,7 @@ module Projects
     end
 
     def show
+      @order_details = @project.order_details.order(ordered_at: :desc).paginate(page: params[:page])
     end
 
     def update

--- a/vendor/engines/projects/app/views/projects/projects/show.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/show.html.haml
@@ -9,7 +9,7 @@
 
   - @date_range_field = :ordered_at
   = render "shared/transactions/table",
-    order_details: @project.order_details.by_ordered_at.paginate(page: params[:page])
+    order_details: @order_details
 
 = link_to t(".edit"),
   edit_facility_project_path(@project.facility, @project),

--- a/vendor/engines/projects/spec/controllers/reports/general_reports_controller_spec.rb
+++ b/vendor/engines/projects/spec/controllers/reports/general_reports_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Reports::GeneralReportsController do
   let(:facility) { item.facility }
   let(:item) { FactoryBot.create(:setup_item) }
-  let!(:order) { FactoryBot.create(:purchased_order, product: item, ordered_at: 1.month.ago) }
+  let!(:order) { FactoryBot.create(:purchased_order, product: item) }
   let!(:no_project_order) { FactoryBot.create(:purchased_order, product: item) }
   let(:project) { FactoryBot.create(:project, facility: facility) }
   let(:administrator) { FactoryBot.create(:user, :administrator) }

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
@@ -17,11 +17,11 @@ module SangerSequencing
 
     accepts_nested_attributes_for :samples, allow_destroy: true
 
-    delegate :order_id, :user, :order_status, :note, :product, to: :order_detail
-    delegate :purchased?, :ordered_at, to: :order
+    delegate :order_id, :user, :order_status, :note, :product, :ordered_at, to: :order_detail
+    delegate :purchased?, to: :order
     alias purchased_at ordered_at
 
-    scope :purchased, -> { joins(:order).merge(Order.purchased.order(ordered_at: :desc)) }
+    scope :purchased, -> { joins(order_detail: :order).merge(Order.purchased).merge(OrderDetail.order(ordered_at: :desc)) }
     scope :for_facility, ->(facility) { where(orders: { facility_id: facility.id }) }
 
     BATCHABLE_STATES = %w(new inprocess complete).freeze

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/access_handlers/order_handler_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/access_handlers/order_handler_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe SecureRooms::AccessHandlers::OrderHandler, type: :service do
         it { is_expected.to be_purchased }
 
         it "sets ordered_at" do
-          expect(order.ordered_at).to be_present
+          expect(order.order_details.map(&:ordered_at)).to all(be_present)
         end
 
         it "stores the associations from the Occupancy" do


### PR DESCRIPTION
# Release Notes

Tech task: Move `Order#ordered_at` onto `OrderDetail`.

# Additional Context

This is in preparation for a feature where adding to an existing order will take the current time rather than the original cart's timestamp.

This will affect the BI queries. I completely removed the field from `orders` to verify I got all the references. I could be convinced that we should leave the original field temporarily for BI.