### PR TITLE
[#140480] Disable reconciliation note field on order detail modal

### DIFF
--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -13,6 +13,7 @@ class OrderDetails::ParamUpdater
         :note,
         :price_change_reason,
         :editing_time_data,
+        :reconciled_note,
         reservation: [
           :reserve_start_date,
           :reserve_start_hour,

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -56,7 +56,8 @@
     .row
       .span5
         = f.input :note, input_html: { class: "note", rows: 3 }
-        = render "reconcile_note", f: f
+        - if @order_detail.can_reconcile? || @order_detail.reconciled?
+          = f.input :reconciled_note, input_html: { class: "note" }
 
       .span4
         - if @order_detail.actual_cost?

--- a/app/views/order_management/order_details/_reconcile_note.html.haml
+++ b/app/views/order_management/order_details/_reconcile_note.html.haml
@@ -1,2 +1,0 @@
-- if @order_detail.can_reconcile? || @order_detail.reconciled?
-  = f.input :reconciled_note, :input_html => { :class => ['note', 'js-always-enabled'] }


### PR DESCRIPTION
# Release Notes

Disable reconciliation note field on order detail modal as it is not editable. Also fix bug where filling in the reconciliation note field would not persist to the database.

# Screenshot

![Screen Shot 2020-01-08 at 7 41 55 PM](https://user-images.githubusercontent.com/1099111/72030549-f3f55180-324e-11ea-8029-98d42058d76e.png)
