### PR TITLE
[#151885] Fixes for oracle on adding to bulk upload

### DIFF
--- a/app/support/order_row_importer.rb
+++ b/app/support/order_row_importer.rb
@@ -86,7 +86,7 @@ class OrderRowImporter
   end
 
   def user
-    @user ||= User.find_by(username: field(:user)) || User.find_by(email: field(:user))
+    @user ||= User.find_by(username: field(:user).downcase) || User.find_by(email: field(:user).downcase)
   end
 
   def product

--- a/spec/models/order_import_csv_spec.rb
+++ b/spec/models/order_import_csv_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe OrderImport do
   describe "adding to existing orders" do
     let!(:user) { create(:user, username: "sst123@example.com") }
     let!(:item) { create(:setup_item, name: "Example Item", facility: facility) }
-    let!(:account) { create(:nufs_account, :with_account_owner, account_number: "12345", owner: user) }
-    let!(:account2) { create(:nufs_account, :with_account_owner, account_number: "67890", owner: user) }
-    let!(:original_account) { create(:nufs_account, :with_account_owner, account_number: "99999", owner: user) }
+    let!(:account) { create(:nufs_account, :with_account_owner, owner: user) }
+    let!(:account2) { create(:nufs_account, :with_account_owner, owner: user) }
+    let!(:original_account) { create(:nufs_account, :with_account_owner, owner: user) }
     let!(:order) { create(:purchased_order, product: item, account: original_account, user: user, created_by: user.id) }
     let!(:order2) { create(:purchased_order, product: item, account: original_account, user: user, created_by: user.id) }
     let(:file) { create(:csv_stored_file, file: StringIO.new(body)) }
@@ -20,15 +20,15 @@ RSpec.describe OrderImport do
       let(:body) do
         <<~CSV
           Netid / Email,Chart String,Product Name,Quantity,Order Date,Fulfillment Date,Note,Order
-          sst123@example.com,12345,Example Item,1,02/15/2020,02/15/2020,Add to 1,#{order.id}
-          sst123@example.com,67890,Example Item,1,02/15/2020,02/15/2020,Add to 2,#{order.id}
-          sst123@example.com,67890,Example Item,1,02/15/2020,02/15/2020,Add to other,#{order2.id}
-          sst123@example.com,12345,Example Item,1,02/15/2020,02/15/2020,New 1,
-          SST123@EXAMPLE.COM,12345,Example Item,1,02/15/2020,02/15/2020,New 1-2 - Miscased,
-          sst123@example.com,67890,Example Item,1,02/15/2020,02/15/2020,New 2 - Different Account,
-          sst123@example.com,67890,Example Item,1,02/15/2020,02/15/2020,New 2-2,
-          sst123@example.com,67890,Example Item,1,02/01/2020,02/15/2020,New 3 - Different Order Date,
-          sst123@example.com,67890,Example Item,1,02/15/2020,02/16/2020,New 2-3 - Different fulfilled,
+          sst123@example.com,#{account.account_number},Example Item,1,02/15/2020,02/15/2020,Add to 1,#{order.id}
+          sst123@example.com,#{account2.account_number},Example Item,1,02/15/2020,02/15/2020,Add to 2,#{order.id}
+          sst123@example.com,#{account2.account_number},Example Item,1,02/15/2020,02/15/2020,Add to other,#{order2.id}
+          sst123@example.com,#{account.account_number},Example Item,1,02/15/2020,02/15/2020,New 1,
+          SST123@EXAMPLE.COM,#{account.account_number},Example Item,1,02/15/2020,02/15/2020,New 1-2 - Miscased,
+          sst123@example.com,#{account2.account_number},Example Item,1,02/15/2020,02/15/2020,New 2 - Different Account,
+          sst123@example.com,#{account2.account_number},Example Item,1,02/15/2020,02/15/2020,New 2-2,
+          sst123@example.com,#{account2.account_number},Example Item,1,02/01/2020,02/15/2020,New 3 - Different Order Date,
+          sst123@example.com,#{account2.account_number},Example Item,1,02/15/2020,02/16/2020,New 2-3 - Different fulfilled,
         CSV
       end
 


### PR DESCRIPTION
# Release Notes

Tech task: Fixes for add for add to order on bulk upload for NU-specific.

# Additional Context

The original PR #2220 had a spec that was failing on NU because of its chartstring validation. Oracle also does not do case-insensitive WHERE, so the mis-cased email address was not being found in the database.
