### PR TITLE
TECH TASK: Rollback libv8 and mini_racer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,11 @@ gem "paranoia"
 gem "sass-rails"
 gem "coffee-rails"
 gem "uglifier", "= 4.1.18" # 4.1.19 has an issue https://github.com/mishoo/UglifyJS2/issues/3245
-gem "mini_racer"
+# TO DO: consider using nodejs instead of mini_racer
+# libv8 8+ does not like to compile on our boxes. It's easier to lock down
+# libv8 and mini_racer for now than to try to get them upgraded on the server.
+gem "mini_racer", "< 0.3"
+gem "libv8", "< 8"
 gem "bootstrap-sass", "~> 2.3.2" # will not upgrade
 gem "haml"
 gem "will_paginate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,7 +344,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.7.0)
       launchy (~> 2.2)
-    libv8 (8.4.255.0)
+    libv8 (7.3.492.27.1)
     loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -359,8 +359,8 @@ GEM
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    mini_racer (0.3.1)
-      libv8 (~> 8.4.255)
+    mini_racer (0.2.15)
+      libv8 (> 7.3)
     minitest (5.14.1)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
@@ -641,7 +641,8 @@ DEPENDENCIES
   jquery-ui-rails
   ldap_authentication!
   letter_opener
-  mini_racer
+  libv8 (< 8)
+  mini_racer (< 0.3)
   mysql2
   nested_form_fields
   nokogiri


### PR DESCRIPTION
# Release Notes

The current versions of these gems aren't compiling on our servers.  We should look into using NodeJS instead of `mini_racer`.