### PR TITLE
[#153160] Add a CSV export for global user roles

### DIFF
--- a/app/controllers/global_user_roles_controller.rb
+++ b/app/controllers/global_user_roles_controller.rb
@@ -4,8 +4,20 @@ class GlobalUserRolesController < GlobalSettingsController
 
   before_action :load_user, only: [:destroy, :edit, :update]
 
+  include CsvEmailAction
+
   def index
-    @users = User.with_global_roles
+    report = Reports::GlobalUserRolesReport.new(users: User.with_global_roles)
+
+    respond_to do |format|
+      format.html do
+        @users = report.users.paginate(per_page: 50, page: params[:page])
+      end
+
+      format.csv do
+        queue_csv_report_email(report)
+      end
+    end
   end
 
   def destroy

--- a/app/models/reports/global_user_roles_report.rb
+++ b/app/models/reports/global_user_roles_report.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Reports
+
+  class GlobalUserRolesReport
+
+    include Reports::CsvExporter
+
+    attr_reader :users
+
+    def initialize(users:)
+      @users = users
+    end
+
+    def default_report_hash
+      {
+        name: :full_name,
+        username: :username,
+        email: :email,
+        roles: :global_role_list,
+      }
+    end
+
+    def report_data_query
+      UserPresenter.wrap(users)
+    end
+
+    def filename
+      "global_user_roles.csv"
+    end
+
+    def description
+      "Global User Roles Report #{format_usa_datetime(Date.today)}"
+    end
+
+    protected
+
+    def translation_scope
+      "global_user_roles.index"
+    end
+
+  end
+
+end

--- a/app/models/reports/log_events_report.rb
+++ b/app/models/reports/log_events_report.rb
@@ -1,4 +1,7 @@
+## frozen_string_literal: true
+
 module Reports
+
   class LogEventsReport
 
     include Reports::CsvExporter
@@ -48,4 +51,5 @@ module Reports
     end
 
   end
+
 end

--- a/app/views/global_user_roles/edit.html.haml
+++ b/app/views/global_user_roles/edit.html.haml
@@ -19,6 +19,8 @@
     = label_tag :email, nil, class: "require"
     = text_field_tag :email, user.email, disabled: true
 
+    = render_view_hook("additional_user_attributes_form", user: user)
+
     -# Chosen attempts to disable autocomplete, but Chrome still does.
     -# This hidden field tells Chrome to really disable autocomplete:
     %input.hidden{type: "text", id: "PreventChromeAutocomplete", name: "PreventChromeAutocomplete"}

--- a/app/views/global_user_roles/index.html.haml
+++ b/app/views/global_user_roles/index.html.haml
@@ -26,6 +26,7 @@
         %th= t(".th.username")
         %th= t(".th.email")
         %th= t(".th.roles")
+        = render_view_hook("additional_user_attribute_headers")
     %tbody
       - UserPresenter.wrap(@users).each do |user|
         %tr
@@ -43,3 +44,4 @@
               = link_to user.username, edit_global_user_role_path(user.id)
           %td= user.email
           %td= user.global_role_list
+          = render_view_hook("additional_user_attributes", user: user)

--- a/app/views/global_user_roles/index.html.haml
+++ b/app/views/global_user_roles/index.html.haml
@@ -12,6 +12,12 @@
 - if @users.empty?
   %p.notice= t(".no_users")
 - else
+  = link_to t(".export"), url_for(format: :csv), class: "js--exportSearchResults pull-right", data: { form: ".search_form" }
+  = form_tag(global_user_roles_path, method: :get, class: "search_form") do
+    .row
+      .span3
+        = hidden_field_tag :email, current_user.email, disabled: true
+        = hidden_field_tag :format, params[:format], disabled: true
   %table.table.table-striped.table-hover
     %thead
       %tr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -409,6 +409,7 @@ en:
       grant_roles: Grant Roles
       remove_roles: Remove Roles
       remove_roles_confirm: Are you sure?
+      export: Export as CSV
       th:
         email: Email
         name: Name

--- a/spec/models/reports/global_user_roles_report_spec.rb
+++ b/spec/models/reports/global_user_roles_report_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Reports::GlobalUserRolesReport do
+
+  subject(:report) { described_class.new(users: users) }
+  let(:users) { create_list(:user, 3, :global_billing_administrator) }
+  let(:report_users) { report.report_data_query }
+
+  describe "for an item" do
+    it "exports correct number of line items" do
+      expect(report.to_csv.split("\n").length).to eq(4)
+    end
+
+    it "populates the report" do
+      expect(report).to have_column_values(
+        "Name" => report_users.map(&:full_name),
+        "Username" => report_users.map(&:username),
+        "Email" => report_users.map(&:email),
+        "Roles" => report_users.map(&:global_role_list),
+      )
+    end
+  end
+
+end


### PR DESCRIPTION
# Release Notes

In support of https://github.com/tablexi/nucore-nu/pull/602

Add view hooks for additional user attributes on the Global User Roles page
Add an Export to CSV function on the Global User Roles page