### PR TITLE
Tech task: switch to newer prawn-rails library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem "rubyzip"
 
 ## controllers
 gem "prawn"
-gem "prawn_rails"
+gem "prawn-rails"
 gem "prawn-table"
 
 ## other

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,11 +402,12 @@ GEM
     prawn (2.3.0)
       pdf-core (~> 0.8.1)
       ttfunk (~> 1.6)
+    prawn-rails (1.3.0)
+      prawn
+      prawn-table
+      rails (>= 3.1.0)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
-    prawn_rails (0.0.11)
-      prawn (>= 0.11.1)
-      railties (>= 3.0.0)
     pry (0.13.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -651,8 +652,8 @@ DEPENDENCIES
   parallel_tests
   paranoia
   prawn
+  prawn-rails
   prawn-table
-  prawn_rails
   projects!
   pry-byebug
   pry-rails


### PR DESCRIPTION
# Release Notes

Tech task: switch to newer prawn-rails library.

# Additional Context

The older [prawn_rails](https://github.com/Whoops/prawn-rails) hasn't been updated since 2012. I'm amazed it still continued to work. It will no longer work in Rails 6.

The newer [prawn-rails](https://github.com/cortiz/prawn-rails) library has the same API, but is actually maintained 
