### PR TITLE
Upgrade I18n to 1.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,7 +331,7 @@ GEM
       sysexits (~> 1.1)
     health_check (3.0.0)
       railties (>= 5.0)
-    i18n (1.7.0)
+    i18n (1.7.1)
       concurrent-ruby (~> 1.0)
     icalendar (2.6.1)
       ice_cube (~> 0.16)

--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -3,7 +3,7 @@
 module TranslationHelper
 
   def t_manage_models(clazz)
-    I18n.t("pages.manage", model: clazz.model_name.human.pluralize)
+    I18n.t("pages.manage", model: clazz.model_name.human(count: :many))
   end
 
   def t_create_model(clazz)
@@ -11,11 +11,11 @@ module TranslationHelper
   end
 
   def t_create_models(clazz)
-    I18n.t("pages.create", model: clazz.model_name.human.pluralize)
+    I18n.t("pages.create", model: clazz.model_name.human(count: :many))
   end
 
   def t_my(clazz)
-    I18n.t("pages.my_tab", model: clazz.model_name.human.pluralize)
+    I18n.t("pages.my_tab", model: clazz.model_name.human(count: :many))
   end
 
   def t_model_error(clazz, error, *options)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -150,9 +150,9 @@ class Account < ApplicationRecord
 
   def display_status
     if suspended?
-      I18n.t("activerecord.models.account.statuses.suspended")
+      I18n.t("account.statuses.suspended")
     else
-      I18n.t("activerecord.models.account.statuses.active")
+      I18n.t("account.statuses.active")
     end
   end
 

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -142,9 +142,6 @@ en:
         one: Payment Source
         other: Payment Sources
         owner: Owner
-        statuses:
-          active: Active
-          suspended: Suspended
       account_user:
         one: Account User
         other: Account Users

--- a/config/locales/models/en.account.yml
+++ b/config/locales/models/en.account.yml
@@ -5,3 +5,7 @@ en:
         account:
           not_open: "The %{model} is not open for the required account"
           missing_owner: Must have an account owner
+  account:
+    statuses:
+      active: Active
+      suspended: Suspended


### PR DESCRIPTION
# Release Notes

Tech task: Bump I18n gem to 1.7.1.

# Additional Context

This change in I18n https://github.com/ruby-i18n/i18n/pull/503 breaks our lookup for one/many when there is also a nested hash.

`Account.model_name.human` was returning the hash `{:one=>"Payment Source", :other=>"Payment Sources", :owner=>"Owner", :statuses=>{:active=>"Active", :suspended=>"Suspended"}}`.

Cleaning this up seemed simpler than trying to dig in to I18n.

