### PR TITLE
Add version numbers to ActiveRecord Migrations

### DIFF
--- a/db/migrate/20100101000000_initial_schema.rb
+++ b/db/migrate/20100101000000_initial_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class InitialSchema < ActiveRecord::Migration
+class InitialSchema < ActiveRecord::Migration[4.2]
 
   def self.up
     # This migration is handling the fact that the initial commits on nucore

--- a/db/migrate/20100422215947_create_orders.rb
+++ b/db/migrate/20100422215947_create_orders.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateOrders < ActiveRecord::Migration
+class CreateOrders < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :orders do |t|

--- a/db/migrate/20100423185710_create_order_details.rb
+++ b/db/migrate/20100423185710_create_order_details.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateOrderDetails < ActiveRecord::Migration
+class CreateOrderDetails < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :statements do |t|

--- a/db/migrate/20100427192902_add_subsidies.rb
+++ b/db/migrate/20100427192902_add_subsidies.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddSubsidies < ActiveRecord::Migration
+class AddSubsidies < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :price_policies, :usage_subsidy, :decimal, precision: 9, scale: 2

--- a/db/migrate/20100427202835_adjust_order.rb
+++ b/db/migrate/20100427202835_adjust_order.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AdjustOrder < ActiveRecord::Migration
+class AdjustOrder < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :orders do |t|

--- a/db/migrate/20100428152408_remove_facility_from_order.rb
+++ b/db/migrate/20100428152408_remove_facility_from_order.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveFacilityFromOrder < ActiveRecord::Migration
+class RemoveFacilityFromOrder < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :orders do |t|

--- a/db/migrate/20100430184238_add_facility_order.rb
+++ b/db/migrate/20100430184238_add_facility_order.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddFacilityOrder < ActiveRecord::Migration
+class AddFacilityOrder < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :orders do |t|

--- a/db/migrate/20100430222700_change_reservations.rb
+++ b/db/migrate/20100430222700_change_reservations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeReservations < ActiveRecord::Migration
+class ChangeReservations < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :reservations do |t|

--- a/db/migrate/20100506170137_add_order_state.rb
+++ b/db/migrate/20100506170137_add_order_state.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddOrderState < ActiveRecord::Migration
+class AddOrderState < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :orders do |t|

--- a/db/migrate/20100511164522_change_price_policies.rb
+++ b/db/migrate/20100511164522_change_price_policies.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangePricePolicies < ActiveRecord::Migration
+class ChangePricePolicies < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :price_policies do |t|

--- a/db/migrate/20100512222847_set_order_states.rb
+++ b/db/migrate/20100512222847_set_order_states.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SetOrderStates < ActiveRecord::Migration
+class SetOrderStates < ActiveRecord::Migration[4.2]
 
   def self.up
     Order.where(ordered_at: nil).update_all(state: "new")

--- a/db/migrate/20100521172707_add_price_group_display_order.rb
+++ b/db/migrate/20100521172707_add_price_group_display_order.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddPriceGroupDisplayOrder < ActiveRecord::Migration
+class AddPriceGroupDisplayOrder < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :price_groups, :display_order, :integer, precision: 38, scale: 0, default: 3, null: false

--- a/db/migrate/20100524203345_remove_product_id_from_price_policies.rb
+++ b/db/migrate/20100524203345_remove_product_id_from_price_policies.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveProductIdFromPricePolicies < ActiveRecord::Migration
+class RemoveProductIdFromPricePolicies < ActiveRecord::Migration[4.2]
 
   def self.up
     remove_column :price_policies, :product_id

--- a/db/migrate/20100526190311_add_description_to_account.rb
+++ b/db/migrate/20100526190311_add_description_to_account.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDescriptionToAccount < ActiveRecord::Migration
+class AddDescriptionToAccount < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :accounts, :description, :string, limit: 200, null: true

--- a/db/migrate/20100527225704_update_decimal_precision.rb
+++ b/db/migrate/20100527225704_update_decimal_precision.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UpdateDecimalPrecision < ActiveRecord::Migration
+class UpdateDecimalPrecision < ActiveRecord::Migration[4.2]
 
   def self.up
     change_column :schedule_rules, :discount_percent,    :decimal, precision: 10, scale: 2, null: false, default: 0

--- a/db/migrate/20100528190549_update_varchar_fields.rb
+++ b/db/migrate/20100528190549_update_varchar_fields.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UpdateVarcharFields < ActiveRecord::Migration
+class UpdateVarcharFields < ActiveRecord::Migration[4.2]
 
   def self.up
     change_column :facilities, :url_name,      :string, limit: 50,  null: false

--- a/db/migrate/20100528195301_add_cancel_audit_to_reservation.rb
+++ b/db/migrate/20100528195301_add_cancel_audit_to_reservation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCancelAuditToReservation < ActiveRecord::Migration
+class AddCancelAuditToReservation < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :reservations, :canceled_at,     :datetime,             null: true

--- a/db/migrate/20100528201017_rename_order_details_total_to_actual.rb
+++ b/db/migrate/20100528201017_rename_order_details_total_to_actual.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RenameOrderDetailsTotalToActual < ActiveRecord::Migration
+class RenameOrderDetailsTotalToActual < ActiveRecord::Migration[4.2]
 
   def self.up
     rename_column :order_details, :total_cost, :actual_cost

--- a/db/migrate/20100528201316_remove_orders_totals.rb
+++ b/db/migrate/20100528201316_remove_orders_totals.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveOrdersTotals < ActiveRecord::Migration
+class RemoveOrdersTotals < ActiveRecord::Migration[4.2]
 
   def self.up
     remove_column :orders, :total_cost

--- a/db/migrate/20100528203109_order_details_add_and_remove_fields.rb
+++ b/db/migrate/20100528203109_order_details_add_and_remove_fields.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class OrderDetailsAddAndRemoveFields < ActiveRecord::Migration
+class OrderDetailsAddAndRemoveFields < ActiveRecord::Migration[4.2]
 
   def self.up
     # Oracle will drop the foreign key as part of the remove_column

--- a/db/migrate/20100528204023_add_fields_to_accounts.rb
+++ b/db/migrate/20100528204023_add_fields_to_accounts.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddFieldsToAccounts < ActiveRecord::Migration
+class AddFieldsToAccounts < ActiveRecord::Migration[4.2]
 
   class Account < ActiveRecord::Base
   end

--- a/db/migrate/20100528212342_add_account_users_table.rb
+++ b/db/migrate/20100528212342_add_account_users_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAccountUsersTable < ActiveRecord::Migration
+class AddAccountUsersTable < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :account_users do |t|

--- a/db/migrate/20100528230042_add_order_detail_statuses_table.rb
+++ b/db/migrate/20100528230042_add_order_detail_statuses_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddOrderDetailStatusesTable < ActiveRecord::Migration
+class AddOrderDetailStatusesTable < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :order_detail_statuses do |t|

--- a/db/migrate/20100528230902_add_product_users_table.rb
+++ b/db/migrate/20100528230902_add_product_users_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddProductUsersTable < ActiveRecord::Migration
+class AddProductUsersTable < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :product_users do |t|

--- a/db/migrate/20100604214008_rename_order_detail_statuses_updated_fields_to_created.rb
+++ b/db/migrate/20100604214008_rename_order_detail_statuses_updated_fields_to_created.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RenameOrderDetailStatusesUpdatedFieldsToCreated < ActiveRecord::Migration
+class RenameOrderDetailStatusesUpdatedFieldsToCreated < ActiveRecord::Migration[4.2]
 
   def self.up
     rename_column :order_detail_statuses, :updated_by, :created_by

--- a/db/migrate/20100607194341_remove_order_price_group.rb
+++ b/db/migrate/20100607194341_remove_order_price_group.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveOrderPriceGroup < ActiveRecord::Migration
+class RemoveOrderPriceGroup < ActiveRecord::Migration[4.2]
 
   def self.up
     remove_column :orders, :price_group_id

--- a/db/migrate/20100607194817_remove_account_owner_user_id.rb
+++ b/db/migrate/20100607194817_remove_account_owner_user_id.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveAccountOwnerUserId < ActiveRecord::Migration
+class RemoveAccountOwnerUserId < ActiveRecord::Migration[4.2]
 
   def self.up
     accounts = Account.all

--- a/db/migrate/20100609205743_remove_default_for_display_order.rb
+++ b/db/migrate/20100609205743_remove_default_for_display_order.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveDefaultForDisplayOrder < ActiveRecord::Migration
+class RemoveDefaultForDisplayOrder < ActiveRecord::Migration[4.2]
 
   def self.up
     remove_column :price_groups, :display_order

--- a/db/migrate/20100615182659_create_surveys.rb
+++ b/db/migrate/20100615182659_create_surveys.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSurveys < ActiveRecord::Migration
+class CreateSurveys < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :surveys do |t|

--- a/db/migrate/20100615182660_create_survey_sections.rb
+++ b/db/migrate/20100615182660_create_survey_sections.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSurveySections < ActiveRecord::Migration
+class CreateSurveySections < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :survey_sections do |t|

--- a/db/migrate/20100615182661_create_questions.rb
+++ b/db/migrate/20100615182661_create_questions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateQuestions < ActiveRecord::Migration
+class CreateQuestions < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :questions do |t|

--- a/db/migrate/20100615182662_create_question_groups.rb
+++ b/db/migrate/20100615182662_create_question_groups.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateQuestionGroups < ActiveRecord::Migration
+class CreateQuestionGroups < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :question_groups do |t|

--- a/db/migrate/20100615182663_create_answers.rb
+++ b/db/migrate/20100615182663_create_answers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateAnswers < ActiveRecord::Migration
+class CreateAnswers < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :answers do |t|

--- a/db/migrate/20100615182664_create_response_sets.rb
+++ b/db/migrate/20100615182664_create_response_sets.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateResponseSets < ActiveRecord::Migration
+class CreateResponseSets < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :response_sets do |t|

--- a/db/migrate/20100615182665_create_responses.rb
+++ b/db/migrate/20100615182665_create_responses.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateResponses < ActiveRecord::Migration
+class CreateResponses < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :responses do |t|

--- a/db/migrate/20100615182666_create_dependencies.rb
+++ b/db/migrate/20100615182666_create_dependencies.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateDependencies < ActiveRecord::Migration
+class CreateDependencies < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :dependencies do |t|

--- a/db/migrate/20100615182667_create_dependency_conditions.rb
+++ b/db/migrate/20100615182667_create_dependency_conditions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateDependencyConditions < ActiveRecord::Migration
+class CreateDependencyConditions < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :dependency_conditions do |t|

--- a/db/migrate/20100615182668_create_validations.rb
+++ b/db/migrate/20100615182668_create_validations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateValidations < ActiveRecord::Migration
+class CreateValidations < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :validations do |t|

--- a/db/migrate/20100615182669_create_validation_conditions.rb
+++ b/db/migrate/20100615182669_create_validation_conditions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateValidationConditions < ActiveRecord::Migration
+class CreateValidationConditions < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :validation_conditions do |t|

--- a/db/migrate/20100615182670_add_display_order_to_surveys.rb
+++ b/db/migrate/20100615182670_add_display_order_to_surveys.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDisplayOrderToSurveys < ActiveRecord::Migration
+class AddDisplayOrderToSurveys < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :surveys, :display_order, :integer

--- a/db/migrate/20100615182671_add_correct_answer_id_to_questions.rb
+++ b/db/migrate/20100615182671_add_correct_answer_id_to_questions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCorrectAnswerIdToQuestions < ActiveRecord::Migration
+class AddCorrectAnswerIdToQuestions < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :questions, :correct_answer_id, :integer

--- a/db/migrate/20100615182672_add_index_to_response_sets.rb
+++ b/db/migrate/20100615182672_add_index_to_response_sets.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIndexToResponseSets < ActiveRecord::Migration
+class AddIndexToResponseSets < ActiveRecord::Migration[4.2]
 
   def self.up
     add_index(:response_sets, :access_code, name: "response_sets_ac_idx")

