### PR TITLE
[#154126] Refactor welcome email

### DIFF
--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -26,4 +26,10 @@ module TranslationHelper
     I18n.t(value.to_s, scope: "boolean")
   end
 
+  # Strips HTML line breaks. Useful when using text-helper's `text` method so you
+  # can have a single line break.
+  def strip_br(string)
+    string.gsub(/<br\/?>/, "")
+  end
+
 end

--- a/app/mailers/account_search_result_mailer.rb
+++ b/app/mailers/account_search_result_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AccountSearchResultMailer < BaseMailer
+class AccountSearchResultMailer < ApplicationMailer
 
   def search_result(to_email, search_term, facility)
     accounts = AccountSearcher.new(search_term, scope: Account.for_facility(facility)).results

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-class BaseMailer < ActionMailer::Base
+class ApplicationMailer < ActionMailer::Base
 
   default from: Settings.email.from
+
+  add_template_helper TranslationHelper
 
   def mail(arguments)
     super

--- a/app/mailers/cancellation_mailer.rb
+++ b/app/mailers/cancellation_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CancellationMailer < BaseMailer
+class CancellationMailer < ApplicationMailer
 
   def notify_facility(order_detail)
     @order_detail = order_detail

--- a/app/mailers/csv_report_mailer.rb
+++ b/app/mailers/csv_report_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CsvReportMailer < BaseMailer
+class CsvReportMailer < ApplicationMailer
 
   def csv_report_email(to_address, report)
     attachments[report.filename] = report.to_csv if report.has_attachment?

--- a/app/mailers/instrument_issue_mailer.rb
+++ b/app/mailers/instrument_issue_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class InstrumentIssueMailer < BaseMailer
+class InstrumentIssueMailer < ApplicationMailer
 
   def create(product:, user:, message:, recipients:)
     @product = product

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -4,7 +4,6 @@ class Notifier < ActionMailer::Base
 
   include DateHelper
   add_template_helper ApplicationHelper
-  add_template_helper TranslationHelper
   add_template_helper ViewHookHelper
 
   default from: Settings.email.from, content_type: "multipart/alternative"

--- a/app/mailers/offline_cancellation_mailer.rb
+++ b/app/mailers/offline_cancellation_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class OfflineCancellationMailer < BaseMailer
+class OfflineCancellationMailer < ApplicationMailer
 
   include OfflineReservationArguments
 

--- a/app/mailers/order_assignment_mailer.rb
+++ b/app/mailers/order_assignment_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class OrderAssignmentMailer < BaseMailer
+class OrderAssignmentMailer < ApplicationMailer
 
   def notify_assigned_user(order_details)
     @order_details = Array(order_details)

--- a/app/mailers/order_detail_dispute_mailer.rb
+++ b/app/mailers/order_detail_dispute_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class OrderDetailDisputeMailer < BaseMailer
+class OrderDetailDisputeMailer < ApplicationMailer
 
   add_template_helper DateHelper
 

--- a/app/mailers/problem_order_mailer.rb
+++ b/app/mailers/problem_order_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProblemOrderMailer < BaseMailer
+class ProblemOrderMailer < ApplicationMailer
 
   def notify_user(order_detail)
     @order_detail = order_detail

--- a/app/mailers/purchase_notifier.rb
+++ b/app/mailers/purchase_notifier.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-class PurchaseNotifier < ActionMailer::Base
+class PurchaseNotifier < ApplicationMailer
 
   include DateHelper
   add_template_helper ApplicationHelper
-  add_template_helper TranslationHelper
   add_template_helper OrdersHelper
   add_template_helper ViewHookHelper
 

--- a/app/mailers/results_file_notifier_mailer.rb
+++ b/app/mailers/results_file_notifier_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ResultsFileNotifierMailer < BaseMailer
+class ResultsFileNotifierMailer < ApplicationMailer
 
   def file_uploaded(file)
     @order_detail = file.order_detail

--- a/app/mailers/training_request_mailer.rb
+++ b/app/mailers/training_request_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class TrainingRequestMailer < BaseMailer
+class TrainingRequestMailer < ApplicationMailer
 
   def notify_facility_staff(user, product)
     @user = user

--- a/app/mailers/upcoming_offline_reservation_mailer.rb
+++ b/app/mailers/upcoming_offline_reservation_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UpcomingOfflineReservationMailer < BaseMailer
+class UpcomingOfflineReservationMailer < ApplicationMailer
 
   include OfflineReservationArguments
 

--- a/app/views/notifier/new_user.html.haml
+++ b/app/views/notifier/new_user.html.haml
@@ -1,8 +1,8 @@
-= html("intro_html", first_name: @user.first_name, last_name: @user.last_name, login_url: new_user_session_url)
+= html("intro", first_name: @user.first_name, last_name: @user.last_name, login_url: new_user_session_url)
 
 - if @password
-  = html("username_and_password_html", username: @user.username, password: @password, login_url: new_user_session_url)
+  = html("username_and_password", username: @user.username, password: @password, login_url: new_user_session_url)
 - else
-  = html("only_username_html", username: @user.username, login_url: new_user_session_url)
+  = html("only_username", username: @user.username, login_url: new_user_session_url)
 
-= html("outro_html")
+= html("outro")

--- a/app/views/notifier/new_user.text.erb
+++ b/app/views/notifier/new_user.text.erb
@@ -1,10 +1,10 @@
-<%= text("intro_text", first_name: @user.first_name, last_name: @user.last_name, login_url: new_user_session_url) %>
+<%= text("intro", first_name: @user.first_name, last_name: @user.last_name, login_url: new_user_session_url) %>
 
 <% # non-standard indentation below is to prevent indents appearing in the text formatting of this email %>
 <% if @password %>
-<%= text("username_and_password_text", username: @user.username, password: @password, login_url: new_user_session_url) %>
+<%= strip_br text("username_and_password", username: @user.username, password: @password, login_url: new_user_session_url) %>
 <% else %>
-<%= text("only_username_text", username: @user.username, login_url: new_user_session_url) %>
+<%= strip_br text("only_username", username: @user.username, login_url: new_user_session_url) %>
 <% end %>
 
-<%= text("outro_text") %>
+<%= text("outro") %>

--- a/app/views/order_detail_dispute_mailer/dispute_resolved.text.erb
+++ b/app/views/order_detail_dispute_mailer/dispute_resolved.text.erb
@@ -1,4 +1,4 @@
-<%= text("body",
+<%= strip_br text("body",
   user: @user,
   facility: @order_detail.facility.name,
   order_detail: @order_detail,
@@ -6,5 +6,5 @@
   dispute_resolved_at: format_usa_date(@order_detail.dispute_resolved_at),
   dispute_resolved_reason: @order_detail.dispute_resolved_reason,
   facility_email: @order_detail.facility.email,
-  ).gsub("<br>", "")
+  )
 %>

--- a/config/locales/en.notifier.yml
+++ b/config/locales/en.notifier.yml
@@ -4,19 +4,19 @@ en:
       account_update:
         subject: "!app_name! Payment Method Updated"
       new_user:
-        intro_html: "Congratulations, %{first_name}. A !app_name! account has been created for you. You may log in at [%{login_url}](%{login_url})."
-        intro_text: "Congratulations, %{first_name}. A !app_name! account has been created for you. You may log in at %{login_url}."
-        only_username_text: You may log in with your username and password.
-        only_username_html: You may log in with your username and password.
         subject: "Welcome to !app_name!"
-        username_and_password_text: |
-          Username: %{username}
-          Password: %{password}
-        username_and_password_html: |
+        intro: |
+          Hello, %{first_name}.
+
+          A !app_name! account has been created for you. You may log in at [%{login_url}](%{login_url})."
+        only_username: |
+          Log in using your NetID and password.
+        username_and_password: |
+          You may log in with your username and password.
+
           Username: %{username}<br/>
           Password: %{password}
-        outro_html: ""
-        outro_text: ""
+        outro: ""
       order_detail_status_changed:
         subject:
         body: |

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,6 +4,8 @@ FactoryBot.define do
   factory :user do
     sequence(:username) { |n| "username#{n}" }
     first_name { "User" }
+    password { "password" }
+    password_confirmation { "password" }
     sequence(:last_name) { |n| "Last#{n}" }
     sequence(:email) { |n| "user#{n}@example.com" }
 
@@ -22,8 +24,11 @@ FactoryBot.define do
 
     trait :external do
       username { email }
-      password { "password" }
-      password_confirmation { "password" }
+    end
+
+    trait :netid do
+      password { nil }
+      password_confirmation { nil }
     end
 
     trait :account_manager do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,8 +4,6 @@ FactoryBot.define do
   factory :user do
     sequence(:username) { |n| "username#{n}" }
     first_name { "User" }
-    password { "password" }
-    password_confirmation { "password" }
     sequence(:last_name) { |n| "Last#{n}" }
     sequence(:email) { |n| "user#{n}@example.com" }
 
@@ -24,6 +22,8 @@ FactoryBot.define do
 
     trait :external do
       username { email }
+      password { "password" }
+      password_confirmation { "password" }
     end
 
     trait :account_manager do

--- a/spec/mailers/previews/notifier_preview.rb
+++ b/spec/mailers/previews/notifier_preview.rb
@@ -20,9 +20,14 @@ class NotifierPreview < ActionMailer::Preview
     )
   end
 
