### PR TITLE
[#152079] Fix error on merge orders containing timed services

### DIFF
--- a/app/views/facility_orders/_merge_order.html.haml
+++ b/app/views/facility_orders/_merge_order.html.haml
@@ -14,18 +14,18 @@
 
       %tbody
         - @merge_orders.each do |order|
-          - order.order_details.each do |detail|
+          - order.order_details.each do |order_detail|
             %tr
-              %td.centered= link_to "Remove", facility_order_order_detail_path(current_facility, order, detail), method: :delete
+              %td.centered= link_to "Remove", facility_order_order_detail_path(current_facility, order, order_detail), method: :delete
               %td
-                = render partial: "orders/#{detail.product.class.name.downcase}_desc", locals: { order_detail: detail }
+                = render partial: "orders/#{order_detail.product.class.name.underscore}_desc", locals: { order_detail: order_detail }
               %td.centered
-                = detail.quantity
-              - if detail.cost_estimated?
-                %td.currency= show_estimated_cost(detail)
+                = QuantityPresenter.new(order_detail.product, order_detail.quantity)
+              - if order_detail.cost_estimated?
+                %td.currency= show_estimated_cost(order_detail)
                 - if @order.has_subsidies?
-                  %td.currency= show_estimated_subsidy(detail)
-                %td.currency= show_estimated_total(detail)
+                  %td.currency= show_estimated_subsidy(order_detail)
+                %td.currency= show_estimated_total(order_detail)
               - else
                 %td.currency Unassigned
                 - if @order.has_subsidies?


### PR DESCRIPTION
# Release Notes

Fix error that happens when a timed service is included with a bundle containing
a reservation or a service containing an order form.


# Additional Context

Looks like this was an edge case we just missed along the way. These partials are shared with the cart rows and it looks like that one is turning `TimedService` into `timed_service` while this was turning it to `timedservice`.

https://rollbar.com/tablexi/nucore-nu/items/472/

```
ActionView::MissingTemplate:
Missing partial orders/_timedservice_desc with {:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :coffee, :prawn, :haml]}
```