### PR TITLE
Tech task: Update default PDF paper size to letter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,10 +63,8 @@ gem "fine_uploader", path: "vendor/engines/fine_uploader"
 gem "fullcalendar", path: "vendor/engines/fullcalendar"
 gem "rubyzip"
 
-## controllers
-gem "prawn"
+## PDF generation
 gem "prawn-rails"
-gem "prawn-table"
 
 ## other
 gem "delayed_job_active_record"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -652,9 +652,7 @@ DEPENDENCIES
   paperclip
   parallel_tests
   paranoia
-  prawn
   prawn-rails
-  prawn-table
   projects!
   pry-byebug
   pry-rails

--- a/app/support/statement_pdf.rb
+++ b/app/support/statement_pdf.rb
@@ -12,6 +12,7 @@ class StatementPdf
     right_margin: 50,
     top_margin: 50,
     bottom_margin: 75,
+    page_size: "LETTER", # "A4" is now the default size in prawn-rails
   }.freeze
 
   def initialize(statement, download: false)


### PR DESCRIPTION
# Release Notes

Tech task: update default paper size in PDFs to US Letter.

# Additional Context

When we upgraded the Prawn gems in #2377, that changed the default paper size to A4. Fortunately, CI caught some errors in NU because one of the tables wasn't wide enough in the new paper size.

The documentation [suggests putting this configuration into an initializer](https://github.com/cortiz/prawn-rails#default-configuration), but this is the only place we make PDFs, this seems to be a more obvious spot a developer might see to change it if they're working on making a custom statement. (A4 is a very standard paper size outside the US).