### PR TITLE
[#155218][#156344] Make columns in billing tables sortable

### DIFF
--- a/app/controllers/concerns/sortable_billing_table.rb
+++ b/app/controllers/concerns/sortable_billing_table.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module SortableBillingTable
+
+  extend ActiveSupport::Concern
+
+  include SortableColumnController
+
+  # Default to "desc" sorting direction
+  def sort_direction
+    params[:dir] == "asc" ? "asc" : "desc"
+  end
+
+  def sort_lookup_hash
+    @sort_lookup_hash ||=
+      if @extra_date_column
+        { @extra_date_column.to_s => "order_details.#{@extra_date_column}" }.merge(default_sort_lookup_hash)
+      else
+        default_sort_lookup_hash
+      end
+  end
+
+  def default_sort_lookup_hash
+    {
+      "date_range_field" => "order_details.fulfilled_at",
+      "order_number" => ["order_details.order_id", "order_details.id"],
+      "order_detail_number" => "order_details.id",
+      "ordered_for" => ["users.last_name", "order_details.fulfilled_at"],
+      "payment_source" => "order_details.account_id",
+      "order_status" => "order_details.order_status_id",
+    }
+  end
+
+  def enable_sorting
+    @sorting_enabled = true
+  end
+
+end

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -5,12 +5,14 @@ class FacilityJournalsController < ApplicationController
   include DateHelper
   include CSVHelper
   include OrderDetailsCsvExport
+  include SortableBillingTable
 
   admin_tab     :all
   before_action :authenticate_user!
   before_action :check_acting_as
   before_action :check_billing_access
   before_action :init_journals, except: :create
+  before_action :enable_sorting, only: [:new]
 
   layout lambda {
     action_name.in?(%w(new)) ? "two_column_head" : "two_column"
@@ -35,7 +37,7 @@ class FacilityJournalsController < ApplicationController
     @search_form = TransactionSearch::SearchForm.new(params[:search])
     @search = TransactionSearch::Searcher.billing_search(order_details, @search_form, include_facilities: current_facility.cross_facility?)
     @date_range_field = @search_form.date_params[:field]
-    @order_details = @search.order_details
+    @order_details = @search.order_details.reorder(sort_clause)
 
     set_earliest_journal_date
 

--- a/app/controllers/facility_statements_controller.rb
+++ b/app/controllers/facility_statements_controller.rb
@@ -6,6 +6,7 @@ class FacilityStatementsController < ApplicationController
   before_action :authenticate_user!
   before_action :check_acting_as
   before_action { @facility = current_facility }
+  before_action :enable_sorting, only: [:new]
 
   load_and_authorize_resource class: Statement
 
@@ -14,6 +15,7 @@ class FacilityStatementsController < ApplicationController
   }
 
   include CsvEmailAction
+  include SortableBillingTable
 
   def initialize
     @active_tab = "admin_billing"
@@ -50,7 +52,7 @@ class FacilityStatementsController < ApplicationController
     @search_form = TransactionSearch::SearchForm.new(params[:search], defaults: defaults)
     @search = TransactionSearch::Searcher.billing_search(order_details, @search_form, include_facilities: current_facility.cross_facility?)
     @date_range_field = @search_form.date_params[:field]
-    @order_details = @search.order_details
+    @order_details = @search.order_details.reorder(sort_clause)
   end
 
   # POST /facilities/:facility_id/statements

--- a/app/views/shared/transactions/_in_review.html.haml
+++ b/app/views/shared/transactions/_in_review.html.haml
@@ -14,6 +14,7 @@
 
 - if @recently_reviewed.any?
   .grid_12
+    - @sorting_enabled = false
     - @order_detail_link = nil
     - @order_detail_action = nil
     - @extra_date_column_header = :reviewed_at_past

--- a/app/views/shared/transactions/_sortable_table_headers.html.haml
+++ b/app/views/shared/transactions/_sortable_table_headers.html.haml
@@ -1,0 +1,16 @@
+%th.nowrap= sortable "order_number", Order.model_name.human
+%th.nowrap= sortable "order_detail_number", OrderDetail.model_name.human
+%th.nowrap= sortable "date_range_field", OrderDetail.human_attribute_name(@date_range_field)
+- if @extra_date_column
+  %th.nowrap= sortable @extra_date_column.to_s, OrderDetail.human_attribute_name(@extra_date_column_header || @extra_date_column)
+- if current_facility.blank? || cross_facility?
+  %th= Facility.model_name.human
+%th.order-note= OrderDetail.human_attribute_name("description")
+%th.nowrap= sortable "ordered_for", OrderDetail.human_attribute_name("user")
+- unless @account
+  %th= sortable "payment_source", Account.model_name.human
+  %th= Account.human_attribute_name("owner")
+%th.currency= OrderDetail.human_attribute_name("cost")
+%th= sortable "order_status", OrderDetail.human_attribute_name("order_status")
+- if local_assigns[:show_statements]
+  %th= Statement.model_name.human

--- a/app/views/shared/transactions/_table_headers.html.haml
+++ b/app/views/shared/transactions/_table_headers.html.haml
@@ -1,0 +1,16 @@
+%th.nowrap=  Order.model_name.human
+%th.nowrap=  OrderDetail.model_name.human
+%th.nowrap=  OrderDetail.human_attribute_name(@date_range_field)
+- if @extra_date_column
+  %th.nowrap= OrderDetail.human_attribute_name(@extra_date_column_header || @extra_date_column)
+- if current_facility.blank? || cross_facility?
+  %th= Facility.model_name.human
+%th.order-note= OrderDetail.human_attribute_name("description")
+%th.nowrap=  OrderDetail.human_attribute_name("user")
+- unless @account
+  %th=  Account.model_name.human
+  %th= Account.human_attribute_name("owner")
+%th.currency= OrderDetail.human_attribute_name("cost")
+%th=  OrderDetail.human_attribute_name("order_status")
+- if local_assigns[:show_statements]
+  %th= Statement.model_name.human

--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -2,7 +2,9 @@
 %table.table.table-striped.table-hover.dense.old-table
   %thead
     %tr
-      -if @order_detail_action or @order_detail_link
+      -if @order_detail_action
+        %th
+      -if @order_detail_link
         %th
       - if @sorting_enabled
         = render "shared/transactions/sortable_table_headers"

--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -4,22 +4,10 @@
     %tr
       -if @order_detail_action or @order_detail_link
         %th
-      %th= Order.model_name.human
-      %th= OrderDetail.model_name.human
-      %th.nowrap= OrderDetail.human_attribute_name(@date_range_field)
-      - if @extra_date_column
-        %th.nowrap= OrderDetail.human_attribute_name(@extra_date_column_header || @extra_date_column)
-      - if current_facility.blank? || cross_facility?
-        %th= Facility.model_name.human
-      %th.order-note= OrderDetail.human_attribute_name("description")
-      %th.nowrap= OrderDetail.human_attribute_name("user")
-      - unless @account
-        %th= Account.model_name.human
-        %th= Account.human_attribute_name("owner")
-      %th.currency= OrderDetail.human_attribute_name("cost")
-      %th= OrderDetail.human_attribute_name("order_status")
-      - if local_assigns[:show_statements]
-        %th= Statement.model_name.human
+      - if @sorting_enabled
+        = render "shared/transactions/sortable_table_headers"
+      - else
+        = render "shared/transactions/table_headers"
   %tbody
     / We need to keep track of how many columns there are to the left of the Cost column,
     / so we can position the Total correctly.


### PR DESCRIPTION
# Release Notes

Addresses column headers being misaligned (#156344).
Adds a new "Disputed at" column on the Disputed Orders page.

Adds sorting to the following columns:
* Order
* Order Detail
* Fulfilled Date
* Ordered For
* Payment Source
* Order Status

...and where appropriate:
* Disputed at (a new column on the Disputed Orders page)
* Review Closes

Sorting is only enabled on the following admin billing pages:
* All Transactions
* Move Transactions
* Disputed Orders
* Send Notifications
* Orders in Review
* Create Journal
* Create Statements

...and also:
* My Transactions
* My Transactions in Review (but not the Recently Reviewed table)