### PR TITLE
[#153119] Update and reorganize help text for Bulk Import

### DIFF
--- a/app/services/order_row_importer.rb
+++ b/app/services/order_row_importer.rb
@@ -50,6 +50,14 @@ class OrderRowImporter
     HEADERS.to_a.join(",")
   end
 
+  def self.optional_fields
+    (HEADERS.to_a - REQUIRED_HEADERS.to_a - ["Errors"]).to_sentence
+  end
+
+  def self.importable_products
+    importable_product_types.map { |type| type.name.titleize }.to_sentence
+  end
+
   def initialize(row, order_import)
     @row = row
     @order_import = order_import

--- a/app/services/order_row_importer.rb
+++ b/app/services/order_row_importer.rb
@@ -51,7 +51,7 @@ class OrderRowImporter
   end
 
   def self.optional_fields
-    (HEADERS.to_a - REQUIRED_HEADERS.to_a - ["Errors"]).to_sentence
+    (HEADERS.to_a - REQUIRED_HEADERS.to_a - [header(:errors)]).to_sentence
   end
 
   def self.importable_products

--- a/app/views/order_imports/new.html.haml
+++ b/app/views/order_imports/new.html.haml
@@ -4,16 +4,17 @@
 = content_for :tabnav do
   = render partial: "admin/shared/tabnav_order"
 
-#bulk-import
-  %h2= text(".h2")
-  = html("instructions")
-  = simple_form_for [:facility, @order_import], html: { multipart: true } do |f|
-    .well.well-small#bulk-import-fields
-      .pull-right
-        = link_to text("download_link"), "#{root_path}templates/bulk_import_template.csv", id: "bulk-import-template"
-      = f.file_field :upload_file
-      = f.input :fail_on_error, inline_label: text("fail_on_error"), label: false
-      = f.input :send_receipts, inline_label: text("send_receipts"), label: false
+  #bulk-import
+    %h2= text(".h2")
+    = html("instructions", importable_products: OrderRowImporter.importable_products, optional_fields: OrderRowImporter.optional_fields)
+    = simple_form_for [:facility, @order_import], html: { multipart: true } do |f|
+      .well.well-small#bulk-import-fields
+        .pull-right
+          = link_to text("download_link"), "#{root_path}templates/bulk_import_template.csv", id: "bulk-import-template"
+        = f.file_field :upload_file
+        = html("upload_file_hint")
+        = f.input :fail_on_error, inline_label: text("fail_on_error"), label: false, hint: html("fail_on_error_hint")
+        = f.input :send_receipts, inline_label: text("send_receipts"), label: false, hint: text("send_receipts_hint")
       %label
         = text("send_report_to")
         = text_field_tag :report_recipient, @current_user.email

--- a/config/locales/views/admin/en.order_imports.yml
+++ b/config/locales/views/admin/en.order_imports.yml
@@ -7,13 +7,21 @@ en:
         in_process: "In process"
         send_receipts: "Send receipts"
         send_report_to: "Send results to"
-        download_link: "Right-click and choose 'save target' to download import template"
+        download_link: "Download import template"
         submit: Import
         instructions: |
-          <p>Bulk imports are done using a CSV formatted file (from Excel, save as “CSV (Comma delimited)”). The required fields are defined in the template, downloadable below.</p>
-          <p>To upload the completed CSV file, click the "Choose File" button to select the file and then click the "Import" button to add the orders to your !facility_downcase!.</p>
-          <p>By default, if import errors occur the valid entries are imported and the failed entries are returned in a CSV file for you to correct and upload later.
-          If you prefer to halt the import process entirely when any import error occurs (allowing you to correct the file and try again), then check the "Halt import on error" box.</p>
-          <p>By default receipts are NOT sent to customers for bulk imported orders. If you would like receipts to be sent to customers check the "send receipts" box.</p>
+          <p>Bulk imports are done by uploading a CSV formatted file (from Excel, save as “CSV (Comma delimited)”). The available fields are defined in the import template, downloadable below.</p>
+          <p>All fields are required except for %{optional_fields}.</p>
+          <p>Only %{importable_products} products can be imported.</p>
+          <p>Rows that include an existing Order Number will be added to that order.</p>
+          <p>Any rows without an Order Number will be added to a new order,
+          along with any other rows with the same NetID/Email, Chart String, and Order Date.</p>
+        upload_file_hint: |
+          <p>Click the "Choose File" button to select the completed CSV file to upload, then click the "Import" button to add the orders to your !facility_downcase!.</p>
+        fail_on_error_hint:
+          <p>When checked, an import error will halt the import process entirely, allowing you to correct the file and try again.</p>
+          <p>Un-check to import valid entries and return any failed entries in a CSV file for you to correct and upload later.</p>
+        send_receipts_hint:
+          <p>Check this box to send receipts. By default receipts are NOT sent to customers for bulk imported orders. </p>
         history:
           head: Import History


### PR DESCRIPTION
# Release Notes
- List optional fields and available product types
- Correctly describe default behavior (`fail_on_error` defaults to true)
- Download link doesn't require a right-click
- Move hint text closer to the relevant form elements
- Clarify logic for adding to existing orders vs creating new orders

# Screenshot

Note: The file upload button text is "Browse" on Firefox, but "Choose File" is still accurate for Chrome

![Screen Shot 2020-11-24 at 5 50 48 PM](https://user-images.githubusercontent.com/30355046/100164566-bb1d9580-2e7d-11eb-8123-ba22159914bd.png)
