### PR TITLE
Research safety refactors for UMass

### DIFF
--- a/app/services/research_safety_always_certified_adapter.rb
+++ b/app/services/research_safety_always_certified_adapter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# This is the default adapter and should only be used for demo/initial implementation
+# purposes. It should be replaced by an actual call to an API or other lookup.
+class ResearchSafetyAlwaysCertifiedAdapter
+
+  def initialize(user)
+    @user = user
+  end
+
+  def certified?(certificate)
+    true
+  end
+
+end

--- a/app/services/research_safety_certification_lookup.rb
+++ b/app/services/research_safety_certification_lookup.rb
@@ -2,7 +2,9 @@
 
 class ResearchSafetyCertificationLookup
 
-  cattr_accessor(:adapter_class) { UmassCorum::OwlApiAdapter }
+  # Replace the value of this attribute in your engine to connect to the school's
+  # custom API.
+  cattr_accessor(:adapter_class) { ResearchSafetyAlwaysCertifiedAdapter }
 
   # This is a class method for easier stubbing in specs
   def self.adapter(user)
@@ -22,6 +24,7 @@ class ResearchSafetyCertificationLookup
     @user = user
   end
 
+  # Allows either a single certificate or an array of certificates
   def certified?(certificates)
     Array(certificates).all? { |certificate| adapter.certified?(certificate) }
   end
@@ -38,8 +41,11 @@ class ResearchSafetyCertificationLookup
 
   private
 
+  # This is memoized so the adapter class can do its own internal caching/memoization
+  # For example, it might only make one HTTP request to return all of the user's
+  # certifications.
   def adapter
-    self.class.adapter(@user)
+    @adapter ||= self.class.adapter(@user)
   end
 
 end

--- a/app/services/research_safety_certification_lookup.rb
+++ b/app/services/research_safety_certification_lookup.rb
@@ -2,14 +2,44 @@
 
 class ResearchSafetyCertificationLookup
 
-  def self.certified?(user, certificate)
-    Nu::ResearchSafetyCertificationAdapter.new(user).certified?(certificate)
+  cattr_accessor(:adapter_class) { UmassCorum::OwlApiAdapter }
+
+  # This is a class method for easier stubbing in specs
+  def self.adapter(user)
+    adapter_class.new(user)
+  end
+
+  # Allows either a single certificate or an array of certificates
+  def self.certified?(user, certificates)
+    new(user).certified?(certificates)
   end
 
   def self.certificates_with_status_for(user)
+    new(user).certificates_with_status
+  end
+
+  def initialize(user)
+    @user = user
+  end
+
+  def certified?(certificates)
+    Array(certificates).all? { |certificate| adapter.certified?(certificate) }
+  end
+
+  def missing_from(certificates)
+    certificates.reject { |certificate| adapter.certified?(certificate) }
+  end
+
+  def certificates_with_status
     ResearchSafetyCertificate.ordered.each_with_object({}) do |certificate, hash|
-      hash[certificate] = certified?(user, certificate)
+      hash[certificate] = adapter.certified?(certificate)
     end
+  end
+
+  private
+
+  def adapter
+    self.class.adapter(@user)
   end
 
 end

--- a/app/views/product_research_safety_certification_requirements/index.html.haml
+++ b/app/views/product_research_safety_certification_requirements/index.html.haml
@@ -29,6 +29,6 @@
       - @product_certification_requirements.each do |cert_req|
         %tr
           %td.centered= link_to text("remove"), facility_product_product_research_safety_certification_requirement_path(current_facility, @product, cert_req), method: :delete if can? :destroy, cert_req
-          %td= cert_req.research_safety_certificate
+          %td= cert_req.research_safety_certificate.name
 - else
   %p.notice= text("none")

--- a/spec/features/admin/user_research_safety_certifications_controller_spec.rb
+++ b/spec/features/admin/user_research_safety_certifications_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Viewing a user's safety certifications" do
+  include ResearchSafetyTestHelpers
+
   let(:user) { FactoryBot.create(:user) }
   let(:facility) { FactoryBot.create(:facility) }
   let(:admin) { FactoryBot.create(:user, :facility_director, facility: facility) }
@@ -12,8 +14,7 @@ RSpec.describe "Viewing a user's safety certifications" do
     let!(:certificate_b) { FactoryBot.create(:research_safety_certificate) }
 
     before do
-      expect(ResearchSafetyCertificationLookup).to receive(:certified?).with(user, certificate_a).and_return(true)
-      expect(ResearchSafetyCertificationLookup).to receive(:certified?).with(user, certificate_b).and_return(false)
+      stub_research_safety_lookup(user, valid: certificate_a, invalid: certificate_b)
     end
 
     it "can see the user's certifications" do

--- a/spec/features/research_safety/placing_a_reservation_spec.rb
+++ b/spec/features/research_safety/placing_a_reservation_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Placing a reservation with a certification requirement" do
+  include ResearchSafetyTestHelpers
+
   let!(:instrument) { FactoryBot.create(:setup_instrument) }
   let(:facility) { instrument.facility }
   let!(:cert1) { create(:product_certification_requirement, product: instrument).research_safety_certificate }
@@ -26,7 +28,7 @@ RSpec.describe "Placing a reservation with a certification requirement" do
 
     context "who does not have their certifications" do
       before do
-        allow(ResearchSafetyCertificationLookup).to receive(:certified?).and_return(false)
+        stub_research_safety_lookup(user, invalid: [cert1, cert2])
       end
 
       it "displays an error on the page" do
