### PR TITLE
[#38893] Fix ordering of product groups on facility homepage

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -52,7 +52,8 @@ class FacilitiesController < ApplicationController
     else
       @product_scope = @product_scope.active # Active also excludes hidden
     end
-    @product_display_groups = current_facility.product_display_groups
+
+    @product_display_groups = current_facility.product_display_groups.sorted
     @product_display_groups = @product_display_groups.to_a + ProductDisplayGroup.fake_groups_by_type(current_facility.products.without_display_group)
 
     render layout: "application"

--- a/app/models/product_display_group.rb
+++ b/app/models/product_display_group.rb
@@ -27,7 +27,7 @@ class ProductDisplayGroup < ApplicationRecord
   end
 
   def set_default_positions
-    self.position = facility.product_display_groups.maximum(:position).to_i + 1
+    self.position ||= facility.product_display_groups.maximum(:position).to_i + 1
   end
 
   def associated_errors

--- a/spec/controllers/facilities_controller_spec.rb
+++ b/spec/controllers/facilities_controller_spec.rb
@@ -216,6 +216,26 @@ RSpec.describe FacilitiesController do
         do_request
         expect(response.body).not_to include("Daily View")
       end
+
+      describe "product_display_groups" do
+        let!(:product1) { create(:item, facility: facility) }
+        let!(:product2) { create(:item, facility: facility) }
+        let!(:not_in_group) { create(:item, facility: facility) }
+        let!(:product_display_group1) { create(:product_display_group, position: 2, name: "Second", products: [product1], facility: facility) }
+        let!(:product_display_group2) { create(:product_display_group, position: 1, name: "First", products: [product2], facility: facility) }
+
+        it "returns the product groups in the right order" do
+          do_request
+          expect(assigns(:product_display_groups).first).to eq(product_display_group2)
+          expect(assigns(:product_display_groups).second).to eq(product_display_group1)
+        end
+
+        it "includes an unpersisted group which includes the last item" do
+          do_request
+          items_group = assigns(:product_display_groups).to_a.find { |p| p.name == "Items" }
+          expect(items_group.products).to include(not_in_group)
+        end
+      end
     end
 
     context "when requesting the 'all' facility (cross-facility)" do

--- a/spec/models/product_display_group_spec.rb
+++ b/spec/models/product_display_group_spec.rb
@@ -38,4 +38,19 @@ RSpec.describe ProductDisplayGroup do
     expect(group.associated_errors.flat_map(&:full_messages)).to include("Product #{product.name} is already in a group")
   end
 
+  describe "position" do
+    it "sets an incrementing default position on create" do
+      group1 = create(:product_display_group, facility: facility)
+      expect(group1.position).to eq(1)
+
+      group2 = create(:product_display_group, facility: facility)
+      expect(group2.position).to eq(2)
+    end
+
+    it "does not overwrite the position if you explicitly set it" do
+      group = create(:product_display_group, position: 39, facility: facility)
+      expect(group.position).to eq(39)
+    end
+  end
+
 end


### PR DESCRIPTION
# Release Notes

Fix ordering of product groups on facility homepage.

# Additional Context

I have no idea how I missed adding the `sorted` scope in the original PR.
