### PR TITLE
[#153890] Custom display order for instruments

### DIFF
--- a/app/controllers/instrument_schedule_positions_controller.rb
+++ b/app/controllers/instrument_schedule_positions_controller.rb
@@ -12,7 +12,7 @@ class InstrumentSchedulePositionsController < ApplicationController
 
   # GET /facilities/:facility_id/instrument_schedule_position
   def show
-    authorize! :read, @schedules.first
+    authorize! :read, @schedules&.first || Schedule
   end
 
   # GET /facilities/:facility_id/instrument_schedule_position/edit
@@ -37,7 +37,7 @@ class InstrumentSchedulePositionsController < ApplicationController
   end
 
   def authorize_schedules
-    authorize! :edit, @schedules.first
+    authorize! :edit, @schedules&.first || Schedule
   end
 
   def load_schedules

--- a/app/controllers/instrument_schedule_positions_controller.rb
+++ b/app/controllers/instrument_schedule_positions_controller.rb
@@ -21,9 +21,11 @@ class InstrumentSchedulePositionsController < ApplicationController
 
   # PUT/PATCH /facilities/:facility_id/instrument_schedule_position
   def update
-    @schedules.each do |schedule|
-      position = params[:instrument_schedule_position][:schedule_ids].index(schedule.id.to_s)
-      schedule.update!(position: position)
+    Schdeule.transaction do
+      @schedules.each do |schedule|
+        position = params[:instrument_schedule_position][:schedule_ids].index(schedule.id.to_s)
+        schedule.update!(position: position)
+      end
     end
     redirect_to facility_instrument_schedule_position_path, notice: text("success")
   end

--- a/app/controllers/instrument_schedule_positions_controller.rb
+++ b/app/controllers/instrument_schedule_positions_controller.rb
@@ -12,7 +12,7 @@ class InstrumentSchedulePositionsController < ApplicationController
 
   # GET /facilities/:facility_id/instrument_schedule_position
   def show
-    authorize! :read, Schedule
+    authorize! :read, @schedules.first
   end
 
   # GET /facilities/:facility_id/instrument_schedule_position/edit
@@ -37,7 +37,7 @@ class InstrumentSchedulePositionsController < ApplicationController
   end
 
   def authorize_schedules
-    authorize! :edit, Schedule
+    authorize! :edit, @schedules.first
   end
 
   def load_schedules

--- a/app/controllers/instrument_schedule_positions_controller.rb
+++ b/app/controllers/instrument_schedule_positions_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class InstrumentSchedulePositionsController < ApplicationController
+
+  layout "two_column"
+
+  admin_tab :all
+  before_action :authenticate_user!
+  before_action :init_current_facility
+  before_action :authorize_schedules, except: [:show]
+  before_action :load_schedules
+
+  # GET /facilities/:facility_id/instrument_schedule_position
+  def show
+    authorize! :read, Schedule
+  end
+
+  # GET /facilities/:facility_id/instrument_schedule_position/edit
+  def edit
+  end
+
+  # PUT/PATCH /facilities/:facility_id/instrument_schedule_position
+  def update
+    @schedules.each do |schedule|
+      position = params[:instrument_schedule_position][:schedule_ids].index(schedule.id.to_s)
+      schedule.update!(position: position)
+    end
+    redirect_to facility_instrument_schedule_position_path, notice: text("success")
+  end
+
+  private
+
+  def update_params
+    params.require(:instrument_schedule_position).permit(schedule_ids: [])
+  end
+
+  def authorize_schedules
+    authorize! :edit, Schedule
+  end
+
+  def load_schedules
+    @schedules = Schedule
+                 .order_by_asc_nulls_last(:position)
+                 .order(:name)
+                 .joins(facility: :instruments)
+                 .merge(
+                    Instrument
+                    .active
+                    .in_active_facility
+                    .for_facility(current_facility)
+                 )
+                 .distinct
+  end
+
+end

--- a/app/controllers/instrument_schedule_positions_controller.rb
+++ b/app/controllers/instrument_schedule_positions_controller.rb
@@ -21,7 +21,7 @@ class InstrumentSchedulePositionsController < ApplicationController
 
   # PUT/PATCH /facilities/:facility_id/instrument_schedule_position
   def update
-    Schdeule.transaction do
+    Schedule.transaction do
       @schedules.each do |schedule|
         position = params[:instrument_schedule_position][:schedule_ids].index(schedule.id.to_s)
         schedule.update!(position: position)

--- a/app/controllers/instrument_schedule_positions_controller.rb
+++ b/app/controllers/instrument_schedule_positions_controller.rb
@@ -7,8 +7,8 @@ class InstrumentSchedulePositionsController < ApplicationController
   admin_tab :all
   before_action :authenticate_user!
   before_action :init_current_facility
-  before_action :authorize_schedules, except: [:show]
   before_action :load_schedules
+  before_action :authorize_schedules, except: [:show]
 
   # GET /facilities/:facility_id/instrument_schedule_position
   def show

--- a/app/controllers/instruments_dashboard_controller.rb
+++ b/app/controllers/instruments_dashboard_controller.rb
@@ -26,6 +26,7 @@ class InstrumentsDashboardController < ApplicationController
       .current_in_use
       .merge(Product.alphabetized)
       .includes(:product, order: :user)
+      .sort_by { |r| [r.product.schedule.position ? 0 : 1, r.product.schedule.position] }
   end
 
   def authenticate_token

--- a/app/controllers/instruments_dashboard_controller.rb
+++ b/app/controllers/instruments_dashboard_controller.rb
@@ -24,9 +24,9 @@ class InstrumentsDashboardController < ApplicationController
   def init_reservations
     @reservations = current_facility.reservations
       .current_in_use
-      .merge(Product.alphabetized)
       .includes(:product, order: :user)
-      .sort_by { |r| r.product.schedule.position || 9999 } # there's no direct relation between reservation and schedule, and we want nil's last
+      .joins(instrument: :schedule)
+      .merge(Schedule.positioned)
   end
 
   def authenticate_token

--- a/app/controllers/instruments_dashboard_controller.rb
+++ b/app/controllers/instruments_dashboard_controller.rb
@@ -26,7 +26,7 @@ class InstrumentsDashboardController < ApplicationController
       .current_in_use
       .merge(Product.alphabetized)
       .includes(:product, order: :user)
-      .sort_by { |r| [r.product.schedule.position ? 0 : 1, r.product.schedule.position] }
+      .sort_by { |r| r.product.schedule.position || 9999 } # there's no direct relation between reservation and schedule, and we want nil's last
   end
 
   def authenticate_token

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -126,6 +126,7 @@ class Facility < ApplicationRecord
     schedules
     .active
     .includes(instruments_association => [:alert, :current_offline_reservations, :relay, :schedule_rules])
+    .order_by_asc_nulls_last(:position)
     .order(:name)
   end
 

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -16,6 +16,7 @@ class Reservation < ApplicationRecord
   # Associations
   #####
   belongs_to :product
+  belongs_to :instrument, foreign_key: :product_id
   belongs_to :order_detail, inverse_of: :reservation
   belongs_to :created_by, class_name: "User"
   has_one :order, through: :order_detail

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -17,7 +17,7 @@ class Schedule < ApplicationRecord
 
   validates_presence_of :facility
 
-  scope :active, -> { where(id: Instrument.not_archived.with_schedule.select(:schedule_id)).order(:name) }
+  scope :active, -> { where(id: Instrument.not_archived.with_schedule.select(:schedule_id)) }
 
   def shared?
     products.count > 1

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -30,4 +30,8 @@ class Schedule < ApplicationRecord
     "#{I18n.t(key)}: #{name}"
   end
 
+  def display_order_name
+    shared? ? display_name : name
+  end
+
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -6,6 +6,8 @@ class Schedule < ApplicationRecord
 
   belongs_to :facility
 
+  scope :positioned, -> { order_by_asc_nulls_last(:position) }
+
   with_options class_name: "Instrument" do |schedule|
     schedule.has_many :facility_instruments, -> { not_archived }
     schedule.has_many :products

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -2,6 +2,8 @@
 
 class Schedule < ApplicationRecord
 
+  include Nucore::Database::SortHelper
+
   belongs_to :facility
 
   with_options class_name: "Instrument" do |schedule|

--- a/app/views/admin/shared/_sidenav_product.html.haml
+++ b/app/views/admin/shared/_sidenav_product.html.haml
@@ -6,6 +6,7 @@
 
   %li.divider
   = tab ProductDisplayGroup.model_name.human(count: :many), facility_product_display_groups_path, sidenav_tab == "product_display_groups"
+  = tab "Instrument Display Order", facility_instrument_schedule_position_path, sidenav_tab == "instrument_display_order"
 
   - if SettingsHelper.feature_on?(:training_requests) && current_ability.can?(:index, TrainingRequest)
     %li.divider

--- a/app/views/admin/shared/_sidenav_product.html.haml
+++ b/app/views/admin/shared/_sidenav_product.html.haml
@@ -6,7 +6,7 @@
 
   %li.divider
   = tab ProductDisplayGroup.model_name.human(count: :many), facility_product_display_groups_path, sidenav_tab == "product_display_groups"
-  = tab "Instrument Display Order", facility_instrument_schedule_position_path, sidenav_tab == "instrument_display_order"
+  = tab text("views.instrument_schedule_positions.show.title"), facility_instrument_schedule_position_path, sidenav_tab == "instrument_display_order"
 
   - if SettingsHelper.feature_on?(:training_requests) && current_ability.can?(:index, TrainingRequest)
     %li.divider

--- a/app/views/instrument_schedule_positions/edit.html.haml
+++ b/app/views/instrument_schedule_positions/edit.html.haml
@@ -3,7 +3,7 @@
 = content_for :sidebar do
   = render "admin/shared/sidenav_product", sidenav_tab: "instrument_schedule_position"
 
-%h2== Instrument Display Order
+%h2= text("title")
 
 = simple_form_for :instrument_schedule_position, url: facility_instrument_schedule_position_path, method: :patch do |f|
   .container

--- a/app/views/instrument_schedule_positions/edit.html.haml
+++ b/app/views/instrument_schedule_positions/edit.html.haml
@@ -9,7 +9,7 @@
   .container
     .row.moveBetweenSelects
       .span4
-        = f.input :schedule_ids, collection: @schedules, label_method: :display_name, input_html: { multiple: true, class: "tall pull-left js--selectAllOnSubmit" }, label: text("label")
+        = f.input :schedule_ids, collection: @schedules, label_method: :display_order_name, input_html: { multiple: true, class: "tall pull-left js--selectAllOnSubmit" }, label: text("label")
         .multiSelectReorder__buttons
           = link_to "#", class: "btn js--multiSelectReorder__moveUp", data: { target: "#instrument_schedule_position_schedule_ids" }, title: text("shared.reorder.move_up") do
             = content_tag :i, "", class: "fa fa-arrow-up"

--- a/app/views/instrument_schedule_positions/edit.html.haml
+++ b/app/views/instrument_schedule_positions/edit.html.haml
@@ -1,0 +1,21 @@
+= content_for :h1 do
+  = current_facility
+= content_for :sidebar do
+  = render "admin/shared/sidenav_product", sidenav_tab: "instrument_schedule_position"
+
+%h2== Instrument Display Order
+
+= simple_form_for :instrument_schedule_position, url: facility_instrument_schedule_position_path, method: :patch do |f|
+  .container
+    .row.moveBetweenSelects
+      .span4
+        = f.input :schedule_ids, collection: @schedules, label_method: :display_name, input_html: { multiple: true, class: "tall pull-left js--selectAllOnSubmit" }, label: text("label")
+        .multiSelectReorder__buttons
+          = link_to "#", class: "btn js--multiSelectReorder__moveUp", data: { target: "#instrument_schedule_position_schedule_ids" }, title: text("shared.reorder.move_up") do
+            = content_tag :i, "", class: "fa fa-arrow-up"
+          = link_to "#", class: "btn js--multiSelectReorder__moveDown ", data: { target: "#instrument_schedule_position_schedule_ids" }, title: text("shared.reorder.move_down") do
+            = content_tag :i, "", class: "fa fa-arrow-down"
+    .row
+      .span12
+        = f.submit text("submit"), class: "btn btn-primary"
+        = link_to text("shared.cancel"), facility_instrument_schedule_position_path

--- a/app/views/instrument_schedule_positions/show.html.haml
+++ b/app/views/instrument_schedule_positions/show.html.haml
@@ -1,0 +1,22 @@
+= content_for :h1 do
+  = current_facility
+= content_for :sidebar do
+  = render "admin/shared/sidenav_product", sidenav_tab: "instrument_schedule_position"
+
+%h2== Instrument Display Order
+
+.container
+  - if can?(:update, Schedule)
+    .row
+      .span12
+        %p= link_to "Edit", edit_facility_instrument_schedule_position_path, class: "btn"
+
+  .row
+    .span5
+      %ul
+        - @schedules.each do |schedule|
+          .well
+            - if schedule.shared?
+              %legend== Shared Schedule
+            - schedule.products.each do |product|
+              %li= ProductPresenter.new(product)

--- a/app/views/instrument_schedule_positions/show.html.haml
+++ b/app/views/instrument_schedule_positions/show.html.haml
@@ -13,14 +13,15 @@
 
   .row
     .span7
+      %p= text("hint")
       %ul
         - @schedules.each do |schedule|
           - if schedule.shared?
             %li
               %strong= schedule.display_name
-            %ul
-              - schedule.products.each do |product|
-                %li= ProductPresenter.new(product)
+              %ul
+                - schedule.products.each do |product|
+                  %li= ProductPresenter.new(product)
           - else
             - schedule.products.each do |product|
               %li= ProductPresenter.new(product)

--- a/app/views/instrument_schedule_positions/show.html.haml
+++ b/app/views/instrument_schedule_positions/show.html.haml
@@ -3,20 +3,24 @@
 = content_for :sidebar do
   = render "admin/shared/sidenav_product", sidenav_tab: "instrument_schedule_position"
 
-%h2== Instrument Display Order
+%h2= text("title")
 
 .container
   - if can?(:update, Schedule)
     .row
       .span12
-        %p= link_to "Edit", edit_facility_instrument_schedule_position_path, class: "btn"
+        %p= link_to text("shared.edit"), edit_facility_instrument_schedule_position_path, class: "btn"
 
   .row
-    .span5
+    .span7
       %ul
         - @schedules.each do |schedule|
-          .well
-            - if schedule.shared?
-              %legend== Shared Schedule
+          - if schedule.shared?
+            %li
+              %strong= schedule.display_name
+            %ul
+              - schedule.products.each do |product|
+                %li= ProductPresenter.new(product)
+          - else
             - schedule.products.each do |product|
               %li= ProductPresenter.new(product)

--- a/app/views/instruments/_instrument_fields.html.haml
+++ b/app/views/instruments/_instrument_fields.html.haml
@@ -8,7 +8,7 @@
 
 - if f.object.new_record?
   = f.association :schedule,
-    collection: current_facility.schedules.active,
+    collection: current_facility.schedules.active.order(:name),
     include_blank: text("instruments.instrument_fields.schedule.unshared")
 - else
   = f.input :schedule, as: :readonly, value_method: :display_name, hint: false

--- a/config/locales/views/admin/en.instrument_schedule_positions.yml
+++ b/config/locales/views/admin/en.instrument_schedule_positions.yml
@@ -1,0 +1,12 @@
+en:
+  controllers:
+    instrument_schedule_positions:
+      success: The Instruments have been reordered
+
+  views:
+    instrument_schedule_positions:
+      edit:
+        label: Instrument Schedules
+        reorder: Reorder Instrument Schedules
+        submit: Update Ordering
+

--- a/config/locales/views/admin/en.instrument_schedule_positions.yml
+++ b/config/locales/views/admin/en.instrument_schedule_positions.yml
@@ -6,7 +6,10 @@ en:
   views:
     instrument_schedule_positions:
       edit:
+        title: Instrument Display Order
         label: Instrument Schedules
         reorder: Reorder Instrument Schedules
         submit: Update Ordering
+      show:
+        title: Instrument Display Order
 

--- a/config/locales/views/admin/en.instrument_schedule_positions.yml
+++ b/config/locales/views/admin/en.instrument_schedule_positions.yml
@@ -12,4 +12,4 @@ en:
         submit: Update Ordering
       show:
         title: Instrument Display Order
-
+        hint: Instruments will be displyed in this order on the admin timeline, public timeline, and instrument dashboard.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,8 @@ Rails.application.routes.draw do
       end
     end
 
+    resource "instrument_schedule_position", only: [:edit, :update, :show]
+
     get "instrument_statuses", to: "instruments#instrument_statuses", as: "instrument_statuses"
 
     resources :training_requests, only: [:index, :destroy] if SettingsHelper.feature_on?(:training_requests)

--- a/db/migrate/20200904185502_add_position_to_schedules.rb
+++ b/db/migrate/20200904185502_add_position_to_schedules.rb
@@ -1,0 +1,7 @@
+class AddPositionToSchedules < ActiveRecord::Migration[5.2]
+  def change
+    change_table :schedules do |t|
+      t.integer :position
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_23_191759) do
+ActiveRecord::Schema.define(version: 2020_09_04_185502) do
 
   create_table "account_facility_joins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "facility_id", null: false