--- a/db/migrate/20100615182673_add_index_to_surveys.rb
+++ b/db/migrate/20100615182673_add_index_to_surveys.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIndexToSurveys < ActiveRecord::Migration
+class AddIndexToSurveys < ActiveRecord::Migration[4.2]
 
   def self.up
     add_index(:surveys, :access_code, name: "surveys_ac_idx")

--- a/db/migrate/20100615182674_add_unique_indicies.rb
+++ b/db/migrate/20100615182674_add_unique_indicies.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddUniqueIndicies < ActiveRecord::Migration
+class AddUniqueIndicies < ActiveRecord::Migration[4.2]
 
   def self.up
     remove_index(:response_sets, name: "response_sets_ac_idx")

--- a/db/migrate/20100615183227_add_service_surveys.rb
+++ b/db/migrate/20100615183227_add_service_surveys.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddServiceSurveys < ActiveRecord::Migration
+class AddServiceSurveys < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :service_surveys do |t|

--- a/db/migrate/20100616192941_add_response_set_to_order_detail.rb
+++ b/db/migrate/20100616192941_add_response_set_to_order_detail.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddResponseSetToOrderDetail < ActiveRecord::Migration
+class AddResponseSetToOrderDetail < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :order_details, :response_set_id, :integer

--- a/db/migrate/20100628183740_add_column_restrict_purchase_to_price_policies.rb
+++ b/db/migrate/20100628183740_add_column_restrict_purchase_to_price_policies.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddColumnRestrictPurchaseToPricePolicies < ActiveRecord::Migration
+class AddColumnRestrictPurchaseToPricePolicies < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :price_policies, :restrict_purchase, :boolean, null: true

--- a/db/migrate/20100628204300_change_price_policies_restrict_purchase.rb
+++ b/db/migrate/20100628204300_change_price_policies_restrict_purchase.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangePricePoliciesRestrictPurchase < ActiveRecord::Migration
+class ChangePricePoliciesRestrictPurchase < ActiveRecord::Migration[4.2]
 
   def self.up
     execute "UPDATE price_policies SET restrict_purchase = 0 WHERE restrict_purchase IS NULL"

--- a/db/migrate/20100630233226_create_vestal_versions.rb
+++ b/db/migrate/20100630233226_create_vestal_versions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateVestalVersions < ActiveRecord::Migration
+class CreateVestalVersions < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :versions do |t|

--- a/db/migrate/20100701000551_add_order_detail_fields.rb
+++ b/db/migrate/20100701000551_add_order_detail_fields.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddOrderDetailFields < ActiveRecord::Migration
+class AddOrderDetailFields < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :order_details do |t|

--- a/db/migrate/20100701183019_create_facility_accounts.rb
+++ b/db/migrate/20100701183019_create_facility_accounts.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateFacilityAccounts < ActiveRecord::Migration
+class CreateFacilityAccounts < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :facility_accounts do |t|

--- a/db/migrate/20100701232820_change_order_detail_status.rb
+++ b/db/migrate/20100701232820_change_order_detail_status.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeOrderDetailStatus < ActiveRecord::Migration
+class ChangeOrderDetailStatus < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :order_details, :order_status_id, :integer, null: true

--- a/db/migrate/20100707185202_add_statement_fields.rb
+++ b/db/migrate/20100707185202_add_statement_fields.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddStatementFields < ActiveRecord::Migration
+class AddStatementFields < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :statements, :account_id,  :integer,  null: false

--- a/db/migrate/20100707190304_add_account_transactions_table.rb
+++ b/db/migrate/20100707190304_add_account_transactions_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAccountTransactionsTable < ActiveRecord::Migration
+class AddAccountTransactionsTable < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table   :account_transactions do |t|

--- a/db/migrate/20100708000052_add_order_detail_state.rb
+++ b/db/migrate/20100708000052_add_order_detail_state.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddOrderDetailState < ActiveRecord::Migration
+class AddOrderDetailState < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :order_details do |t|

--- a/db/migrate/20100708195447_alter_account_transactions_add_fields.rb
+++ b/db/migrate/20100708195447_alter_account_transactions_add_fields.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterAccountTransactionsAddFields < ActiveRecord::Migration
+class AlterAccountTransactionsAddFields < ActiveRecord::Migration[4.2]
 
   def self.up
     execute "DELETE FROM account_transactions"

--- a/db/migrate/20100708221022_remove_statement_id_from_order_details.rb
+++ b/db/migrate/20100708221022_remove_statement_id_from_order_details.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveStatementIdFromOrderDetails < ActiveRecord::Migration
+class RemoveStatementIdFromOrderDetails < ActiveRecord::Migration[4.2]
 
   def self.up
     # Oracle will drop the foreign key as part of the remove_column

--- a/db/migrate/20100712194630_add_account_suspended_at_field.rb
+++ b/db/migrate/20100712194630_add_account_suspended_at_field.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAccountSuspendedAtField < ActiveRecord::Migration
+class AddAccountSuspendedAtField < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :accounts do |t|

--- a/db/migrate/20100713171653_add_reference_number_to_account_transactions.rb
+++ b/db/migrate/20100713171653_add_reference_number_to_account_transactions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddReferenceNumberToAccountTransactions < ActiveRecord::Migration
+class AddReferenceNumberToAccountTransactions < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :account_transactions, :reference, :string, limit: 50, null: true

--- a/db/migrate/20100713200332_rename_account_transaction_transaction_type.rb
+++ b/db/migrate/20100713200332_rename_account_transaction_transaction_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RenameAccountTransactionTransactionType < ActiveRecord::Migration
+class RenameAccountTransactionTransactionType < ActiveRecord::Migration[4.2]
 
   def self.up
     rename_column :account_transactions, :transaction_type, :type

--- a/db/migrate/20100713224404_change_account_transactions_description_to_nullable.rb
+++ b/db/migrate/20100713224404_change_account_transactions_description_to_nullable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeAccountTransactionsDescriptionToNullable < ActiveRecord::Migration
+class ChangeAccountTransactionsDescriptionToNullable < ActiveRecord::Migration[4.2]
 
   def self.up
     change_column :account_transactions, :description, :string, limit: 200, null: true

--- a/db/migrate/20100714154110_add_service_surveys_preview_code.rb
+++ b/db/migrate/20100714154110_add_service_surveys_preview_code.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddServiceSurveysPreviewCode < ActiveRecord::Migration
+class AddServiceSurveysPreviewCode < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :service_surveys do |t|

--- a/db/migrate/20100715171938_add_journals_table.rb
+++ b/db/migrate/20100715171938_add_journals_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddJournalsTable < ActiveRecord::Migration
+class AddJournalsTable < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :journals do |t|

--- a/db/migrate/20100715223533_add_balance_to_journaled_accounts.rb
+++ b/db/migrate/20100715223533_add_balance_to_journaled_accounts.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddBalanceToJournaledAccounts < ActiveRecord::Migration
+class AddBalanceToJournaledAccounts < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :journaled_accounts, :balance, :decimal, null: false, precision: 10, scale: 2

--- a/db/migrate/20100719192104_add_table_statement_accounts.rb
+++ b/db/migrate/20100719192104_add_table_statement_accounts.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddTableStatementAccounts < ActiveRecord::Migration
+class AddTableStatementAccounts < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :statement_accounts do |t|

--- a/db/migrate/20100721183524_add_constraint_to_order_details.rb
+++ b/db/migrate/20100721183524_add_constraint_to_order_details.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddConstraintToOrderDetails < ActiveRecord::Migration
+class AddConstraintToOrderDetails < ActiveRecord::Migration[4.2]
 
   def self.up
     execute "ALTER TABLE order_details ADD CONSTRAINT fk_od_accounts FOREIGN KEY (account_id) REFERENCES accounts (id)"

--- a/db/migrate/20100726171853_add_files_table.rb
+++ b/db/migrate/20100726171853_add_files_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddFilesTable < ActiveRecord::Migration
+class AddFilesTable < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :files do |t|

--- a/db/migrate/20100727184318_add_dispute_credit_to_order_details.rb
+++ b/db/migrate/20100727184318_add_dispute_credit_to_order_details.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDisputeCreditToOrderDetails < ActiveRecord::Migration
+class AddDisputeCreditToOrderDetails < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :order_details, :dispute_resolved_credit, :decimal, null: true, precision: 10, scale: 2

--- a/db/migrate/20100729174129_rebuild_files_table.rb
+++ b/db/migrate/20100729174129_rebuild_files_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RebuildFilesTable < ActiveRecord::Migration
+class RebuildFilesTable < ActiveRecord::Migration[4.2]
 
   def self.up
     drop_table :files

--- a/db/migrate/20100804191731_add_display_account_number_to_accounts.rb
+++ b/db/migrate/20100804191731_add_display_account_number_to_accounts.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDisplayAccountNumberToAccounts < ActiveRecord::Migration
+class AddDisplayAccountNumberToAccounts < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :accounts do |t|

--- a/db/migrate/20100804225934_add_instruments_relay_username_and_password.rb
+++ b/db/migrate/20100804225934_add_instruments_relay_username_and_password.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddInstrumentsRelayUsernameAndPassword < ActiveRecord::Migration
+class AddInstrumentsRelayUsernameAndPassword < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :products, :relay_username, :string, null: true, limit: 50

--- a/db/migrate/20100805165201_add_instrument_statuses_table.rb
+++ b/db/migrate/20100805165201_add_instrument_statuses_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddInstrumentStatusesTable < ActiveRecord::Migration
+class AddInstrumentStatusesTable < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :instrument_statuses do |t|

--- a/db/migrate/20100805175405_add_accepts_flags_to_facilities.rb
+++ b/db/migrate/20100805175405_add_accepts_flags_to_facilities.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAcceptsFlagsToFacilities < ActiveRecord::Migration
+class AddAcceptsFlagsToFacilities < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :facilities do |t|

--- a/db/migrate/20100806160008_rename_files_table.rb
+++ b/db/migrate/20100806160008_rename_files_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RenameFilesTable < ActiveRecord::Migration
+class RenameFilesTable < ActiveRecord::Migration[4.2]
 
   def self.up
     rename_table :files, :file_uploads

--- a/db/migrate/20100806161930_add_attachments_file_to_file_upload.rb
+++ b/db/migrate/20100806161930_add_attachments_file_to_file_upload.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAttachmentsFileToFileUpload < ActiveRecord::Migration
+class AddAttachmentsFileToFileUpload < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :file_uploads, :file_file_name, :string

--- a/db/migrate/20100812170701_add_budgeted_chart_string.rb
+++ b/db/migrate/20100812170701_add_budgeted_chart_string.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddBudgetedChartString < ActiveRecord::Migration
+class AddBudgetedChartString < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :budgeted_chart_strings do |t|

--- a/db/migrate/20100827204813_add_in_dispute_to_account_transactions.rb
+++ b/db/migrate/20100827204813_add_in_dispute_to_account_transactions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddInDisputeToAccountTransactions < ActiveRecord::Migration
+class AddInDisputeToAccountTransactions < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :account_transactions, :is_in_dispute, :boolean, null: true

--- a/db/migrate/20100908224462_add_section_id_to_responses.rb
+++ b/db/migrate/20100908224462_add_section_id_to_responses.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddSectionIdToResponses < ActiveRecord::Migration
+class AddSectionIdToResponses < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :responses, :survey_section_id, :integer

--- a/db/migrate/20100914171717_add_facility_account_to_account_transactions.rb
+++ b/db/migrate/20100914171717_add_facility_account_to_account_transactions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddFacilityAccountToAccountTransactions < ActiveRecord::Migration
+class AddFacilityAccountToAccountTransactions < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :account_transactions do |t|

--- a/db/migrate/20100916154915_add_paperclip_to_journal.rb
+++ b/db/migrate/20100916154915_add_paperclip_to_journal.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddPaperclipToJournal < ActiveRecord::Migration
+class AddPaperclipToJournal < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :journals, :file_file_name, :string

--- a/db/migrate/20100917145745_alter_account_transactions_facility_account_nullable.rb
+++ b/db/migrate/20100917145745_alter_account_transactions_facility_account_nullable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterAccountTransactionsFacilityAccountNullable < ActiveRecord::Migration
+class AlterAccountTransactionsFacilityAccountNullable < ActiveRecord::Migration[4.2]
 
   def self.up
     change_column :account_transactions, :facility_account_id, :integer, precision: 38, scale: 0, null: true

