### PR TITLE
Tech task: Remove recharge account feature flag

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -44,9 +44,8 @@ class Product < ApplicationRecord
       if: :requires_account?,
     )
   end
-  if SettingsHelper.feature_on? :recharge_accounts
-    validates :facility_account_id, presence: true, if: :requires_account?
-  end
+
+  validates :facility_account_id, presence: true, if: :requires_account?
 
   # Use lambda so we can dynamically enable/disable in specs
   validate if: -> { SettingsHelper.feature_on?(:product_specific_contacts) } do

--- a/app/services/journal_row_builder.rb
+++ b/app/services/journal_row_builder.rb
@@ -28,7 +28,6 @@ class JournalRowBuilder
     @journal_rows = []
     @journaled_facility_ids = Set.new
     @product_recharges = {}
-    @recharge_enabled = SettingsHelper.feature_on?(:recharge_accounts)
   end
 
   # Builds journal rows based the order details coming back from the Transformer
@@ -155,11 +154,9 @@ class JournalRowBuilder
   # If recharge_enabled, then sum up the product_recharges by product so each
   # product recharge can later be added as an additional journal_row.
   def update_product_recharges(order_detail)
-    if recharge_enabled
-      product_id = order_detail.product_id
-      product_recharges[product_id] ||= 0
-      product_recharges[product_id] += order_detail.total
-    end
+    product_id = order_detail.product_id
+    product_recharges[product_id] ||= 0
+    product_recharges[product_id] += order_detail.total
   end
 
   # When you’re creating a journal, for a single order detail you’ll have one

--- a/app/views/admin/products/_account_fields.html.haml
+++ b/app/views/admin/products/_account_fields.html.haml
@@ -1,14 +1,13 @@
-- if SettingsHelper.feature_on? :recharge_accounts
-  -# Use `label_text` to add * marking the field as required because
-  -# `include_blank: false` gets ignored if you use `required: true`
-  = f.input :facility_account_id,
-    label: FacilityAccount.model_name.human,
-    label_text: -> (label, _required, _) { "* #{label}" },
-    include_blank: false,
-    collection: current_facility.facility_accounts.active,
-    hint: text("hints.deposit_account")
+-# Use `label_text` to add * marking the field as required because
+-# `include_blank: false` gets ignored if you use `required: true`
+= f.input :facility_account_id,
+  label: FacilityAccount.model_name.human,
+  label_text: -> (label, _required, _) { "* #{label}" },
+  include_blank: false,
+  collection: current_facility.facility_accounts.active,
+  hint: text("hints.deposit_account")
 
-  %p= link_to text("deposit_account.add"), :facility_facility_accounts
+%p= link_to text("deposit_account.add"), :facility_facility_accounts
 
 - if SettingsHelper.feature_on? :expense_accounts
   = f.input :account, hint: text("hints.account"), required: true

--- a/app/views/admin/shared/_sidenav_admin.html.haml
+++ b/app/views/admin/shared/_sidenav_admin.html.haml
@@ -1,8 +1,7 @@
 %ul.sidebar-nav
   = tab t("shared.sidenav_admin.overview"), manage_facility_path(current_facility), sidenav_tab == "overview"
 
-  - if SettingsHelper.feature_on? :recharge_accounts
-    = tab FacilityAccount.model_name.human(count: 2), facility_facility_accounts_path(current_facility), sidenav_tab == "recharge_accounts"
+  = tab FacilityAccount.model_name.human(count: 2), facility_facility_accounts_path(current_facility), sidenav_tab == "recharge_accounts"
   = tab text("facility_users.title"), facility_facility_users_path(current_facility), sidenav_tab == "staff"
   = tab PriceGroup.model_name.human(count: 2), facility_price_groups_path(current_facility), sidenav_tab == "price_groups"
   = tab OrderStatus.model_name.human(count: 2), facility_order_statuses_path(current_facility), sidenav_tab == "statuses"

--- a/app/views/products_common/manage.html.haml
+++ b/app/views/products_common/manage.html.haml
@@ -15,9 +15,8 @@
   = f.input :description, input_html: { class: "wysiwyg" }
 
   - unless @product.is_a?(Bundle)
