### PR TITLE
Tech task: Increase capybara browser size so screenshots are easier to read

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,7 +28,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system, js: true) do
-    driven_by :selenium_chrome_headless
+    driven_by :selenium, using: :headless_chrome, screen_size: [1366, 768]
   end
 
   Capybara.server = :webrick


### PR DESCRIPTION
# Release Notes

Tech task: Increase capybara/chrome browser size so screenshot on test failures are easier to read.

# Additional Context

Before, especially on the front end, we were getting the responsive view.

# Screenshots

Before
![image](https://user-images.githubusercontent.com/1099111/95889052-8fb86e80-0d47-11eb-9743-22be84bde9b4.png)

After
![image](https://user-images.githubusercontent.com/1099111/95889002-79aaae00-0d47-11eb-8750-7cae06b555b3.png)

