### PR TITLE
Tech Task: Lock capistrano version at 3.15

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lock "~> 3.14.0"
+lock "~> 3.15.0"
 
 set :application, "nucore"
 set :eye_config, "config/eye.yml.erb"


### PR DESCRIPTION
# Release Notes

Updates the deployment config to match the newly updated capistrano version.