### PR TITLE
Remove constricting spec

### DIFF
--- a/spec/models/stored_file_spec.rb
+++ b/spec/models/stored_file_spec.rb
@@ -53,10 +53,6 @@ RSpec.describe StoredFile do
       expect(file_upload).to be_valid
     end
 
-    it "is stored with a partitioned path" do
-      expect(file_upload.file.url).to match(%r{\A/files/\d+/\d+/\d+/})
-    end
-
     it "stored the file content" do
       expect(file_upload.read).to eq(File.read(file1))
     end


### PR DESCRIPTION
# Release Notes

Tech task: remove spec that restricts what locations we can put uploaded files in.

# Additional Context

This spec makes it very difficult to use a different pattern for the storage location. Now
we can change the setting to be whatever we want and it won't break specs.

In UMass we're storing them in `public/uploads`.

