### PR TITLE
[#146482] Ensure price policy is assigned when resolving a problem

### DIFF
--- a/app/controllers/problem_reservations_controller.rb
+++ b/app/controllers/problem_reservations_controller.rb
@@ -9,25 +9,14 @@ class ProblemReservationsController < ApplicationController
   before_action :prevent_double_update, only: :update
   before_action { @active_tab = "reservations" }
 
+  delegate :editable?, :resolved?, to: :problem_reservation_resolver
+
   def edit
     render :resolved if !editable? && resolved?
   end
 
   def update
-    @order_detail.assign_attributes(
-      problem_description_key_was: @order_detail.problem_description_key,
-      problem_resolved_at: Time.current,
-      problem_resolved_by: current_user,
-    )
-    @reservation.assign_times_from_params(update_params)
-    # This would have been set to the reserve_end_at by the auto expirer, but it should
-    # be the actual_end_at.
-    @order_detail.fulfilled_at = @reservation.actual_end_at
-    # The changes we made above won't trigger an automatic repricing, so we need to
-    # do it manually.
-    @order_detail.assign_price_policy
-
-    if @reservation.save
+    if problem_reservation_resolver.resolve(update_params.merge(current_user: current_user))
       if @order_detail.accessories?
         redirect_to new_order_order_detail_accessory_path(@order_detail.order, @order_detail), notice: text("update.success")
       else
@@ -50,12 +39,8 @@ class ProblemReservationsController < ApplicationController
     )
   end
 
-  def editable?
-    OrderDetails::ProblemResolutionPolicy.new(@order_detail).user_can_resolve?
-  end
-
-  def resolved?
-    OrderDetails::ProblemResolutionPolicy.new(@order_detail).user_did_resolve?
+  def problem_reservation_resolver
+    @problem_reservation_resolver ||= ProblemReservationResolver.new(@reservation)
   end
 
   def load_and_authorize_reservation

--- a/app/controllers/problem_reservations_controller.rb
+++ b/app/controllers/problem_reservations_controller.rb
@@ -20,6 +20,12 @@ class ProblemReservationsController < ApplicationController
       problem_resolved_by: current_user,
     )
     @reservation.assign_times_from_params(update_params)
+    # This would have been set to the reserve_end_at by the auto expirer, but it should
+    # be the actual_end_at.
+    @order_detail.fulfilled_at = @reservation.actual_end_at
+    # The changes we made above won't trigger an automatic repricing, so we need to
+    # do it manually.
+    @order_detail.assign_price_policy
 
     if @reservation.save
       if @order_detail.accessories?

--- a/app/services/problem_reservation_resolver.rb
+++ b/app/services/problem_reservation_resolver.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class ProblemReservationResolver
+
+  attr_reader :reservation
+  delegate :order_detail, to: :reservation
+
+  def initialize(reservation)
+    @reservation = reservation
+  end
+
+  def resolve(params)
+    order_detail.assign_attributes(
+      problem_description_key_was: order_detail.problem_description_key,
+      problem_resolved_at: Time.current,
+      problem_resolved_by: params[:current_user],
+    )
+    reservation.assign_times_from_params(params)
+    # This would have been set to the reserve_end_at by the auto expirer, but it should
+    # be the actual_end_at.
+    order_detail.fulfilled_at = reservation.actual_end_at
+    # The changes we made above won't trigger an automatic repricing, so we need to
+    # do it manually.
+    order_detail.assign_price_policy
+    reservation.save
+  end
+
+  def editable?
+    OrderDetails::ProblemResolutionPolicy.new(order_detail).user_can_resolve?
+  end
+
+  def resolved?
+    OrderDetails::ProblemResolutionPolicy.new(order_detail).user_did_resolve?
+  end
+
+end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -126,13 +126,17 @@ FactoryBot.define do
   end
 
   factory :setup_instrument, class: Instrument, parent: :setup_product do
+    transient do
+      charge_for { "reservation" }
+    end
+
     reserve_interval { 1 }
 
     schedule { create :schedule, facility: facility }
 
-    after(:create) do |product|
+    after(:create) do |product, evaluator|
       create :schedule_rule, product: product
-      create :instrument_price_policy, price_group: product.facility.price_groups.last, usage_rate: 1, product: product
+      create :instrument_price_policy, price_group: product.facility.price_groups.last, usage_rate: 1, product: product, charge_for: evaluator.charge_for
       product.reload
     end
 

--- a/spec/features/fixing_a_problem_reservation_spec.rb
+++ b/spec/features/fixing_a_problem_reservation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Fixing a problem reservation" do
@@ -7,8 +9,18 @@ RSpec.describe "Fixing a problem reservation" do
   before { login_as reservation.user }
 
   # Permissions and some other failure cases are covered in controllers/problem_reservations_controller_spec
+  # and services/problem_reservation_resolver_spec
   describe "a problem reservation" do
