### PR TITLE
Tech task: Update version lock in capistrano deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lock "~> 3.12.0"
+lock "~> 3.13.0"
 
 set :application, "nucore"
 set :eye_config, "config/eye.yml.erb"


### PR DESCRIPTION
# Release Notes

Tech task: Update version lock in capistrano deploy. This was preventing automated deployment of open to the TXI stage and likely would have caused deployment failures downstream.

# Additional Context

See: https://circleci.com/gh/tablexi/nucore-open/8725
