### PR TITLE
Update validation so it works properly with expense_accounts feature disabled

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -40,15 +40,13 @@ class Product < ApplicationRecord
             email_format: true,
             allow_blank: true
 
-  if SettingsHelper.feature_on? :expense_accounts
-    validates(
-      :account,
-      presence: true,
-      numericality: { only_integer: true },
-      length: { minimum: 1, maximum: Settings.accounts.product_default.to_s.length },
-      if: :requires_account?,
-    )
-  end
+  validates(
+    :account,
+    presence: true,
+    numericality: { only_integer: true },
+    length: { minimum: 1, maximum: Settings.accounts.product_default.to_s.length },
+    if: -> { SettingsHelper.feature_on?(:expense_accounts) && requires_account? },
+  )
 
   validates :facility_account_id, presence: true, if: :requires_account?
 


### PR DESCRIPTION
# Release Notes

Tech task: Update `Product#account` validation so it works properly in tests when the feature is disabled.

# Additional Context

Originally, this validation would never be added at all if the `expense_accounts` feature were disabled (like it is a UConn, and I'm guessing _was_ at UIC). Then, when we turned on the feature in the specs (see `spec/models/product_spec.rb:172`), the validation would not be run because it's not there. Now it will conditionally run based on the setting at runtime rather than compile/load time.
