### PR TITLE
Tech Task - Remove relay switch logging

### DIFF
--- a/app/support/reservation_instrument_switcher.rb
+++ b/app/support/reservation_instrument_switcher.rb
@@ -9,23 +9,23 @@ class ReservationInstrumentSwitcher
   end
 
   def switch_on!
-    raise relay_error_msg("on", "can't switch") unless reservation.can_switch_instrument_on?
+    raise relay_error_msg unless reservation.can_switch_instrument_on?
 
     if switch_relay_on
       @reservation.start_reservation!
     else
-      raise relay_error_msg("on", "relay status")
+      raise relay_error_msg
     end
     instrument.instrument_statuses.create(is_on: true)
   end
 
   def switch_off!
-    raise relay_error_msg("off", "can't switch") unless reservation.can_switch_instrument_off?
+    raise relay_error_msg unless reservation.can_switch_instrument_off?
 
     if switch_relay_off == false
       @reservation.end_reservation!
     else
-      raise relay_error_msg("off", "relay status")
+      raise relay_error_msg
     end
     instrument.instrument_statuses.create(is_on: false)
   end
@@ -62,8 +62,7 @@ class ReservationInstrumentSwitcher
     instrument.relay
   end
 
-  def relay_error_msg(switch, reason)
-    Rollbar.error("Failed to switch #{switch} reservation #{@reservation.id}, relay status: #{relay.get_status}, reason: #{reason}") if defined?(Rollbar)
+  def relay_error_msg
     "An error was encountered while attempting to toggle the instrument. Please try again."
   end
 


### PR DESCRIPTION
The intent of this logging was to confirm whether there was an issue in the relay switch logic that would explain large numbers of problem reservations in one particular facility (at UMass).  The logging didn't reveal any bugs, so we don't need the noise.