### PR TITLE
Tech task: Clean up capitalization of Nucore module

### DIFF
--- a/app/models/journal_cutoff_date.rb
+++ b/app/models/journal_cutoff_date.rb
@@ -47,7 +47,7 @@ class JournalCutoffDate < ApplicationRecord
   end
 
   def self.time_section_equal(section, time)
-    if NUCore::Database.oracle?
+    if Nucore::Database.oracle?
       # EXTRACT(MONTH from cutoff_date)
       where("EXTRACT(#{section} FROM cutoff_date) = ?", time)
     else

--- a/app/services/admin_reservation_expirer.rb
+++ b/app/services/admin_reservation_expirer.rb
@@ -9,7 +9,7 @@ class AdminReservationExpirer
   private
 
   def expired_reservations
-    if NUCore::Database.oracle?
+    if Nucore::Database.oracle?
       AdminReservation.where("reserve_start_at - expires_mins_before / (60*24) < TO_TIMESTAMP(?)", Time.current)
     else
       AdminReservation.where("SUBTIME(reserve_start_at, MAKETIME(expires_mins_before DIV 60, expires_mins_before MOD 60, 0)) < ?", Time.current)

--- a/app/support/auto_canceler.rb
+++ b/app/support/auto_canceler.rb
@@ -34,7 +34,7 @@ class AutoCanceler
   private
 
   def time_condition
-    if NUCore::Database.oracle?
+    if Nucore::Database.oracle?
       "(:now - reserve_start_at) >= NumToDSInterval(auto_cancel_mins, 'MINUTE')"
     else
       "TIMESTAMPDIFF(MINUTE, reserve_start_at, :now) >= auto_cancel_mins"

--- a/app/support/journals/closer.rb
+++ b/app/support/journals/closer.rb
@@ -30,7 +30,7 @@ class Journals::Closer
 
   def mark_as_failed
     # Oracle is sometimes not converting false to null
-    false_value = NUCore::Database.boolean(false)
+    false_value = Nucore::Database.boolean(false)
     if journal.update_attributes(params.merge(is_successful: false_value))
       # remove all the orders from the journal
       # Do not use the Journal#order_details relation because it goes through journal_rows

--- a/db/migrate/20100528203109_order_details_add_and_remove_fields.rb
+++ b/db/migrate/20100528203109_order_details_add_and_remove_fields.rb
@@ -4,11 +4,11 @@ class OrderDetailsAddAndRemoveFields < ActiveRecord::Migration[4.2]
 
   def self.up
     # Oracle will drop the foreign key as part of the remove_column
-    remove_foreign_key :order_details, :order_statuses if NUCore::Database.mysql?
+    remove_foreign_key :order_details, :order_statuses if Nucore::Database.mysql?
     remove_column :order_details, :order_status_id
     remove_column :order_details, :unit_cost
     remove_column :order_details, :unit_subsidy
-    remove_foreign_key :order_details, :reservations if NUCore::Database.mysql?
+    remove_foreign_key :order_details, :reservations if Nucore::Database.mysql?
     remove_column :order_details, :reservation_id
 
     add_column :order_details, :estimated_cost,    :decimal, precision: 10, scale: 2, null: true

--- a/db/migrate/20100708221022_remove_statement_id_from_order_details.rb
+++ b/db/migrate/20100708221022_remove_statement_id_from_order_details.rb
@@ -4,7 +4,7 @@ class RemoveStatementIdFromOrderDetails < ActiveRecord::Migration[4.2]
 
   def self.up
     # Oracle will drop the foreign key as part of the remove_column
-    remove_foreign_key :order_details, :statements if NUCore::Database.mysql?
+    remove_foreign_key :order_details, :statements if Nucore::Database.mysql?
     remove_column :order_details, :statement_id
   end
 

--- a/db/migrate/20110729173029_change_vestal_versions.rb
+++ b/db/migrate/20110729173029_change_vestal_versions.rb
@@ -9,7 +9,7 @@ class ChangeVestalVersions < ActiveRecord::Migration[4.2]
 
     rename_column :versions, :data_changes, :modifications
 
-    if NUCore::Database.oracle?
+    if Nucore::Database.oracle?
       execute %( ALTER TABLE versions RENAME COLUMN "NUMBER" TO "VERSION_NUMBER" )
     else
       rename_column :versions, :number, :version_number
