### PR TITLE
[#152924] Prevent error when updating order with auto-scaled accessories

### DIFF
--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -31,9 +31,9 @@ class OrderManagement::OrderDetailsController < ApplicationController
     updater = OrderDetails::ParamUpdater.new(@order_detail, user: session_user, cancel_fee: params[:with_cancel_fee] == "1")
 
     if updater.update_attributes(params[:order_detail] || empty_params)
-      flash[:notice] = "The order was successfully updated."
+      flash[:notice] = text("update.success")
       if @order_detail.updated_children.any?
-        flash[:notice] << " Auto-scaled accessories have been updated as well."
+        flash[:notice] = text("update.success_with_auto_scaled")
         flash[:updated_order_details] = @order_detail.updated_children.map(&:id)
       end
       if modal?
@@ -42,7 +42,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
         redirect_to [current_facility, @order]
       end
     else
-      flash.now[:error] = "Error while updating order"
+      flash.now[:error] = text("update.error")
       render :edit, layout: !modal?, status: 406
     end
   end
@@ -65,9 +65,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
   def remove_from_journal
     OrderDetailJournalRemover.remove_from_journal(@order_detail)
 
-    flash[:notice] =
-      I18n.t "controllers.order_management.order_details.remove_from_journal.notice"
-
+    flash[:notice] = text("remove_from_journal.notice")
     if modal?
       head :ok
     else

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -100,11 +100,6 @@ en:
         success: The order has been updated
         error: There was a problem updating the order
 
-    order_management:
-      order_details:
-        remove_from_journal:
-          notice: "The order has been removed from its journal"
-
     price_groups:
       create:
         notice: "Price Group was successfully created"

--- a/config/locales/views/admin/en.order_management.yml
+++ b/config/locales/views/admin/en.order_management.yml
@@ -1,0 +1,9 @@
+en:
+  controllers:
+    order_management/order_details:
+      update:
+        success: The order was successfully updated.
+        success_with_auto_scaled: "!controllers.order_management/order_details.update.success! Auto-scaled accessories have been updated as well."
+        error: Error while updating order
+      remove_from_journal:
+        notice: The order has been removed from its journal

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -377,6 +377,22 @@ RSpec.describe OrderManagement::OrderDetailsController do
           end
         end
 
+        describe "when there are auto-scaled accessories" do
+          let!(:accessory) { create(:time_based_accessory, parent: instrument, facility: facility, scaling_type: "auto") }
+
+          before do
+            allow_any_instance_of(OrderDetail).to receive(:updated_children).and_return([build_stubbed(:order_detail)])
+            @params[:order_detail] = {
+              reservation: { actual_duration_mins: 45 },
+            }
+          end
+
+          it "sets the flash" do
+            do_request
+            expect(flash[:notice]).to include "Auto-scaled accessories"
+          end
+        end
+
         context "across fiscal year/price policy expiration lines" do
           let(:first_price_policy) { order_detail.product.price_policies.first }
           let(:reservation) { FactoryBot.create(:completed_reservation, product: instrument) }


### PR DESCRIPTION
# Release Notes

Fix error when modifying an order detail with auto-scaled accessories.

# Additional Context

To replicate:

- Create an instrument with an auto-scaled accessory
- Complete a reservation and add the auto-scaled accessory
- Visit the order detail popup
- Change the actual times
- Submit and you should get this error
