### PR TITLE
Fix downstream specs

### DIFF
--- a/spec/features/admin/recharge_accounts_spec.rb
+++ b/spec/features/admin/recharge_accounts_spec.rb
@@ -5,15 +5,21 @@ RSpec.describe "Managing recharge accounts (FacilityFacilityAccountsController)"
   let(:facility) { FactoryBot.create(:facility) }
   let!(:director) { FactoryBot.create(:user, :facility_director, facility: facility) }
   let(:default_revenue_account) { Settings.accounts.revenue_account_default }
-  let(:dummy_account) { build(:facility_account) }
+  # Build and destroy so any school-specific callbacks run, but the actual FacilityAccount
+  # should no longer exist. `account_number_parts` must be initialized before the destruction
+  # or we trigger a "cannot modify frozen Hash" error
+  let(:dummy_account) { create(:facility_account).tap(&:account_number_parts).destroy }
 
+  # Setup
   before do
+    allow_any_instance_of(FacilityFacilityAccountsController).to receive(:form_class).and_return ::FacilityAccountForm
     define_open_account default_revenue_account, dummy_account.account_number
-    login_as director
-    visit manage_facility_path(facility)
   end
 
   it "can create a recharge account" do
+    login_as director
+    visit manage_facility_path(facility)
+
     click_link "Recharge Chart Strings"
     click_link "Add Recharge Chart String"
 
@@ -22,11 +28,11 @@ RSpec.describe "Managing recharge accounts (FacilityFacilityAccountsController)"
     # Project, etc. while the default just has a
     # Individual schools should implement a similar spec in their engine that
     # is more explicit in which fields it fills out.
-    dummy_account.account_number_fields.each do |field, _values|
+    dummy_account.account_number_fields.each do |field, _options|
       if field == :account_number
         fill_in "Account Number", with: dummy_account.account_number
       else
-        fill_in I18n.t("facility_account.account_fields.label.account_number.#{field}"), with: dummy_account.account_number_parts[field]
+        fill_in I18n.t(field, scope: "facility_account.account_fields.label.account_number"), with: dummy_account.account_number_parts[field]
       end
     end
 
@@ -40,6 +46,9 @@ RSpec.describe "Managing recharge accounts (FacilityFacilityAccountsController)"
     let!(:facility_account) { FactoryBot.create(:facility_account, facility: facility) }
 
     it "cannot edit most fields, but can mark it as inactive" do
+      login_as director
+      visit manage_facility_path(facility)
+
       click_link "Recharge Chart Strings"
       click_link facility_account.to_s
 

--- a/spec/features/admin/recharge_accounts_spec.rb
+++ b/spec/features/admin/recharge_accounts_spec.rb
@@ -5,36 +5,19 @@ RSpec.describe "Managing recharge accounts (FacilityFacilityAccountsController)"
   let(:facility) { FactoryBot.create(:facility) }
   let!(:director) { FactoryBot.create(:user, :facility_director, facility: facility) }
   let(:default_revenue_account) { Settings.accounts.revenue_account_default }
-  # Build and destroy so any school-specific callbacks run, but the actual FacilityAccount
-  # should no longer exist. `account_number_parts` must be initialized before the destruction
-  # or we trigger a "cannot modify frozen Hash" error
-  let(:dummy_account) { create(:facility_account).tap(&:account_number_parts).destroy }
+  # Use this so schools can override their own formats
+  let(:dummy_account) { build(:facility_account) }
 
-  # Setup
-  before do
-    allow_any_instance_of(FacilityFacilityAccountsController).to receive(:form_class).and_return ::FacilityAccountForm
-    define_open_account default_revenue_account, dummy_account.account_number
-  end
-
-  it "can create a recharge account" do
+  # This will run only in schools who have not overridden their validator with a
+  # custom one. If it's custom, then the school should write their own feature spec.
+  it "can create a recharge account", if: ValidatorFactory.validator_class == ::ValidatorDefault do
     login_as director
     visit manage_facility_path(facility)
 
     click_link "Recharge Chart Strings"
     click_link "Add Recharge Chart String"
 
-    # This is a somewhat convoluted way to fill out the form, but each school will
-    # have different fields for their chart strings. E.g. NU has Fund, Department,
-    # Project, etc. while the default just has a
-    # Individual schools should implement a similar spec in their engine that
-    # is more explicit in which fields it fills out.
-    dummy_account.account_number_fields.each do |field, _options|
-      if field == :account_number
-        fill_in "Account Number", with: dummy_account.account_number
-      else
-        fill_in I18n.t(field, scope: "facility_account.account_fields.label.account_number"), with: dummy_account.account_number_parts[field]
-      end
-    end
+    fill_in "Account Number", with: dummy_account.account_number
 
     click_button "Create"
 

--- a/spec/services/reports/account_search_csv_spec.rb
+++ b/spec/services/reports/account_search_csv_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Reports::AccountSearchCsv do
   let(:facility) { build(:facility, name: "Single Facility", abbreviation: "SF") }
   let(:facility2) { build(:facility, name: "Other Facility", abbreviation: "OF") }
   let(:owner) { create(:user, first_name: "My", last_name: "Owner") }
-  let(:account) { create(:nufs_account, :with_account_owner, account_number: "12345", description: "Testing", owner: owner, expires_at: Time.zone.parse("2020-01-01")) }
-  let(:suspended) { create(:nufs_account, :with_account_owner, account_number: "54321", description: "Testing Susp", owner: owner, suspended_at: Time.zone.parse("2019-12-01"), expires_at: Time.zone.parse("2020-01-02")) }
-  let(:multi_facility) { create(:nufs_account, :with_account_owner, facilities: [facility, facility2]) }
+  let(:account) { create(:account, :with_account_owner, account_number: "12345", description: "Testing", owner: owner, expires_at: Time.zone.parse("2020-01-01")) }
+  let(:suspended) { create(:account, :with_account_owner, account_number: "54321", description: "Testing Susp", owner: owner, suspended_at: Time.zone.parse("2019-12-01"), expires_at: Time.zone.parse("2020-01-02")) }
+  let(:multi_facility) { create(:account, :with_account_owner, facilities: [facility, facility2]) }
 
   let(:accounts) { [account, suspended, multi_facility] }
 


### PR DESCRIPTION
# Release Notes

Tech task: Fix specs that break downstream in the schools.

# Additional Context

I've run these changes in all three schools, but I'm only issuing the PR here for now.

The second commit is my first attempt at fixing the recharge feature spec. It's particularly nasty, though. It needs to account for making sure Dartmouth doesn't make an API call, create the `api_speed_type` for UMass (which we only do on `create`, and handle a case where NU is setting the components of a chart string lazily so trying to change an attribute of a destroyed model triggers an error.

I ended up deciding it's much cleaner to conditionally run the spec based on if we're in `open` or a school that hasn't built custom validation yet.