### PR TITLE
Tech task: Shorten index name because oracle

### DIFF
--- a/db/migrate/20200215061232_add_display_order_to_product_display_group_products.rb
+++ b/db/migrate/20200215061232_add_display_order_to_product_display_group_products.rb
@@ -2,7 +2,7 @@ class AddDisplayOrderToProductDisplayGroupProducts < ActiveRecord::Migration[5.2
 
   def change
     add_column :product_display_group_products, :position, :integer
-    add_index :product_display_group_products, [:product_display_group_id, :position], name: "i_product_display_group_position"
+    add_index :product_display_group_products, [:product_display_group_id, :position], name: "i_product_display_group_pos"
   end
 
 end

--- a/db/migrate/20200224215210_fix_product_display_group_index_name.rb
+++ b/db/migrate/20200224215210_fix_product_display_group_index_name.rb
@@ -1,0 +1,8 @@
+class FixProductDisplayGroupIndexName < ActiveRecord::Migration[5.2]
+  def up
+    # The name is too long for oracle. This will fix it if the previous migration had already run.
+    if index_exists?(:product_display_group_products, [:product_display_group_id, :position], name: "i_product_display_group_position")
+      rename_index :product_display_group_products, "i_product_display_group_position", "i_product_display_group_pos"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_15_061232) do
+ActiveRecord::Schema.define(version: 2020_02_24_215210) do
 
   create_table "account_facility_joins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "facility_id", null: false
@@ -489,7 +489,7 @@ ActiveRecord::Schema.define(version: 2020_02_15_061232) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position"
-    t.index ["product_display_group_id", "position"], name: "i_product_display_group_position"
+    t.index ["product_display_group_id", "position"], name: "i_product_display_group_pos"
     t.index ["product_display_group_id"], name: "index_product_display_group_products_on_product_display_group_id"
     t.index ["product_id"], name: "index_product_display_group_products_on_product_id"
   end


### PR DESCRIPTION
# Release Notes

Tech task: shorten index name for product display groups position field because it is too long for Oracle.

# Additional Context

Oracle has a limit of 30 characters. I had given it an explicit name because Mysql also has some restrictions around index names.

I added this as a separate migration so that if the previous migration (which I have now changed) has already run, it'll clean up the name there.
