### PR TITLE
Allow longer revenue accounts

### DIFF
--- a/app/views/facility_facility_accounts/_facility_account_fields.html.haml
+++ b/app/views/facility_facility_accounts/_facility_account_fields.html.haml
@@ -1,7 +1,6 @@
 .well
   = render "shared/account_fields", f: f, account_class: FacilityAccount, readonly: local_assigns[:readonly]
-  = f.label :revenue_account, class: "require"
-  = f.text_field :revenue_account, maxLength: 5, size: 10, readonly: local_assigns[:readonly]
+  = f.input :revenue_account, readonly: local_assigns[:readonly], required: true, input_html: { maxlength: Settings.accounts.revenue_account_default.to_s.length, size: 10 }
 
   = f.label :is_active do
     = f.check_box :is_active

--- a/app/views/facility_facility_accounts/edit.html.haml
+++ b/app/views/facility_facility_accounts/edit.html.haml
@@ -9,7 +9,7 @@
 
 %h2= text("admin.shared.edit", model: FacilityAccount.model_name.human)
 %p= text(".main")
-= form_for @facility_account, url: facility_facility_account_path do |f|
+= simple_form_for @facility_account, url: facility_facility_account_path(@facility_account) do |f|
   = f.error_messages
   = render "facility_account_fields", f: f, readonly: true
   %ul.inline

--- a/app/views/facility_facility_accounts/new.html.haml
+++ b/app/views/facility_facility_accounts/new.html.haml
@@ -8,7 +8,7 @@
   = javascript_include_tag "accounts.js"
 
 %h2= text("admin.shared.add", model: FacilityAccount.model_name.human)
-= form_for @facility_account, url: facility_facility_accounts_path do |f|
+= simple_form_for @facility_account, url: facility_facility_accounts_path do |f|
   = f.error_messages
   = render "facility_account_fields", f: f
   %ul.inline

--- a/db/migrate/20191219162724_increase_revenue_account_field_length.rb
+++ b/db/migrate/20191219162724_increase_revenue_account_field_length.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class IncreaseRevenueAccountFieldLength < ActiveRecord::Migration[5.0]
+
+  def up
+    change_column :journal_rows, :account, :string, limit: nil
+  end
+
+  def down
+    change_column :journal_rows, :account, :string, limit: 5
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191126153900) do
+ActiveRecord::Schema.define(version: 20191219162724) do
 
   create_table "account_facility_joins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "facility_id", null: false
@@ -212,7 +212,7 @@ ActiveRecord::Schema.define(version: 20191126153900) do
   create_table "journal_rows", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "journal_id",                                          null: false
     t.integer "order_detail_id"
-    t.string  "account",         limit: 5
+    t.string  "account"
     t.decimal "amount",                      precision: 9, scale: 2, null: false
     t.string  "description",     limit: 512
     t.integer "account_id"


### PR DESCRIPTION
# Release Notes

Tech task: allow longer revenue accounts

# Additional Context

NU has five-digit revenue accounts, but UMass has 6 digits. There is no real reason to restrict the length of this field down so hard in the database.