### PR TITLE
Clean up formatting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,30 +162,43 @@ NUcore uses [Rspec](http://rspec.info) to run tests. Try any of the following fr
 
 #### Parallel Tests
 
-You can run specs in parallel during local development using the `parallel_tests` gem.
+You can run specs in parallel during local development using the [`parallel_tests`](https://github.com/grosser/parallel_tests) gem.
 
 * Create additional databases:
     rake parallel:create
 
 * Run migrations (only needed if building from scratch):
+
+    ```
     rake parallel:create
+    ```
+  
   OR
+  
+    ```
     rake parallel:load_schema
+    ```
 
 * Copy development schema (repeat after migrations):
+	
+	```
     rake parallel:prepare
-
+	```
+	
 * Run tests:
+
+    ```
     rake parallel:spec
+    ```
 
 * Example RegEx patterns (ZSH users may require putting rake task in quotes to support args):
+
+	```
     rake parallel:spec[^spec/requests] # every spec file in spec/requests folder
     rake parallel:spec[user]  # run users_controller + user_helper + user specs
     rake parallel:spec['user|instrument']  # run user and product related specs
     rake parallel:spec['spec\/(?!features)'] # run RSpec tests except the tests in spec/features
-
-`parallel_tests' [README](https://github.com/grosser/parallel_tests/blob/master/Readme.md)
-
+    ```
 
 ## Optional Modules
 

--- a/README.md
+++ b/README.md
@@ -146,26 +146,36 @@ _Known issue: if you run `db:setup` or all three in one rake command, the next t
     ./script/delayed_job run
     ```
 
-
 ### Test it
 
 NUcore uses [Rspec](http://rspec.info) to run tests. Try any of the following from NUcore's root directory.
 
 * To run all tests (this will take awhile!)
+
+    ```
     rake spec
-
+    ```
+    
 * To run just the model tests
-    rake spec:models
 
+    ```
+    rake spec:models
+    ```
+    
 * To run just the controller tests
+    ```
     rake spec:controllers
+    ```
 
 #### Parallel Tests
 
 You can run specs in parallel during local development using the [`parallel_tests`](https://github.com/grosser/parallel_tests) gem.
 
 * Create additional databases:
+
+    ```
     rake parallel:create
+    ```
 
 * Run migrations (only needed if building from scratch):
 


### PR DESCRIPTION
# Release Notes

Clean up formatting of commands in README.

# Additional Context

The commands weren't being formatted as code when parsed by Github's markdown parser. I noticed this because of some merge conflicts when bringing this downstream (we have some other school-specific info in the same spot of the file--easy enough to keep both).

