### PR TITLE
[#152892] Fix oracle query for event logs

### DIFF
--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -53,7 +53,7 @@ class Statement < ApplicationRecord
   end
 
   def self.where_invoice_number(query)
-    return nil unless /\A(?<account_id>\d+)-(?<id>\d+)\z/ =~ query
+    return none unless /\A(?<account_id>\d+)-(?<id>\d+)\z/ =~ query
     where(id: id, account_id: account_id)
   end
 

--- a/app/services/log_event_searcher.rb
+++ b/app/services/log_event_searcher.rb
@@ -59,7 +59,7 @@ class LogEventSearcher
     users = UserFinder.search(query).unscope(:order)
     account_users = AccountUser.where(account_id: accounts).or(AccountUser.where(user_id: users))
     journals = Journal.where(id: query)
-    statements = Statement.where_invoice_number(query)
+    statements = Statement.where_invoice_number(query).unscope(:order)
     facilities = Facility.name_query(query)
     user_roles = UserRole.with_deleted.where(user_id: users).or(UserRole.with_deleted.where(facility_id: facilities))
     order_details = OrderDetail.where_order_number(query)


### PR DESCRIPTION
# Release Notes

Fix Oracle error on statement search of LogEvents.

The default scope on statements was messing up oracle. Didn't seem to be an issue on mysql.