### PR TITLE
Rails 5.2 - Fix for Oracle: cannot where(type: Class). Must be strings.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,9 @@ gem "bootsnap", require: false
 ## database
 gem "mysql2"
 # To use Oracle, remove the mysql2 gem above and uncomment these lines
-# gem "ruby-oci8"
 # gem "activerecord-oracle_enhanced-adapter"
+# gem "ruby-oci8" # only for CRuby users
+
 
 ## auth
 gem "cancancan"

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -66,12 +66,12 @@ class Product < ApplicationRecord
   end
 
   def self.mergeable_types
-    @mergeable_types ||= [Instrument, Item, Service, TimedService, Bundle]
+    @mergeable_types ||= ["Instrument", "Item", "Service", "TimedService", "Bundle"]
   end
 
   # Products that can be used as accessories
   def self.accessorizable
-    where(type: [Item, Service, TimedService])
+    where(type: ["Item", "Service", "TimedService"])
   end
 
   def self.exclude(products)


### PR DESCRIPTION
# Release Notes

Tech task: Fix for oracle when upgrading to Rails 5.2
