### PR TITLE
TECH TASK: Use one common email address for staging emails

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,7 +43,8 @@ email:
   from: 'noreply@example.com'
   fake:
     enabled: false
-    to: nucore@tablexi.com
+    to:
+      - nucore@tablexi.com
     whitelist:
   exceptions:
     sender: 'noreply@example.com'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,7 +43,7 @@ email:
   from: 'noreply@example.com'
   fake:
     enabled: false
-    to:
+    to: nucore@tablexi.com
     whitelist:
   exceptions:
     sender: 'noreply@example.com'


### PR DESCRIPTION
This will make it easier to manage forwarded staging emails from the various schools.