### PR TITLE
Bump devise_ldap_authenticatable to 0.8.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,7 @@ GEM
       warden (~> 1.2.3)
     devise-encryptable (0.2.0)
       devise (>= 2.1.0)
-    devise_ldap_authenticatable (0.8.6)
+    devise_ldap_authenticatable (0.8.7)
       devise (>= 3.4.1)
       net-ldap (>= 0.16.0)
     devise_saml_authenticatable (1.6.0)
@@ -371,7 +371,7 @@ GEM
       coffee-rails (>= 3.2.1)
       jquery-rails
       rails (>= 3.2.0)
-    net-ldap (0.16.1)
+    net-ldap (0.16.2)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)


### PR DESCRIPTION
# Release Notes

Bump devise_ldap_authenticatable to 0.8.7

# Additional Context

Looks like we don't get dependabot updates to nested dependencies (this is required through the engine).
