### PR TITLE
[#155076] Use html helper in place of the view hook for welcome helper text

### DIFF
--- a/app/views/facilities/index.html.haml
+++ b/app/views/facilities/index.html.haml
@@ -1,7 +1,7 @@
 - if SettingsHelper.feature_on?(:equipment_list)
   = render "shared/nav/equipment_list_nav"
 
-.alert.alert-info= html(".welcome")
+.alert.alert-info= html("welcome")
 
 - if azlist_on?
   .az_list_container

--- a/app/views/facilities/index.html.haml
+++ b/app/views/facilities/index.html.haml
@@ -1,9 +1,7 @@
 - if SettingsHelper.feature_on?(:equipment_list)
   = render "shared/nav/equipment_list_nav"
 
-.alert.alert-info
-  = text(".welcome")
-  = render_view_hook("after_welcome")
+.alert.alert-info= html(".welcome")
 
 - if azlist_on?
   .az_list_container


### PR DESCRIPTION
# Release Notes

A view hook is more than we need for the wording change we need to make in the UMass fork.

See https://github.com/tablexi/nucore-umass/pull/82