### PR TITLE
Tech task: Lock ckeditor to < 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,8 @@ gem "bootstrap-sass", "~> 2.3.2" # will not upgrade
 gem "haml"
 gem "will_paginate"
 gem "dynamic_form"
-gem "ckeditor"
+# 5.0 has breaking changes based which need to be addressed before we can upgrade
+gem "ckeditor", "< 5"
 gem "jquery-rails"
 gem "jquery-ui-rails"
 gem "vuejs-rails", "~> 1.0.26" # 2.0 introduces breaking changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -613,7 +613,7 @@ DEPENDENCIES
   capybara
   capybara-email
   chosen-rails
-  ckeditor
+  ckeditor (< 5)
   clockpunch
   coffee-rails
   coffeelint


### PR DESCRIPTION
# Release Notes

Tech task: Lock ckeditor to < 5 because the new version has breaking changes.

# Additional Context

It's not quite clear to me what we would need to do in order to upgrade, so it seemed better to just lock it down for now. https://github.com/galetahub/ckeditor/compare/v4.3.0...v5.0.0

Original dependabot PR https://github.com/tablexi/nucore-open/pull/1914
