### PR TITLE
[#152604] Prevent abandoned reservation carts

### DIFF
--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -23,12 +23,10 @@ class InstrumentsController < ProductsCommonController
   # GET /facilities/:facility_id/instruments/:instrument_id
   def show
     instrument_for_cart = InstrumentForCart.new(@product)
-    if instrument_for_cart.purchasable_by?(acting_user, session_user)
+    # TODO: Remove this instance variable-not used anywhere but tests
+    @add_to_cart = instrument_for_cart.purchasable_by?(acting_user, session_user)
+    if @add_to_cart
       redirect_to new_facility_instrument_single_reservation_path(current_facility, @product)
-      # redirect_to add_order_path(
-      #   acting_user.cart(session_user),
-      #   order: { order_details: [{ product_id: @product.id, quantity: 1 }] },
-      # )
     elsif instrument_for_cart.error_path
       redirect_to instrument_for_cart.error_path, notice: instrument_for_cart.error_message
     else

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -23,12 +23,12 @@ class InstrumentsController < ProductsCommonController
   # GET /facilities/:facility_id/instruments/:instrument_id
   def show
     instrument_for_cart = InstrumentForCart.new(@product)
-    @add_to_cart = instrument_for_cart.purchasable_by?(acting_user, session_user)
-    if @add_to_cart
-      redirect_to add_order_path(
-        acting_user.cart(session_user),
-        order: { order_details: [{ product_id: @product.id, quantity: 1 }] },
-      )
+    if instrument_for_cart.purchasable_by?(acting_user, session_user)
+      redirect_to new_facility_instrument_single_reservation_path(current_facility, @product)
+      # redirect_to add_order_path(
+      #   acting_user.cart(session_user),
+      #   order: { order_details: [{ product_id: @product.id, quantity: 1 }] },
+      # )
     elsif instrument_for_cart.error_path
       redirect_to instrument_for_cart.error_path, notice: instrument_for_cart.error_message
     else

--- a/app/controllers/single_reservations_controller.rb
+++ b/app/controllers/single_reservations_controller.rb
@@ -1,0 +1,82 @@
+class SingleReservationsController < ApplicationController
+
+  customer_tab  :all
+  before_action :authenticate_user!
+  load_resource :facility, find_by: :url_name
+  load_resource :instrument, through: :facility, find_by: :url_name
+  before_action :build_order
+  before_action { @submit_action = facility_instrument_single_reservations_path }
+
+  def new
+    options = current_user.can_override_restrictions?(@instrument) ? {} : { user: acting_user }
+    next_available = @instrument.next_available_reservation(after: 1.minute.from_now, duration: default_reservation_mins.minutes, options: options)
+    @reservation = next_available || default_reservation
+    @reservation.order_detail = @order_detail
+
+    authorize! :new, @reservation
+
+    @reservation.round_reservation_times
+    unless @instrument.can_be_used_by?(acting_user)
+      flash[:notice] = text(".acting_as_not_on_approval_list")
+    end
+    set_windows
+    render "reservations/new"
+  end
+
+  def create
+    creator = ReservationCreator.new(@order, @order_detail, params)
+    @reservation = creator.reservation
+    authorize! :create, @reservation
+    if creator.save(session_user)
+      flash[:notice] = I18n.t "controllers.reservations.create.success"
+      flash[:error] = I18n.t("controllers.reservations.create.admin_hold_warning") if creator.reservation.conflicting_admin_reservation?
+      redirect_to purchase_order_path(@order, params.permit(:send_notification))
+    else
+      flash.now[:error] = creator.error.html_safe
+      set_windows
+      render "reservations/new"
+    end
+  end
+
+  private
+
+  def ability_resource
+    @reservation
+  end
+
+  def build_order
+    @order = Order.new(user: current_user,
+                       facility: current_facility,
+                       created_by: session_user.id,
+                       )
+    @order_detail = @order.order_details.build(
+      product: @instrument,
+      quantity: 1,
+      created_by: session_user.id,
+    )
+  end
+
+  def default_reservation
+    Reservation.new(instrument: @instrument,
+                    reserve_start_at: Time.zone.now,
+                    reserve_end_at: default_reservation_mins.minutes.from_now)
+  end
+
+  def default_reservation_mins
+    @instrument.min_reserve_mins.to_i > 0 ? @instrument.min_reserve_mins : 30
+  end
+
+  def set_windows
+    @max_window = max_reservation_window
+    @max_days_ago = session_user.operator_of?(@facility) ? -365 : 0
+    # initialize calendar time constraints
+    @min_date     = (Time.zone.now + @max_days_ago.days).strftime("%Y%m%d")
+    @max_date     = (Time.zone.now + @max_window.days).strftime("%Y%m%d")
+  end
+
+  def max_reservation_window
+    return 365 if session_user.operator_of?(current_facility)
+    @reservation.longest_reservation_window(current_user.price_groups)
+  end
+
+end

--- a/app/controllers/single_reservations_controller.rb
+++ b/app/controllers/single_reservations_controller.rb
@@ -8,14 +8,11 @@ class SingleReservationsController < ApplicationController
   before_action { @submit_action = facility_instrument_single_reservations_path }
 
   def new
-    options = current_user.can_override_restrictions?(@instrument) ? {} : { user: acting_user }
-    next_available = @instrument.next_available_reservation(after: 1.minute.from_now, duration: default_reservation_mins.minutes, options: options)
-    @reservation = next_available || default_reservation
+    @reservation = NextAvailableReservationFinder.new(@instrument).next_available_for(current_user, acting_user)
     @reservation.order_detail = @order_detail
 
     authorize! :new, @reservation
 
-    @reservation.round_reservation_times
     unless @instrument.can_be_used_by?(acting_user)
       flash[:notice] = text(".acting_as_not_on_approval_list")
     end
@@ -58,27 +55,8 @@ class SingleReservationsController < ApplicationController
     )
   end
 