--- a/db/migrate/20100930180831_add_facility_account_id_to_journaled_accounts.rb
+++ b/db/migrate/20100930180831_add_facility_account_id_to_journaled_accounts.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddFacilityAccountIdToJournaledAccounts < ActiveRecord::Migration
+class AddFacilityAccountIdToJournaledAccounts < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :journaled_accounts, :facility_account_id, :integer, null: false

--- a/db/migrate/20101007204359_modify_accounts_credit_card_fields.rb
+++ b/db/migrate/20101007204359_modify_accounts_credit_card_fields.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ModifyAccountsCreditCardFields < ActiveRecord::Migration
+class ModifyAccountsCreditCardFields < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column    :accounts, :credit_card_number_encrypted, :string, limit: 200, null: true

--- a/db/migrate/20101007224415_remove_cvv_from_accounts.rb
+++ b/db/migrate/20101007224415_remove_cvv_from_accounts.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveCvvFromAccounts < ActiveRecord::Migration
+class RemoveCvvFromAccounts < ActiveRecord::Migration[4.2]
 
   def self.up
     remove_column :accounts, :cvv

--- a/db/migrate/20101011172245_add_short_description_to_facilities.rb
+++ b/db/migrate/20101011172245_add_short_description_to_facilities.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddShortDescriptionToFacilities < ActiveRecord::Migration
+class AddShortDescriptionToFacilities < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :facilities, :short_description, :text, null: false

--- a/db/migrate/20101011184759_add_price_group_type_to_price_groups.rb
+++ b/db/migrate/20101011184759_add_price_group_type_to_price_groups.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddPriceGroupTypeToPriceGroups < ActiveRecord::Migration
+class AddPriceGroupTypeToPriceGroups < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :price_groups, :is_internal, :boolean, null: false

--- a/db/migrate/20101012164247_remove_unit_size_and_rename_column_in_products.rb
+++ b/db/migrate/20101012164247_remove_unit_size_and_rename_column_in_products.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveUnitSizeAndRenameColumnInProducts < ActiveRecord::Migration
+class RemoveUnitSizeAndRenameColumnInProducts < ActiveRecord::Migration[4.2]
 
   def self.up
     remove_column :products, :unit_size

--- a/db/migrate/20101012181426_add_account_and_revenue_account_fields.rb
+++ b/db/migrate/20101012181426_add_account_and_revenue_account_fields.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAccountAndRevenueAccountFields < ActiveRecord::Migration
+class AddAccountAndRevenueAccountFields < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :products, :account, :integer, null: true

--- a/db/migrate/20101015210647_edits_for_invoicing_and_journaling_refacting.rb
+++ b/db/migrate/20101015210647_edits_for_invoicing_and_journaling_refacting.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EditsForInvoicingAndJournalingRefacting < ActiveRecord::Migration
+class EditsForInvoicingAndJournalingRefacting < ActiveRecord::Migration[4.2]
 
   def self.up
     # update the account_transaction table

--- a/db/migrate/20101015215418_remove_reference_from_account_transactions.rb
+++ b/db/migrate/20101015215418_remove_reference_from_account_transactions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveReferenceFromAccountTransactions < ActiveRecord::Migration
+class RemoveReferenceFromAccountTransactions < ActiveRecord::Migration[4.2]
 
   def self.up
     remove_column :account_transactions, :reference

--- a/db/migrate/20101018192720_add_account_transaction_id_to_journal_rows.rb
+++ b/db/migrate/20101018192720_add_account_transaction_id_to_journal_rows.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAccountTransactionIdToJournalRows < ActiveRecord::Migration
+class AddAccountTransactionIdToJournalRows < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :journal_rows, :account_transaction_id, :integer, null: true

--- a/db/migrate/20101018203424_add_reference_back_to_account_transactions.rb
+++ b/db/migrate/20101018203424_add_reference_back_to_account_transactions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddReferenceBackToAccountTransactions < ActiveRecord::Migration
+class AddReferenceBackToAccountTransactions < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :account_transactions, :reference, :string, limit: 50, null: true

--- a/db/migrate/20101018221409_bundle_related_updates.rb
+++ b/db/migrate/20101018221409_bundle_related_updates.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class BundleRelatedUpdates < ActiveRecord::Migration
+class BundleRelatedUpdates < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :order_details, :bundle_order_detail_id, :integer, null: true

--- a/db/migrate/20101019163858_update_product_table_for_bundles.rb
+++ b/db/migrate/20101019163858_update_product_table_for_bundles.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UpdateProductTableForBundles < ActiveRecord::Migration
+class UpdateProductTableForBundles < ActiveRecord::Migration[4.2]
 
   def self.up
     change_column :products, :initial_order_status_id, :integer, null: true

--- a/db/migrate/20101020162405_alter_order_details_for_bundles.rb
+++ b/db/migrate/20101020162405_alter_order_details_for_bundles.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterOrderDetailsForBundles < ActiveRecord::Migration
+class AlterOrderDetailsForBundles < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column    :order_details, :group_id,           :integer, null: true

--- a/db/migrate/20101027175630_update_po_and_invoice_fields.rb
+++ b/db/migrate/20101027175630_update_po_and_invoice_fields.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UpdatePoAndInvoiceFields < ActiveRecord::Migration
+class UpdatePoAndInvoiceFields < ActiveRecord::Migration[4.2]
 
   def self.up
     # add PO remit-to

--- a/db/migrate/20110203223006_set_journal_rows_order_detail_id_nullable.rb
+++ b/db/migrate/20110203223006_set_journal_rows_order_detail_id_nullable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SetJournalRowsOrderDetailIdNullable < ActiveRecord::Migration
+class SetJournalRowsOrderDetailIdNullable < ActiveRecord::Migration[4.2]
 
   def self.up
     change_column :journal_rows, :order_detail_id, :integer, null: true

--- a/db/migrate/20110208211613_alter_journal_rows_make_project_nullable.rb
+++ b/db/migrate/20110208211613_alter_journal_rows_make_project_nullable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterJournalRowsMakeProjectNullable < ActiveRecord::Migration
+class AlterJournalRowsMakeProjectNullable < ActiveRecord::Migration[4.2]
 
   def self.up
     change_column :journal_rows, :project, :integer, null: true

--- a/db/migrate/20110215200647_create_users.rb
+++ b/db/migrate/20110215200647_create_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table(:users) do |t|

--- a/db/migrate/20110216002247_create_user_roles.rb
+++ b/db/migrate/20110216002247_create_user_roles.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateUserRoles < ActiveRecord::Migration
+class CreateUserRoles < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :user_roles do |t|

--- a/db/migrate/20110216164102_add_facilities_journal_mask_column.rb
+++ b/db/migrate/20110216164102_add_facilities_journal_mask_column.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddFacilitiesJournalMaskColumn < ActiveRecord::Migration
+class AddFacilitiesJournalMaskColumn < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :facilities, :journal_mask, :string, limit: 50, null: true # TODO: why? , :after =>

--- a/db/migrate/20110216205725_remove_facility_affiliate_id.rb
+++ b/db/migrate/20110216205725_remove_facility_affiliate_id.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveFacilityAffiliateId < ActiveRecord::Migration
+class RemoveFacilityAffiliateId < ActiveRecord::Migration[4.2]
 
   def self.up
     remove_column(:facilities, :pers_affiliate_id)

--- a/db/migrate/20110221225822_change_journal_rows_values_to_strings.rb
+++ b/db/migrate/20110221225822_change_journal_rows_values_to_strings.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeJournalRowsValuesToStrings < ActiveRecord::Migration
+class ChangeJournalRowsValuesToStrings < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :journal_rows, :fund_string,     :string, limit: 3, null: true, after: :fund

--- a/db/migrate/20110224063354_remove_credit_card_number.rb
+++ b/db/migrate/20110224063354_remove_credit_card_number.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveCreditCardNumber < ActiveRecord::Migration
+class RemoveCreditCardNumber < ActiveRecord::Migration[4.2]
 
   def self.up
     remove_column :accounts, :credit_card_number_encrypted

--- a/db/migrate/20110314201317_alter_users_null_passwords.rb
+++ b/db/migrate/20110314201317_alter_users_null_passwords.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterUsersNullPasswords < ActiveRecord::Migration
+class AlterUsersNullPasswords < ActiveRecord::Migration[4.2]
 
   def self.up
     change_column(:users, :encrypted_password, :string, null: true, default: nil)

--- a/db/migrate/20110403013939_add_order_detail_note.rb
+++ b/db/migrate/20110403013939_add_order_detail_note.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddOrderDetailNote < ActiveRecord::Migration
+class AddOrderDetailNote < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :order_details, :note, :string, limit: 25

--- a/db/migrate/20110411215240_create_price_group_products.rb
+++ b/db/migrate/20110411215240_create_price_group_products.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreatePriceGroupProducts < ActiveRecord::Migration
+class CreatePriceGroupProducts < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :price_group_products do |t|

--- a/db/migrate/20110412174924_alter_price_policies.rb
+++ b/db/migrate/20110412174924_alter_price_policies.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterPricePolicies < ActiveRecord::Migration
+class AlterPricePolicies < ActiveRecord::Migration[4.2]
 
   def self.up
     remove_column(:price_policies, :reservation_window)

--- a/db/migrate/20110415224140_alter_price_policies_restrict_expire_date.rb
+++ b/db/migrate/20110415224140_alter_price_policies_restrict_expire_date.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterPricePoliciesRestrictExpireDate < ActiveRecord::Migration
+class AlterPricePoliciesRestrictExpireDate < ActiveRecord::Migration[4.2]
 
   def self.up
     change_column(:price_policies, :expire_date, :datetime, null: false)

--- a/db/migrate/20110425225944_alter_order_details_drop_dispute_resolved_credit.rb
+++ b/db/migrate/20110425225944_alter_order_details_drop_dispute_resolved_credit.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterOrderDetailsDropDisputeResolvedCredit < ActiveRecord::Migration
+class AlterOrderDetailsDropDisputeResolvedCredit < ActiveRecord::Migration[4.2]
 
   def self.up
     details = OrderDetail.where("dispute_resolved_credit IS NOT NULL")

--- a/db/migrate/20110426221701_remove_reviewable_state.rb
+++ b/db/migrate/20110426221701_remove_reviewable_state.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveReviewableState < ActiveRecord::Migration
+class RemoveReviewableState < ActiveRecord::Migration[4.2]
 
   def self.up
     reviewable = OrderStatus.find_by(name: "Reviewable")

--- a/db/migrate/20110428204626_create_statement_rows.rb
+++ b/db/migrate/20110428204626_create_statement_rows.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateStatementRows < ActiveRecord::Migration
+class CreateStatementRows < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :statement_rows do |t|

--- a/db/migrate/20110428204714_alter_order_details.rb
+++ b/db/migrate/20110428204714_alter_order_details.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterOrderDetails < ActiveRecord::Migration
+class AlterOrderDetails < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :order_details do |t|

--- a/db/migrate/20110428204720_alter_statements.rb
+++ b/db/migrate/20110428204720_alter_statements.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterStatements < ActiveRecord::Migration
+class AlterStatements < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :statements do |t|

--- a/db/migrate/20110428204746_migrate_and_drop_account_transactions.rb
+++ b/db/migrate/20110428204746_migrate_and_drop_account_transactions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MigrateAndDropAccountTransactions < ActiveRecord::Migration
+class MigrateAndDropAccountTransactions < ActiveRecord::Migration[4.2]
 
   def self.up
     OrderDetail.reset_column_information

--- a/db/migrate/20110506191358_remove_invoice_date_from_statements.rb
+++ b/db/migrate/20110506191358_remove_invoice_date_from_statements.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveInvoiceDateFromStatements < ActiveRecord::Migration
+class RemoveInvoiceDateFromStatements < ActiveRecord::Migration[4.2]
 
   def self.up
     statements = Statement.all

--- a/db/migrate/20110507055026_add_journal_date_to_journals.rb
+++ b/db/migrate/20110507055026_add_journal_date_to_journals.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddJournalDateToJournals < ActiveRecord::Migration
+class AddJournalDateToJournals < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :journals, :journal_date, :datetime, null: true

