### PR TITLE
[#153049] Fix export raw link

### DIFF
--- a/app/assets/javascripts/app/reports.coffee
+++ b/app/assets/javascripts/app/reports.coffee
@@ -8,7 +8,7 @@ class TabbableReports
     @init_export_all_handler()
 
   export_all_link: ->
-    $("#export-all")
+    $(".js--exportRaw")
 
   update_parameters: ->
     @update_href $(@current_tab())
@@ -97,7 +97,7 @@ class TabbableReports
     @export_all_link().attr("href", @export_all_link().data("original-url") + @build_query_string())
 
   init_export_all_handler: ->
-    @$emailToAddressField = $('#email_to_address')
+    @$emailToAddressField = $('.js--exportRawEmailField')
     @export_all_link()
       .attr("data-remote", true)
       .data("original-url", @export_all_link().attr("href"))
@@ -107,7 +107,7 @@ class TabbableReports
     event.preventDefault()
 
     new_to = prompt(
-      'Have the report emailed to this address:'
+      'Have the report emailed to this address:',
       @$emailToAddressField.val()
     )
 

--- a/app/views/reports/report.html.haml
+++ b/app/views/reports/report.html.haml
@@ -18,8 +18,8 @@
       - if can?(:export_all, Reports::ReportsController)
         = link_to t("reports.export.raw"),
           export_csv_report_path,
-          id: "export-all"
-        = hidden_field_tag :email_to_address, current_user.email
+          class: "js--exportRaw"
+        = hidden_field_tag :email, current_user.email, class: "js--exportRawEmailField"
 
   %div#tabs
     = render "report_tabs"


### PR DESCRIPTION
# Release Notes

Fixes the export raw link that was somewhat broken in #2317. 

# Additional Context

Because the controller changed to use a different parameter, whatever you put in the dialog prompt was getting ignored and it was always falling back to the current user's email address.

I considered trying to refactor it use all the newer shared code in `export_csv_report.coffee`, but this code is doing a lot of extra stuff like munging query parameters and it seemed like more effort than it was worth. I did do some renaming so it uses our more modern `js--` class prefix rather than IDs.
