### PR TITLE
Fix "Manage Journal" and add "s" on billing side bar

### DIFF
--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -166,6 +166,9 @@ en:
       item:
         one: Item
         other: Items
+      journal:
+        one: Journal
+        other: Journals
       journal_cutoff_date:
         one: Journal Cutoff Date
         other: Journal Cutoff Dates


### PR DESCRIPTION
# Release Notes

"Manage Journals" got reverted to "Manage Journal". Add the "s" back on.

# Additional Context

Looks like it was broken by https://github.com/tablexi/nucore-open/pull/2152 because we didn't have a journal translation/pluralization in the locales. It was using `model.human_name.pluralize` before; now it's using `model.human_name(count: :many)`.
