### PR TITLE
Fix demo:seed after multi-facility accounts

### DIFF
--- a/lib/tasks/demo_seed.rake
+++ b/lib/tasks/demo_seed.rake
@@ -423,7 +423,7 @@ namespace :demo do
                                               created_by: user_director.id,
                                               affiliate_id: other_affiliate.id,
                                               affiliate_other: "Some Affiliate",
-                                              facility_id: facility.id,
+                                              facilities: [facility],
                                               account_users_attributes: account_users_attributes)
       end
 
@@ -434,7 +434,7 @@ namespace :demo do
                                                  description: "Paul PI's Purchase Order",
                                                  expires_at: Time.zone.now + 1.year,
                                                  created_by: user_director.id,
-                                                 facility_id: facility.id,
+                                                 facilities: [facility],
                                                  affiliate_id: other_affiliate.id,
                                                  affiliate_other: "Some Affiliate",
                                                  remittance_information: "Billing Dept\nEdward External\n1702 E Research Dr\nAuburn, AL 36830",


### PR DESCRIPTION
# Release Notes

Tech task: Fix for demo seeds broken by moving from single facility accounts to multi-facility accounts. 

# Additional Context

Likely broken since we merged in #1841.