### PR TITLE
[#155220] Add mailto link to new/in process reservations page

### DIFF
--- a/app/views/facility_reservations/index.html.haml
+++ b/app/views/facility_reservations/index.html.haml
@@ -37,7 +37,7 @@
               %td.centered= check_box_tag("order_detail_ids[]", od.id, false, {class: "toggle", id: nil })
               %td.centered= link_to od.order_id, facility_order_path(current_facility, order)
               %td.centered= link_to od.id, manage_order_detail_path(od), class: "manage-order-detail"
-              %td= order.user.full_name
+              %td= mail_to(order.user.email, order.user.full_name)
               %td{colspan: 2}
                 = format_usa_datetime(od.ordered_at)
               %td{colspan: 2}


### PR DESCRIPTION
# Release Notes

Make it easier for admins to email users from the New/In Process tab of the Reservations page.