### PR TITLE
[#156687] Manage auto_cancel process via secrets.yml

### DIFF
--- a/config/eye.yml.erb
+++ b/config/eye.yml.erb
@@ -56,8 +56,8 @@ processes:
       user_commands:
         rotate: "kill -USR1 {PID}"
 
-# This should only run on 1 instance.
-# See run_auto_cancel in secrets.yml
+  # This should only run on 1 instance.
+  # See run_auto_cancel in secrets.yml
   - name: auto_cancel
     config:
       start_command: ruby lib/daemons/auto_cancel.rb start -- --no-monitor

--- a/config/eye.yml.erb
+++ b/config/eye.yml.erb
@@ -1,7 +1,5 @@
 <% app_root = File.expand_path("..", __dir__) %>
 <% rails_env = ENV["RAILS_ENV"] %>
-# Some processes should only run on 1 instance.
-<% is_first_host = rails_env != "production" || ENV["HOSTNAME"] == "production.hostname.edu" %>
 ---
 name: "nucore_open_<%= rails_env %>"
 
@@ -58,7 +56,8 @@ processes:
       user_commands:
         rotate: "kill -USR1 {PID}"
 
-<% if is_first_host %>
+# This should only run on 1 instance.
+# See run_auto_cancel in secrets.yml
   - name: auto_cancel
     config:
       start_command: ruby lib/daemons/auto_cancel.rb start -- --no-monitor
@@ -75,7 +74,6 @@ processes:
           times: 3
           every: 20 seconds
           below: 256 megabytes
-<% end %>
 
   - name: delayed_job
     config:

--- a/config/secrets.yml.template
+++ b/config/secrets.yml.template
@@ -1,6 +1,7 @@
 defaults: &defaults
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   rollbar: <%= ENV["ROLLBAR_ACCESS_TOKEN"] %>
+  run_auto_cancel: true
 
   # You should change this if you want to be able to access the API
   api:

--- a/lib/daemons/auto_cancel.rb
+++ b/lib/daemons/auto_cancel.rb
@@ -3,8 +3,11 @@
 require File.expand_path("base", File.dirname(__FILE__))
 
 Daemons::Base.new("auto_cancel").start do
-  canceler = AutoCanceler.new
-  canceler.cancel_reservations
+  # Only run on 1 instance.
+  if Rails.application.secrets.run_auto_cancel
+    canceler = AutoCanceler.new
+    canceler.cancel_reservations
+  end
 
   sleep 1.minute.to_i
 end


### PR DESCRIPTION
# Release Notes

The `ENV["HOSTNAME"]` is not set when the eye config gets loaded.  Instead, use the value of `run_auto_cancel` to control which instances run the auto_cancel process.

NOTE:  I've already set the value on the server.