--- a/db/migrate/20110511180455_add_relay_type_to_products.rb
+++ b/db/migrate/20110511180455_add_relay_type_to_products.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddRelayTypeToProducts < ActiveRecord::Migration
+class AddRelayTypeToProducts < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :products, :relay_type, :string, limit: 50, null: true

--- a/db/migrate/20110608215021_drop_surveyor.rb
+++ b/db/migrate/20110608215021_drop_surveyor.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DropSurveyor < ActiveRecord::Migration
+class DropSurveyor < ActiveRecord::Migration[4.2]
 
   def self.up
     drop_table :answers

--- a/db/migrate/20110608222354_create_external_services.rb
+++ b/db/migrate/20110608222354_create_external_services.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateExternalServices < ActiveRecord::Migration
+class CreateExternalServices < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :external_services do |t|

--- a/db/migrate/20110608222406_create_external_service_passers.rb
+++ b/db/migrate/20110608222406_create_external_service_passers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateExternalServicePassers < ActiveRecord::Migration
+class CreateExternalServicePassers < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :external_service_passers do |t|

--- a/db/migrate/20110608222657_create_external_service_receivers.rb
+++ b/db/migrate/20110608222657_create_external_service_receivers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateExternalServiceReceivers < ActiveRecord::Migration
+class CreateExternalServiceReceivers < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :external_service_receivers do |t|

--- a/db/migrate/20110627182814_add_show_details_to_instruments.rb
+++ b/db/migrate/20110627182814_add_show_details_to_instruments.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddShowDetailsToInstruments < ActiveRecord::Migration
+class AddShowDetailsToInstruments < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :products do |t|

--- a/db/migrate/20110729173029_change_vestal_versions.rb
+++ b/db/migrate/20110729173029_change_vestal_versions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeVestalVersions < ActiveRecord::Migration
+class ChangeVestalVersions < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :versions, :reason_for_update, :string

--- a/db/migrate/20110810225150_create_affiliates.rb
+++ b/db/migrate/20110810225150_create_affiliates.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateAffiliates < ActiveRecord::Migration
+class CreateAffiliates < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :affiliates do |t|

--- a/db/migrate/20110810232349_alter_accounts_for_affiliates.rb
+++ b/db/migrate/20110810232349_alter_accounts_for_affiliates.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterAccountsForAffiliates < ActiveRecord::Migration
+class AlterAccountsForAffiliates < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :accounts do |t|

--- a/db/migrate/20111209185608_base_rate_rename.rb
+++ b/db/migrate/20111209185608_base_rate_rename.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class BaseRateRename < ActiveRecord::Migration
+class BaseRateRename < ActiveRecord::Migration[4.2]
 
   def self.up
     pg = PriceGroup.find_by(name: "Northwestern Base Rate")

--- a/db/migrate/20111219210901_create_relays.rb
+++ b/db/migrate/20111219210901_create_relays.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateRelays < ActiveRecord::Migration
+class CreateRelays < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :relays do |t|

--- a/db/migrate/20111219213559_migrate_relays.rb
+++ b/db/migrate/20111219213559_migrate_relays.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MigrateRelays < ActiveRecord::Migration
+class MigrateRelays < ActiveRecord::Migration[4.2]
 
   def self.up
     Relay.reset_column_information

--- a/db/migrate/20111219220830_alter_products_remove_relays.rb
+++ b/db/migrate/20111219220830_alter_products_remove_relays.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterProductsRemoveRelays < ActiveRecord::Migration
+class AlterProductsRemoveRelays < ActiveRecord::Migration[4.2]
 
   def self.up
     remove_column(:products, :relay_ip)

--- a/db/migrate/20111220164710_add_recoverable_to_user.rb
+++ b/db/migrate/20111220164710_add_recoverable_to_user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddRecoverableToUser < ActiveRecord::Migration
+class AddRecoverableToUser < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :users do |t|

--- a/db/migrate/20120117210956_alter_products_add_auto_cancel_mins.rb
+++ b/db/migrate/20120117210956_alter_products_add_auto_cancel_mins.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterProductsAddAutoCancelMins < ActiveRecord::Migration
+class AlterProductsAddAutoCancelMins < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :products, :auto_cancel_mins, :integer

--- a/db/migrate/20120203185844_alter_users_add_uid.rb
+++ b/db/migrate/20120203185844_alter_users_add_uid.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterUsersAddUid < ActiveRecord::Migration
+class AlterUsersAddUid < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :users, :uid, :integer

--- a/db/migrate/20120209231652_create_product_accessories.rb
+++ b/db/migrate/20120209231652_create_product_accessories.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateProductAccessories < ActiveRecord::Migration
+class CreateProductAccessories < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :product_accessories do |t|

--- a/db/migrate/20120222161624_add_product_access_groups.rb
+++ b/db/migrate/20120222161624_add_product_access_groups.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddProductAccessGroups < ActiveRecord::Migration
+class AddProductAccessGroups < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :product_access_groups do |t|

--- a/db/migrate/20120420204254_make_journals_facility_id_nullable.rb
+++ b/db/migrate/20120420204254_make_journals_facility_id_nullable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MakeJournalsFacilityIdNullable < ActiveRecord::Migration
+class MakeJournalsFacilityIdNullable < ActiveRecord::Migration[4.2]
 
   def self.up
     change_column :journals, :facility_id, :integer, null: true

--- a/db/migrate/20120502223446_alter_journal_rows_remove_nu.rb
+++ b/db/migrate/20120502223446_alter_journal_rows_remove_nu.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterJournalRowsRemoveNu < ActiveRecord::Migration
+class AlterJournalRowsRemoveNu < ActiveRecord::Migration[4.2]
 
   def self.up
     if NUCore::Database.oracle?

--- a/db/migrate/20120503203910_od_note_length_to_one_hundred.rb
+++ b/db/migrate/20120503203910_od_note_length_to_one_hundred.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class OdNoteLengthToOneHundred < ActiveRecord::Migration
+class OdNoteLengthToOneHundred < ActiveRecord::Migration[4.2]
 
   def self.up
     change_column :order_details, :note, :string, limit: 100

--- a/db/migrate/20120510172358_add_bi_table.rb
+++ b/db/migrate/20120510172358_add_bi_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddBiTable < ActiveRecord::Migration
+class AddBiTable < ActiveRecord::Migration[4.2]
 
   def self.up
     if NUCore::Database.oracle?

--- a/db/migrate/20120512014131_add_accepts_multi_add_to_facilities.rb
+++ b/db/migrate/20120512014131_add_accepts_multi_add_to_facilities.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAcceptsMultiAddToFacilities < ActiveRecord::Migration
+class AddAcceptsMultiAddToFacilities < ActiveRecord::Migration[4.2]
 
   def self.up
     change_table :facilities do |t|

--- a/db/migrate/20120620181642_flatten_price_policy_foreign_keys.rb
+++ b/db/migrate/20120620181642_flatten_price_policy_foreign_keys.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class FlattenPricePolicyForeignKeys < ActiveRecord::Migration
+class FlattenPricePolicyForeignKeys < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :price_policies, :product_id, :integer, after: :type

--- a/db/migrate/20120622185758_move_can_purchase_into_price_policy.rb
+++ b/db/migrate/20120622185758_move_can_purchase_into_price_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MoveCanPurchaseIntoPricePolicy < ActiveRecord::Migration
+class MoveCanPurchaseIntoPricePolicy < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :price_policies, :can_purchase, :boolean, after: :price_group_id, default: false, null: false

--- a/db/migrate/20120723203745_make_order_detail_order_status_nullable.rb
+++ b/db/migrate/20120723203745_make_order_detail_order_status_nullable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MakeOrderDetailOrderStatusNullable < ActiveRecord::Migration
+class MakeOrderDetailOrderStatusNullable < ActiveRecord::Migration[4.2]
 
   def self.up
     change_column :order_details, :order_status_id, :integer, null: true

--- a/db/migrate/20120801161003_add_contact_email_to_product.rb
+++ b/db/migrate/20120801161003_add_contact_email_to_product.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddContactEmailToProduct < ActiveRecord::Migration
+class AddContactEmailToProduct < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :products, :contact_email, :string

--- a/db/migrate/20120801223135_journal_rows_allow_null_account.rb
+++ b/db/migrate/20120801223135_journal_rows_allow_null_account.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class JournalRowsAllowNullAccount < ActiveRecord::Migration
+class JournalRowsAllowNullAccount < ActiveRecord::Migration[4.2]
 
   def self.up
     if NUCore::Database.oracle?

--- a/db/migrate/20120809185702_add_orders_merge_with_order_id.rb
+++ b/db/migrate/20120809185702_add_orders_merge_with_order_id.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddOrdersMergeWithOrderId < ActiveRecord::Migration
+class AddOrdersMergeWithOrderId < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :orders, :merge_with_order_id, :integer

--- a/db/migrate/20120809185703_add_order_details_created_by.rb
+++ b/db/migrate/20120809185703_add_order_details_created_by.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddOrderDetailsCreatedBy < ActiveRecord::Migration
+class AddOrderDetailsCreatedBy < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :order_details, :created_by, :integer

--- a/db/migrate/20120824185714_create_notifications.rb
+++ b/db/migrate/20120824185714_create_notifications.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateNotifications < ActiveRecord::Migration
+class CreateNotifications < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :notifications do |t|

--- a/db/migrate/20121031184855_rename_file_uploads.rb
+++ b/db/migrate/20121031184855_rename_file_uploads.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RenameFileUploads < ActiveRecord::Migration
+class RenameFileUploads < ActiveRecord::Migration[4.2]
 
   def self.up
     rename_table :file_uploads, :stored_files

--- a/db/migrate/20121031193852_create_order_imports.rb
+++ b/db/migrate/20121031193852_create_order_imports.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateOrderImports < ActiveRecord::Migration
+class CreateOrderImports < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :order_imports do |t|

--- a/db/migrate/20121031230321_alter_orders_add_order_import.rb
+++ b/db/migrate/20121031230321_alter_orders_add_order_import.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterOrdersAddOrderImport < ActiveRecord::Migration
+class AlterOrdersAddOrderImport < ActiveRecord::Migration[4.2]
 
   def self.up
     add_column :orders, :order_import_id, :integer

--- a/db/migrate/20130108190516_create_schedules.rb
+++ b/db/migrate/20130108190516_create_schedules.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSchedules < ActiveRecord::Migration
+class CreateSchedules < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :schedules do |t|

--- a/db/migrate/20130108221731_reservations_change_from_instrument_to_product.rb
+++ b/db/migrate/20130108221731_reservations_change_from_instrument_to_product.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ReservationsChangeFromInstrumentToProduct < ActiveRecord::Migration
+class ReservationsChangeFromInstrumentToProduct < ActiveRecord::Migration[4.2]
 
   def self.up
     # remove_foreign_key :reservations, name: "reservations_instrument_id_fk"

--- a/db/migrate/20130619223329_add_parent_order_detail_id.rb
+++ b/db/migrate/20130619223329_add_parent_order_detail_id.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddParentOrderDetailId < ActiveRecord::Migration
+class AddParentOrderDetailId < ActiveRecord::Migration[4.2]
 
   def change
     add_column :order_details, :parent_order_detail_id, :integer, after: :order_id

--- a/db/migrate/20130621220044_add_scaling_type_to_product_accessory.rb
+++ b/db/migrate/20130621220044_add_scaling_type_to_product_accessory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddScalingTypeToProductAccessory < ActiveRecord::Migration
+class AddScalingTypeToProductAccessory < ActiveRecord::Migration[4.2]
 
   def change
     add_column :product_accessories, :scaling_type, :string, null: false, default: :quantity

--- a/db/migrate/20130624220923_add_product_accessory_to_order_detail.rb
+++ b/db/migrate/20130624220923_add_product_accessory_to_order_detail.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddProductAccessoryToOrderDetail < ActiveRecord::Migration
+class AddProductAccessoryToOrderDetail < ActiveRecord::Migration[4.2]
 
   def change
     add_column :order_details, :product_accessory_id, :integer

