### PR TITLE
Lock FactoryBot to 4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,7 @@ end
 
 group :development, :test do
   gem "awesome_print"
-  gem "factory_bot_rails"
+  gem "factory_bot_rails", "< 5"
   gem "guard-rspec", require: false
   gem "guard-teaspoon", require: false
   gem "pry-rails"


### PR DESCRIPTION
# Release Notes

Pin FactoryBot to version 4.x for compatibility with Rails 5.2

