### PR TITLE
[#151928] Fix hard error on cross-facility Payment Sources

### DIFF
--- a/app/controllers/facility_accounts_controller.rb
+++ b/app/controllers/facility_accounts_controller.rb
@@ -21,7 +21,6 @@ class FacilityAccountsController < ApplicationController
   # GET /facilties/:facility_id/accounts
   def index
     accounts = Account.with_orders_for_facility(current_facility)
-    accounts = accounts.where(facility_id: nil) if current_facility.cross_facility?
 
     @accounts = accounts.paginate(page: params[:page])
   end

--- a/app/views/facility_accounts/_account_table.html.haml
+++ b/app/views/facility_accounts/_account_table.html.haml
@@ -8,12 +8,16 @@
         %th= t(".th.account")
         %th= t(".th.owner")
         %th= Account.human_attribute_name(:expires_at)
+        - if current_facility.cross_facility?
+          %th= Facility.model_name.human
     %tbody
       - @accounts.each do |account|
         %tr
           %td= payment_source_link_or_text(account)
           %td= account.owner_user.full_name if account.owner_user
           %td= human_date(account.expires_at)
+          - if current_facility.cross_facility?
+            %td= account.per_facility? ? account.facilities.alphabetized.join(", ") : html("all", inline: true)
 
   - if params[:search_term].present?
     = will_paginate(@accounts, class: "ajax_links",

--- a/config/locales/views/en.facility_accounts.yml
+++ b/config/locales/views/en.facility_accounts.yml
@@ -1,6 +1,8 @@
 en:
   views:
     facility_accounts:
+      account_table:
+        all: "!views.accounts.index.all!"
       show_statement:
         no_transactions: No transactions exist for this period.
         transaction_date: Transaction Date

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -29,4 +29,30 @@ FactoryBot.define do
       account.account_users << build(:account_user, user: evaluator.owner)
     end
   end
+
+  trait :with_order do
+    with_account_owner
+
+    transient do
+      product { nil }
+    end
+
+    account_users_attributes { [FactoryBot.attributes_for(:account_user, user: owner)] }
+
+    after(:create) do |account, evaluator|
+      order = FactoryBot.create(
+        :order,
+        user: evaluator.owner,
+        created_by: evaluator.owner.id,
+        facility: evaluator.product.facility,
+      )
+
+      FactoryBot.create(
+        :order_detail,
+        product: evaluator.product,
+        order: order,
+        account: account,
+      )
+    end
+  end
 end

--- a/spec/factories/nufs_accounts.rb
+++ b/spec/factories/nufs_accounts.rb
@@ -19,32 +19,6 @@ FactoryBot.modify do
     after(:build) do |account, evaluator|
       account.facilities << evaluator.facility if evaluator.facility
     end
-
-    trait :with_order do
-      with_account_owner
-
-      transient do
-        product { nil }
-      end
-
-      account_users_attributes { [FactoryBot.attributes_for(:account_user, user: owner)] }
-
-      after(:create) do |account, evaluator|
-        order = FactoryBot.create(
-          :order,
-          user: evaluator.owner,
-          created_by: evaluator.owner.id,
-          facility: evaluator.product.facility,
-        )
-
-        FactoryBot.create(
-          :order_detail,
-          product: evaluator.product,
-          order: order,
-          account: account,
-        )
-      end
-    end
   end
 end
 


### PR DESCRIPTION
# Release Notes

Fixes a hard error on global "Users > Payment Sources". (`/facilities/all/accounts`).

# Additional Context

This was broken by the removal of the `accountsfacility_id` column in #1863. We didn't have a test around that view, which would have caught it. This changes the behavior slightly: before we were only showing global accounts before. But when you searched that restriction when away. Now on the page, it'll include credit card and POs. I also added a facility column that will appear in the cross-facility context.

# Screenshot

![Screen Shot 2020-03-06 at 2 13 10 PM](https://user-images.githubusercontent.com/1099111/76119228-9eba8f80-5fb4-11ea-8028-2f9c992e46ad.png)

