### PR TITLE
[#151885] Fixes for add to order on bulk upload

### DIFF
--- a/app/support/order_row_importer.rb
+++ b/app/support/order_row_importer.rb
@@ -72,7 +72,7 @@ class OrderRowImporter
   end
 
   def order_key
-    @order_key ||= [field(:user), field(:chart_string), field(:order_date)]
+    @order_key ||= field(:order_number).presence || [field(:user), field(:chart_string), field(:order_date)]
   end
 
   def row_with_errors
@@ -108,14 +108,16 @@ class OrderRowImporter
     ActiveRecord::Base.transaction do
       begin
         @order = field(:order_number).present? ? existing_order : @order_import.fetch_or_create_order!(self)
+
+        attributes = { note: field(:notes), account: account }
         # The order adding feature has some quirky behavior because of the "order form"
         # feature: if you add multiple of a timed service, it creates multiple line items
         # in your cart. Also, in the "add to order" feature, there is a separate `duration`
         # field. To account for this idiosyncrasy, we need to handle it as a special case.
         if product.quantity_as_time?
-          @order_details = order.add(product, 1, duration: field(:quantity), note: field(:notes))
+          @order_details = order.add(product, 1, attributes.merge(duration: field(:quantity)))
         else
-          @order_details = order.add(product, field(:quantity), note: field(:notes))
+          @order_details = order.add(product, field(:quantity), attributes)
         end
         purchase_order! unless order.purchased?
         backdate_order_details_to_complete!

--- a/app/support/order_row_importer.rb
+++ b/app/support/order_row_importer.rb
@@ -72,7 +72,7 @@ class OrderRowImporter
   end
 
   def order_key
-    @order_key ||= field(:order_number).presence || [field(:user), field(:chart_string), field(:order_date)]
+    @order_key ||= field(:order_number).presence || [field(:user).downcase, field(:chart_string).downcase, field(:order_date)]
   end
 
   def row_with_errors

--- a/spec/models/order_import_csv_spec.rb
+++ b/spec/models/order_import_csv_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+# This is a higher-level test. See order_import_spec and order_row_importer_spec
+# for more details.
+RSpec.describe OrderImport do
+  let(:facility) { create(:setup_facility) }
+
+  describe "adding to existing orders" do
+    let!(:user) { create(:user, username: "sst123@example.com") }
+    let!(:item) { create(:setup_item, name: "Example Item", facility: facility) }
+    let!(:account) { create(:nufs_account, :with_account_owner, account_number: "12345", owner: user) }
+    let!(:account2) { create(:nufs_account, :with_account_owner, account_number: "67890", owner: user) }
+    let!(:original_account) { create(:nufs_account, :with_account_owner, account_number: "99999", owner: user) }
+    let!(:order) { create(:purchased_order, product: item, account: original_account, user: user, created_by: user.id) }
+    let!(:order2) { create(:purchased_order, product: item, account: original_account, user: user, created_by: user.id) }
+    let(:file) { create(:csv_stored_file, file: StringIO.new(body)) }
+    let(:order_import) { described_class.new(facility: facility, created_by: user.id, upload_file: file) }
+
+    describe "happy path" do
+      let(:body) do
+        <<~CSV
+          Netid / Email,Chart String,Product Name,Quantity,Order Date,Fulfillment Date,Note,Order
+          sst123@example.com,12345,Example Item,1,02/15/2020,02/15/2020,Add to 1,#{order.id}
+          sst123@example.com,67890,Example Item,1,02/15/2020,02/15/2020,Add to 2,#{order.id}
+          sst123@example.com,67890,Example Item,1,02/15/2020,02/15/2020,Add to other,#{order2.id}
+          sst123@example.com,12345,Example Item,1,02/15/2020,02/15/2020,New 1,
+          sst123@example.com,67890,Example Item,1,02/15/2020,02/15/2020,New 2 - Different Account,
+          sst123@example.com,67890,Example Item,1,02/15/2020,02/15/2020,New 2-2,
+          sst123@example.com,67890,Example Item,1,02/01/2020,02/15/2020,New 3 - Different Order Date,
+          sst123@example.com,67890,Example Item,1,02/15/2020,02/16/2020,New 2-3 - Different fulfilled,
+        CSV
+      end
+
+      it "adds the two items to the order" do
+        expect { order_import.process_upload! }.to change(order.reload.order_details, :count).by(2)
+      end
+
+      it "puts the right accounts on the added details" do
+        order_import.process_upload!
+        expect(order.reload.order_details).to match([
+          anything, # this is the original detail
+          having_attributes(account: account, note: "Add to 1"),
+          having_attributes(account: account2, note: "Add to 2"),
+        ])
+      end
+
+      it "adds to the second order" do
+        expect { order_import.process_upload! }.to change(order2.reload.order_details, :count).by(1)
+      end
+
+      it "creates additional orders based on the keys" do
+        existing = Order.all.to_a
+        expect { order_import.process_upload! }.to change(Order, :count).by(3)
+
+        expect(Order.all.to_a - existing).to match([
+          having_attributes(
+            order_details: [having_attributes(account: account, note: "New 1")]
+          ),
+          having_attributes(
+            order_details: [
+              having_attributes(account: account2, note: "New 2 - Different Account"),
+              having_attributes(account: account2, note: "New 2-2", fulfilled_at: Time.zone.parse("2020-02-15")),
+              having_attributes(account: account2, note: "New 2-3 - Different fulfilled", fulfilled_at: Time.zone.parse("2020-02-16"))
+            ]
+          ),
+          having_attributes(
+            order_details: [having_attributes(account: account2, note: "New 3 - Different Order Date")]
+          ),
+        ])
+      end
+
+    end
+  end
+end

--- a/spec/models/order_import_csv_spec.rb
+++ b/spec/models/order_import_csv_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe OrderImport do
           sst123@example.com,67890,Example Item,1,02/15/2020,02/15/2020,Add to 2,#{order.id}
           sst123@example.com,67890,Example Item,1,02/15/2020,02/15/2020,Add to other,#{order2.id}
           sst123@example.com,12345,Example Item,1,02/15/2020,02/15/2020,New 1,
+          SST123@EXAMPLE.COM,12345,Example Item,1,02/15/2020,02/15/2020,New 1-2 - Miscased,
           sst123@example.com,67890,Example Item,1,02/15/2020,02/15/2020,New 2 - Different Account,
           sst123@example.com,67890,Example Item,1,02/15/2020,02/15/2020,New 2-2,
           sst123@example.com,67890,Example Item,1,02/01/2020,02/15/2020,New 3 - Different Order Date,
@@ -54,7 +55,10 @@ RSpec.describe OrderImport do
 
         expect(Order.all.to_a - existing).to match([
           having_attributes(
-            order_details: [having_attributes(account: account, note: "New 1")]
+            order_details: [
+              having_attributes(account: account, note: "New 1"),
+              having_attributes(account: account, note: "New 1-2 - Miscased"),
+            ]
           ),
           having_attributes(
             order_details: [


### PR DESCRIPTION
# Release Notes

Fixes for adding to an existing order in bulk upload.

# Additional Context

Fixes to #2167.

> If the Payment Source varies for order details that are being added to an order, the Payment Source displayed in NUcore will only reflect the first Payment Source that is designated in the upload file. Behavior should be that the Payment Source matches the upload (assuming the Payment Source is valid, and the Purchaser is on it).

What was happening is for adding-on lines, it was taking the original order's account. It was still validating that user has permission to use the chart string specified in the upload; it just wasn't persisting it.

> If a Bulk Upload contains some rows with an Order number and other rows without an Order number, all orders will still be added to the Order. Behavior should be that lines without an Order should generate new Order ID's.

The specific case is: a line item that adds to an order; a line item that does not add to an order, but matches the user, chartstring, and order date of the first line. If they didn't match, they would get split out onto separate orders.

The way the upload always (well, at least the past long while) behaved before this feature and how it behaves now for non-add-to orders (with the column blank): We roll up all the lines that have the same user, chartstring, and order date and put them onto the same order. We essentially build a cache of orders as we go down the CSV and key them by those fields.

In the new feature, if the cache got populated with an existing order, future orders that match the keys would get added to that existing order, even if the order number field was blank. This also was a problem if the order number was different, it would end up on the first specified order.
