### PR TITLE
Fix time range display issue where times are the same day of the month

### DIFF
--- a/app/models/time_range.rb
+++ b/app/models/time_range.rb
@@ -32,7 +32,7 @@ class TimeRange
   end
 
   def end_string
-    if start_at && end_at && start_at.day == end_at.day
+    if start_at && end_at && start_at.to_date == end_at.to_date
       localize(end_at, format: :timeonly)
     else
       localize(end_at)

--- a/spec/models/offline_reservation_spec.rb
+++ b/spec/models/offline_reservation_spec.rb
@@ -50,9 +50,8 @@ RSpec.describe OfflineReservation do
       let(:reserve_end_at) { reserve_start_at + 1.month }
 
       it "renders as a range with an ending" do
-        pending "TODO: Reservation#range_to_s is not handling this correctly"
         expect(subject.to_s)
-          .to eq "Fri, 07/01/2016 12:00 PM - Fri, 08/01/2016 01:00 PM"
+          .to eq "Fri, 07/01/2016 12:00 PM - Mon, 08/01/2016 12:00 PM"
       end
     end
   end

--- a/spec/models/time_range_spec.rb
+++ b/spec/models/time_range_spec.rb
@@ -53,6 +53,21 @@ RSpec.describe TimeRange do
       it { is_expected.to eq("Wed, 04/26/2017 2:00 PM - Thu, 04/27/2017 4:00 PM") }
     end
 
+    describe "when the day of the month is the same" do
+      let(:start_at) { Time.zone.local(2017, 4, 26, 14, 0, 15) }
+      let(:end_at) { Time.zone.local(2017, 5, 26, 14, 0, 15) }
+      it { is_expected.to eq("Wed, 04/26/2017 2:00 PM - Fri, 05/26/2017 2:00 PM") }
+    end
+
+    describe "when it spans midnight in UTC" do
+      around do |example|
+        Time.use_zone("Central Time (US & Canada)") { example.call }
+      end
+      let(:start_at) { Time.zone.local(2017, 4, 26, 19, 0) }
+      let(:end_at) { Time.zone.local(2017, 4, 26, 22, 0) }
+      it { is_expected.to eq("Wed, 04/26/2017 7:00 PM - 10:00 PM") }
+    end
+
     describe "when missing the start time" do
       let(:start_at) { nil }
       let(:end_at) { Time.zone.local(2017, 4, 26, 14, 0, 15) }


### PR DESCRIPTION
# Release Notes

Fix time range display when times are one month apart on the same day of month (e.g. 7/1 and 8/1).

# Additional Context

They were being treated as if they were on the same day, so the range was appearing as `Fri, 07/01/2016 12:00 PM - 12:00 PM`.

I happened to notice the pending test, so I figured I'd take a quick look into this.
