### PR TITLE
[#153971] Add payment_url field to facilities

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -218,6 +218,7 @@ class FacilitiesController < ApplicationController
       show_instrument_availability
       url_name
       dashboard_enabled
+      payment_url
     )
   end
 

--- a/app/views/facilities/_facility_fields.html.haml
+++ b/app/views/facilities/_facility_fields.html.haml
@@ -32,6 +32,8 @@
   = f.input :phone_number
   = f.input :fax_number
   = f.input :email
+  - if SettingsHelper.feature_on?(:facility_payment_urls)
+    = f.input :payment_url
 
 .well
   %p= text(".order_notification")

--- a/app/views/facilities/manage.html.haml
+++ b/app/views/facilities/manage.html.haml
@@ -20,6 +20,8 @@
   = f.input :phone_number, default_value: "None Entered"
   = f.input :fax_number, default_value: "None Entered"
   = f.input :email, default_value: "None Entered"
+  - if SettingsHelper.feature_on?(:facility_payment_urls)
+    = f.input :payment_url
   = f.input :journal_mask
   = f.input :order_notification_recipient, default_value: "None Entered"
 

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -256,6 +256,7 @@ en:
       facility:
         banner_notice: Banner Notice
         fax_number: Fax Number
+        payment_url: Payment URL
         is_active: Is Active?
         journal_mask: CoreID
         phone_number: Phone Number

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -117,6 +117,7 @@ feature:
   multi_facility_accounts: true
   facility_directors_can_manage_price_groups: true
   account_reference_field: false
+  facility_payment_urls: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/db/migrate/20200702212036_add_payment_url_to_facilities.rb
+++ b/db/migrate/20200702212036_add_payment_url_to_facilities.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddPaymentUrlToFacilities < ActiveRecord::Migration[5.2]
+  def change
+    change_table :facilities do |t|
+      t.string :payment_url
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_201622) do
+ActiveRecord::Schema.define(version: 2020_07_02_212036) do
 
   create_table "account_facility_joins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "facility_id", null: false
@@ -170,6 +170,7 @@ ActiveRecord::Schema.define(version: 2020_05_26_201622) do
     t.boolean "sanger_sequencing_enabled", default: false, null: false
     t.text "banner_notice"
     t.string "dashboard_token"
+    t.string "payment_url"
     t.index ["abbreviation"], name: "index_facilities_on_abbreviation", unique: true
     t.index ["is_active", "name"], name: "index_facilities_on_is_active_and_name"
     t.index ["name"], name: "index_facilities_on_name", unique: true


### PR DESCRIPTION
# Release Notes

Adds a 'Payment URL' field for facilities. This field is feature flagged and disabled by default.

In support of https://github.com/tablexi/nucore-umass/pull/48 and https://pm.tablexi.com/issues/153971

# Screenshot

Edit:
<img width="989" alt="Screen Shot 2020-07-02 at 5 10 58 PM" src="https://user-images.githubusercontent.com/30355046/86413539-1197f680-bc87-11ea-9e43-7f40fe7c6511.png">

Show:
<img width="500" alt="Screen Shot 2020-07-02 at 5 10 38 PM" src="https://user-images.githubusercontent.com/30355046/86413537-1066c980-bc87-11ea-81fa-53ee0c2c3f20.png">

