### PR TITLE
[#153552] Fix issue where relays were getting deleted

### DIFF
--- a/app/models/concerns/products/relay_support.rb
+++ b/app/models/concerns/products/relay_support.rb
@@ -64,8 +64,13 @@ module Products::RelaySupport
   # causes too much trouble. Just get rid of the old relay and
   # setup from scratch.
   def destroy_and_init_relay
+    # This instance variable is only present when using the instrument edit form.
+    # We're adding this check to avoid any autosave or association validations
+    # from triggering this callback.
+    return unless @control_mechanism
+
     attrs = relay.try(:attributes) || {}
-    relay.try :destroy
+    relay&.destroy
 
     case control_mechanism
     when Relay::CONTROL_MECHANISMS[:timer]

--- a/app/models/product_display_group.rb
+++ b/app/models/product_display_group.rb
@@ -2,7 +2,7 @@ class ProductDisplayGroup < ApplicationRecord
 
   belongs_to :facility
   has_many :product_display_group_products, -> { sorted }, inverse_of: :product_display_group, dependent: :destroy
-  has_many :products, through: :product_display_group_products
+  has_many :products, through: :product_display_group_products, validate: false
 
   validates :name, presence: true
 

--- a/spec/app_support/auto_logout_spec.rb
+++ b/spec/app_support/auto_logout_spec.rb
@@ -156,8 +156,8 @@ RSpec.describe AutoLogout, :time_travel do
   end
 
   describe "two reservations with unique instruments sharing a calendar" do
-    let!(:shared_instrument_1) { create(:setup_instrument, min_reserve_mins: 1, relay: create(:relay_syna, auto_logout: true)) }
-    let!(:shared_instrument_2) { create(:setup_instrument, min_reserve_mins: 1, schedule: shared_instrument_1.schedule, relay: create(:relay_syna, auto_logout: true)) }
+    let!(:shared_instrument_1) { create(:setup_instrument, min_reserve_mins: 1, relay: build(:relay_syna, auto_logout: true)) }
+    let!(:shared_instrument_2) { create(:setup_instrument, min_reserve_mins: 1, schedule: shared_instrument_1.schedule, relay: build(:relay_syna, auto_logout: true)) }
     let!(:reservation_done) { create(:purchased_reservation, :yesterday, product: shared_instrument_1, actual_start_at: 1.day.ago) }
     let!(:reservation_running) { create(:purchased_reservation, product: shared_instrument_2, reserve_start_at: 30.minutes.ago, reserve_end_at: 30.minutes.from_now, actual_start_at: 30.minutes.ago) }
 

--- a/spec/app_support/end_reservation_only_spec.rb
+++ b/spec/app_support/end_reservation_only_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe EndReservationOnly, :time_travel do
         end_at = 1.minute.ago
 
         create(:purchased_reservation,
-               product: create(:setup_instrument, min_reserve_mins: 1, relay: create(:relay_syna)),
+               product: create(:setup_instrument, min_reserve_mins: 1, relay: build(:relay_syna)),
                reserve_start_at: start_at,
                reserve_end_at: end_at)
       end

--- a/spec/app_support/reservation_instrument_switcher_spec.rb
+++ b/spec/app_support/reservation_instrument_switcher_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe ReservationInstrumentSwitcher do
-  let(:instrument) { FactoryBot.create(:setup_instrument, relay: create(:relay_syna)) }
+  let(:instrument) { FactoryBot.create(:setup_instrument, relay: build(:relay_syna)) }
   let(:reservation) { FactoryBot.create(:purchased_reservation, product: instrument) }
   let(:action) { described_class.new(reservation) }
 

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -255,6 +255,13 @@ RSpec.describe Instrument do
           expect(@instrument.reload.control_mechanism).to eq("timer")
         end
       end
+
+      context "just running a validation" do
+        it "does not affect the relay" do
+          expect(@instrument).to be_valid
+          expect(@instrument.reload.relay).to be_present
+        end
+      end
     end
 
     context "existing type: manual 'Reservation Only'" do

--- a/spec/models/product_display_group_spec.rb
+++ b/spec/models/product_display_group_spec.rb
@@ -38,6 +38,19 @@ RSpec.describe ProductDisplayGroup do
     expect(group.associated_errors.flat_map(&:full_messages)).to include("Product #{product.name} is already in a group")
   end
 
+  it "does not care about the validity of the product" do
+    product = create(:item, :without_validation, facility: facility)
+    group = build(:product_display_group, facility: facility, products: [product])
+    expect(group).to be_valid
+  end
+
+  it "does not affect the relay of an instrument" do
+    facility = create(:setup_facility)
+    instrument = create(:setup_instrument, facility: facility, relay: build(:relay))
+    group = create(:product_display_group, facility: facility, products: [instrument])
+    expect(instrument.reload.relay).to be_present
+  end
+
   describe "position" do
     it "sets an incrementing default position on create" do
       group1 = create(:product_display_group, facility: facility)


### PR DESCRIPTION
# Release Notes

Fix situation where when creating a new product group containing an instrument with a relay the instrument was getting set to "Reservation Only"

# Additional Context

This seems to be happening only when creating a new product group. Adding to an existing group does not trigger the bug.

I'm actually a little surprised this hasn't bitten us before in some other case like bundles.

What's happening is that the validations on `Product`/`Instrument` are being triggered as part of the `ProductDisplayGroup`'s validation. I can't explain why it's only being triggered in this single case. But because we're triggering the validations, there's some code in there that should only be triggered during product edit that deletes and rebuilds the relay. However, since we're only running the validations and not the save, the new relay is not persisted.

I ended up doing two things to fix it:

* At the base level, only run the destroy/create relay callback during the product edit/update process. This should avoid us getting bitten by this in other associations we may create at some point.

* Don't validate the products from the display groups. In this case, we should be safe to assume the products are already valid.