### PR TITLE
[#153933] Don't show hints in show view

### DIFF
--- a/app/views/facility_accounts/show.html.haml
+++ b/app/views/facility_accounts/show.html.haml
@@ -8,7 +8,7 @@
 
 %h2= @account
 
-= readonly_form_for :account do |f|
+= readonly_form_for :account, defaults: { hint: false } do |f|
 
   = f.input :owner_user
   = f.input :type_string


### PR DESCRIPTION
# Release Notes

There were hints showing up in the "show" view for Dartmouth.

At some point we may want to set hints to false globally for all `ReadonlyInput`s.