--- a/db/migrate/20130808193707_add_availability_to_facility.rb
+++ b/db/migrate/20130808193707_add_availability_to_facility.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAvailabilityToFacility < ActiveRecord::Migration
+class AddAvailabilityToFacility < ActiveRecord::Migration[4.2]
 
   def change
     add_column :facilities, :show_instrument_availability, :boolean, default: false, null: false

--- a/db/migrate/20131118175503_alter_product_accessories_add_deleted_at.rb
+++ b/db/migrate/20131118175503_alter_product_accessories_add_deleted_at.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterProductAccessoriesAddDeletedAt < ActiveRecord::Migration
+class AlterProductAccessoriesAddDeletedAt < ActiveRecord::Migration[4.2]
 
   def change
     change_table :product_accessories do |t|

--- a/db/migrate/20131202225104_alter_products_add_reserve_interval.rb
+++ b/db/migrate/20131202225104_alter_products_add_reserve_interval.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterProductsAddReserveInterval < ActiveRecord::Migration
+class AlterProductsAddReserveInterval < ActiveRecord::Migration[4.2]
 
   def change
     add_column :products, :reserve_interval, :integer

--- a/db/migrate/20131202225331_alter_price_policies_change_precision.rb
+++ b/db/migrate/20131202225331_alter_price_policies_change_precision.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterPricePoliciesChangePrecision < ActiveRecord::Migration
+class AlterPricePoliciesChangePrecision < ActiveRecord::Migration[4.2]
 
   def up
     change_column :price_policies, :usage_rate, :decimal, precision: 12, scale: 4

--- a/db/migrate/20131204214611_migrate_duration_mins.rb
+++ b/db/migrate/20131204214611_migrate_duration_mins.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MigrateDurationMins < ActiveRecord::Migration
+class MigrateDurationMins < ActiveRecord::Migration[4.2]
 
   def up
     instrument_duration_mins.each do |instrument_id, duration_mins|

--- a/db/migrate/20131205230514_alter_schedule_rules_drop_duration_mins.rb
+++ b/db/migrate/20131205230514_alter_schedule_rules_drop_duration_mins.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterScheduleRulesDropDurationMins < ActiveRecord::Migration
+class AlterScheduleRulesDropDurationMins < ActiveRecord::Migration[4.2]
 
   def up
     remove_column :schedule_rules, :duration_mins

--- a/db/migrate/20131218205335_alter_price_policies_add_charge_for.rb
+++ b/db/migrate/20131218205335_alter_price_policies_add_charge_for.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterPricePoliciesAddChargeFor < ActiveRecord::Migration
+class AlterPricePoliciesAddChargeFor < ActiveRecord::Migration[4.2]
 
   def up
     add_column :price_policies, :charge_for, :string

--- a/db/migrate/20140320184445_convert_external_service_receiver_data.rb
+++ b/db/migrate/20140320184445_convert_external_service_receiver_data.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ConvertExternalServiceReceiverData < ActiveRecord::Migration
+class ConvertExternalServiceReceiverData < ActiveRecord::Migration[4.2]
 
   def up
     ExternalServiceReceiver.find_each do |receiver|

--- a/db/migrate/20140325172600_rename_external_service_type.rb
+++ b/db/migrate/20140325172600_rename_external_service_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RenameExternalServiceType < ActiveRecord::Migration
+class RenameExternalServiceType < ActiveRecord::Migration[4.2]
 
   def up
     ExternalService.where(type: "Surveyor").update_all type: UrlService.name

--- a/db/migrate/20140410170132_alter_external_service_receivers_add_external_id.rb
+++ b/db/migrate/20140410170132_alter_external_service_receivers_add_external_id.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlterExternalServiceReceiversAddExternalId < ActiveRecord::Migration
+class AlterExternalServiceReceiversAddExternalId < ActiveRecord::Migration[4.2]
 
   def change
     add_column :external_service_receivers, :external_id, :string

--- a/db/migrate/20140527201943_make_external_service_response_data_text_field.rb
+++ b/db/migrate/20140527201943_make_external_service_response_data_text_field.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MakeExternalServiceResponseDataTextField < ActiveRecord::Migration
+class MakeExternalServiceResponseDataTextField < ActiveRecord::Migration[4.2]
 
   def up
     add_column :external_service_receivers, :response_data_text, :text

--- a/db/migrate/20140730215658_drop_amount_from_statement_row.rb
+++ b/db/migrate/20140730215658_drop_amount_from_statement_row.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DropAmountFromStatementRow < ActiveRecord::Migration
+class DropAmountFromStatementRow < ActiveRecord::Migration[4.2]
 
   def up
     remove_column :statement_rows, :amount

--- a/db/migrate/20140730222842_add_problem_to_order_detail.rb
+++ b/db/migrate/20140730222842_add_problem_to_order_detail.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddProblemToOrderDetail < ActiveRecord::Migration
+class AddProblemToOrderDetail < ActiveRecord::Migration[4.2]
 
   def change
     add_column :order_details, :problem, :boolean, null: false, default: false

--- a/db/migrate/20140831183702_standardize_canceled_spelling.rb
+++ b/db/migrate/20140831183702_standardize_canceled_spelling.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class StandardizeCanceledSpelling < ActiveRecord::Migration
+class StandardizeCanceledSpelling < ActiveRecord::Migration[4.2]
 
   def up
     ActiveRecord::Base.transaction do

--- a/db/migrate/20140908192950_create_delayed_jobs.rb
+++ b/db/migrate/20140908192950_create_delayed_jobs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateDelayedJobs < ActiveRecord::Migration
+class CreateDelayedJobs < ActiveRecord::Migration[4.2]
 
   def change
     create_table :delayed_jobs, force: true do |table|

--- a/db/migrate/20140917204555_fail_on_error_default_true.rb
+++ b/db/migrate/20140917204555_fail_on_error_default_true.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class FailOnErrorDefaultTrue < ActiveRecord::Migration
+class FailOnErrorDefaultTrue < ActiveRecord::Migration[4.2]
 
   def up
     change_column :order_imports, :fail_on_error, :boolean, default: true

--- a/db/migrate/20140924163849_add_disputed_by_to_order_detail.rb
+++ b/db/migrate/20140924163849_add_disputed_by_to_order_detail.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDisputedByToOrderDetail < ActiveRecord::Migration
+class AddDisputedByToOrderDetail < ActiveRecord::Migration[4.2]
 
   def change
     add_column :order_details, :dispute_by_id, :integer, after: :dispute_at

--- a/db/migrate/20140924204847_drop_journal_rows_reference.rb
+++ b/db/migrate/20140924204847_drop_journal_rows_reference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DropJournalRowsReference < ActiveRecord::Migration
+class DropJournalRowsReference < ActiveRecord::Migration[4.2]
 
   def up
     remove_column :journal_rows, :reference

--- a/db/migrate/20140924211413_add_admin_note_to_reservations.rb
+++ b/db/migrate/20140924211413_add_admin_note_to_reservations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAdminNoteToReservations < ActiveRecord::Migration
+class AddAdminNoteToReservations < ActiveRecord::Migration[4.2]
 
   def change
     add_column :reservations, :admin_note, :string

--- a/db/migrate/20140924222724_add_lock_window_to_products.rb
+++ b/db/migrate/20140924222724_add_lock_window_to_products.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddLockWindowToProducts < ActiveRecord::Migration
+class AddLockWindowToProducts < ActiveRecord::Migration[4.2]
 
   def change
     add_column :products, :lock_window, :integer, null: false, default: 0

--- a/db/migrate/20141104233110_add_indexes_to_order_details.rb
+++ b/db/migrate/20141104233110_add_indexes_to_order_details.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIndexesToOrderDetails < ActiveRecord::Migration
+class AddIndexesToOrderDetails < ActiveRecord::Migration[4.2]
 
   def change
     add_index :order_details, :assigned_user_id

--- a/db/migrate/20141120172247_everyone_gets_an_index.rb
+++ b/db/migrate/20141120172247_everyone_gets_an_index.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EveryoneGetsAnIndex < ActiveRecord::Migration
+class EveryoneGetsAnIndex < ActiveRecord::Migration[4.2]
 
   def change
     add_index :account_users,       :user_id

--- a/db/migrate/20141125002918_add_even_more_indexes.rb
+++ b/db/migrate/20141125002918_add_even_more_indexes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddEvenMoreIndexes < ActiveRecord::Migration
+class AddEvenMoreIndexes < ActiveRecord::Migration[4.2]
 
   def change
     add_index :orders, :user_id

--- a/db/migrate/20150115151805_add_facility_to_order_import.rb
+++ b/db/migrate/20150115151805_add_facility_to_order_import.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddFacilityToOrderImport < ActiveRecord::Migration
+class AddFacilityToOrderImport < ActiveRecord::Migration[4.2]
 
   def up
     add_column :order_imports, :facility_id, :integer, after: :id

--- a/db/migrate/20150121202952_add_processed_at_to_order_import.rb
+++ b/db/migrate/20150121202952_add_processed_at_to_order_import.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddProcessedAtToOrderImport < ActiveRecord::Migration
+class AddProcessedAtToOrderImport < ActiveRecord::Migration[4.2]
 
   def up
     add_column :order_imports, :processed_at, :timestamp, after: :created_by

--- a/db/migrate/20150204174650_add_admin_editable_to_price_group.rb
+++ b/db/migrate/20150204174650_add_admin_editable_to_price_group.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAdminEditableToPriceGroup < ActiveRecord::Migration
+class AddAdminEditableToPriceGroup < ActiveRecord::Migration[4.2]
 
   def up
     add_column :price_groups, :admin_editable, :boolean, after: :is_internal, null: false, default: true

--- a/db/migrate/20150318015754_add_auto_logout_minutes_to_relays.rb
+++ b/db/migrate/20150318015754_add_auto_logout_minutes_to_relays.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAutoLogoutMinutesToRelays < ActiveRecord::Migration
+class AddAutoLogoutMinutesToRelays < ActiveRecord::Migration[4.2]
 
   def change
     add_column :relays, :auto_logout_minutes, :integer, default: 60

--- a/db/migrate/20150605165610_create_training_requests.rb
+++ b/db/migrate/20150605165610_create_training_requests.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateTrainingRequests < ActiveRecord::Migration
+class CreateTrainingRequests < ActiveRecord::Migration[4.2]
 
   def change
     create_table :training_requests do |t|

--- a/db/migrate/20150611175130_add_requested_at_to_product_user.rb
+++ b/db/migrate/20150611175130_add_requested_at_to_product_user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddRequestedAtToProductUser < ActiveRecord::Migration
+class AddRequestedAtToProductUser < ActiveRecord::Migration[4.2]
 
   def change
     add_column :product_users, :requested_at, :datetime, null: true

--- a/db/migrate/20150930213606_add_active_facilities_index.rb
+++ b/db/migrate/20150930213606_add_active_facilities_index.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddActiveFacilitiesIndex < ActiveRecord::Migration
+class AddActiveFacilitiesIndex < ActiveRecord::Migration[4.2]
 
   def change
     add_index :facilities, [:is_active, :name]

--- a/db/migrate/20151003051241_schema_cleanup.rb
+++ b/db/migrate/20151003051241_schema_cleanup.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SchemaCleanup < ActiveRecord::Migration
+class SchemaCleanup < ActiveRecord::Migration[4.2]
 
   def up
     change_column :affiliates, :created_at, :datetime, null: false

--- a/db/migrate/20151113205331_create_payments_received.rb
+++ b/db/migrate/20151113205331_create_payments_received.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreatePaymentsReceived < ActiveRecord::Migration
+class CreatePaymentsReceived < ActiveRecord::Migration[4.2]
 
   def up
     create_table :payments do |t|

--- a/db/migrate/20151201221103_add_processing_fee_to_payments.rb
+++ b/db/migrate/20151201221103_add_processing_fee_to_payments.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddProcessingFeeToPayments < ActiveRecord::Migration
+class AddProcessingFeeToPayments < ActiveRecord::Migration[4.2]
 
   def change
     add_column :payments, :processing_fee, :decimal, precision: 10, scale: 2

