### PR TITLE
[#155203] Allow resending statement emails

### DIFF
--- a/app/controllers/facility_statements_controller.rb
+++ b/app/controllers/facility_statements_controller.rb
@@ -72,7 +72,7 @@ class FacilityStatementsController < ApplicationController
     redirect_to action: :new
   end
 
-  # GET /facilities/:facility_id/statements/:id/resend_emails
+  # POST /facilities/:facility_id/statements/:id/resend_emails
   def resend_emails
     if SettingsHelper.feature_on?(:send_statement_emails)
       statement = Statement.find(params[:id])

--- a/app/controllers/facility_statements_controller.rb
+++ b/app/controllers/facility_statements_controller.rb
@@ -72,6 +72,16 @@ class FacilityStatementsController < ApplicationController
     redirect_to action: :new
   end
 
+  # GET /facilities/:facility_id/statements/:id/resend_emails
+  def resend_emails
+    if SettingsHelper.feature_on?(:send_statement_emails)
+      statement = Statement.find(params[:id])
+      statement.send_emails
+      flash[:notice] = text("success_with_email_html", accounts: statement.account)
+    end
+    redirect_to action: :index
+  end
+
   # GET /facilities/:facility_id/statements/:id
   def show
     @statement = Statement.find(params[:id])

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -86,4 +86,15 @@ class Statement < ApplicationRecord
     "Statement: #{invoice_number}"
   end
 
+  def send_emails
+    account.notify_users.each do |user|
+        Notifier.statement(
+          user: user,
+          facility: facility,
+          account: account,
+          statement: self
+        ).deliver_later
+    end
+  end
+
 end

--- a/app/services/statement_creator.rb
+++ b/app/services/statement_creator.rb
@@ -27,14 +27,14 @@ class StatementCreator
 
   def send_statement_emails
     if SettingsHelper.feature_on?(:send_statement_emails)
-      account_statements.each do |account, statement|
-        account.notify_users.each { |u| Notifier.statement(user: u, facility: statement.facility, account: account, statement: statement).deliver_later }
+      account_statements.each do |_account, statement|
+        statement.send_emails
       end
     end
   end
 
   def account_list
-    account_statements.map { |a, _s| a.account_list_item }
+    account_statements.map { |account, _statement| account.account_list_item }
   end
 
   def formatted_account_list

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -24,7 +24,7 @@
             = link_to t("statements.pdf.download"), path
             - if SettingsHelper.feature_on?(:send_statement_emails) && current_facility
               %br
-              = link_to(t("statements.resend"), resend_emails_facility_statement_path(current_facility, s))
+              = link_to(t("statements.resend"), resend_emails_facility_statement_path(current_facility, s), method: :post)
           %td= format_usa_datetime(s.created_at)
           %td= s.account.notify_users.map(&:full_name).join(', ')
           - unless @account

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -24,7 +24,7 @@
             = link_to t("statements.pdf.download"), path
             - if SettingsHelper.feature_on?(:send_statement_emails) && current_facility
               %br
-              = link_to("Resend", resend_emails_facility_statement_path(current_facility, s))
+              = link_to(t("statements.resend"), resend_emails_facility_statement_path(current_facility, s))
           %td= format_usa_datetime(s.created_at)
           %td= s.account.notify_users.map(&:full_name).join(', ')
           - unless @account

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -22,6 +22,9 @@
             %br
             - path = current_facility ? statement_path(s) : account_statement_path(s.account, s, format: :pdf)
             = link_to t("statements.pdf.download"), path
+            - if SettingsHelper.feature_on?(:send_statement_emails) && current_facility
+              %br
+              = link_to("Resend", resend_emails_facility_statement_path(current_facility, s))
           %td= format_usa_datetime(s.created_at)
           %td= s.account.notify_users.map(&:full_name).join(', ')
           - unless @account

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -618,6 +618,7 @@ en:
     reconciled:
       "true": Reconciled
       "false": Unreconciled
+    resend: Resend
 
   orders:
     add_account:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -302,7 +302,9 @@ Rails.application.routes.draw do
     post "movable_transactions/confirm", to: "facilities#confirm_transactions"
     post "movable_transactions/move", to: "facilities#move_transactions"
 
-    resources :statements, controller: "facility_statements", only: [:index, :new, :show, :create]
+    resources :statements, controller: "facility_statements", only: [:index, :new, :show, :create] do
+      get "resend_emails", on: :member
+    end
 
     get "general_reports/raw", to: "reports/export_raw_reports#export_all", as: "export_raw_reports"
     get "general_reports/:report_by", to: "reports/general_reports#index", as: "general_reports"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -303,7 +303,7 @@ Rails.application.routes.draw do
     post "movable_transactions/move", to: "facilities#move_transactions"
 
     resources :statements, controller: "facility_statements", only: [:index, :new, :show, :create] do
-      get "resend_emails", on: :member
+      post "resend_emails", on: :member
     end
 
     get "general_reports/raw", to: "reports/export_raw_reports#export_all", as: "export_raw_reports"

--- a/spec/system/admin/facility_statements_spec.rb
+++ b/spec/system/admin/facility_statements_spec.rb
@@ -95,4 +95,17 @@ RSpec.describe "Facility Statement Admin" do
       expect { click_link "Export as CSV" }.to change(ActionMailer::Base.deliveries, :count)
     end
   end
+
+  describe "resending statement emails" do
+    let!(:statement) { create(:statement, created_at: 3.days.ago, order_details: [order_details.first], account: order_details.first.account, facility: facility) }
+
+    before do
+      login_as director
+      visit facility_statements_path(facility)
+    end
+
+    it "resends the statement email" do
+      expect { click_link "Resend" }.to change(ActionMailer::Base.deliveries, :count)
+    end
+  end
 end


### PR DESCRIPTION
# Release Notes

Adds a "Resend" link to each statement in the Statement History tab.

# Screenshot

![Screen Shot 2021-04-22 at 6 06 20 PM](https://user-images.githubusercontent.com/30355046/115795398-79920780-a395-11eb-95ed-64af8db6664f.png)
