### PR TITLE
[#154551] Use correct app name in mailers

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -57,7 +57,7 @@ class Notifier < ActionMailer::Base
     @order_detail = OrderDetail.includes(:order, :order_status, :product).find(order_detail_id)
     mail(
       to: @order_detail.order.user.email,
-      subject: "[NUcore #{@order_detail.facility.abbreviation}] Order Status Changed To: #{@order_detail.order_status.name}"
+      subject: "[#{text(:app_name)} #{@order_detail.facility.abbreviation}] Order Status Changed To: #{@order_detail.order_status.name}"
     )
   end
 

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -53,11 +53,12 @@ class Notifier < ActionMailer::Base
     send_nucore_mail args[:user].email, text("views.notifier.statement.subject", facility: @facility)
   end
 
-  def order_detail_status_changed(order_detail_id)
-    @order_detail = OrderDetail.includes(:order, :order_status, :product).find(order_detail_id)
+  def order_detail_status_changed(order_detail)
+    facility = order_detail.facility.abbreviation
+    status = order_detail.order_status.name
     mail(
-      to: @order_detail.order.user.email,
-      subject: "[#{text(:app_name)} #{@order_detail.facility.abbreviation}] Order Status Changed To: #{@order_detail.order_status.name}"
+      to: order_detail.order.user.email,
+      subject: text(:subject, facility: facility, status: status)
     )
   end
 

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -54,11 +54,12 @@ class Notifier < ActionMailer::Base
   end
 
   def order_detail_status_changed(order_detail)
+    @order_detail = order_detail
     facility = order_detail.facility.abbreviation
     status = order_detail.order_status.name
     mail(
       to: order_detail.order.user.email,
-      subject: text(:subject, facility: facility, status: status)
+      subject: text("views.notifier.order_detail_status_changed.subject", facility: facility, status: status)
     )
   end
 

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -891,7 +891,7 @@ class OrderDetail < ApplicationRecord
 
   def notify_purchaser_of_order_status
     if product.email_purchasers_on_order_status_changes? && !reconciled?
-      Notifier.order_detail_status_changed(id).deliver_later
+      Notifier.order_detail_status_changed(self).deliver_later
     end
   end
 

--- a/config/locales/en.notifier.yml
+++ b/config/locales/en.notifier.yml
@@ -31,6 +31,7 @@ en:
           Sincerely,
 
           %{facility}
+        subject: "[!app_name! %{facility}] Order Status Changed To: %{status}"
 
       review_orders:
         subject: "!app_name! Orders For Review: %{abbreviation}"

--- a/config/locales/en.notifier.yml
+++ b/config/locales/en.notifier.yml
@@ -18,7 +18,6 @@ en:
           Password: %{password}
         outro: ""
       order_detail_status_changed:
-        subject:
         body: |
           Hello %{user},
 

--- a/config/locales/en.notifier.yml
+++ b/config/locales/en.notifier.yml
@@ -22,9 +22,9 @@ en:
         body: |
           Hello %{user},
 
-          The %{facility} has updated the status of your order for %{product} (NUcore order %{order_detail}) to **%{new_status}**.
+          The %{facility} has updated the status of your order for %{product} (!app_name! order %{order_detail}) to **%{new_status}**.
 
-          To view all your NUcore orders, please visit: <%{link}>
+          To view all your !app_name! orders, please visit: <%{link}>
 
           If you have any questions, please contact us at <%{facility_mailto}>.
 

--- a/spec/mailers/previews/notifier_preview.rb
+++ b/spec/mailers/previews/notifier_preview.rb
@@ -32,7 +32,7 @@ class NotifierPreview < ActionMailer::Preview
 
   def order_detail_status_changed
     order_detail = Nucore::Database.random(OrderDetail.complete)
-    Notifier.order_detail_status_changed(order_detail.id)
+    Notifier.order_detail_status_changed(order_detail)
   end
 
 end

--- a/spec/mailers/previews/notifier_preview.rb
+++ b/spec/mailers/previews/notifier_preview.rb
@@ -32,7 +32,7 @@ class NotifierPreview < ActionMailer::Preview
 
   def order_detail_status_changed
     order_detail = Nucore::Database.random(OrderDetail.complete)
-    Notifier.order_detail_status_changed(order_detail)
+    Notifier.order_detail_status_changed(order_detail.id)
   end
 
 end


### PR DESCRIPTION
# Release Notes

Set the app name dynamically so that each school's emails will include the appropriate app name (CORUM, Radar. or NUCore).