### PR TITLE
[#149740] Add reference_id to OrderDetail

### DIFF
--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -81,7 +81,7 @@ class FacilityOrdersController < ApplicationController
   private
 
   def add_to_order_params
-    params.require(:add_to_order_form).permit(:quantity, :product_id, :order_status_id, :note, :fulfilled_at, :duration, :account_id)
+    params.require(:add_to_order_form).permit(:quantity, :product_id, :order_status_id, :note, :fulfilled_at, :duration, :account_id, :reference_id)
   end
 
   def batch_updater

--- a/app/forms/add_to_order_form.rb
+++ b/app/forms/add_to_order_form.rb
@@ -6,7 +6,7 @@ class AddToOrderForm
   include TextHelpers::Translation
 
   attr_reader :original_order, :current_facility
-  attr_accessor :quantity, :product_id, :order_status_id, :note, :duration, :created_by, :fulfilled_at, :account_id
+  attr_accessor :quantity, :product_id, :order_status_id, :note, :duration, :created_by, :fulfilled_at, :account_id, :reference_id
   attr_accessor :error_message
 
   validates :account_id, presence: true
@@ -14,6 +14,7 @@ class AddToOrderForm
   validates :product_id, presence: true
   validates :order_status_id, presence: true
   validates :quantity, numericality: { greater_than: 0, only_integer: true }
+  validates :reference_id, length: { minimum: 0, maximum: 30 }, allow_blank: true
 
   def initialize(original_order)
     @original_order = original_order
@@ -97,6 +98,7 @@ class AddToOrderForm
       duration: duration,
       created_by: created_by.id,
       account: account,
+      reference_id: reference_id,
     }
   end
 

--- a/app/models/reports/export_raw.rb
+++ b/app/models/reports/export_raw.rb
@@ -109,6 +109,7 @@ module Reports
         problem_resolved_at: :problem_resolved_at,
         problem_description: ->(od) { I18n.t("order_details.notices.#{od.problem_description_key_was}.badge") if od.problem_description_key_was? },
         problem_resolved_by: :problem_resolved_by,
+        reference_id: :reference_id,
       }
       if SettingsHelper.has_review_period?
         hash

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -37,7 +37,7 @@ class Reservation < ApplicationRecord
   # Delegations
   #####
   delegate :note, :note=, :ordered_on_behalf_of?, :complete?, :account, :order,
-           :complete!, :price_policy, to: :order_detail, allow_nil: true
+           :complete!, :price_policy, :reference_id, :reference_id=, to: :order_detail, allow_nil: true
 
   delegate :account, :in_cart?, :user, to: :order, allow_nil: true
   delegate :facility, to: :product, allow_nil: true

--- a/app/services/order_detail_update_param_hash_extractor.rb
+++ b/app/services/order_detail_update_param_hash_extractor.rb
@@ -18,10 +18,10 @@ class OrderDetailUpdateParamHashExtractor
   def to_h
     # TODO: clean up this and _cart_row.html.haml
     params.permit!.to_h.each_with_object({}) do |(key, value), memo|
-      match = key.match(/\A(note|quantity)(\d+)\z/) || next
+      match = key.match(/\A(note|quantity|reference_id)(\d+)\z/) || next
       property = match[1].to_sym
       id = match[2].to_i
-      next if property == :note && !value
+      next if property.in?([:note, :reference_id]) && !value
 
       (memo[id] ||= {})[property] = value
     end

--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -14,6 +14,7 @@ class OrderDetails::ParamUpdater
         :price_change_reason,
         :editing_time_data,
         :reconciled_note,
+        :reference_id,
         reservation: [
           :reserve_start_date,
           :reserve_start_hour,

--- a/app/services/reservation_creator.rb
+++ b/app/services/reservation_creator.rb
@@ -63,7 +63,7 @@ class ReservationCreator
   def reservation_create_params
     params.require(:reservation)
           .except(:reserve_end_date, :reserve_end_hour, :reserve_end_min, :reserve_end_meridian)
-          .permit(:reserve_start_date, :reserve_start_hour, :reserve_start_min, :reserve_start_meridian, :duration_mins, :note, :project_id)
+          .permit(:reserve_start_date, :reserve_start_hour, :reserve_start_min, :reserve_start_meridian, :duration_mins, :note, :reference_id, :project_id)
           .merge(product: @order_detail.product)
   end
 

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -31,9 +31,12 @@
            complete_target: "#add_to_order_form_order_status_id" },
         class: "datepicker__data string optional js--showOnCompleteStatus"
 
