### PR TITLE
[#169636849] Accessibility tweaks

### DIFF
--- a/app/assets/stylesheets/app/homepage.scss
+++ b/app/assets/stylesheets/app/homepage.scss
@@ -1,0 +1,34 @@
+li.facility_listing {
+  &.recent {
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
+
+  .facility_listing__header {
+    font-size: 1rem;
+    font-weight: bold;
+    line-height: 1.5rem;
+  }
+}
+
+.product_list {
+  ul {
+    @extend .unstyled;
+  }
+  input {
+    width: 2em;
+    padding: 0 3px;
+    margin-top: 5px;
+    margin-bottom: 5px;
+  }
+  a.fa-calendar {
+    text-decoration: none;
+    color: $textColor;
+    &.available {
+      color: $successText;
+    }
+    &.in-use {
+      color: $errorText;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,7 @@ $baseFontSize: 12px; // Default is 14px
 @import "app/product_list";
 @import "app/chosen-override";
 @import "app/global_alert_banner";
+@import "app/homepage";
 
 @import "fine-uploader/fine-uploader-new";
 @import "fine-uploader-override";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
-$baseFontSize: 12px;
+$baseFontSize: 12px; // Default is 14px
 
+@import "bootstrap-accessibility";
 @import "bootstrap-variables";
 @import "bootstrap";
 @import "bootstrap-responsive";

--- a/app/assets/stylesheets/bootstrap-accessibility.scss
+++ b/app/assets/stylesheets/bootstrap-accessibility.scss
@@ -1,0 +1,24 @@
+/***
+ * Override some of Bootstrap's defaults to address accessibility issues like
+ * color contrast.
+ ***/
+
+// Darken the default color to reach 4.5:1 against a white background
+$linkColor: darken(#0088cc, 3.5%);
+
+/***
+ * Alerts. The raw colors represent Bootstrap's default colors. The darken/lighten
+ * percentages were largely trial and error to reach a 4.5:1 contrast;
+ ***/
+$warningText: darken(#c09853, 16%);
+$warningBackground: lighten(#fcf8e3, 3%);
+
+$errorText: darken(#b94a48, 3.5%);
+$errorBackground: lighten(#f2dede, 1%);
+
+$successText: darken(#468847, 4.5%);
+$successBackground: lighten(#dff0d8, 3%);
+
+$infoText: darken(#3a87ad, 6.7%);
+$infoBackground: lighten(#d9edf7, 2.2%);
+

--- a/app/assets/stylesheets/bootstrap-accessibility.scss
+++ b/app/assets/stylesheets/bootstrap-accessibility.scss
@@ -8,7 +8,9 @@
 $linkColor: darken(#0088cc, 4.5%);
 
 /***
- * Alerts. The raw colors represent Bootstrap's default colors. The darken/lighten
+ * Alerts
+ *
+ * The raw colors represent Bootstrap's default colors. The darken/lighten
  * percentages were largely trial and error to reach a 4.5:1 contrast;
  ***/
 $warningText: darken(#c09853, 16%);
@@ -23,3 +25,10 @@ $successBackground: lighten(#dff0d8, 3%);
 $infoText: darken(#3a87ad, 6.7%);
 $infoBackground: lighten(#d9edf7, 2.2%);
 
+/***
+ * Badges/Labels
+ *
+ * Badges/labels with white text such as warnings (orange background) may technically
+ * fail the contrast ratio checks, but are more readable than with  dark text.
+ * See https://modus.medium.com/the-myths-of-color-contrast-accessibility-4b7fcba77317
+ ***/

--- a/app/assets/stylesheets/bootstrap-accessibility.scss
+++ b/app/assets/stylesheets/bootstrap-accessibility.scss
@@ -3,8 +3,9 @@
  * color contrast.
  ***/
 
-// Darken the default color to reach 4.5:1 against a white background
-$linkColor: darken(#0088cc, 3.5%);
+// Darken the default color to reach 4.5:1 against both a white background and
+// a light gray background like we use in some of our tables
+$linkColor: darken(#0088cc, 4.5%);
 
 /***
  * Alerts. The raw colors represent Bootstrap's default colors. The darken/lighten

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -140,32 +140,6 @@ li.nav-spacer {
 }
 
 /*
-  Product List
-*/
-
-.product_list {
-  ul {
-    @extend .unstyled;
-  }
-  input {
-    width: 2em;
-    padding: 0 3px;
-    margin-top: 5px;
-    margin-bottom: 5px;
-  }
-  a.fa-calendar {
-    text-decoration: none;
-    color: $textColor;
-    &.available {
-      color: $successText;
-    }
-    &.in-use {
-      color: $errorText;
-    }
-  }
-}
-
-/*
   Product View
 */
 

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -139,10 +139,6 @@ li.nav-spacer {
   margin-bottom: 0;
 }
 
-.alert {
-  color: #24506B; // minimum lightness for WCAG AAA compliance (accessibility).
-}
-
 /*
   Product List
 */

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -85,7 +85,7 @@ li.nav-spacer {
 
 .footer__copyright {
   font-size: 85%;
-  color: #919191;
+  color: #595959; // maximum lightness for WCAG AAA compliance (accessibility).
   text-align: right;
   float: right;
 }
@@ -137,6 +137,10 @@ li.nav-spacer {
 
 .alert p:last-child {
   margin-bottom: 0;
+}
+
+.alert {
+  color: #24506B; // minimum lightness for WCAG AAA compliance (accessibility).
 }
 
 /*

--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -1,7 +1,7 @@
 /* Bootstrap overrides go here. This is included after bootstrap. */
 $navCollapseBackgroundColor: #f7f7f7;
 $navbarLinkColorActive: #e6e6e6;
-$navCollapseColor: #777;
+$navCollapseColor: #545454; // maximim lightness for WCAG AAA compliance (accessibility).
 $navbarActiveBorderColor: #aaa;
 
 /* 979px - 980px is where nav-collapse gets triggered */

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -78,10 +78,10 @@ module DateHelper
 
   # This is to DRY up many of the legacy places where hour/min/meridian is used in forms
   def time_select(f, field, options_tag = {}, html_options = {})
-    output =  f.select(:"#{field}_hour", (1..12).to_a, {}, html_options)
-    output += f.select(:"#{field}_min", minute_options(options_tag[:minute_step]), {}, html_options)
-    output += f.select(:"#{field}_meridian", %w(AM PM), {}, html_options)
-    content_tag :div, output.html_safe, class: "time-select"
+    output =  f.select(:"#{field}_hour", (1..12).to_a, {}, html_options.merge("aria-label": f.object.class.human_attribute_name("#{field}_hour")))
+    output.safe_concat f.select(:"#{field}_min", minute_options(options_tag[:minute_step]), {}, html_options.merge("aria-label": f.object.class.human_attribute_name("#{field}_min")))
+    output.safe_concat f.select(:"#{field}_meridian", %w(AM PM), {}, html_options.merge("aria-label": f.object.class.human_attribute_name("#{field}_meridian")))
+    content_tag :div, output, class: "time-select"
   end
 
   def time_select24(f, field, options = {})

--- a/app/views/facilities/_facilities_list.html.haml
+++ b/app/views/facilities/_facilities_list.html.haml
@@ -1,9 +1,10 @@
 - if @facilities.any?
   %h2.facility_listing.js--facility_listing.all_header= text(".all")
-  - @azlist.map.with_index do |(letter, matched_facilities), index|
-    - matched_facilities.each do |facility|
-      .facility_listing.js--facility_listing{ class: az_classname_for_facility(index, letter) }
-        %h3.header-tight= link_to facility, facility_path(facility)
-        %p= facility.short_description
+  %ul.unstyled
+    - @azlist.map.with_index do |(letter, matched_facilities), index|
+      - matched_facilities.each do |facility|
+        %li.facility_listing.js--facility_listing{ class: az_classname_for_facility(index, letter) }
+          .facility_listing.facility_listing__header= link_to facility, facility_path(facility)
+          %p= facility.short_description
 - else
   .alert.alert-info= text("none")

--- a/app/views/facilities/_facilities_list.html.haml
+++ b/app/views/facilities/_facilities_list.html.haml
@@ -1,9 +1,9 @@
 - if @facilities.any?
-  %h4.facility_listing.js--facility_listing.all_header= text(".all")
+  %h2.facility_listing.js--facility_listing.all_header= text(".all")
   - @azlist.map.with_index do |(letter, matched_facilities), index|
     - matched_facilities.each do |facility|
       .facility_listing.js--facility_listing{ class: az_classname_for_facility(index, letter) }
-        %h4.header-tight= link_to facility, facility_path(facility)
+        %h3.header-tight= link_to facility, facility_path(facility)
         %p= facility.short_description
 - else
   .alert.alert-info= text("none")

--- a/app/views/facilities/_product.html.haml
+++ b/app/views/facilities/_product.html.haml
@@ -2,8 +2,8 @@
   - if local_assigns[:f]
     = f.fields_for :order_details do |builder|
       - if session_user.can_override_restrictions?(product) || product.can_be_used_by?(acting_user)
-        = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil
-        = builder.hidden_field :product_id, value: product.id, index: nil
+        = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil, aria: { label: text("quantity", product: product) }, id: "order_order_details_#{product.id}_quantity"
+        = builder.hidden_field :product_id, value: product.id, index: nil, id: "order_order_details_#{product.id}_product_id"
   = public_calendar_link(product)
   = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(product.facility, product)
   - if acting_user.present? && !product.can_be_used_by?(acting_user)

--- a/app/views/facilities/_recently_used_facilities.html.haml
+++ b/app/views/facilities/_recently_used_facilities.html.haml
@@ -1,5 +1,6 @@
 - if @recently_used_facilities.present?
-  %h4.facility_listing.js--facility_listing.recent= text("title")
-  - @recently_used_facilities.each do |facility|
-    .facility_listing.js--facility_listing.recent
-      %h4.header-tight= link_to facility, facility_path(facility)
+  %h3.facility_listing.js--facility_listing.recent= text("title")
+  %ul.unstyled
+    - @recently_used_facilities.each do |facility|
+      %li.facility_listing.js--facility_listing.recent
+        = link_to facility, facility_path(facility)

--- a/app/views/facilities/_recently_used_products.html.haml
+++ b/app/views/facilities/_recently_used_products.html.haml
@@ -1,5 +1,5 @@
 - if products.any?
-  %h4= text("title")
+  %h3= text("title")
   .product_list
     %ul
       = render partial: "product", collection: products

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -15,7 +15,10 @@
       .container
         .row
           .span12
-            %h1= yield :h1
+            - if content_for?(:h1)
+              %h1= yield :h1
+            - else
+              %hr
             = yield :tabnav
             = render partial: "shared/flashes"
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-%html
+%html{lang: "en"}
   %head
     = render "/shared/head"
   %body{ class: SettingsHelper.feature_on?(:use_manage) && manage_mode? ? "manage-mode" : "" }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -15,13 +15,11 @@
       .container
         .row
           .span12
-            - if content_for?(:h1)
-              %h1= yield :h1
-            - else
-              %hr
+            %h1= yield :h1
             = yield :tabnav
             = render partial: "shared/flashes"
 
+            %div{aria: { role: "main" }}
             = yield
     %footer
       = render "/shared/footer"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,7 +11,7 @@
     %nav
       = render "/shared/nav"
     = render "/shared/breadcrumb", breadcrumb: yield(:breadcrumb)
-    #content
+    #content{ role: "main" }
       .container
         .row
           .span12
@@ -19,7 +19,6 @@
             = yield :tabnav
             = render partial: "shared/flashes"
 
-            %div{aria: { role: "main" }}
             = yield
     %footer
       = render "/shared/footer"

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -27,6 +27,7 @@
             as: :order_detail_quantity,
             disabled: order_detail.quantity_locked_by_survey?,
             input_html: { name: "quantity#{order_detail.id}",
+            aria: { label: "#{order_detail.product} #{OrderDetail.human_attribute_name(:quantity)}" },
             id: "quantity#{order_detail.id}",
             class: "cart__quantityField" },
             label: false

--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -52,14 +52,14 @@
 
     - url_after_action = facility_path(@instrument.facility)
     %li
-    - if @order.to_be_merged?
-      = link_to t("shared.cancel"), facility_order_path(@instrument.facility, @order.merge_order)
-    - elsif @order_detail.bundled?
-      = link_to t("shared.cancel"), url_after_action
-    - else
-      = link_to t("shared.cancel"),
-        remove_order_path(@order, @order_detail, redirect_to: url_after_action),
-        method: :put
+      - if @order.to_be_merged?
+        = link_to t("shared.cancel"), facility_order_path(@instrument.facility, @order.merge_order)
+      - elsif @order_detail.bundled?
+        = link_to t("shared.cancel"), url_after_action
+      - else
+        = link_to t("shared.cancel"),
+          remove_order_path(@order, @order_detail, redirect_to: url_after_action),
+          method: :put
 
 #overlay
   #spinner

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -42,6 +42,6 @@
               - if responsive? && !acting_as? && current_user
                 %li
                   = form_tag global_search_path, class: "navbar-search pull-right hidden-with-nav" do
-                    = text_field_tag :search, nil, placeholder: t("global_search.search"), class: "search-query span2", "aria-label": "Search"
+                    = text_field_tag :search, nil, placeholder: t("global_search.search"), class: "search-query span2", aria: { label: t("global_search.search") }
 
 

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -40,7 +40,8 @@
               = render "shared/message_summary"
               %li= link_to t('pages.logout'), sign_out_user_path
               - if responsive? && !acting_as? && current_user
-                = form_tag global_search_path, class: "navbar-search pull-right hidden-with-nav" do
-                  = text_field_tag :search, nil, placeholder: t("global_search.search"), class: "search-query span2"
+                %li
+                  = form_tag global_search_path, class: "navbar-search pull-right hidden-with-nav" do
+                    = text_field_tag :search, nil, placeholder: t("global_search.search"), class: "search-query span2", "aria-label": "Search"
 
 

--- a/app/views/shared/nav/_nav_links.html.haml
+++ b/app/views/shared/nav/_nav_links.html.haml
@@ -23,7 +23,7 @@
 
 -# .visible-with-nav is visible > 979px
 = form_tag global_search_path, class: "navbar-search pull-right visible-with-nav" do
-  = text_field_tag :search, nil, placeholder: t("global_search.search"), class: "search-query span2"
+  = text_field_tag :search, nil, placeholder: t("global_search.search"), class: "search-query span2", "aria-label": "navSearch"
 
 -# trailing "<" enables use of .nav-collapse .nav:empty in boostrap-responsive-overrides.scss
 %ul.nav.pull-right<

--- a/app/views/shared/nav/_nav_links.html.haml
+++ b/app/views/shared/nav/_nav_links.html.haml
@@ -23,7 +23,7 @@
 
 -# .visible-with-nav is visible > 979px
 = form_tag global_search_path, class: "navbar-search pull-right visible-with-nav" do
-  = text_field_tag :search, nil, placeholder: t("global_search.search"), class: "search-query span2", "aria-label": "navSearch"
+  = text_field_tag :search, nil, placeholder: t("global_search.search"), class: "search-query span2", aria: { label: t("global_search.search") }
 
 -# trailing "<" enables use of .nav-collapse .nav:empty in boostrap-responsive-overrides.scss
 %ul.nav.pull-right<

--- a/config/locales/views/en.facilities.yml
+++ b/config/locales/views/en.facilities.yml
@@ -13,7 +13,8 @@ en:
       facilities_list:
         all: All !Facilities!
         none: "No !facilities_downcase! are available at this time."
-
+      product:
+        quantity: "%{product} Quantity"
       azlist:
         all_short: All
         recently_used_short: Recent


### PR DESCRIPTION
Adds several tweaks to make nucore slightly more accessible. To identify the issues we have within nucore I used a browser extention called Axe. To find the most suitable contrast ratios for our colors I used a contrast tool found here: https://webaim.org/resources/contrastchecker/.


Outside of the changes introduced here there were a number of additional warnings that I either was not able to fix, or did not find it necessary to fix.

1. "IDs of active elements must be unique" - I was unable to fix this due to how we adjust the navbar based on screen size. Within the code, we dynamically assign IDs depending on the link type, which means we generate the same ID for the same link within the dropdown nav and the static nav on larger screens. I tinkered with it for a while, but was unable to find a solution that didn't involve completely changing our existing logic. Ultimately, since one nav is hidden and the other is visible at any given time, I thought it was best to skip any potentially involved work here.

2. "Headings must not be empty" - Skipped due to the fact that it is not a violation, just a missed opportunity at a "Best Practice". We populate an h1 as a result of a block yeild, it's empty if the block does not return anything.

3. "Document must have one main landmark" - Also skipped due to not being a violation.

Other notes:
- If running tests locally, whatever tool you use may throw errors related to color contrast. Many of these errors are due to a tool's inability to determine the color contrast rather than an actual violation. I manually inspected each potential violation and adjusted the colors accordingly. A tool may not be able to discern contrast due to usage of gradiants, or overlapping divs.
