### PR TITLE
[#153141] Fix orders missing ordered at

### DIFF
--- a/app/forms/add_to_order_form.rb
+++ b/app/forms/add_to_order_form.rb
@@ -147,7 +147,7 @@ class AddToOrderForm
     return @merge_order if defined?(@merge_order)
 
     products = product.is_a?(Bundle) ? product.products : [product]
-    @merge_order = if products.any?(&:mergeable?)
+    @merge_order = if products.any?(&:requires_merge?)
                      Order.create!(
                        merge_with_order_id: original_order.id,
                        facility_id: original_order.facility_id,

--- a/app/forms/add_to_order_form.rb
+++ b/app/forms/add_to_order_form.rb
@@ -165,7 +165,10 @@ class AddToOrderForm
     # `manual_fulfilled_at` already handles the proper string parsing so we can use
     # it instead of duplicating the parsing effort.
     order_detail.manual_fulfilled_at = fulfilled_at
-    if order_detail.valid_for_purchase?
+    # If we are a merge order (i.e. requires more action like uploading an order form),
+    # we do not want to set the ordered_at just yet. It will be set after the issues have
+    # been resolved.
+    if merge_order == original_order
       order_detail.ordered_at = order_detail.manual_fulfilled_at_time || Time.current
     end
   end

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -64,7 +64,7 @@ class Instrument < Product
     days = price_group_products.collect(&:reservation_window).max.to_i
   end
 
-  def mergeable?
+  def requires_merge?
     true
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -277,7 +277,7 @@ class Product < ApplicationRecord
     !hidden?
   end
 
-  def mergeable?
+  def requires_merge?
     false
   end
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -26,7 +26,7 @@ class Service < Product
     stored_files.template.count > 0
   end
 
-  def mergeable?
+  def requires_merge?
     active_survey? || active_template?
   end
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -555,23 +555,23 @@ RSpec.describe Product do
     end
   end
 
-  describe "#mergeable?" do
+  describe "#requires_merge?" do
     context "when it's a Bundle" do
       subject { FactoryBot.build(:bundle) }
 
-      it { is_expected.not_to be_mergeable }
+      it { is_expected.not_to be_requires_merge }
     end
 
     context "when it's an Item" do
       subject { FactoryBot.build(:item) }
 
-      it { is_expected.not_to be_mergeable }
+      it { is_expected.not_to be_requires_merge }
     end
 
     context "when it's an Instrument" do
       subject { FactoryBot.build(:instrument) }
 
-      it { is_expected.to be_mergeable }
+      it { is_expected.to be_requires_merge }
     end
 
     context "when it's a Service" do
@@ -583,13 +583,13 @@ RSpec.describe Product do
         context "with an active template" do
           before { allow(subject).to receive(:active_template?).and_return(true) }
 
-          it { is_expected.to be_mergeable }
+          it { is_expected.to be_requires_merge }
         end
 
         context "without an active template" do
           before { allow(subject).to receive(:active_template?).and_return(false) }
 
-          it { is_expected.to be_mergeable }
+          it { is_expected.to be_requires_merge }
         end
       end
 
@@ -599,13 +599,13 @@ RSpec.describe Product do
         context "with an active template" do
           before { allow(subject).to receive(:active_template?).and_return(true) }
 
-          it { is_expected.to be_mergeable }
+          it { is_expected.to be_requires_merge }
         end
 
         context "without an active template" do
           before { allow(subject).to receive(:active_template?).and_return(false) }
 
-          it { is_expected.not_to be_mergeable }
+          it { is_expected.not_to be_requires_merge }
         end
       end
     end

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -82,6 +82,18 @@ RSpec.describe "Adding to an existing order" do
         end
       end
     end
+
+    describe "and it does not have pricing set up yet" do
+      let(:product) { super().tap { |p| p.price_policies.destroy_all } }
+
+      it "gets purchased with an ordered_at" do
+        click_button "Add To Order"
+        expect(order.reload.order_details.count).to eq(2)
+        new_order_detail = order.order_details.order(:id).last
+
+        expect(new_order_detail.ordered_at).to be_present
+      end
+    end
   end
 
   describe "adding a backdated service with an order form" do


### PR DESCRIPTION
# Release Notes

Fix issue where order details added to an existing order could be missing `ordered_at`.

# Additional Context

When adding to an existing order, if there was something to make it invalid for purchase the `ordered_at` field was not being set.

The simplest way to reproduce:
* Set up a new item or service
* Do not add any pricing
* Add the new product to an existing order. 
* It doesn't matter if you set the status to new or complete, it ends up missing the ordered_at. Fulfilled date does get set if you set it to complete.

Another way (very unlikely to actually happen in practice):
* Load the order page
* Open another tab and archive a product
* Go back to the first tab and add the archived product to the existing order. 
* No ordered_at 

We exclude archived products from the dropdown so in practice this shouldn't happen.

You could probably have the same multi-tab issue with account suspension, but once again we limit the options so this is very unlikely to actually happen.