-      = f.input :note, as: :text, input_html: { class: "wide", maxlength: 1000 }
-
-      %br
+      .container
+        .row
+          .span8
+            = f.input :note, as: :text, input_html: { class: "wide", maxlength: 1000 }
+          .span4
+            = f.input :reference_id
 
       = submit_tag text("admin.shared.add_to", model: @order.class),
         class: "btn btn-primary",

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -50,6 +50,9 @@
         .span5.js--pricingUpdate
           = f.input :quantity, as: :order_detail_quantity, hint_html: { class: "help-inline" }
 
+      .span4
+        = f.input :reference_id
+
       .span5
         = render "costs", f: f
 

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -50,9 +50,6 @@
         .span5.js--pricingUpdate
           = f.input :quantity, as: :order_detail_quantity, hint_html: { class: "help-inline" }
 
-      .span4
-        = f.input :reference_id
-
       .span5
         = render "costs", f: f
 
@@ -73,6 +70,10 @@
       .span4
         = render "assigned_user", f: f
       .span1= render "facility_orders/order_file_icon", od: @order_detail
+
+    .row
+      .span5
+        = f.input :reference_id
 
     - if @order_detail.dispute_at
       .row= render "dispute", f: f

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -17,6 +17,12 @@
           id: "note#{order_detail.id}",
           name: "note#{order_detail.id}" }
 
+      - if acting_as?
+        = odf.input :reference_id ,
+          input_html: { id: "reference_id#{order_detail.id}",
+          name: "reference_id#{order_detail.id}",
+          maxlength: 30 }
+
       - if order_detail.product.is_a?(Instrument)
         %td
       - elsif order_detail.bundle

--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -33,12 +33,17 @@
 
   - if acting_as?
     .row
+      .span4
+        = f.input :reference_id
+    .row
       - if @order.order_details.size == 1
         .span6.send-notification
           = label_tag :send_notification, class: "checkbox" do
             = hidden_field_tag :send_notification, 0
             = check_box_tag :send_notification, 1, params[:send_notification] == "1"
             = t(".notify")
+
+
 
   - if @instrument.offline?
     %p.alert.alert-danger= text("instruments.offline.notice")

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -332,6 +332,7 @@ en:
         quantity: Quantity
         reconciled_note: Reconciliation Note
         reconciled_at: Reconciliation Date
+        reference_id: Reference ID
         reviewed_at: Review Closes
         reviewed_at_past: Review Closed
         status: Status

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -379,6 +379,7 @@ en:
         canceled_at: Canceled At
         type: Type
         reserve_range: Reserved For
+        reference_id: Reference ID
       statement:
         id: "Invoice #"
         created_by: Sent By

--- a/config/locales/forms/en.add_to_order_form.yml
+++ b/config/locales/forms/en.add_to_order_form.yml
@@ -11,3 +11,4 @@ en:
       add_to_order_form:
         account: Payment Source
         account_id: Payment Source
+        reference_id: Reference ID

--- a/db/migrate/20200130153146_add_reference_id_to_order_details.rb
+++ b/db/migrate/20200130153146_add_reference_id_to_order_details.rb
@@ -1,5 +1,5 @@
 class AddReferenceIdToOrderDetails < ActiveRecord::Migration[5.2]
   def change
-    add_column :order_details, :reference_id, :string, limit: 30
+    add_column :order_details, :reference_id, :string
   end
 end

--- a/db/migrate/20200130153146_add_reference_id_to_order_details.rb
+++ b/db/migrate/20200130153146_add_reference_id_to_order_details.rb
@@ -1,0 +1,5 @@
+class AddReferenceIdToOrderDetails < ActiveRecord::Migration[5.2]
+  def change
+    add_column :order_details, :reference_id, :string, limit: 30
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -327,7 +327,7 @@ ActiveRecord::Schema.define(version: 2020_01_30_153146) do
     t.string "problem_description_key_was"
     t.timestamp "problem_resolved_at"
     t.integer "problem_resolved_by_id"
