### PR TITLE
[151925] Remove 'a/an' from the email text.

### DIFF
--- a/config/locales/en.notifier.yml
+++ b/config/locales/en.notifier.yml
@@ -74,9 +74,9 @@ en:
       user_update:
         subject: "%{user} has been added to your !app_name! Payment Source"
         body: |
-          %{user} has been added to the !app_name! Payment Source "%{account}" as a/an %{role} by administrator %{created_by}.
+          %{user} has been added to the !app_name! Payment Source "%{account}" as %{role} by administrator %{created_by}.
           If this is incorrect, please log in to !app_name! at %{login_url} and remove this user or contact the administrator named above.
         body_html: |
-          %{user} has been added to the !app_name! Payment Source "%{account}" as a/an %{role} by administrator %{created_by}.
+          %{user} has been added to the !app_name! Payment Source "%{account}" as %{role} by administrator %{created_by}.
 
           If this is incorrect, please [log in to !app_name!](%{login_url}) and remove this user or contact the administrator named above.

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Notifier do
       [email_html, email_text].each do |email_content|
         expect(email_content)
           .to include(
-            "#{user} has been added to the #{I18n.t('app_name')} Payment Source \"#{account}\" as a/an Purchaser by administrator #{admin_user}",
+            "#{user} has been added to the #{I18n.t('app_name')} Payment Source \"#{account}\" as Purchaser by administrator #{admin_user}",
           )
       end
     end


### PR DESCRIPTION
# Release Notes

Clean up the email wording be eliding the text "a/an", as it seems to be unnecessary
