### PR TITLE
Tech task: Add AASM dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem "devise-encryptable"
 
 ## models
 gem "aasm"
+gem "after_commit_everywhere", "~> 0.1", ">= 0.1.5" # Needed by AASM
 gem "paperclip"
 gem "paper_trail"
 gem "awesome_nested_set"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    after_commit_everywhere (0.1.5)
+      activerecord (>= 4.2)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (9.0.0)
@@ -594,6 +596,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm
+  after_commit_everywhere (~> 0.1, >= 0.1.5)
   awesome_nested_set
   awesome_print
   bcrypt_pbkdf (>= 1.0, < 2.0)


### PR DESCRIPTION
# Release Notes

Tech task add `after_commit_everywhere` which is apparently now a non-explicit AASM dependency.

# Additional Context

Fixes this message I'm seeing after https://github.com/tablexi/nucore-open/pull/2366

```
[DEPRECATION] :after_commit AASM callback is not safe in terms of race conditions and redundant calls.
              Please add `gem 'after_commit_everywhere', '~> 0.1', '>= 0.1.5'` to your Gemfile in order to fix that.
```

