### PR TITLE
Fix forrmatting of Order Date on "My Orders"

### DIFF
--- a/app/views/shared/_order_details_table.html.haml
+++ b/app/views/shared/_order_details_table.html.haml
@@ -14,7 +14,7 @@
         %td.centered
           = link_to order_detail,
             current_facility ? order_detail.show_order_path : order_detail.show_order_detail_path
-        %td= order_detail.ordered_at
+        %td= format_usa_datetime(order_detail.ordered_at)
         %td.centered= order_detail.wrapped_quantity
         %td.order-note.order-note--wide
           %ul.unstyled


### PR DESCRIPTION
# Release Notes

Fix formatting of "Order Date" column on "My Orders" pages on both "Pending" and "All" tabs.

# Screenshot

Before

![Screen Shot 2020-01-08 at 6 49 23 PM](https://user-images.githubusercontent.com/1099111/72028348-c527ad00-3247-11ea-83a1-d38906b54ebf.png)

After

![Screen Shot 2020-01-08 at 6 49 08 PM](https://user-images.githubusercontent.com/1099111/72028353-c953ca80-3247-11ea-8170-cc1975cdbf75.png)

