### PR TITLE
TECH TASK: Use exact_text option instead of exact

### DIFF
--- a/spec/system/admin/review_period_spec.rb
+++ b/spec/system/admin/review_period_spec.rb
@@ -97,8 +97,8 @@ RSpec.describe "Review period - Sending notifications and marking as reviewed", 
     visit facility_notifications_path(facility)
 
     within(".old-table tfoot") do
-      expect(page).to have_selector("th", text: "Total", exact: true)
-      expect(page).to have_selector("td", text: "$1.00", exact: true)
+      expect(page).to have_selector("th", text: "Total", exact_text: true)
+      expect(page).to have_selector("td", text: "$1.00", exact_text: true)
     end
   end
 


### PR DESCRIPTION
# Release Notes

There were warnings in the test logs:
```
The :exact option only has an effect on queries using the XPath#is method. Using it with the query "th" has no effect.
The :exact option only has an effect on queries using the XPath#is method. Using it with the query "td" has no effect.
```
... and in fact the `:exact` option had no effect.  For example, `expect(page).to have_selector("td", text: "$1.0", exact: true)` passes unexpectedly.  

This change restores expected behavior and resolves the log noise.