-    - if SettingsHelper.feature_on? :recharge_accounts
-      = f.input :facility_account,
-        input_html: { value: @product.facility_account.account_number + (@product.facility_account.is_active? ? "" : " (inactive)") }
+    = f.input :facility_account,
+      input_html: { value: @product.facility_account.account_number + (@product.facility_account.is_active? ? "" : " (inactive)") }
 
     = f.input :initial_order_status
     = f.input :requires_approval

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,11 +165,9 @@ Nucore::Application.routes.draw do
       resources :user_research_safety_certifications, only: [:index]
     end
 
-    if SettingsHelper.feature_on? :recharge_accounts
-      resources :facility_accounts,
-                controller: "facility_facility_accounts",
-                only: [:index, :new, :create, :edit, :update], path: "#{I18n.t('facility_downcase')}_accounts"
-    end
+    resources :facility_accounts,
+              controller: "facility_facility_accounts",
+              only: [:index, :new, :create, :edit, :update], path: "#{I18n.t('facility_downcase')}_accounts"
 
     resources :orders, controller: "facility_orders", only: [:index, :update, :show] do
       member do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -86,7 +86,6 @@ feature:
   manage_payment_sources_with_users: true
   order_assignment_notifications: true
   password_update: true
-  recharge_accounts: true
   expense_accounts: true
   edit_accounts: true
   suspend_accounts: true

--- a/lib/settings_helper.rb
+++ b/lib/settings_helper.rb
@@ -35,6 +35,7 @@ module SettingsHelper
   #   If you want to check setting 'feature.password_update' then this parameter
   # .  would be :password_update. Will raise an error if the setting does not exist.
   def self.feature_on?(feature)
+    raise "Deprecated feature" if feature.to_s == "recharge_accounts"
     !!Settings.feature.to_h.fetch(feature)
   end
 

--- a/spec/controllers/facility_facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_facility_accounts_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "controller_spec_helper"
 
-RSpec.describe FacilityFacilityAccountsController, feature_setting: { recharge_accounts: true, reload_routes: true } do
+RSpec.describe FacilityFacilityAccountsController do
   render_views
 
   around(:each) do |example|

--- a/spec/services/journal_row_builder_spec.rb
+++ b/spec/services/journal_row_builder_spec.rb
@@ -30,18 +30,6 @@ RSpec.describe JournalRowBuilder, type: :service do
       expect(builder.product_recharges).to eq({})
     end
 
-    context "when recharge_accounts enabled", feature_setting: { recharge_accounts: true } do
-      it "assigns recharge_enabled" do
-        expect(builder.recharge_enabled).to eq(true)
-      end
-    end
-
-    context "when recharge_accounts disabled", feature_setting: { recharge_accounts: false } do
-      it "assigns recharge_enabled" do
-        expect(builder.recharge_enabled).to eq(false)
-      end
-    end
-
   end
 
   describe "#build" do
@@ -64,28 +52,12 @@ RSpec.describe JournalRowBuilder, type: :service do
       order_details.each(&:to_complete!)
     end
 
-    context "when recharge_accounts enabled", feature_setting: { recharge_accounts: true } do
-
-      it "builds two journal_rows for each order_detail" do
-        expect(builder.build.journal_rows.size).to eq(order_details.size * 2)
-      end
-
-      it "builds a product_recharge for each order_detail" do
-        expect(builder.build.product_recharges.size).to eq(order_details.size)
-      end
-
+    it "builds two journal_rows for each order_detail" do
+      expect(builder.build.journal_rows.size).to eq(order_details.size * 2)
     end
 
-    context "when recharge_accounts disabled", feature_setting: { recharge_accounts: false } do
-
-      it "builds a journal_row for each order_detail" do
-        expect(builder.build.journal_rows.size).to eq(order_details.size)
-      end
-
-      it "does not have product_recharges" do
-        expect(builder.build.product_recharges).to be_empty
-      end
-
+    it "builds a product_recharge for each order_detail" do
+      expect(builder.build.product_recharges.size).to eq(order_details.size)
     end
 
   end


### PR DESCRIPTION
# Release Notes

Tech task: remove `recharge_accounts` feature flag.

# Additional Context

UIC is the only one who used this feature flag.
