### PR TITLE
[#140079] Improve product search for Oracle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,9 @@ gem "bootsnap", require: false
 ## database
 gem "mysql2"
 # To use Oracle, remove the mysql2 gem above and uncomment these lines
-# gem "activerecord-oracle_enhanced-adapter"
+# There are fixes for fulltext indexing in the 6.0 master of the gem, but we need
+# to backport them to support 5.2.
+# gem "activerecord-oracle_enhanced-adapter", git: "https://github.com/jhanggi/oracle-enhanced", branch: "release52"
 # gem "ruby-oci8" # only for CRuby users
 
 

--- a/app/models/full_text_search/model.rb
+++ b/app/models/full_text_search/model.rb
@@ -7,12 +7,17 @@ module FullTextSearch
     mattr_accessor :full_text_searcher do
       if Nucore::Database.mysql?
         FullTextSearch::MysqlSearcher
+      elsif Nucore::Database.oracle?
+        FullTextSearch::OracleSearcher
       else
         FullTextSearch::LikeSearcher
       end
     end
 
     included do
+      if Nucore::Database.oracle?
+        has_context_index
+      end
       scope :full_text, ->(fields, query) { FullTextSearch::Model.full_text_searcher.new(self).search(fields, query) }
     end
 

--- a/app/models/full_text_search/oracle_searcher.rb
+++ b/app/models/full_text_search/oracle_searcher.rb
@@ -1,0 +1,20 @@
+module FullTextSearch
+
+  class OracleSearcher < BaseSearcher
+
+    def search(fields, query)
+      return @scope.none if query.blank?
+
+      formatted_query = query.to_s.split.join(",")
+      # If we leave the label out `:label`, we end up with duplicate labels which Oracle doesn't like.
+      # If we don't handle the `order` ourselves, then AR's `or` complains about incompatible `ORDER BY`s.
+      array = Array(fields)
+      relation = array.map.with_index { |field, i| @scope.contains("#{arel_table.name}.#{field}", formatted_query, label: i).unscope(:order) }.inject(&:or)
+      array.length.times.inject(relation) do |relation, label|
+        relation.order(Arel.sql("SCORE(#{label}) DESC"))
+      end
+    end
+
+  end
+
+end

--- a/db/migrate/20200213005326_add_full_text_index_for_oracle.rb
+++ b/db/migrate/20200213005326_add_full_text_index_for_oracle.rb
@@ -1,16 +1,18 @@
 class AddFullTextIndexForOracle < ActiveRecord::Migration[5.2]
+
   def change
     if NUCore::Database.oracle?
       reversible do |dir|
         dir.up do
-          add_context_index :products, :name, sync: 'ON COMMIT'
-          add_context_index :products, :description, sync: 'ON COMMIT'
+          add_context_index :products, :name, sync: "ON COMMIT"
+          add_context_index :products, :description, sync: "ON COMMIT"
         end
         dir.down do
           remove_context_index :products, :name
           remove_context_index :products, :description
         end
       end
-    else
+    end
   end
+
 end

--- a/db/migrate/20200213005326_add_full_text_index_for_oracle.rb
+++ b/db/migrate/20200213005326_add_full_text_index_for_oracle.rb
@@ -1,0 +1,16 @@
+class AddFullTextIndexForOracle < ActiveRecord::Migration[5.2]
+  def change
+    if NUCore::Database.oracle?
+      reversible do |dir|
+        dir.up do
+          add_context_index :products, :name, sync: 'ON COMMIT'
+          add_context_index :products, :description, sync: 'ON COMMIT'
+        end
+        dir.down do
+          remove_context_index :products, :name
+          remove_context_index :products, :description
+        end
+      end
+    else
+  end
+end

--- a/spec/models/full_text_search/oracle_searcher_spec.rb
+++ b/spec/models/full_text_search/oracle_searcher_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe FullTextSearch::OracleSearcher, if: Nucore::Database.oracle? do
+  before(:context) do
+    # Do not use factories to ensure we don't end up with any zombie associations
+    facility = Facility.new(name: "name", abbreviation: "EF", url_name: "facility", is_active: true, short_description: "abc", journal_mask: "C01")
+    facility.save(validate: false)
+    item = Item.new(url_name: "lsc-andor", name: "LSC Andor Spinning Disk", facility: facility)
+    item.save(validate: false)
+  end
+
+  after(:context) do
+    Item.delete_all
+    Facility.delete_all
+  end
+
+  let(:facility) { Facility.find_by(url_name: "facility") }
+  let(:item) { Item.find_by!(url_name: "lsc-andor") }
+
+  subject(:results) { described_class.new(Product.all).search([:name, :description], query) }
+
+  context "when the query is nil" do
+    let(:query) { nil }
+    it { is_expected.to be_empty }
+  end
+
+  context "when the query is whitespace only" do
+    let(:query) { " " }
+    it { is_expected.to be_empty }
+  end
+
+  context "when the query matches no products" do
+    let(:query) { "gobbledy gook" }
+    it { is_expected.to be_empty }
+  end
+
+  context "when the query case does not match the db case" do
+    let(:query) { "lsc" }
+    it { is_expected.to contain_exactly(item) }
+  end
+
+  context "when it matches multiple words, but not exactly" do
+    before(:context) do
+      facility = Facility.find_by(url_name: "facility")
+      Item.new(name: "LSC Nikon A1RSi", facility: facility, url_name: "lsc_nikon").save(validate: false)
+    end
+    after(:context) do
+      Item.find_by(url_name: "lsc_nikon").destroy
+    end
+
+    let(:item2) { Item.find_by(url_name: "lsc_nikon") }
+    let(:query) { "lsc spinning disk" }
+
+    it "matches both products with the one matching more words first" do
+      is_expected.to eq([item, item2])
+    end
+  end
+
+end


### PR DESCRIPTION
Adds on to #2209 to support Oracle

This is blocked on PRs into the oracle adapter. Right now, the schema dumper fails if there is a fulltext index and a regular index. It also does not dump the `sync: "ON COMMIT"`, which we would need in order to ensure the index is being updated properly.