### PR TITLE
[#153781] Handle special characters and reserved words in oracle search

### DIFF
--- a/app/models/full_text_search/oracle_searcher.rb
+++ b/app/models/full_text_search/oracle_searcher.rb
@@ -5,7 +5,14 @@ module FullTextSearch
     def search(fields, query)
       return @scope.none if query.blank?
 
-      formatted_query = query.to_s.split.join(",")
+      query_elements = query.to_s.split
+      # By wrapping each portion in {}, it escapes what's inside so it handles special
+      # characters and other reserved words
+      # https://docs.oracle.com/cd/B10501_01/text.920/a96518/cqspcl.htm#20741
+      formatted_query = query_elements
+        .map { |s| s.gsub(/[{}]/, "") } # remove any existing curly braces
+        .map { |s| "{#{s}}" }
+        .join(",")
       # If we leave the label out `:label`, we end up with duplicate labels which Oracle doesn't like.
       # If we don't handle the `order` ourselves, then AR's `or` complains about incompatible `ORDER BY`s.
       array = Array(fields)

--- a/spec/models/full_text_search/oracle_searcher_spec.rb
+++ b/spec/models/full_text_search/oracle_searcher_spec.rb
@@ -59,4 +59,56 @@ RSpec.describe FullTextSearch::OracleSearcher, if: Nucore::Database.oracle? do
     end
   end
 
+  context "when the query contains function names or other characters" do
+    context "AND" do
+      let(:query) { "lsc and andor" }
+      it { is_expected.to contain_exactly(item) }
+    end
+
+    context "OR" do
+      let(:query) { "lsc or andor" }
+      it { is_expected.to contain_exactly(item) }
+    end
+
+    context "about" do
+      let(:query) { "something about andor" }
+      it { is_expected.to contain_exactly(item) }
+    end
+
+    context "&" do
+      let(:query) { "lsc & andor" }
+      it { is_expected.to contain_exactly(item) }
+    end
+
+    context "double quotes" do
+      let(:query) { '"lsc"' }
+      it { is_expected.to contain_exactly(item) }
+    end
+
+    context "single quotes" do
+      let(:query) { "'lsc' 'andor'" }
+      it { is_expected.to contain_exactly(item) }
+    end
+
+    context "open curly brace" do
+      let(:query) { "{lsc andor" }
+      it { is_expected.to contain_exactly(item) }
+    end
+
+    context "close curly brace" do
+      let(:query) { "lsc andor}" }
+      it { is_expected.to contain_exactly(item) }
+    end
+
+    context "curly braces" do
+      let(:query) { "{lsc andor}" }
+      it { is_expected.to contain_exactly(item) }
+    end
+
+    context "backslash" do
+      let(:query) { "lsc \\andor" }
+      it { is_expected.to contain_exactly(item) }
+    end
+  end
+
 end


### PR DESCRIPTION
# Release Notes

Fixes an issue where Oracle would error when parsing reserved words like "and", "or", or "about" when doing a search for products.

# Additional Context

See https://docs.oracle.com/cd/B10501_01/text.920/a96518/cqspcl.htm#20741 for a list of the reserved words.

See https://github.com/tablexi/nucore-nu/pull/573 (private) for verification this passes CI.