### PR TITLE
[#153973] Allow full domain names for relays

### DIFF
--- a/db/migrate/20200723191759_remove_limit_from_relays_ip.rb
+++ b/db/migrate/20200723191759_remove_limit_from_relays_ip.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveLimitFromRelaysIp < ActiveRecord::Migration[5.2]
+  def up
+    change_column :relays, :ip, :string, limit: nil
+  end
+
+  def down
+    change_column :relays, :ip, :string, limit: 15
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_02_212036) do
+ActiveRecord::Schema.define(version: 2020_07_23_191759) do
 
   create_table "account_facility_joins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "facility_id", null: false
@@ -583,7 +583,7 @@ ActiveRecord::Schema.define(version: 2020_07_02_212036) do
 
   create_table "relays", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "instrument_id"
-    t.string "ip", limit: 15
+    t.string "ip"
     t.integer "outlet"
     t.string "username", limit: 50
     t.string "password", limit: 50

--- a/spec/models/relay_spec.rb
+++ b/spec/models/relay_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe Relay do
         expect(relay2).to be_valid
       end
 
+      it "allows FQDN for IP/host" do
+        @relay.ip = "gatekeeper.cns.umass.edu"
+        expect(@relay).to be_valid
+      end
+
     end
 
     it "should alias host to ip" do


### PR DESCRIPTION
# Release Notes

Removes the max length restriction from the `ip` column.