### PR TITLE
[#153876] Event log improvements

### DIFF
--- a/app/models/log_event.rb
+++ b/app/models/log_event.rb
@@ -19,9 +19,21 @@ class LogEvent < ApplicationRecord
       start_date: start_date, end_date: end_date, events: events, query: query).search
   end
 
-# The reason that we are doing this is because in some case we can't add a default value to a text column 
+# The reason that we are doing this is because in some case we can't add a default value to a text column
   def metadata
     self[:metadata] || {}
+  end
+
+  def facility
+    if loggable.respond_to?(:facility)
+      loggable.facility
+    elsif loggable.respond_to?(:price_group_with_deleted)
+      loggable.price_group_with_deleted.facility
+    elsif loggable.respond_to?(:facilities)
+      loggable.facilities.first if loggable.facilities.count == 1
+    elsif loggable.respond_to?(:user)
+      loggable.user.facilities.first if loggable.user.facilities.count == 1
+    end
   end
 
   def locale_tag

--- a/app/models/log_event.rb
+++ b/app/models/log_event.rb
@@ -25,15 +25,7 @@ class LogEvent < ApplicationRecord
   end
 
   def facility
-    if loggable.respond_to?(:facility)
-      loggable.facility
-    elsif loggable.respond_to?(:price_group_with_deleted)
-      loggable.price_group_with_deleted.facility
-    elsif loggable.respond_to?(:facilities)
-      loggable.facilities.first if loggable.facilities.count == 1
-    elsif loggable.respond_to?(:user)
-      loggable.user.facilities.first if loggable.user.facilities.count == 1
-    end
+    loggable.facility if loggable.respond_to?(:facility)
   end
 
   def locale_tag

--- a/app/models/price_group_member.rb
+++ b/app/models/price_group_member.rb
@@ -3,13 +3,14 @@
 class PriceGroupMember < ApplicationRecord
 
   belongs_to :price_group
+  belongs_to :price_group_with_deleted, -> { with_deleted }, foreign_key: :price_group_id, class_name: "PriceGroup"
 
   acts_as_paranoid
 
   validates_presence_of :price_group_id
 
   def to_log_s
-    "#{user} / #{price_group}"
+    "#{user} / #{price_group_with_deleted}"
   end
 
 end

--- a/app/models/price_group_member.rb
+++ b/app/models/price_group_member.rb
@@ -4,6 +4,7 @@ class PriceGroupMember < ApplicationRecord
 
   belongs_to :price_group
   belongs_to :price_group_with_deleted, -> { with_deleted }, foreign_key: :price_group_id, class_name: "PriceGroup"
+  delegate :facility, to: :price_group_with_deleted
 
   acts_as_paranoid
 

--- a/app/models/product_user.rb
+++ b/app/models/product_user.rb
@@ -8,6 +8,7 @@ class ProductUser < ApplicationRecord
   belongs_to :product
   belongs_to :product_access_group
   belongs_to :approved_by_user, class_name: "User", foreign_key: "approved_by", inverse_of: false
+  delegate :facility, to: :product
 
   validates_numericality_of :product_id, :user_id, :approved_by, only_integer: true
   validates_uniqueness_of :user_id, scope: :product_id, message: "is already approved"

--- a/app/views/log_events/index.html.haml
+++ b/app/views/log_events/index.html.haml
@@ -46,6 +46,7 @@
       %th= text("event_time")
       %th= text("event")
       %th= text("object")
+      %th= "Facility"
       %th= text("user_label")
 
   %tbody
@@ -54,6 +55,7 @@
         %td= format_usa_datetime(log_event.event_time)
         %td= text(log_event.locale_tag, log_event.metadata.symbolize_keys)
         %td= log_event.loggable_to_s
+        %td= log_event.facility
         %td= log_event.user.try(:to_s)
 
 = will_paginate(@log_events)

--- a/app/views/log_events/index.html.haml
+++ b/app/views/log_events/index.html.haml
@@ -46,7 +46,7 @@
       %th= text("event_time")
       %th= text("event")
       %th= text("object")
-      %th= "Facility"
+      %th= Facility.model_name.human
       %th= text("user_label")
 
   %tbody


### PR DESCRIPTION
# Release Notes

Includes the facility name for event logs where possible.  Also includes the price group name for soft deleted price groups.

# Screenshot

<img width="1284" alt="Screen Shot 2020-07-13 at 10 24 50 AM" src="https://user-images.githubusercontent.com/30355046/87322604-38f68b00-c4f3-11ea-8a6b-558bcb94a675.png">
