### PR TITLE
Tech task: Remove `ruby-erd` dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,6 @@ group :development do
   gem "ed25519", ">= 1.2", "< 2.0", require: false # Required to support ed25519 SSH keys for capistrano. https://github.com/net-ssh/net-ssh/issues/565
   gem "haml_lint", require: false
   gem "letter_opener"
-  gem "rails-erd"
   gem "rubocop", "0.58", require: false
   gem "rubocop-rspec"
   gem "web-console"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,6 @@ GEM
     celluloid-supervision (0.20.6)
       timers (>= 4.1.1)
     childprocess (3.0.0)
-    choice (0.2.0)
     chosen-rails (1.8.7)
       coffee-rails (>= 3.2)
       railties (>= 3.0)
@@ -464,11 +463,6 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-erd (1.6.0)
-      activerecord (>= 4.2)
-      activesupport (>= 4.2)
-      choice (~> 0.2.0)
-      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     rails-observers (0.1.5)
@@ -531,7 +525,6 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-rspec (1.30.0)
       rubocop (>= 0.58.0)
-    ruby-graphviz (1.2.4)
     ruby-ole (1.2.12.2)
     ruby-progressbar (1.10.1)
     ruby-saml (1.11.0)
@@ -699,7 +692,6 @@ DEPENDENCIES
   pry-rails
   rails (= 5.2.4.2)
   rails-controller-testing
-  rails-erd
   rails-observers
   rake
   rollbar


### PR DESCRIPTION
# Release Notes

Tech task: Remove `ruby-erd` dependency.

# Additional Context

[ruby-erd](https://github.com/voormedia/rails-erd) is used to generate model diagrams (entity relationship diagrams). It can be useful from time to time, but it doesn't provide enough value regularly to keep in the app. When it would be useful
we can always temporarily add it back in--or manually install the gem.

