### PR TITLE
[#152849] Fix movable transaction when order is missing costs

### DIFF
--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -71,7 +71,7 @@
           %td= link_to "Download", account_statement_path(order_detail.account, order_detail.statement_id, format: :pdf) if order_detail.statement
   - unless order_details.respond_to? :total_pages
     %tfoot
-      %th.total{colspan: colspan_for_total, scope: "row"}= t(".total")
-      %td.currency= number_to_currency(order_details.sum(&:actual_or_estimated_total))
-      %td{colspan: local_assigns[:show_statements] ? 2 : 1}
+      %th.total{ colspan: colspan_for_total, scope: "row" }= t(".total")
+      %td.currency= number_to_currency(order_details.map(&:actual_or_estimated_total).compact.sum)
+      %td{ colspan: local_assigns[:show_statements] ? 2 : 1 }
 = will_paginate(order_details) if order_details.respond_to? :total_pages

--- a/spec/system/admin/moving_transactions_spec.rb
+++ b/spec/system/admin/moving_transactions_spec.rb
@@ -67,4 +67,28 @@ RSpec.describe "Moving transactions between accounts" do
 
     expect(order_details.map(&:reload).map(&:account)).to eq([accounts.first, accounts.first, other_account])
   end
+
+  it "Renders when problem orders" do
+    # E.g. missing a price policy
+    order_details.first.update!(actual_cost: nil, actual_subsidy: nil, estimated_cost: nil, estimated_subsidy: nil)
+
+    login_as director
+    visit facility_movable_transactions_path(facility)
+
+    order_details.each do |od|
+      find("input[value='#{od.id}']").click
+    end
+
+    click_button "Reassign Chart Strings"
+
+    expect(page).to have_content("All chart strings listed above are available")
+
+    select accounts.first.account_list_item, from: "Payment Source"
+    click_button "Reassign Chart String"
+
+    expect(page).to have_content("Confirm Transaction Moves")
+
+    click_button "Reassign Chart String"
+    expect(order_details.map(&:reload).map(&:account)).to eq([accounts.first, accounts.first, other_account])
+  end
 end


### PR DESCRIPTION
# Release Notes

Fix for movable transaction when order is missing costs.

# Additional Context

This would usually be a problem order, or could also be a canceled order.

There are two errors `NoMethodError: undefined method '+' for nil:NilClass` and `TypeError: nil can't be coerced into BigDecimal`. They're both manifestations of the same thing, just depends on the order: `nil + something` or `something + nil`.
