### PR TITLE
[#147850] Set ordered_at when adding to an order

### DIFF
--- a/app/forms/add_to_order_form.rb
+++ b/app/forms/add_to_order_form.rb
@@ -79,6 +79,10 @@ class AddToOrderForm
     OrderDetail.transaction do
       merge_order.add(product, quantity, params).each do |order_detail|
         order_detail.manual_fulfilled_at = fulfilled_at
+        # `fulfilled_at` is a string which might get misinterpretted as DD/MM instead of MM/DD
+        if order_detail.valid_for_purchase?
+          order_detail.ordered_at = order_detail.manual_fulfilled_at_time || Time.current
+        end
         order_detail.set_default_status!
         order_detail.change_status!(order_status) if order_status.present?
 

--- a/app/forms/add_to_order_form.rb
+++ b/app/forms/add_to_order_form.rb
@@ -78,11 +78,8 @@ class AddToOrderForm
   def add_to_order!
     OrderDetail.transaction do
       merge_order.add(product, quantity, params).each do |order_detail|
-        order_detail.manual_fulfilled_at = fulfilled_at
-        # `fulfilled_at` is a string which might get misinterpretted as DD/MM instead of MM/DD
-        if order_detail.valid_for_purchase?
-          order_detail.ordered_at = order_detail.manual_fulfilled_at_time || Time.current
-        end
+        backdate(order_detail)
+
         order_detail.set_default_status!
         order_detail.change_status!(order_status) if order_status.present?
 
@@ -122,6 +119,16 @@ class AddToOrderForm
                    else
                      original_order
                    end
+  end
+
+  def backdate(order_detail)
+    # `fulfilled_at` is a string and might get misinterpretted as DD/MM instead of MM/DD.
+    # `manual_fulfilled_at` already handles the proper string parsing so we can use
+    # it instead of duplicating the parsing effort.
+    order_detail.manual_fulfilled_at = fulfilled_at
+    if order_detail.valid_for_purchase?
+      order_detail.ordered_at = order_detail.manual_fulfilled_at_time || Time.current
+    end
   end
 
 end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -835,12 +835,12 @@ class OrderDetail < ApplicationRecord
     @manual_fulfilled_at = ValidFulfilledAtDate.new(string)
   end
 
-  def valid_manual_fulfilled_at
-    errors.add(:fulfilled_at, @manual_fulfilled_at.error) if @manual_fulfilled_at&.invalid?
-  end
-
   def manual_fulfilled_at_time
     @manual_fulfilled_at&.to_time
+  end
+
+  def valid_manual_fulfilled_at
+    errors.add(:fulfilled_at, @manual_fulfilled_at.error) if @manual_fulfilled_at&.invalid?
   end
 
   def time_data

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -839,6 +839,10 @@ class OrderDetail < ApplicationRecord
     errors.add(:fulfilled_at, @manual_fulfilled_at.error) if @manual_fulfilled_at&.invalid?
   end
 
+  def manual_fulfilled_at_time
+    @manual_fulfilled_at&.to_time
+  end
+
   def time_data
     if product.respond_to?(:time_data_field)
       public_send(product.time_data_field) || TimeData::RequiredTimeData.new

--- a/app/models/order_detail_observer.rb
+++ b/app/models/order_detail_observer.rb
@@ -12,12 +12,15 @@ class OrderDetailObserver < ActiveRecord::Observer
     order = order_detail.order
     product = order_detail.product
 
+    # Is the order 100% ready to be merged?
+    # TODO: Can this be changed to `order.to_be_merged? && order_detail.valid_for_purchase?
     if order.to_be_merged? && (product.is_a?(Item) ||
                               (product.is_a?(Service) && order_detail.valid_service_meta?) ||
                               (product.is_a?(Instrument) && order_detail.valid_reservation?))
 
-      # move this detail to the original order if it is 100% valid
+      # move this detail to the original order and update its ordered_at
       order_detail.order_id = order.merge_order.id
+      order_detail.ordered_at = order_detail.fulfilled_at || Time.current
     end
   end
 

--- a/app/models/order_detail_observer.rb
+++ b/app/models/order_detail_observer.rb
@@ -13,12 +13,12 @@ class OrderDetailObserver < ActiveRecord::Observer
     product = order_detail.product
 
     # Is the order 100% ready to be merged?
-    # TODO: Can this be changed to `order.to_be_merged? && order_detail.valid_for_purchase?
     if order.to_be_merged? && (product.is_a?(Item) ||
                               (product.is_a?(Service) && order_detail.valid_service_meta?) ||
                               (product.is_a?(Instrument) && order_detail.valid_reservation?))
 
-      # move this detail to the original order and update its ordered_at
+      # move this detail to the original order and backdate its ordered_at if
+      # it was ordered in the past.
       order_detail.order_id = order.merge_order.id
       order_detail.ordered_at = order_detail.fulfilled_at || Time.current
     end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
     transient do
       product { nil }
       quantity { 1 }
+      ordered_at { Time.current }
     end
     facility { product.facility }
     association :account, factory: :setup_account
@@ -43,6 +44,7 @@ FactoryBot.define do
         order.order_details_ordered_at = evaluator.ordered_at
         order.validate_order!
         order.purchase!
+        order.order_details.update_all(ordered_at: evaluator.ordered_at)
       end
     end
 

--- a/spec/features/admin/adding_to_an_order_spec.rb
+++ b/spec/features/admin/adding_to_an_order_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "Adding to an existing order" do
   let(:facility) { product.facility }
-  let(:order) { create(:purchased_order, product: product) }
+  let(:order) { create(:purchased_order, product: product, ordered_at: 1.week.ago) }
   let(:user) { create(:user, :staff, facility: facility) }
   let!(:other_account) { create(:nufs_account, :with_account_owner, owner: order.user, description: "Other Account") }
 
@@ -31,9 +31,13 @@ RSpec.describe "Adding to an existing order" do
         expect(order.reload.order_details.count).to eq(2)
         expect(order.order_details.last.note).to eq("My Note")
       end
+
+      it "sets the ordered_at to now" do
+        expect(order.order_details.order(:id).last.ordered_at).to be_within(1.second).of(Time.current)
+      end
     end
 
-    describe "adding it as Complete" do
+    describe "adding it as Complete with a backdate" do
       let(:fulfilled_at_string) { I18n.l(1.day.ago.to_date, format: :usa) }
 
       before do
@@ -44,8 +48,10 @@ RSpec.describe "Adding to an existing order" do
 
       it "has a new order detail with the right status and fulfilled_at" do
         expect(order.reload.order_details.count).to eq(2)
-        expect(order.order_details.last).to be_complete
-        expect(I18n.l(order.order_details.last.fulfilled_at.to_date, format: :usa)).to eq(fulfilled_at_string)
+        new_order_detail = order.order_details.order(:id).last
+        expect(new_order_detail).to be_complete
+        expect(I18n.l(new_order_detail.fulfilled_at.to_date, format: :usa)).to eq(fulfilled_at_string)
+        expect(I18n.l(new_order_detail.ordered_at.to_date, format: :usa)).to eq(fulfilled_at_string)
       end
     end
 
@@ -92,16 +98,31 @@ RSpec.describe "Adding to an existing order" do
       click_button "Add To Order"
     end
 
+    it "does not have an ordered_at yet" do
+      expect(order.reload.order_details.count).to be(1)
+      expect(OrderDetail.order(:id).last.ordered_at).to be_blank
+    end
+
     it "requires a file to be uploaded before adding to the order" do
       expect(page).to have_content("The following order details need your attention.")
+    end
 
-      click_link "Upload Order Form"
-      attach_file "stored_file[file]", Rails.root.join("spec", "files", "template1.txt")
-      click_button "Upload"
+    describe "after uploading the file" do
+      before do
+        click_link "Upload Order Form"
+        attach_file "stored_file[file]", Rails.root.join("spec", "files", "template1.txt")
+        click_button "Upload"
+      end
 
-      expect(order.reload.order_details.count).to be(2)
-      expect(order.order_details.last).to be_complete
-      expect(I18n.l(order.order_details.last.fulfilled_at.to_date, format: :usa)).to eq(fulfilled_at_string)
+      it "sets the expected attributes", :aggregate_failures do
+        expect(order.reload.order_details.count).to be(2)
+
+        new_order_detail = order.order_details.order(:id).last
+
+        expect(new_order_detail).to be_complete
+        expect(I18n.l(new_order_detail.fulfilled_at.to_date, format: :usa)).to eq(fulfilled_at_string)
+        expect(I18n.l(new_order_detail.ordered_at.to_date, format: :usa)).to eq(fulfilled_at_string)
+      end
     end
   end
 

--- a/spec/features/admin/adding_to_an_order_spec.rb
+++ b/spec/features/admin/adding_to_an_order_spec.rb
@@ -58,12 +58,12 @@ RSpec.describe "Adding to an existing order" do
     describe "adding it to another account" do
       describe "while the original account is still active" do
         before do
-          select other_account, from: "Payment Source"
+          select other_account.to_s, from: "Payment Source"
           click_button "Add To Order"
         end
 
         it "creates the order detail with the new account" do
-          click_link(order.reload.order_details.last)
+          click_link(order.reload.order_details.last.to_s)
           expect(page).to have_select("Payment Source", selected: other_account.to_s)
         end
       end


### PR DESCRIPTION
# Release Notes

Set ordered_at to "now" or match fulfilled at when adding onto an existing order.

# Additional Context

This continues from #2116.

When ordering on behalf: Orders take on whatever date/time you put it under the "More options". If left blank, or unexpanded, it defaults to setting ordered_at to "now". This behavior should be unchanged.

When adding to an order:

"New" orders - get "now" as the ordered_at. If it's a reservation/service with order form, the order will receive the ordered_at of when the details gets fully added to the order (once you've resolved any issues like uploading the order form).
"Complete" - if you set a fulfilled at, both fulfilled_at and ordered_at will take on that time (the logic we've used is 12:00 noon Chicago time of the date you put in)
If you don't set a fulfilled date, both fulfilled_at ordered_at will fall back to "now".

Imported orders have an ordered at column. This will continue to be used. It's just the location of the column is on a different table.

Secure Rooms/Doors should maintain their same behavior.
