### PR TITLE
Allow longer expense accounts for products

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -39,11 +39,8 @@ class Product < ApplicationRecord
     validates(
       :account,
       presence: true,
-      numericality: {
-        only_integer: true,
-        greater_than_or_equal_to: 0,
-        less_than_or_equal_to: 99_999,
-      },
+      numericality: { only_integer: true },
+      length: { minimum: 1, maximum: Settings.accounts.product_default.to_s.length },
       if: :requires_account?,
     )
   end

--- a/db/migrate/20200106194222_remove_limit_from_product_expense_account.rb
+++ b/db/migrate/20200106194222_remove_limit_from_product_expense_account.rb
@@ -1,0 +1,12 @@
+
+class RemoveLimitFromProductExpenseAccount < ActiveRecord::Migration[5.0]
+
+  def up
+    change_column :products, :account, :string, limit: nil
+  end
+
+  def down
+    change_column :products, :account, :string, limit: 5
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191219162724) do
+ActiveRecord::Schema.define(version: 20200106194222) do
 
   create_table "account_facility_joins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "facility_id", null: false
@@ -514,7 +514,7 @@ ActiveRecord::Schema.define(version: 20191219162724) do
     t.integer  "max_reserve_mins"
     t.integer  "min_cancel_hours"
     t.integer  "facility_account_id"
-    t.string   "account",                                  limit: 5
+    t.string   "account"
     t.boolean  "show_details",                                           default: false,    null: false
     t.integer  "auto_cancel_mins"
     t.string   "contact_email"

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -153,6 +153,32 @@ RSpec.describe Product do
       end
     end
 
+    context "expense accounts", feature_setting: { expense_accounts: true } do
+      it "allows the default expense account" do
+        product = build(:product, account: Settings.accounts.product_default)
+        product.valid?
+        expect(product.errors).not_to include(:account)
+      end
+
+      it "does not allow something longer than the default expense account" do
+        product = build(:product, account: "0#{Settings.accounts.product_default}")
+        expect(product).to be_invalid
+        expect(product.errors).to be_added(:account, :too_long, count: Settings.accounts.product_default.to_s.length)
+      end
+
+      it "does allows a short value" do
+        product = build(:product, account: "123")
+        product.valid?
+        expect(product.errors).not_to include(:account)
+      end
+
+      it "does not allow a non-numeric" do
+        product = build(:product, account: "aaaa")
+        expect(product).to be_invalid
+        expect(product.errors).to be_added(:account, :not_a_number)
+      end
+    end
+
     context "email", feature_setting: { expense_accounts: false } do
       before :each do
         @facility = FactoryBot.create(:facility, email: "facility@example.com")


### PR DESCRIPTION
# Release Notes

Tech task: allow longer expense account values on Products.

# Additional Context

Similar to #2136, UMass has six digit revenue accounts rather that NU's five (DC has 4 digit).
