### PR TITLE
Fix recharge account editing

### DIFF
--- a/app/views/facility_facility_accounts/edit.html.haml
+++ b/app/views/facility_facility_accounts/edit.html.haml
@@ -9,7 +9,7 @@
 
 %h2= text("admin.shared.edit", model: FacilityAccount.model_name.human)
 %p= text(".main")
-= simple_form_for @facility_account, url: facility_facility_account_path(@facility_account) do |f|
+= simple_form_for @facility_account, url: facility_facility_account_path(current_facility, @facility_account) do |f|
   = f.error_messages
   = render "facility_account_fields", f: f, readonly: true
   %ul.inline

--- a/app/views/facility_facility_accounts/new.html.haml
+++ b/app/views/facility_facility_accounts/new.html.haml
@@ -8,7 +8,7 @@
   = javascript_include_tag "accounts.js"
 
 %h2= text("admin.shared.add", model: FacilityAccount.model_name.human)
-= simple_form_for @facility_account, url: facility_facility_accounts_path do |f|
+= simple_form_for @facility_account, url: facility_facility_accounts_path(current_facility) do |f|
   = f.error_messages
   = render "facility_account_fields", f: f
   %ul.inline

--- a/spec/features/admin/recharge_accounts_spec.rb
+++ b/spec/features/admin/recharge_accounts_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe "Managing recharge accounts (FacilityFacilityAccountsController)" do
+
+  let(:facility) { FactoryBot.create(:facility) }
+  let!(:director) { FactoryBot.create(:user, :facility_director, facility: facility) }
+  let(:default_revenue_account) { Settings.accounts.revenue_account_default }
+  let(:dummy_account) { build(:facility_account) }
+
+  before do
+    define_open_account default_revenue_account, dummy_account.account_number
+    login_as director
+    visit manage_facility_path(facility)
+  end
+
+  it "can create a recharge account" do
+    click_link "Recharge Chart Strings"
+    click_link "Add Recharge Chart String"
+
+    # This is a somewhat convoluted way to fill out the form, but each school will
+    # have different fields for their chart strings. E.g. NU has Fund, Department,
+    # Project, etc. while the default just has a
+    # Individual schools should implement a similar spec in their engine that
+    # is more explicit in which fields it fills out.
+    dummy_account.account_number_fields.each do |field, _values|
+      fill_in I18n.t("facility_account.account_fields.label.account_number.#{field}"), with: dummy_account.public_send(field)
+    end
+
+    click_button "Create"
+
+    expect(page).to have_content("Recharge Chart String was successfully created")
+    expect(page).to have_link(dummy_account.to_s)
+  end
+
+  describe "editing an existing" do
+    let!(:facility_account) { FactoryBot.create(:facility_account, facility: facility) }
+
+    it "cannot edit most fields, but can mark it as inactive" do
+      click_link "Recharge Chart Strings"
+      click_link facility_account.to_s
+
+      dummy_account.account_number_fields.each do |field, _values|
+        expect(page).to have_field(I18n.t(field, scope: "facility_account.account_fields.label.account_number"), readonly: true)
+      end
+
+      uncheck "Is Active?"
+      click_button "Save"
+      expect(page).to have_content("(inactive)")
+    end
+  end
+end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -310,7 +310,8 @@ RSpec.describe Account do
 
       context "bundles" do
         before :each do
-          @item2 = @facility.items.create(FactoryBot.attributes_for(:item, account: 78_960, facility_account_id: @facility_account.id))
+          account_number = Settings.accounts.product_default
+          @item2 = @facility.items.create(FactoryBot.attributes_for(:item, account: account_number, facility_account_id: @facility_account.id))
           @bundle = @facility.bundles.create(FactoryBot.attributes_for(:bundle, facility_account_id: @facility_account.id))
           [@item, @item2].each do |item|
             price_policy = item.item_price_policies.create(FactoryBot.attributes_for(:item_price_policy, price_group: @price_group))


### PR DESCRIPTION
# Release Notes

Fix recharge account editing. Clicking "Save" would take the user to a 404 page.

# Additional Context

Editing a recharge account was broken and we didn't have a good spec around it. It's possible it was broken in #2136 by changing `form_for` to `simple_form_for`.

The spec is a little funky in how it fills out the form, but it needs to be in order for NU and Dartmouth to pass since they use different sets of fields.

