### PR TITLE
[#152645] Kiosk View page

### DIFF
--- a/app/assets/stylesheets/app/kiosk.scss
+++ b/app/assets/stylesheets/app/kiosk.scss
@@ -1,0 +1,8 @@
+.kiosk-login {
+  padding: 0px 15px;
+}
+
+.kiosk-modal {
+  margin-bottom: 0;
+  padding-bottom: 0;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,6 +33,7 @@ $baseFontSize: 12px; // Default is 14px
 @import "app/no_modal";
 @import "app/homepage";
 @import "app/move_between_selects";
+@import "app/kiosk";
 
 @import "fine-uploader/fine-uploader-new";
 @import "fine-uploader-override";

--- a/app/controllers/concerns/reservation_switch.rb
+++ b/app/controllers/concerns/reservation_switch.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module ReservationSwitch
+
+  extend ActiveSupport::Concern
+
+  def switch_instrument!(switch)
+    case
+    when switch == "on"
+      switch_instrument_on!
+    when switch == "off"
+      switch_instrument_off!
+    end
+  rescue AASM::InvalidTransition => e
+    if e.failures.include?(:time_data_completeable?)
+      respond_error(text("switch_instrument.prior_is_still_running"))
+    else
+      respond_error(e.message)
+    end
+  rescue => e
+    respond_error(e.message)
+  end
+
+  def respond_error(message)
+    flash[:error] = message
+  end
+
+  def switch_instrument_off!
+    unless @reservation.other_reservation_using_relay?
+      ReservationInstrumentSwitcher.new(@reservation).switch_off!
+      flash[:notice] = switch_off_success
+    end
+    session[:reservation_auto_logout] = true if params[:reservation_ended].present?
+  end
+
+  def switch_instrument_on!
+    ReservationInstrumentSwitcher.new(@reservation).switch_on!
+    flash[:notice] = "The instrument has been activated successfully"
+    session[:reservation_auto_logout] = true if params[:reservation_started].present?
+  end
+
+  def switch_value_present?
+    params[:switch] && (params[:switch] == "on" || params[:switch] == "off")
+  end
+
+  def switch_off_success
+    "The instrument has been deactivated successfully"
+  end
+
+end

--- a/app/controllers/kiosk_accessories_controller.rb
+++ b/app/controllers/kiosk_accessories_controller.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class KioskAccessoriesController < ApplicationController
+
+  load_resource :order
+  load_resource :order_detail, through: :order
+
+  before_action :load_product_and_reservation
+
+  include ReservationSwitch
+
+  layout false
+
+  def new
+    @switch = params[:switch]
+    @order_details = accessorizer.accessory_order_details
+  end
+
+  def create
+    respond_error(text("authentication.error")) && return unless can_create?
+
+    update_data = update_accessories
+    @order_details = update_data.order_details
+    if update_data.valid?
+      @persisted_count = update_data.persisted_count
+      if params[:switch] == "off"
+        switch_instrument!(params[:switch])
+      else
+        flash[:notice] = text("create.success", accessories: helpers.pluralize(@persisted_count, "accessory"))
+      end
+      head :ok
+    else
+      respond_error(text("update.error"))
+    end
+  end
+
+  private
+
+  def can_create?
+    password = params.dig(:kiosk_accessories, :password)
+    kiosk_user = Users::AuthChecker.new(@reservation.user, password)
+    kiosk_user.authenticated? && kiosk_user.authorized?(:add_accessories, @order_detail)
+  end
+
+  def switch_off_success
+    text("create.switch_off", accessories: helpers.pluralize(@persisted_count, "accessory"))
+  end
+
+  def respond_error(message)
+    @order_details = accessorizer.build_order_details_from(params[:kiosk_accessories])
+    @switch = params[:switch]
+    flash.now[:error] = message
+    render :new, status: 406, layout: false
+  end
+
+  def update_accessories
+    accessorizer.update_attributes(params[:kiosk_accessories])
+  end
+
+  def accessorizer
+    @accessorizer ||= Accessories::Accessorizer.new(@order_detail)
+  end
+
+  def ability_resource
+    @order_detail
+  end
+
+  def load_product_and_reservation
+    @product = @order_detail.product
+    @reservation = Reservation.find(@order_detail.reservation.id)
+  end
+
+end

--- a/app/controllers/kiosk_reservations_controller.rb
+++ b/app/controllers/kiosk_reservations_controller.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Mostly copied over from ReservationsController, making some
+# changes as needed to fit the use case of the Kiosk View page.
+# The Kiosk View page provides easy access to commonly used
+# reservation actions, saving some clicks for the user.
+# The user should be prompted to login before action is taken,
+# then logged out and redirected back to the Kiosk View.
+class KioskReservationsController < ApplicationController
+
+  before_action :check_acting_as, only: [:switch_instrument]
+  before_action :load_and_check_resources, except: [:index]
+
+  include ReservationSwitch
+
+  def index
+    sign_out if params[:sign_out].present?
+    schedules = current_facility.schedules_for_timeline(:public_instruments)
+    instrument_ids = schedules.flat_map { |schedule| schedule.public_instruments.map(&:id) }
+    @reservations = Reservation.for_timeline(Time.current.beginning_of_day, instrument_ids)
+  end
+
+  def begin
+    @switch = "on"
+    render layout: false
+  end
+
+  def stop
+    @switch = "off"
+    render layout: false
+  end
+
+  # GET /orders/:order_id/order_details/:order_detail_id/kiosk_reservations/switch_instrument
+  def switch_instrument
+    if can_switch? && switch_value_present?
+      switch_instrument!(params[:switch])
+      head :ok
+    elsif can_switch?
+      respond_error(text("switch.error"))
+    else
+      respond_error(text("authentication.error"))
+    end
+  end
+
+  private
+
+  def can_switch?
+    password = params.dig(:kiosk_reservations, :password)
+    kiosk_user = Users::AuthChecker.new(@reservation.user, password)
+    kiosk_user.authenticated? && kiosk_user.authorized?(:start_stop, @reservation)
+  end
+
+  def load_basic_resources
+    @order = Order.find(params[:order_id])
+    # It's important that the order_detail be the same object as the one in @order.order_details.first
+    @order_detail = @order.order_details.find { |od| od.id.to_i == params[:order_detail_id].to_i }
+    raise ActiveRecord::RecordNotFound if @order_detail.blank?
+    @reservation = @order_detail.reservation
+    @instrument = @order_detail.product
+    @facility = @instrument.facility
+  rescue ActiveRecord::RecordNotFound
+    flash[:error] = text("order_detail_removed")
+    if @order
+      redirect_to action: :index
+    else
+      raise
+    end
+  end
+
+  def load_and_check_resources
+    load_basic_resources
+    raise ActiveRecord::RecordNotFound if @reservation.blank?
+  end
+
+  def ability_resource
+    if action_name == "index"
+      current_facility
+    else
+      @reservation
+    end
+  end
+
+  def respond_error(message)
+    @switch = params[:switch]
+    flash[:error] = message
+    render :begin, status: 406, layout: false
+  end
+
+end

--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -12,6 +12,10 @@ module ReservationsHelper
     new_order_order_detail_accessory_path(reservation.order_detail.order, reservation.order_detail)
   end
 
+  def kiosk_reservation_pick_accessories_path(reservation, switch=nil)
+    new_order_order_detail_kiosk_accessory_path(reservation.order_detail.order, reservation.order_detail, switch: switch)
+  end
+
   def default_duration
     duration = @instrument.min_reserve_mins
     duration = nil if duration == 0
@@ -26,6 +30,12 @@ module ReservationsHelper
   def reservation_actions(reservation)
     delimiter = "&nbsp;|&nbsp;".html_safe
     links = ReservationUserActionPresenter.new(self, reservation).user_actions
+    safe_join(links, delimiter)
+  end
+
+  def kiosk_reservation_actions(reservation)
+    delimiter = "&nbsp;|&nbsp;".html_safe
+    links = ReservationUserActionPresenter.new(self, reservation).kiosk_user_actions
     safe_join(links, delimiter)
   end
 

--- a/app/presenters/reservation_user_action_presenter.rb
+++ b/app/presenters/reservation_user_action_presenter.rb
@@ -38,6 +38,13 @@ class ReservationUserActionPresenter
     actions.compact
   end
 
+  def kiosk_user_actions
+    actions = []
+    actions << kiosk_accessories_link if accessories?
+    actions << kiosk_switch_actions if can_switch_instrument?
+    actions.compact
+  end
+
   def view_edit_link
     link_to reservation, view_edit_path
   end
@@ -66,6 +73,10 @@ class ReservationUserActionPresenter
     link_to I18n.t("product_accessories.pick_accessories.title"), reservation_pick_accessories_path(reservation), class: "has_accessories persistent"
   end
 
+  def kiosk_accessories_link
+    link_to I18n.t("product_accessories.pick_accessories.title"), kiosk_reservation_pick_accessories_path(reservation), class: "has_accessories persistent"
+  end
+
   def view_edit_path
     if can_customer_edit?
       edit_order_order_detail_reservation_path(order, order_detail, reservation)
@@ -86,6 +97,26 @@ class ReservationUserActionPresenter
                 order, order_detail, reservation,
                 switch: "off", reservation_ended: "on"),
               class: end_reservation_class(reservation),
+              data: { refresh_on_cancel: true }
+    end
+  end
+
+  def kiosk_switch_actions
+    kiosk_path = facility_kiosk_reservations_path(reservation.facility)
+    if can_switch_instrument_on?
+      link_to I18n.t("reservations.switch.start"),
+              order_order_detail_reservation_kiosk_begin_path(order, order_detail, reservation),
+              class: "has_accessories",
+              data: { refresh_on_cancel: true }
+    elsif can_switch_instrument_off? && order_detail.accessories?
+      link_to I18n.t("reservations.switch.end"),
+              kiosk_reservation_pick_accessories_path(reservation, "off"),
+              class: end_reservation_class(reservation),
+              data: { refresh_on_cancel: true }
+    elsif can_switch_instrument_off?
+      link_to I18n.t("reservations.switch.end"),
+              order_order_detail_reservation_kiosk_stop_path(order, order_detail, reservation),
+              class: "has_accessories",
               data: { refresh_on_cancel: true }
     end
   end

--- a/app/services/users/auth_checker.rb
+++ b/app/services/users/auth_checker.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Users
+
+  class AuthChecker
+
+    def initialize(user, password)
+      @user = user
+      @password = password
+    end
+
+    def authorized?(action, object)
+      return false if @user.nil?
+
+      kiosk_user_ability = Ability.new(@user, object)
+      kiosk_user_ability.can?(action, object)
+    end
+
+    def authenticated?
+      return false if @user.nil?
+
+      if @user.authenticated_locally?
+        @user.valid_password?(@password)
+      elsif LdapAuthentication.configured?
+        @user.valid_ldap_authentication?(@password)
+      elsif Settings.saml.present?
+        # TODO
+      end
+    end
+
+  end
+
+end

--- a/app/support/accessories/accessorizer.rb
+++ b/app/support/accessories/accessorizer.rb
@@ -52,6 +52,14 @@ class Accessories::Accessorizer
     od
   end
 
+  def build_order_details_from(params)
+    order_details = accessory_order_details.collect do |od|
+      detail_params = params[od.product_id.to_s]
+      od.assign_attributes(detail_params.permit(:enabled, :quantity)) if detail_params
+      od
+    end
+  end
+
   private
 
   def update_attributes_of(order_details, params)

--- a/app/views/facility_reservations/timeline.html.haml
+++ b/app/views/facility_reservations/timeline.html.haml
@@ -8,6 +8,9 @@
 = content_for :tabnav do
   = render partial: "admin/shared/tabnav_reservation", locals: { secondary_tab: "daily" }
 
+- if SettingsHelper.feature_on?(:kiosk_view) && current_facility.instruments.active.any?
+  %h3= link_to t(".kiosk_view"), facility_kiosk_reservations_path(current_facility, sign_out: "true")
+
 .timeline_header
   = modelless_form_for url: timeline_facility_reservations_path(current_facility), method: :get, id: "timeline_date_search" do |f|
     #reservation_date_container

--- a/app/views/kiosk_accessories/new.html.haml
+++ b/app/views/kiosk_accessories/new.html.haml
@@ -1,0 +1,38 @@
+.modal
+  .modal-header
+    = modal_close_button
+    - if @switch == "off"
+      %h2= text("end_title", user: @order_detail.reservation.user)
+    - else
+      %h2= text("title", user: @order_detail.reservation.user)
+    %h3= @order_detail.reservation.instrument
+  = simple_form_for :kiosk_accessories, url: url_for(action: :create, switch: @switch), remote: true, html: { "data-type" => "html", id: "accessory-form", class: :pick_accessories_form } do |f|
+    .modal-body
+      = render partial: "shared/flashes"
+      - if @order_detail.reservation.ongoing? && @order_detail.reservation.actual_duration_mins.present?
+        %p= t("product_accessories.pick_accessories.actual_time_ongoing_html", time: @order_detail.reservation.actual_duration_mins)
+      - elsif @order_detail.reservation.actual_duration_mins.present?
+        %p= t("product_accessories.pick_accessories.actual_time_html", time: @order_detail.reservation.actual_duration_mins)
+
+      %fieldset.well.kiosk-modal
+        %h4= text("accessories")
+        %table.table
+          - @order_details.each do |od|
+            = f.simple_fields_for od.product.id.to_s, od do |p|
+              %tr{class: ["accessory-row", "scaling-#{od.class.name.demodulize.underscore}"]}
+                %td
+                  = p.input :enabled, as: :boolean, label: false, inline_label:  "#{od.product.to_s} (#{t("product_accessories.type.#{od.scaling_type}")})", checked_value: "true", unchecked_value: "false"
+
+                %td= p.input :quantity,
+                    disabled: !od.quantity_editable?,
+                    label: false,
+                    input_html: { value: od.quantity,
+                                  class: od.quantity_as_time? ? "timeinput" : "",
+                                  data: { always_disabled: !od.quantity_editable? } }
+    .kiosk-login
+      %fieldset.well
+        %h4= text("confirm")
+        = f.input :password, required: false
+    .modal-footer
+      = f.submit text("submit"), class: "btn btn-primary"
+      = modal_cancel_button text: text("cancel")

--- a/app/views/kiosk_reservations/begin.html.haml
+++ b/app/views/kiosk_reservations/begin.html.haml
@@ -1,0 +1,14 @@
+.modal
+  .modal-header
+    = modal_close_button
+    %h2= text("title", user: @reservation.user)
+    %h3= @reservation.instrument
+  = simple_form_for :kiosk_reservations, method: :get, url: url_for(action: :switch_instrument, switch: @switch), remote: true do |f|
+    .modal-body
+      = render partial: "shared/flashes"
+      %fieldset.well
+        %h4= text("confirm")
+        = f.input :password, required: false
+    .modal-footer
+      = f.submit text("submit"), class: "btn btn-primary"
+      = modal_cancel_button text: text("cancel")

--- a/app/views/kiosk_reservations/index.html.haml
+++ b/app/views/kiosk_reservations/index.html.haml
@@ -1,0 +1,26 @@
+= content_for :h1 do
+  = text("title", facility: current_facility)
+
+- if @reservations.any?
+  %table.table.table-striped.table-hover.old-table.js--responsive_table
+    %thead
+      %tr
+        %th= text("name")
+        %th= text("reservation")
+        %th= OrderDetail.human_attribute_name(:product)
+        %th.centered= text("actions")
+    %tbody
+      - @reservations.each do |res|
+        %tr
+          %td
+            = res.user.full_name
+          %td
+            = res
+          %td
+            = res.product.name
+            = warning_if_instrument_is_offline_or_partially_available(res.product)
+          %td.centered
+            = kiosk_reservation_actions(res)
+            &nbsp;
+- else
+  %p.notice= text("none")

--- a/app/views/kiosk_reservations/stop.html.haml
+++ b/app/views/kiosk_reservations/stop.html.haml
@@ -1,0 +1,14 @@
+.modal
+  .modal-header
+    = modal_close_button
+    %h2= text("title", user: @reservation.user)
+    %h3= @reservation.instrument
+  = simple_form_for :kiosk_reservations, method: :get, url: url_for(action: :switch_instrument, switch: @switch), remote: true do |f|
+    .modal-body
+      = render partial: "shared/flashes"
+      %fieldset.well
+        %h4= text("confirm")
+        = f.input :password, required: false
+    .modal-footer
+      = f.submit text("submit"), class: "btn btn-primary"
+      = modal_cancel_button text: text("cancel")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -381,6 +381,8 @@ en:
   facility_reservations:
     index:
       no_new_or_inprocess_reservations: There are no "New" or "In Process" reservations.
+    timeline:
+      kiosk_view: Launch Kiosk View
     disputed:
       no_disputed_reservations: There are no disputed reservations
     show_problems:
@@ -573,7 +575,7 @@ en:
       confirm: Would you like to move your reservation?
       error: There was an error retrieving earliest possible move date.
     notices:
-      can_switch_off: Do not forget to click the "End Reservation" link when you finished your %{reservation} reservation.
+      can_switch_off: Do not forget to click the "End Reservation" link when you finish your %{reservation} reservation.
       can_switch_on: You may click the "Begin Reservation" link when you are ready to begin your %{reservation} reservation.
       upcoming: You have an upcoming reservation for %{reservation}.
     account_field:

--- a/config/locales/views/en.kiosk_accessories.yml
+++ b/config/locales/views/en.kiosk_accessories.yml
@@ -1,0 +1,22 @@
+en:
+  views:
+    kiosk_accessories:
+      new:
+        title: "Add Accessories (%{user})"
+        end_title: "End Reservation (%{user})"
+        accessories: Select Accessories
+        confirm: Sign in to Confirm
+        submit: Save Changes
+        cancel: Discard Changes
+
+  controllers:
+    kiosk_accessories:
+      switch_instrument:
+        prior_is_still_running: Cannot "Begin Reservation" when a previously scheduled reservation is ongoing.
+      create:
+        success: "%{accessories} added."
+        switch_off: "The instrument has been deactivated successfully.  %{accessories} added."
+      authentication:
+        error: Invalid password.
+      update:
+        error: Something went wrong, please try again.

--- a/config/locales/views/en.kiosk_reservations.yml
+++ b/config/locales/views/en.kiosk_reservations.yml
@@ -1,0 +1,31 @@
+en:
+  views:
+    kiosk_reservations:
+      index:
+        title: "Kiosk View: %{facility}"
+        name: Name
+        reservation: Reservation
+        actions: Actions
+        none: No active reservations found for today
+      begin:
+        title: Begin Reservation (%{user})
+        confirm: Sign in to Confirm
+        submit: Begin Reservation
+        cancel: Cancel
+      stop:
+        title: End Reservation (%{user})
+        confirm: Sign in to Confirm
+        submit: End Reservation
+        cancel: Cancel
+
+  controllers:
+    kiosk_reservations:
+      switch_instrument:
+        prior_is_still_running: Cannot "Begin Reservation" when a previously scheduled reservation is ongoing.
+      order_detail_removed: |
+        The instrument order has been removed from your cart.
+        Please add it again to make a reservation.
+      authentication:
+        error: Invalid password.
+      switch:
+        error: Something went wrong, please try again.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -218,6 +218,9 @@ Rails.application.routes.draw do
       get "error_report", to: "order_imports#error_report", on: :member
     end
 
+    resources :kiosk_reservations, only: :index do
+    end
+
     resources :reservations, controller: "facility_reservations", only: :index do
       collection do
         post "assign_price_policies_to_problem_orders"
@@ -358,9 +361,13 @@ Rails.application.routes.draw do
         get "/move",               to: "reservations#earliest_move_possible"
         post "/move",              to: "reservations#move",              as: "move_reservation"
         get "/switch_instrument",  to: "reservations#switch_instrument", as: "switch_instrument"
+        get "/kiosk_switch_instrument",  to: "kiosk_reservations#switch_instrument", as: "kiosk_switch_instrument"
+        get "begin", to: "kiosk_reservations#begin", as: "kiosk_begin"
+        get "stop", to: "kiosk_reservations#stop", as: "kiosk_stop"
       end
 
       resources :accessories, only: [:new, :create]
+      resources :kiosk_accessories, only: [:new, :create]
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -118,6 +118,7 @@ feature:
   facility_directors_can_manage_price_groups: true
   account_reference_field: false
   facility_payment_urls: false
+  kiosk_view: true
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -12,7 +12,7 @@ class Ability
   #   A model +user+ is authorized against
   # [_controller_]
   #   The controller whose authorization request is being handled. Used to provide
-  #   a context for the sticky situation that is multiple controllers managing one
+  #   a context for the sticky situation that is multiple controllers managing
   #   one model each with their own authorization rules.
   def initialize(user, resource, controller = nil)
     return unless user

--- a/spec/presenters/reservation_user_action_presenter_spec.rb
+++ b/spec/presenters/reservation_user_action_presenter_spec.rb
@@ -201,4 +201,78 @@ RSpec.describe ReservationUserActionPresenter do
       end
     end
   end
+
+  context "#kiosk_user_actions" do
+    before :each do
+      allow(order_detail).to receive(:reservation).and_return reservation
+    end
+    subject(:text) { presenter.kiosk_user_actions.join }
+
+    describe "switching (kiosk page)" do
+      let(:encoded_link) { CGI.escapeHTML(link) }
+
+      context "can switch on" do
+        let(:link) do
+          order_order_detail_reservation_kiosk_begin_path(
+            order,
+            order_detail,
+            reservation,
+          )
+        end
+
+        before :each do
+          allow(reservation)
+            .to receive(:can_switch_instrument_on?)
+            .and_return true
+        end
+
+        it "includes the switch on event" do
+          expect(text).to include encoded_link
+        end
+      end
+
+      context "can switch off" do
+        let(:link) do
+          order_order_detail_reservation_kiosk_stop_path(
+            order,
+            order_detail,
+            reservation,
+          )
+        end
+
+        before :each do
+          allow(reservation)
+            .to receive(:can_switch_instrument_off?)
+            .and_return true
+        end
+
+        it "includes the switch off event" do
+          expect(text).to include encoded_link
+        end
+      end
+
+      context "can switch off with accessories" do
+        let(:link) do
+          new_order_order_detail_kiosk_accessory_path(
+            order,
+            order_detail,
+            switch: "off",
+          )
+        end
+
+        before :each do
+          allow(reservation)
+            .to receive(:can_switch_instrument_off?)
+            .and_return true
+          allow(order_detail)
+            .to receive(:accessories?)
+            .and_return true
+        end
+
+        it "includes the switch off event" do
+          expect(text).to include encoded_link
+        end
+      end
+    end
+  end
 end

--- a/spec/services/users/auth_checker_spec.rb
+++ b/spec/services/users/auth_checker_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe Users::AuthChecker do
+
+  describe "#authenticated?" do
+    context "with an external user" do
+      let(:user) { create(:user, email: "external@example.org", username: "external@example.org", password: "something") }
+
+      context "with the correct password" do
+        let(:auth_user) { described_class.new(user, "something") }
+
+        it "returns true" do
+          expect(auth_user.authenticated?).to eq true
+        end
+      end
+
+      context "with the wrong password" do
+        let(:auth_user) { described_class.new(user, "wrong") }
+
+        it "returns false" do
+          expect(auth_user.authenticated?).to eq false
+        end
+      end
+    end
+
+    context "with a netid user" do
+      let(:user) { create(:user, :netid, email: "internal@example.org", username: "netid") }
+
+      before(:each) do
+        allow(LdapAuthentication).to receive(:configured?).and_return(true)
+        User.define_method(:valid_ldap_authentication?) { |password| password == "netidpassword" }
+      end
+
+      after(:all) do
+        User.remove_method(:valid_ldap_authentication?)
+      end
+
+      context "with the correct password" do
+        let(:auth_user) { described_class.new(user, "netidpassword") }
+
+        it "returns true" do
+          expect(auth_user.authenticated?).to eq true
+        end
+      end
+
+      context "with the wrong password" do
+        let(:auth_user) { described_class.new(user, "wrong") }
+
+        it "returns false" do
+          expect(auth_user.authenticated?).to eq false
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/system/admin/launch_kiosk_view_spec.rb
+++ b/spec/system/admin/launch_kiosk_view_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Launching Kiosk View" do
+RSpec.describe "Launching Kiosk View", feature_setting: { kiosk_view: true } do
   let(:facility) { create(:setup_facility) }
   let(:director) { create(:user, :facility_director, facility: facility) }
 
@@ -22,6 +22,14 @@ RSpec.describe "Launching Kiosk View" do
   end
 
   context "with no active reservations" do
+    it "cannot launch the Kiosk View" do
+      login_as director
+      visit timeline_facility_reservations_path(facility)
+      expect(page).not_to have_content("Launch Kiosk View")
+    end
+  end
+
+  context "with the feature flag turned off", feature_setting: { kiosk_view: false } do
     it "cannot launch the Kiosk View" do
       login_as director
       visit timeline_facility_reservations_path(facility)

--- a/spec/system/admin/launch_kiosk_view_spec.rb
+++ b/spec/system/admin/launch_kiosk_view_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Launching Kiosk View" do
+  let(:facility) { create(:setup_facility) }
+  let(:director) { create(:user, :facility_director, facility: facility) }
+
+  context "with active reservations" do
+    let(:instrument) { create(:setup_instrument, facility: facility, control_mechanism: "timer") }
+    let!(:reservation) { create(:purchased_reservation, :running, product: instrument) }
+
+    it "can launch the Kiosk View" do
+      login_as director
+      visit timeline_facility_reservations_path(facility)
+      click_link "Launch Kiosk View"
+
+      expect(page.current_path).to eq facility_kiosk_reservations_path(facility)
+      # user should be logged out
+      expect(page).to have_content("Login")
+    end
+  end
+
+  context "with no active reservations" do
+    it "cannot launch the Kiosk View" do
+      login_as director
+      visit timeline_facility_reservations_path(facility)
+      expect(page).not_to have_content("Launch Kiosk View")
+    end
+  end
+end

--- a/spec/system/kiosk_view_spec.rb
+++ b/spec/system/kiosk_view_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Launching Kiosk View", :js do
+  let(:facility) { create(:setup_facility) }
+  let(:account) { create(:setup_account) }
+  let!(:account_user) { FactoryBot.create(:account_user, :purchaser, account: account, user: user) }
+
+  let(:order_detail) { FactoryBot.create(:setup_order, product: instrument, account: account).order_details.first }
+  let(:instrument) { create(:setup_instrument, facility: facility, control_mechanism: "timer") }
+
+  shared_examples "kiosk_actions" do |login_label, password|
+    context "with an active reservation that hasn't been started" do
+      let!(:reservation) { create(:purchased_reservation, reserve_start_at: 15.minutes.ago, product: instrument, user: user) }
+
+      it "can start reservations with a valid password" do
+        visit facility_kiosk_reservations_path(facility)
+        expect(page).to have_content(login_label)
+        click_link "Begin Reservation"
+        fill_in "Password", with: password
+        click_button "Begin Reservation"
+
+        expect(page.current_path).to eq facility_kiosk_reservations_path(facility)
+        expect(page).to have_content("End Reservation")
+        expect(page).to have_content(login_label)
+      end
+
+      it "cannot start reservations with an invalid password" do
+        visit facility_kiosk_reservations_path(facility)
+        expect(page).to have_content(login_label)
+        click_link "Begin Reservation"
+        fill_in "Password", with: "not-the-password"
+        click_button "Begin Reservation"
+
+        expect(page.current_path).to eq facility_kiosk_reservations_path(facility)
+        expect(page).to have_content("Invalid password")
+
+        visit facility_kiosk_reservations_path(facility)
+        expect(page).to have_content("Begin Reservation") # the reservation still hasn't started
+        expect(page).to have_content(login_label)
+      end
+    end
+
+    context "with an active reservation that is running" do
+      let!(:reservation) { create(:purchased_reservation, reserve_start_at: 15.minutes.ago, actual_start_at: 10.minutes.ago, product: instrument, user: user) }
+
+      it "can end reservations with a valid password" do
+        visit facility_kiosk_reservations_path(facility)
+        expect(page).to have_content(login_label)
+        expect(page).not_to have_content("Add Accessories")
+        click_link "End Reservation"
+        fill_in "Password", with: password
+        click_button "End Reservation"
+
+        expect(page).not_to have_content("End Reservation")
+        expect(page).not_to have_content("Begin Reservation")
+        expect(page.current_path).to eq facility_kiosk_reservations_path(facility)
+        expect(page).to have_content(login_label)
+      end
+
+      it "cannot end reservations with an invalid password" do
+        visit facility_kiosk_reservations_path(facility)
+        expect(page).to have_content(login_label)
+        click_link "End Reservation"
+        fill_in "Password", with: "not-the-password"
+        click_button "End Reservation"
+
+        expect(page.current_path).to eq facility_kiosk_reservations_path(facility)
+        expect(page).to have_content("Invalid password")
+
+        visit facility_kiosk_reservations_path(facility)
+        expect(page).to have_content("End Reservation") # the reservation still hasn't started
+        expect(page).to have_content(login_label)
+      end
+    end
+
+    context "with an active reservation (with accessories) that is running" do
+      let!(:reservation) { create(:purchased_reservation, reserve_start_at: 15.minutes.ago, actual_start_at: 10.minutes.ago, product: instrument, user: user, order_detail: order_detail) }
+      let!(:accessory) { create(:accessory, parent: instrument) }
+
+      it "can add accessories to reservations with a valid password" do
+        visit facility_kiosk_reservations_path(facility)
+        expect(page).to have_content(login_label)
+        click_link "Add Accessories"
+        check accessory.name
+        fill_in "kiosk_accessories_#{accessory.id}_quantity", with: "3"
+        fill_in "Password", with: password
+        click_button "Save Changes"
+
+        expect(page).to have_content("1 accessory added")
+        expect(page).to have_content("End Reservation")
+        expect(page.current_path).to eq facility_kiosk_reservations_path(facility)
+        expect(page).to have_content(login_label)
+      end
+
+      it "cannot add accessories with an invalid password" do
+        visit facility_kiosk_reservations_path(facility)
+        expect(page).to have_content(login_label)
+        click_link "Add Accessories"
+        check accessory.name
+        fill_in "kiosk_accessories_#{accessory.id}_quantity", with: "3"
+        fill_in "Password", with: "not-the-password"
+        click_button "Save Changes"
+        expect(page).not_to have_content("1 accessory added")
+        expect(page).to have_content("End Reservation")
+        expect(page.current_path).to eq facility_kiosk_reservations_path(facility)
+        expect(page).to have_content(login_label)
+      end
+
+      it "can add accessories when ending reservations with a valid password" do
+        visit facility_kiosk_reservations_path(facility)
+        expect(page).to have_content(login_label)
+        click_link "End Reservation"
+        check accessory.name
+        fill_in "kiosk_accessories_#{accessory.id}_quantity", with: "3"
+        fill_in "Password", with: password
+        click_button "Save Changes"
+
+        expect(page).not_to have_content("End Reservation")
+        expect(page).not_to have_content("Begin Reservation")
+        expect(page.current_path).to eq facility_kiosk_reservations_path(facility)
+        expect(page).to have_content(login_label)
+      end
+
+      it "cannot end reservations with an invalid password" do
+        visit facility_kiosk_reservations_path(facility)
+        expect(page).to have_content(login_label)
+        click_link "End Reservation"
+        check accessory.name
+        fill_in "kiosk_accessories_#{accessory.id}_quantity", with: "3"
+        fill_in "Password", with: "not-the-password"
+        click_button "Save Changes"
+
+        expect(page.current_path).to eq facility_kiosk_reservations_path(facility)
+        expect(page).to have_content("Invalid password")
+
+        visit facility_kiosk_reservations_path(facility)
+        expect(page).to have_content("End Reservation") # the reservation still hasn't started
+        expect(page).to have_content(login_label)
+      end
+    end
+  end
+
+  context "with an LDAP authenticated user" do
+    let(:user) { create(:user, :netid, :purchaser, account: account, email: "internal@example.org", username: "netid") }
+
+    before(:each) do
+      allow(LdapAuthentication).to receive(:configured?).and_return(true)
+      User.define_method(:valid_ldap_authentication?) { |password| password == "netidpassword" }
+    end
+
+    after(:all) do
+      User.remove_method(:valid_ldap_authentication?)
+    end
+
+    it_behaves_like "kiosk_actions", "Login", "netidpassword"
+  end
+
+  context "with a locally authenticated user" do
+    let(:user) { create(:user, :external, :purchaser, password: "password", account: account) }
+
+    it_behaves_like "kiosk_actions", "Login", "password"
+  end
+
+  context "with a locally authenticated user who is signed in" do
+    let(:user) { create(:user, :external, :purchaser, password: "password", account: account) }
+
+    before { login_as(user) }
+
+    it_behaves_like "kiosk_actions", "Logout", "password"
+  end
+end

--- a/vendor/engines/ldap_authentication/README.md
+++ b/vendor/engines/ldap_authentication/README.md
@@ -196,4 +196,4 @@ bundle exec rails console
 
 Try logging in to NUcore with username `cgreen` and password `secret`.
 You should login successfully, and you should see activity in the LDAP server's
-the standard output.
+standard output.


### PR DESCRIPTION
# Release Notes

In this PR:
- [x]  The Kiosk page should be accessible without logging in.
- [x]  The Kiosk page should be a list of upcoming reservations for the current calendar day, excluding admin holds.
- [x]  For each reservation, show the reserving user's name, the instrument name and the start time, sorted by start time.
- [x]  There should be three things to click on: start reservation, add accessory, end reservation.
- [x]  Start or End reservation should prompt the user for their password with a message telling them that successful authentication will start or end the reservation and then return to the list.  No option to stay logged in, no delay.
- [x]  Add accessory should occur if appropriate when ending the reservation.
- [x] The "Launch Kiosk View" link logs out the user and redirects to the Kiosk View page.  
- [x]  Add accessory should take you to the accessory page and then return to the Kiosk page when you're done.
- [x] Write some specs

In the next PR:
- Facilities should have the option to show or hide the Kiosk page and the link to get there.

# Screenshot
![Screen Shot 2021-01-14 at 4 58 03 PM](https://user-images.githubusercontent.com/30355046/104659121-b7daa500-5689-11eb-9966-02be1f9cf86b.png)
