### PR TITLE
[#152604] Check the price_groups from order_detail when setting max reservation window

### DIFF
--- a/app/services/reservation_window.rb
+++ b/app/services/reservation_window.rb
@@ -6,7 +6,7 @@ class ReservationWindow
 
   def max_window
     return 365 if operator?
-    @reservation.longest_reservation_window(@reservation.user.price_groups)
+    @reservation.longest_reservation_window(@reservation.order_detail.price_groups)
   end
 
   def max_days_ago

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -694,11 +694,29 @@ RSpec.describe ReservationsController do
     end
 
     # guests should only be able to go the default reservation window into the future
-    it_should_allow_all [:guest] do
-      expect(assigns[:reservation_window].max_window).to eq(PriceGroupProduct::DEFAULT_RESERVATION_WINDOW)
-      expect(assigns[:reservation_window].max_days_ago).to eq(0)
-      expect(assigns[:reservation_window].max_date).to eq((Time.zone.now + PriceGroupProduct::DEFAULT_RESERVATION_WINDOW.days).strftime("%Y%m%d"))
-      expect(assigns[:reservation_window].min_date).to eq(Time.zone.now.strftime("%Y%m%d"))
+    context "with a guest user" do
+      describe "without user based price groups", feature_setting: { user_based_price_groups: false } do
+        it "sets the reservation window correctly" do
+          sign_in @guest
+          do_request
+          expect(assigns[:reservation_window].max_window).to eq(PriceGroupProduct::DEFAULT_RESERVATION_WINDOW)
+          expect(assigns[:reservation_window].max_days_ago).to eq(0)
+          expect(assigns[:reservation_window].max_date).to eq((Time.zone.now + PriceGroupProduct::DEFAULT_RESERVATION_WINDOW.days).strftime("%Y%m%d"))
+          expect(assigns[:reservation_window].min_date).to eq(Time.zone.now.strftime("%Y%m%d"))
+        end
+      end
+
+      describe "with user based price groups", feature_setting: { user_based_price_groups: true } do
+        it "sets the reservation window correctly" do
+          @guest.create_default_price_group!
+          sign_in @guest
+          do_request
+          expect(assigns[:reservation_window].max_window).to eq(PriceGroupProduct::DEFAULT_RESERVATION_WINDOW)
+          expect(assigns[:reservation_window].max_days_ago).to eq(0)
+          expect(assigns[:reservation_window].max_date).to eq((Time.zone.now + PriceGroupProduct::DEFAULT_RESERVATION_WINDOW.days).strftime("%Y%m%d"))
+          expect(assigns[:reservation_window].min_date).to eq(Time.zone.now.strftime("%Y%m%d"))
+        end
+      end
     end
 
     it_behaves_like "it can handle having its order_detail removed"

--- a/spec/system/admin/price_group_management_spec.rb
+++ b/spec/system/admin/price_group_management_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Managing Price Groups", :aggregate_failures do
   end
 
   describe "manage users of a price group" do
-    describe "as a facility admin", feature_setting: { facility_directors_can_manage_price_groups: true } do
+    describe "as a facility admin", feature_setting: { user_based_price_groups: true, facility_directors_can_manage_price_groups: true } do
       let(:user) { FactoryBot.create(:user, :facility_director, facility: facility) }
       let(:user2) { FactoryBot.create(:user) }
       let!(:price_group) { FactoryBot.create(:price_group, facility: facility) }


### PR DESCRIPTION
# Release Notes

While [updating specs](https://github.com/tablexi/nucore-dartmouth/pull/303) for Dartmouth that use a `user_based_price_groups: false` context, discovered a small error in the logic for reservation max windows.  This shouldn't impact NU or other contexts that use the `user_based_price_groups` feature.  