@@ -21,7 +21,7 @@ class ChangeVestalVersions < ActiveRecord::Migration[4.2]
   def self.down
     remove_index :versions, :commit_label
 
-    if NUCore::Database.oracle?
+    if Nucore::Database.oracle?
       execute %( ALTER TABLE versions RENAME COLUMN "VERSION_NUMBER" TO "NUMBER" )
     else
       rename_column :versions, :version_number, :number

--- a/db/migrate/20120502223446_alter_journal_rows_remove_nu.rb
+++ b/db/migrate/20120502223446_alter_journal_rows_remove_nu.rb
@@ -3,7 +3,7 @@
 class AlterJournalRowsRemoveNu < ActiveRecord::Migration[4.2]
 
   def self.up
-    if NUCore::Database.oracle?
+    if Nucore::Database.oracle?
       puts <<-WARN
         >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
         You're running Oracle. Doing so usually requires NU columns on journal_rows. This migration removes those

--- a/db/migrate/20120510172358_add_bi_table.rb
+++ b/db/migrate/20120510172358_add_bi_table.rb
@@ -3,7 +3,7 @@
 class AddBiTable < ActiveRecord::Migration[4.2]
 
   def self.up
-    if NUCore::Database.oracle?
+    if Nucore::Database.oracle?
       create_table :bi_netids do |t|
         t.string :netid, null: false
         t.references :facility, null: false

--- a/db/migrate/20120801223135_journal_rows_allow_null_account.rb
+++ b/db/migrate/20120801223135_journal_rows_allow_null_account.rb
@@ -3,7 +3,7 @@
 class JournalRowsAllowNullAccount < ActiveRecord::Migration[4.2]
 
   def self.up
-    if NUCore::Database.oracle?
+    if Nucore::Database.oracle?
       execute "alter table journal_rows modify (account null)"
     else
       change_column :journal_rows, :account, :string, limit: 5, null: true
@@ -11,7 +11,7 @@ class JournalRowsAllowNullAccount < ActiveRecord::Migration[4.2]
   end
 
   def self.down
-    if NUCore::Database.oracle?
+    if Nucore::Database.oracle?
       execute "alter table journal_rows modify (account not null)"
     else
       change_column :journal_rows, :account, :string, limit: 5, null: false

--- a/db/migrate/20160415231343_clean_duplicate_reservations.rb
+++ b/db/migrate/20160415231343_clean_duplicate_reservations.rb
@@ -15,7 +15,7 @@ class CleanDuplicateReservations < ActiveRecord::Migration[4.2]
     order_details_with_multiple_reservations.each do |order_detail_id|
       Reservation.where(order_detail_id: order_detail_id).last.destroy
     end
-    if NUCore::Database.oracle?
+    if Nucore::Database.oracle?
       begin
         remove_index :reservations, :order_detail_id
       rescue
@@ -27,7 +27,7 @@ class CleanDuplicateReservations < ActiveRecord::Migration[4.2]
 
   def down
     remove_index :reservations, name: "res_od_uniq_fk"
-    if NUCore::Database.oracle?
+    if Nucore::Database.oracle?
       add_index :reservations, :order_detail_id, name: "i_reservations_order_detail_id", tablespace: "bc_nucore"
     end
   end

--- a/db/migrate/20170112204251_increase_delayed_jobs_handler_capacity.rb
+++ b/db/migrate/20170112204251_increase_delayed_jobs_handler_capacity.rb
@@ -3,13 +3,13 @@
 class IncreaseDelayedJobsHandlerCapacity < ActiveRecord::Migration[4.2]
 
   def up
-    if NUCore::Database.mysql?
+    if Nucore::Database.mysql?
       change_column :delayed_jobs, :handler, :text, limit: (2**32 - 1)
     end
   end
 
   def down
-    if NUCore::Database.mysql?
+    if Nucore::Database.mysql?
       change_column :delayed_jobs, :handler, :text
     end
   end

--- a/db/migrate/20180907190857_fix_oracle_timestamps.rb
+++ b/db/migrate/20180907190857_fix_oracle_timestamps.rb
@@ -5,7 +5,7 @@
 class FixOracleTimestamps < ActiveRecord::Migration[5.0]
 
   def change
