### PR TITLE
Fix issue in Log event index dropdown

### DIFF
--- a/app/views/log_events/index.html.haml
+++ b/app/views/log_events/index.html.haml
@@ -20,7 +20,7 @@
   .row
     .span3
       = label_tag(text(:event_filter))
-      - option_list = LogEventSearcher::ALLOWED_EVENTS.map { |event| [text(event), event] }
+      - option_list = LogEventSearcher::ALLOWED_EVENTS.map { |event| [text("dropdown_titles.#{event}", default: event.to_sym), event] }
       = select_tag(:events,
         options_for_select(option_list, params[:events]),
         multiple: true,

--- a/config/locales/views/admin/en.log_events.yml
+++ b/config/locales/views/admin/en.log_events.yml
@@ -2,6 +2,9 @@ en:
   views:
     log_events:
       index:
+        dropdown_titles:
+          order_detail:
+            problem_queue: Order added to problem queue
         account:
           create: Payment Source created
           update: Payment Source updated


### PR DESCRIPTION
# Release Notes
Fix issues with dropdown for event type in the log event index
# Additional Content
Error Reported: Dropdown contain "Order added to problem queue %{cause}"
