### PR TITLE
[#152015] Fix error on receipts containing sanger results files

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,9 @@ module Nucore
 
     config.active_record.observers = :order_detail_observer
 
+    # Override the default ("#{Rails.root}/**/spec/mailers/previews") to also load
+    # previews from within our engines.
+    config.action_mailer.preview_path = "#{Rails.root}/**/spec/mailers/previews"
   end
 
 end

--- a/vendor/engines/sanger_sequencing/app/presenters/sanger_sequencing/receipt_submission_presenter.rb
+++ b/vendor/engines/sanger_sequencing/app/presenters/sanger_sequencing/receipt_submission_presenter.rb
@@ -14,7 +14,7 @@ module SangerSequencing
 
     def to_s
       return "" unless submission
-      render("sanger_sequencing/submissions/samples_table", submission: submission, caption: caption)
+      render("sanger_sequencing/purchase_notifier/samples_table", submission: submission, caption: caption)
         .safe_concat(render(body: print_me_text))
     end
 

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/purchase_notifier/_samples_table.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/purchase_notifier/_samples_table.html.haml
@@ -1,5 +1,7 @@
 %div
   %table.table.table-striped.table-tight
+    - if local_assigns[:caption]
+      %caption= local_assigns[:caption]
     %thead
       %tr
         %th= SangerSequencing::Sample.human_attribute_name(:customer_sample_id)
@@ -11,8 +13,3 @@
         %tr
           %td= sample.customer_sample_id
           %td= sample.id
-          - if submission.has_results_files?
-            %td
-              %ul.unstyled
-                - sample.results_files.each do |file|
-                  %li= link_to file.name, facility_sample_result_path(file)

--- a/vendor/engines/sanger_sequencing/spec/mailers/previews/purchase_notifier_preview.rb
+++ b/vendor/engines/sanger_sequencing/spec/mailers/previews/purchase_notifier_preview.rb
@@ -1,0 +1,12 @@
+class PurchaseNotifierPreview < ActionMailer::Preview
+
+  def sanger_order_notification
+    submission = NUCore::Database.random(SangerSequencing::Submission.joins(:order_detail).merge(OrderDetail.purchased))
+    order_detail = submission.order_detail
+    PurchaseNotifier.order_notification(
+      order_detail.order,
+      order_detail.user,
+    )
+  end
+
+end

--- a/vendor/engines/sanger_sequencing/spec/mailers/purchase_notifier_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/mailers/purchase_notifier_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+require_relative "../support/shared_contexts/setup_sanger_service"
+
+RSpec.describe PurchaseNotifier, type: :mailer do
+  include_context "Setup Sanger Service"
+
+  let!(:order) { FactoryBot.create(:purchased_order, product: service, account: account) }
+  let(:order_detail) { order.order_details.first }
+  let!(:submission) { FactoryBot.create(:sanger_sequencing_submission, order_detail: order_detail, sample_count: 3) }
+
+  let(:external_service) { create(:external_service, location: new_sanger_sequencing_submission_path) }
+  let!(:sanger_order_form) { create(:external_service_passer, external_service: external_service, active: true, passer: service) }
+  let!(:receiver) do
+    ExternalServiceReceiver.create(
+      external_service: external_service,
+      receiver: order_detail,
+      response_data: { show_url: sanger_sequencing_submission_path(submission) }.to_json,
+    )
+  end
+  let(:mailer) { described_class.order_notification(order, order.user) }
+
+  it "includes the samples in the mailer" do
+    expect(mailer.body.encoded).to include(submission.samples.first.customer_sample_id)
+  end
+
+  describe "when the sample has results" do
+    let!(:result) { FactoryBot.create(:stored_file, :results, name: "#{submission.samples.first.id}_test.txt", order_detail: order_detail) }
+
+    it "includes the samples in the mailer" do
+      expect(mailer.body.encoded).to include(submission.samples.first.customer_sample_id)
+    end
+  end
+
+end


### PR DESCRIPTION
# Release Notes

Fix rare error when sending receipts for orders containing Sanger Sequencing submissions which have already been fulfilled and have results files uploaded.

# Additional Context

`ActionView::Template::Error: undefined method `facility_sample_result_path'` because the path helper is not available in the mailer, but there was a partial that was being shared between regular web views and the email.

This should normally not be an issue since the receipt is usually sent immediately on purchase, so logically it hasn't been fulfilled and no results files have been uploaded. However, on the facility admin's order view, there is a "Send Receipt" button which re-triggers the email, so there is a possibility of this error being triggered in the future.

It also happened when delayed_job had crashed for a couple days and receipts for fulfilled orders were still queued up.

See https://rollbar.com/tablexi/nucore-dartmouth/items/138/ and https://rollbar.com/tablexi/nucore-dartmouth/items/162/