### PR TITLE
[#144829] Display Date Added on product access lists

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -100,7 +100,7 @@ class UsersController < ApplicationController
     @facility = current_facility
     @products_by_type = Product.for_facility(@facility).requiring_approval_by_type
     @training_requested_product_ids = @user.training_requests.pluck(:product_id)
-    @access_granted_date_by_product_id = @user.product_users.map{|product_user| [product_user.product_id, product_user.approved_at]}.to_h
+    @user_approved_at_for_product_id = @user.approval_dates_by_product
   end
 
   # POST /facilities/:facility_id/users/:user_id/access_list/approvals

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -100,6 +100,7 @@ class UsersController < ApplicationController
     @facility = current_facility
     @products_by_type = Product.for_facility(@facility).requiring_approval_by_type
     @training_requested_product_ids = @user.training_requests.pluck(:product_id)
+    @access_granted_date_by_product_id = @user.product_users.map{|product_user| [product_user.product_id, product_user.approved_at]}.to_h
   end
 
   # POST /facilities/:facility_id/users/:user_id/access_list/approvals

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -49,6 +49,10 @@ module DateHelper
     date.strftime("%B %e, %Y")
   end
 
+  def month_day_year(date)
+    date.strftime("%m/%d/%Y")
+  end
+
   def human_time(dt)
     return nil if dt.nil?
     begin

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -156,6 +156,12 @@ class User < ApplicationRecord
     acts
   end
 
+  # Returns a hash of product_id => approved_at date when this user was granted
+  # access to the product
+  def approval_dates_by_product
+    product_users.pluck(:product_id, :approved_at).to_h
+  end
+
   def administered_order_details
     OrderDetail.where(account_id: Account.administered_by(self))
   end

--- a/app/views/product_users/_table.html.haml
+++ b/app/views/product_users/_table.html.haml
@@ -21,7 +21,7 @@
         %td
           = link_to user.last_first_name, [current_facility, user]
 
-        %td= product_user.approved_at.strftime("%Y/%M/%d")
+        %td= month_day_year(product_user.approved_at)
         %td= user.username
         %td= user.email
         - if local_assigns[:f]

--- a/app/views/product_users/_table.html.haml
+++ b/app/views/product_users/_table.html.haml
@@ -3,7 +3,7 @@
     %tr
       %th
       %th= User.human_attribute_name(:name)
-      %th= User.human_attribute_name(:date_added)
+      %th= ProductUser.human_attribute_name(:date_added)
       %th= User.human_attribute_name(:username)
       %th= User.human_attribute_name(:email)
       - if local_assigns[:f]

--- a/app/views/product_users/_table.html.haml
+++ b/app/views/product_users/_table.html.haml
@@ -3,6 +3,7 @@
     %tr
       %th
       %th= User.human_attribute_name(:name)
+      %th= User.human_attribute_name(:date_added)
       %th= User.human_attribute_name(:username)
       %th= User.human_attribute_name(:email)
       - if local_assigns[:f]
@@ -20,6 +21,7 @@
         %td
           = link_to user.last_first_name, [current_facility, user]
 
+        %td= product_user.approved_at.strftime("%Y/%M/%d")
         %td= user.username
         %td= user.email
         - if local_assigns[:f]

--- a/app/views/users/access_list.html.haml
+++ b/app/views/users/access_list.html.haml
@@ -24,21 +24,26 @@
           %tr
             %th.approval-column= Product.human_attribute_name(:can_be_used_by?)
             %th.product-column= Product.model_name.human
+            %th.product-column= ProductUser.human_attribute_name(:date_added)
             %th.scheduling-group-column= ProductAccessGroup.model_name.human
 
         %tbody
           - products.each do |product|
+            - access_granted_at = @access_granted_date_by_product_id[product.id]
             %tr.js--access-list-row
               %td.approval-column.approval-checkbox
                 = check_box_tag "approved_products[]",
                   product.id,
-                  product.can_be_used_by?(@user),
+                  access_granted_at.present?,
                   aria: {label: product.name}
               %td.product-column
                 - if training_requested_for?(product)
                   %span.label.label-important
                     = text("users.access_list.training_requested")
                 = link_to product, [product.facility, product, :users]
+              %td.product-column
+                - if access_granted_at.present?
+                  = access_granted_at.strftime("%Y/%M/%d")
               %td.scheduling-group-column
                 - if product.has_product_access_groups?
                   = scheduling_group_select(product, @user)

--- a/app/views/users/access_list.html.haml
+++ b/app/views/users/access_list.html.haml
@@ -29,7 +29,7 @@
 
         %tbody
           - products.each do |product|
-            - access_granted_at = @access_granted_date_by_product_id[product.id]
+            - access_granted_at = @user_approved_at_for_product_id[product.id]
             %tr.js--access-list-row
               %td.approval-column.approval-checkbox
                 = check_box_tag "approved_products[]",
@@ -43,7 +43,7 @@
                 = link_to product, [product.facility, product, :users]
               %td.product-column
                 - if access_granted_at.present?
-                  = access_granted_at.strftime("%Y/%M/%d")
+                  = month_day_year(access_granted_at)
               %td.scheduling-group-column
                 - if product.has_product_access_groups?
                   = scheduling_group_select(product, @user)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe UsersController do
     end
 
     before(:each) do
+      FactoryBot.create(:product_user, user: user, product: instruments.last)
       @method = :get
       @action = :access_list
       @params[:user_id] = user.id
@@ -122,6 +123,7 @@ RSpec.describe UsersController do
       expect(assigns[:facility]).to eq(facility)
       expect(assigns[:products_by_type]["Instrument"]).to match_array(instruments)
       expect(assigns[:products_by_type]["Service"]).to match_array(services)
+      expect(assigns[:access_granted_date_by_product_id]).to have_key(instruments.last.id)
       expect(assigns[:training_requested_product_ids]).to match_array [
         instruments.last.id,
         services.first.id,

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -113,7 +113,6 @@ RSpec.describe UsersController do
     end
 
     before(:each) do
-      FactoryBot.create(:product_user, user: user, product: instruments.last)
       @method = :get
       @action = :access_list
       @params[:user_id] = user.id
@@ -123,7 +122,6 @@ RSpec.describe UsersController do
       expect(assigns[:facility]).to eq(facility)
       expect(assigns[:products_by_type]["Instrument"]).to match_array(instruments)
       expect(assigns[:products_by_type]["Service"]).to match_array(services)
-      expect(assigns[:access_granted_date_by_product_id]).to have_key(instruments.last.id)
       expect(assigns[:training_requested_product_ids]).to match_array [
         instruments.last.id,
         services.first.id,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -150,6 +150,20 @@ RSpec.describe User do
     end
   end
 
+  describe "#approval_dates_by_product" do
+    context "when the user is on the access list for a product" do
+      let(:product) { create(:instrument_requiring_approval) }
+
+      before { create(:product_user, product: product, user: user) }
+
+      it { expect(user.approval_dates_by_product).to have_key(product.id) }
+    end
+
+    context "when the user is not on any access lists for products" do
+      it { expect(user.approval_dates_by_product).to eq({}) }
+    end
+  end
+
   describe "#cart" do
     let(:order) { user.orders.create(attributes_for(:order, created_by: user.id, facility: facility)) }
 

--- a/spec/system/admin/user_access_list_spec.rb
+++ b/spec/system/admin/user_access_list_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe "User access list" do
       login_as admin
       visit facility_user_path(facility, user)
       click_on "Access List"
+      expect(page).to have_content("Date added")
+      expect(page).to have_content(product_user.approved_at.strftime("%m/%d/%Y"))
       uncheck product1.name
       check product2.name
       click_button "Update Access List"


### PR DESCRIPTION
Added new "Date added" column to the User access list for Product and likewise on the Product access list for Users. This column reads from the existing `ProductUser.approved_at` field and indicates when a person was granted access to a restricted product.

User Access List:
![user-access-list](https://user-images.githubusercontent.com/411614/117481009-5ee09680-af30-11eb-84aa-37f41efe920a.png)

Product Access List
![product-access-list](https://user-images.githubusercontent.com/411614/117481028-6607a480-af30-11eb-8454-6323deaf14d5.png)
