### PR TITLE
[#38893] Add inactive tag to product names in groups

### DIFF
--- a/app/presenters/product_presenter.rb
+++ b/app/presenters/product_presenter.rb
@@ -2,8 +2,12 @@
 
 class ProductPresenter < SimpleDelegator
 
-  def with_archived_tag
-    is_archived? ? I18n.t("products.archived", product: name) : name
+  def to_s
+    tags = []
+    tags << :hidden if is_hidden?
+    tags << :archived if is_archived?
+
+    ([name] + tags.map { |t| I18n.t(t, scope: "products.tags") }).join(" ")
   end
 
 end

--- a/app/presenters/product_presenter.rb
+++ b/app/presenters/product_presenter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ProductPresenter < SimpleDelegator
+
+  def with_archived_tag
+    is_archived? ? I18n.t("products.archived", product: name) : name
+  end
+
+end

--- a/app/views/facilities/_product.html.haml
+++ b/app/views/facilities/_product.html.haml
@@ -9,7 +9,7 @@
         = builder.hidden_field :product_id, value: product.id, index: nil, id: "order_order_details_#{product.id}_product_id"
     = tooltip_icon "fa fa-question-circle-o text__alert", text("line_items") if !product.is_a?(Instrument) && Orders::ItemAdder.multiline?(product)
   = public_calendar_link(product)
-  = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(product.facility, product)
+  = link_to ProductPresenter.new(product), facility_product_path(product.facility, product)
   - if acting_user.present? && !product.can_be_used_by?(acting_user)
     %i.fa.fa-lock
     = " (#{product.class.human_attribute_name(:requires_approval_show)})"

--- a/app/views/global_search/_products.html.haml
+++ b/app/views/global_search/_products.html.haml
@@ -11,7 +11,7 @@
     - results.take(20).each do |product|
       %tr
         %td.table-product-results__name
-          = link_to product.name + (product.is_hidden? ? ' (hidden)' : ''), facility_product_path(product.facility, product)
+          = link_to ProductPresenter.new(product), facility_product_path(product.facility, product)
         %td.table-product-results__type
           = product.model_name.human
         %td.table-product-results__facility

--- a/app/views/product_display_groups/_form.html.haml
+++ b/app/views/product_display_groups/_form.html.haml
@@ -11,7 +11,7 @@
         -# Include both so the page still works without JS. The JS will clear anything in
         -# the excluded list from this. Uniq is to prevent duplicates in the case of validation
         -# errors and a product might be in both places.
-        = f.input :product_ids, collection: (@product_display_group.products + @ungrouped_products).uniq, input_html: { multiple: true, class: "tall js--included pull-left" }
+        = f.input :product_ids, collection: (@product_display_group.products + @ungrouped_products).uniq, input_html: { multiple: true, class: "tall js--included pull-left" }, label_method: ->(product) { ProductPresenter.new(product).with_archived_tag }
         .multiSelectReorder__buttons
           = link_to "#", class: "btn js--multiSelectReorder__moveUp", data: { target: "#product_display_group_product_ids" }, title: text("shared.reorder.move_up") do
             = content_tag :i, "", class: "fa fa-arrow-up"
@@ -27,5 +27,5 @@
       .span4
         = simple_fields_for :ungrouped do |u|
           -# In the case of validation errors, ensure this collection does not include those added in the previous POST/PATCH
-          = u.input :product_ids, collection: @ungrouped_products - @product_display_group.products, input_html: { multiple: true, class: "tall js--excluded" }, required: false, label: ProductDisplayGroup.human_attribute_name(:ungrouped_product_ids)
+          = u.input :product_ids, collection: @ungrouped_products - @product_display_group.products, input_html: { multiple: true, class: "tall js--excluded" }, required: false, label: ProductDisplayGroup.human_attribute_name(:ungrouped_product_ids), label_method: ->(product) { ProductPresenter.new(product).with_archived_tag }
   = f.submit class: "btn btn-primary"

--- a/app/views/product_display_groups/_form.html.haml
+++ b/app/views/product_display_groups/_form.html.haml
@@ -11,7 +11,7 @@
         -# Include both so the page still works without JS. The JS will clear anything in
         -# the excluded list from this. Uniq is to prevent duplicates in the case of validation
         -# errors and a product might be in both places.
-        = f.input :product_ids, collection: (@product_display_group.products + @ungrouped_products).uniq, input_html: { multiple: true, class: "tall js--included pull-left" }, label_method: ->(product) { ProductPresenter.new(product).with_archived_tag }
+        = f.input :product_ids, collection: (@product_display_group.products + @ungrouped_products).uniq, input_html: { multiple: true, class: "tall js--included pull-left" }, label_method: ->(product) { ProductPresenter.new(product) }
         .multiSelectReorder__buttons
           = link_to "#", class: "btn js--multiSelectReorder__moveUp", data: { target: "#product_display_group_product_ids" }, title: text("shared.reorder.move_up") do
             = content_tag :i, "", class: "fa fa-arrow-up"
@@ -27,5 +27,5 @@
       .span4
         = simple_fields_for :ungrouped do |u|
           -# In the case of validation errors, ensure this collection does not include those added in the previous POST/PATCH
-          = u.input :product_ids, collection: @ungrouped_products - @product_display_group.products, input_html: { multiple: true, class: "tall js--excluded" }, required: false, label: ProductDisplayGroup.human_attribute_name(:ungrouped_product_ids), label_method: ->(product) { ProductPresenter.new(product).with_archived_tag }
+          = u.input :product_ids, collection: @ungrouped_products - @product_display_group.products, input_html: { multiple: true, class: "tall js--excluded" }, required: false, label: ProductDisplayGroup.human_attribute_name(:ungrouped_product_ids), label_method: ->(product) { ProductPresenter.new(product) }
   = f.submit class: "btn btn-primary"

--- a/app/views/product_display_groups/index.html.haml
+++ b/app/views/product_display_groups/index.html.haml
@@ -23,11 +23,11 @@
               .pull-right= link_to "Edit", edit_facility_product_display_group_path(current_facility, product_display_group), class: "btn"
           %ul.js--dropTargetElement
             - product_display_group.products.each do |product|
-              %li= ProductPresenter.new(product).with_archived_tag
+              %li= ProductPresenter.new(product)
     .span4
       .well
         %legend= ProductDisplayGroup.human_attribute_name(:ungrouped_product_ids)
         %ul
           - @ungrouped_products.alphabetized.each do |product|
-            %li= ProductPresenter.new(product).with_archived_tag
+            %li= ProductPresenter.new(product)
 

--- a/app/views/product_display_groups/index.html.haml
+++ b/app/views/product_display_groups/index.html.haml
@@ -23,11 +23,11 @@
               .pull-right= link_to "Edit", edit_facility_product_display_group_path(current_facility, product_display_group), class: "btn"
           %ul.js--dropTargetElement
             - product_display_group.products.each do |product|
-              %li= product
+              %li= ProductPresenter.new(product).with_archived_tag
     .span4
       .well
         %legend= ProductDisplayGroup.human_attribute_name(:ungrouped_product_ids)
         %ul
           - @ungrouped_products.alphabetized.each do |product|
-            %li= product
+            %li= ProductPresenter.new(product).with_archived_tag
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -520,6 +520,7 @@ en:
       hidden: "No"
       optional: Optional
       required: Required
+    archived: "%{product} (Inactive)"
 
   admin_reservations:
     categories:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -520,7 +520,9 @@ en:
       hidden: "No"
       optional: Optional
       required: Required
-    archived: "%{product} (Inactive)"
+    tags:
+      archived: (Inactive)
+      hidden: (Hidden)
 
   admin_reservations:
     categories:

--- a/spec/presenters/product_presenter_spec.rb
+++ b/spec/presenters/product_presenter_spec.rb
@@ -4,21 +4,38 @@ require "rails_helper"
 
 RSpec.describe ProductPresenter do
 
-  describe "with_archived_tag" do
+  describe "to_s" do
     subject(:presenter) { described_class.new(product) }
+
     describe "is archived" do
       let(:product) { build(:item, name: "Widget", is_archived: true) }
 
       it "has the inactive tag on it" do
-        expect(presenter.with_archived_tag).to eq("Widget (Inactive)")
+        expect(presenter.to_s).to eq("Widget (Inactive)")
       end
     end
 
-    describe "is not archived (is active)" do
-      let(:product) { build(:item, name: "Widget", is_archived: false) }
+    describe "is hidden" do
+      let(:product) { build(:item, name: "Widget", is_hidden: true) }
 
-      it "does not have the inactive tag on it" do
-        expect(presenter.with_archived_tag).to eq("Widget")
+      it "has the hidden tag on it" do
+        expect(presenter.to_s).to eq("Widget (Hidden)")
+      end
+    end
+
+    describe "is both archived and hidden" do
+      let(:product) { build(:item, name: "Widget", is_archived: true, is_hidden: true) }
+
+      it "has both tags on it" do
+        expect(presenter.to_s).to eq("Widget (Hidden) (Inactive)")
+      end
+    end
+
+    describe "is active and visible" do
+      let(:product) { build(:item, name: "Widget") }
+
+      it "is just the name" do
+        expect(presenter.to_s).to eq("Widget")
       end
     end
   end

--- a/spec/presenters/product_presenter_spec.rb
+++ b/spec/presenters/product_presenter_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProductPresenter do
+
+  describe "with_archived_tag" do
+    subject(:presenter) { described_class.new(product) }
+    describe "is archived" do
+      let(:product) { build(:item, name: "Widget", is_archived: true) }
+
+      it "has the inactive tag on it" do
+        expect(presenter.with_archived_tag).to eq("Widget (Inactive)")
+      end
+    end
+
+    describe "is not archived (is active)" do
+      let(:product) { build(:item, name: "Widget", is_archived: false) }
+
+      it "does not have the inactive tag on it" do
+        expect(presenter.with_archived_tag).to eq("Widget")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

Display "Inactive" next to product names in the product group management pages.

# Additional Context

Per the client:

> This would be helpful in terms of organizing currently Active products versus Inactive products when viewing, creating, and editing Display Groups.

I also moved "Hidden" in here to allow some sharing of code with the homepage (and getting rid of the hard-coded string in the view).
