### PR TITLE
[#156326] Handle reservation save issues

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -321,7 +321,7 @@ class Reservation < ApplicationRecord
   end
 
   def has_actuals?
-    actual_start_at.present? && actual_end_at.present?
+    actual_start_at.present? && actual_end_at.present? && actual_end_at > actual_start_at
   end
 
   def started?

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -5,6 +5,7 @@ require "date"
 class Reservation < ApplicationRecord
 
   acts_as_paranoid # soft deletes
+  has_paper_trail
 
   include DateHelper
   include Reservations::DateSupport

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -379,9 +379,8 @@ class Reservation < ApplicationRecord
     self.billable_minutes = calculated_billable_minutes
   end
 
-  # FIXME: Temporary override to include reconciled orders, so we can backfill them
   def calculated_billable_minutes
-    if (order_detail&.complete? || order_detail&.reconciled?) && order_detail&.canceled_at.blank? && price_policy.present?
+    if order_detail&.complete? && order_detail&.canceled_at.blank? && price_policy.present?
       case price_policy.charge_for
       when InstrumentPricePolicy::CHARGE_FOR.fetch(:reservation)
         TimeRange.new(reserve_start_at, reserve_end_at).duration_mins

--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -70,8 +70,8 @@ class OrderDetails::ParamUpdater
 
     @order_detail.transaction do
       assign_price_changed_by_user
-      if @order_detail.reservation
-        log_and_rollback unless @order_detail.reservation.save_as_user(@editing_user)
+      if @order_detail.reservation.present?
+        @order_detail.reservation.save_as_user(@editing_user) || log_and_rollback
       end
       if order_status_id && order_status_id.to_i != @order_detail.order_status_id
         change_order_status(order_status_id, @options[:cancel_fee]) || raise(ActiveRecord::Rollback)

--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -93,7 +93,9 @@ class OrderDetails::ParamUpdater
   private
 
   def log_and_rollback
-    Rollbar.error("Failed save for reservation #{@order_detail.reservation.id}: #{@order_detail.reservation.errors.full_messages}")
+    # TODO: Determine why reservations are failing to save at this point, then remove logging.
+    ActiveSupport::Notifications.instrument("background_error", exception: e, information: "Failed save for reservation #{@order_detail.reservation.id}: #{@order_detail.reservation.errors.full_messages}")
+    # If the reservation save fails, the order detail should stay in the problem queue.
     raise(ActiveRecord::Rollback)
   end
 

--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -94,7 +94,7 @@ class OrderDetails::ParamUpdater
 
   def log_and_rollback
     # TODO: Determine why reservations are failing to save at this point, then remove logging.
-    ActiveSupport::Notifications.instrument("background_error", exception: e, information: "Failed save for reservation #{@order_detail.reservation.id}: #{@order_detail.reservation.errors.full_messages}")
+    Rollbar.error("Failed save for reservation #{@order_detail.reservation.id}: #{@order_detail.reservation.errors.full_messages}") if defined?(Rollbar)
     # If the reservation save fails, the order detail should stay in the problem queue.
     raise(ActiveRecord::Rollback)
   end

--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -93,7 +93,7 @@ class OrderDetails::ParamUpdater
   private
 
   def log_and_rollback
-    logger.error("errors for reservation #{@order_detail.reservation.id}: #{@order_detail.reservation.errors.full_messages}")
+    Rollbar.error("Failed save for reservation #{@order_detail.reservation.id}: #{@order_detail.reservation.errors.full_messages}")
     raise(ActiveRecord::Rollback)
   end
 

--- a/db/migrate/20210126230013_add_object_changes_to_versions.rb
+++ b/db/migrate/20210126230013_add_object_changes_to_versions.rb
@@ -1,0 +1,7 @@
+class AddObjectChangesToVersions < ActiveRecord::Migration[5.2]
+  def change
+    change_table :versions do |t|
+      t.text :object_changes
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_04_185502) do
+ActiveRecord::Schema.define(version: 2021_01_26_230013) do
 
   create_table "account_facility_joins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "facility_id", null: false
@@ -856,6 +856,7 @@ ActiveRecord::Schema.define(version: 2020_09_04_185502) do
     t.string "whodunnit"
     t.text "object", limit: 4294967295
     t.datetime "created_at"
+    t.text "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -539,7 +539,7 @@ RSpec.describe OrderDetail do
           end
 
           describe "when it has actuals" do
-            before { order_detail.reservation.update_attributes(actual_start_at: Time.current, actual_end_at: Time.current) }
+            before { order_detail.reservation.update_attributes(actual_start_at: Time.current, actual_end_at: Time.current + 1.minute) }
             it do
               expect(order_detail.problem_description_key).to eq(:missing_price_policy)
             end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1434,9 +1434,15 @@ RSpec.describe Reservation do
       expect(reservation).not_to be_has_actuals
     end
 
+    it "should not have actuals if the start and end are the same" do
+      reservation.actual_start_at = Time.zone.now
+      reservation.actual_end_at = reservation.actual_start_at
+      expect(reservation).not_to be_has_actuals
+    end
+
     it "should have actuals" do
       reservation.actual_start_at = Time.zone.now
-      reservation.actual_end_at = Time.zone.now
+      reservation.actual_end_at = Time.zone.now + 1.minute
       expect(reservation).to be_has_actuals
     end
   end


### PR DESCRIPTION
# Release Notes

When adding actual times to an order detail, it's possible for the reservation update to fail silently.  This results in the order detail being moved out of the problem queue even though the reservation record is still missing actual times.

Also:
- Adds paper_trail tracking to the Reservation model.  
- Adds an `object_changes` column to the Versions table to make working with paper trail easier
- Remove temporary code.