### PR TITLE
[#152645] Kiosk auto-refresh

### DIFF
--- a/app/controllers/facility_notifications_controller.rb
+++ b/app/controllers/facility_notifications_controller.rb
@@ -22,7 +22,7 @@ class FacilityNotificationsController < ApplicationController
     raise ActionController::RoutingError.new("Notifications disabled with a zero-day review period") unless SettingsHelper.has_review_period?
   end
 
-  # GET /facilities/notifications
+  # GET /facilities/:facility_id/notifications
   def index
     order_details = OrderDetail.need_notification.for_facility(current_facility)
 
@@ -34,7 +34,7 @@ class FacilityNotificationsController < ApplicationController
     @order_detail_action = :send_notifications
   end
 
-  # POST /facilities/notifications/send
+  # POST /facilities/:facility_id/notifications/send
   def send_notifications
     if params[:order_detail_ids].nil? || params[:order_detail_ids].empty?
       flash[:error] = I18n.t "controllers.facility_notifications.no_selection"
@@ -58,7 +58,7 @@ class FacilityNotificationsController < ApplicationController
     redirect_to action: :index
   end
 
-  # GET /facilities/notifications/in_review
+  # GET /facilities/:facility_id/in_review
   def in_review
     order_details = OrderDetail.in_review.for_facility(current_facility)
 
@@ -71,7 +71,7 @@ class FacilityNotificationsController < ApplicationController
     @extra_date_column = :reviewed_at
   end
 
-  # GET /facilities/notifications/in_review/mark
+  # GET /facilities/:facility_id/in_review/mark
   def mark_as_reviewed
     if params[:order_detail_ids].nil? || params[:order_detail_ids].empty?
       flash[:error] = I18n.t "controllers.facility_notifications.no_selection"

--- a/app/controllers/kiosk_accessories_controller.rb
+++ b/app/controllers/kiosk_accessories_controller.rb
@@ -30,7 +30,7 @@ class KioskAccessoriesController < ApplicationController
       end
       head :ok
     else
-      respond_error(text("update.error"))
+      respond_error(text("create.error"))
     end
   end
 

--- a/app/controllers/kiosk_reservations_controller.rb
+++ b/app/controllers/kiosk_reservations_controller.rb
@@ -19,6 +19,9 @@ class KioskReservationsController < ApplicationController
     schedules = current_facility.schedules_for_timeline(:public_instruments)
     instrument_ids = schedules.flat_map { |schedule| schedule.public_instruments.map(&:id) }
     @reservations = Reservation.for_timeline(Time.current.beginning_of_day, instrument_ids)
+    if params[:refresh]
+      render partial: "reservations_table", locals: { reservations: @reservations }
+    end
   end
 
   def begin

--- a/app/controllers/kiosk_reservations_controller.rb
+++ b/app/controllers/kiosk_reservations_controller.rb
@@ -18,7 +18,7 @@ class KioskReservationsController < ApplicationController
     sign_out if params[:sign_out].present?
     schedules = current_facility.schedules_for_timeline(:public_instruments)
     instrument_ids = schedules.flat_map { |schedule| schedule.public_instruments.map(&:id) }
-    @reservations = Reservation.for_timeline(Time.current.beginning_of_day, instrument_ids)
+    @reservations = Reservation.for_timeline(Time.current.beginning_of_day, instrument_ids).select(&:can_switch_instrument?)
     if params[:refresh]
       render partial: "reservations_table", locals: { reservations: @reservations }
     end

--- a/app/controllers/kiosk_reservations_controller.rb
+++ b/app/controllers/kiosk_reservations_controller.rb
@@ -36,14 +36,11 @@ class KioskReservationsController < ApplicationController
 
   # GET /orders/:order_id/order_details/:order_detail_id/kiosk_reservations/switch_instrument
   def switch_instrument
-    if can_switch? && switch_value_present?
-      switch_instrument!(params[:switch])
-      head :ok
-    elsif can_switch?
-      respond_error(text("switch.error"))
-    else
-      respond_error(text("authentication.error"))
-    end
+    respond_error(text("authentication.error")) && return unless can_switch?
+    respond_error(text("switch.error")) && return unless switch_value_present?
+
+    switch_instrument!(params[:switch])
+    head :ok
   end
 
   private
@@ -87,7 +84,14 @@ class KioskReservationsController < ApplicationController
   def respond_error(message)
     @switch = params[:switch]
     flash[:error] = message
-    render :begin, status: 406, layout: false
+    template = if @switch == "off"
+                 :stop
+               elsif @switch == "on"
+                 :begin
+               else
+                 :error
+               end
+    render template, status: 406, layout: false
   end
 
   def check_kiosk_enabled

--- a/app/support/reservation_instrument_switcher.rb
+++ b/app/support/reservation_instrument_switcher.rb
@@ -62,7 +62,7 @@ class ReservationInstrumentSwitcher
   end
 
   def relay_error_msg
-    "An error was encountered while attempted to toggle the instrument. Please try again."
+    "An error was encountered while attempting to toggle the instrument. Please try again."
   end
 
 end

--- a/app/views/kiosk_reservations/_reservations_table.html.haml
+++ b/app/views/kiosk_reservations/_reservations_table.html.haml
@@ -1,0 +1,23 @@
+- if reservations.any?
+  %table.table.table-striped.table-hover.old-table.js--responsive_table
+    %thead
+      %tr
+        %th= text("name")
+        %th= text("reservation")
+        %th= OrderDetail.human_attribute_name(:product)
+        %th.centered= text("actions")
+    %tbody
+      - reservations.each do |res|
+        %tr
+          %td
+            = res.user.full_name
+          %td
+            = res
+          %td
+            = res.product.name
+            = warning_if_instrument_is_offline_or_partially_available(res.product)
+          %td.centered
+            = kiosk_reservation_actions(res)
+            &nbsp;
+- else
+  %p.notice= text("none")

--- a/app/views/kiosk_reservations/error.html.haml
+++ b/app/views/kiosk_reservations/error.html.haml
@@ -1,0 +1,9 @@
+.modal
+  .modal-header
+    = modal_close_button
+    %h2= text("title", user: @reservation.user)
+    %h3= @reservation.instrument
+    .modal-body
+      = render partial: "shared/flashes"
+    .modal-footer
+      = modal_cancel_button text: "Back"

--- a/app/views/kiosk_reservations/index.html.haml
+++ b/app/views/kiosk_reservations/index.html.haml
@@ -1,26 +1,8 @@
+= content_for :head_content do
+  = javascript_include_tag "dashboard_refresh"
+
 = content_for :h1 do
   = text("title", facility: current_facility)
 
-- if @reservations.any?
-  %table.table.table-striped.table-hover.old-table.js--responsive_table
-    %thead
-      %tr
-        %th= text("name")
-        %th= text("reservation")
-        %th= OrderDetail.human_attribute_name(:product)
-        %th.centered= text("actions")
-    %tbody
-      - @reservations.each do |res|
-        %tr
-          %td
-            = res.user.full_name
-          %td
-            = res
-          %td
-            = res.product.name
-            = warning_if_instrument_is_offline_or_partially_available(res.product)
-          %td.centered
-            = kiosk_reservation_actions(res)
-            &nbsp;
-- else
-  %p.notice= text("none")
+.js--dashboardRefresh{ data: { refresh_interval: 5.minutes } }
+  = render partial: "reservations_table", locals: { reservations: @reservations }

--- a/config/locales/views/en.kiosk_accessories.yml
+++ b/config/locales/views/en.kiosk_accessories.yml
@@ -16,7 +16,6 @@ en:
       create:
         success: "%{accessories} added."
         switch_off: "The instrument has been deactivated successfully.  %{accessories} added."
+        error: Something went wrong, please try again.
       authentication:
         error: Invalid password.
-      update:
-        error: Something went wrong, please try again.

--- a/config/locales/views/en.kiosk_reservations.yml
+++ b/config/locales/views/en.kiosk_reservations.yml
@@ -18,6 +18,8 @@ en:
         confirm: Sign in to Confirm
         submit: End Reservation
         cancel: Cancel
+      error:
+        title: "Reservation (%{user})"
 
   controllers:
     kiosk_reservations:

--- a/config/locales/views/en.kiosk_reservations.yml
+++ b/config/locales/views/en.kiosk_reservations.yml
@@ -3,6 +3,7 @@ en:
     kiosk_reservations:
       index:
         title: "Kiosk View: %{facility}"
+      reservations_table:
         name: Name
         reservation: Reservation
         actions: Actions


### PR DESCRIPTION
# Release Notes

Adds a 5 minute auto refresh and limits the list of reservations to those that are actionable.
Also a bit of clean up.