### PR TITLE
[#152604] Fix cancel button behavior on new reservation page

### DIFF
--- a/app/controllers/single_reservations_controller.rb
+++ b/app/controllers/single_reservations_controller.rb
@@ -14,7 +14,7 @@ class SingleReservationsController < ApplicationController
     authorize! :new, @reservation
 
     unless @instrument.can_be_used_by?(acting_user)
-      flash[:notice] = text(".acting_as_not_on_approval_list")
+      flash[:notice] = text("controllers.reservations.acting_as_not_on_approval_list")
     end
     set_windows
     render "reservations/new"
@@ -25,7 +25,7 @@ class SingleReservationsController < ApplicationController
     if creator.save(session_user)
       @reservation = creator.reservation
       authorize! :create, @reservation
-      flash[:notice] = I18n.t "controllers.reservations.create.success"
+      flash[:notice] = I18n.t("controllers.reservations.create.success")
       flash[:error] = I18n.t("controllers.reservations.create.admin_hold_warning") if creator.reservation.conflicting_admin_reservation?
       redirect_to purchase_order_path(@order, params.permit(:send_notification))
     else

--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -54,16 +54,13 @@
         id: "reservation_submit",
         data: { disable_with: t("shared.create") }
 
-    - url_after_action = facility_path(@instrument.facility)
     %li
       - if @order.to_be_merged?
         = link_to t("shared.cancel"), facility_order_path(@instrument.facility, @order.merge_order)
-      - elsif @order_detail.bundled?
-        = link_to t("shared.cancel"), url_after_action
       - elsif @order.persisted?
-        = link_to t("shared.cancel"),
-          remove_order_path(@order, @order_detail, redirect_to: url_after_action),
-          method: :put
+        = link_to t("shared.cancel"), cart_path
+      - else
+        = link_to t("shared.cancel"), facility_path(@instrument.facility)
 
 #overlay
   #spinner

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -158,6 +158,14 @@ RSpec.describe "Adding to an existing order" do
       expect(order.reload.order_details.count).to be(2)
       expect(order.order_details.last.product).to eq(instrument)
     end
+
+    it "brings you back to the facility order path on 'Cancel'" do
+      click_link "Make a Reservation"
+      click_link "Cancel"
+
+      expect(current_path).to eq(facility_order_path(facility, order))
+      expect(page).to have_link("Make a Reservation")
+    end
   end
 
   describe "adding a timed service" do

--- a/spec/system/purchasing_a_reservation_on_behalf_of_spec.rb
+++ b/spec/system/purchasing_a_reservation_on_behalf_of_spec.rb
@@ -72,6 +72,20 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
     end
   end
 
+  describe "when the user is not authorized" do
+    before do
+      instrument.update!(requires_approval: true)
+    end
+
+    it "can purchase" do
+      click_link instrument.name
+      expect(page).to have_content("The user you are ordering for is not on the authorized list for this instrument.")
+      select user.accounts.first.description, from: "Payment Source"
+
+      click_button "Create"
+    end
+  end
+
   describe "creating multiple reservations" do
     it "can create reservations in the future" do
       fill_in "order[order_details][][quantity]", with: "2"

--- a/spec/system/purchasing_a_reservation_on_behalf_of_spec.rb
+++ b/spec/system/purchasing_a_reservation_on_behalf_of_spec.rb
@@ -83,6 +83,8 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
       select user.accounts.first.description, from: "Payment Source"
 
       click_button "Create"
+
+      expect(page).to have_content("Order Receipt")
     end
   end
 

--- a/spec/system/purchasing_a_reservation_spec.rb
+++ b/spec/system/purchasing_a_reservation_spec.rb
@@ -116,6 +116,13 @@ RSpec.describe "Purchasing a reservation" do
 
   end
 
+  it "clicking 'cancel' returns you to the facility page" do
+    click_link instrument.name
+    click_link "Cancel"
+
+    expect(current_path).to eq(facility_path(facility))
+  end
+
   describe "ordering on an order form" do
     before do
       fill_in "order[order_details][][quantity]", with: "2"
@@ -149,6 +156,17 @@ RSpec.describe "Purchasing a reservation" do
       fill_in "Duration", with: "90"
       click_button "Create"
       expect(page).to have_content("Reserve start at must be in the future")
+    end
+
+    it "clicking cancel returns you to the cart as it was" do
+      expect(page).to have_selector("h1", text: "Cart")
+      cart_path = current_path # should be the cart_path
+      click_link "Make a Reservation", match: :first
+      click_link "Cancel"
+
+      expect(current_path).to eq(cart_path)
+      expect(page).to have_selector("h1", text: "Cart")
+      expect(page).to have_link("Make a Reservation", count: 2)
     end
   end
 end


### PR DESCRIPTION
# Release Notes

Fixes the "Cancel" button behavior on new reservation page.

# Additional Context

This does modify behavior a little bit, but the behavior before felt unexpected.

There are a couple ways to get to this page:

* Clicking on an instrument from the facility homepage. This is the new order-less reservation flow from #2292. 
  * Before: The cancel button was missing
  * After: The cancel button will return you the facility homepage.
* The reservation was in the cart because it was a bundle.
  * Before: The cancel button brought you back to the facility homepage, but left everything in your cart
  * After: The cancel button brings you back to your cart
* The reservation was in a cart because it was added with the order form
  * Before: The order detail was removed from your cart (this seemed wrong) and brought you to the facility homepage
  * After: You are returned to your cart and everything is left alone. If you want to remove the line from your cart, you can use the "Remove" button
* Adding to an existing order
  * Before: You are brought back to the existing order's page and the line item still requires resolution.
  * After: Same behavior

