### PR TITLE
[#152855] Properly filter unpurchased orders from movable

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -168,8 +168,10 @@ class OrderDetail < ApplicationRecord
   }
 
   def self.all_movable
-    where(journal_id: nil)
-      .where.not(state: ["ordered", "reconciled"])
+    ordered_at
+      .unreconciled
+      .where(journal_id: nil)
+
   end
 
   scope :in_review, lambda {

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -1200,6 +1200,19 @@ RSpec.describe OrderDetail do
         expect(OrderDetail.non_canceled).to_not include(order_detail)
       end
     end
+
+    describe "all_movable" do
+      let(:product) { Product.last }
+      let!(:unpurchased_order_detail) { create(:setup_order, product: product).order_details.first }
+      let!(:new_order_detail) { create(:purchased_order, product: product).order_details.first }
+      let!(:completed_order_detail) { create(:complete_order, product: product).order_details.first }
+      let!(:journaled_order)  { create(:complete_order, product: product).order_details.first }
+      before { journaled_order.update!(journal: create(:journal)) }
+
+      it "includes everything but the unpurchased and journaled" do
+        expect(described_class.all_movable).to contain_exactly(new_order_detail, completed_order_detail)
+      end
+    end
   end
 
   context "ordered_on_behalf_of?" do


### PR DESCRIPTION
# Release Notes

Fix movable orders page when filtering by "Ordered at" and there's an unpurchased order in the cart.

# Additional Context

We were not filtering out unpurchased orders from the `all_movable` scope. This only manifests itself in the "ordered" filter because fulfilled (the default filter) and journaled are always purchased.

```
facilities movable_transactions (ActionView::Template::Error) "undefined method `owner_user' for nil:NilClass"
```
