### PR TITLE
[#155889] Fix instrument display order on Instrument Dashboard

### DIFF
--- a/app/controllers/instrument_schedule_positions_controller.rb
+++ b/app/controllers/instrument_schedule_positions_controller.rb
@@ -42,8 +42,7 @@ class InstrumentSchedulePositionsController < ApplicationController
 
   def load_schedules
     @schedules = Schedule
-                 .order_by_asc_nulls_last(:position)
-                 .order(:name)
+                 .positioned
                  .joins(facility: :instruments)
                  .merge(
                     Instrument

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -126,8 +126,7 @@ class Facility < ApplicationRecord
     schedules
     .active
     .includes(instruments_association => [:alert, :current_offline_reservations, :relay, :schedule_rules])
-    .order_by_asc_nulls_last(:position)
-    .order(:name)
+    .positioned
   end
 
   def dashboard_enabled

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -6,7 +6,7 @@ class Schedule < ApplicationRecord
 
   belongs_to :facility
 
-  scope :positioned, -> { order_by_asc_nulls_last(:position) }
+  scope :positioned, -> { order_by_asc_nulls_last(:position).order(:name) }
 
   with_options class_name: "Instrument" do |schedule|
     schedule.has_many :facility_instruments, -> { not_archived }

--- a/spec/system/admin/instrument_schedule_positions_spec.rb
+++ b/spec/system/admin/instrument_schedule_positions_spec.rb
@@ -5,12 +5,16 @@ RSpec.describe "Instrument Schedule Display Order" do
   let!(:instrument) { create(:instrument, name: "First", facility: facility) }
   let!(:instrument2) { create(:instrument, name: "Second", facility: facility) }
   let!(:instrument3) { create(:instrument, name: "Third", facility: facility, schedule: instrument2.schedule, is_hidden: true) }
-  let!(:instrument4) { create(:instrument, name: "New (no position)", facility: facility) }
+  let!(:instrument_z) { create(:instrument, name: "ZZZ New Instrument (no position)", facility: facility) }
+  let!(:instrument_a) { create(:instrument, name: "AAA New Instrument (no position)", facility: facility) }
+  let!(:instrument_c) { create(:instrument, name: "CCC New Instrument (no position)", facility: facility) }
 
   let!(:reservation) { create :reservation, :running, product: instrument }
   let!(:reservation2) { create :reservation, :running, product: instrument2 }
   let!(:reservation3) { create :reservation, :running, product: instrument3 }
-  let!(:reservation4) { create :reservation, :running, product: instrument4 }
+  let!(:reservation4) { create :reservation, :running, product: instrument_z }
+  let!(:reservation5) { create :reservation, :running, product: instrument_c }
+  let!(:reservation6) { create :reservation, :running, product: instrument_a }
 
   before do
     instrument.schedule.update(position: 0)
@@ -24,33 +28,33 @@ RSpec.describe "Instrument Schedule Display Order" do
     it "can reorder the schedules", :js do
       # check starting display order
       visit dashboard_facility_instruments_path(facility)
-      expect(["First", "Second", "New (no position"]).to appear_in_order
+      expect(["First", "Second", "AAA New", "CCC New", "ZZZ New"]).to appear_in_order
 
       visit timeline_facility_reservations_path(facility)
-      expect(["First", "Second", "Third", "New (no position"]).to appear_in_order
+      expect(["First", "Second", "Third", "AAA New", "CCC New", "ZZZ New"]).to appear_in_order
 
       visit facility_public_timeline_path(facility)
-      expect(["First", "Second", "New (no position"]).to appear_in_order
+      expect(["First", "Second", "AAA New", "CCC New", "ZZZ New"]).to appear_in_order
 
       # change the display order
       visit facility_instrument_schedule_position_path(facility)
       click_link "Instrument Display Order"
       click_link "Edit"
-      expect(["First", "Shared schedule: Second Schedule", "New (no position"]).to appear_in_order
+      expect(["First", "Shared schedule: Second Schedule", "AAA New", "CCC New", "ZZZ New"]).to appear_in_order
       select "Second Schedule", from: "Instrument Schedules"
       find("[title='Move Up']").click
       click_button "Update Ordering"
-      expect(["Second", "Third", "First", "New (no position"]).to appear_in_order
+      expect(["Second", "Third", "First", "AAA New", "CCC New", "ZZZ New"]).to appear_in_order
 
       # check the new display order
       visit timeline_facility_reservations_path(facility)
-      expect(["Second", "Third", "First", "New (no position"]).to appear_in_order
+      expect(["Second", "Third", "First", "AAA New", "CCC New", "ZZZ New"]).to appear_in_order
 
       visit facility_public_timeline_path(facility)
-      expect(["Second", "First", "New (no position"]).to appear_in_order
+      expect(["Second", "First", "AAA New", "CCC New", "ZZZ New"]).to appear_in_order
 
       visit dashboard_facility_instruments_path(facility)
-      expect(["Second", "First", "New (no position"]).to appear_in_order
+      expect(["Second", "First", "AAA New", "CCC New", "ZZZ New"]).to appear_in_order
     end
   end
 
@@ -60,7 +64,7 @@ RSpec.describe "Instrument Schedule Display Order" do
     it "can view the show page, but not edit the display order" do
       visit facility_instrument_schedule_position_path(facility)
       click_link "Instrument Display Order"
-      expect(["First", "Shared schedule: Second Schedule", "New (no position"]).to appear_in_order
+      expect(["First", "Shared schedule: Second Schedule", "AAA New", "CCC New", "ZZZ New"]).to appear_in_order
       expect(page).not_to have_link("Edit")
     end
 


### PR DESCRIPTION
# Release Notes

On the [Manager Timeline](https://nucore-staging.northwestern.edu/facilities/all_prods/reservations/timeline) and [User Timeline](https://nucore-staging.northwestern.edu/facilities/all_prods/public_timeline) we sort first by instrument display order (`schedules.position`), then by instrument name.  

The [Instrument Dashboard](https://nucore-staging.northwestern.edu/facilities/all_prods/instruments/dashboard) was missing the sorting by name (see [here](https://github.com/tablexi/nucore-open/blob/master/app/controllers/instruments_dashboard_controller.rb#L29)), so instruments with no display order set were appearing un-sorted.  