### PR TITLE
[#147850] Set ordered_at for accessories

### DIFF
--- a/app/support/accessories/accessorizer.rb
+++ b/app/support/accessories/accessorizer.rb
@@ -115,7 +115,8 @@ class Accessories::Accessorizer
                 note: options[:note],
                 quantity: options[:quantity],
                 product_accessory: product_accessory(accessory),
-                state: "new")
+                state: "new",
+                ordered_at: Time.current)
   end
 
   def current_accessories

--- a/app/support/accessories/accessorizer.rb
+++ b/app/support/accessories/accessorizer.rb
@@ -109,14 +109,15 @@ class Accessories::Accessorizer
   end
 
   def detail_attributes(accessory, options)
-    attrs = @order_detail.attributes.slice("account_id", "created_by")
-    attrs.merge(order: @order_detail.order,
-                product: accessory,
-                note: options[:note],
-                quantity: options[:quantity],
-                product_accessory: product_accessory(accessory),
-                state: "new",
-                ordered_at: Time.current)
+    attrs = @order_detail.attributes.slice("account_id", "created_by", "ordered_at")
+    attrs.merge(
+      order: @order_detail.order,
+      product: accessory,
+      note: options[:note],
+      quantity: options[:quantity],
+      product_accessory: product_accessory(accessory),
+      state: "new",
+    )
   end
 
   def current_accessories

--- a/spec/models/order_details/accessorized_order_detail_spec.rb
+++ b/spec/models/order_details/accessorized_order_detail_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OrderDetail do
   let(:instrument) { FactoryBot.create(:setup_instrument, :timer) }
   let(:facility) { instrument.facility }
   let(:reservation) { FactoryBot.create(:completed_reservation, product: instrument) }
-  let(:order_detail) { reservation.order_detail.tap { |od| od.update(note: "original") } }
+  let(:order_detail) { reservation.order_detail.tap { |od| od.update(note: "original", ordered_at: 1.day.ago) } }
   let(:accessorizer) { Accessories::Accessorizer.new(order_detail) }
 
   before :each do
@@ -45,8 +45,8 @@ RSpec.describe OrderDetail do
       expect(accessory_order_detail.reload.account).to eq new_account
     end
 
-    it "has an ordered_at" do
-      expect(accessory_order_detail.ordered_at).to be_present
+    it "takes the ordered_at of the original order" do
+      expect(accessory_order_detail.ordered_at).to eq(order_detail.ordered_at)
     end
   end
 

--- a/spec/models/order_details/accessorized_order_detail_spec.rb
+++ b/spec/models/order_details/accessorized_order_detail_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe OrderDetail do
       expect(accessory_order_detail.quantity).to eq(reservation.actual_duration_mins)
     end
 
-    skip "defaults to 1 if less than a minute" do
-      reservation.update_attributes(actual_end_at: reservation.actual_start_at + 30.seconds)
-      expect(reservation.actual_duration_mins).to eq(0)
+    it "defaults to 1 if less than a minute" do
+      reservation.update_attributes(actual_end_at: reservation.actual_start_at + 29.seconds)
+      expect(reservation.actual_duration_mins).to eq(1)
       expect(accessory_order_detail.reload.quantity).to eq(1)
     end
 
@@ -118,9 +118,9 @@ RSpec.describe OrderDetail do
       expect(accessory_order_detail.quantity).to eq(reservation.actual_duration_mins)
     end
 
-    skip "defaults to 1 if less than a minute" do
-      reservation.update_attributes(actual_end_at: reservation.actual_start_at + 30.seconds)
-      expect(reservation.actual_duration_mins).to eq(0)
+    it "defaults to 1 if less than a minute" do
+      reservation.update_attributes(actual_end_at: reservation.actual_start_at + 29.seconds)
+      expect(reservation.actual_duration_mins).to eq(1)
       expect(accessory_order_detail.reload.quantity).to eq(1)
     end
 

--- a/spec/models/order_details/accessorized_order_detail_spec.rb
+++ b/spec/models/order_details/accessorized_order_detail_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe OrderDetail do
       order_detail.update_attributes(account: new_account)
       expect(accessory_order_detail.reload.account).to eq new_account
     end
+
+    it "has an ordered_at" do
+      expect(accessory_order_detail.ordered_at).to be_present
+    end
   end
 
   context "quantity based accessory" do


### PR DESCRIPTION
# Release Notes

Set `ordered_at` when adding an accessory to a reservation to match the original order's `ordered_at`.

# Additional Context

Using the original order's `ordered_at` is what the client decided over using the timestamp of when the accessory is actually added.