### PR TITLE
[#156326] Fix error messaging for 0 min actual duration

### DIFF
--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -32,6 +32,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
 
     if updater.update_attributes(params[:order_detail] || empty_params)
       flash[:notice] = text("update.success")
+      flash[:alert] = text("update.success_with_missing_actuals", order: @order_detail) if @order_detail.requires_but_missing_actuals?
       if @order_detail.updated_children.any?
         flash[:notice] = text("update.success_with_auto_scaled")
         flash[:updated_order_details] = @order_detail.updated_children.map(&:id)

--- a/config/locales/views/admin/en.order_management.yml
+++ b/config/locales/views/admin/en.order_management.yml
@@ -3,6 +3,7 @@ en:
     order_management/order_details:
       update:
         success: The order was successfully updated.
+        success_with_missing_actuals: "Order %{order} is still missing actuals."
         success_with_auto_scaled: "!controllers.order_management/order_details.update.success! Auto-scaled accessories have been updated as well."
         error: Error while updating order
       remove_from_journal:

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/occupancy.rb
@@ -83,6 +83,8 @@ module SecureRooms
         :missing_entry
       elsif exit_at.blank?
         :missing_exit
+      elsif exit_at <= entry_at
+        entry_event.present? ? :missing_exit : :missing_entry
       end
     end
 

--- a/vendor/engines/secure_rooms/spec/factories/occupancy.rb
+++ b/vendor/engines/secure_rooms/spec/factories/occupancy.rb
@@ -20,12 +20,12 @@ FactoryBot.define do
     end
 
     trait :with_entry do
-      association :entry_event, factory: :event
+      entry_event { create(:event, occurred_at: Time.current) }
       entry_at { entry_event.occurred_at }
     end
 
     trait :with_exit do
-      association :exit_event, factory: :event
+      exit_event { create(:event, occurred_at: Time.current + 2.hours) }
       exit_at { exit_event.occurred_at }
     end
 

--- a/vendor/engines/secure_rooms/spec/models/secure_rooms/occupancy_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/secure_rooms/occupancy_spec.rb
@@ -25,5 +25,25 @@ RSpec.describe SecureRooms::Occupancy do
 
       it { is_expected.to eq :missing_exit }
     end
+
+    context "0 min actual duration" do
+      before do
+        now = Time.current
+        occupancy.entry_at = now
+        occupancy.exit_at = now
+      end
+
+      context "with an entry event" do
+        before { occupancy.entry_event = SecureRooms::Event.new }
+
+        it { is_expected.to eq :missing_exit }
+      end
+
+      context "with an exit event" do
+        before { occupancy.exit_event = SecureRooms::Event.new }
+
+        it { is_expected.to eq :missing_entry }
+      end
+    end
   end
 end


### PR DESCRIPTION
# Release Notes

Addresses a missing translation key caused by problem_description_key returning nil.
Also improves the flash displayed when a "missing actuals" reservation is edited successfully with no actual start date and no actual duration mins.