### PR TITLE
Cleanup specs

### DIFF
--- a/spec/features/admin/all_transactions_search_spec.rb
+++ b/spec/features/admin/all_transactions_search_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "All Transactions Search" do
 
     select accounts.first.account_list_item, from: "Payment Sources"
     click_button "Filter"
-    expect(page).to have_link(order_detail.id, href: manage_facility_order_order_detail_path(facility, orders.first, orders.first.order_details.first))
-    expect(page).not_to have_link(orders.second.order_details.first.id)
+    expect(page).to have_link(order_detail.id.to_s, href: manage_facility_order_order_detail_path(facility, orders.first, orders.first.order_details.first))
+    expect(page).not_to have_link(orders.second.order_details.first.id.to_s)
   end
 end

--- a/spec/features/admin/manage_order_detail_spec.rb
+++ b/spec/features/admin/manage_order_detail_spec.rb
@@ -109,7 +109,6 @@ RSpec.describe "Managing an order detail" do
     end
 
     it "cannot do anything", :js do
-      save_and_open_screenshot
       expect(page).to have_field("Reconciliation Note", with: "I was reconciled", disabled: true)
       expect(page).not_to have_button("Save")
     end


### PR DESCRIPTION
# Release Notes

Tech task: Clean up specs.

# Additional Context

Gets rid of a leftover debugging command as well as a couple capybara deprecations where it wants the selector to be a string rather than an integer.
