### PR TITLE
Tech task: Update journal row account validation to handle settings properly

### DIFF
--- a/app/models/journal_row.rb
+++ b/app/models/journal_row.rb
@@ -7,7 +7,7 @@ class JournalRow < ApplicationRecord
 
   validates_presence_of :journal_id, :amount
   # Note this is NOT a belongs_to :account. This is an expense account field.
-  validates_presence_of :account if SettingsHelper.feature_on? :expense_accounts
+  validates_presence_of :account, if: -> { SettingsHelper.feature_on?(:expense_accounts) }
 
   delegate :fulfilled_at, to: :order_detail, allow_nil: true
 

--- a/spec/models/journal_row_spec.rb
+++ b/spec/models/journal_row_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe JournalRow do
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:journal_id) }
+    it { is_expected.to validate_presence_of(:amount) }
+
+    describe "with expense_accounts on", feature_setting: { expense_accounts: true } do
+      it { is_expected.to validate_presence_of(:account) }
+    end
+
+    describe "with expense_accounts on", feature_setting: { expense_accounts: false } do
+      it { is_expected.not_to validate_presence_of(:account) }
+    end
+  end
+
+  describe "fulfilled_at" do
+    it "defaults to nil" do
+      journal_row = described_class.new
+      expect(journal_row.fulfilled_at).to be_blank
+    end
+
+    it "delegates to the order detail do" do
+      one_day_ago = 1.day.ago
+      order_detail = OrderDetail.new(fulfilled_at: one_day_ago)
+      journal_row = described_class.new(order_detail: order_detail)
+      expect(journal_row.fulfilled_at).to eq(one_day_ago)
+    end
+  end
+
+end


### PR DESCRIPTION
# Release Notes

Tech task: use proc for journal row validation to better handle testing no matter what the expense_account feature flag is set to.

# Additional Context

See also #2385 
