### PR TITLE
Prevent invalid query parameters from causing exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "sprockets", "< 4" # Temporarily lock as we upgrade
 gem "config"
 gem "bootsnap", require: false
 gem "puma"
+gem "rack-utf8_sanitizer"
 
 ## database
 gem "mysql2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,6 +402,8 @@ GEM
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rack-utf8_sanitizer (1.7.0)
+      rack (>= 1.0, < 3.0)
     rails (5.2.5)
       actioncable (= 5.2.5)
       actionmailer (= 5.2.5)
@@ -637,6 +639,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma
+  rack-utf8_sanitizer
   rails (= 5.2.5)
   rails-controller-testing
   rails-observers

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,6 +48,9 @@ module Nucore
     # Override the default ("#{Rails.root}/**/spec/mailers/previews") to also load
     # previews from within our engines.
     config.action_mailer.preview_path = "#{Rails.root}/**/spec/mailers/previews"
+
+    # Prevent invalid (usually malicious) URLs from causing exceptions/issues
+    config.middleware.insert 0, Rack::UTF8Sanitizer
   end
 
 end

--- a/spec/system/accessing_invalid_files_spec.rb
+++ b/spec/system/accessing_invalid_files_spec.rb
@@ -4,6 +4,13 @@ require "rails_helper"
 
 RSpec.describe "Accessing invalid formats" do
 
+  it "handles invalid utf8 query parameters" do
+    visit "/users/sign_in?utf8=%E2%9C%93&user[username]=&user[password]=&commit=Sign+in&authenticity_token=f%e5u6%ac%5d%df%c8S%fc%9c7%b3%ff%26A%c3y%85%a3"
+
+    expect(page.current_path).to eq("/users/sign_in")
+    expect(page.text).to include("Support Login")
+  end
+
   it "renders a 404 for a missing page in pdf" do
     visit "/#{I18n.t('facilities_downcase')}/examp.pdf"
 

--- a/spec/system/accessing_invalid_files_spec.rb
+++ b/spec/system/accessing_invalid_files_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Accessing invalid formats" do
     visit "/users/sign_in?utf8=%E2%9C%93&user[username]=&user[password]=&commit=Sign+in&authenticity_token=f%e5u6%ac%5d%df%c8S%fc%9c7%b3%ff%26A%c3y%85%a3"
 
     expect(page.current_path).to eq("/users/sign_in")
-    expect(page.text).to include("Support Login")
+    expect(page.text).to include("Login")
   end
 
   it "renders a 404 for a missing page in pdf" do


### PR DESCRIPTION
# Release Notes

Introduce rack-utf8_sanitizer in order to prevent malicious/invalid query parameters.

This should prevent our exception-monitoring from having many results if/when an outside system scans.

