### PR TITLE
[#153177] Fix incorrect order numbers when adding forms to an existing order

### DIFF
--- a/app/controllers/formio/submissions_controller.rb
+++ b/app/controllers/formio/submissions_controller.rb
@@ -25,8 +25,8 @@ module Formio
     # NUcore’s SurveysController expects a referer param, which contains the page
     # to which NUcore should redirect after it processes a form submission. However,
     # the success_url that we get from UrlService does not include this param. Instead,
-    # we get it as a separate pram, so we construct the full redirect_url here to
-    # avoid changing having to change code for unrelated integrations
+    # we get it as a separate param, so we construct the full redirect_url here to
+    # avoid changing code for unrelated integrations
     def redirect_url
       referer_url = URI(params[:referer])
       URI(params[:success_url]).tap do |success_url|

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -680,7 +680,7 @@ class OrderDetail < ApplicationRecord
   end
 
   def order_number
-    "#{order_id}-#{id}"
+    "#{order.merge_with_order_id || order_id}-#{id}"
   end
   alias to_s order_number
 

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -1961,4 +1961,23 @@ RSpec.describe OrderDetail do
       end
     end
   end
+
+  describe "#order_number" do
+
+    it "includes the merge_with_order_id when present" do
+      merge_to_order = @order.dup
+      merge_to_order.save
+      @order.update_attribute :merge_with_order_id, merge_to_order.id
+      @order_detail.reload
+
+      expect(@order_detail.order.merge_with_order_id).to be_present
+      expect(@order_detail.order_number).to eq "#{merge_to_order.id}-#{@order_detail.id}"
+    end
+
+    it "includes the order_id when no merge_with_order_id exists" do
+      expect(@order_detail.order.merge_with_order_id).to be_blank
+      expect(@order_detail.order_number).to eq "#{@order_detail.order.id}-#{@order_detail.id}"
+    end
+
+  end
 end

--- a/vendor/engines/sanger_sequencing/README.md
+++ b/vendor/engines/sanger_sequencing/README.md
@@ -40,5 +40,5 @@ Facility.find_by(url_name: "facility-name").update_attributes(sanger_sequencing_
   SangerSequencing::ProductGroup.create(product: product, group: "fragment")
   ```
 
-A product can only be part of a single group. If it isnot part of a group,
-it fall back to a "default" group, which is the standard Sanger Sequencing.
+A product can only be part of a single group. If it is not part of a group,
+it falls back to a "default" group, which is the standard Sanger Sequencing.

--- a/vendor/engines/split_accounts/spec/services/order_detail_splitter_spec.rb
+++ b/vendor/engines/split_accounts/spec/services/order_detail_splitter_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe SplitAccounts::OrderDetailSplitter, type: :service do
                                    estimated_cost: BigDecimal("29.99"),
                                    estimated_subsidy: BigDecimal("39.99"),
                                    account: split_account,
+                                   order: order,
                                    note: "this is a note")
     end
 


### PR DESCRIPTION
# Release Notes

Includes the merge_with_order_id in the order number when adding to an order with form.io or IMSERC forms.
Also used when adding to an order with ACGT/Sanger forms, but that flow isn't allowed with current permissions.

## Additional Context
I tested ACGT forms by adjusting [permissions](https://github.com/tablexi/nucore-open/blob/master/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/ability.rb#L12), removing the `user: user` scoping.  With this change, it is possible to add ACGT forms to an existing order, but the user is redirected to an invalid route afterwards (`/orders/:id`).  Leaving this alone for now, assuming that this flow isn't needed.  
