### PR TITLE
[#153460] Fix error on journal creation with split account

### DIFF
--- a/app/models/journal_row.rb
+++ b/app/models/journal_row.rb
@@ -3,7 +3,7 @@
 class JournalRow < ApplicationRecord
 
   belongs_to :journal
-  belongs_to :order_detail
+  belongs_to :order_detail, autosave: false
 
   validates_presence_of :journal_id, :amount
   # Note this is NOT a belongs_to :account. This is an expense account field.

--- a/vendor/engines/split_accounts/app/services/split_accounts/order_detail_splitter.rb
+++ b/vendor/engines/split_accounts/app/services/split_accounts/order_detail_splitter.rb
@@ -84,6 +84,7 @@ module SplitAccounts
       # N+1s because the "fake" order detail will not think it needs to hit the DB.
       copy_associations(split_order_detail)
 
+      split_order_detail.readonly! # Don't accidentally try to write something to the database
       split_order_detail
     end
 

--- a/vendor/engines/split_accounts/spec/services/order_detail_splitter_spec.rb
+++ b/vendor/engines/split_accounts/spec/services/order_detail_splitter_spec.rb
@@ -173,7 +173,9 @@ RSpec.describe SplitAccounts::OrderDetailSplitter, type: :service do
 
     it "does not do anything to the reservation" do
       order_detail.update_attributes!(account: split_account)
-      described_class.new(order_detail, split_time_data: true).split
+      expect {
+        described_class.new(order_detail, split_time_data: true).split
+      }.not_to change(Reservation, :count)
       expect(reservation.reload).to be_persisted
     end
   end


### PR DESCRIPTION
# Release Notes

Fixes an error when creating a journal containing a split account.

# Additional Context

The error is: `Mysql2::Error: Duplicate entry '148655' for key 'PRIMARY'`

This came up at Dartmouth. I was able to reproduce it in open, but struggled to generate a test case that failed. It seemed to be happening when the purchaser of the order detail was a member of all of the subaccounts (this may be coincidental).

What is happening is for split accounts, when you create a journal we generate virtual order details containing the split data (which account, cost, etc). We then generate a journal row for each of these virtual order details. In some cases, when we are saving the journal row to the database, Rails is also trying to auto-save the virtual order detail. Since the virtual order detail has the same ID as the actual order detail, we are unable to save it because of the duplicate ID.

This autosaving does not happen all the time. And we've never seen this error at NU. So it's not clear what triggers the autosave.

As I said, I was unable to write a test case that triggers the error, but the fix worked in my testing in the dev environment.