### PR TITLE
[#156362] Add hourly refersh for My Reservations Page

### DIFF
--- a/app/assets/javascripts/page_refresh.js
+++ b/app/assets/javascripts/page_refresh.js
@@ -1,5 +1,5 @@
 /***
- * Triggers a full refreseh of the page at a specified internval.
+ * Triggers a full refresh of the page at a specified interval.
  *
  * Usage:
    = content_for :head_content do

--- a/app/assets/javascripts/page_refresh.js
+++ b/app/assets/javascripts/page_refresh.js
@@ -1,0 +1,20 @@
+/***
+ * Triggers a full refreseh of the page at a specified internval.
+ *
+ * Usage:
+   = content_for :head_content do
+     = javascript_include_tag "page_refresh"
+
+   .js--pageRefresh{ data: { refresh_interval: 1.hour } }
+***/
+
+document.addEventListener("DOMContentLoaded", function() {
+  const page = document.getElementsByClassName("js--pageRefresh")[0];
+  const refreshInterval = page.dataset["refreshInterval"] || 60; // in seconds
+
+  function refresh() {
+    window.location.reload()
+  }
+
+  window.setInterval(refresh, refreshInterval * 1000);
+});

--- a/app/views/reservations/list.html.haml
+++ b/app/views/reservations/list.html.haml
@@ -1,3 +1,8 @@
+= content_for :head_content do
+  = javascript_include_tag "page_refresh"
+
+.js--pageRefresh{ data: { refresh_interval: 1.hour } }
+
 = content_for :h1 do
   = t_my(Reservation)
 


### PR DESCRIPTION
# Release Notes

Adds additional logging for reservation switch failures, and an hourly refresh to the My Reservations page.

The refresh is intended to prevent a possible edge case:
* The user starts a reservation, and leaves the "My Reservations" tab open with an "End Reservation" link on it
*  The user doesn't end the reservation, and 12 hours later the reservation is moved to the problem queue
*  The user clicks the stale "End Reservation" link
*  The user will not see an error, and may think they have ended their reservation