### PR TITLE
Tech Task: Set email address in the correct place

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,7 +44,6 @@ email:
   fake:
     enabled: false
     to:
-      - nucore@tablexi.com
     whitelist:
   exceptions:
     sender: 'noreply@example.com'

--- a/config/settings/stage.yml
+++ b/config/settings/stage.yml
@@ -2,7 +2,8 @@ email:
   from: "nucore-noreply@nucore.stage.tablexi.com"
   fake:
     enabled: true
-    to: ["jason@tablexi.com", "meara@tablexi.com"]
+    to:
+      - nucore@tablexi.com
     whitelist: []
 
 # paperclip:


### PR DESCRIPTION
# Release Notes

In https://github.com/tablexi/nucore-open/pull/2414 the email address was set in `settings.yml` but we just want to make the change for staging, so it belongs in `stage.yml`.