### PR TITLE
Add parallel_tests gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "guard-rspec", require: false
   gem "guard-teaspoon", require: false
+  gem "parallel_tests"
   gem "pry-rails"
   gem "pry-byebug"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,6 +416,8 @@ GEM
       mimemagic (~> 0.3.0)
       terrapin (~> 0.6.0)
     parallel (1.19.1)
+    parallel_tests (2.30.1)
+      parallel
     paranoia (2.4.2)
       activerecord (>= 4.0, < 6.1)
     parser (2.6.5.0)
@@ -688,6 +690,7 @@ DEPENDENCIES
   oj
   paper_trail
   paperclip
+  parallel_tests
   paranoia
   poltergeist
   prawn

--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ NUcore uses [Rspec](http://rspec.info) to run tests. Try any of the following fr
 * Create additional databases:
     rake parallel:create
 
+* Run migrations (only needed if building from scratch):
+    rake parallel:create
+  OR
+    rake parallel:load_schema
+
 * Copy development schema (repeat after migrations):
     rake parallel:prepare
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ NUcore uses [Rspec](http://rspec.info) to run tests. Try any of the following fr
 
 #### Parallel Tests
 
+You can run specs in parallel during local development using the `parallel_tests` gem.
+
 * Create additional databases:
     rake parallel:create
 
@@ -181,6 +183,8 @@ NUcore uses [Rspec](http://rspec.info) to run tests. Try any of the following fr
     rake parallel:spec[user]  # run users_controller + user_helper + user specs
     rake parallel:spec['user|instrument']  # run user and product related specs
     rake parallel:spec['spec\/(?!features)'] # run RSpec tests except the tests in spec/features
+
+`parallel_tests' [README](https://github.com/grosser/parallel_tests/blob/master/Readme.md)
 
 
 ## Optional Modules

--- a/README.md
+++ b/README.md
@@ -160,6 +160,23 @@ NUcore uses [Rspec](http://rspec.info) to run tests. Try any of the following fr
 * To run just the controller tests
     rake spec:controllers
 
+#### Parallel Tests
+
+* Create additional databases:
+    rake parallel:create
+
+* Copy development schema (repeat after migrations):
+    rake parallel:prepare
+
+* Run tests:
+    rake parallel:spec
+
+* Example RegEx patterns (ZSH users may require putting rake task in quotes to support args):
+    rake parallel:spec[^spec/requests] # every spec file in spec/requests folder
+    rake parallel:spec[user]  # run users_controller + user_helper + user specs
+    rake parallel:spec['user|instrument']  # run user and product related specs
+    rake parallel:spec['spec\/(?!features)'] # run RSpec tests except the tests in spec/features
+
 
 ## Optional Modules
 

--- a/config/database.yml.mysql.template
+++ b/config/database.yml.mysql.template
@@ -9,8 +9,8 @@ defaults: &defaults
 
 development:
   <<: *defaults
-  database: nucore_open_development
+  database: nucore_open_development<%= ENV['TEST_ENV_NUMBER'] %>
 
 test:
   <<: *defaults
-  database: nucore_open_test
+  database: nucore_open_test<%= ENV['TEST_ENV_NUMBER'] %>


### PR DESCRIPTION
# Release Notes

Adds the [parallel_tests](https://github.com/grosser/parallel_tests) gem to speed up running tests locally. Usage is optional, but it can reduce the amount of time your test suite takes to run dramatically. Personally, `rspec spec` will take about 21 minutes to finish; `rake parallel:spec` reduces that to 4 minutes.

Caveat: if you're expecting a lot of errors, the output can be a little annoying to parse through. These sorts of things can be tweaked with additions to an optional `.rspec_parallel` file.

See the updated README for instructions on how to run.