### PR TITLE
Add case insensitive rspec matcher

### DIFF
--- a/spec/support/matchers/case_insensitive_content.rb
+++ b/spec/support/matchers/case_insensitive_content.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :have_content_i do |expected|
+  match do |actual|
+    actual.text =~ /#{Regexp.quote expected}/i
+  end
+
+  failure_message do |actual|
+     "expected to find text #{expected.inspect} (case ignored) in #{actual.text.inspect}"
+  end
+
+  failure_message_when_negated do |actual|
+    "expected to not to find text #{expected.inspect} (case ignored) in #{actual.text.inspect}"
+  end
+end

--- a/spec/system/placing_an_order_on_behalf_of_spec.rb
+++ b/spec/system/placing_an_order_on_behalf_of_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Placing an item order" do
     expect(page).to have_css(".currency .estimated_cost", count: 0)
     expect(page).to have_css(".currency .actual_cost", count: 2) # Cost and Total
 
-    expect(page).to have_content("Ordered Date\n#{I18n.l(2.days.ago.to_date, format: :usa)}")
+    expect(page).to have_content_i("Ordered Date\n#{I18n.l(2.days.ago.to_date, format: :usa)}")
   end
 
   it "can set a reference ID" do


### PR DESCRIPTION
# Release Notes

Add case-insensitive RSpec matcher and change a test to use it.


# Additional Context

There is a test failing in the nucore-uconn fork due to case sensitivity in the `have_content` matcher. We have added a `text-transform: uppercase` that is causing the test `it "can backdate an order"` to fail in `spec/system/placing_an_order_on_behalf_of_spec.rb` on this line:

```
expect(page).to have_content("Ordered Date\n#{I18n.l(2.days.ago.to_date, format: :usa)}")
```

The test output is:

```
Failures:

  1) Placing an item order can backdate an order
     Failure/Error: expect(page).to have_content("Ordered Date\n#{I18n.l(2.days.ago.to_date, format: :usa)}")
       expected to find text "Ordered Date\n09/09/2020" in "You are ordering for User Last3 (username3)\nExit\nCIDER\nMy Orders » Order Receipt\nOrder Receipt\nWarning: you are on staging!\nThank you for your order.\nFACILITY\nFacilityAAAAAAAB (FA2)\nPAYMENT SOURCE\nnufs account aaaaaaab / 999-0000001\nORDERED DATE\n09/09/2020 9:30 AM\nORDERED FOR\nUser Last3\nORDERED BY\nUser Last4\nOrder #\n366-184\nQuantity\n1\nProduct\nProduct 2\nCost\n$33.25\nTotal\n$33.25\nTotal\n$33.25\nOrange amounts are estimates. Green amounts are final. Pricing will soon be assigned to completed transactions with unassigned amounts.\n© Copyright 2018–2020 University of Connecticut". (However, it was found 1 time using a case insensitive search.)
```

To fix this test in a way that works for both nucore-uconn and nucore-open, I would like to add a custom matcher: `have_content_i` which is a case-insensitive version of `have_content`. This should ensure the test passes on both forks while still still covering the same functionality.

This PR would change only this one test case to use the new matcher, but it will be available if there is a similar scenario in other tests in the future.