@@ -38,7 +40,7 @@ RSpec.describe "Placing a reservation with a certification requirement" do
 
     context "who does have their certifications" do
       before do
-        allow(ResearchSafetyCertificationLookup).to receive(:certified?).and_return(true)
+        stub_research_safety_lookup(user, invalid: [cert1, cert2])
       end
 
       it "saves the reservation and brings you back to My Reservations" do
@@ -52,6 +54,8 @@ RSpec.describe "Placing a reservation with a certification requirement" do
       let(:facility_staff) { create(:user, :staff, facility: facility) }
 
       before do
+        stub_research_safety_lookup(user)
+
         login_as facility_staff
         visit facility_users_path(facility)
         fill_in "search_term", with: user.email

--- a/spec/support/research_safety_test_helpers.rb
+++ b/spec/support/research_safety_test_helpers.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ResearchSafetyTestHelpers
+
+  def stub_research_safety_lookup(user, valid: [], invalid: [])
+    api = double("ResearchSafetyAdapter")
+    Array(valid).each { |certificate| expect(api).to receive(:certified?).with(certificate).and_return(true) }
+    Array(invalid).each { |certificate| expect(api).to receive(:certified?).with(certificate).and_return(false) }
+    allow(ResearchSafetyCertificationLookup).to receive(:adapter).with(user).and_return(api)
+  end
+
+end

--- a/spec/validators/order_research_safety_certification_validator_spec.rb
+++ b/spec/validators/order_research_safety_certification_validator_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe OrderResearchSafetyCertificationValidator do
+  include ResearchSafetyTestHelpers
+
   let(:product_one) { FactoryBot.create(:setup_item) }
   let(:certificate_a) { FactoryBot.create(:product_certification_requirement, product: product_one).research_safety_certificate }
   let(:user) { FactoryBot.create(:user) }
@@ -20,8 +22,7 @@ RSpec.describe OrderResearchSafetyCertificationValidator do
 
     context "with one invalid product" do
       before do
-        expect(ResearchSafetyCertificationLookup).to receive(:certified?).with(user, certificate_a).and_return(true)
-        expect(ResearchSafetyCertificationLookup).to receive(:certified?).with(user, certificate_b).and_return(false)
+        stub_research_safety_lookup(user, valid: certificate_a, invalid: certificate_b)
       end
 
       it { is_expected.not_to be_valid }
@@ -29,8 +30,7 @@ RSpec.describe OrderResearchSafetyCertificationValidator do
 
     context "with both products valid" do
       before do
-        expect(ResearchSafetyCertificationLookup).to receive(:certified?).with(user, certificate_a).and_return(true)
-        expect(ResearchSafetyCertificationLookup).to receive(:certified?).with(user, certificate_b).and_return(true)
+        stub_research_safety_lookup(user, valid: [certificate_a, certificate_b])
       end
 
       it { is_expected.to be_valid }
@@ -41,7 +41,7 @@ RSpec.describe OrderResearchSafetyCertificationValidator do
 
       context "with one invalid product" do
         before do
-          expect(ResearchSafetyCertificationLookup).not_to receive(:certified?)
+          stub_research_safety_lookup(user)
         end
 
         it { is_expected.to be_valid }
@@ -54,8 +54,7 @@ RSpec.describe OrderResearchSafetyCertificationValidator do
 
     context "with one invalid product" do
       before do
-        expect(ResearchSafetyCertificationLookup).to receive(:certified?).with(user, certificate_a).and_return(true)
-        expect(ResearchSafetyCertificationLookup).to receive(:certified?).with(user, certificate_b).and_return(false)
+        stub_research_safety_lookup(user, valid: certificate_a, invalid: certificate_b)
       end
 
       it "has the correct missing certs" do
@@ -72,8 +71,7 @@ RSpec.describe OrderResearchSafetyCertificationValidator do
 
     context "with both products valid" do
       before do
-        expect(ResearchSafetyCertificationLookup).to receive(:certified?).with(user, certificate_a).and_return(true)
-        expect(ResearchSafetyCertificationLookup).to receive(:certified?).with(user, certificate_b).and_return(true)
+        stub_research_safety_lookup(user, valid: [certificate_a, certificate_b])
       end
 
       it "returns nothing" do

--- a/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/requires_research_safety_certifications_rule.rb
+++ b/vendor/engines/secure_rooms/app/services/secure_rooms/access_rules/requires_research_safety_certifications_rule.rb
@@ -13,9 +13,7 @@ module SecureRooms
       private
 
       def certified?
-        secure_room.research_safety_certificates.all? do |certificate|
-          ResearchSafetyCertificationLookup.certified?(user, certificate)
-        end
+        ResearchSafetyCertificationLookup.certified?(user, secure_room.research_safety_certificates)
       end
 
     end


### PR DESCRIPTION
# Release Notes

Tech task: refactor parts of research safety to make it better for UMass.

# Additional Context

The big thing this does is allow the forks to do their own internal caching of API calls. UMass will be doing a single call per user which returns a list of all of the active certifications. With this change, it uses the same object for multiple `certified?` checks so the HTTP response can be memoized.

I refactored this in conjunction with https://github.com/tablexi/nucore-umass/commit/fa658ac6cfc784f2a2d4be1298393ea6a1d52122 (which is not ready due to us still needing some additional data from them).

It also sets up a default that assumes a user is always certified. We'll need to swap this out in NU and UMass.