### PR TITLE
Update spec to handle forks with different account types

### DIFF
--- a/vendor/engines/split_accounts/spec/controllers/facility_accounts_controller_spec.rb
+++ b/vendor/engines/split_accounts/spec/controllers/facility_accounts_controller_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe FacilityAccountsController, :enable_split_accounts do
       before { get :new, params: { facility_id: facility.url_name, owner_user_id: user.id, account_type: "SplitAccounts::SplitAccount" } }
 
       it "falls back to the default account type" do
-        expect(assigns(:account)).to be_a(NufsAccount)
+        expect(assigns(:account)).to be_a(Account.config.account_types.first.constantize)
       end
     end
   end


### PR DESCRIPTION
# Release Notes

Tech task: update spec to handle forks of NUcore which use custom account types.

# Additional Context

This will fix a broken test in https://github.com/tablexi/nucore-umass/pull/31

This change already exists in Dartmouth, but was never pulled up to open