### PR TITLE
[#152079] Fix adding timed service bundle

### DIFF
--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -1710,6 +1710,12 @@ RSpec.describe OrderDetail do
           expect { Order.find(order.id) }.to raise_error ActiveRecord::RecordNotFound
         end
 
+        it "merges the order if it's a timed service" do
+          timed_service = FactoryBot.create(:timed_service, facility: facility)
+          @order_detail.update!(product: timed_service)
+          expect { Order.find(order.id) }.to raise_error ActiveRecord::RecordNotFound
+        end
+
         it "should not affect non merge orders" do
           assert @order_detail.save
           expect(@order_detail.reload.order).to eq(@merge_to_order)


### PR DESCRIPTION
# Release Notes

Fix an issue where a timed service as part of a bundle cannot be added to an existing order. It was getting stuck as if there were an issue like a missing order form.

# Screenshot

What was happening before:

![All Bundle Add to Order](https://user-images.githubusercontent.com/1099111/71695338-69f14880-2d77-11ea-8c0c-8b79c602abd5.png)

# Additional Context

We fixed a hard error in #2128, but this was still having a problem while validating the order.
