### PR TITLE
[#153933] Add hooks for extending POs

### DIFF
--- a/vendor/engines/c2po/app/services/purchase_order_account_builder.rb
+++ b/vendor/engines/c2po/app/services/purchase_order_account_builder.rb
@@ -4,6 +4,9 @@
 # Dynamically called via the `AccountBuilder.for()` factory.
 class PurchaseOrderAccountBuilder < AccountBuilder
 
+  # Needs to be overridable by engines
+  cattr_accessor(:permitted_account_params) { [] }
+
   protected
 
   # Override strong_params for `build` account.
@@ -17,7 +20,7 @@ class PurchaseOrderAccountBuilder < AccountBuilder
       :formatted_expires_at,
       :outside_contact_info,
       :ar_number,
-    ]
+    ] + permitted_account_params
   end
 
   # Override strong_params for `update` account.
@@ -31,7 +34,7 @@ class PurchaseOrderAccountBuilder < AccountBuilder
       :formatted_expires_at,
       :outside_contact_info,
       :ar_number,
-    ]
+    ] + permitted_account_params
   end
 
   # Hooks into superclass's `build` method.

--- a/vendor/engines/c2po/app/views/facility_accounts/account_fields/_purchase_order_account.html.haml
+++ b/vendor/engines/c2po/app/views/facility_accounts/account_fields/_purchase_order_account.html.haml
@@ -22,3 +22,5 @@
   label: text("ar_number_label"),
   hint: text("ar_number_hint"),
   hint_html: { class: "help-inline" }
+
+= render_view_hook "additional_fields", f: f

--- a/vendor/engines/c2po/app/views/facility_accounts/purchase_order_account/_show.html.haml
+++ b/vendor/engines/c2po/app/views/facility_accounts/purchase_order_account/_show.html.haml
@@ -1,3 +1,5 @@
 = f.input :outside_contact_info
 
 = f.input :ar_number
+
+= render_view_hook "additional_fields", f: f


### PR DESCRIPTION
# Release Notes

TECH TASK:  
Add hooks for adding additional form fields for POs.  Used by Dartmouth to capture federal funding info.  Extracted from https://github.com/tablexi/nucore-dartmouth/pull/302

https://pm.tablexi.com/issues/153933