### PR TITLE
Tech task: remove GS/NUcore maintenance group from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-* @tablexi/nucore @tablexi/gs-nucore-maintenance
+* @tablexi/nucore


### PR DESCRIPTION
# Release Notes

Tech task: remove GS/NUcore maintenance group from codeowners so it's just our internal team now.

# Additional Context

@giladshanan you should now be part of the tablexi/nucore group so you should get tagged automatically on any new PRs once this is merged.
