### PR TITLE
Tech Task: Fix download links from S3

### DIFF
--- a/app/models/concerns/downloadable_file.rb
+++ b/app/models/concerns/downloadable_file.rb
@@ -5,7 +5,10 @@ module DownloadableFile
   extend ActiveSupport::Concern
 
   included do
-    has_attached_file :file, PaperclipSettings.config.merge(validate_media_type: false)
+    has_attached_file :file, PaperclipSettings.config.merge(
+      validate_media_type: false,
+      s3_url_options: { response_content_disposition: "attachment" } # this is ignored when using local storage
+    )
 
     # TODO: Limit attachment types for safe uploads
     do_not_validate_attachment_file_type :file


### PR DESCRIPTION
# Release Notes

This is a side effect of the switch from fog to the `aws-sdk-s3` gem.  