### PR TITLE
[#148320] Improve performance of relay statuses

### DIFF
--- a/app/models/concerns/products/relay_support.rb
+++ b/app/models/concerns/products/relay_support.rb
@@ -6,7 +6,7 @@ module Products::RelaySupport
 
   included do
     has_one  :relay, inverse_of: :instrument, dependent: :destroy
-    has_many :instrument_statuses, foreign_key: "instrument_id"
+    has_many :instrument_statuses, foreign_key: "instrument_id", inverse_of: :instrument
 
     accepts_nested_attributes_for :relay
 

--- a/app/models/instrument_status.rb
+++ b/app/models/instrument_status.rb
@@ -9,20 +9,14 @@ class InstrumentStatus < ApplicationRecord
 
   attr_accessor :error_message
 
-  def status_string
-    return error_message if error_message
-    is_on? ? "On" : "Off"
-  end
-
   def as_json(_options = {})
     {
       instrument_status: {
-        created_at: created_at,
+        name: instrument.name,
         instrument_id: instrument.id,
+        type: instrument.relay&.type,
         is_on: is_on?,
         error_message: @error_message,
-        name: instrument.name,
-        type: instrument.relay.type,
       },
     }
   end

--- a/app/models/instrument_status.rb
+++ b/app/models/instrument_status.rb
@@ -2,9 +2,10 @@
 
 class InstrumentStatus < ApplicationRecord
 
-  belongs_to :instrument
+  belongs_to :instrument, inverse_of: :instrument_statuses
 
   validates_numericality_of :instrument_id
+  alias_attribute :on, :is_on
 
   attr_accessor :error_message
 
@@ -20,6 +21,8 @@ class InstrumentStatus < ApplicationRecord
         instrument_id: instrument.id,
         is_on: is_on?,
         error_message: @error_message,
+        name: instrument.name,
+        type: instrument.relay.type,
       },
     }
   end

--- a/app/models/power_relay.rb
+++ b/app/models/power_relay.rb
@@ -29,15 +29,45 @@ module PowerRelay
   end
 
   def toggle(status)
-    relay_connection.toggle(outlet, status)
+    log_power_relay_connection(:toggle) do
+      relay_connection.toggle(outlet, status)
+    end
   end
 
   def query_status
-    relay_connection.status(outlet)
+    log_power_relay_connection(:status) do
+      relay_connection.status(outlet)
+    end
   end
 
   def relay_connection
     raise NotImplementedError.new("Subclass must define")
+  end
+
+  private
+
+  def log_power_relay_connection(event_type)
+    ActiveSupport::Notifications.instrument("#{event_type}.power_relays") do |payload|
+      payload.merge!(log_power_relay_options)
+      begin
+        payload[:status] = yield
+      rescue => e
+        payload[:status] = e
+        raise e
+      end
+    end
+  end
+
+  def log_power_relay_options
+    {
+      options: {
+        instrument: instrument.name,
+        type: type,
+        host: host,
+        ip_port: ip_port,
+        outlet: outlet,
+      }.merge(connection_options.except(:username, :password))
+    }
   end
 
 end

--- a/app/models/power_relay.rb
+++ b/app/models/power_relay.rb
@@ -44,6 +44,25 @@ module PowerRelay
     raise NotImplementedError.new("Subclass must define")
   end
 
+  # Shared schedules might use the same physical relay on multiple instruments, but
+  # each of these are a different database record. In these situations, we only want to
+  # fetch the status once.
+  # Note that if one has nil (e.g. default) and the other has "80", it will still do two
+  # network queries. This is so this model can be agnostic about the actual relay's default port
+  # (e.g. Synaccess is 80 while Dataprobe is 9200).
+  def status_cache_key
+    [
+      ip,
+      ip_port,
+      outlet,
+      # Include username/password so that if one of the shared schedule is right and
+      # the other is wrong we still do multiple queries: one gets an error and the other
+      # doesn't.
+      username,
+      password,
+    ]
+  end
+
   private
 
   def log_power_relay_connection(event_type)

