### PR TITLE
[#152761] Improve performance of occupancies dashboard

### DIFF
--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms/occupancies_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms/occupancies_controller.rb
@@ -19,7 +19,7 @@ module SecureRooms
     private
 
     def load_secure_room
-      @secure_room = SecureRoom.includes(:occupancies).find_by(dashboard_token: params[:secure_room_id])
+      @secure_room = SecureRoom.find_by(dashboard_token: params[:secure_room_id])
     end
 
   end

--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms/occupancies_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms/occupancies_controller.rb
@@ -19,7 +19,7 @@ module SecureRooms
     private
 
     def load_secure_room
-      @secure_room = SecureRoom.find_by(dashboard_token: params[:secure_room_id])
+      @secure_room = SecureRoom.find_by!(dashboard_token: params[:secure_room_id])
     end
 
   end

--- a/vendor/engines/secure_rooms/app/views/secure_rooms/occupancies/index.html.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_rooms/occupancies/index.html.haml
@@ -7,6 +7,7 @@
     window.setInterval(function() {
       $.ajax({
         url: $("#secure-rooms-dashboard").data("url"),
+        headers: { accept: "text/html" },
         success: function(response) {
           $("#secure-rooms-dashboard").html(response);
         },

--- a/vendor/engines/secure_rooms/app/views/secure_rooms/shared/_secure_rooms_dashboard.html.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_rooms/shared/_secure_rooms_dashboard.html.haml
@@ -1,10 +1,11 @@
 %label= text(:time_label)
 .refreshed_at= format_usa_datetime(Time.current)
-- current_occupancies = room.occupancies.current
+- per_column = 10
+- current_occupancies = room.occupancies.current.includes(:user).limit(per_column * 2)
 .row
-  .span4= render "secure_rooms/shared/dashboard_column", occupancies: current_occupancies.limit(10), header: text(:current), timestamp: :entry_at
-  - second_column_occupancies = current_occupancies.offset(10)
+  .span4= render "secure_rooms/shared/dashboard_column", occupancies: current_occupancies.first(per_column), header: text(:current), timestamp: :entry_at
+  - second_column_occupancies = current_occupancies.drop(per_column)
   .span4
-    = render "secure_rooms/shared/dashboard_column", occupancies: second_column_occupancies, header: text(:current_continued), timestamp: :entry_at if second_column_occupancies.any?
+    = render "secure_rooms/shared/dashboard_column", occupancies: second_column_occupancies, header: text(:current_continued), timestamp: :entry_at if second_column_occupancies.present?
 
-  .span4= render "secure_rooms/shared/dashboard_column", occupancies: room.occupancies.recent, header: text(:recent), timestamp: :exit_at
+  .span4= render "secure_rooms/shared/dashboard_column", occupancies: room.occupancies.recent.includes(:user), header: text(:recent), timestamp: :exit_at


### PR DESCRIPTION
# Release Notes

Improve performance of public occupancies dashboard.

# Additional Context

Skylight was highlighting this view as a painful page, partly because it is hit so often (every five seconds).

There were a couple things to improve:
* We were preloading **all** occupancies for the room. I think we thought we were preloading only the queried occupancies, but it turns out we were getting all of them. This dropped the render time from ~4-5 seconds to < 1 second
* Adding the `Accept` header in the ajax request dropped it from that 1 second to ~100ms. I believe this is because Rails didn't know how to respond so it searched through the templates to find something.
* Get rid of an N+1 and cut down the number of queries done on the view. This didn't make a significant improvement in the performance, but I do think it's a little easier to understand.
