### PR TITLE
Fix Oracle syntax error in autocanceler

### DIFF
--- a/app/support/auto_canceler.rb
+++ b/app/support/auto_canceler.rb
@@ -35,7 +35,7 @@ class AutoCanceler
 
   def time_condition
     if Nucore::Database.oracle?
-      "(:now - reserve_start_at) >= NumToDSInterval(auto_cancel_mins, 'MINUTE')"
+      "(to_timestamp(:now) - reserve_start_at) >= NumToDSInterval(auto_cancel_mins, 'MINUTE')"
     else
       "TIMESTAMPDIFF(MINUTE, reserve_start_at, :now) >= auto_cancel_mins"
     end


### PR DESCRIPTION
# Release Notes

Fix Oracle syntax error in AutoCanceler.

# Additional Context

This was fixed in NU, but the fix never made it upstream.

Originally fixed as https://github.com/tablexi/nucore-nu/pull/407/commits/0234e93b4bbd3d195cf442ada85b8e6bf14b4648 as part of the Rails 5 upgrade. https://github.com/tablexi/nucore-nu/pull/407/files (note: this is a private repo)