-  def default_reservation
-    Reservation.new(instrument: @instrument,
-                    reserve_start_at: Time.zone.now,
-                    reserve_end_at: default_reservation_mins.minutes.from_now)
-  end
-
-  def default_reservation_mins
-    @instrument.min_reserve_mins.to_i > 0 ? @instrument.min_reserve_mins : 30
-  end
-
   def set_windows
-    @max_window = max_reservation_window
-    @max_days_ago = session_user.operator_of?(@facility) ? -365 : 0
-    # initialize calendar time constraints
-    @min_date     = (Time.zone.now + @max_days_ago.days).strftime("%Y%m%d")
-    @max_date     = (Time.zone.now + @max_window.days).strftime("%Y%m%d")
-  end
-
-  def max_reservation_window
-    return 365 if session_user.operator_of?(current_facility)
-    @reservation.longest_reservation_window(current_user.price_groups)
+    @reservation_window = ReservationWindow.new(@reservation, current_user)
   end
 
 end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -44,7 +44,7 @@ class OrderDetail < ApplicationRecord
 
   after_save :update_billable_minutes_on_reservation, if: :reservation
 
-  belongs_to :product
+  belongs_to :product, required: true
   belongs_to :price_policy
   belongs_to :statement, inverse_of: :order_details
   belongs_to :journal
@@ -100,7 +100,7 @@ class OrderDetail < ApplicationRecord
     journal_date || statement_date
   end
 
-  validates_presence_of :product_id, :created_by
+  validates_presence_of :created_by
   validates_numericality_of :quantity, only_integer: true, greater_than_or_equal_to: 1
   validates_numericality_of :actual_cost, greater_than_or_equal_to: 0, if: ->(o) { o.actual_cost_changed? && !o.actual_cost.nil? }
   validates_numericality_of :actual_subsidy, greater_than_or_equal_to: 0, if: ->(o) { o.actual_subsidy_changed? && !o.actual_cost.nil? }

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -48,7 +48,7 @@ class OrderDetail < ApplicationRecord
   belongs_to :price_policy
   belongs_to :statement, inverse_of: :order_details
   belongs_to :journal
-  belongs_to :order, inverse_of: :order_details
+  belongs_to :order, inverse_of: :order_details, required: true
   belongs_to :assigned_user, class_name: "User", foreign_key: "assigned_user_id"
   belongs_to :created_by_user, class_name: "User", foreign_key: :created_by
   belongs_to :dispute_by, class_name: "User"
@@ -100,7 +100,7 @@ class OrderDetail < ApplicationRecord
     journal_date || statement_date
   end
 
