### PR TITLE
[#153876] Fix error when viewing logs for account price groups

### DIFF
--- a/app/controllers/concerns/price_group_members_controller.rb
+++ b/app/controllers/concerns/price_group_members_controller.rb
@@ -28,7 +28,7 @@ module PriceGroupMembersController
     raise NUCore::PermissionDenied unless @price_group.can_manage_price_group_members?
 
     if price_group_member.save
-      LogEvent.log(price_group_member, :create, current_user)
+      LogEvent.log(price_group_member, :create, current_user, metadata: { member_type: price_group.member_type })
       set_flash(:notice, :create, create_flash_arguments)
     else
       set_flash(:error, :create, create_flash_arguments)
@@ -40,7 +40,7 @@ module PriceGroupMembersController
     raise NUCore::PermissionDenied unless @price_group.can_manage_price_group_members?
 
     if destroy_price_group_member!
-      LogEvent.log(price_group_member, :delete, current_user)
+      LogEvent.log(price_group_member, :delete, current_user, metadata: { member_type: price_group.member_type })
       set_flash(:notice, :destroy)
     else
       set_flash(:error, :destroy)

--- a/app/controllers/concerns/price_group_members_controller.rb
+++ b/app/controllers/concerns/price_group_members_controller.rb
@@ -28,7 +28,7 @@ module PriceGroupMembersController
     raise NUCore::PermissionDenied unless @price_group.can_manage_price_group_members?
 
     if price_group_member.save
-      LogEvent.log(price_group_member, :create, current_user, metadata: { member_type: price_group.member_type })
+      LogEvent.log(price_group_member, :create, current_user, metadata: { member_type: price_group_member.member_type })
       set_flash(:notice, :create, create_flash_arguments)
     else
       set_flash(:error, :create, create_flash_arguments)
@@ -40,7 +40,7 @@ module PriceGroupMembersController
     raise NUCore::PermissionDenied unless @price_group.can_manage_price_group_members?
 
     if destroy_price_group_member!
-      LogEvent.log(price_group_member, :delete, current_user, metadata: { member_type: price_group.member_type })
+      LogEvent.log(price_group_member, :delete, current_user, metadata: { member_type: price_group_member.member_type })
       set_flash(:notice, :destroy)
     else
       set_flash(:error, :destroy)

--- a/app/models/account_price_group_member.rb
+++ b/app/models/account_price_group_member.rb
@@ -7,4 +7,8 @@ class AccountPriceGroupMember < PriceGroupMember
   validates_presence_of :account_id
   validates_uniqueness_of :account_id, scope: [:price_group_id]
 
+  def to_log_s
+    "#{account} / #{price_group_with_deleted}"
+  end
+
 end

--- a/app/models/price_group_member.rb
+++ b/app/models/price_group_member.rb
@@ -10,4 +10,8 @@ class PriceGroupMember < ApplicationRecord
 
   validates_presence_of :price_group_id
 
+  def member_type
+    type.sub("PriceGroupMember", "")
+  end
+
 end

--- a/app/models/price_group_member.rb
+++ b/app/models/price_group_member.rb
@@ -10,8 +10,4 @@ class PriceGroupMember < ApplicationRecord
 
   validates_presence_of :price_group_id
 
-  def to_log_s
-    "#{user} / #{price_group_with_deleted}"
-  end
-
 end

--- a/app/models/user_price_group_member.rb
+++ b/app/models/user_price_group_member.rb
@@ -7,4 +7,8 @@ class UserPriceGroupMember < PriceGroupMember
   validates_presence_of :user_id
   validates_uniqueness_of :user_id, scope: [:price_group_id]
 
+  def to_log_s
+    "#{user} / #{price_group_with_deleted}"
+  end
+
 end

--- a/config/locales/views/admin/en.log_events.yml
+++ b/config/locales/views/admin/en.log_events.yml
@@ -31,8 +31,8 @@ en:
           create: User added to access list
           delete: User removed from access list
         price_group_member:
-          create: User added to price group
-          delete: User removed from price group
+          create: "%{member_type} added to price group"
+          delete: "%{member_type} removed from price group"
         facility:
           activate: Turned on all relays
           deactivate: Turned off all relays

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -35,9 +35,9 @@ namespace :cleanup do
   namespace :log_events do
     desc "update metadata for PriceGroupMembers"
     task metadata: :environment do
-      events = LogEvent.where("loggable_type LIKE ?", "PriceGroupMember").where(metadata: nil)
+      events = LogEvent.where(loggable_type: "PriceGroupMember").where(metadata: nil)
       puts "Updating #{events.size} LogEvents..."
-      events.each do |event|
+      events.find_each do |event|
         event.update(metadata: { member_type: event.loggable.member_type })
       end
     end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -31,4 +31,15 @@ namespace :cleanup do
       puts "Price group with id: #{pg.id}, name: #{cc_name} has been destroyed."
     end
   end
+
+  namespace :log_events do
+    desc "update metadata for PriceGroupMembers"
+    task metadata: :environment do
+      events = LogEvent.where("loggable_type LIKE ?", "PriceGroupMember").where(metadata: nil)
+      puts "Updating #{events.size} LogEvents..."
+      events.each do |event|
+        event.update(metadata: { member_type: event.loggable.member_type })
+      end
+    end
+  end
 end

--- a/spec/models/price_group_spec.rb
+++ b/spec/models/price_group_spec.rb
@@ -43,6 +43,20 @@ RSpec.describe PriceGroup do
 
   end
 
+  describe "to_log_s" do
+    it "should be loggable with account price groups" do
+      account = create(:setup_account)
+      account_price_group_member = create(:account_price_group_member, price_group: @price_group, account: account)
+      expect(account_price_group_member.to_log_s).to include(account.to_s)
+    end
+
+    it "should be loggable with user price groups" do
+      user = create(:user)
+      account_price_group_member = create(:user_price_group_member, price_group: @price_group, user: user)
+      expect(account_price_group_member.to_log_s).to include(user.to_s)
+    end
+  end
+
   describe "can_delete?" do
     it "should not be deletable if global" do
       @global_price_group = FactoryBot.build(:price_group, facility: nil)
@@ -65,6 +79,14 @@ RSpec.describe PriceGroup do
     it "should be able to delete a price group with price group members" do
       user = create(:user)
       user_price_group_member = create(:user_price_group_member, price_group: @price_group, user: user)
+      @price_group.destroy
+      expect { PriceGroup.find(@price_group.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(PriceGroup.with_deleted.find(@price_group.id)).to be_present
+    end
+
+    it "should be able to delete a price group with price group accounts" do
+      account = create(:setup_account)
+      account_price_group_member = create(:account_price_group_member, price_group: @price_group, account: account)
       @price_group.destroy
       expect { PriceGroup.find(@price_group.id) }.to raise_error(ActiveRecord::RecordNotFound)
       expect(PriceGroup.with_deleted.find(@price_group.id)).to be_present


### PR DESCRIPTION
# Release Notes

I think this has actually been broken since https://github.com/tablexi/nucore-open/pull/2302.

Run `rake cleanup:log_events:metadata` after merging