### PR TITLE
[#153781] Fixes for oracle full text search

### DIFF
--- a/app/models/full_text_search/oracle_searcher.rb
+++ b/app/models/full_text_search/oracle_searcher.rb
@@ -2,17 +2,19 @@ module FullTextSearch
 
   class OracleSearcher < BaseSearcher
 
+    # Example: search([:name, :description], "spinning disk")
     def search(fields, query)
-      return @scope.none if query.blank?
-
-      query_elements = query.to_s.split
       # By wrapping each portion in {}, it escapes what's inside so it handles special
       # characters and other reserved words
       # https://docs.oracle.com/cd/B10501_01/text.920/a96518/cqspcl.htm#20741
-      formatted_query = query_elements
-        .map { |s| s.gsub(/[{}]/, "") } # remove any existing curly braces
+      formatted_query = query.to_s
+        .gsub(/[{}]/, "") # remove any existing curly braces
+        .split
         .map { |s| "{#{s}}" }
         .join(",")
+
+      return @scope.none if formatted_query.blank?
+
       # If we leave the label out `:label`, we end up with duplicate labels which Oracle doesn't like.
       # If we don't handle the `order` ourselves, then AR's `or` complains about incompatible `ORDER BY`s.
       array = Array(fields)

--- a/spec/models/full_text_search/oracle_searcher_spec.rb
+++ b/spec/models/full_text_search/oracle_searcher_spec.rb
@@ -24,12 +24,17 @@ RSpec.describe FullTextSearch::OracleSearcher, if: Nucore::Database.oracle? do
 
   context "when the query is nil" do
     let(:query) { nil }
-    it { is_expected.to be_empty }
+    it { is_expected.to be_none }
+  end
+
+  context "when the query is an empty string" do
+    let(:query) { "" }
+    it { is_expected.to be_none }
   end
 
   context "when the query is whitespace only" do
     let(:query) { " " }
-    it { is_expected.to be_empty }
+    it { is_expected.to be_none }
   end
 
   context "when the query matches no products" do
@@ -107,6 +112,21 @@ RSpec.describe FullTextSearch::OracleSearcher, if: Nucore::Database.oracle? do
 
     context "backslash" do
       let(:query) { "lsc \\andor" }
+      it { is_expected.to contain_exactly(item) }
+    end
+
+    context "just curly braces" do
+      let(:query) { "{}" }
+      it { is_expected.to be_none }
+    end
+
+    context "just curly braces with spaces" do
+      let(:query) { " {  }  " }
+      it { is_expected.to be_none }
+    end
+
+    context "with commas" do
+      let(:query) { "lsc,andor," }
       it { is_expected.to contain_exactly(item) }
     end
   end


### PR DESCRIPTION
# Release Notes

Fixes a hard error in product searching in oracle when the query contains only curly braces. 

# Additional Context

We were handling the empty string case before, but once we started removing the braces, it would pass the empty string check, but then become empty. Oracle doesn't like those kinds of queries.

I'll have a PR in NU with this same code in NU to validate the specs against oracle.
