### PR TITLE
[#153876] Fix dropdown options for price group members

### DIFF
--- a/config/locales/views/admin/en.log_events.yml
+++ b/config/locales/views/admin/en.log_events.yml
@@ -7,6 +7,9 @@ en:
             problem_queue: Order added to problem queue
           user:
             default_price_group_changed: User price group changed
+          price_group_member:
+            create: "User or account added to price group"
+            delete: "User or account removed from price group"
         account:
           create: Payment Source created
           update: Payment Source updated


### PR DESCRIPTION
# Release Notes

The filters work against `PriceGroupMember`, which could be `UserPriceGroupMember` or `AccountPriceGroupMember`, so the options need to be inclusive instead of doing interpolation.  