### PR TITLE
Tech task: Fix migration by removing index name

### DIFF
--- a/db/migrate/20200514155649_remove_unique_index_price_group.rb
+++ b/db/migrate/20200514155649_remove_unique_index_price_group.rb
@@ -1,10 +1,11 @@
 class RemoveUniqueIndexPriceGroup < ActiveRecord::Migration[5.2]
   def up
     remove_foreign_key :price_groups, :facilities
-    remove_index :price_groups, name: "index_price_groups_on_facility_id_and_name"
+    remove_index :price_groups, [:facility_id, :name]
     add_foreign_key :price_groups, :facilities
-    add_index(:price_groups, [:facility_id, :name], unique: false, name: "index_price_groups_on_facility_id_and_name")
+    add_index :price_groups, [:facility_id, :name], unique: false
   end
+
   def down
     raise ActiveRecord::IrreversibleMigration
   end


### PR DESCRIPTION
# Release Notes

Tech task: fix a migration that was causing problems in Oracle.

# Additional Context

Migration introduced in #2300. I tested this by going back to the commit before that, loading the schema, adding that commit back in and running `rake db:migrate`. It ended up with the same resulting `schema.rb`.