### PR TITLE
Fix sporadic test failure

### DIFF
--- a/app/models/budgeted_chart_string.rb
+++ b/app/models/budgeted_chart_string.rb
@@ -2,7 +2,7 @@
 
 class BudgetedChartString < ApplicationRecord
 
-  include NUCore::Database::DateHelper
+  include Nucore::Database::DateHelper
 
   validates_presence_of :fund, :dept, :starts_at, :expires_at
   validates_length_of   :fund, is: 3

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -38,7 +38,8 @@ class Instrument < Product
   # Callbacks
   # --------
 
-  after_create :set_default_pricing
+  # Triggered by Product
+  # after_create :create_default_price_group_products
 
   # Scopes
   # --------
@@ -68,9 +69,12 @@ class Instrument < Product
     true
   end
 
-  def set_default_pricing
-    PriceGroup.globals.find_each do |pg|
-      PriceGroupProduct.create!(product: self, price_group: pg, reservation_window: PriceGroupProduct::DEFAULT_RESERVATION_WINDOW)
+  def create_default_price_group_products
+    PriceGroup.globals.find_each do |price_group|
+      price_group_products.create!(
+        price_group: price_group,
+        reservation_window: PriceGroupProduct::DEFAULT_RESERVATION_WINDOW
+      )
     end
   end
 

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -2,7 +2,7 @@
 
 class PricePolicy < ApplicationRecord
 
-  include NUCore::Database::DateHelper
+  include Nucore::Database::DateHelper
 
   belongs_to :price_group
   belongs_to :product

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -23,6 +23,8 @@ class Product < ApplicationRecord
   has_one :product_display_group_product
   has_one :product_display_group, through: :product_display_group_product
 
+  after_create :create_default_price_group_products
+
   email_list_attribute :training_request_contacts
 
   # Allow us to use `product.hidden?`
@@ -113,9 +115,6 @@ class Product < ApplicationRecord
     order(:type, :name).group_by { |product| product.class.model_name.human }
   end
 
-  ## AR Hooks
-  after_create :set_default_pricing
-
   def initial_order_status
     self[:initial_order_status_id] ? OrderStatus.find(self[:initial_order_status_id]) : OrderStatus.default_order_status
   end
@@ -184,9 +183,9 @@ class Product < ApplicationRecord
     to_s + (is_archived? ? " (inactive)" : "")
   end
 
-  def set_default_pricing
-    PriceGroup.globals.find_each do |pg|
-      PriceGroupProduct.create!(product: self, price_group: pg)
+  def create_default_price_group_products
+    PriceGroup.globals.find_each do |price_group|
+      price_group_products.create!(price_group: price_group)
     end
   end
 

--- a/spec/lib/nucore/database/date_helper_spec.rb
+++ b/spec/lib/nucore/database/date_helper_spec.rb
@@ -2,10 +2,10 @@
 
 require "rails_helper"
 
-RSpec.describe NUCore::Database::DateHelper do
+RSpec.describe Nucore::Database::DateHelper do
   class DateHelperClass
 
-    include NUCore::Database::DateHelper
+    include Nucore::Database::DateHelper
 
   end
 

--- a/spec/models/full_text_search/mysql_searcher_spec.rb
+++ b/spec/models/full_text_search/mysql_searcher_spec.rb
@@ -1,8 +1,10 @@
 require "rails_helper"
 
 RSpec.describe FullTextSearch::MysqlSearcher, if: Nucore::Database.mysql? do
+  # We can't do this in a `before(:each)` block because the full text search index only
+  # gets updated on commit and we're using transactions. Do not use factories to
+  # ensure we don't end up with any zombie associations.
   before(:context) do
-    # Do not use factories to ensure we don't end up with any zombie associations
     facility = Facility.new(name: "name", abbreviation: "EF", url_name: "facility", is_active: true, short_description: "abc", journal_mask: "C01")
     facility.save(validate: false)
     item = Item.new(url_name: "lsc-andor", name: "LSC Andor Spinning Disk", facility: facility)
@@ -12,6 +14,7 @@ RSpec.describe FullTextSearch::MysqlSearcher, if: Nucore::Database.mysql? do
   after(:context) do
     Item.delete_all
     Facility.delete_all
+    PriceGroupProduct.delete_all # these get created by an after_create callback on Products
   end
 
   let(:facility) { Facility.find_by(url_name: "facility") }

--- a/spec/models/full_text_search/oracle_searcher_spec.rb
+++ b/spec/models/full_text_search/oracle_searcher_spec.rb
@@ -1,8 +1,10 @@
 require "rails_helper"
 
 RSpec.describe FullTextSearch::OracleSearcher, if: Nucore::Database.oracle? do
+  # We can't do this in a `before(:each)` block because the full text search index only
+  # gets updated on commit and we're using transactions. Do not use factories to
+  # ensure we don't end up with any zombie associations.
   before(:context) do
-    # Do not use factories to ensure we don't end up with any zombie associations
     facility = Facility.new(name: "name", abbreviation: "EF", url_name: "facility", is_active: true, short_description: "abc", journal_mask: "C01")
     facility.save(validate: false)
     item = Item.new(url_name: "lsc-andor", name: "LSC Andor Spinning Disk", facility: facility)
@@ -12,6 +14,7 @@ RSpec.describe FullTextSearch::OracleSearcher, if: Nucore::Database.oracle? do
   after(:context) do
     Item.delete_all
     Facility.delete_all
+    PriceGroupProduct.delete_all # these get created by an after_create callback on Products
   end
 
   let(:facility) { Facility.find_by(url_name: "facility") }

--- a/vendor/engines/sanger_sequencing/spec/controllers/sanger_sequencing/submissions_controller_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/controllers/sanger_sequencing/submissions_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SangerSequencing::SubmissionsController do
       before { sign_in user }
       it "has access" do
         get :edit, params: { id: submission.id }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
 

--- a/vendor/engines/secure_rooms/spec/controllers/facility_orders_controller_spec.rb
+++ b/vendor/engines/secure_rooms/spec/controllers/facility_orders_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe FacilityOrdersController do
     before { get :index, params: { facility_id: facility } }
 
     it "does not include the occupancies" do
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(assigns(:order_details)).to eq([])
     end
   end


### PR DESCRIPTION
# Release Notes

Tech task: Fix sporadic test failure.

# Additional Context

The mysql/oracle full text searcher spec was not cleaning up after itself properly. When I wrote those tests I didn't realize that `PriceGroupProduct`s were being created in an `after_create` hook on the product so there were a couple of those that were being left in the database after the spec ran.

I was able to consistently reproduce the failures with

```
bundle exec rspec  spec/models/full_text_search/mysql_searcher_spec.rb spec/controllers/price_group_products_controller_spec.rb --order defined
```

```
Failure/Error: expect(PriceGroupProduct.count).to eq(PriceGroup.count)

  expected: 3
       got: 7

  (compared using ==)
./spec/controllers/price_group_products_controller_spec.rb:47:in `block (3 levels) in <top (required)>'
./spec/controller_spec_helper.rb:158:in `instance_exec'
./spec/controller_spec_helper.rb:158:in `block in it_should_allow_managers_only'
./spec/controller_spec_helper.rb:114:in `instance_exec'
./spec/controller_spec_helper.rb:114:in `block (2 levels) in it_should_allow_all'
```

To be honest, I'm not sure if we ever use the `PriceGroupProduct`s on non-instruments and considered removing the callback from `Product` and only leaving it in `Instrument`, but that felt like a larger behavior change I didn't want to make.

This also does a little additional cleanup.