--- a/db/migrate/20151221210653_make_processing_fee_non_null.rb
+++ b/db/migrate/20151221210653_make_processing_fee_non_null.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MakeProcessingFeeNonNull < ActiveRecord::Migration
+class MakeProcessingFeeNonNull < ActiveRecord::Migration[4.2]
 
   def up
     change_column :payments, :processing_fee, :decimal, precision: 10, scale: 2, null: false, default: 0

--- a/db/migrate/20160120162354_add_contact_email_for_training_requests.rb
+++ b/db/migrate/20160120162354_add_contact_email_for_training_requests.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddContactEmailForTrainingRequests < ActiveRecord::Migration
+class AddContactEmailForTrainingRequests < ActiveRecord::Migration[4.2]
 
   def change
     add_column :products, :training_request_contacts, :text

--- a/db/migrate/20160201171348_add_journal_cutoffs.rb
+++ b/db/migrate/20160201171348_add_journal_cutoffs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddJournalCutoffs < ActiveRecord::Migration
+class AddJournalCutoffs < ActiveRecord::Migration[4.2]
 
   def change
     create_table :journal_cutoff_dates do |t|

--- a/db/migrate/20160309224521_add_account_id_to_journal_rows.rb
+++ b/db/migrate/20160309224521_add_account_id_to_journal_rows.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAccountIdToJournalRows < ActiveRecord::Migration
+class AddAccountIdToJournalRows < ActiveRecord::Migration[4.2]
 
   def change
     add_column :journal_rows, :account_id, :integer

--- a/db/migrate/20160322175922_add_order_notification_recipient_to_facility.rb
+++ b/db/migrate/20160322175922_add_order_notification_recipient_to_facility.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddOrderNotificationRecipientToFacility < ActiveRecord::Migration
+class AddOrderNotificationRecipientToFacility < ActiveRecord::Migration[4.2]
 
   def change
     add_column :facilities, :order_notification_recipient, :string, null: true

--- a/db/migrate/20160405203240_add_deactivated_to_user.rb
+++ b/db/migrate/20160405203240_add_deactivated_to_user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDeactivatedToUser < ActiveRecord::Migration
+class AddDeactivatedToUser < ActiveRecord::Migration[4.2]
 
   def change
     add_column :users, :deactivated_at, :timestamp

--- a/db/migrate/20160415231343_clean_duplicate_reservations.rb
+++ b/db/migrate/20160415231343_clean_duplicate_reservations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CleanDuplicateReservations < ActiveRecord::Migration
+class CleanDuplicateReservations < ActiveRecord::Migration[4.2]
 
   class Reservation < ActiveRecord::Base
   end

--- a/db/migrate/20160426231556_add_reconciliation_date_to_order_detail.rb
+++ b/db/migrate/20160426231556_add_reconciliation_date_to_order_detail.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddReconciliationDateToOrderDetail < ActiveRecord::Migration
+class AddReconciliationDateToOrderDetail < ActiveRecord::Migration[4.2]
 
   def up
     add_column :order_details, :reconciled_at, :datetime

--- a/db/migrate/20160601214939_add_quantity_lock_to_external_service_receivers.rb
+++ b/db/migrate/20160601214939_add_quantity_lock_to_external_service_receivers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddQuantityLockToExternalServiceReceivers < ActiveRecord::Migration
+class AddQuantityLockToExternalServiceReceivers < ActiveRecord::Migration[4.2]
 
   def change
     add_column :external_service_receivers, :manages_quantity, :boolean, default: false, null: false

--- a/db/migrate/20160602153918_increase_decimal_precision.rb
+++ b/db/migrate/20160602153918_increase_decimal_precision.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class IncreaseDecimalPrecision < ActiveRecord::Migration
+class IncreaseDecimalPrecision < ActiveRecord::Migration[4.2]
 
   def up
     change_column :price_policies, :overage_rate, :decimal, precision: 12, scale: 4

--- a/db/migrate/20160602232926_add_note_available_to_products.rb
+++ b/db/migrate/20160602232926_add_note_available_to_products.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddNoteAvailableToProducts < ActiveRecord::Migration
+class AddNoteAvailableToProducts < ActiveRecord::Migration[4.2]
 
   def change
     add_column :products, :note_available_to_users, :boolean, default: false, null: false

--- a/db/migrate/20160614185348_add_type_to_reservations.rb
+++ b/db/migrate/20160614185348_add_type_to_reservations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddTypeToReservations < ActiveRecord::Migration
+class AddTypeToReservations < ActiveRecord::Migration[4.2]
 
   class Reservation < ActiveRecord::Base
   end

--- a/db/migrate/20160706195345_fix_product_column_on_results_files.rb
+++ b/db/migrate/20160706195345_fix_product_column_on_results_files.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class FixProductColumnOnResultsFiles < ActiveRecord::Migration
+class FixProductColumnOnResultsFiles < ActiveRecord::Migration[4.2]
 
   class StoredFile < ActiveRecord::Base
 

--- a/db/migrate/20160715220430_create_email_events.rb
+++ b/db/migrate/20160715220430_create_email_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateEmailEvents < ActiveRecord::Migration
+class CreateEmailEvents < ActiveRecord::Migration[4.2]
 
   def change
     create_table :email_events do |t|

--- a/db/migrate/20160720200222_add_category_to_reservations.rb
+++ b/db/migrate/20160720200222_add_category_to_reservations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCategoryToReservations < ActiveRecord::Migration
+class AddCategoryToReservations < ActiveRecord::Migration[4.2]
 
   def change
     add_column :reservations, :category, :string, null: true

--- a/db/migrate/20160907170059_change_order_import_processed_at_type.rb
+++ b/db/migrate/20160907170059_change_order_import_processed_at_type.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # This has no effect in MySQL, but corrects a timezone issue in Oracle.
-class ChangeOrderImportProcessedAtType < ActiveRecord::Migration
+class ChangeOrderImportProcessedAtType < ActiveRecord::Migration[4.2]
 
   def up
     change_column :order_imports, :processed_at, :datetime

--- a/db/migrate/20160908162845_update_timestamp_types.rb
+++ b/db/migrate/20160908162845_update_timestamp_types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # No effect on MySQL, but important for oracle so times are returned with zones.
-class UpdateTimestampTypes < ActiveRecord::Migration
+class UpdateTimestampTypes < ActiveRecord::Migration[4.2]
 
   def up
     change_column :users, :deactivated_at, :datetime

--- a/db/migrate/20161213173410_add_cutoff_time_to_products.rb
+++ b/db/migrate/20161213173410_add_cutoff_time_to_products.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCutoffTimeToProducts < ActiveRecord::Migration
+class AddCutoffTimeToProducts < ActiveRecord::Migration[4.2]
 
   def change
     add_column :products, :cutoff_hours, :integer, null: false, default: 0

--- a/db/migrate/20170112204251_increase_delayed_jobs_handler_capacity.rb
+++ b/db/migrate/20170112204251_increase_delayed_jobs_handler_capacity.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class IncreaseDelayedJobsHandlerCapacity < ActiveRecord::Migration
+class IncreaseDelayedJobsHandlerCapacity < ActiveRecord::Migration[4.2]
 
   def up
     if NUCore::Database.mysql?

--- a/db/migrate/20170123183841_change_note_limit_for_order_details.rb
+++ b/db/migrate/20170123183841_change_note_limit_for_order_details.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeNoteLimitForOrderDetails < ActiveRecord::Migration
+class ChangeNoteLimitForOrderDetails < ActiveRecord::Migration[4.2]
 
   def up
     add_column :order_details, :temp_note, :text

--- a/db/migrate/20170210214106_add_subaffiliates_enabled_flag_to_affiliates.rb
+++ b/db/migrate/20170210214106_add_subaffiliates_enabled_flag_to_affiliates.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddSubaffiliatesEnabledFlagToAffiliates < ActiveRecord::Migration
+class AddSubaffiliatesEnabledFlagToAffiliates < ActiveRecord::Migration[4.2]
 
   def up
     add_column :affiliates, :subaffiliates_enabled, :boolean, default: false, null: false

--- a/db/migrate/20170306212934_create_certificates.rb
+++ b/db/migrate/20170306212934_create_certificates.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateCertificates < ActiveRecord::Migration
+class CreateCertificates < ActiveRecord::Migration[4.2]
 
   def change
     create_table :nu_safety_certificates do |t|

--- a/db/migrate/20170308030632_change_schedule_rule_to_belong_to_product.rb
+++ b/db/migrate/20170308030632_change_schedule_rule_to_belong_to_product.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeScheduleRuleToBelongToProduct < ActiveRecord::Migration
+class ChangeScheduleRuleToBelongToProduct < ActiveRecord::Migration[4.2]
 
   def up
     # MySQL 5.6+ will rename the foreign key with the column, but Mariadb 5.5

--- a/db/migrate/20170315192738_create_product_certification_requirements.rb
+++ b/db/migrate/20170315192738_create_product_certification_requirements.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateProductCertificationRequirements < ActiveRecord::Migration
+class CreateProductCertificationRequirements < ActiveRecord::Migration[4.2]
 
   def change
     create_table :nu_product_cert_requirements do |t|

