### PR TITLE
[#155874] Add feature flag for using the kiosk without authenticating

### DIFF
--- a/app/services/users/auth_checker.rb
+++ b/app/services/users/auth_checker.rb
@@ -18,18 +18,23 @@ module Users
 
     def authenticated?
       return false if @user.nil?
+      return true if bypass_kiosk_auth?
 
       if @user.authenticated_locally?
         @user.valid_password?(@password)
       elsif ldap_enabled?
         @user.valid_ldap_authentication?(@password)
-      elsif Settings.saml.present?
-        # TODO
       end
     end
 
     def ldap_enabled?
       SettingsHelper.feature_on?(:uses_ldap_authentication) && LdapAuthentication.configured?
+    end
+
+    # TODO - Decide if we need to authenticate against employee ID, a reservation passcode, or IdP/LDAP API.
+    # Starting with the easiest implementation while gathering feedback from potential users.
+    def bypass_kiosk_auth?
+      SettingsHelper.feature_on?(:bypass_kiosk_auth)
     end
 
   end

--- a/app/views/kiosk_accessories/new.html.haml
+++ b/app/views/kiosk_accessories/new.html.haml
@@ -29,10 +29,11 @@
                     input_html: { value: od.quantity,
                                   class: od.quantity_as_time? ? "timeinput" : "",
                                   data: { always_disabled: !od.quantity_editable? } }
-    .kiosk-login
-      %fieldset.well
-        %h4= text("confirm")
-        = f.input :password, required: false
+    - if SettingsHelper.feature_off?(:bypass_kiosk_auth)
+      .kiosk-login
+        %fieldset.well
+          %h4= text("confirm")
+          = f.input :password, required: false
     .modal-footer
       = f.submit text("submit"), class: "btn btn-primary"
       = modal_cancel_button text: text("cancel")

--- a/app/views/kiosk_reservations/begin.html.haml
+++ b/app/views/kiosk_reservations/begin.html.haml
@@ -6,9 +6,10 @@
   = simple_form_for :kiosk_reservations, method: :get, url: url_for(action: :switch_instrument, switch: @switch), remote: true do |f|
     .modal-body
       = render partial: "shared/flashes"
-      %fieldset.well
-        %h4= text("confirm")
-        = f.input :password, required: false
+      - if SettingsHelper.feature_off?(:bypass_kiosk_auth)
+        %fieldset.well
+          %h4= text("confirm")
+          = f.input :password, required: false
     .modal-footer
       = f.submit text("submit"), class: "btn btn-primary"
       = modal_cancel_button text: text("cancel")

--- a/app/views/kiosk_reservations/stop.html.haml
+++ b/app/views/kiosk_reservations/stop.html.haml
@@ -6,9 +6,10 @@
   = simple_form_for :kiosk_reservations, method: :get, url: url_for(action: :switch_instrument, switch: @switch), remote: true do |f|
     .modal-body
       = render partial: "shared/flashes"
-      %fieldset.well
-        %h4= text("confirm")
-        = f.input :password, required: false
+      - if SettingsHelper.feature_off?(:bypass_kiosk_auth)
+        %fieldset.well
+          %h4= text("confirm")
+          = f.input :password, required: false
     .modal-footer
       = f.submit text("submit"), class: "btn btn-primary"
       = modal_cancel_button text: text("cancel")

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -120,6 +120,7 @@ feature:
   facility_payment_urls: false
   uses_ldap_authentication: false
   kiosk_view: true
+  bypass_kiosk_auth: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts


### PR DESCRIPTION
# Release Notes

Adds a feature flag that allows users to take actions from the kiosk view without authenticating.
The intent is to allow gathering some user feedback while exploring further options for enabling the kiosk view feature with SSO.