### PR TITLE
Tech Task: Rename attribute field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Because we use squash and merge, you should be able to see the changes by lookin
 at the [commit log](https://github.com/tablexi/nucore-open/commits/master). However, we have begun keeping track of breaking changes
 or optional rake tasks.
 
+### Rename username attribute key in `ldap.yml.template` ([#2440](https://github.com/tablexi/nucore-open/pull/2440))
+
+If you are using the [LDAP Authenitcation engine](link) and have set a value for the `attribute` key in `ldap.yml`, you will need to rename the key to `username_attribute`.
+
+```yaml
+# Old setting
+attribute: uid
+
+# New setting
+username_attribute: uid
+```
+
 ### Uploaded file storage path change ([#2365](https://github.com/tablexi/nucore-open/pull/2365))
 
 We want to move everything into `public/system`, which is the more modern standard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ or optional rake tasks.
 
 ### Rename username attribute key in `ldap.yml.template` ([#2440](https://github.com/tablexi/nucore-open/pull/2440))
 
-If you are using the [LDAP Authenitcation engine](link) and have set a value for the `attribute` key in `ldap.yml`, you will need to rename the key to `username_attribute`.
+If you are using the [LDAP Authenitcation engine](vendor/engines/ldap_authentication/README.md) and have set a value for the `attribute` key in `ldap.yml`, you will need to rename the key to `username_attribute`.
 
 ```yaml
 # Old setting

--- a/config/ldap.yml.template
+++ b/config/ldap.yml.template
@@ -9,7 +9,7 @@ development:
   host: <%= ENV.fetch("LDAP_HOST", "localhost") %>
   port: <%= ENV.fetch("LDAP_PORT", 389) %>
   base: dc=example,dc=org
-  attribute: uid
+  username_attribute: uid
   admin_user: "cn=admin,dc=example,dc=org"
   admin_password: admin
   additional_user_attributes: [] # attributes to update on log in

--- a/vendor/engines/ldap_authentication/lib/ldap_authentication.rb
+++ b/vendor/engines/ldap_authentication/lib/ldap_authentication.rb
@@ -31,8 +31,8 @@ module LdapAuthentication
     @admin_connection ||= Devise::LDAP::Connection.admin
   end
 
-  def self.attribute_field
-    config.fetch("attribute", "uid")
+  def self.username_attribute
+    config.fetch("username_attribute", "uid")
   end
 
   def self.additional_user_attributes

--- a/vendor/engines/ldap_authentication/lib/ldap_authentication/user_entry.rb
+++ b/vendor/engines/ldap_authentication/lib/ldap_authentication/user_entry.rb
@@ -14,7 +14,7 @@ module LdapAuthentication
 
       ldap_entries = nil
       ActiveSupport::Notifications.instrument "search.ldap_authentication" do |payload|
-        ldap_entries = with_retry { admin_ldap.search(filter: Net::LDAP::Filter.eq(LdapAuthentication.attribute_field, uid)) }
+        ldap_entries = with_retry { admin_ldap.search(filter: Net::LDAP::Filter.eq(LdapAuthentication.username_attribute, uid)) }
         payload[:uid] = uid
         payload[:results] = ldap_entries
       end
@@ -37,7 +37,7 @@ module LdapAuthentication
     end
 
     def username
-      ldap_entry.public_send(LdapAuthentication.attribute_field).last
+      ldap_entry.public_send(LdapAuthentication.username_attribute).last
     end
 
     def first_name

--- a/vendor/engines/ldap_authentication/lib/tasks/ldap_authentication.rake
+++ b/vendor/engines/ldap_authentication/lib/tasks/ldap_authentication.rake
@@ -33,7 +33,7 @@ namespace :ldap_authentication do
   desc "Updates User records based on LDAP directory"
   task update_users: :environment do
     updated_users = 0
-    users_to_update = User.authenticated_externally.unexpired
+    users_to_update = User.authenticated_by_netid.unexpired
     users_to_update.find_each do |user|
       entry = LdapAuthentication::UserEntry.find(user.username)
       if entry.present?


### PR DESCRIPTION
# Release Notes

Using `username_attribute` is more accurate and desciptive.
Also, fix an instance of a scope that no longer exists (`authenticated_externally`).