### PR TITLE
[#152869] Log resolve order problem queue

### DIFF
--- a/app/controllers/problem_reservations_controller.rb
+++ b/app/controllers/problem_reservations_controller.rb
@@ -22,7 +22,6 @@ class ProblemReservationsController < ApplicationController
       else
         redirect_to reservations_status_path(status: "all"), notice: text("update.success")
       end
-      LogEvent.log(@order_detail, :resolve_from_problem_queue, current_user)
     else
       render :edit
     end

--- a/app/controllers/problem_reservations_controller.rb
+++ b/app/controllers/problem_reservations_controller.rb
@@ -22,6 +22,7 @@ class ProblemReservationsController < ApplicationController
       else
         redirect_to reservations_status_path(status: "all"), notice: text("update.success")
       end
+      LogEvent.log(@order_detail, :resolve_from_problem_queue, current_user)
     else
       render :edit
     end

--- a/app/services/log_event_searcher.rb
+++ b/app/services/log_event_searcher.rb
@@ -11,6 +11,7 @@ class LogEventSearcher
                     "order_detail.dispute", "order_detail.resolve",
                     "order_detail.notify", "order_detail.review",
                     "order_detail.problem_queue", "order_detail.price_change",
+                    "order_detail.resolve_from_problem_queue",
                     ].freeze
 
   def self.beginning_of_time

--- a/app/services/problem_reservation_resolver.rb
+++ b/app/services/problem_reservation_resolver.rb
@@ -22,6 +22,7 @@ class ProblemReservationResolver
     # The changes we made above won't trigger an automatic repricing, so we need to
     # do it manually.
     order_detail.assign_price_policy
+    LogEvent.log(order_detail, :resolve_from_problem_queue, params[:current_user])
     reservation.save
   end
 

--- a/app/services/problem_reservation_resolver.rb
+++ b/app/services/problem_reservation_resolver.rb
@@ -22,6 +22,7 @@ class ProblemReservationResolver
     # The changes we made above won't trigger an automatic repricing, so we need to
     # do it manually.
     order_detail.assign_price_policy
+    LogEvent.log(order_detail, :resolve_from_problem_queue, :current_user)
     reservation.save
   end
 

--- a/app/services/problem_reservation_resolver.rb
+++ b/app/services/problem_reservation_resolver.rb
@@ -22,7 +22,6 @@ class ProblemReservationResolver
     # The changes we made above won't trigger an automatic repricing, so we need to
     # do it manually.
     order_detail.assign_price_policy
-    LogEvent.log(order_detail, :resolve_from_problem_queue, :current_user)
     reservation.save
   end
 

--- a/config/locales/views/admin/en.log_events.yml
+++ b/config/locales/views/admin/en.log_events.yml
@@ -21,6 +21,7 @@ en:
           review: Order reviewed
           problem_queue: Order added to problem queue %{cause}
           price_change: Order's price was manually change
+          resolve_from_problem_queue: Order remove from problem queue
         end_date: End Date
         event_filter: Event
         event_placeholder: Filter on one or more events

--- a/config/locales/views/admin/en.log_events.yml
+++ b/config/locales/views/admin/en.log_events.yml
@@ -20,8 +20,8 @@ en:
           notify: Billing notified
           review: Order reviewed
           problem_queue: Order added to problem queue %{cause}
-          price_change: Order's price was manually change
-          resolve_from_problem_queue: Order remove from problem queue
+          price_change: Order's price was manually changed
+          resolve_from_problem_queue: Problem order resolved
         end_date: End Date
         event_filter: Event
         event_placeholder: Filter on one or more events

--- a/spec/services/problem_reservation_resolver_spec.rb
+++ b/spec/services/problem_reservation_resolver_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ProblemReservationResolver do
   before { MoveToProblemQueue.move!(problem_reservation.order_detail, cause: :reservation_started) }
 
   describe "resolve" do
-    it "sets the problem resolution attributes" do
+    it "sets the problem resolution attributes and log the resolution" do
       resolver.resolve(actual_end_at: 15.minutes.ago, current_user: user)
 
       expect(problem_reservation.order_detail.reload).to have_attributes(
@@ -28,6 +28,8 @@ RSpec.describe ProblemReservationResolver do
         problem_resolved_at: be_present,
         problem_resolved_by: user,
       )
+      log_event = LogEvent.find_by(loggable: problem_reservation.order_detail, event_type: :resolve_from_problem_queue)
+      expect(log_event).to be_present
     end
 
     it "moves the fulfilled_at to the actual_end_at" do

--- a/spec/services/problem_reservation_resolver_spec.rb
+++ b/spec/services/problem_reservation_resolver_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ProblemReservationResolver do
         problem_resolved_at: be_present,
         problem_resolved_by: user,
       )
-      log_event = LogEvent.find_by(loggable: problem_reservation.order_detail, event_type: :resolve_from_problem_queue)
+      log_event = LogEvent.find_by(loggable: problem_reservation.order_detail, event_type: :resolve_from_problem_queue, user: user)
       expect(log_event).to be_present
     end
 


### PR DESCRIPTION
# Release Notes

Log the following event: Who/when someone resolves an order in the problem queue


# Additional Context

We are only logging when a user resolves the problem, and we are not logging or tracking when a facility resolves the problem 
