### PR TITLE
Add parent account to export raw reports

### DIFF
--- a/vendor/engines/split_accounts/app/models/split_accounts/reports/export_raw_transformer.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/reports/export_raw_transformer.rb
@@ -11,7 +11,8 @@ module SplitAccounts
       include ActionView::Helpers::NumberHelper
 
       def transform(original_hash)
-        insert_into_hash_after(original_hash, :actual_total, split_percent: method(:split_percent))
+        transformed_hash = insert_into_hash_after(original_hash, :actual_total, split_percent: method(:split_percent))
+        insert_into_hash_after(transformed_hash, :account_description, parent_account: method(:parent_account))
       end
 
       private
@@ -19,6 +20,12 @@ module SplitAccounts
       def split_percent(order_detail)
         if order_detail.respond_to?(:split) && order_detail.split
           number_with_precision(order_detail.split.percent, strip_insignificant_zeros: true) + "%"
+        end
+      end
+
+      def parent_account(order_detail)
+        if order_detail.respond_to?(:split) && order_detail.split
+          order_detail.split.parent_split_account.description_to_s
         end
       end
 

--- a/vendor/engines/split_accounts/spec/models/reports/export_raw_spec.rb
+++ b/vendor/engines/split_accounts/spec/models/reports/export_raw_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe Reports::ExportRaw, :enable_split_accounts do
         "Calculated Subsidy" => ["$0.50", "$0.50"],
         "Account" => subaccounts.map(&:account_number),
         "Split Percent" => ["50%", "50%"],
+        "Parent Account" => [account.description_to_s, account.description_to_s],
       )
     end
   end


### PR DESCRIPTION
# Release Notes

Adds a Parent Account column to split account rows in the Export Raw CSV.