### PR TITLE
Fix Oracle error test involving metadata

### DIFF
--- a/spec/controllers/offline_reservations_controller_spec.rb
+++ b/spec/controllers/offline_reservations_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe OfflineReservationsController do
         post :create, params: params
         log_event = LogEvent.find_by(loggable: reservation.order_detail, event_type: :problem_queue)
         expect(log_event).to be_present
-        expect(log_event.metadata).to eq({"cause"=>"new_offline_reservation"})
+        expect(log_event.metadata).to eq("cause"=>"new_offline_reservation")
       end
 
       it "triggers an email" do

--- a/spec/controllers/offline_reservations_controller_spec.rb
+++ b/spec/controllers/offline_reservations_controller_spec.rb
@@ -43,8 +43,9 @@ RSpec.describe OfflineReservationsController do
 
       it "logs the problem reservation" do
         post :create, params: params
-        log_event = LogEvent.find_by(loggable: reservation.order_detail, event_type: :problem_queue, metadata: {"cause"=>"new_offline_reservation"})
+        log_event = LogEvent.find_by(loggable: reservation.order_detail, event_type: :problem_queue)
         expect(log_event).to be_present
+        expect(log_event.metadata).to eq({"cause"=>"new_offline_reservation"})
       end
 
       it "triggers an email" do

--- a/spec/services/auto_expire_reservation_spec.rb
+++ b/spec/services/auto_expire_reservation_spec.rb
@@ -32,8 +32,9 @@ RSpec.describe AutoExpireReservation, :time_travel do
 
       it "logs the problem reservation" do
         action.perform
-        log_event = LogEvent.find_by(loggable: reservation.order_detail, event_type: :problem_queue, metadata: {"cause"=>"auto_expire"})
+        log_event = LogEvent.find_by(loggable: reservation.order_detail, event_type: :problem_queue)
         expect(log_event).to be_present
+        expect(log_event.metadata).to eq({"cause"=>"auto_expire"})
       end
 
       it "does not assign pricing" do

--- a/spec/services/auto_expire_reservation_spec.rb
+++ b/spec/services/auto_expire_reservation_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe AutoExpireReservation, :time_travel do
         action.perform
         log_event = LogEvent.find_by(loggable: reservation.order_detail, event_type: :problem_queue)
         expect(log_event).to be_present
-        expect(log_event.metadata).to eq({"cause"=>"auto_expire"})
+        expect(log_event.metadata).to eq("cause"=>"auto_expire")
       end
 
       it "does not assign pricing" do


### PR DESCRIPTION
# Release Notes

Fix error involving metadata in WHERE clause in tests. 

# Additional Context
In Oracle, we can't put a CLOB in the WHERE clause. Because Large objects (LOBs) are not supported in comparison conditions.