--- a/app/models/power_relay.rb
+++ b/app/models/power_relay.rb
@@ -61,7 +61,7 @@ module PowerRelay
   def log_power_relay_options
     {
       options: {
-        instrument: instrument.name,
+        instrument: instrument&.name,
         type: type,
         host: host,
         ip_port: ip_port,

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -33,6 +33,10 @@ class Relay < ApplicationRecord
     CONTROL_MECHANISMS[:manual]
   end
 
+  def networked_relay?
+    control_mechanism == CONTROL_MECHANISMS[:relay]
+  end
+
   private
 
   def toggle(_status)

--- a/app/services/instrument_status_fetcher.rb
+++ b/app/services/instrument_status_fetcher.rb
@@ -20,31 +20,23 @@ class InstrumentStatusFetcher
 
   def instrument_status_for(instrument)
     # Always return true/on if the relay feature is disabled
-    current_on = SettingsHelper.relays_enabled_for_admin? ? status_of(instrument.relay) : true
-    previous_instrument_status = instrument.current_instrument_status
-    # if the status hasn't changed, don't create a new status
-    if previous_instrument_status && current_on == previous_instrument_status.on?
-      previous_instrument_status
-    else
-      # || false will ensure that the value of is_on is not nil (causes a DB error)
-      instrument.instrument_statuses.create!(on: current_on || NUCore::Database.boolean(false))
-    end
-  rescue => e
-    Rails.logger.error e.message
-    InstrumentStatus.new(instrument: instrument, error_message: e.message)
-  end
+    return InstrumentStatus.new(on: true, instrument: instrument) unless SettingsHelper.relays_enabled_for_admin?
 
-  def status_of(relay)
-    @cache ||= {}
     # Shared schedules might use the same relay on multiple instruments. In these
     # situations, we only want to fetch the status once.
-    key = [relay.ip, relay.ip_port, relay.outlet]
+    key = [instrument.relay.ip, instrument.relay.ip_port, instrument.relay.outlet]
 
-    if @cache.key?(key)
-      @cache[key]
-    else
-      @cache[key] = relay.get_status
+    return status_cache[key] if status_cache.key?(key)
+
+    begin
+      status_cache[key] = InstrumentStatus.new(on: instrument.relay.get_status, instrument: instrument)
+    rescue => e
+      status_cache[key] = InstrumentStatus.new(error_message: e.message, instrument: instrument)
     end
+  end
+
+  def status_cache
+    @status_cache ||= {}
   end
 
 end

--- a/app/services/instrument_status_fetcher.rb
+++ b/app/services/instrument_status_fetcher.rb
@@ -15,7 +15,7 @@ class InstrumentStatusFetcher
   private
 
   def instruments
-    @facility.instruments.order(:id).includes(:relay).select { |instrument| instrument.relay.present? }
+    @facility.instruments.order(:id).includes(:relay).select { |instrument| instrument.relay&.networked_relay? }
   end
 
   def instrument_status_for(instrument)

--- a/app/services/instrument_status_fetcher.rb
+++ b/app/services/instrument_status_fetcher.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class InstrumentStatusFetcher
+
+  def initialize(facility)
+    @facility = facility
+  end
+
+  def statuses
+    @instrument_statuses = instruments.map do |instrument|
+      instrument_status_for(instrument)
+    end
+  end
+
+  private
+
+  def instruments
+    @facility.instruments.order(:id).includes(:relay).select { |instrument| instrument.relay.present? }
+  end
+
+  def instrument_status_for(instrument)
+    # Always return true/on if the relay feature is disabled
+    current_on = SettingsHelper.relays_enabled_for_admin? ? instrument.relay.get_status : true
+    previous_instrument_status = instrument.current_instrument_status
+    # if the status hasn't changed, don't create a new status
+    if previous_instrument_status && current_on == previous_instrument_status.on?
+      previous_instrument_status
+    else
+      # || false will ensure that the value of is_on is not nil (causes a DB error)
+      instrument.instrument_statuses.create!(on: current_on || NUCore::Database.boolean(false))
+    end
+  rescue => e
+    Rails.logger.error e.message
+    InstrumentStatus.new(instrument: instrument, error_message: e.message)
+  end
+
+end

--- a/app/services/instrument_status_fetcher.rb
+++ b/app/services/instrument_status_fetcher.rb
@@ -22,10 +22,7 @@ class InstrumentStatusFetcher
     # Always return true/on if the relay feature is disabled
     return InstrumentStatus.new(on: true, instrument: instrument) unless SettingsHelper.relays_enabled_for_admin?
 
-    # Shared schedules might use the same relay on multiple instruments. In these
-    # situations, we only want to fetch the status once.
-    key = [instrument.relay.ip, instrument.relay.ip_port, instrument.relay.outlet]
-
+    key = instrument.relay.status_cache_key
     return status_cache[key] if status_cache.key?(key)
 
     begin

--- a/config/initializers/power_relay_logger.rb
+++ b/config/initializers/power_relay_logger.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class PowerRelayLogger < ActiveSupport::LogSubscriber
+
+  def status(event)
+    render event, "Got status with options #{event.payload[:options]}. Status: #{event.payload[:status]}"
+  end
+
+  def toggle(event)
+    render event, "Toggled status with options #{event.payload[:options]}. Status: #{event.payload[:result]}"
+  end
+
+  private
+
+  def render(event, message, display_color: GREEN)
+    return unless logger.debug?
+
+    debug color("[PowerRelays] (#{event.duration.round(1)}ms) #{message}", display_color, true)
+  end
+
+end
+
+PowerRelayLogger.attach_to :power_relays

--- a/spec/services/instrument_status_fetcher_spec.rb
+++ b/spec/services/instrument_status_fetcher_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe InstrumentStatusFetcher do
+  let(:facility) { create(:setup_facility) }
+  let!(:relay) { create(:relay_syna, instrument: instrument_with_relay) }
+  let!(:instrument_with_relay) { create(:instrument, no_relay: true, facility: facility) }
+  let!(:instrument_with_dummy_relay) { create(:instrument, facility: facility) }
+  let!(:reservation_only_instrument) { create(:instrument, no_relay: true, facility: facility) }
+  subject(:fetcher) { described_class.new(facility) }
+  let(:statuses) { fetcher.statuses }
+
+  # Otherwise
+  before do
+    allow(SettingsHelper).to receive(:relays_enabled_for_admin?).and_return(true)
+    allow_any_instance_of(RelaySynaccessRevA).to receive(:query_status).and_return(true)
+  end
+
+  describe "#statuses" do
+    it "includes the instrument with real relays" do
+      expect(statuses.map(&:instrument)).to include(instrument_with_relay)
+    end
+
+    it "excludes instruments without relays" do
+      expect(statuses.map(&:instrument)).not_to include(reservation_only_instrument)
+    end
+
+    it "excludes instruments with timers" do
+      expect(statuses.map(&:instrument)).not_to include(instrument_with_dummy_relay)
+    end
+
+    it "has the status" do
+      expect(statuses.find { |status| status.instrument == instrument_with_relay }).to be_on
+    end
+
+    it "has a false status" do
+      allow_any_instance_of(RelaySynaccessRevA).to receive(:query_status).and_return(false)
+      expect(statuses.find { |status| status.instrument == instrument_with_relay }).not_to be_on
+    end
+
+    it "can have an error" do
+      allow_any_instance_of(RelaySynaccessRevA).to receive(:query_status).and_raise(StandardError.new("Error!"))
+      expect(statuses.first.error_message).to eq("Error!")
+    end
+  end
+
+  describe "caching" do
+    it "only fetches once" do
+      allow_any_instance_of(Instrument).to receive(:relay).and_return relay
+      expect(relay).to receive(:query_status).once
+      statuses
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

Improves the performance of relay status fetching from the reservation timeline view.

* Only query a relay once based on IP/port/outlet
* Avoid unnecessary database lookups and inserts
* Do not return non-physical relays as they do not display on the timeline view.

It also adds some logging to the network queries.

# Additional Context

I'm not 100% we need the `InstrumentStatus`es stored in the database. I suspect there was an intention of using it as a kind of cache, but it's not really used anywhere. I feel like the entire model/database table could be removed, but I think that's beyond the scope of this PR. Values are still inserted when switching an instrument on and off.

Another improvement that would be possible is to only query by IP/port so if a relay has two outlets we only query it once.