### PR TITLE
[#154764] Fix issue where quantity was not being updated

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -239,11 +239,12 @@ class OrdersController < ApplicationController
       @order.assign_attributes(order_params)
 
       if OrderDetailUpdater.new(@order, order_update_params).update
-        # Must show instead of render to maintain "more options" state when
+        # Must render instead of redirect to maintain "more options" state when
         # ordering on behalf of
+        flash.now[:notice] = "Cart has been updated"
       else
         logger.debug "errors #{@order.errors.full_messages}"
-        flash[:error] = @order.errors.full_messages.join("<br/>").html_safe
+        flash.now[:error] = @order.errors.full_messages.join("<br/>").html_safe
       end
       render :show
     end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -8,7 +8,7 @@ class Order < ApplicationRecord
   belongs_to :account
   belongs_to :facility
   belongs_to :order_import
-  has_many   :order_details, dependent: :destroy
+  has_many   :order_details, inverse_of: :order, dependent: :destroy
 
   validates_presence_of :user_id, :created_by
 
@@ -131,8 +131,9 @@ class Order < ApplicationRecord
 
   ## TODO: this doesn't pass errors up to the caller.. does it need to?
   def update_details(order_detail_updates)
-    order_details = self.order_details.find(order_detail_updates.keys)
-    order_details.each do |order_detail|
+    order_details_to_update = order_detail_updates.keys.map(&:to_i)
+    selected_order_details = self.order_details.select { |od| od.id.in?(order_details_to_update) }
+    selected_order_details.each do |order_detail|
       updates = order_detail_updates[order_detail.id]
       # reset quantity (if present)
       quantity = updates[:quantity].present? ? updates[:quantity].to_i : order_detail.quantity

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -1010,8 +1010,7 @@ RSpec.describe OrdersController do
         @params["quantity#{@order_detail.id}"] = "1.5"
         maybe_grant_always_sign_in :guest
         do_request
-        is_expected.to set_flash.to(/quantity/i)
-        is_expected.to set_flash.to(/integer/i)
+        is_expected.to set_flash.now[:error].to("Quantity must be an integer")
         is_expected.to render_template :show
       end
     end

--- a/spec/system/placing_an_order_on_behalf_of_spec.rb
+++ b/spec/system/placing_an_order_on_behalf_of_spec.rb
@@ -40,6 +40,43 @@ RSpec.describe "Placing an item order" do
     expect(page).to have_content "$33.25"
   end
 
+  describe "trying to purchase after updating the quantity" do
+    before do
+      click_link product.name
+      click_link "Add to cart"
+      choose account.to_s
+      click_button "Continue"
+      fill_in "Note", with: "A note"
+      fill_in "Reference ID", with: "Ref123"
+      fill_in "Quantity", with: "45"
+      click_button "Purchase"
+    end
+
+    it "returns to the cart, and the fields are properly updated" do
+      expect(page).to have_content "Quantities have changed."
+      expect(page).to have_field("Note", with: "A note")
+      expect(page).to have_field("Reference ID", with: "Ref123")
+      expect(page).to have_field("Quantity", with: "45")
+    end
+  end
+
+  describe "trying to purchase after updating just the note/ref id fields" do
+    before do
+      click_link product.name
+      click_link "Add to cart"
+      choose account.to_s
+      click_button "Continue"
+      fill_in "Note", with: "A note"
+      fill_in "Reference ID", with: "Ref123"
+      click_button "Purchase"
+    end
+
+    it "purchases" do
+      expect(page).to have_content("Order Receipt")
+      expect(page).to have_content("Note: A note")
+    end
+  end
+
   it "can backdate an order", :js do # js needed for More options expansion
     visit facility_path(facility)
     click_link product.name


### PR DESCRIPTION
# Release Notes

Fix an issue when ordering on behalf if you update the quantity field, the value of quantity nor note and reference id are not persisted.

# Additional Context

To replicate:
* Add an item with a note to the cart
* Fill in the note and reference id fields
* Change the quantity field
* Click "Purchase"
* You will see the "Quantities have change. Please review" message, but the note, quantity, and reference fields all revert to their previous values.
* Clicking Update does the same thing

It always reverted to it's previous vlue:
Put in 3, click update -> reverts to 1
Put in 4, click update -> field shows 3

## Tech notes

While I had no problem replicating this in the browser, I struggled to get a failing spec. I'm not sure what the difference in behavior is. I left in the specs, but they were still passing before the other changes. I eventually gave up.

Ultimately, the issue is the order details getting updated are not the same objects as those that were getting displayed. So when you submitted the form, the it would read the database values into one set of objects, update another, and then update the first set of objected.

Both of the changes: the `inverse_of` and the `select` fixed the issue on its own, but it felt like both were reasonable things to put in.