### PR TITLE
[#153934] Add view hook for custom reconciliation workflows

### DIFF
--- a/app/views/admin/shared/_sidenav_billing.html.haml
+++ b/app/views/admin/shared/_sidenav_billing.html.haml
@@ -27,3 +27,4 @@
       - route_name = Account.config.account_type_to_route(account_type)
       = tab text("reconcile", model: account_type.constantize.model_name.human(count: 2)),
         [route_name, FacilityAccount], (sidenav_tab == route_name)
+  = render_view_hook("custom_reconcilable_account_types", sidenav_tab: sidenav_tab)


### PR DESCRIPTION
# Release Notes

Adds a view hook to the bottom of the billing sidenav.
Can be used to add additional links for custom reconciliation workflows.
In support of https://github.com/tablexi/nucore-umass/pull/103
https://pm.tablexi.com/issues/155876