### PR TITLE
[#149739] Maintain status/completion date after add to order

### DIFF
--- a/app/forms/add_to_order_form.rb
+++ b/app/forms/add_to_order_form.rb
@@ -4,6 +4,7 @@ class AddToOrderForm
 
   include ActiveModel::Model
   include TextHelpers::Translation
+  include DateHelper
 
   attr_reader :original_order, :current_facility
   attr_accessor :quantity, :product_id, :order_status_id, :note, :duration, :created_by, :fulfilled_at, :account_id, :reference_id
@@ -96,8 +97,9 @@ class AddToOrderForm
     @duration = 1
 
     if previously_added_to?
-      # This is a string so it displays on the form correctly
-      @fulfilled_at = I18n.l(previously_added_order_detail.fulfilled_at.to_date, format: :usa)
+      # This is a string so it displays on the form correctly.
+      # It may be nil if the order is not complete
+      @fulfilled_at = format_usa_date(previously_added_order_detail.fulfilled_at)
       @order_status_id = previously_added_order_detail.order_status_id
     else
       @fulfilled_at = nil
@@ -119,8 +121,8 @@ class AddToOrderForm
     return @previously_added_order_detail if defined?(@previously_added_order_detail)
 
     order_details = @original_order.order_details.order(:id)
-    original_ordered_at = order_details.first.ordered_at
-    @previously_added_order_detail = order_details.reverse.find { |od| od.ordered_at != original_ordered_at }
+    original_order_detail = order_details.first
+    @previously_added_order_detail = order_details.reverse.find { |od| od.ordered_at != original_order_detail.ordered_at }
   end
 
   def params

--- a/app/models/order_status.rb
+++ b/app/models/order_status.rb
@@ -19,6 +19,7 @@ class OrderStatus < ApplicationRecord
 
   scope :for_facility, ->(facility) { where(facility_id: [nil, facility.id]).order(:lft) }
 
+  # This one is different because `new` is a reserved keyword
   def self.new_status
     find_by(name: "New")
   end

--- a/spec/forms/add_to_order_form_spec.rb
+++ b/spec/forms/add_to_order_form_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AddToOrderForm do
+  include DateHelper
+  let(:order) { create(:complete_order, product: product, ordered_at: 1.week.ago) }
+  let(:product) { create(:setup_item, :with_facility_account) }
+  subject(:form) { described_class.new(order) }
+
+  describe "default values" do
+    describe "when the order has had nothing added to it" do
+      it "has order_status_id of New" do
+        expect(form.order_status_id).to eq(OrderStatus.new_status.id)
+      end
+
+      it "has has the original order's account" do
+        expect(form.account_id).to eq(order.account_id)
+      end
+
+      it "has other default attributes" do
+        expect(form).to have_attributes(
+          quantity: 1,
+          fulfilled_at: be_blank,
+          note: be_blank,
+          reference_id: be_blank,
+          product_id: be_blank,
+        )
+      end
+    end
+
+    describe "when there were multiple items in the original cart" do
+      let(:second_order_detail) do
+        create(:order_detail, order: order, ordered_at: order.order_details.first.ordered_at, product: product)
+      end
+      before do
+        order.reload
+        second_order_detail.backdate_to_complete!(10.minutes.ago)
+      end
+
+      it "has an order status of New" do
+        expect(form.order_status_id).to eq(OrderStatus.new_status.id)
+      end
+
+      it "does not have a fulfilled_at" do
+        expect(form.fulfilled_at).to be_blank
+      end
+    end
+
+    describe "when the order has something else added to it already" do
+      let(:other_account) { create(:nufs_account, :with_account_owner, owner: order.user, description: "Other Account") }
+      let(:other_product) { create(:setup_item, facility: product.facility) }
+      let(:second_order_detail) do
+        create(:order_detail, order: order, account: other_account, product: product, note: "somenote", ordered_at: 1.day.ago)
+      end
+
+      before do
+        order.reload
+        second_order_detail.backdate_to_complete!(1.day.ago)
+      end
+
+      it "has a status of complete" do
+        expect(form.order_status_id).to eq(OrderStatus.complete.id)
+      end
+
+      it "has the second order's fulfilled_at to the matching date" do
+        expect(parse_usa_date(form.fulfilled_at)).to eq(second_order_detail.fulfilled_at.beginning_of_day)
+      end
+
+      it "still has the original order's account" do
+        expect(form.account_id).to eq(order.account_id)
+      end
+
+      it "has other default attributes" do
+        expect(form).to have_attributes(
+          quantity: 1,
+          note: be_blank,
+          reference_id: be_blank,
+          product_id: be_blank,
+        )
+      end
+    end
+  end
+
+end

--- a/spec/forms/add_to_order_form_spec.rb
+++ b/spec/forms/add_to_order_form_spec.rb
@@ -54,30 +54,40 @@ RSpec.describe AddToOrderForm do
         create(:order_detail, order: order, account: other_account, product: product, note: "somenote", ordered_at: 1.day.ago)
       end
 
-      before do
-        order.reload
-        second_order_detail.backdate_to_complete!(1.day.ago)
+      before { order.reload }
+
+      describe "and it is still New" do
+        it "has a status of complete" do
+          expect(form.order_status_id).to eq(OrderStatus.new_status.id)
+        end
+
+        it "has the second order's fulfilled_at to the matching date" do
+          expect(form.fulfilled_at).to be_blank
+        end
+
+        it "still has the original order's account" do
+          expect(form.account_id).to eq(order.account_id)
+        end
+
+        it "has other default attributes" do
+          expect(form).to have_attributes(
+            quantity: 1,
+            note: be_blank,
+            reference_id: be_blank,
+            product_id: be_blank,
+          )
+        end
       end
 
-      it "has a status of complete" do
-        expect(form.order_status_id).to eq(OrderStatus.complete.id)
-      end
+      describe "and it is Complete" do
+        before { second_order_detail.backdate_to_complete!(1.day.ago) }
+        it "has a status of complete" do
+          expect(form.order_status_id).to eq(OrderStatus.complete.id)
+        end
 
-      it "has the second order's fulfilled_at to the matching date" do
-        expect(parse_usa_date(form.fulfilled_at)).to eq(second_order_detail.fulfilled_at.beginning_of_day)
-      end
-
-      it "still has the original order's account" do
-        expect(form.account_id).to eq(order.account_id)
-      end
-
-      it "has other default attributes" do
-        expect(form).to have_attributes(
-          quantity: 1,
-          note: be_blank,
-          reference_id: be_blank,
-          product_id: be_blank,
-        )
+        it "has the second order's fulfilled_at to the matching date" do
+          expect(parse_usa_date(form.fulfilled_at)).to eq(second_order_detail.fulfilled_at.beginning_of_day)
+        end
       end
     end
   end


### PR DESCRIPTION
# Release Notes

After adding to an existing order, use the most recent order's status and fulfillment date as the default in the next form.

# Additional Context

We had a good amount of back and forth and decided this should do the trick.

- Sort the order details by creation time (i.e. ID)
- Look at the first order detail's ordered_at (this would be one of the orders in the original cart)
- Starting from the most recent, find most recent line item that does not match the original ordered date
- Use that for the defaults
- If there are no orders that don't match the original, fall back to "New"
