### PR TITLE
Fix circular dependency issue

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -67,12 +67,22 @@ class Product < ApplicationRecord
     left_outer_joins(:product_display_group_product).where(product_display_group_products: { id: nil })
   }
 
-  # All product types
-  cattr_accessor(:types) { [Instrument, Item, Service, TimedService, Bundle] }
+  # All product types. This cannot be a cattr_accessor because the block is evaluated
+  # at definition time (not lazily as I expected) and this causes a circular dependency
+  # in some schools.
+  def self.types
+    @types ||= [Instrument, Item, Service, TimedService, Bundle]
+  end
+
   # Those that can be added to an order by an administrator
-  cattr_accessor(:mergeable_types) { ["Instrument", "Item", "Service", "TimedService", "Bundle"] }
+  def self.mergeable_types
+    @mergeable_types ||= ["Instrument", "Item", "Service", "TimedService", "Bundle"]
+  end
+
   # Those that can be ordered via the NUcore homepage
-  cattr_accessor(:orderable_types) { ["Instrument", "Item", "Service", "TimedService", "Bundle"] }
+  def self.orderable_types
+    @orderable_types ||= ["Instrument", "Item", "Service", "TimedService", "Bundle"]
+  end
 
   # Products that can be used as accessories
   scope :accessorizable, -> { where(type: ["Item", "Service", "TimedService"]) }


### PR DESCRIPTION
# Release Notes

Tech task: Fix circular dependency issue happening in Dartmouth.

# Additional context

I switched these over to `cattr_accessor` because I find the syntax a lot more readable. This came in from the product grouping in #2215. 

I'm not quite sure exactly why, but enabling the SecureRooms engine prevents this error from happening. I know that it appends to the `Product.types` array, but why it doesn't cause the circular dependency, I don't really understand.

That's why this was fine in open and NU since they both have the engine enabled while Dartmouth does not.