### PR TITLE
Update codeowners to use github teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-* @arnamak @jhanggi @rolfrussell
+* @tablexi/nucore @tablexi/gs-nucore-maintenance


### PR DESCRIPTION
# Release Notes

Tech task: Update codeowners to use github teams.

# Additional Context

Hopefully this will help us out from needing to change this file too much in the future.