@@ -679,6 +679,7 @@ ActiveRecord::Schema.define(version: 2020_07_23_191759) do
     t.integer "facility_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "position"
     t.index ["facility_id"], name: "i_schedules_facility_id"
   end
 

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -300,6 +300,7 @@ class Ability
 
     can :read, Notification
     can :read, ProductDisplayGroup
+    can :read, Schedule
 
     can [
       :administer,
@@ -378,6 +379,7 @@ class Ability
       ProductAccessGroup,
       ProductAccessory,
       Reports::ReportsController,
+      Schedule,
       ScheduleRule,
       Statement,
       StoredFile,

--- a/lib/nucore/database/sort_helper.rb
+++ b/lib/nucore/database/sort_helper.rb
@@ -24,6 +24,11 @@ module Nucore
           order(Arel.sql(sanitize_sql_for_order(order_by)))
         end
 
+        def order_by_asc_nulls_last(field)
+          order_by = Nucore::Database.oracle? ? field.to_s : "#{field} IS NULL, #{field} ASC"
+          order(Arel.sql(sanitize_sql_for_order(order_by)))
+        end
+
       end
 
     end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -127,6 +127,7 @@ RSpec.describe Ability do
     end
 
     it { is_expected.to be_allowed_to(:read, Notification) }
+    it { is_expected.to be_allowed_to(:manage, Schedule) }
 
     describe StoredFile do
       describe "#download" do
@@ -251,6 +252,7 @@ RSpec.describe Ability do
     it_is_allowed_to([:bring_online, :create, :edit, :new, :update], OfflineReservation)
     it { is_expected.to be_allowed_to(:manage, Account) }
     it { is_expected.to be_allowed_to(:read, Notification) }
+    it { is_expected.to be_allowed_to(:manage, Schedule) }
     it { is_expected.to be_allowed_to(:manage, TrainingRequest) }
     it { is_expected.to be_allowed_to(:show_problems, Reservation) }
     it { is_expected.to be_allowed_to(:batch_update, Order) }
@@ -292,6 +294,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:manage, Account) }
     it { is_expected.to be_allowed_to(:manage, TrainingRequest) }
     it { is_expected.to be_allowed_to(:read, Notification) }
