### PR TITLE
[#152892] Fix error in audit log query

### DIFF
--- a/app/controllers/clone_account_memberships_controller.rb
+++ b/app/controllers/clone_account_memberships_controller.rb
@@ -15,7 +15,7 @@ class CloneAccountMembershipsController < ApplicationController
   end
 
   def search
-    @users, _count = UserFinder.search(params[:search_term])
+    @users = UserFinder.search(params[:search_term])
 
     render :search
   end

--- a/app/controllers/log_events_controller.rb
+++ b/app/controllers/log_events_controller.rb
@@ -8,7 +8,8 @@ class LogEventsController < GlobalSettingsController
       end_date: parse_usa_date(params[:end_date]),
       events: params[:events],
       query: params[:query],
-    ).paginate(per_page: 50, page: params[:page])
+    ).reverse_chronological
+     .paginate(per_page: 50, page: params[:page])
   end
 
 end

--- a/app/controllers/log_events_controller.rb
+++ b/app/controllers/log_events_controller.rb
@@ -8,8 +8,7 @@ class LogEventsController < GlobalSettingsController
       end_date: parse_usa_date(params[:end_date]),
       events: params[:events],
       query: params[:query],
-    ).reverse_chronological
-     .paginate(per_page: 50, page: params[:page])
+    ).reverse_chronological.paginate(per_page: 50, page: params[:page])
   end
 
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -13,7 +13,7 @@ class SearchController < ApplicationController
     @account = Account.find(params[:account_id]) if params[:account_id].present?
     @product = Product.find(params[:product_id]) if params[:product_id].present?
     @search_type = valid_search_types.find { |t| t == params[:search_type] }
-    @users, @count = UserFinder.search(params[:search_term], @limit)
+    @users, @count = UserFinder.search_with_count(params[:search_term], @limit)
 
     render layout: false
   end

--- a/app/models/log_event.rb
+++ b/app/models/log_event.rb
@@ -7,18 +7,6 @@ class LogEvent < ApplicationRecord
 
   scope :reverse_chronological, -> { order(event_time: :desc) }
 