-  def new_user
-    user = User.first
-    Notifier.new_user(user: user, password: "password")
+  def new_internal_user
+    user = FactoryBot.build(:user, username: "mynetid")
+    Notifier.new_user(user: user, password: user.password)
+  end
+
+  def new_external_user
+    user = FactoryBot.build(:user, :external)
+    Notifier.new_user(user: user, password: user.password)
   end
 
   def order_detail_status_changed

--- a/spec/mailers/previews/notifier_preview.rb
+++ b/spec/mailers/previews/notifier_preview.rb
@@ -21,12 +21,12 @@ class NotifierPreview < ActionMailer::Preview
   end
 
   def new_internal_user
-    user = FactoryBot.build(:user, username: "mynetid")
+    user = FactoryBot.build(:user, :netid, username: "mynetid")
     Notifier.new_user(user: user, password: user.password)
   end
 
   def new_external_user
-    user = FactoryBot.build(:user, :external)
+    user = FactoryBot.build(:user, password: "abc123")
     Notifier.new_user(user: user, password: user.password)
   end
 

--- a/vendor/engines/bulk_email/app/mailers/bulk_email/mailer.rb
+++ b/vendor/engines/bulk_email/app/mailers/bulk_email/mailer.rb
@@ -2,7 +2,7 @@
 
 module BulkEmail
 
-  class Mailer < BaseMailer
+  class Mailer < ApplicationMailer
 
     def send_mail(recipient:, subject:, body:, reply_to: nil, facility:)
       @recipient = recipient


### PR DESCRIPTION
# Release Notes

Tech task: Refactor new user welcome email

# Additional Context

I wanted to do this as part of the updating of the welcome email for UMass. There was a lot of duplication that we don't need between the text version and the html version. This will require a little bit of cleanup in the other schools but it should be straightforward, plus I improved the mailer preview so there's separate previews for internal vs external users.

One last thing I did was renamed `BaseMailer` to `ApplicationMailer`, which is the standard name for the mailer superclass for Rails (we originally created these classes before Rails had a standard superclass).
