### PR TITLE
TECH TASK: docker-compose config update

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,7 +49,9 @@ services:
     logging:
       driver: none
   mailcatcher:
-    build: .
+    build:
+      context: .
+      target: develop
     command: bash -c "gem install mailcatcher && mailcatcher --ip 0.0.0.0 --no-quit -f"
     ports:
       - "1080:1080"


### PR DESCRIPTION
# Release Notes

Currently, there is not a context set for the mailcatcher build, so when running docker-compose is defaults to the production docker-file, which is not what's needed for a local environment setup. 