### PR TITLE
[#155218] Sortable columns fixes

### DIFF
--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -48,6 +48,7 @@ class FacilityJournalsController < ApplicationController
 
     @valid_order_details, @invalid_order_details = ValidatorFactory.partition_valid_order_details(@order_details.unexpired_account)
     @invalid_order_details += @order_details.expired_account
+    @invalid_order_details = @invalid_order_details.sort_by(&:fulfilled_at)
 
     respond_to do |format|
       format.csv do

--- a/app/views/facilities/disputed_orders.html.haml
+++ b/app/views/facilities/disputed_orders.html.haml
@@ -9,4 +9,7 @@
 = content_for :top_block do
   = render "shared/transactions/top", tab: "disputed_orders"
 
-= render "shared/transactions/table", order_details: @order_details if @order_details.present?
+- if @order_details.present?
+  .grid_12= render "shared/transactions/table", order_details: @order_details
+- else
+  %p.notice= text("facilities.disputed_orders.no_transactions")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -823,6 +823,7 @@ en:
     disputed_orders:
       head: Disputed Orders
       no_orders: There are no disputed orders for this !facility_downcase!
+      no_transactions: There are no disputed transactions matching the search parameters.
 
     show:
       daily_view: 'Daily View'


### PR DESCRIPTION
# Release Notes

Adds a helpful message when there are no orders in dispute.
Removes column-based sorting from the invalid orders table.