-  validates_presence_of :product_id, :order_id, :created_by
+  validates_presence_of :product_id, :created_by
   validates_numericality_of :quantity, only_integer: true, greater_than_or_equal_to: 1
   validates_numericality_of :actual_cost, greater_than_or_equal_to: 0, if: ->(o) { o.actual_cost_changed? && !o.actual_cost.nil? }
   validates_numericality_of :actual_subsidy, greater_than_or_equal_to: 0, if: ->(o) { o.actual_subsidy_changed? && !o.actual_cost.nil? }

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -434,6 +434,11 @@ class OrderDetail < ApplicationRecord
     change_status! product.initial_order_status
   end
 
+  def valid_as_user?(user)
+    @being_purchased_by_admin = user.operator_of?(product.facility)
+    valid?
+  end
+
   def save_as_user(user)
     @being_purchased_by_admin = user.operator_of?(product.facility)
     save

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -44,7 +44,7 @@ class OrderDetail < ApplicationRecord
 
   after_save :update_billable_minutes_on_reservation, if: :reservation
 
-  belongs_to :product, required: true
+  belongs_to :product
   belongs_to :price_policy
   belongs_to :statement, inverse_of: :order_details
   belongs_to :journal
@@ -72,7 +72,7 @@ class OrderDetail < ApplicationRecord
   # allow access to the vestal data.
   # once that data is no longer needed, this line and the
   # associated class can be removed
-  has_many   :vestal_versions, as: :versioned
+  has_many :vestal_versions, as: :versioned
 
   delegate :edit_url, to: :external_service_receiver, allow_nil: true
   delegate :in_cart?, :facility, :user, to: :order
@@ -100,7 +100,7 @@ class OrderDetail < ApplicationRecord
     journal_date || statement_date
   end
 
-  validates_presence_of :created_by
+  validates_presence_of :product_id, :created_by
   validates_numericality_of :quantity, only_integer: true, greater_than_or_equal_to: 1
   validates_numericality_of :actual_cost, greater_than_or_equal_to: 0, if: ->(o) { o.actual_cost_changed? && !o.actual_cost.nil? }
   validates_numericality_of :actual_subsidy, greater_than_or_equal_to: 0, if: ->(o) { o.actual_subsidy_changed? && !o.actual_cost.nil? }

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -206,6 +206,16 @@ class Reservation < ApplicationRecord
     self.actual_end_at   ||= reserve_end_at
   end
 
+  def valid_as_user?(user)
+    if user.operator_of?(product.facility)
+      self.reserved_by_admin = true
+      valid?
+    else
+      self.reserved_by_admin = false
+      valid?(context: :user_purchase)
+    end
+  end
+
   def save_as_user(user)
     if user.operator_of?(product.facility)
       self.reserved_by_admin = true

--- a/app/services/move_to_problem_queue.rb
+++ b/app/services/move_to_problem_queue.rb
@@ -20,8 +20,8 @@ class MoveToProblemQueue
 
     @order_detail.time_data.force_completion = @force
     @order_detail.complete!
-    # TODO: Can probably remove this at some point, but it's a safety check for now
     LogEvent.log(@order_detail, :problem_queue, @user, metadata: {cause: @cause})
+    # TODO: Can probably remove this at some point, but it's a safety check for now
     raise "Trying to move Order ##{@order_detail} to problem queue, but it's not a problem" unless @order_detail.problem?
 
     if OrderDetails::ProblemResolutionPolicy.new(@order_detail).user_can_resolve?

--- a/app/services/next_available_reservation_finder.rb
+++ b/app/services/next_available_reservation_finder.rb
@@ -1,0 +1,30 @@
+# Used by the reservations controllers to find the default reservation times to display
+
+class NextAvailableReservationFinder
+  def initialize(product)
+    @product = product
+  end
+
+  def next_available_for(current_user, acting_user)
+    options = current_user.can_override_restrictions?(@product) ? {} : { user: acting_user }
+    next_available = @product.next_available_reservation(
+      after: 1.minute.from_now,
+      duration: default_reservation_mins.minutes,
+      options: options
+    )
+    next_available ||= default_reservation
+    next_available.round_reservation_times
+  end
+
+  private
+
+  def default_reservation
+    Reservation.new(instrument: @product,
+                    reserve_start_at: Time.current,
+                    reserve_end_at: default_reservation_mins.minutes.from_now)
+  end
+
+  def default_reservation_mins
+    @product.min_reserve_mins.to_i > 0 ? @product.min_reserve_mins : 30
+  end
+end