+    it { is_expected.to be_allowed_to(:manage, Schedule) }
     it { is_expected.to be_allowed_to(:show_problems, Reservation) }
     it { is_expected.to be_allowed_to(:batch_update, Order) }
     it_is_allowed_to([:batch_update, :cancel, :index], Reservation)
@@ -396,6 +399,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:batch_update, Order) }
     it_is_allowed_to([:batch_update, :cancel, :index], Reservation)
     it { is_expected.to be_allowed_to(:read, Notification) }
+    it { is_expected.to be_allowed_to(:read, Schedule) }
     it { is_expected.to be_allowed_to(:administer, User) }
     it { is_expected.to be_allowed_to(:read, UserPriceGroupMember) }
     it { is_expected.not_to be_allowed_to(:manage, PriceGroup) }

--- a/spec/support/matchers/display_order_matchers.rb
+++ b/spec/support/matchers/display_order_matchers.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :appear_before do |later_content|
+  match do |earlier_content|
+    page.body.index(earlier_content) < page.body.index(later_content)
+  end
+end
+
+RSpec::Matchers.define :appear_in_order do
+  match do |expected_order|
+    actual_order = actual_order_for(expected_order)
+    actual_order == expected_order
+  end
+
+  failure_message do |expected_order|
+    actual_order = actual_order_for(expected_order)
+    "expected #{expected_order}, but actual order was #{actual_order}"
+  end
+
+  def actual_order_for(expected_content)
+    actual_order = expected_content.map do |content|
+      next if page.body.index(content).nil?
+
+      [content, page.body.index(content)]
+    end
+    actual_order.compact.sort_by(&:last).map(&:first)
+  end
+end

