### PR TITLE
[#154741] Move Parent Account column to the right

### DIFF
--- a/vendor/engines/split_accounts/app/models/split_accounts/reports/export_raw_transformer.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/reports/export_raw_transformer.rb
@@ -12,7 +12,7 @@ module SplitAccounts
 
       def transform(original_hash)
         transformed_hash = insert_into_hash_after(original_hash, :actual_total, split_percent: method(:split_percent))
-        insert_into_hash_after(transformed_hash, :account_description, parent_account: method(:parent_account))
+        insert_into_hash_after(transformed_hash, :reference_id, parent_account: method(:parent_account))
       end
 
       private


### PR DESCRIPTION
# Release Notes

Move the new Parent Account column to the right-most position in the export raw report. NU uploads the report to their BI software so the column order matters.  At some point we should review column ordering as a whole.  