### PR TITLE
[#152869] Preload associations in log event view

### DIFF
--- a/app/controllers/log_events_controller.rb
+++ b/app/controllers/log_events_controller.rb
@@ -8,7 +8,7 @@ class LogEventsController < GlobalSettingsController
       end_date: parse_usa_date(params[:end_date]),
       events: params[:events],
       query: params[:query],
-    ).reverse_chronological.paginate(per_page: 50, page: params[:page])
+    ).includes(:user, :loggable).reverse_chronological.paginate(per_page: 50, page: params[:page])
   end
 
 end


### PR DESCRIPTION
# Release Notes

Tech task: preload event log associations.

# Additional Context

This is a very minor performance enhancement. It doesn't help with any associations beyond the loggable (e.g. statement->facility or AccountUser->Account), but it helps with the initial associations.
