### PR TITLE
[#148320] Fix caching issue with shared relays

### DIFF
--- a/app/models/instrument_status.rb
+++ b/app/models/instrument_status.rb
@@ -14,6 +14,7 @@ class InstrumentStatus < ApplicationRecord
       instrument_status: {
         name: instrument.name,
         instrument_id: instrument.id,
+        schedule_id: instrument.schedule_id,
         type: instrument.relay&.type,
         is_on: is_on?,
         error_message: @error_message,

--- a/app/services/instrument_status_fetcher.rb
+++ b/app/services/instrument_status_fetcher.rb
@@ -23,7 +23,8 @@ class InstrumentStatusFetcher
     return InstrumentStatus.new(on: true, instrument: instrument) unless SettingsHelper.relays_enabled_for_admin?
 
     key = instrument.relay.status_cache_key
-    return status_cache[key] if status_cache.key?(key)
+    # If it exists in the cache, we can use that value, but we need to update the instrument
+    return status_cache[key].dup.tap { |status| status.instrument = instrument } if status_cache.key?(key)
 
     begin
       status_cache[key] = InstrumentStatus.new(on: instrument.relay.get_status, instrument: instrument)

--- a/spec/services/instrument_status_fetcher_spec.rb
+++ b/spec/services/instrument_status_fetcher_spec.rb
@@ -44,10 +44,19 @@ RSpec.describe InstrumentStatusFetcher do
   end
 
   describe "caching" do
-    it "only fetches once" do
-      allow_any_instance_of(Instrument).to receive(:relay).and_return relay
-      expect(relay).to receive(:query_status).once
-      statuses
+    describe "with a second identical relay" do
+      let!(:relay2) {create(:relay_syna, relay.attributes.except("id").merge(instrument: instrument_with_relay2)) }
+      let(:instrument_with_relay2) { create(:instrument, no_relay: true, facility: facility, schedule: instrument_with_relay.schedule) }
+
+      it "only fetches once" do
+        allow_any_instance_of(Instrument).to receive(:relay).and_return relay
+        expect(relay).to receive(:query_status).once
+        statuses
+      end
+
+      it "returns two instrument_ids" do
+        expect(statuses.map(&:instrument)).to contain_exactly(instrument_with_relay, instrument_with_relay2)
+      end
     end
   end
 end


### PR DESCRIPTION
# Release Notes

Fix issue where second relay on a shared schedule would be left in a spinning state on the timeline view.

# Additional Context

Before, in the response we would get two entries but they'd be sharing the same `instrument_id`. This was causing the second relay to be left in a spinning state. This now makes sure that if there are two relays on different instruments, we return different `instrument_id`s.

