### PR TITLE
[#139340] Fix location of search button on account search

### DIFF
--- a/app/views/facility_accounts/index.html.haml
+++ b/app/views/facility_accounts/index.html.haml
@@ -5,14 +5,13 @@
 
 %h2= t(".head")
 
-= form_tag search_results_facility_accounts_path, id: "ajax_form", class: "search_form", method: :get do
+= form_tag search_results_facility_accounts_path, id: "ajax_form", method: :get, class: "js--searchForm" do
   = label_tag :search_term, t(".label.search_term")
   = hidden_field_tag :email, current_user.email, disabled: true
   = hidden_field_tag :format, params[:format], disabled: true
   %br
   = text_field_tag :search_term, nil, size: 30, class: "search-query"
   = submit_tag t(".search"), class: "btn"
-  = link_to t(".clear_search"), facility_accounts_path
 
 %hr
 

--- a/app/views/facility_accounts/search_results.html.haml
+++ b/app/views/facility_accounts/search_results.html.haml
@@ -3,5 +3,5 @@
 
 - else
   .pull-right
-    = link_to text('reports.export_as_csv'), url_for(format: :csv), class: 'js--exportSearchResults pull-right', data: { form: '.search_form' }
+    = link_to text("reports.export_as_csv"), url_for(format: :csv), class: "js--exportSearchResults pull-right", data: { form: ".js--searchForm" }
   = render "account_table"


### PR DESCRIPTION
# Release Notes

Fix location of search button on account search.

# Additional Context

The button was being pulled to the right. Introduced in #2155 