--- a/spec/support/matchers/display_order_matchers.rb
+++ b/spec/support/matchers/display_order_matchers.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
-RSpec::Matchers.define :appear_before do |later_content|
-  match do |earlier_content|
-    page.body.index(earlier_content) < page.body.index(later_content)
-  end
-end
-
+# Based on http://launchware.com/articles/acceptance-testing-asserting-sort-order
+# Matcher to decribe the expected display order in the DOM.
+# Pass in an array of Strings in the expected display order.
+#
+# Usage:
+# visit timeline_facility_reservations_path(facility)
+# expect(["First", "Second", "Third"]).to appear_in_order
 RSpec::Matchers.define :appear_in_order do
   match do |expected_order|
     actual_order = actual_order_for(expected_order)

--- a/spec/system/admin/instrument_schedule_positions_spec.rb
+++ b/spec/system/admin/instrument_schedule_positions_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe "Instrument Schedule Display Order" do
+  let(:facility) { create(:setup_facility) }
+  let!(:instrument) { create(:instrument, name: "First", facility: facility) }
+  let!(:instrument2) { create(:instrument, name: "Second", facility: facility) }
+  let!(:instrument3) { create(:instrument, name: "Third", facility: facility, schedule: instrument2.schedule, is_hidden: true) }
+  let!(:instrument4) { create(:instrument, name: "New (no position)", facility: facility) }
+
+  let!(:reservation) { create :reservation, :running, product: instrument }
+  let!(:reservation2) { create :reservation, :running, product: instrument2 }
+  let!(:reservation3) { create :reservation, :running, product: instrument3 }
+  let!(:reservation4) { create :reservation, :running, product: instrument4 }
+
+  before do
+    instrument.schedule.update(position: 0)
+    instrument2.schedule.update(position: 1)
+    login_as user
+  end
+
+  describe "as a director" do
+    let(:user) { create(:user, :facility_director, facility: facility) }
+
+    it "can reorder the schedules", :js do
+      # check starting display order
+      visit dashboard_facility_instruments_path(facility)
+      expect(["First", "Second", "New (no position"]).to appear_in_order
+
+      visit timeline_facility_reservations_path(facility)
+      expect(["First", "Second", "Third", "New (no position"]).to appear_in_order
+
+      visit facility_public_timeline_path(facility)
+      expect(["First", "Second", "New (no position"]).to appear_in_order
+
+      # change the display order
+      visit facility_instrument_schedule_position_path(facility)
+      click_link "Instrument Display Order"
+      click_link "Edit"
+      expect(["First", "Shared schedule: Second Schedule", "New (no position"]).to appear_in_order
+      select "Second Schedule", from: "Instrument Schedules"
+      find("[title='Move Up']").click
+      click_button "Update Ordering"
+      expect(["Second", "Third", "First", "New (no position"]).to appear_in_order
+
+      # check the new display order
+      visit timeline_facility_reservations_path(facility)
+      expect(["Second", "Third", "First", "New (no position"]).to appear_in_order
+
+      visit facility_public_timeline_path(facility)
+      expect(["Second", "First", "New (no position"]).to appear_in_order
+
+      visit dashboard_facility_instruments_path(facility)
+      expect(["Second", "First", "New (no position"]).to appear_in_order
+    end
+  end
+
+  describe "as facility staff" do
+    let(:user) { create(:user, :staff, facility: facility) }
+
+    it "can view the show page, but not edit the display order" do
+      visit facility_instrument_schedule_position_path(facility)
+      click_link "Instrument Display Order"
+      expect(["First", "Shared schedule: Second Schedule", "New (no position"]).to appear_in_order
+      expect(page).not_to have_link("Edit")
+    end
+
+    it "can't directly access the edit page" do
+      visit edit_facility_instrument_schedule_position_path(facility)
+      expect(page.status_code).to eq(403)
+    end
+  end
+
+end


### PR DESCRIPTION
# Release Notes

Allow admins to set the display order for instruments in the Instruments Dashboard and Daily timeline views.
Instruments are ordered by schedule, so instruments that share a schedule will appear together as a group, in alphabetical order.  

# Screenshot
<img width="725" alt="Screen Shot 2020-09-13 at 3 28 33 PM" src="https://user-images.githubusercontent.com/30355046/93027919-dd6d7a00-f5d5-11ea-9e19-9c4357f6b93c.png">

<img width="728" alt="Screen Shot 2020-09-11 at 6 23 54 PM" src="https://user-images.githubusercontent.com/30355046/92980472-fd792e00-f45b-11ea-9590-b45f50848311.png">

