### PR TITLE
[#148167] Add order for button

### DIFF
--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -14,7 +14,6 @@
 
   - if @users.any?
     = render "search/results_table",
-      order_for: current_facility.try(:single_facility?),
       users: @users
 
     = will_paginate(@users)

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -23,15 +23,15 @@
   = render_view_hook "additional_user_fields", f: f
 
 %ul.inline
-  - if current_ability.can?(:switch_to, @user) && @user.active? && !current_facility.cross_facility?
-    %li= link_to text("search.results_table.order_for"), facility_user_switch_to_path(current_facility, @user), class: "btn btn-primary"
   - if can?(:edit, @user)
-    %li= link_to text("shared.edit"), edit_facility_user_path(current_facility, @user), class: "btn btn-primary"
+    %li= link_to text("shared.edit"), edit_facility_user_path(current_facility, @user), class: "btn"
     - if can?(:unexpire, @user) && @user.expired?
       %li= link_to text("unexpire"), unexpire_facility_user_path(current_facility, @user), class: "btn", method: :patch
     - elsif can?(:deactivate, @user) && @user.suspended?
       = link_to t("shared.activate"), facility_user_suspension_path(current_facility, @user), class: "btn", method: :delete
-- if can?(:edit, @user) && can?(:deactivate, @user) && @user.active?
+  - if current_ability.can?(:switch_to, @user) && @user.active? && current_facility.single_facility?
+    %li= link_to text("search.results_table.order_for"), facility_user_switch_to_path(current_facility, @user), class: "btn btn-primary"
+- if can?(:edit, @user) && @user.active?
   %fieldset.well
     = simple_form_for @user, url: facility_user_suspension_path(current_facility, @user), method: :post do |f|
       = f.input :suspension_note

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -22,9 +22,13 @@
 
   = render_view_hook "additional_user_fields", f: f
 
+- show_order_for_link = current_ability.can?(:switch_to, @user) && @user.active? && !current_facility.cross_facility?
 - if can? :edit, @user
   %ul.inline
     %li= link_to text("shared.edit"), edit_facility_user_path(current_facility, @user), class: "btn btn-primary"
+
+    - if show_order_for_link
+      %li= link_to text("search.results_table.order_for"), facility_user_switch_to_path(current_facility, @user), class: "btn btn-primary"
 
     - if can?(:unexpire, @user) && @user.expired?
       %li= link_to text("unexpire"), unexpire_facility_user_path(current_facility, @user), class: "btn", method: :patch
@@ -35,6 +39,6 @@
       = simple_form_for @user, url: facility_user_suspension_path(current_facility, @user), method: :post do |f|
         = f.input :suspension_note
         = f.submit t("shared.suspend"), class: "btn btn-danger"
-
-
-
+- elsif show_order_for_link
+  %ul.inline
+    %li= link_to text("search.results_table.order_for"), facility_user_switch_to_path(current_facility, @user), class: "btn btn-primary"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -22,23 +22,17 @@
 
   = render_view_hook "additional_user_fields", f: f
 
-- show_order_for_link = current_ability.can?(:switch_to, @user) && @user.active? && !current_facility.cross_facility?
-- if can? :edit, @user
-  %ul.inline
+%ul.inline
+  - if current_ability.can?(:switch_to, @user) && @user.active? && !current_facility.cross_facility?
+    %li= link_to text("search.results_table.order_for"), facility_user_switch_to_path(current_facility, @user), class: "btn btn-primary"
+  - if can?(:edit, @user)
     %li= link_to text("shared.edit"), edit_facility_user_path(current_facility, @user), class: "btn btn-primary"
-
-    - if show_order_for_link
-      %li= link_to text("search.results_table.order_for"), facility_user_switch_to_path(current_facility, @user), class: "btn btn-primary"
-
     - if can?(:unexpire, @user) && @user.expired?
       %li= link_to text("unexpire"), unexpire_facility_user_path(current_facility, @user), class: "btn", method: :patch
     - elsif can?(:deactivate, @user) && @user.suspended?
       = link_to t("shared.activate"), facility_user_suspension_path(current_facility, @user), class: "btn", method: :delete
-  - if can?(:deactivate, @user) && !@user.suspended? && !@user.expired?
-    %fieldset.well
-      = simple_form_for @user, url: facility_user_suspension_path(current_facility, @user), method: :post do |f|
-        = f.input :suspension_note
-        = f.submit t("shared.suspend"), class: "btn btn-danger"
-- elsif show_order_for_link
-  %ul.inline
-    %li= link_to text("search.results_table.order_for"), facility_user_switch_to_path(current_facility, @user), class: "btn btn-primary"
+- if can?(:edit, @user) && can?(:deactivate, @user) && @user.active?
+  %fieldset.well
+    = simple_form_for @user, url: facility_user_suspension_path(current_facility, @user), method: :post do |f|
+      = f.input :suspension_note
+      = f.submit t("shared.suspend"), class: "btn btn-danger"

--- a/lib/ability_helper.rb
+++ b/lib/ability_helper.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module AbilityHelper
+
+  # A convenience method to help clarify permissions for various user roles.
+  #
+  # [_users_]
+  #   A collection of User objects to test
+  # [_resource_]
+  #   A class or instance that each +user+ will be authorized against
+  # [_controller_]
+  #   The controller whose authorization request is being handled.
+  #
+  # Example usage:
+  # check_permissions_for(users: User.all, resource: Facility.last, actions: [:edit, :deactivate], controller: UsersController.new)
+  def check_permissions_for(users: User.all, resource: Facility.last, actions: [], controller: nil)
+    results = {}
+    users.each do |user|
+      user_data = []
+      user_data << "User #{user.id}:"
+      user_data << "Roles: #{user.user_roles.map(&:role)}"
+      ability = Ability.new(user, resource, controller)
+      actions.each { |action| user_data << "Can #{action}: #{ability.can?(action, resource)}" }
+      results[user.last_name] = user_data
+    end
+    results
+  end
+
+end

--- a/lib/ability_helper.rb
+++ b/lib/ability_helper.rb
@@ -3,11 +3,12 @@
 module AbilityHelper
 
   # A convenience method to help clarify permissions for various user roles.
+  # Useful for developer debugging, this method is not actually invoked anywhere.
   #
   # [_users_]
-  #   A collection of User objects to test
+  #   A collection of User objects to test.
   # [_resource_]
-  #   A class or instance that each +user+ will be authorized against
+  #   A class or instance that each +user+ will be authorized against.
   # [_controller_]
   #   The controller whose authorization request is being handled.
   #


### PR DESCRIPTION
# Release Notes

[Additional Order For Button](https://pm.tablexi.com/issues/148167)

It looks to me like it is possible to have a case where user cannot `:edit`, but they can `:switch_to`.  This is my attempt to handle both of those cases while also adding the new button inline with other buttons if they exist.