--- a/app/services/reservation_creator.rb
+++ b/app/services/reservation_creator.rb
@@ -51,7 +51,7 @@ class ReservationCreator
   end
 
   def reservation
-    return @reservation if @reservation
+    return @reservation if defined?(@reservation)
     @reservation = @order_detail.build_reservation
     @reservation.assign_attributes(reservation_create_params)
     @reservation.assign_times_from_params(reservation_create_params)

--- a/app/services/reservation_creator.rb
+++ b/app/services/reservation_creator.rb
@@ -70,10 +70,16 @@ class ReservationCreator
   end
 
   def update_order_account
-    if params[:order_account].present?
-      account = Account.find(params[:order_account].to_i)
-      @order.invalidate if @order.account.present? && account != @order.account
+    return if params[:order_account].blank?
+
+    account = Account.find(params[:order_account].to_i)
+    # If the account has changed, we need to re-do validations on the order. We're
+    # only saving the changes if the reservation is part of a cart. Otherwise, we
+    # just modify the object in-memory for redisplay.
+    if account != @order.account
+      @order.invalidate if @order.persisted?
       @order.account = account
+      @order.save! if @order.persisted?
     end
   end
 

--- a/app/services/reservation_window.rb
+++ b/app/services/reservation_window.rb
@@ -1,0 +1,29 @@
+class ReservationWindow
+  def initialize(reservation, user)
+    @reservation = reservation
+    @user = user
+  end
+
+  def max_window
+    return 365 if operator?
+    @reservation.longest_reservation_window(@reservation.user.price_groups)
+  end
+
+  def max_days_ago
+    operator? ? -365 : 0
+  end
+
+  def min_date
+    max_days_ago.days.from_now.strftime("%Y%m%d")
+  end
+
+  def max_date
+    max_window.days.from_now.strftime("%Y%m%d")
+  end
+
+  private
+
+  def operator?
+    @user.operator_of?(@reservation.facility)
+  end
+end

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -178,7 +178,9 @@ module Reservations::Validations
   end
 
   def in_the_future
-    errors.add(:reserve_start_at, :in_past) unless in_the_future?
+    if reserve_start_at_changed?
+      errors.add(:reserve_start_at, :in_past) unless in_the_future?
+    end
   end
 
   # checks that the reservation is within the longest window for the groups the user is in

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -178,9 +178,7 @@ module Reservations::Validations
   end
 
   def in_the_future
-    if reserve_start_at_changed?
-      errors.add(:reserve_start_at, :in_past) unless in_the_future?
-    end
+    errors.add(:reserve_start_at, :in_past) unless in_the_future?
   end
 
   # checks that the reservation is within the longest window for the groups the user is in

--- a/app/views/reservations/_js_variables.html.haml
+++ b/app/views/reservations/_js_variables.html.haml
@@ -1,9 +1,9 @@
 :javascript
   var events_path     = "#{facility_instrument_reservations_path(@instrument.facility, @instrument, format: 'js', with_details: @instrument.show_details?)}";
-  var minDate         = "#{@min_date}";
-  var maxDate         = "#{@max_date}";
-  var maxDaysFromNow  = #{@max_window};
-  var minDaysFromNow  = #{@max_days_ago};
+  var minDate         = "#{@reservation_window&.min_date}";
+  var maxDate         = "#{@reservation_window&.max_date}";
+  var maxDaysFromNow  = #{@reservation_window&.max_window};
+  var minDaysFromNow  = #{@reservation_window&.max_days_ago};
   var minTime         = #{@instrument.first_available_hour};
   var maxTime         = #{@instrument.last_available_hour+1};
   var isBundle        = #{@order_detail.bundled? || @order.order_details.count > 1};

--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -25,7 +25,6 @@
   %p.alert.alert-warning= text("instruments.schedule.instrument_alert_is_active", note: @instrument.alert.note)
 
 = render "products_common/description", product: @instrument
