### PR TITLE
[#153975] Remove admin link from cross-facility management

### DIFF
--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -121,7 +121,7 @@ class NavTab::LinkCollection
   end
 
   def admin_facility
-    if ability.can?(:edit, facility)
+    if single_facility? && ability.can?(:edit, facility)
       NavTab::Link.new(tab: :admin_facility, url: manage_facility_path(facility))
     end
   end


### PR DESCRIPTION
# Release Notes

Remove "Admin" link from nav bar in cross-facility management. 

# Screenshot

![Screen Shot 2020-06-30 at 6 04 40 PM](https://user-images.githubusercontent.com/1099111/90568583-cb80ee80-e171-11ea-87d8-04f3069f75a5.png)


# Additional Context

This link is only relevant within the context of an actual facility and was 404ing. I found this while looking through commits UConn had made that didn't make it upstream.