-    return unless NUCore::Database.oracle?
+    return unless Nucore::Database.oracle?
 
     reversible do |dir|
       dir.up { change_all_columns_types(:date, :datetime) }

--- a/db/migrate/20190104011154_change_account_facility_relationship_144419.rb
+++ b/db/migrate/20190104011154_change_account_facility_relationship_144419.rb
@@ -9,7 +9,7 @@ class ChangeAccountFacilityRelationship144419 < ActiveRecord::Migration[5.0]
       t.timestamps
     end
 
-    if NUCore::Database.oracle?
+    if Nucore::Database.oracle?
       execute <<~SQL
         INSERT INTO account_facility_joins (id, account_id, facility_id, created_at, updated_at)
         SELECT ACCOUNT_FACILITY_JOINS_SEQ.NEXTVAL, account_id, facility_id, created_at, updated_at

--- a/db/migrate/20191114122118_move_ordered_at_to_order_detail.rb
+++ b/db/migrate/20191114122118_move_ordered_at_to_order_detail.rb
@@ -6,7 +6,7 @@ class MoveOrderedAtToOrderDetail < ActiveRecord::Migration[5.0]
       t.datetime :ordered_at
     end
 
-    execute NUCore::Database.oracle? ? oracle_up : mysql_up
+    execute Nucore::Database.oracle? ? oracle_up : mysql_up
 
     change_table :orders do |t|
       t.remove :ordered_at

--- a/db/migrate/20200213005326_add_full_text_index_for_oracle.rb
+++ b/db/migrate/20200213005326_add_full_text_index_for_oracle.rb
@@ -1,7 +1,7 @@
 class AddFullTextIndexForOracle < ActiveRecord::Migration[5.2]
 
   def change
-    if NUCore::Database.oracle?
+    if Nucore::Database.oracle?
       reversible do |dir|
         dir.up do
           add_context_index :products, :name, sync: "ON COMMIT"

--- a/lib/nucore/database.rb
+++ b/lib/nucore/database.rb
@@ -59,10 +59,3 @@ module Nucore
   end
 
 end
-
-# All of the Database and other sub-modules used to be in this file. Now, in order
-# to deal with Rails autoloading, they need to be in `Nucore`. However, there are
-# many legacy uses of the `NUCore` capitalization. Until we go through and clean them
-# up, provide an alias.
-# TODO: Replace usage of old capitalization
-NUCore::Database = Nucore::Database

--- a/spec/mailers/previews/cancelation_mailer_preview.rb
+++ b/spec/mailers/previews/cancelation_mailer_preview.rb
@@ -4,8 +4,8 @@ class CancellationMailerPreview < ActionMailer::Preview
 
   def notify_facility
     products_with_contacts = Product.where("LENGTH(cancellation_email_recipients) > 0")
-    product = NUCore::Database.random(products_with_contacts)
-    CancellationMailer.notify_facility(NUCore::Database.random(product.order_details.canceled))
+    product = Nucore::Database.random(products_with_contacts)
+    CancellationMailer.notify_facility(Nucore::Database.random(product.order_details.canceled))
   end
 
 end

--- a/spec/mailers/previews/instrument_issue_mailer_preview.rb
+++ b/spec/mailers/previews/instrument_issue_mailer_preview.rb
@@ -3,7 +3,7 @@
 class InstrumentIssueMailerPreview < ActionMailer::Preview
 
   def create