-
 = simple_form_for [@order, @order_detail, @reservation], html: { class: "js--reservationForm js--reservationUpdateCreateAndStart" }, url: @submit_action do |f|
   = f.error_messages
   = render "reservations/account_field", f: f unless @order_detail.bundled?

--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -1,7 +1,7 @@
 = content_for :head_content do
   = render "shared/headers/calendar"
   = javascript_include_tag "reservations.js"
-  = render "js_variables"
+  = render "reservations/js_variables"
 
 = content_for :breadcrumb do
   %ul.breadcrumb
@@ -26,10 +26,10 @@
 
 = render "products_common/description", product: @instrument
 
-= simple_form_for [@order, @order_detail, @reservation], html: { class: "js--reservationForm js--reservationUpdateCreateAndStart" } do |f|
+= simple_form_for [@order, @order_detail, @reservation], html: { class: "js--reservationForm js--reservationUpdateCreateAndStart" }, url: @submit_action do |f|
   = f.error_messages
-  = render "account_field", f: f unless @order_detail.bundled?
-  = render "reservation_fields", f: f
+  = render "reservations/account_field", f: f unless @order_detail.bundled?
+  = render "reservations/reservation_fields", f: f
 
   - if acting_as?
     .row
@@ -61,7 +61,7 @@
         = link_to t("shared.cancel"), facility_order_path(@instrument.facility, @order.merge_order)
       - elsif @order_detail.bundled?
         = link_to t("shared.cancel"), url_after_action
-      - else
+      - elsif @order.persisted?
         = link_to t("shared.cancel"),
           remove_order_path(@order, @order_detail, redirect_to: url_after_action),
           method: :put

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,8 @@ Rails.application.routes.draw do
       get :dashboard, to: "instruments_dashboard#dashboard", on: :collection
       get :public_dashboard, to: "instruments_dashboard#public_dashboard", on: :collection
 
+      resources :single_reservations, controller: "single_reservations", only: [:new, :create]
+
       collection do
         get "list", to: "instruments#public_list"
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,7 +83,7 @@ Rails.application.routes.draw do
       get :dashboard, to: "instruments_dashboard#dashboard", on: :collection
       get :public_dashboard, to: "instruments_dashboard#public_dashboard", on: :collection
 
-      resources :single_reservations, controller: "single_reservations", only: [:new, :create]
+      resources :single_reservations, only: [:new, :create]
 
       collection do
         get "list", to: "instruments#public_list"

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -108,12 +108,7 @@ RSpec.describe InstrumentsController do
 
         it "succeeds" do
           expect(flash).to be_empty
-          assert_redirected_to(
-            add_order_path(
-              Order.all.last,
-              order: { order_details: [product_id: instrument.id, quantity: 1] },
-            ),
-          )
+          assert_redirected_to new_facility_instrument_single_reservation_path(facility, instrument)
         end
       end
     end

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -683,25 +683,22 @@ RSpec.describe ReservationsController do
       expect(assigns[:order_detail]).to eq(@order_detail)
       expect(assigns[:instrument]).to eq(@instrument)
       expect(assigns(:reservation)).to be_kind_of Reservation
-      expect(assigns(:max_window)).to be_kind_of Integer
-
-      expect(assigns[:max_date]).to eq((Time.zone.now + assigns[:max_window].days).strftime("%Y%m%d"))
     end
 
     # Managers should be able to go far out into the future
     it_should_allow_all facility_operators do
-      expect(assigns[:max_window]).to eq(365)
-      expect(assigns[:max_days_ago]).to eq(-365)
-      expect(assigns[:min_date]).to eq((Time.zone.now + assigns[:max_days_ago].days).strftime("%Y%m%d"))
-      expect(assigns[:max_date]).to eq((Time.zone.now + 365.days).strftime("%Y%m%d"))
+      expect(assigns[:reservation_window].max_window).to eq(365)
+      expect(assigns[:reservation_window].max_days_ago).to eq(-365)
+      expect(assigns[:reservation_window].min_date).to eq((Time.zone.now - 365.days).strftime("%Y%m%d"))
+      expect(assigns[:reservation_window].max_date).to eq((Time.zone.now + 365.days).strftime("%Y%m%d"))
     end
 
     # guests should only be able to go the default reservation window into the future
     it_should_allow_all [:guest] do
