### PR TITLE
Tech Task: Use owner_user method, set expiration for split accounts after splits

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -21,7 +21,7 @@ class Notifier < ActionMailer::Base
     @user = args[:user]
     @account = args[:account]
     @created_by = args[:created_by]
-    send_nucore_mail @account.owner.user.email, text("views.notifier.user_update.subject")
+    send_nucore_mail @account.owner_user.email, text("views.notifier.user_update.subject")
   end
 
   # Any changes to the financial accounts will alert the PI(s), admin(s)

--- a/app/models/api/order_detail.rb
+++ b/app/models/api/order_detail.rb
@@ -22,7 +22,7 @@ class Api::OrderDetail
 
   def account_to_hash
     if account.present?
-      { id: account.id, owner: user_to_hash(account.owner.user) }
+      { id: account.id, owner: user_to_hash(account.owner_user) }
     end
   end
 

--- a/app/support/example_statement_pdf.rb
+++ b/app/support/example_statement_pdf.rb
@@ -33,7 +33,7 @@ class ExampleStatementPdf < StatementPdf
     pdf.text @facility.to_s, size: 20, font_style: :bold
     pdf.text "Invoice ##{@statement.invoice_number}"
     pdf.text "Account: #{@account}"
-    pdf.text "Owner: #{@account.owner.user.full_name(suspended_label: false)}"
+    pdf.text "Owner: #{@account.owner_user.full_name(suspended_label: false)}"
     pdf.move_down(10)
   end
 

--- a/spec/controllers/reports/general_reports_controller_spec.rb
+++ b/spec/controllers/reports/general_reports_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Reports::GeneralReportsController do
   run_report_tests([
                      { report_by: :product, index: 0, report_on_label: "Product", report_on: proc { |od| od.product.name } },
                      { report_by: :account, index: 1, report_on_label: "Account", report_on: proc { |od| od.account } },
-                     { report_by: :account_owner, index: 2, report_on_label: "Account Owner", report_on: proc { |od| owner = od.account.owner.user; "#{owner.last_name}, #{owner.first_name} (#{owner.username})" } },
+                     { report_by: :account_owner, index: 2, report_on_label: "Account Owner", report_on: proc { |od| owner = od.account.owner_user; "#{owner.last_name}, #{owner.first_name} (#{owner.username})" } },
                      { report_by: :purchaser, index: 3, report_on_label: "Purchaser", report_on: proc { |od| usr = od.order.user; "#{usr.last_name}, #{usr.first_name} (#{usr.username})" } },
                      { report_by: :price_group, index: 4, report_on_label: "Price Group", report_on: proc { |od| od.price_policy ? od.price_policy.price_group.name : "Unassigned" } },
                    ])

--- a/spec/controllers/reports/instrument_reports_controller_spec.rb
+++ b/spec/controllers/reports/instrument_reports_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Reports::InstrumentReportsController do
   run_report_tests([
                      { report_by: :instrument, index: 0, report_on_label: nil, report_on: proc { |res| [res.product.url_name] } },
                      { report_by: :account, index: 1, report_on_label: "Account", report_on: proc { |res| [res.product.url_name, res.order_detail.account.to_s] } },
-                     { report_by: :account_owner, index: 2, report_on_label: "Account Owner", report_on: proc { |res| owner = res.order_detail.account.owner.user; [res.product.url_name, "#{owner.full_name} (#{owner.username})"] } },
+                     { report_by: :account_owner, index: 2, report_on_label: "Account Owner", report_on: proc { |res| owner = res.order_detail.account.owner_user; [res.product.url_name, "#{owner.full_name} (#{owner.username})"] } },
                      { report_by: :purchaser, index: 3, report_on_label: "Purchaser", report_on: proc { |res| usr = res.order_detail.order.user; [res.product.url_name, "#{usr.full_name} (#{usr.username})"] } },
                    ])
 

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -24,8 +24,8 @@ FactoryBot.define do
     end
     facility { product.facility }
     association :account, factory: :setup_account
-    user { account.owner.user }
-    created_by { account.owner.user.id }
+    user { account.owner_user }
+    created_by { account.owner_user.id }
 
     after(:create) do |order, evaluator|
       # build().save will allow an already existing relation without raising an error

--- a/vendor/engines/split_accounts/app/services/split_accounts/split_account_builder.rb
+++ b/vendor/engines/split_accounts/app/services/split_accounts/split_account_builder.rb
@@ -19,8 +19,8 @@ module SplitAccounts
 
     # Hooks into superclass's `build` method.
     def after_build
-      set_expires_at
       setup_default_splits if account.splits.none?
+      set_expires_at
     end
 
     private

--- a/vendor/engines/split_accounts/spec/factories/split_accounts.rb
+++ b/vendor/engines/split_accounts/spec/factories/split_accounts.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     created_by { 0 }
 
     trait :with_three_splits do
-      callback(:after_build, :before_create) do |split_account, _evalutor|
+      callback(:after_build) do |split_account, _evalutor|
         split_account.splits << build(:split, percent: 33.33, apply_remainder: true, parent_split_account: split_account)
         split_account.splits << build(:split, percent: 33.33, apply_remainder: false, parent_split_account: split_account)
         split_account.splits << build(:split, percent: 33.34, apply_remainder: false, parent_split_account: split_account)
@@ -23,7 +23,7 @@ FactoryBot.define do
 
     # Leave this at the bottom of the factory.
     # Add valid splits if none exist and if transient `without_splits` is false.
-    callback(:after_build, :before_create) do |split_account, evaluator|
+    callback(:after_build) do |split_account, evaluator|
       unless split_account.splits.present? || evaluator.without_splits
         split_account.splits << build(:split, percent: 50, apply_remainder: true, parent_split_account: split_account)
         split_account.splits << build(:split, percent: 50, apply_remainder: false, parent_split_account: split_account)


### PR DESCRIPTION
# Release Notes

Cleans up a few small things:
- user `owner_user` method instead of `owner.user`
- call `set_expires_at` after splits are built (see [code comment)](https://github.com/tablexi/nucore-open/compare/code-cleanup?expand=1#diff-570e17173f9997f4a981687a1401edd517058c7f801d702605b76fe8e4a293e9R29)
- remove unnecessary callbacks in factories