### PR TITLE
[#153972] Add the option to remove the cancer center PriceGroup

### DIFF
--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -32,10 +32,6 @@ class PriceGroup < ApplicationRecord
     globals.find_by(name: Settings.price_group.name.external)
   end
 
-  def self.cancer_center
-    globals.find_by(name: Settings.price_group.name.cancer_center)
-  end
-
   def is_not_global?
     !global?
   end

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -17,7 +17,7 @@ class PriceGroup < ApplicationRecord
 
   default_scope -> { order(is_internal: :desc, display_order: :asc, name: :asc) }
 
-  before_destroy :throw_abort, if: :global?
+  before_destroy { throw :abort if global? }
   before_destroy { price_policies.destroy_all } # Cannot be a dependent: :destroy because of ordering of callbacks
   before_create  ->(o) { o.display_order = 999 unless o.facility_id.nil? }
 
@@ -75,10 +75,6 @@ class PriceGroup < ApplicationRecord
 
   def external?
     !is_internal?
-  end
-
-  def throw_abort
-    throw :abort
   end
 
 end

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -17,7 +17,7 @@ class PriceGroup < ApplicationRecord
 
   default_scope -> { order(is_internal: :desc, display_order: :asc, name: :asc) }
 
-  before_destroy { throw :abort if global? }
+  before_destroy :throw_abort, if: :global?
   before_destroy { price_policies.destroy_all } # Cannot be a dependent: :destroy because of ordering of callbacks
   before_create  ->(o) { o.display_order = 999 unless o.facility_id.nil? }
 
@@ -79,6 +79,10 @@ class PriceGroup < ApplicationRecord
 
   def external?
     !is_internal?
+  end
+
+  def throw_abort
+    throw :abort
   end
 
 end

--- a/db/migrate/20150204174650_add_admin_editable_to_price_group.rb
+++ b/db/migrate/20150204174650_add_admin_editable_to_price_group.rb
@@ -5,9 +5,11 @@ class AddAdminEditableToPriceGroup < ActiveRecord::Migration[4.2]
   def up
     add_column :price_groups, :admin_editable, :boolean, after: :is_internal, null: false, default: true
 
-    (PriceGroup.globals - [PriceGroup.cancer_center]).each do |price_group|
-      price_group.update_attribute(:admin_editable, false)
-    end
+    # This was relevant for updating records when the migration was run back in 2015.
+    # The PriceGroup#cancer_center method no longer exists.  Leaving this here for documentation.
+    # (PriceGroup.globals - [PriceGroup.cancer_center]).each do |price_group|
+    #   price_group.update_attribute(:admin_editable, false)
+    # end
   end
 
   def down

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -26,7 +26,7 @@ namespace :cleanup do
       pg = PriceGroup.find_by(name: cc_name)
       abort("No cancer center price group found with name #{cc_name}") unless pg
 
-      PriceGroup.skip_callback(:destroy, :before, :throw_abort)
+      pg.facility = Facility.first
       pg.destroy!
       puts "Price group with id: #{pg.id}, name: #{cc_name} has been destroyed."
     end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -18,4 +18,17 @@ namespace :cleanup do
       Cart.destroy_all_instrument_only_carts(5.days.ago)
     end
   end
+
+  namespace :price_groups do
+    desc "remove cancer center"
+    task :cancer_center, [:cancer_center_name] => :environment do |_t, args|
+      cc_name = args[:cancer_center_name] || "Cancer Center Rate"
+      pg = PriceGroup.find_by(name: cc_name)
+      abort("No cancer center price group found with name #{cc_name}") unless pg
+
+      PriceGroup.skip_callback(:destroy, :before, :throw_abort)
+      pg.destroy!
+      puts "Price group with id: #{pg.id}, name: #{cc_name} has been destroyed."
+    end
+  end
 end


### PR DESCRIPTION
# Release Notes

UMass doesn't have a cancer center Price Group.  The seed file will just skip creating a cancer center PriceGroup if no `cancer_center` key is found in `settings.yml`.  I added a rake task that makes it easier to destroy an existing global PriceGroup if needed.  The rake task will fail if the PriceGroup has any associated `order_details`.