### PR TITLE
[#155425] Sign out user after 29 days of inactivity

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   include Nucore::Database::WhereIdsIn
 
   # ldap_authenticatable is included via a to_prepare hook if ldap is enabled
-  devise :database_authenticatable, :encryptable, :trackable, :recoverable, :lockable
+  devise :database_authenticatable, :encryptable, :trackable, :recoverable, :lockable, :timeoutable
 
   has_many :account_users, -> { where(deleted_at: nil) }
   has_many :accounts, through: :account_users

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -61,7 +61,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again.
-  # config.timeout_in = 10.minutes
+  config.timeout_in = 29.days
 
   # ==> Configuration for :lockable
   # Number of authentication tries before locking an account.


### PR DESCRIPTION
# Release Notes

After 29 days of inactivity, users will need to log in again.