### PR TITLE
[#152933] Fix print styles on Formio embeds

### DIFF
--- a/app/views/layouts/formio.html.haml
+++ b/app/views/layouts/formio.html.haml
@@ -3,8 +3,8 @@
   %head
     %meta{ "http-equiv" => "content-type", "content" => "text/html; charset=UTF-8" }
     = render_view_hook "head"
-    = stylesheet_link_tag "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
-    = stylesheet_link_tag "https://unpkg.com/formiojs@3.28.0/dist/formio.full.min.css"
+    = stylesheet_link_tag "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css", media: "all"
+    = stylesheet_link_tag "https://unpkg.com/formiojs@3.28.0/dist/formio.full.min.css", media: "all"
     = javascript_include_tag "https://unpkg.com/formiojs@3.28.0/dist/formio.full.min.js"
     :css
       #formio {


### PR DESCRIPTION
# Release Notes

Fix print styles on Formio embeds.

# Additional Context

When I changed from using raw html to more rails/haml-y syntax in #2212, I switched to using `stylesheet_link_tag`. According to the [docs](https://apidock.com/rails/ActionView/Helpers/AssetTagHelper/stylesheet_link_tag), "For historical reasons, the ‘media’ attribute will always be present and defaults to “screen”, so you must explicitly set it to “all” for the stylesheet(s) to apply to all media types.".

So, because it was now `media="screen"`, the styles were not being applied to print.