-    reservation = NUCore::Database.random(Reservation.user)
+    reservation = Nucore::Database.random(Reservation.user)
     InstrumentIssueMailer.create(
       product: reservation.product,
       user: reservation.user,

--- a/spec/mailers/previews/notifier_preview.rb
+++ b/spec/mailers/previews/notifier_preview.rb
@@ -4,7 +4,7 @@ class NotifierPreview < ActionMailer::Preview
 
   def review_orders
     Notifier.review_orders(
-      accounts: ::NUCore::Database.sample(Account, 3),
+      accounts: ::Nucore::Database.sample(Account, 3),
       facility: Facility.first,
       user: User.first,
     )
@@ -31,7 +31,7 @@ class NotifierPreview < ActionMailer::Preview
   end
 
   def order_detail_status_changed
-    order_detail = NUCore::Database.random(OrderDetail.complete)
+    order_detail = Nucore::Database.random(OrderDetail.complete)
     Notifier.order_detail_status_changed(order_detail)
   end
 

--- a/spec/mailers/previews/order_detail_dispute_mailer_preview.rb
+++ b/spec/mailers/previews/order_detail_dispute_mailer_preview.rb
@@ -3,7 +3,7 @@
 class OrderDetailDisputeMailerPreview < ActionMailer::Preview
 
   def dispute_resolved
-    order_detail = NUCore::Database.random(OrderDetail.where.not(dispute_resolved_at: nil))
+    order_detail = Nucore::Database.random(OrderDetail.where.not(dispute_resolved_at: nil))
     OrderDetailDisputeMailer.dispute_resolved(order_detail: order_detail, user: order_detail.user)
   end
 

--- a/spec/mailers/previews/problem_order_mailer_preview.rb
+++ b/spec/mailers/previews/problem_order_mailer_preview.rb
@@ -3,12 +3,12 @@
 class ProblemOrderMailerPreview < ActionMailer::Preview
 
   def notify_user
-    order_detail = NUCore::Database.random(Reservation.user.joins(:order_detail).merge(OrderDetail.complete)).order_detail
+    order_detail = Nucore::Database.random(Reservation.user.joins(:order_detail).merge(OrderDetail.complete)).order_detail
     ProblemOrderMailer.notify_user(order_detail)
   end
 
   def notify_user_with_resolution_option
-    order_detail = NUCore::Database.random(Reservation.user.joins(:order_detail).merge(OrderDetail.complete)).order_detail
+    order_detail = Nucore::Database.random(Reservation.user.joins(:order_detail).merge(OrderDetail.complete)).order_detail
     ProblemOrderMailer.notify_user_with_resolution_option(order_detail)
   end
 

--- a/spec/mailers/previews/training_request_mailer_preview.rb
+++ b/spec/mailers/previews/training_request_mailer_preview.rb
@@ -5,8 +5,8 @@ class TrainingRequestMailerPreview < ActionMailer::Preview
   def notify_facility_staff
     # Is not null and not blank. Oracle does not support `where.not(traning_request_contacts: "")` for CLOBS.
     products_with_contacts = Product.requiring_approval.where("LENGTH(training_request_contacts) > 0")
-    product = NUCore::Database.random(products_with_contacts)
-    user = NUCore::Database.random(User.all)
+    product = Nucore::Database.random(products_with_contacts)
+    user = Nucore::Database.random(User.all)
     TrainingRequestMailer.notify_facility_staff(user, product)
   end
 

--- a/spec/support/matchers/sql_matchers.rb
+++ b/spec/support/matchers/sql_matchers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if NUCore::Database.oracle?
+if Nucore::Database.oracle?
 
   def timestamp_pattern(field, operator, time)
     timestamp = time.utc.strftime("%Y-%m-%d\\s%H:%M:%S")

--- a/vendor/engines/sanger_sequencing/db/migrate/20160519030413_create_sanger_sequencing_submissions.rb
+++ b/vendor/engines/sanger_sequencing/db/migrate/20160519030413_create_sanger_sequencing_submissions.rb
@@ -17,7 +17,7 @@ class CreateSangerSequencingSubmissions < ActiveRecord::Migration[4.2]
       t.timestamps
     end
 
-    if NUCore::Database.mysql?
+    if Nucore::Database.mysql?
       execute "ALTER TABLE sanger_sequencing_samples AUTO_INCREMENT = 11111"
     end
 

--- a/vendor/engines/sanger_sequencing/spec/mailers/previews/purchase_notifier_preview.rb
+++ b/vendor/engines/sanger_sequencing/spec/mailers/previews/purchase_notifier_preview.rb
@@ -1,7 +1,7 @@
 class PurchaseNotifierPreview < ActionMailer::Preview
 
   def sanger_order_notification
-    submission = NUCore::Database.random(SangerSequencing::Submission.joins(:order_detail).merge(OrderDetail.purchased))
+    submission = Nucore::Database.random(SangerSequencing::Submission.joins(:order_detail).merge(OrderDetail.purchased))
     order_detail = submission.order_detail
     PurchaseNotifier.order_notification(
       order_detail.order,


### PR DESCRIPTION
# Release Notes

Tech task: update capitalization of `Nucore` module name so it's consistent throughout the codebase.

# Additional Context

It needs to be `Nucore` so that Rails's autoloader loads it properly from `nucore` directory/files.
