### PR TITLE
Tech task: Fix spurious spec failure

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,12 +2,12 @@
 
 FactoryBot.define do
   factory :user do
-    sequence(:username) { |n| "username#{n}" }
+    sequence(:username) { |n| "username#{n + 638}" }
     first_name { "User" }
     password { "password" }
     password_confirmation { "password" }
-    sequence(:last_name, &:to_s)
-    sequence(:email) { |n| "user#{n}@example.com" }
+    sequence(:last_name) { |n| n + 723 }
+    sequence(:email) { |n| "user#{n + 721}@example.com" }
 
     trait :suspended do
       suspended_at { 1.day.ago }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,12 +2,12 @@
 
 FactoryBot.define do
   factory :user do
-    sequence(:username) { |n| "username#{n + 638}" }
+    sequence(:username) { |n| "username#{n}" }
     first_name { "User" }
     password { "password" }
     password_confirmation { "password" }
-    sequence(:last_name) { |n| n + 723 }
-    sequence(:email) { |n| "user#{n + 721}@example.com" }
+    sequence(:last_name) { |n| "Last#{n}" }
+    sequence(:email) { |n| "user#{n}@example.com" }
 
     trait :suspended do
       suspended_at { 1.day.ago }

--- a/spec/services/order_row_importer_spec.rb
+++ b/spec/services/order_row_importer_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe OrderRowImporter do
         it_behaves_like "an invalid order_date"
       end
 
-      context "is in he future" do
+      context "is in the future" do
         let(:order_date) { I18n.l(1.day.from_now.to_date, format: :usa) }
 
         it_behaves_like "an invalid order_date"

--- a/spec/system/admin/clones_account_memberships_spec.rb
+++ b/spec/system/admin/clones_account_memberships_spec.rb
@@ -34,8 +34,7 @@ RSpec.describe "Cloning account membership" do
       click_button "Search"
 
       unless page.has_link?("Clone Payment Source Memberships", count: 1)
-        save_and_open_page
-        raise "Too many links for user: #{original_user.name} -- All: #{User.all.map(&:name) }"
+        raise "Too many links for user: #{original_user.name} -- All: #{User.all.map(&:name) }\n#{page.body}"
       end
 
       click_link "Clone Payment Source Memberships"

--- a/spec/system/admin/clones_account_memberships_spec.rb
+++ b/spec/system/admin/clones_account_memberships_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "Cloning account membership" do
       click_button "Search"
 
       unless page.has_link?("Clone Payment Source Memberships", count: 1)
+        save_and_open_page
         raise "Too many links for user: #{original_user.name} -- All: #{User.all.map(&:name) }"
       end
 

--- a/spec/system/admin/clones_account_memberships_spec.rb
+++ b/spec/system/admin/clones_account_memberships_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Cloning account membership" do
   let(:facility) { create(:facility) }
-
   let(:original_user) { create(:user) }
   let(:new_user) { create(:user) }
   let!(:owned_account) { create(:account, :with_account_owner, owner: original_user) }
@@ -33,6 +32,10 @@ RSpec.describe "Cloning account membership" do
       click_link "Clone Payment Source Membership"
       fill_in "search_term", with: original_user.name
       click_button "Search"
+
+      unless page.has_link?("Clone Payment Source Memberships", count: 1)
+        raise "Too many links for user: #{original_user.name} -- All: #{User.all.map(&:name) }"
+      end
 
       click_link "Clone Payment Source Memberships"
 

--- a/spec/system/admin/clones_account_memberships_spec.rb
+++ b/spec/system/admin/clones_account_memberships_spec.rb
@@ -30,12 +30,8 @@ RSpec.describe "Cloning account membership" do
       visit facility_user_accounts_path("all", new_user)
 
       click_link "Clone Payment Source Membership"
-      fill_in "search_term", with: original_user.name
+      fill_in "search_term", with: original_user.email
       click_button "Search"
-
-      unless page.has_link?("Clone Payment Source Memberships", count: 1)
-        raise "Too many links for user: #{original_user.name} -- All: #{User.all.map(&:name) }\n#{page.body}"
-      end
 
       click_link "Clone Payment Source Memberships"
 

--- a/vendor/engines/secure_rooms/spec/controllers/secure_rooms_api/events_controller_spec.rb
+++ b/vendor/engines/secure_rooms/spec/controllers/secure_rooms_api/events_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe SecureRoomsApi::EventsController do
       describe "response" do
         subject { response }
 
-        it { is_expected.to be_success }
+        it { is_expected.to be_successful }
       end
 
       describe "new alarm_event" do


### PR DESCRIPTION
# Release Notes

Tech task: Fix spurious test failure.

# Additional Context

```
Failure/Error: click_link "Clone Payment Source Memberships"

Capybara::Ambiguous:
  Ambiguous match, found 2 elements matching visible link "Clone Payment Source Memberships"

./vendor/bundle/ruby/2.5.0/gems/capybara-3.31.0/lib/capybara/node/finders.rb:300:in `block in synced_resolve'
./vendor/bundle/ruby/2.5.0/gems/capybara-3.31.0/lib/capybara/node/base.rb:83:in `synchronize'
./vendor/bundle/ruby/2.5.0/gems/capybara-3.31.0/lib/capybara/node/finders.rb:291:in `synced_resolve'
./vendor/bundle/ruby/2.5.0/gems/capybara-3.31.0/lib/capybara/node/finders.rb:52:in `find'
./vendor/bundle/ruby/2.5.0/gems/capybara-3.31.0/lib/capybara/node/actions.rb:42:in `click_link'
./vendor/bundle/ruby/2.5.0/gems/capybara-3.31.0/lib/capybara/session.rb:759:in `block (2 levels) in <class:Session>'
./vendor/bundle/ruby/2.5.0/gems/capybara-3.31.0/lib/capybara/dsl.rb:58:in `block (2 levels) in <module:DSL>'
./spec/system/admin/clones_account_memberships_spec.rb:37:in `block (3 levels) in <top (required)>'
```

This was super tricky to figure out. What it came down to is we have a couple users whose sequence of name coming out of the factory is out of sync with the sequence of email addresses. I think this happens where if you explicitly set the value in a `FactoryBot.create` it doesn't increment the sequence, and I know we do that in a few places.

So we had one user with name "User 724" and email "user722@example.com" and then another user with "User 726" and "user724@example.com". Because our user search is pretty generous (in order to support first name, last name, and full name searching), a search for "User 724" matches the first user's name and the second user's email address. 

That's why we were seeing two results come back which was then confusing capybara. I figured this out by throwing this code in there so I could actually see what was happening on the failures on CI. There's probably a way to do `save_and_open_page` on CI, but I don't know how.

```ruby
unless page.has_link?("Clone Payment Source Memberships", count: 1)
  raise "Too many links for user: #{original_user.name} -- All: #{User.all.map(&:name) }\n#{page.body}"
end
```

The detail is the query gets converted to `%user%724%` and then matched against the various columns. In general I'm ok with it being as lenient as it is and no one's complained about it. Better for the search to return more results than to not return a result.