-    t.string "reference_id", limit: 30
+    t.string "reference_id"
     t.index ["account_id"], name: "fk_od_accounts"
     t.index ["assigned_user_id"], name: "index_order_details_on_assigned_user_id"
     t.index ["bundle_product_id"], name: "fk_bundle_prod_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_13_131617) do
+ActiveRecord::Schema.define(version: 2020_01_30_153146) do
 
   create_table "account_facility_joins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "facility_id", null: false
@@ -327,6 +327,7 @@ ActiveRecord::Schema.define(version: 2020_01_13_131617) do
     t.string "problem_description_key_was"
     t.timestamp "problem_resolved_at"
     t.integer "problem_resolved_by_id"
+    t.string "reference_id", limit: 30
     t.index ["account_id"], name: "fk_od_accounts"
     t.index ["assigned_user_id"], name: "index_order_details_on_assigned_user_id"
     t.index ["bundle_product_id"], name: "fk_bundle_prod_id"

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -256,6 +256,24 @@ RSpec.describe FacilityOrdersController do
           end
         end
 
+        context "when setting a reference id" do
+          context "of an appropriate length" do
+            before { @params[:add_to_order_form][:reference_id] = "Ref123" }
+
+            it_should_allow :director, "to set the reference id" do
+              expect(order_detail.reference_id).to eq("Ref123")
+            end
+          end
+
+          context "that is too long" do
+            before { @params[:add_to_order_form][:reference_id] = "a" * 31 }
+            it_should_allow :director, "to set the reference id" do
+              expect(order_detail).to be_blank
+              expect(flash[:error]).to include("Reference ID is too long")
+            end
+          end
+        end
+
         context "when specifying an account" do
           let(:other_account) { create(:nufs_account, :with_account_owner, owner: order.user) }
           before { @params[:add_to_order_form][:account_id] = other_account.id }

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -744,6 +744,14 @@ RSpec.describe OrderManagement::OrderDetailsController do
           end
         end
 
+        describe "when adding a reference id" do
+          it "updates the reference_id" do
+            @params[:order_detail] = { reference_id: "Ref 123" }
+            do_request
+            expect(order_detail.reload.reference_id).to eq("Ref 123")
+          end
+        end
+
         describe "assigning to a user" do
           let(:staff_user) { FactoryBot.create(:user, :staff, facility: facility) }
 

--- a/spec/features/placing_an_order_on_behalf_of_spec.rb
+++ b/spec/features/placing_an_order_on_behalf_of_spec.rb
@@ -60,4 +60,16 @@ RSpec.describe "Placing an item order" do
 
     expect(page).to have_content("Ordered Date\n#{I18n.l(2.days.ago.to_date, format: :usa)}")
   end
+
+  it "can set a reference ID" do
+    visit facility_path(facility)
+    click_link product.name
+    click_link "Add to cart"
+    choose account.to_s
+    click_button "Continue"
+
+    fill_in "Reference ID", with: "Ref123"
+    click_button "Purchase"
+    expect(OrderDetail.last.reference_id).to eq("Ref123")
+  end
 end

--- a/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
+++ b/spec/features/purchasing_a_reservation_on_behalf_of_spec.rb
@@ -33,12 +33,17 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
       click_link instrument.name
       select user.accounts.first.description, from: "Payment Source"
       fill_in "Note", with: "A note"
+      fill_in "Reference ID", with: "Ref123"
       click_button "Create"
     end
 
     it "returns to My Reservations" do
       expect(page).to have_content "Order Receipt"
+    end
+
+    it "has optional attributes set" do
       expect(Reservation.last.note).to eq("A note")
+      expect(Reservation.last.reference_id).to eq("Ref123")
     end
   end
 


### PR DESCRIPTION
# Release Notes

Adds a field to `OrderDetail` and updates relevant forms.

This still needs a little work. Some of the context lost on me has likely left holes in areas that require updating.