### PR TITLE
[#154684] Update bulk email queries

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -258,7 +258,7 @@ class Product < ApplicationRecord
     product_accessories.where(accessory_id: id).first
   end
 
-  def has_access_list?
+  def has_product_access_groups?
     respond_to?(:product_access_groups) && product_access_groups.any?
   end
 

--- a/app/views/product_users/index.html.haml
+++ b/app/views/product_users/index.html.haml
@@ -19,7 +19,7 @@
 - elsif @product_users.empty?
   %p.notice= text("none")
 - else
-  - if @product.respond_to?(:product_access_groups) && @product.product_access_groups.any?
+  - if @product.has_access_list?
     = form_for @product, url: [current_facility, @product, :update_restrictions], method: :put do |f|
       = render "table", f: f
       = f.submit text("update", plural_label: ProductAccessGroup.model_name.human.pluralize),

--- a/app/views/product_users/index.html.haml
+++ b/app/views/product_users/index.html.haml
@@ -19,7 +19,7 @@
 - elsif @product_users.empty?
   %p.notice= text("none")
 - else
-  - if @product.has_access_list?
+  - if @product.has_product_access_groups?
     = form_for @product, url: [current_facility, @product, :update_restrictions], method: :put do |f|
       = render "table", f: f
       = f.submit text("update", plural_label: ProductAccessGroup.model_name.human.pluralize),

--- a/app/views/schedule_rules/_schedule_rule_fields.html.haml
+++ b/app/views/schedule_rules/_schedule_rule_fields.html.haml
@@ -21,5 +21,5 @@
   = f.number_field :discount_percent, size: 4
   = "%"
 
-- if @product.respond_to?(:product_access_groups) && @product.product_access_groups.any?
+- if @product.has_access_list?
   = f.association :product_access_groups, as: :check_boxes, collection: @product.product_access_groups, wrapper_html: { class: "inline-checkbox-list" }

--- a/app/views/schedule_rules/_schedule_rule_fields.html.haml
+++ b/app/views/schedule_rules/_schedule_rule_fields.html.haml
@@ -21,5 +21,5 @@
   = f.number_field :discount_percent, size: 4
   = "%"
 
-- if @product.has_access_list?
+- if @product.has_product_access_groups?
   = f.association :product_access_groups, as: :check_boxes, collection: @product.product_access_groups, wrapper_html: { class: "inline-checkbox-list" }

--- a/app/views/users/access_list.html.haml
+++ b/app/views/users/access_list.html.haml
@@ -40,7 +40,7 @@
                     = text("users.access_list.training_requested")
                 = link_to product, [product.facility, product, :users]
               %td.scheduling-group-column
-                - if product.has_access_list?
+                - if product.has_product_access_groups?
                   = scheduling_group_select(product, @user)
 
     = submit_tag text("users.access_list.update_approvals.submit"),

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -501,7 +501,7 @@ RSpec.describe Product do
       end
     end
 
-    context "#has_access_list?" do
+    context "#has_product_access_groups?" do
       context "when its type supports access groups" do
         context "when it has an access group" do
           before :each do
@@ -509,13 +509,13 @@ RSpec.describe Product do
           end
 
           it "has an access list" do
-            expect(product.has_access_list?).to be true
+            expect(product.has_product_access_groups?).to be true
           end
         end
 
         context "when it has no access groups" do
           it "does not have an access list" do
-            expect(product.has_access_list?).to be false
+            expect(product.has_product_access_groups?).to be false
           end
         end
       end
@@ -524,7 +524,7 @@ RSpec.describe Product do
         let(:generic_item) { build(:setup_item) }
 
         it "does not have an access list" do
-          expect(generic_item.has_access_list?).to be false
+          expect(generic_item.has_product_access_groups?).to be false
         end
       end
     end

--- a/vendor/engines/bulk_email/app/services/bulk_email/recipient_searcher.rb
+++ b/vendor/engines/bulk_email/app/services/bulk_email/recipient_searcher.rb
@@ -88,7 +88,7 @@ module BulkEmail
     end
 
     def products_from_params
-      query = Product.for_facility(facility)
+      query = Product.for_facility(facility).active.requiring_approval
       query = query.where(facility: search_fields[:facilities]) if search_fields[:facilities].present?
       query = query.where(id: search_fields[:products]) if search_fields[:products].present?
       query
@@ -106,6 +106,8 @@ module BulkEmail
     def find_order_details
       OrderDetail
         .for_products(search_fields[:products])
+        .joins(:product)
+        .merge(Product.active)
         .for_facility(facility) # If cross_facility, will not add any restrictions
         .for_facilities(search_fields[:facilities])
         .ordered_or_reserved_in_range(start_date, end_date)


### PR DESCRIPTION
# Release Notes

*Users on Training Request List*: exclude users who have requested training on inactive products or products that no longer have an access list
*Authorized Users*: exclude users who are authorized on inactive products or products that no longer have an access list
*Customers*: exclude customers who have only purchased products that are now inactive
*Account Owners*: exclude owners whose accounts have only been used to purchase that are now inactive

Also refactors the `RecipientSearcher` queries to make them more consistent and easier to understand.  