-  # Allows you to LEFT OUTER JOIN a polymorphic table so you can query on it
-  # Example: relation.joins_polymorphic(Account)
-  # => LEFT OUTER JOINS accounts ON loggable_type = 'Account' AND accounts.id = loggable_id
-  scope :joins_polymorphic, ->(clazz) {
-    join_table = clazz.arel_table
-
-    join_on = arel_table[:loggable_type].eq(clazz)
-      .and(join_table[:id].eq(arel_table[:loggable_id]))
-    arel_join = arel_table.join(join_table, Arel::Nodes::OuterJoin).on(join_on)
-    joins(arel_join.join_sources)
-  }
-
   def self.log(loggable, event_type, user, event_time: Time.current)
     create(
       loggable: loggable, event_type: event_type,

--- a/app/services/log_event_searcher.rb
+++ b/app/services/log_event_searcher.rb
@@ -48,8 +48,8 @@ class LogEventSearcher
   end
 
   def filter_query
-    accounts = Account.where(Account.arel_table[:account_number].lower.matches("%#{query.downcase}%")).select(:id)
-    users = UserFinder.search(query).select(:id).unscope(:order)
+    accounts = Account.where(Account.arel_table[:account_number].lower.matches("%#{query.downcase}%"))
+    users = UserFinder.search(query).unscope(:order)
     account_users = AccountUser.where(account_id: accounts).or(AccountUser.where(user_id: users))
 
     [

--- a/app/services/log_event_searcher.rb
+++ b/app/services/log_event_searcher.rb
@@ -51,8 +51,8 @@ class LogEventSearcher
     relation = LogEvent.joins_polymorphic(Account)
       .joins_polymorphic(User)
       .joins_polymorphic(AccountUser)
-      .joins("LEFT OUTER JOIN accounts AS account_user_accounts ON account_users.account_id = account_user_accounts.id")
-      .joins("LEFT OUTER JOIN users AS account_user_users ON account_users.user_id = account_user_users.id")
+      .joins("LEFT OUTER JOIN accounts account_user_accounts ON account_users.account_id = account_user_accounts.id")
+      .joins("LEFT OUTER JOIN users account_user_users ON account_users.user_id = account_user_users.id")
 
     [
       Account.where("accounts.account_number LIKE ?", "%#{query}%"),

--- a/app/services/log_event_searcher.rb
+++ b/app/services/log_event_searcher.rb
@@ -39,14 +39,12 @@ class LogEventSearcher
     LogEvent.where(event_time: (dates.min.beginning_of_day..dates.max.end_of_day))
   end
 
-  # When this gets updated to Rails 5, you can use ActiveRecord#or directly
-  # Also, the event name comes in as <loggable_type>.<event_type>
+  # The event name comes in as <loggable_type>.<event_type>
   def filter_event
-    where_strings = events.flatten.map do |event|
+    ors = events.flatten.map do |event|
       loggable_type, event_type = event.split(".")
-      "(loggable_type = '#{loggable_type.camelize}' AND event_type = '#{event_type}')"
-    end
-    LogEvent.where(where_strings.join(" OR "))
+      LogEvent.where(loggable_type: loggable_type.camelize, event_type: event_type)
+    end.inject(&:or)
   end
 
   def filter_query

--- a/app/services/user_finder.rb
+++ b/app/services/user_finder.rb
@@ -13,9 +13,9 @@ class UserFinder
     "email",
   ]
 
-  def self.search_with_counts(search_term, limit = nil)
+  def self.search_with_count(search_term, limit = nil)
     if search_term.present?
-      new(search_term, limit).result_with_counts
+      new(search_term, limit).result_with_count
     else
       [nil, nil]
     end
@@ -35,7 +35,7 @@ class UserFinder
     @table_alias = table_alias
   end
 
-  def result_with_counts
+  def result_with_count
     [result, relation.count]
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,11 +3,7 @@
 require File.expand_path("factories_env", File.dirname(__FILE__))
 
 FactoryBot.define do
-  factory :log_event do
-    loggable { "" }
-    event_type { "MyString" }
-    user { nil }
-  end
+  # Global trait
   trait :without_validation do
     to_create { |instance| instance.save(validate: false) }
   end

--- a/spec/factories/log_events.rb
+++ b/spec/factories/log_events.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+
+  factory :log_event do
+    loggable {}
+    event_type { "MyString" }
+    user { nil }
+  end
+
+end

--- a/spec/models/log_event_spec.rb
+++ b/spec/models/log_event_spec.rb
@@ -3,15 +3,4 @@
 require "rails_helper"
 
 RSpec.describe LogEvent do
-
-  describe "polymorphic joins" do
-    let(:account) { create(:account, :with_account_owner, account_number: "123456") }
-    let(:log_event) { create(:log_event, loggable: account) }
-
-    it "can join polymorphicly to an account" do
-      relation = described_class.joins_polymorphic(Account).where(accounts: { account_number: "123456" })
-      expect(relation).to include(log_event)
-    end
-  end
-
 end

--- a/spec/models/log_event_spec.rb
+++ b/spec/models/log_event_spec.rb
@@ -4,94 +4,14 @@ require "rails_helper"
 
 RSpec.describe LogEvent do
 
-  describe "search" do
+  describe "polymorphic joins" do
+    let(:account) { create(:account, :with_account_owner, account_number: "123456") }
+    let(:log_event) { create(:log_event, loggable: account) }
 
-    let!(:log_1) do
-      create(:log_event, loggable_type: "Account",
-                         loggable_id: 1, event_type: :create,
-                         event_time: 1.month.ago)
+    it "can join polymorphicly to an account" do
+      relation = described_class.joins_polymorphic(Account).where(accounts: { account_number: "123456" })
+      expect(relation).to include(log_event)
     end
-    let!(:log_2) do
-      create(:log_event, loggable_type: "AccountUser",
-                         loggable_id: 2, event_type: :create,
-                         event_time: 1.week.ago)
-    end
-    let!(:log_3) do
-      create(:log_event, loggable_type: "User",
-                         loggable_id: 3, event_type: :create,
-                         event_time: 1.day.ago)
-    end
-
-    it "finds all the items without a date filter" do
-      expect(LogEvent.search.to_a).to eq([log_1, log_2, log_3])
-    end
-
-    it "works with a date filter" do
-      expect(LogEvent.search(start_date: 2.weeks.ago, end_date: 2.days.ago).to_a)
-        .to eq([log_2])
-    end
-
-    it "works with a flipped date filter" do
-      expect(LogEvent.search(start_date: 2.days.ago, end_date: 2.weeks.ago).to_a)
-        .to eq([log_2])
-    end
-
-    it "works without a start_date" do
-      expect(LogEvent.search(end_date: 2.days.ago).to_a)
-        .to eq([log_1, log_2])
-    end
-
-    it "works without an end date" do
-      expect(LogEvent.search(start_date: 2.weeks.ago).to_a)
-        .to eq([log_2, log_3])
-    end
-
-    it "filters on event type" do
-      expect(LogEvent.search(events: ["account.create"]).to_a).to eq([log_1])
-      expect(LogEvent.search(events: ["account_user.create"]).to_a).to eq([log_2])
-      expect(LogEvent.search(events: ["user.create"]).to_a).to eq([log_3])
-      expect(LogEvent.search(events: ["user.create", "account_user.create"]).to_a)
-        .to eq([log_2, log_3])
-    end
-
-    it "whitelists event type" do
-      search = LogEventSearcher.new(events: ["user.create", "cheeseburger.create", "user.update"])
-      expect(search.events).to eq(["user.create"])
-    end
-
-  end
-
-  describe "search by string" do
-
-    let!(:owner) { create(:user, first_name: "Admin", last_name: "Person") }
-    let!(:kermit) { create(:user, first_name: "Kermit", last_name: "Frog") }
-    let!(:piggy) { create(:user, first_name: "Miss", last_name: "Piggy") }
-    let!(:account_007) { create(:account, :with_account_owner, account_number: "007-a1") }
-    let!(:account_010) { create(:account, :with_account_owner, account_number: "010-frog1") }
-    let!(:au_kermit_007) { create(:account_user, account: account_007, user: kermit, user_role: "Purchaser") }
-    let!(:au_piggy_010) { create(:account_user, account: account_010, user: piggy, user_role: "Purchaser") }
-
-    let!(:log_007) { LogEvent.log(account_007, :create, owner, event_time: 1.week.ago) }
-    let!(:log_010) { LogEvent.log(account_010, :create, owner, event_time: 1.week.ago) }
-    let!(:log_kermit) { LogEvent.log(kermit, :create, owner, event_time: 1.week.ago) }
-    let!(:log_piggy) { LogEvent.log(piggy, :create, owner, event_time: 1.week.ago) }
-    let!(:log_au_kermit) { LogEvent.log(au_kermit_007, :create, owner, event_time: 1.week.ago) }
-    let!(:log_au_piggy) { LogEvent.log(au_piggy_010, :create, owner, event_time: 1.week.ago) }
-
-    it "searches based on account number" do
-      expect(LogEvent.search(query: "007").to_a).to eq([log_007, log_au_kermit])
-    end
-
-    it "searches based on user name" do
-      expect(LogEvent.search(query: "Kermit").to_a).to eq(
-        [log_kermit, log_au_kermit])
-    end
-
-    it "could find either" do
-      expect(LogEvent.search(query: "frog").to_a).to eq(
-        [log_010, log_kermit, log_au_kermit, log_au_piggy])
-    end
-
   end
 
 end

--- a/spec/services/log_event_searcher_spec.rb
+++ b/spec/services/log_event_searcher_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+RSpec.describe LogEventSearcher do
+
+  describe "filtering by dates" do
+    let!(:log_1) { create(:log_event, event_time: 1.month.ago) }
+    let!(:log_2) { create(:log_event, event_time: 1.week.ago) }
+    let!(:log_3) { create(:log_event, event_time: 1.day.ago) }
+
+    it "finds all the items without a date filter" do
+      expect(LogEvent.search).to match_array([log_1, log_2, log_3])
+    end
+
+    it "works with a date filter" do
+      expect(LogEvent.search(start_date: 2.weeks.ago, end_date: 2.days.ago))
+        .to match_array([log_2])
+    end
+
+    it "works with a flipped date filter" do
+      expect(LogEvent.search(start_date: 2.days.ago, end_date: 2.weeks.ago))
+        .to match_array([log_2])
+    end
+
+    it "works without a start_date" do
+      expect(LogEvent.search(end_date: 2.days.ago))
+        .to match_array([log_1, log_2])
+    end
+
+    it "works without an end date" do
+      expect(LogEvent.search(start_date: 2.weeks.ago))
+        .to match_array([log_2, log_3])
+    end
+  end
+
+  describe "filtering by events" do
+    let(:account) { create(:account, :with_account_owner) }
+    let(:user) { account.owner_user }
+    let(:account_user) { account.owner }
+    let!(:log_1) { create(:log_event, loggable: account, event_type: :create) }
+    let!(:log_2) { create(:log_event, loggable: account_user, event_type: :create) }
+    let!(:log_3) { create(:log_event, loggable: user, event_type: :create) }
+
+    it "whitelists event type" do
+      search = LogEventSearcher.new(events: ["user.create", "cheeseburger.create", "user.update"])
+      expect(search.events).to contain_exactly("user.create")
+    end
+
+    it "filters on event type" do
+      expect(LogEvent.search(events: ["account.create"])).to match_array([log_1])
+      expect(LogEvent.search(events: ["account_user.create"])).to match_array([log_2])
+      expect(LogEvent.search(events: ["user.create"])).to match_array([log_3])
+      expect(LogEvent.search(events: ["user.create", "account_user.create"]))
+        .to match_array([log_2, log_3])
+    end
+  end
+
+  describe "finding accounts" do
+    let(:account) { create(:account, :with_account_owner, account_number: "12345-12345") }
+    let!(:log_event) { create(:log_event, loggable: account, event_type: :create) }
+
+    it "finds the account" do
+      results = described_class.new(query: "12345-12345").search
+      expect(results).to include(log_event)
+    end
+
+    it "does not find it if it is not a match" do
+      results = described_class.new(query: "54321").search
+      expect(results).not_to include(log_event)
+    end
+  end
+
+  describe "finding users" do
+    let(:user) { create(:user, username: "myuser") }
+    let!(:log_event) { create(:log_event, loggable: user, event_type: :create) }
+
+    it "finds the user" do
+      results = described_class.new(query: "myuser").search
+      expect(results).to include(log_event)
+    end
+
+    it "does not find the user if it is not a match" do
+      results = described_class.new(query: "random").search
+      expect(results).not_to include(log_event)
+    end
+  end
+
+  describe "finds account user memberships" do
+    let(:user) { create(:user, username: "myuser") }
+    let(:account) { create(:account, :with_account_owner, account_number: "12345-12345") }
+    let(:account_user) { create(:account_user, :purchaser, user: user, account: account) }
+    let!(:log_event) { create(:log_event, loggable: account_user, event_type: :create) }
+
+    it "finds it by the user" do
+      results = described_class.new(query: "myuser").search
+      expect(results).to include(log_event)
+    end
+
+    it "finds it by the account" do
+      results = described_class.new(query: "12345-12345").search
+      expect(results).to include(log_event)
+    end
+
+    it "does not find it if no match" do
+      results = described_class.new(query: "random").search
+      expect(results).not_to include(log_event)
+    end
+  end
+end

--- a/spec/services/user_finder_spec.rb
+++ b/spec/services/user_finder_spec.rb
@@ -41,18 +41,18 @@ RSpec.describe UserFinder do
     end
   end
 
-  describe ".search_with_counts" do
+  describe ".search_with_count" do
     it "searches and returns a count" do
       first_name = SecureRandom.hex(8)
       user = FactoryBot.create(:user, first_name: first_name)
-      found_users, count = UserFinder.search_with_counts(first_name, nil)
+      found_users, count = UserFinder.search_with_count(first_name, nil)
       expect(found_users).to include(user)
       expect(count).to eq(1)
     end
 
     it "returns nothing and 0 if not found" do
       user = FactoryBot.create(:user)
-      found_users, count = UserFinder.search_with_counts("something random", nil)
+      found_users, count = UserFinder.search_with_count("something random", nil)
       expect(found_users).to be_empty
       expect(count).to eq(0)
     end

--- a/spec/services/user_finder_spec.rb
+++ b/spec/services/user_finder_spec.rb
@@ -7,21 +7,21 @@ RSpec.describe UserFinder do
     it "finds users by first_name" do
       first_name = SecureRandom.hex(8)
       user = FactoryBot.create(:user, first_name: first_name)
-      found_users = UserFinder.search(first_name, nil).first
+      found_users = UserFinder.search(first_name, nil)
       expect(found_users).to include(user)
     end
 
     it "finds users by last_name" do
       last_name = SecureRandom.hex(8)
       user = FactoryBot.create(:user, last_name: last_name)
-      found_users = UserFinder.search(last_name, nil).first
+      found_users = UserFinder.search(last_name, nil)
       expect(found_users).to include(user)
     end
 
     it "finds users by username" do
       username = SecureRandom.hex(8)
       user = FactoryBot.create(:user, username: username)
-      found_users = UserFinder.search(username, nil).first
+      found_users = UserFinder.search(username, nil)
       expect(found_users).to include(user)
     end
 
@@ -29,15 +29,32 @@ RSpec.describe UserFinder do
       first_name = SecureRandom.hex(8)
       last_name = SecureRandom.hex(8)
       user = FactoryBot.create(:user, first_name: first_name, last_name: last_name)
-      found_users = UserFinder.search([first_name, last_name].join, nil).first
+      found_users = UserFinder.search([first_name, last_name].join, nil)
       expect(found_users).to include(user)
     end
 
     it "finds users by email" do
       email = "#{SecureRandom.hex(8)}@example.com"
       user = FactoryBot.create(:user, email: email)
-      found_users = UserFinder.search(email, nil).first
+      found_users = UserFinder.search(email, nil)
       expect(found_users).to include(user)
+    end
+  end
+
+  describe ".search_with_counts" do
+    it "searches and returns a count" do
+      first_name = SecureRandom.hex(8)
+      user = FactoryBot.create(:user, first_name: first_name)
+      found_users, count = UserFinder.search_with_counts(first_name, nil)
+      expect(found_users).to include(user)
+      expect(count).to eq(1)
+    end
+
+    it "returns nothing and 0 if not found" do
+      user = FactoryBot.create(:user)
+      found_users, count = UserFinder.search_with_counts("something random", nil)
+      expect(found_users).to be_empty
+      expect(count).to eq(0)
     end
   end
 end

--- a/vendor/engines/secure_rooms/spec/services/user_finder_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/user_finder_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe UserFinder do
     it "finds users by card_number" do
       card_number = SecureRandom.hex(8)
       user = FactoryBot.create(:user, card_number: card_number)
-      found_users = UserFinder.search(card_number, nil).first
+      found_users = UserFinder.search(card_number, nil)
       expect(found_users).to include(user)
     end
   end


### PR DESCRIPTION
# Release Notes

Fix error when querying the audit log and the response comes back with more than 1000 accounts. Also, orders events reverse chronologically.

# Additional Context

The way we were handling the queries before would fail if our query matched more than 1000 things. This often happened if they were querying for a partial chart string (e.g. a department). It would trigger Oracle's `OCIError: ORA-01795: maximum number of expressions in a list is 1000`.

For a good time, I recommend the ridiculousness of what I was attempting by looking at an interim query in the "much simpler query" commit.
