### PR TITLE
[#154227] Properly handle commas in facility names when setting the "from" name in bulk email

### DIFF
--- a/vendor/engines/bulk_email/app/mailers/bulk_email/mailer.rb
+++ b/vendor/engines/bulk_email/app/mailers/bulk_email/mailer.rb
@@ -14,11 +14,9 @@ module BulkEmail
     end
 
     def sender
-      if @facility.try(:single_facility?)
-        "#{@facility.name} <#{default_params[:from]}>"
-      else
-        default_params[:from]
-      end
+      address = Mail::Address.new(default_params[:from])
+      address.display_name = @facility.name if @facility.try(:single_facility?)
+      address
     end
 
   end

--- a/vendor/engines/bulk_email/spec/mailers/bulk_email/mailer_spec.rb
+++ b/vendor/engines/bulk_email/spec/mailers/bulk_email/mailer_spec.rb
@@ -25,28 +25,33 @@ RSpec.describe BulkEmail::Mailer do
     context "with a single facility sender" do
       let(:facility) { FactoryBot.build_stubbed(:facility) }
       let(:args) { { body: body, subject: custom_subject, recipient: recipient, facility: facility } }
-      let(:sender_string) { "From: #{facility.name} <#{Settings.email.from}>" }
 
       it "includes the facility name as the sender" do
-        expect(email.to_s).to include(sender_string)
+        expect(email.to_s).to include("From: #{facility.name} <#{Settings.email.from}>")
+      end
+    end
+
+    context "with a single facility sender with a comma in the name" do
+      let(:facility) { FactoryBot.build_stubbed(:facility, name: "Testing, Testing, and More Testing") }
+      let(:args) { { body: body, subject: custom_subject, recipient: recipient, facility: facility } }
+
+      it "includes the facility name as the sender" do
+        expect(email.to_s).to include("From: \"Testing, Testing, and More Testing\" <#{Settings.email.from}>")
       end
     end
 
     context "with cross-facility sender" do
       let(:facility) { Facility.cross_facility }
       let(:args) { { body: body, subject: custom_subject, recipient: recipient, facility: facility } }
-      let(:sender_string) { "From: #{Settings.email.from}" }
 
       it "does not include a facility name" do
-        expect(email.to_s).to include(sender_string)
+        expect(email.to_s).to include("From: #{Settings.email.from}")
       end
     end
 
     context "with a nil facility" do
-      let(:sender_string) { "From: #{Settings.email.from}" }
-
       it "does not include a facility name" do
-        expect(email.to_s).to include(sender_string)
+        expect(email.to_s).to include("From: #{Settings.email.from}")
       end
     end
 


### PR DESCRIPTION
# Release Notes

Fix issue in bulk email when the facility has a comma in the name.

# Additional Context

Dartmouth was having deliveries get blocked because they would see multiple "From" addresses in the email header. This was being caused because of how the comma was being interpreted. With this change, the from header will have quotes where necessary to probably escape everything.

This was from the facility "Electron Microscopy - Irradiation, Pre-clinical Imaging and Microscopy Resource".

```
From: <Electron.Microscopy.-.Irradiation@radar-app01.dartmouth.edu>,
Pre-clinical Imaging and Microscopy Resource
<Cancer.Center.Core.Operations@Dartmouth.edu>
```