-    let!(:reservation) { create(:purchased_reservation, product: instrument, reserve_start_at: 2.hours.ago, reserve_end_at: 1.hour.ago, actual_start_at: 1.hour.ago, actual_end_at: nil) }
+    let!(:reservation) do
+      create(
+        :purchased_reservation,
+        product: instrument,
+        reserve_start_at: 2.hours.ago,
+        reserve_end_at: 1.hour.ago,
+        actual_start_at: 1.hour.ago,
+        actual_end_at: nil
+      )
+    end
     before { MoveToProblemQueue.move!(reservation.order_detail) }
 
     it "can edit the reservation" do
@@ -16,42 +28,11 @@ RSpec.describe "Fixing a problem reservation" do
       click_link "Fix Usage"
       fill_in "Actual Duration", with: "45"
       click_button "Save"
+
       expect(page).not_to have_content("Fix Usage")
-    end
-
-    it "updates the order detail's fields" do
-      visit edit_problem_reservation_path(reservation)
-      fill_in "Actual Duration", with: "45"
-      click_button "Save"
-
       expect(reservation.order_detail.reload.problem_description_key_was).to eq("missing_actuals")
       expect(reservation.order_detail.problem_resolved_at).to be_present
       expect(reservation.order_detail.problem_resolved_by).to eq(reservation.user)
-
-      expect(reservation.order_detail.problem_description_key).to eq(nil)
-    end
-
-    it "moves the fulfilled_at to the actual end at" do
-      visit edit_problem_reservation_path(reservation)
-      fill_in "Actual Duration", with: "45"
-      click_button "Save"
-
-      expect(reservation.reload.actual_start_at).to eq(1.hour.ago)
-      expect(reservation.actual_end_at).to eq(15.minutes.ago)
-      expect(reservation.order_detail.reload.fulfilled_at).to eq(15.minutes.ago)
-    end
-
-    describe "when there is not a price policy" do
-      before { instrument.price_policies.destroy_all }
-
-      it "leaves it as a problem if it is still missing a price policy" do
-        visit edit_problem_reservation_path(reservation)
-        fill_in "Actual Duration", with: "45"
-        click_button "Save"
-
-        expect(reservation.order_detail.reload.problem_description_key_was).to eq("missing_actuals")
-        expect(reservation.order_detail.problem_description_key).to eq(:missing_price_policy)
-      end
     end
 
     it "errors if zero" do

--- a/spec/services/problem_reservation_resolver_spec.rb
+++ b/spec/services/problem_reservation_resolver_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe ProblemReservationResolver do
+  let(:facility) { create(:setup_facility) }
+  let(:instrument) { create(:setup_instrument, :timer, :always_available, charge_for: :usage, facility: facility, problems_resolvable_by_user: true) }
+  let(:user) { create(:user) }
+  let!(:problem_reservation) do
+    create(
+      :purchased_reservation,
+      product: instrument,
+      reserve_start_at: 2.hours.ago,
+      reserve_end_at: 1.hour.ago,
+      actual_start_at: 1.hour.ago,
+      actual_end_at: nil
+    )
+  end
+  subject(:resolver) { described_class.new(problem_reservation) }
+
+  before { MoveToProblemQueue.move!(problem_reservation.order_detail) }
+
+  describe "resolve" do
+    it "sets the problem resolution attributes" do
+      resolver.resolve(actual_end_at: 15.minutes.ago, current_user: user)
+
+      expect(problem_reservation.order_detail.reload).to have_attributes(
+        problem_description_key_was: "missing_actuals",
+        problem_resolved_at: be_present,
+        problem_resolved_by: user,
+      )
+    end
+
+    it "moves the fulfilled_at to the actual_end_at" do
+      end_at = 15.minutes.ago
+      expect do
+        resolver.resolve(actual_end_at: end_at)
+      end.to change { problem_reservation.order_detail.reload.fulfilled_at }.to eq(end_at)
+    end
+
+    describe "when there is no price policy" do
+      before { instrument.price_policies.destroy_all }
+
+      it "leaves it as a problem reservation" do
+        resolver.resolve(actual_end_at: 15.minutes.ago)
+        expect(problem_reservation.order_detail.reload.problem_description_key_was).to eq("missing_actuals")
+        expect(problem_reservation.order_detail.problem_description_key).to eq(:missing_price_policy)
+      end
+    end
+
+    it "adds an error to the reservation if it is invalid" do
+      # Reservations cannot be zero length
+      expect(resolver.resolve(actual_end_at: problem_reservation.actual_start_at)).to be_falsy
+      expect(problem_reservation.errors).to be_added(:actual_duration_mins, :zero_minutes)
+    end
+
+  end
+
+end


### PR DESCRIPTION
# Release Notes

Ensure price policy is assigned when a user is resolving their own problem reservation. This also updates the "Fulfilled At" field to match the actual end time.
