### PR TITLE
Tech task: Move google analytics key out of constant into settings

### DIFF
--- a/app/views/shared/_google.html.erb
+++ b/app/views/shared/_google.html.erb
@@ -1,7 +1,7 @@
-<% if GOOGLE_ANALYTICS_KEY %>
+<% if Settings.google_analytics_key.present? %>
 <script type="text/javascript">
   var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', '<%= GOOGLE_ANALYTICS_KEY %>']);
+  _gaq.push(['_setAccount', '<%= Settings.google_analytics_key %>']);
   _gaq.push(['_trackPageview']);
 (function() {
     var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,6 +73,3 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end
-
-# What's this for?
-GOOGLE_ANALYTICS_KEY = nil # move to secrets

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -109,6 +109,3 @@ Rails.application.configure do
                         }
 
 end
-
-# What's this for?
-GOOGLE_ANALYTICS_KEY = nil # move to secrets

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,5 +50,3 @@ Rails.application.configure do
 
   Delayed::Worker.delay_jobs = false
 end
-
-GOOGLE_ANALYTICS_KEY = nil # move this

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -153,3 +153,5 @@ paperclip:
 
 price_policy_note_options: ~
 order_detail_price_change_reason_options: ~
+
+google_analytics_key: ~


### PR DESCRIPTION
# Release Notes

Tech task: Move google analytics key out of per-environment constant into Settings.

# Additional Context

NU is the only one that uses this as far as I know. My plan is to open a new PR in nucore-nu that adds the key to `config/settings/production.yml` so that it's prepped for when this comes in.