-      expect(assigns[:max_window]).to eq(PriceGroupProduct::DEFAULT_RESERVATION_WINDOW)
-      expect(assigns[:max_days_ago]).to eq(0)
-      expect(assigns[:max_date]).to eq((Time.zone.now + PriceGroupProduct::DEFAULT_RESERVATION_WINDOW.days).strftime("%Y%m%d"))
-      expect(assigns[:min_date]).to eq(Time.zone.now.strftime("%Y%m%d"))
+      expect(assigns[:reservation_window].max_window).to eq(PriceGroupProduct::DEFAULT_RESERVATION_WINDOW)
+      expect(assigns[:reservation_window].max_days_ago).to eq(0)
+      expect(assigns[:reservation_window].max_date).to eq((Time.zone.now + PriceGroupProduct::DEFAULT_RESERVATION_WINDOW.days).strftime("%Y%m%d"))
+      expect(assigns[:reservation_window].min_date).to eq(Time.zone.now.strftime("%Y%m%d"))
     end
 
     it_behaves_like "it can handle having its order_detail removed"
@@ -831,7 +828,7 @@ RSpec.describe ReservationsController do
         pgp2 = FactoryBot.create(:price_group_product, product: @instrument, price_group: FactoryBot.create(:price_group, facility: @authable), reservation_window: 7)
         pgp3 = FactoryBot.create(:price_group_product, product: @instrument, price_group: FactoryBot.create(:price_group, facility: @authable), reservation_window: 21)
         do_request
-        expect(assigns(:max_window)).to eq(7)
+        expect(assigns(:reservation_window).max_window).to eq(7)
       end
     end
 

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe OrderDetail do
   end
 
   it "should have a product" do
-    is_expected.not_to allow_value(nil).for(:product)
+    is_expected.not_to allow_value(nil).for(:product_id)
   end
 
   it "should have an order" do

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -206,11 +206,11 @@ RSpec.describe OrderDetail do
   end
 
   it "should have a product" do
-    is_expected.not_to allow_value(nil).for(:product_id)
+    is_expected.not_to allow_value(nil).for(:product)
   end
 
   it "should have an order" do
-    is_expected.not_to allow_value(nil).for(:order_id)
+    is_expected.not_to allow_value(nil).for(:order)
   end
 
   it "should have a quantity of at least 1" do


### PR DESCRIPTION
# Release Notes

Prevent abandoned carts created when clicking an instrument name. This should also help prevent order/detail IDs from growing too fast.

# TODO

- [x] Refactor so there is less duplicated code between the old ReservationsController and the new controller
- [x]  Try to get rid of `@add_to_order` in the old controller
- [x] Further testing/QA

# Additional Context

Before, if you click an instrument, a new order and order detail are created. Users are often doing this to check the schedule for the instrument. If the user closes the tab comes back to the instrument, yet another order detail is created. We were deleting the cart if the user clicks "Cancel", but the order and order detail IDs were still eaten up.

Now, for normal single-reservation purchases, we go to a parallel controller where we do not create the order/detail prior to the user filling out the form. I did need to rework some of the code to avoid persisting and then rolling back the order/detail. Without these changes, the abandoned carts would not be created, but the IDs would still be used up.

For the order form (purchasing more than one or with other things) or part of a bundle, as well as edit/update, we are continuing to use the old controller.

Some offline discussion for context:

From Aaron:

> What we highly suspect is that users are clicking on the instrument links to check out the calendar, and then closing the tab. I assume that if a user clicks on an instrument name bringing them to a "Create Reservation" page, and then clicks "cancel" then this will not generate an abandoned cart? Clicking cancel from the one-off "Create Reservation" page generates the banner: "the product has been removed." I assume the Order Number has still been used up, but that this wouldn't create an "abandoned cart"?

Jason:

> You're right about the cancel button. I did a quick test: if you click "cancel" we do remove the order detail (so that number is used up), but we keep the order. That order gets re-used. So clicking an instrument creates, say, "100-100". Click cancel. Click the instrument again. You get "100-101". This won't count as an abandoned cart. However, if you click the browser's back button or close the tab, it leaves both of them hanging around. So "100-100", click on the instrument again, then you get "101-101". "100-100" is an abandoned cart.