### PR TITLE
[#155438] Sort global users alphabetically by last name, remove pagination

### DIFF
--- a/app/controllers/global_user_roles_controller.rb
+++ b/app/controllers/global_user_roles_controller.rb
@@ -7,11 +7,11 @@ class GlobalUserRolesController < GlobalSettingsController
   include CsvEmailAction
 
   def index
-    report = Reports::GlobalUserRolesReport.new(users: User.with_global_roles)
+    report = Reports::GlobalUserRolesReport.new(users: User.with_global_roles.sort_last_first)
 
     respond_to do |format|
       format.html do
-        @users = report.users.paginate(per_page: 50, page: params[:page])
+        @users = report.users
       end
 
       format.csv do


### PR DESCRIPTION
# Release Notes

I paginated the records but missed adding the `will_paginate(@users)` view helper, so when there are more than 50 records, there were no navigation arrows to get users to the next page. I'm not expecting this list to get much longer than 100 records, so skipping pagination for now.