--- a/db/migrate/20170419011720_remove_legacy_instrument_price_policy_columns.rb
+++ b/db/migrate/20170419011720_remove_legacy_instrument_price_policy_columns.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveLegacyInstrumentPricePolicyColumns < ActiveRecord::Migration
+class RemoveLegacyInstrumentPricePolicyColumns < ActiveRecord::Migration[4.2]
 
   COLUMNS = {
     usage_mins: [:integer, after: :usage_rate],

--- a/db/migrate/20170421154535_create_default_price_groups_for_users.rb
+++ b/db/migrate/20170421154535_create_default_price_groups_for_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateDefaultPriceGroupsForUsers < ActiveRecord::Migration
+class CreateDefaultPriceGroupsForUsers < ActiveRecord::Migration[4.2]
 
   def up
     User.find_each(&:create_default_price_group!)

--- a/db/migrate/20170501201633_add_canceled_to_order_detail.rb
+++ b/db/migrate/20170501201633_add_canceled_to_order_detail.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCanceledToOrderDetail < ActiveRecord::Migration
+class AddCanceledToOrderDetail < ActiveRecord::Migration[4.2]
 
   class Reservation < ActiveRecord::Base
     belongs_to :order_detail

--- a/db/migrate/20170508150135_add_foreign_keys.rb
+++ b/db/migrate/20170508150135_add_foreign_keys.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddForeignKeys < ActiveRecord::Migration
+class AddForeignKeys < ActiveRecord::Migration[4.2]
 
   def change
     add_index :notifications, [:subject_id, :subject_type]

--- a/db/migrate/20170515214930_drop_canceled_from_reservations.rb
+++ b/db/migrate/20170515214930_drop_canceled_from_reservations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DropCanceledFromReservations < ActiveRecord::Migration
+class DropCanceledFromReservations < ActiveRecord::Migration[4.2]
   def change
     remove_column :reservations, :canceled_at, :datetime
     remove_column :reservations, :canceled_by, :integer

--- a/db/migrate/20170531183710_fix_schedule_rule_product_index.rb
+++ b/db/migrate/20170531183710_fix_schedule_rule_product_index.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class FixScheduleRuleProductIndex < ActiveRecord::Migration
+class FixScheduleRuleProductIndex < ActiveRecord::Migration[4.2]
 
   def up
     add_index :schedule_rules, :product_id

--- a/db/migrate/20170609214859_optional_required_notes_field.rb
+++ b/db/migrate/20170609214859_optional_required_notes_field.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class OptionalRequiredNotesField < ActiveRecord::Migration
+class OptionalRequiredNotesField < ActiveRecord::Migration[4.2]
 
   class Product < ActiveRecord::Base
   end

--- a/db/migrate/20170619213358_add_custom_note_field_label_to_product.rb
+++ b/db/migrate/20170619213358_add_custom_note_field_label_to_product.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCustomNoteFieldLabelToProduct < ActiveRecord::Migration
+class AddCustomNoteFieldLabelToProduct < ActiveRecord::Migration[4.2]
 
   def change
     add_column :products, :user_notes_label, :string

--- a/db/migrate/20170627182248_drop_roles_if_exists.rb
+++ b/db/migrate/20170627182248_drop_roles_if_exists.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DropRolesIfExists < ActiveRecord::Migration
+class DropRolesIfExists < ActiveRecord::Migration[4.2]
   def up
     drop_table(:roles) if table_exists?(:roles)
   end

--- a/db/migrate/20170713183443_create_log_events.rb
+++ b/db/migrate/20170713183443_create_log_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateLogEvents < ActiveRecord::Migration
+class CreateLogEvents < ActiveRecord::Migration[4.2]
   def change
     create_table :log_events do |t|
       t.references :loggable, polymorphic: true

--- a/db/migrate/20170719210832_move_versions_table.rb
+++ b/db/migrate/20170719210832_move_versions_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MoveVersionsTable < ActiveRecord::Migration
+class MoveVersionsTable < ActiveRecord::Migration[4.2]
   def change
     rename_table :versions, :vestal_versions
   end

--- a/db/migrate/20170720161356_create_versions.rb
+++ b/db/migrate/20170720161356_create_versions.rb
@@ -2,7 +2,7 @@
 
 # This migration creates the `versions` table, the only schema PT requires.
 # All other migrations PT provides are optional.
-class CreateVersions < ActiveRecord::Migration
+class CreateVersions < ActiveRecord::Migration[4.2]
 
   # The largest text column available in all supported RDBMS is
   # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size

--- a/db/migrate/20170721204610_change_time_stamps_for_event_log.rb
+++ b/db/migrate/20170721204610_change_time_stamps_for_event_log.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeTimeStampsForEventLog < ActiveRecord::Migration
+class ChangeTimeStampsForEventLog < ActiveRecord::Migration[4.2]
   def change
     change_table :log_events do |t|
       t.datetime :event_time

--- a/db/migrate/20170803181918_add_order_notification_recipient_to_product.rb
+++ b/db/migrate/20170803181918_add_order_notification_recipient_to_product.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddOrderNotificationRecipientToProduct < ActiveRecord::Migration
+class AddOrderNotificationRecipientToProduct < ActiveRecord::Migration[4.2]
 
   def change
     add_column :products, :order_notification_recipient, :string, null: true

--- a/db/migrate/20170816180831_lengthen_journal_row_description_column.rb
+++ b/db/migrate/20170816180831_lengthen_journal_row_description_column.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class LengthenJournalRowDescriptionColumn < ActiveRecord::Migration
+class LengthenJournalRowDescriptionColumn < ActiveRecord::Migration[4.2]
 
   def up
     change_column :journal_rows, :description, :string, limit: 512

--- a/db/migrate/20170829193038_create_user_preferences.rb
+++ b/db/migrate/20170829193038_create_user_preferences.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateUserPreferences < ActiveRecord::Migration
+class CreateUserPreferences < ActiveRecord::Migration[4.2]
   def change
     create_table :user_preferences do |t|
       t.references :user, foreign_key: true

--- a/db/migrate/20171003201727_add_expires_minutes_before_to_reservations.rb
+++ b/db/migrate/20171003201727_add_expires_minutes_before_to_reservations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddExpiresMinutesBeforeToReservations < ActiveRecord::Migration
+class AddExpiresMinutesBeforeToReservations < ActiveRecord::Migration[4.2]
   def change
     add_column :reservations, :expires_mins_before, :integer
   end

--- a/db/migrate/20171010205831_add_created_by_id_to_reservations.rb
+++ b/db/migrate/20171010205831_add_created_by_id_to_reservations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCreatedByIdToReservations < ActiveRecord::Migration
+class AddCreatedByIdToReservations < ActiveRecord::Migration[4.2]
   def change
     add_column :reservations, :created_by_id, :integer
     add_foreign_key :reservations, :users, column: :created_by_id

--- a/db/migrate/20171109201156_add_deleted_at_to_reservations.rb
+++ b/db/migrate/20171109201156_add_deleted_at_to_reservations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDeletedAtToReservations < ActiveRecord::Migration
+class AddDeletedAtToReservations < ActiveRecord::Migration[4.2]
   def change
     add_column :reservations, :deleted_at, :datetime
     add_index :reservations, :deleted_at

--- a/db/migrate/20171130224610_add_group_id_to_reservations.rb
+++ b/db/migrate/20171130224610_add_group_id_to_reservations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddGroupIdToReservations < ActiveRecord::Migration
+class AddGroupIdToReservations < ActiveRecord::Migration[4.2]
   def change
     add_column :reservations, :group_id, :string
 

--- a/db/migrate/20180111200920_add_price_change_reason_to_order_details.rb
+++ b/db/migrate/20180111200920_add_price_change_reason_to_order_details.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddPriceChangeReasonToOrderDetails < ActiveRecord::Migration
+class AddPriceChangeReasonToOrderDetails < ActiveRecord::Migration[4.2]
   def change
     add_column :order_details, :price_change_reason, :string
     add_column :order_details, :price_changed_by_user_id, :integer

--- a/db/migrate/20180330180908_add_user_note_to_reservations.rb
+++ b/db/migrate/20180330180908_add_user_note_to_reservations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddUserNoteToReservations < ActiveRecord::Migration
+class AddUserNoteToReservations < ActiveRecord::Migration[4.2]
   def change
     add_column :reservations, :user_note, :string
   end

--- a/db/migrate/20180406211501_rename_user_deactivated_at_to_suspended_at.rb
+++ b/db/migrate/20180406211501_rename_user_deactivated_at_to_suspended_at.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RenameUserDeactivatedAtToSuspendedAt < ActiveRecord::Migration
+class RenameUserDeactivatedAtToSuspendedAt < ActiveRecord::Migration[4.2]
 
   def change
     rename_column :users, :deactivated_at, :suspended_at

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -200,7 +200,6 @@ ActiveRecord::Schema.define(version: 2020_01_13_131617) do
     t.boolean "is_on", null: false
     t.datetime "created_at", null: false
     t.index ["instrument_id", "created_at"], name: "index_instrument_statuses_on_instrument_id_and_created_at"
-    t.index ["instrument_id"], name: "fk_int_stats_product"
   end
 
   create_table "journal_cutoff_dates", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -239,8 +238,8 @@ ActiveRecord::Schema.define(version: 2020_01_13_131617) do
   end
 
   create_table "log_events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "loggable_id"
     t.string "loggable_type"
+    t.integer "loggable_id"
     t.string "event_type"
     t.integer "user_id"
     t.datetime "created_at", null: false
@@ -324,10 +323,10 @@ ActiveRecord::Schema.define(version: 2020_01_13_131617) do
     t.string "canceled_reason"
     t.string "price_change_reason"
     t.integer "price_changed_by_user_id"
-    t.string "problem_description_key_was"
-    t.datetime "problem_resolved_at"
-    t.integer "problem_resolved_by_id"
     t.datetime "ordered_at"
+    t.string "problem_description_key_was"
+    t.timestamp "problem_resolved_at"
+    t.integer "problem_resolved_by_id"
     t.index ["account_id"], name: "fk_od_accounts"
     t.index ["assigned_user_id"], name: "index_order_details_on_assigned_user_id"
     t.index ["bundle_product_id"], name: "fk_bundle_prod_id"
@@ -825,10 +824,10 @@ ActiveRecord::Schema.define(version: 2020_01_13_131617) do
   end
 
   create_table "vestal_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "versioned_id"
     t.string "versioned_type"
-    t.integer "user_id"
+    t.integer "versioned_id"
     t.string "user_type"
+    t.integer "user_id"
     t.string "user_name"
     t.text "modifications"
     t.integer "version_number"

--- a/vendor/engines/bulk_email/db/migrate/20161024213800_create_bulk_email_jobs.rb
+++ b/vendor/engines/bulk_email/db/migrate/20161024213800_create_bulk_email_jobs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateBulkEmailJobs < ActiveRecord::Migration
+class CreateBulkEmailJobs < ActiveRecord::Migration[4.2]
 
   def change
     create_table :bulk_email_jobs do |t|

--- a/vendor/engines/bulk_email/db/migrate/20170130213649_make_bulk_email_job_facility_nullable.rb
+++ b/vendor/engines/bulk_email/db/migrate/20170130213649_make_bulk_email_job_facility_nullable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MakeBulkEmailJobFacilityNullable < ActiveRecord::Migration
+class MakeBulkEmailJobFacilityNullable < ActiveRecord::Migration[4.2]
 
   def up
     change_column :bulk_email_jobs, :facility_id, :integer, null: true

--- a/vendor/engines/c2po/db/migrate/20170608200941_add_outside_user_to_purchase_order.rb
+++ b/vendor/engines/c2po/db/migrate/20170608200941_add_outside_user_to_purchase_order.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddOutsideUserToPurchaseOrder < ActiveRecord::Migration
+class AddOutsideUserToPurchaseOrder < ActiveRecord::Migration[4.2]
 
   def change
     change_table :accounts do |t|

--- a/vendor/engines/c2po/db/migrate/20170609131421_add_ar_number_to_accounts.rb
+++ b/vendor/engines/c2po/db/migrate/20170609131421_add_ar_number_to_accounts.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddArNumberToAccounts < ActiveRecord::Migration
+class AddArNumberToAccounts < ActiveRecord::Migration[4.2]
 
   def change
     change_table :accounts do |t|

--- a/vendor/engines/projects/db/migrate/20160328144628_create_projects.rb
+++ b/vendor/engines/projects/db/migrate/20160328144628_create_projects.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateProjects < ActiveRecord::Migration
+class CreateProjects < ActiveRecord::Migration[4.2][4.2]
 
   def change
     create_table :projects do |t|

--- a/vendor/engines/projects/db/migrate/20160328144628_create_projects.rb
+++ b/vendor/engines/projects/db/migrate/20160328144628_create_projects.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateProjects < ActiveRecord::Migration[4.2][4.2]
+class CreateProjects < ActiveRecord::Migration[4.2]
 
   def change
     create_table :projects do |t|

--- a/vendor/engines/projects/db/migrate/20160503170055_add_active_flag_to_projects.rb
+++ b/vendor/engines/projects/db/migrate/20160503170055_add_active_flag_to_projects.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddActiveFlagToProjects < ActiveRecord::Migration[4.2][4.2]
+class AddActiveFlagToProjects < ActiveRecord::Migration[4.2]
 
   def change
     add_column :projects, :active, :boolean, null: false, default: true

--- a/vendor/engines/projects/db/migrate/20160503170055_add_active_flag_to_projects.rb
+++ b/vendor/engines/projects/db/migrate/20160503170055_add_active_flag_to_projects.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddActiveFlagToProjects < ActiveRecord::Migration
+class AddActiveFlagToProjects < ActiveRecord::Migration[4.2][4.2]
 
   def change
     add_column :projects, :active, :boolean, null: false, default: true

--- a/vendor/engines/projects/db/migrate/20160503184205_add_project_id_to_order_detail.rb
+++ b/vendor/engines/projects/db/migrate/20160503184205_add_project_id_to_order_detail.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddProjectIdToOrderDetail < ActiveRecord::Migration[4.2][4.2]
+class AddProjectIdToOrderDetail < ActiveRecord::Migration[4.2]
 
   def change
     add_column :order_details, :project_id, :integer, null: true

--- a/vendor/engines/projects/db/migrate/20160503184205_add_project_id_to_order_detail.rb
+++ b/vendor/engines/projects/db/migrate/20160503184205_add_project_id_to_order_detail.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddProjectIdToOrderDetail < ActiveRecord::Migration
+class AddProjectIdToOrderDetail < ActiveRecord::Migration[4.2][4.2]
 
   def change
     add_column :order_details, :project_id, :integer, null: true

--- a/vendor/engines/projects/db/migrate/20170524174531_add_foreign_keys_to_projects.rb
+++ b/vendor/engines/projects/db/migrate/20170524174531_add_foreign_keys_to_projects.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddForeignKeysToProjects < ActiveRecord::Migration
+class AddForeignKeysToProjects < ActiveRecord::Migration[4.2]
 
   def change
     add_index :order_details, :project_id

--- a/vendor/engines/sanger_sequencing/db/migrate/20160519030413_create_sanger_sequencing_submissions.rb
+++ b/vendor/engines/sanger_sequencing/db/migrate/20160519030413_create_sanger_sequencing_submissions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSangerSequencingSubmissions < ActiveRecord::Migration
+class CreateSangerSequencingSubmissions < ActiveRecord::Migration[4.2]
 
   def up
     create_table :sanger_sequencing_submissions do |t|

--- a/vendor/engines/sanger_sequencing/db/migrate/20160526192926_add_customer_sample_id_to_sanger_sequencing.rb
+++ b/vendor/engines/sanger_sequencing/db/migrate/20160526192926_add_customer_sample_id_to_sanger_sequencing.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCustomerSampleIdToSangerSequencing < ActiveRecord::Migration
+class AddCustomerSampleIdToSangerSequencing < ActiveRecord::Migration[4.2]
 
   def change
     add_column :sanger_sequencing_samples, :customer_sample_id, :string

--- a/vendor/engines/sanger_sequencing/db/migrate/20160606205228_add_sanger_option_to_facility.rb
+++ b/vendor/engines/sanger_sequencing/db/migrate/20160606205228_add_sanger_option_to_facility.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddSangerOptionToFacility < ActiveRecord::Migration
+class AddSangerOptionToFacility < ActiveRecord::Migration[4.2]
 
   def change
     add_column :facilities, :sanger_sequencing_enabled, :boolean, null: false, default: false

--- a/vendor/engines/sanger_sequencing/db/migrate/20160624190229_add_sanger_sequencing_batches.rb
+++ b/vendor/engines/sanger_sequencing/db/migrate/20160624190229_add_sanger_sequencing_batches.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddSangerSequencingBatches < ActiveRecord::Migration
+class AddSangerSequencingBatches < ActiveRecord::Migration[4.2]
 
   def change
     create_table :sanger_sequencing_batches do |t|

--- a/vendor/engines/sanger_sequencing/db/migrate/20160628194243_add_batch_id_to_submissions.rb
+++ b/vendor/engines/sanger_sequencing/db/migrate/20160628194243_add_batch_id_to_submissions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddBatchIdToSubmissions < ActiveRecord::Migration
+class AddBatchIdToSubmissions < ActiveRecord::Migration[4.2]
 
   def change
     add_column :sanger_sequencing_submissions, :batch_id, :integer, index: true

--- a/vendor/engines/sanger_sequencing/db/migrate/20160629170900_add_facility_to_sanger_batch.rb
+++ b/vendor/engines/sanger_sequencing/db/migrate/20160629170900_add_facility_to_sanger_batch.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddFacilityToSangerBatch < ActiveRecord::Migration
+class AddFacilityToSangerBatch < ActiveRecord::Migration[4.2]
 
   def change
     add_reference :sanger_sequencing_batches, :facility, index: true

--- a/vendor/engines/sanger_sequencing/db/migrate/20160802202924_fix_sanger_sequencing_submission_cascades_for_oracle.rb
+++ b/vendor/engines/sanger_sequencing/db/migrate/20160802202924_fix_sanger_sequencing_submission_cascades_for_oracle.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class FixSangerSequencingSubmissionCascadesForOracle < ActiveRecord::Migration
+class FixSangerSequencingSubmissionCascadesForOracle < ActiveRecord::Migration[4.2]
 
   def change
     # Oracle does not support on_update so we need to remove and re-add it to keep

--- a/vendor/engines/sanger_sequencing/db/migrate/20160812230426_add_sanger_product_groups.rb
+++ b/vendor/engines/sanger_sequencing/db/migrate/20160812230426_add_sanger_product_groups.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddSangerProductGroups < ActiveRecord::Migration
+class AddSangerProductGroups < ActiveRecord::Migration[4.2]
 
   def change
     # sanger_sequencing_product_groups is too long of a table name for Oracle

--- a/vendor/engines/secure_rooms/db/migrate/20170220203130_add_card_number_to_user.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170220203130_add_card_number_to_user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCardNumberToUser < ActiveRecord::Migration
+class AddCardNumberToUser < ActiveRecord::Migration[4.2][4.2]
 
   def change
     add_column :users, :card_number, :string

--- a/vendor/engines/secure_rooms/db/migrate/20170220203130_add_card_number_to_user.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170220203130_add_card_number_to_user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCardNumberToUser < ActiveRecord::Migration[4.2][4.2]
+class AddCardNumberToUser < ActiveRecord::Migration[4.2]
 
   def change
     add_column :users, :card_number, :string

--- a/vendor/engines/secure_rooms/db/migrate/20170301120659_create_card_readers.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170301120659_create_card_readers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateCardReaders < ActiveRecord::Migration
+class CreateCardReaders < ActiveRecord::Migration[4.2][4.2]
 
   def change
     create_table :secure_rooms_card_readers do |t|

--- a/vendor/engines/secure_rooms/db/migrate/20170301120659_create_card_readers.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170301120659_create_card_readers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateCardReaders < ActiveRecord::Migration[4.2][4.2]
+class CreateCardReaders < ActiveRecord::Migration[4.2]
 
   def change
     create_table :secure_rooms_card_readers do |t|

--- a/vendor/engines/secure_rooms/db/migrate/20170316090109_add_description_to_card_readers.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170316090109_add_description_to_card_readers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDescriptionToCardReaders < ActiveRecord::Migration
+class AddDescriptionToCardReaders < ActiveRecord::Migration[4.2][4.2]
 
   def change
     add_column :secure_rooms_card_readers, :description, :string

--- a/vendor/engines/secure_rooms/db/migrate/20170316090109_add_description_to_card_readers.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170316090109_add_description_to_card_readers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDescriptionToCardReaders < ActiveRecord::Migration[4.2][4.2]
+class AddDescriptionToCardReaders < ActiveRecord::Migration[4.2]
 
   def change
     add_column :secure_rooms_card_readers, :description, :string

--- a/vendor/engines/secure_rooms/db/migrate/20170316090613_add_unique_index_to_card_readers.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170316090613_add_unique_index_to_card_readers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddUniqueIndexToCardReaders < ActiveRecord::Migration
+class AddUniqueIndexToCardReaders < ActiveRecord::Migration[4.2][4.2]
 
   def change
     add_index(

--- a/vendor/engines/secure_rooms/db/migrate/20170316090613_add_unique_index_to_card_readers.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170316090613_add_unique_index_to_card_readers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddUniqueIndexToCardReaders < ActiveRecord::Migration[4.2][4.2]
+class AddUniqueIndexToCardReaders < ActiveRecord::Migration[4.2]
 
   def change
     add_index(

--- a/vendor/engines/secure_rooms/db/migrate/20170405172045_add_fields_to_secure_room_card_readers.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170405172045_add_fields_to_secure_room_card_readers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddFieldsToSecureRoomCardReaders < ActiveRecord::Migration[4.2][4.2]
+class AddFieldsToSecureRoomCardReaders < ActiveRecord::Migration[4.2]
 
   def change
     add_column :secure_rooms_card_readers, :direction_in, :boolean, null: false, default: true

--- a/vendor/engines/secure_rooms/db/migrate/20170405172045_add_fields_to_secure_room_card_readers.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170405172045_add_fields_to_secure_room_card_readers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddFieldsToSecureRoomCardReaders < ActiveRecord::Migration
+class AddFieldsToSecureRoomCardReaders < ActiveRecord::Migration[4.2][4.2]
 
   def change
     add_column :secure_rooms_card_readers, :direction_in, :boolean, null: false, default: true

--- a/vendor/engines/secure_rooms/db/migrate/20170405182534_add_tablet_token_to_card_readers.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170405182534_add_tablet_token_to_card_readers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddTabletTokenToCardReaders < ActiveRecord::Migration
+class AddTabletTokenToCardReaders < ActiveRecord::Migration[4.2][4.2]
 
   class SecureRooms::CardReader < ApplicationRecord
   end

--- a/vendor/engines/secure_rooms/db/migrate/20170405182534_add_tablet_token_to_card_readers.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170405182534_add_tablet_token_to_card_readers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddTabletTokenToCardReaders < ActiveRecord::Migration[4.2][4.2]
+class AddTabletTokenToCardReaders < ActiveRecord::Migration[4.2]
 
   class SecureRooms::CardReader < ApplicationRecord
   end

--- a/vendor/engines/secure_rooms/db/migrate/20170406162317_create_events.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170406162317_create_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateEvents < ActiveRecord::Migration
+class CreateEvents < ActiveRecord::Migration[4.2]
 
   def change
     create_table :secure_rooms_events do |t|

--- a/vendor/engines/secure_rooms/db/migrate/20170409125103_create_occupancies.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170409125103_create_occupancies.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateOccupancies < ActiveRecord::Migration
+class CreateOccupancies < ActiveRecord::Migration[4.2]
 
   def change
     create_table :secure_rooms_occupancies do |t|

--- a/vendor/engines/secure_rooms/db/migrate/20170409125104_update_events.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170409125104_update_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UpdateEvents < ActiveRecord::Migration
+class UpdateEvents < ActiveRecord::Migration[4.2]
 
   def change
     change_column :secure_rooms_events, :card_reader_id, :integer, null: false

--- a/vendor/engines/secure_rooms/db/migrate/20170421142844_add_order_detail_to_occupancy.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170421142844_add_order_detail_to_occupancy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddOrderDetailToOccupancy < ActiveRecord::Migration
+class AddOrderDetailToOccupancy < ActiveRecord::Migration[4.2]
 
   def change
     add_column :secure_rooms_occupancies, :order_detail_id, :integer

--- a/vendor/engines/secure_rooms/db/migrate/20170525143813_add_token_to_secure_room.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170525143813_add_token_to_secure_room.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddTokenToSecureRoom < ActiveRecord::Migration
+class AddTokenToSecureRoom < ActiveRecord::Migration[4.2]
 
   class Product < ActiveRecord::Base
   end

--- a/vendor/engines/secure_rooms/db/migrate/20170526170933_create_alarm_events.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20170526170933_create_alarm_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateAlarmEvents < ActiveRecord::Migration
+class CreateAlarmEvents < ActiveRecord::Migration[4.2]
 
   def change
     create_table :secure_rooms_alarm_events do |t|

--- a/vendor/engines/secure_rooms/db/migrate/20180907115057_allow_user_id_to_be_null_on_secure_rooms_events.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20180907115057_allow_user_id_to_be_null_on_secure_rooms_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AllowUserIdToBeNullOnSecureRoomsEvents < ActiveRecord::Migration
+class AllowUserIdToBeNullOnSecureRoomsEvents < ActiveRecord::Migration[4.2]
 
   def up
     change_column :secure_rooms_events, :user_id, :integer, null: true

--- a/vendor/engines/secure_rooms/db/migrate/20180907155501_add_card_number_to_secure_rooms_events.rb
+++ b/vendor/engines/secure_rooms/db/migrate/20180907155501_add_card_number_to_secure_rooms_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCardNumberToSecureRoomsEvents < ActiveRecord::Migration
+class AddCardNumberToSecureRoomsEvents < ActiveRecord::Migration[4.2]
 
   def up
     add_column :secure_rooms_events, :card_number, :string

--- a/vendor/engines/split_accounts/db/migrate/20151117193742_create_splits.rb
+++ b/vendor/engines/split_accounts/db/migrate/20151117193742_create_splits.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSplits < ActiveRecord::Migration
+class CreateSplits < ActiveRecord::Migration[4.2]
 
   def up
     create_table :splits do |t|

--- a/vendor/engines/split_accounts/db/migrate/20160325213918_rename_extra_penny_to_apply_remainder.rb
+++ b/vendor/engines/split_accounts/db/migrate/20160325213918_rename_extra_penny_to_apply_remainder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RenameExtraPennyToApplyRemainder < ActiveRecord::Migration
+class RenameExtraPennyToApplyRemainder < ActiveRecord::Migration[4.2]
 
   def change
     rename_column :splits, :extra_penny, :apply_remainder


### PR DESCRIPTION
# Release Notes

As of [Rails 5.1](https://guides.rubyonrails.org/5_1_release_notes.html) (section 9.3), an [error](https://github.com/rails/rails/commit/249f71a22ab21c03915da5606a063d321f04d4d3) is raised when inheriting from `ActiveRecord::Migration` directly, a version number must be specified. 
