### PR TITLE
Tech task: Add `case_sensitive` flag to uniqueness validations

### DIFF
--- a/app/models/account_user.rb
+++ b/app/models/account_user.rb
@@ -13,7 +13,7 @@ class AccountUser < ApplicationRecord
   validates :created_by, presence: true
   validates :user_role, inclusion: { in: ->(record) { record.class.user_roles }, message: "is invalid" }
   validates :user_id, uniqueness: { scope: [:account_id, :deleted_at] }, unless: :deleted_at?
-  validates :user_role, uniqueness: { scope: [:account_id, :deleted_at] }, if: -> { owner? && !deleted_at? }
+  validates :user_role, uniqueness: { scope: [:account_id, :deleted_at], case_sensitive: false }, if: -> { owner? && !deleted_at? }
   validate :validate_account_has_owner
 
   ACCOUNT_PURCHASER = "Purchaser"

--- a/app/models/facility_account.rb
+++ b/app/models/facility_account.rb
@@ -7,7 +7,7 @@ class FacilityAccount < ApplicationRecord
   belongs_to :facility
 
   validates :revenue_account, numericality: { only_integer: true }
-  validates :account_number, presence: true, uniqueness: { scope: [:revenue_account, :facility_id] }
+  validates :account_number, presence: true, uniqueness: { scope: [:revenue_account, :facility_id], case_sensitive: false }
 
   scope :active, -> { where(is_active: true) }
   scope :inactive, -> { where(is_active: false) }

--- a/app/models/nufs_account.rb
+++ b/app/models/nufs_account.rb
@@ -2,7 +2,7 @@
 
 class NufsAccount < Account
 
-  validates_uniqueness_of :account_number, message: "already exists"
+  validates_uniqueness_of :account_number, message: "already exists", case_sensitive: false
   validates_presence_of :expires_at
 
   validate { validate_account_number }

--- a/app/models/order_status.rb
+++ b/app/models/order_status.rb
@@ -8,7 +8,7 @@ class OrderStatus < ApplicationRecord
   belongs_to :facility
 
   validates_presence_of :name
-  validates_uniqueness_of :name, scope: [:parent_id, :facility_id]
+  validates_uniqueness_of :name, scope: [:parent_id, :facility_id], case_sensitive: false
   validates_each :parent_id do |model, attr, value|
     begin
       model.errors.add(attr, "must be a root") unless value.nil? || OrderStatus.find(value).root?

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -13,7 +13,7 @@ class PriceGroup < ApplicationRecord
 
   validates_presence_of   :facility_id # enforce facility constraint here, though it's not always required
   validates_presence_of   :name
-  validates_uniqueness_of :name, scope: :facility_id, unless: :deleted_at?
+  validates_uniqueness_of :name, scope: :facility_id, case_sensitive: false, unless: :deleted_at?
 
   default_scope -> { order(is_internal: :desc, display_order: :asc, name: :asc) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ApplicationRecord
 
   validates_presence_of :username, :first_name, :last_name
   validates :email, presence: true, email_format: true
-  validates_uniqueness_of :username, :email
+  validates_uniqueness_of :username, :email, case_sensitive: false
   validates :suspension_note, length: { maximum: 255 }
 
   accepts_nested_attributes_for :account_users, allow_destroy: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,8 +27,10 @@ class User < ApplicationRecord
   has_many :user_preferences, dependent: :destroy
 
   validates_presence_of :username, :first_name, :last_name
-  validates :email, presence: true, email_format: true
-  validates_uniqueness_of :username, :email, case_sensitive: false
+  # There are existing duplicate emails in NU -- they're all users that have both a netid
+  # account and a non-netid account.
+  validates :email, presence: true, email_format: true, uniqueness: { case_sensitive: true }
+  validates :username, uniqueness: true
   validates :suspension_note, length: { maximum: 255 }
 
   accepts_nested_attributes_for :account_users, allow_destroy: true

--- a/spec/models/price_group_spec.rb
+++ b/spec/models/price_group_spec.rb
@@ -4,25 +4,36 @@ require "rails_helper"
 
 RSpec.describe PriceGroup do
 
-  let(:facility) { @facility }
+  let(:facility) { FactoryBot.create(:facility) }
+  let(:price_group) { FactoryBot.create(:price_group, facility: facility) }
 
   before :each do
-    @facility = FactoryBot.create(:facility)
-    @price_group = FactoryBot.create(:price_group, facility: facility)
+    @facility = facility
+    @price_group = price_group
   end
 
-  it "should create using factory" do
-    expect(@price_group).to be_valid
+  it "is valid using the factory using factory" do
+    expect(price_group).to be_valid
   end
 
-  it "should require name" do
+  it "requires name" do
     is_expected.to validate_presence_of(:name)
   end
 
-  it "should require unique name within a facility" do
-    @price_group2 = @facility.price_groups.build(FactoryBot.attributes_for(:price_group).update(name: @price_group.name))
-    expect(@price_group2).not_to be_valid
-    expect(@price_group2.errors[:name]).not_to be_nil
+  it "requires unique name within a facility" do
+    price_group2 = build(:price_group, name: price_group.name, facility: facility)
+    expect(price_group2).not_to be_valid
+    expect(price_group2.errors[:name]).to be_present
+  end
+
+  it "requires the unique name case-insensitively" do
+    price_group2 = build(:price_group, name: price_group.name.upcase, facility: facility)
+    expect(price_group2).not_to be_valid
+    expect(price_group2.errors[:name]).to be_present
+
+    price_group2.name.downcase!
+    expect(price_group2).not_to be_valid
+    expect(price_group2.errors[:name]).to be_present
   end
 
   context "can_purchase?" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe User do
     is_expected.to validate_uniqueness_of(:username).case_insensitive
   end
 
+  it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
+
   context "when the created username is mixed-case" do
     subject(:user) { create(:user, username: "AnEmail@example.org") }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe User do
     is_expected.to validate_uniqueness_of(:username).case_insensitive
   end
 
-  it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
+  it { is_expected.to validate_uniqueness_of(:email) }
 
   context "when the created username is mixed-case" do
     subject(:user) { create(:user, username: "AnEmail@example.org") }


### PR DESCRIPTION
# Release Notes

Tech task: Tech task: Add `case_sensitive` flag to uniqueness validations.

# Additional Context

Rails 6 throws a deprecation warning if this is not there. 

I left `email` as case-sensitive since there are 4 users in NU where the email is not unique. They're all users who have both a netid and non-netid account (it appears both directions: at least one is currently external and at least one is currently internal).
