### PR TITLE
[#154004] Fix issue updating an account's description

### DIFF
--- a/app/controllers/facility_accounts_controller.rb
+++ b/app/controllers/facility_accounts_controller.rb
@@ -52,9 +52,7 @@ class FacilityAccountsController < ApplicationController
 
   # PUT /facilities/:facility_id/accounts/:id
   def update
-    account_type = Account.config.account_type_to_param(@account.class)
-
-    @account = AccountBuilder.for(account_type).new(
+    @account = AccountBuilder.for(@account.class).new(
       account: @account,
       current_user: current_user,
       owner_user: @owner_user,

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -26,6 +26,9 @@ FactoryBot.define do
     # to be valid in rails. And foreign key constraints require that each
     # account_user has an account inserted before the account_user is inserted.
     callback(:after_build) do |account, evaluator|
+      # Some subclass factories might already include this trait, so we don't want
+      # to accidentally have two owners.
+      account.account_users = account.account_users.reject(&:owner?)
       account.account_users << build(:account_user, user: evaluator.owner)
     end
   end

--- a/spec/services/account_builder_spec.rb
+++ b/spec/services/account_builder_spec.rb
@@ -63,6 +63,22 @@ RSpec.describe AccountBuilder, type: :service do
       it "returns subclassed builder" do
         expect(described_class.for("Existing")).to eq(ExistingBuilder)
       end
+
+      it "can find it by underscored name" do
+        expect(described_class.for("existing")).to eq(ExistingBuilder)
+      end
+    end
+
+    context "when the builder is namespaced" do
+      before do
+        module TestNamespace
+          ExistingBuilder = Class.new(AccountBuilder)
+        end
+      end
+
+      it "returns the builder" do
+        expect(described_class.for("TestNamespace::Existing")).to eq(TestNamespace::ExistingBuilder)
+      end
     end
 
     context "when subclassed account builder missing" do

--- a/spec/system/admin/managing_payment_sources_spec.rb
+++ b/spec/system/admin/managing_payment_sources_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Managing accounts" do
+  let(:facility) { create(:facility) }
+  let(:director) { create(:user, :facility_director, facility: facility) }
+  let(:owner) { create(:user) }
+
+  before { login_as director }
+
+  describe "creation" do
+    # This should be done in each school's engine because it's complicated to abstract
+    # the different components as well as any prerequisites.
+  end
+
+  describe "editing" do
+    let(:account_factory) { Account.config.account_types.first.demodulize.underscore }
+    let!(:account) { create(account_factory, :with_account_owner, owner: owner) }
+
+    it "can edit a payment source's description" do
+      visit facility_accounts_path(facility)
+      fill_in "search_term", with: account.account_number
+      click_on "Search"
+      click_on account.to_s
+      click_on "Edit"
+      fill_in "Description", with: "New description"
+      click_on "Save"
+      expect(page).to have_content("Description\nNew description")
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

Fixes an issue in UMass where when editing an account's (speed type in their case) description, the field does not get updated.

# Additional Context

This does not seem to be an issue at other schools, but the test here should confirm that.

Dartmouth build: https://app.circleci.com/pipelines/github/tablexi/nucore-dartmouth/23/workflows/d7b389e3-6366-444e-b60a-468270d7dcc1/jobs/1468/steps
UMass build: https://app.circleci.com/pipelines/github/tablexi/nucore-umass/285/workflows/28b86eec-5e70-4b66-875e-e470822515d5/jobs/293/steps
NU build: https://app.circleci.com/pipelines/github/tablexi/nucore-nu/466/workflows/5241863f-92ff-43a3-bc84-7edb015ebeb3/jobs/2593/steps
