### PR TITLE
[#152869] Log payment source suspension

### DIFF
--- a/app/controllers/account_suspend_actions.rb
+++ b/app/controllers/account_suspend_actions.rb
@@ -6,6 +6,7 @@ module AccountSuspendActions
   def suspend
     if @account.suspend
       flash[:notice] = I18n.t("controllers.facility_accounts.suspend.success")
+      LogEvent.log(@account, :suspended, current_user)
     else
       flash[:alert] = I18n.t("controllers.facility_accounts.suspend.failure")
     end
@@ -17,6 +18,7 @@ module AccountSuspendActions
   def unsuspend
     if @account.unsuspend
       flash[:notice] = I18n.t("controllers.facility_accounts.unsuspend.success")
+      LogEvent.log(@account, :unsuspended, current_user)
     else
       flash[:alert] = I18n.t("controllers.facility_accounts.unsuspend.failure", errors: @account.errors.full_messages.join("\n"))
     end

--- a/app/services/log_event_searcher.rb
+++ b/app/services/log_event_searcher.rb
@@ -4,7 +4,7 @@ class LogEventSearcher
 
   ALLOWED_EVENTS = ["account.create", "account.update",
                     "account_user.create", "account_user.delete",
-                    "user.create"].freeze
+                    "user.create", "account.suspended", "account.unsuspended"].freeze
 
   def self.beginning_of_time
     10.years.ago

--- a/config/locales/views/admin/en.log_events.yml
+++ b/config/locales/views/admin/en.log_events.yml
@@ -5,6 +5,8 @@ en:
         account:
           create: Payment Source created
           update: Payment Source updated
+          suspended: Payment Source suspended
+          unsuspended: Payment Source unsuspended
         account_user:
           create: Payment Source User added
           delete: Payment Source User removed

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe AccountsController do
         expect(assigns(:account)).to eq(@account)
         is_expected.to set_flash
         expect(@account.reload).to be_suspended
+        expect(LogEvent.find_by(loggable: @account, event_type: :suspended, user: admin)).to be_present
         assert_redirected_to account_path(@account)
       end
     end
@@ -123,6 +124,7 @@ RSpec.describe AccountsController do
         expect(assigns(:account)).to eq(@account)
         is_expected.to set_flash
         expect(assigns(:account)).not_to be_suspended
+        expect(LogEvent.find_by(loggable: @account, event_type: :unsuspended, user: admin)).to be_present
         assert_redirected_to account_path(@account)
       end
     end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -104,8 +104,15 @@ RSpec.describe AccountsController do
         expect(assigns(:account)).to eq(@account)
         is_expected.to set_flash
         expect(@account.reload).to be_suspended
-        expect(LogEvent.find_by(loggable: @account, event_type: :suspended, user: admin)).to be_present
         assert_redirected_to account_path(@account)
+      end
+
+      it "logs the account when it gets suspended" do
+        admin = create(:user, :administrator)
+        sign_in admin
+        do_request
+        log_event = LogEvent.find_by(loggable: @account, event_type: :suspended, user: admin)
+        expect(log_event).to be_present
       end
     end
 
@@ -124,8 +131,15 @@ RSpec.describe AccountsController do
         expect(assigns(:account)).to eq(@account)
         is_expected.to set_flash
         expect(assigns(:account)).not_to be_suspended
-        expect(LogEvent.find_by(loggable: @account, event_type: :unsuspended, user: admin)).to be_present
         assert_redirected_to account_path(@account)
+      end
+
+      it "logs the account when it gets unsuspended" do
+        admin = create(:user, :administrator)
+        sign_in admin
+        do_request
+        log_event = LogEvent.find_by(loggable: @account, event_type: :unsuspended, user: admin)
+        expect(log_event).to be_present
       end
     end
   end


### PR DESCRIPTION
# Release Notes

Log the following event: Who/when some suspends/un-suspends a payment source
