### PR TITLE
[#156691] Include hidden active products in search results for bulk email

### DIFF
--- a/vendor/engines/bulk_email/app/services/bulk_email/recipient_searcher.rb
+++ b/vendor/engines/bulk_email/app/services/bulk_email/recipient_searcher.rb
@@ -84,7 +84,7 @@ module BulkEmail
     end
 
     def products_from_params
-      query = Product.for_facility(facility).active.requiring_approval
+      query = Product.for_facility(facility).not_archived.requiring_approval
       query = query.where(facility: search_fields[:facilities]) if search_fields[:facilities].present?
       query = query.where(id: search_fields[:products]) if search_fields[:products].present?
       query
@@ -103,7 +103,7 @@ module BulkEmail
       OrderDetail
         .for_products(search_fields[:products])
         .joins(:product)
-        .merge(Product.active)
+        .merge(Product.not_archived)
         .for_facility(facility) # If cross_facility, will not add any restrictions
         .for_facilities(search_fields[:facilities])
         .ordered_or_reserved_in_range(start_date, end_date)

--- a/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_fields.html.haml
+++ b/vendor/engines/bulk_email/app/views/bulk_email/bulk_email/_fields.html.haml
@@ -14,7 +14,7 @@
     .span4.full-width
       - if @search_options[:facilities].present?
         = f.input :facilities, as: :transaction_chosen_old
-      = f.input :products, as: :transaction_chosen_old, data_method: :product_options
+      = f.input :products, as: :transaction_chosen_old, data_method: :product_options, hint: t("bulk_email.search_hint")
 
   .row
     %h4.span8= t("bulk_email.dates.label")

--- a/vendor/engines/bulk_email/config/locales/en.yml
+++ b/vendor/engines/bulk_email/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
     recipients: Recipients
     send_mail: Send Mail
     sending: Sending...
+    search_hint: Inactive users and products are excluded from search results.
 
     product_unavailable_reason_statements:
       other: |

--- a/vendor/engines/bulk_email/spec/services/bulk_email/recipient_searcher_spec.rb
+++ b/vendor/engines/bulk_email/spec/services/bulk_email/recipient_searcher_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe BulkEmail::RecipientSearcher do
 
   let(:facility) { FactoryBot.create(:setup_facility) }
 
-  let(:product) { create_item }
-  let(:product2) { create_item }
+  let(:product) { FactoryBot.create(:setup_item, facility: facility) }
+  let(:product2) { FactoryBot.create(:setup_item, facility: facility, is_hidden: true) }
   let(:product3) { FactoryBot.create(:setup_item, facility: facility, is_archived: true) }
 
   let(:account) { FactoryBot.create(:setup_account, owner: owner) }
@@ -45,10 +45,6 @@ RSpec.describe BulkEmail::RecipientSearcher do
   end
 
   before { ignore_order_detail_account_validations }
-
-  def create_item
-    FactoryBot.create(:setup_item, facility: facility)
-  end
 
   def place_order(purchaser:, product:, account:)
     FactoryBot.create(:setup_order,


### PR DESCRIPTION
# Release Notes

Updates the query scopes to include hidden products if they are active (not archived).
These products are in frequent use and purchasers of these products should be included in bulk emails.

# Screenshot

![Screen Shot 2021-03-17 at 3 48 52 PM](https://user-images.githubusercontent.com/30355046/111536594-707b9e00-8738-11eb-9c7f-97ed232c90c6.png)
