### PR TITLE
[#149739] Fix sorting when deciding most recent order

### DIFF
--- a/app/forms/add_to_order_form.rb
+++ b/app/forms/add_to_order_form.rb
@@ -66,6 +66,24 @@ class AddToOrderForm
     AvailableAccountsFinder.new(original_order.user, current_facility)
   end
 
+  # We're using the ordered_at of the order details to determine if additional OrderDetails
+  # have been added to the order. We find the most recently added order that does not
+  # match the original order's ordered_at and use that for our basis for defaults.
+  # There is an edge case: 1) Upload an order via bulk upload. 2) Add on to that order
+  # here. 3) Upload again via bulk upload matching the ordered_at of the original.
+  # In that situation, we will return the results of #2.
+  def previously_added_order_detail
+    return @previously_added_order_detail if defined?(@previously_added_order_detail)
+
+    # We are ordering by created_at rather than ID because it is possible in Oracle
+    # for the IDs to be assigned out of insert order due to the way it caches sequence values.
+    # https://stackoverflow.com/questions/4866959/oracle-rac-and-sequences
+    order_details = @original_order.order_details.order(:created_at)
+    original_order_detail = order_details.first
+
+    @previously_added_order_detail = order_details.reverse.find { |od| od.ordered_at != original_order_detail.ordered_at }
+  end
+
   protected
 
   def translation_scope
@@ -109,20 +127,6 @@ class AddToOrderForm
 
   def previously_added_to?
     previously_added_order_detail.present?
-  end
-
-  # We're using the ordered_at of the order details to determine if additional OrderDetails
-  # have been added to the order. We find the most recently added order that does not
-  # match the original order's ordered_at and use that for our basis for defaults.
-  # There is an edge case: 1) Upload an order via bulk upload. 2) Add on to that order
-  # here. 3) Upload again via bulk upload matching the ordered_at of the original.
-  # In that situation, we will return the results of #2.
-  def previously_added_order_detail
-    return @previously_added_order_detail if defined?(@previously_added_order_detail)
-
-    order_details = @original_order.order_details.order(:id)
-    original_order_detail = order_details.first
-    @previously_added_order_detail = order_details.reverse.find { |od| od.ordered_at != original_order_detail.ordered_at }
   end
 
   def params

--- a/spec/factories/order_details.rb
+++ b/spec/factories/order_details.rb
@@ -4,7 +4,13 @@ FactoryBot.define do
   factory :order_detail do
     quantity { 1 }
     created_by { 0 }
-    order_status { OrderStatus.new_status }
+    state { "new" }
+    order_status { nil }
+
+    trait :purchased do
+      order_status { OrderStatus.new_status }
+      ordered_at { Time.current }
+    end
 
     trait :completed do
       state { "complete" }

--- a/spec/factories/order_details.rb
+++ b/spec/factories/order_details.rb
@@ -4,17 +4,21 @@ FactoryBot.define do
   factory :order_detail do
     quantity { 1 }
     created_by { 0 }
+    order_status { OrderStatus.new_status }
 
     trait :completed do
       state { "complete" }
+      order_status { OrderStatus.complete }
     end
 
     trait :canceled do
       state { "canceled" }
+      order_status { OrderStatus.canceled }
     end
 
     trait :canceled_with_cost do
       state { "complete" }
+      order_status { OrderStatus.complete }
       canceled_at { 30.minutes.ago }
       actual_cost { 5 }
     end

--- a/spec/forms/add_to_order_form_spec.rb
+++ b/spec/forms/add_to_order_form_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe AddToOrderForm do
 
     describe "when there were multiple items in the original cart" do
       let(:second_order_detail) do
-        create(:order_detail, order: order, ordered_at: order.order_details.first.ordered_at, product: product)
+        create(:order_detail, :purchased, order: order, ordered_at: order.order_details.first.ordered_at, product: product)
       end
       before do
         order.reload
@@ -55,11 +55,11 @@ RSpec.describe AddToOrderForm do
       let(:other_account) { create(:nufs_account, :with_account_owner, owner: order.user, description: "Other Account") }
       let(:other_product) { create(:setup_item, facility: product.facility) }
       let!(:second_order_detail) do
-        create(:order_detail, order: order, account: other_account, product: product, note: "somenote", ordered_at: 1.day.ago, created_at: 5.minutes.from_now)
+        create(:order_detail, :purchased, order: order, account: other_account, product: product, note: "somenote", ordered_at: 1.day.ago, created_at: 5.minutes.from_now)
       end
       # Oracle can have out of sequence IDs due to its caching of allocated values in the sequence.
       let!(:out_of_order_order_detail) do
-        create(:order_detail, order: order, product: product, created_at: 1.minute.from_now)
+        create(:order_detail, :purchased, order: order, product: product, created_at: 1.minute.from_now)
       end
 
       before { order.reload }

--- a/spec/forms/add_to_order_form_spec.rb
+++ b/spec/forms/add_to_order_form_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe AddToOrderForm do
         second_order_detail.backdate_to_complete!(10.minutes.ago)
       end
 
+      it "has no previously ordered" do
+        expect(form.previously_added_order_detail).to be_blank
+      end
+
       it "has an order status of New" do
         expect(form.order_status_id).to eq(OrderStatus.new_status.id)
       end
@@ -50,14 +54,27 @@ RSpec.describe AddToOrderForm do
     describe "when the order has something else added to it already" do
       let(:other_account) { create(:nufs_account, :with_account_owner, owner: order.user, description: "Other Account") }
       let(:other_product) { create(:setup_item, facility: product.facility) }
-      let(:second_order_detail) do
-        create(:order_detail, order: order, account: other_account, product: product, note: "somenote", ordered_at: 1.day.ago)
+      let!(:second_order_detail) do
+        create(:order_detail, order: order, account: other_account, product: product, note: "somenote", ordered_at: 1.day.ago, created_at: 5.minutes.from_now)
+      end
+      # Oracle can have out of sequence IDs due to its caching of allocated values in the sequence.
+      let!(:out_of_order_order_detail) do
+        create(:order_detail, order: order, product: product, created_at: 1.minute.from_now)
       end
 
       before { order.reload }
 
+      it "has the right ordering - i.e. the test is set up correctly" do
+        expect(order.order_details.order(:created_at)).to match([anything, out_of_order_order_detail, second_order_detail])
+        expect(order.order_details.order(:id)).to match([anything, second_order_detail, out_of_order_order_detail])
+      end
+
+      it "gets the right order detail" do
+        expect(form.previously_added_order_detail).to eq(second_order_detail)
+      end
+
       describe "and it is still New" do
-        it "has a status of complete" do
+        it "has a status of new" do
           expect(form.order_status_id).to eq(OrderStatus.new_status.id)
         end
 


### PR DESCRIPTION
# Release Notes

Fix "Add to Order" issue where the defaults may be coming from the wrong order detail.

# Additional Context

See #2207 for the original implementation

In Oracle, it's possible that the IDs of the rows in `order_details` (or really in any table) may not be assigned in the order of the sequence. This is due to the way that Oracle caches values in a sequence: it preallocates them into a cache, but different nodes get their own cache. So you can end up with an `ORDER_BY id` being different than `ORDER BY created_at`.

In the future, we should consider how to ensure proper ordering (see the references), but that is out of scope of the current ticket.

A couple references:
https://asktom.oracle.com/pls/apex/f?p=100:11:::NO::P11_QUESTION_ID:9539374000346423410
https://stackoverflow.com/questions/13513936/oracle-sequence-value-are-not-ordered
https://stackoverflow.com/questions/4866959/oracle-rac-and-sequences
