### PR TITLE
Lock down FactoryBot to < 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,9 @@ end
 
 group :development, :test do
   gem "awesome_print"
-  gem "factory_bot_rails"
+  # FactoryBot 5.X has some breaking changes we haven't sorted out
+  # https://github.com/tablexi/nucore-open/pull/1865
+  gem "factory_bot_rails", "< 5"
   gem "guard-rspec", require: false
   gem "guard-teaspoon", require: false
   gem "parallel_tests"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -667,7 +667,7 @@ DEPENDENCIES
   ed25519 (>= 1.2, < 2.0)
   exception_notification
   eye-patch
-  factory_bot_rails
+  factory_bot_rails (< 5)
   fine_uploader!
   fog-aws
   font-awesome-rails


### PR DESCRIPTION
# Release Notes

Tech task: Lock down FactoryBot to 4.X.

# Additional Context

It's unclear why the upgrade is breaking it, but certain associations aren't
being persisted.

See https://github.com/tablexi/nucore-open/pull/1865 and the CircleCI build.

