### PR TITLE
Tech task: Refactor 404/403 handling for non-HTML pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -131,14 +131,14 @@ class ApplicationController < ActionController::Base
 
   def render_404(_exception)
     # Add :html in case the 404 is a PDF or XML so the view can be found
-    render "/404", status: 404, layout: "application", formats: request.formats + [:html]
+    render "/404", status: 404, layout: "application"
   end
 
   rescue_from NUCore::PermissionDenied, CanCan::AccessDenied, with: :render_403
   def render_403(_exception)
     # if current_user is nil, the user should be redirected to login
     if current_user
-      render "/403", status: 403, layout: "application", formats: request.formats + [:html]
+      render "/403", status: 403, layout: "application"
     else
       store_location_for(:user, request.fullpath)
       redirect_to new_user_session_path
@@ -147,7 +147,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from NUCore::NotPermittedWhileActingAs, with: :render_acting_error
   def render_acting_error
-    render "/acting_error", status: 403, layout: "application", formats: request.formats + [:html]
+    render "/acting_error", status: 403, layout: "application"
   end
 
   def after_sign_out_path_for(_)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -130,15 +130,15 @@ class ApplicationController < ActionController::Base
   end
 
   def render_404(_exception)
-    # Add :html in case the 404 is a PDF or XML so the view can be found
-    render "/404", status: 404, layout: "application"
+    # Add html fallback in case the 404 is a PDF or XML so the view can be found
+    render "/404", status: 404, layout: "application", formats: formats_with_html_fallback
   end
 
   rescue_from NUCore::PermissionDenied, CanCan::AccessDenied, with: :render_403
   def render_403(_exception)
     # if current_user is nil, the user should be redirected to login
     if current_user
-      render "/403", status: 403, layout: "application"
+      render "/403", status: 403, layout: "application", formats: formats_with_html_fallback
     else
       store_location_for(:user, request.fullpath)
       redirect_to new_user_session_path
@@ -147,7 +147,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from NUCore::NotPermittedWhileActingAs, with: :render_acting_error
   def render_acting_error
-    render "/acting_error", status: 403, layout: "application"
+    render "/acting_error", status: 403, layout: "application", formats: formats_with_html_fallback
   end
 
   def after_sign_out_path_for(_)
@@ -200,6 +200,10 @@ class ApplicationController < ActionController::Base
 
   def with_dropped_params(&block)
     QuietStrongParams.with_dropped_params(&block)
+  end
+
+  def formats_with_html_fallback
+    request.formats.map(&:symbol) + [:html]
   end
 
 end


### PR DESCRIPTION
# Release Notes

Tech task: Refactor 404/403 handling for non-HTML pages. 

# Additional Context

The changed code deals with 404 not founds and 403 unauthorized for things like PDFs (statements) and ICS calendar invites to have them display as an HTML error page. For example, if you mess with the ID of a statement, then you should see a 404 page, even if the extension is `.pdf`. Without this handling, we would get template not found errors.

The code as it was broke in Rails 6. This change will work in both Rails 5.2 and 6.0.
