### PR TITLE
Fix account cloner spec when running under oracle

### DIFF
--- a/spec/services/account_membership_cloner_spec.rb
+++ b/spec/services/account_membership_cloner_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe AccountMembershipCloner, type: :service do
   end
 
   describe "when invoked to clone an owned account" do
-    let(:account_users_to_clone) { AccountUser.where(user: original_user, user_role: "owner") }
+    let(:account_users_to_clone) { AccountUser.where(user: original_user, user_role: "Owner") }
 
     it "assigns the cloned user the accepted alternate role" do
       account_users = cloner.perform


### PR DESCRIPTION
# Release Notes

Tech task: Fix account membership cloner spec when running under Oracle.

# Additional Context

Mysql does a case-insensitive search, while Oracle is sensitive.
