### PR TITLE
[#150353] Prevent error when calculating on non-purchasable price policies

### DIFF
--- a/app/models/instrument_price_policy_calculations.rb
+++ b/app/models/instrument_price_policy_calculations.rb
@@ -21,6 +21,8 @@ module InstrumentPricePolicyCalculations
 
   def calculate_cost_and_subsidy(reservation)
     return if reservation.blank?
+    return if restrict_purchase?
+
     return calculate_cancellation_costs(reservation) if reservation.canceled?
 
     case charge_for

--- a/spec/models/instrument_price_policy_calculations_spec.rb
+++ b/spec/models/instrument_price_policy_calculations_spec.rb
@@ -178,6 +178,20 @@ RSpec.describe InstrumentPricePolicyCalculations do
       end
     end
 
+    context "when the price policy is not available for purchase (and blank usage rates)" do
+      before do
+        policy.assign_attributes(
+          can_purchase: false,
+          usage_rate: nil,
+          usage_subsidy: nil
+        )
+      end
+
+      it "returns blank" do
+        expect(policy.calculate_cost_and_subsidy(reservation)).to be_nil
+      end
+    end
+
     context "when configured to charge for usage" do
       before :each do
         policy.charge_for = InstrumentPricePolicy::CHARGE_FOR[:usage]


### PR DESCRIPTION
# Release Notes

Prevent error when calculating on non-purchasable instrument price policies.

# Additional Context

Pulled up from https://github.com/tablexi/nucore-dartmouth/pull/287

If an instrument price policy is not `can_purchase`, it is possible for the `usage_rate` to be `nil` (`presence` is required if `can_purchase` is `true`). This triggers a hard error in the calculations. This is not usually a problem, however Dartmouth has an additional field in their export raw for "Internal Cost". This is the price of an order detail if it had been purchased under the internal price group. Some products are not set up with internal pricing, so those lines was erroring during the export.

Item/Services already have this same logic built in.