### PR TITLE
[#155217] Add notices to transaction report

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -418,7 +418,7 @@ class OrderDetail < ApplicationRecord
   end
 
   def backdate_to_complete!(event_time = Time.zone.now)
-    # if we're setting it to compete, automatically set the actuals for a reservation
+    # if we're setting it to complete, automatically set the actuals for a reservation
     if reservation
       raise NUCore::PurchaseException.new(t_model_error(Reservation, "cannot_be_completed_in_future")) if reservation.reserve_end_at > event_time
       reservation.assign_actuals_off_reserve unless reservation.product.reservation_only?

--- a/app/models/reports/account_transactions_report.rb
+++ b/app/models/reports/account_transactions_report.rb
@@ -69,6 +69,7 @@ class Reports::AccountTransactionsReport
       Account.human_attribute_name(:expires_at),
       OrderDetail.human_attribute_name(:order_status),
       OrderDetail.human_attribute_name(:note),
+      text(".order_detail_notices"),
     ]
   end
 
@@ -98,10 +99,15 @@ class Reports::AccountTransactionsReport
       format_usa_date(order_detail.account.expires_at),
       order_detail.order_status,
       order_detail.note,
+      notices_for(order_detail),
     ]
   end
 
   private
+
+  def notices_for(order_detail)
+    OrderDetailNoticePresenter.new(order_detail).badges_to_text
+  end
 
   def order_detail_duration(order_detail)
     if order_detail.problem?

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -39,6 +39,12 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
     safe_join(filtered.map(&:badge_to_html))
   end
 
+  def badges_to_text(only: [:status, :warning])
+    filtered = notices.select { |notice| Array(only).include?(notice.severity) }
+
+    filtered.map(&:badge_text).join("+")
+  end
+
   def alerts_to_html
     blocks = [
       build_alert(warnings, "error"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -949,6 +949,7 @@ en:
       export: Export as CSV
       subject: "!app_name! Transaction Export"
       body: Your export is ready. Please see the attached file.
+      order_detail_notices: Notices
 
   users:
     new_user:

--- a/spec/presenters/order_detail_notice_presenter_spec.rb
+++ b/spec/presenters/order_detail_notice_presenter_spec.rb
@@ -81,6 +81,66 @@ RSpec.describe OrderDetailNoticePresenter do
     end
   end
 
+  describe "badges_to_text" do
+    it "shows nothing for a blank order detail" do
+      expect(presenter.badges_to_text).to be_blank
+    end
+
+    it "shows nothing for a canceled order detail" do
+      allow(order_detail).to receive(:in_review?).and_return(true)
+      allow(order_detail).to receive(:canceled?).and_return(true)
+      expect(presenter.badges_to_text).to be_blank
+    end
+
+    it "shows in review if the order is in review" do
+      allow(order_detail).to receive(:in_review?).and_return(true)
+      expect(presenter.badges_to_text).to eq("In Review")
+    end
+
+    it "shows in dispute" do
+      allow(order_detail).to receive(:in_dispute?).and_return(true)
+      expect(presenter.badges_to_text).to eq("In Dispute")
+    end
+
+    it "shows can reconcile" do
+      allow(order_detail).to receive(:can_reconcile_journaled?).and_return(true)
+      expect(presenter.badges_to_text).to eq("Can Reconcile")
+    end
+
+    it "shows ready for journal if setting is on", feature_setting: { ready_for_journal_notice: true } do
+      allow(order_detail).to receive(:ready_for_journal?).and_return(true)
+      expect(presenter.badges_to_text).to eq("Ready for Journal")
+    end
+
+    it "does not show ready for journal if setting is off", feature_setting: { ready_for_journal_notice: false } do
+      allow(order_detail).to receive(:ready_for_journal?).and_return(true)
+      expect(presenter.badges_to_text).not_to eq("Ready for Journal")
+    end
+
+    it "shows in open journal" do
+      allow(order_detail).to receive(:in_open_journal?).and_return(true)
+      expect(presenter.badges_to_text).to eq("Open Journal")
+    end
+
+    it "shows an important badge for a problem order" do
+      allow(order_detail).to receive_messages(problem?: true, problem_description_key: :missing_price_policy)
+      expect(presenter.badges_to_text).to eq("Missing Price Policy")
+    end
+
+    it "can have multiple badges" do
+      # These examples are technically mutually exclusive, but this validates the
+      # presenter can handle it.
+      allow(order_detail).to receive_messages(
+        problem?: true,
+        problem_description_key: :missing_price_policy,
+        in_review?: true,
+        in_dispute?: true,
+      )
+
+      expect(presenter.badges_to_text).to eq("In Review+In Dispute+Missing Price Policy")
+    end
+  end
+
   describe "alerts_to_html" do
     matcher :have_alert do |expected_text|
       match do |string|


### PR DESCRIPTION
# Release Notes

Adds a column to the transaction report CSV for order detail notices: Missing Actuals, Missing Price Policy, In Review, In Dispute, Open Journal, Can Reconcile, Ready for Statement, Ready for Journal, and Awaiting Payment.