### PR TITLE
[#156428] Use string instead of symbol

### DIFF
--- a/app/controllers/concerns/new_inprocess_controller.rb
+++ b/app/controllers/concerns/new_inprocess_controller.rb
@@ -14,7 +14,7 @@ module NewInprocessController
                                               TransactionSearch::DateRangeSearcher).search(order_details, @search_form)
     @order_details = @search.order_details.includes(:order_status).joins_assigned_users.reorder(sort_clause)
     @date_range_field = @search_form.date_params[:field]
-    @label_key_prefix = :estimated
+    @label_key_prefix = "estimated"
 
     respond_to do |format|
       format.html { @order_details = @order_details.paginate(page: params[:page]) }

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -111,6 +111,17 @@ RSpec.describe FacilityOrdersController do
         do_request
         expect(assigns[:order_details]).to eq([@order_detail_item])
       end
+
+      context "export" do
+        before :each do
+          @params.merge!(format: :csv)
+        end
+
+        it "renders a csv download" do
+          do_request
+          expect(response.headers["Content-Type"]).to match %r{\Atext/csv\b}
+        end
+      end
     end
   end
 

--- a/spec/controllers/facility_reservations_controller_spec.rb
+++ b/spec/controllers/facility_reservations_controller_spec.rb
@@ -187,6 +187,17 @@ RSpec.describe FacilityReservationsController do
       end
 
     end
+
+    context "export" do
+      before :each do
+        @params.merge!(format: :csv)
+      end
+
+      it "renders a csv download" do
+        do_request
+        expect(response.headers["Content-Type"]).to match %r{\Atext/csv\b}
+      end
+    end
   end
 
   context "#new" do


### PR DESCRIPTION
Fixes: ActiveJob::SerializationError (Unsupported argument type: Symbol)