### PR TITLE
[#155168] Force download of statements rather than open in browser

### DIFF
--- a/app/support/statement_pdf.rb
+++ b/app/support/statement_pdf.rb
@@ -50,7 +50,7 @@ class StatementPdf
 
   def options
     if download?
-      DEFAULT_OPTIONS.merge(filename: filename, force_download: true)
+      DEFAULT_OPTIONS.merge(filename: filename, disposition: "attachment")
     else
       DEFAULT_OPTIONS.dup
     end


### PR DESCRIPTION
# Release Notes

Fix issue where statements were opening in browser rather than downloading.

# Additional Context

The way to specify downloading in Prawn changed when we switched which gem we were using. See #2377

The similarity to issues we had with Paperclip/S3 is purely coincidental. See #2424
