### PR TITLE
[#151494] Use network timeouts to communice with Dataprobe relays

### DIFF
--- a/vendor/engines/dataprobe/lib/dataprobe/ipio.rb
+++ b/vendor/engines/dataprobe/lib/dataprobe/ipio.rb
@@ -4,61 +4,69 @@ module Dataprobe
 
   class Ipio
 
+    CONNECT_TIMEOUT = 5
+    READ_TIMEOUT = 5
+    WRITE_TIMEOUT = 5
+
     attr_reader :ip, :port
     attr_accessor :username, :password
 
     def initialize(host, options = {})
       @ip = host
-      @port = options[:port] || 9100
+      @port = 9100
       @username = (options[:username].presence || "user").ljust(21, "\x00")
       @password = (options[:password].presence || "user").ljust(21, "\x00")
     end
 
     def toggle(outlet, status)
-      mode = status ? 1 : 0
-      socket = hello_socket
-      write_control_cmd socket, mode, outlet
-      raise Dataprobe::Error.new("Error while toggling outlet #{outlet}") unless socket.recv(1) == "\x00"
-      status
-    ensure
-      socket.close
+      with_connection do |socket, message_number|
+        mode = status ? 1 : 0
+        write(socket, "#{authentication_prefix}\x01\x00#{message_number}#{hex_s outlet}#{hex_s mode}")
+        raise Dataprobe::Error.new("Error while toggling outlet #{outlet}") unless read(socket, 1) == "\x00"
+        status
+      end
     end
 
     def status(outlet)
-      socket = hello_socket
-      write_status_cmd socket
-      reply = socket.recv 100
-      stats = reply.unpack "C*"
-      stats[outlet - 1] == 1
-    ensure
-      socket.close
-    end
-
-    def hex_s(int)
-      [int].pack "C"
+      with_connection do |socket, message_number|
+        write(socket, "#{authentication_prefix}\x04\x00#{message_number}")
+        statuses = read(socket, 100).unpack("C*")
+        statuses[outlet - 1] == 1
+      end
     end
 
     private
 
-    def hello_socket
-      socket = TCPSocket.new ip, port
-      socket.write "hello-000\x00"
-      socket
+    def with_connection(&block)
+      socket = Socket.tcp(ip, port, connect_timeout: CONNECT_TIMEOUT)
+      write(socket, "hello-000\x00")
+      sequence_number = read(socket, 2).unpack("s<")
+      sequence_number[0] += 1
+      block.call(socket, sequence_number.pack("s<"))
+    ensure
+      socket.close
     end
 
-    def update_sequence(socket)
-      reply = socket.recv 2
-      seq = reply.unpack "s<"         #  Turn the two bytes received into an integer
-      seq[0] += 1                     #  add 1 to it and turn it back to two bytes
-      seq.pack "s<"
+    def write(socket, string)
+      socket.write_nonblock(string)
+    rescue IO::WaitWritable
+      IO.select(nil, [socket], nil, WRITE_TIMEOUT)
+      retry
     end
 
-    def write_control_cmd(socket, mode, outlet)
-      socket.write "\x03#{username}#{password}\x01\x00#{update_sequence socket}#{hex_s outlet}#{hex_s mode}"
+    def read(socket, bytes)
+      socket.read_nonblock(bytes)
+    rescue IO::WaitReadable
+      IO.select([@socket], nil, nil, READ_TIMEOUT)
+      retry
     end
 
-    def write_status_cmd(socket)
-      socket.write "\x03#{username}#{password}\x04\x00#{update_sequence socket}"
+    def authentication_prefix
+      "\x03#{username}#{password}"
+    end
+
+    def hex_s(int)
+      [int].pack "C"
     end
 
   end

--- a/vendor/engines/dataprobe/lib/dataprobe/ipio.rb
+++ b/vendor/engines/dataprobe/lib/dataprobe/ipio.rb
@@ -57,7 +57,7 @@ module Dataprobe
     def read(socket, bytes)
       socket.read_nonblock(bytes)
     rescue IO::WaitReadable
-      IO.select([@socket], nil, nil, READ_TIMEOUT)
+      IO.select([socket], nil, nil, READ_TIMEOUT)
       retry
     end
 


### PR DESCRIPTION
# Release Notes

Use network timeouts when communicating with Dataprobe relays.

# Additional Context

Currently, when a Dataprobe relay is not reachable via the network, the `TCPSocket.new` call hangs indefinitely, until that request’s Unicorn process is ultimately killed [for timing out](https://github.com/tablexi/nucore-nu/blob/master/config/unicorn/production.rb#L21). This PR switches to using non-blocking IO which emulates blocking IO, but with timeouts for connecting, writing, and reading of 5 seconds each. This way, a nonreachable Dataprobe relay doesn’t take down the entire application by rendering unicorns unusable until they are killed.

For a discussion of networking approaches in ruby, and why it is best to use these options on the system calls (and to never use `Timeout`), these may be helpful:
- https://www.mikeperham.com/2009/03/15/socket-timeouts-in-ruby/
- https://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/
- https://ruby-doc.org/core-2.5.5/IO.html#method-i-read_nonblock

These are cherry-picks from work done downstream in NU. See https://github.com/tablexi/nucore-nu/pull/532 and https://github.com/tablexi/nucore-nu/pull/534