### PR TITLE
[#155473] Fix password update

### DIFF
--- a/app/controllers/user_password_controller.rb
+++ b/app/controllers/user_password_controller.rb
@@ -17,6 +17,7 @@ class UserPasswordController < ApplicationController
     if request.post? && @user.update_password_confirm_current(params[:user])
       @user.clean_up_passwords
       flash[:notice] = I18n.t("user_password.edit.success")
+      redirect_to new_user_session_path
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -106,12 +106,16 @@ class User < ApplicationRecord
       return false
     end
 
+    # let devise-security check password complexity first
+    self.password = params[:password].strip
+    valid?
+
+    # then add our own errors
     errors.add(:password, :empty) if params[:password].blank?
     errors.add(:password, :password_too_short) if params[:password] && params[:password].strip.length < 10
     errors.add(:password_confirmation, :confirmation) if params[:password] != params[:password_confirmation]
 
     if errors.empty?
-      self.password = params[:password].strip
       clear_reset_password_token
       save!
       return true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,24 +93,29 @@ class User < ApplicationRecord
     email_user?
   end
 
+  # Runs various validation checks and then saves the new password.
+  #
+  # Returns: Boolean
+  #
+  # The order of various validity checks here is important,
+  # see numbered comments below.
   def update_password_confirm_current(params)
-    unless valid_password? params[:current_password]
-      errors.add(:current_password, :incorrect)
-    end
-    update_password(params)
-  end
+    # 1) Must run this check before the password is set to a new value,
+    # but we can't set errors until after calling #valid?
+    current_password_valid = valid_password?(params[:current_password])
 
-  def update_password(params)
+    # 2) Bail if somehow the user should be using SSO
     unless password_updatable?
       errors.add(:base, :password_not_updatable)
       return false
     end
 
-    # let devise-security check password complexity first
+    # 3) Set the password so devise-security can check password complexity
     self.password = params[:password].strip
-    valid?
+    valid? # clears any existing errors
 
-    # then add our own errors
+    # 4) Add more validation errors as needed
+    errors.add(:current_password, :incorrect) unless current_password_valid
     errors.add(:password, :empty) if params[:password].blank?
     errors.add(:password, :password_too_short) if params[:password] && params[:password].strip.length < 10
     errors.add(:password_confirmation, :confirmation) if params[:password] != params[:password_confirmation]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -925,7 +925,7 @@ en:
   user_password:
     edit:
       head: Change Password
-      success: Your password has been updated
+      success: Your password has been updated.  Please log in again to continue.
       new_password: New Password
       new_password_hint: Your new password must be at least 10 characters long and contain at least one uppercase letter, lowercase letter, number, and symbol.
     reset:

--- a/spec/system/passwords_spec.rb
+++ b/spec/system/passwords_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Passwords", :aggregate_failures, feature_setting: { password_upd
         click_link "Change Password"
       end
 
-      describe "correct password" do
+      describe "correct current password" do
         before do
           fill_in "Current password", with: "CurrentP@5sw0rd!!"
           fill_in "user[password]", with: "NewP@5sw0rd!!"
@@ -28,7 +28,7 @@ RSpec.describe "Passwords", :aggregate_failures, feature_setting: { password_upd
         end
       end
 
-      describe "incorrect password" do
+      describe "incorrect current password" do
         before do
           fill_in "Current password", with: "random"
           fill_in "user[password]", with: "NewP@5sw0rd!!"
@@ -38,6 +38,21 @@ RSpec.describe "Passwords", :aggregate_failures, feature_setting: { password_upd
 
         it "has an error" do
           expect(page).to have_content "Current password is incorrect"
+        end
+      end
+
+      describe "correct current password, incorrect new password" do
+        before do
+          fill_in "Current password", with: "CurrentP@5sw0rd!!"
+          fill_in "user[password]", with: "currentpassword"
+          fill_in "user[password_confirmation]", with: "currentpassword"
+          click_button "Change Password"
+        end
+
+        it "has an error" do
+          expect(page).to have_content "Password must contain at least one digit"
+          expect(page).to have_content "Password must contain at least one punctuation mark or symbol"
+          expect(page).to have_content "Password must contain at least one upper-case letter"
         end
       end
     end


### PR DESCRIPTION
# Release Notes

Addresses 2 issues with updating an existing user's password:
- If the password fails the complexity check, an exception is raised:  The change you wanted was rejected.
- After updating the password successfully, the user is logged out but remains on the password update page.