### PR TITLE
[#154053] Fix error in next reservation finder

### DIFF
--- a/app/services/next_available_reservation_finder.rb
+++ b/app/services/next_available_reservation_finder.rb
@@ -19,7 +19,7 @@ class NextAvailableReservationFinder
   private
 
   def default_reservation
-    Reservation.new(instrument: @product,
+    Reservation.new(product: @product,
                     reserve_start_at: Time.current,
                     reserve_end_at: default_reservation_mins.minutes.from_now)
   end

--- a/spec/services/next_available_reservation_finder_spec.rb
+++ b/spec/services/next_available_reservation_finder_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+RSpec.describe NextAvailableReservationFinder do
+  let(:instrument) { FactoryBot.build(:instrument, min_reserve_mins: 0) }
+  let(:user) { FactoryBot.build(:user) }
+
+  describe "#next_available_for" do
+    describe "without a next available reservation" do
+      subject(:reservation) { described_class.new(instrument).next_available_for(user, user) }
+
+      before do
+        expect(instrument).to receive(:next_available_reservation).and_return(nil)
+      end
+
+      it "has a reservation starting around now" do
+        expect(reservation.reserve_start_at).to be_within(1.minute).of(Time.current)
+      end
+
+      it "is thirty minutes long" do
+        expect(reservation.duration_mins).to eq(30)
+      end
+
+      it "is on the right product" do
+        expect(reservation.product).to eq(instrument)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

Fix hard error when a next reservation cannot be found.

# Additional Context

Easy way to reproduce: create a series of schedule rules that does not include the current day (e.g. Wednesday). Try to create a new reservation.

Caused by a bad copy/paste in #2292.
