### PR TITLE
[#155203] Rename Sent To column

### DIFF
--- a/app/controllers/facility_statements_controller.rb
+++ b/app/controllers/facility_statements_controller.rb
@@ -40,7 +40,7 @@ class FacilityStatementsController < ApplicationController
   end
 
   def permitted_search_params
-    (params[:statement_search_form] || empty_params).permit(:date_range_start, :date_range_end, :status, accounts: [], sent_to: [], facilities: [])
+    (params[:statement_search_form] || empty_params).permit(:date_range_start, :date_range_end, :status, accounts: [], account_admins: [], facilities: [])
   end
 
   # GET /facilities/:facility_id/statements/new

--- a/app/forms/statement_search_form.rb
+++ b/app/forms/statement_search_form.rb
@@ -5,13 +5,13 @@ class StatementSearchForm
   include DateHelper
   include ActiveModel::Model
 
-  attr_accessor :accounts, :current_facility, :facilities, :sent_to, :status, :date_range_start, :date_range_end
+  attr_accessor :accounts, :current_facility, :facilities, :account_admins, :status, :date_range_start, :date_range_end
 
   def available_accounts
     Account.where(id: all_statements.select(:account_id)).order(:account_number, :description)
   end
 
-  def available_sent_to
+  def available_account_admins
     # Oracle throws an error if there is an ORDER in a subquery
     User.where(id: available_accounts.unscope(:order).joins(:notify_users).select("account_users.user_id")).order(:last_name, :first_name)
   end
@@ -32,7 +32,7 @@ class StatementSearchForm
     results = all_statements
               .for_facilities(facilities) # ANDs with the current facility so
               .for_accounts(accounts)
-              .for_sent_to(sent_to)
+              .for_account_admins(account_admins)
               .created_between(parse_usa_date(date_range_start)&.beginning_of_day, parse_usa_date(date_range_end)&.end_of_day)
     add_reconciled_status_filter(results)
   end

--- a/app/mailers/statement_search_result_mailer.rb
+++ b/app/mailers/statement_search_result_mailer.rb
@@ -34,7 +34,7 @@ class StatementSearchResultMailer < CsvReportMailer
       [
         Statement.human_attribute_name(:invoice_number),
         Statement.human_attribute_name(:created_at),
-        Statement.human_attribute_name(:sent_to),
+        Statement.human_attribute_name(:account_admins),
         Account.model_name.human,
         Facility.model_name.human,
         "# of #{Order.model_name.human.pluralize}",

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -15,8 +15,8 @@ class Statement < ApplicationRecord
   default_scope -> { order(created_at: :desc) }
 
   scope :for_accounts, ->(accounts) { where(account_id: accounts) if accounts.present? }
-  scope :for_sent_to, lambda { |sent_to|
-    where(account: Account.joins(:notify_users).where(account_users: { user_id: sent_to })) if sent_to.present?
+  scope :for_account_admins, lambda { |account_admins|
+    where(account: Account.joins(:notify_users).where(account_users: { user_id: account_admins })) if account_admins.present?
   }
 
   scope :created_between, lambda { |start_at, end_at|

--- a/app/views/facility_statements/index.html.haml
+++ b/app/views/facility_statements/index.html.haml
@@ -11,7 +11,7 @@
       - if @search_form.facility_filter?
         = f.input :facilities, collection: @search_form.available_facilities, as: :transaction_chosen, input_html: { class: "js--chosen" }
       = f.input :accounts, collection: @search_form.available_accounts, as: :transaction_chosen, input_html: { class: "js--chosen" }, label_method: :account_list_item
-      = f.input :account_admins, collection: @search_form.available_account_admins, as: :transaction_chosen, input_html: { class: "js--chosen" }, label: Statement.human_attribute_name(:account_admins), hint: text("account_admins_hint")
+      = f.input :account_admins, collection: @search_form.available_account_admins, as: :transaction_chosen, input_html: { class: "js--chosen" }, label: Statement.human_attribute_name(:account_admins), hint: t(".account_admins_hint")
     %fieldset.span2
       = f.input :status, collection: @search_form.available_statuses
       = f.input :date_range_start, input_html: { class: "datepicker__data" }
@@ -23,5 +23,5 @@
       = f.submit t("shared.filter"), class: "btn float-left"
 
 - if @statements.any?
-  = link_to t('reports.account_transactions.export'), url_for(format: :csv), class: 'js--exportSearchResults pull-right', data: { form: '.search_form' }
+  = link_to t("reports.account_transactions.export"), url_for(format: :csv), class: "js--exportSearchResults pull-right", data: { form: ".search_form" }
 = render partial: "shared/statements_table"

--- a/app/views/facility_statements/index.html.haml
+++ b/app/views/facility_statements/index.html.haml
@@ -11,7 +11,7 @@
       - if @search_form.facility_filter?
         = f.input :facilities, collection: @search_form.available_facilities, as: :transaction_chosen, input_html: { class: "js--chosen" }
       = f.input :accounts, collection: @search_form.available_accounts, as: :transaction_chosen, input_html: { class: "js--chosen" }, label_method: :account_list_item
-      = f.input :account_admins, collection: @search_form.available_account_admins, as: :transaction_chosen, input_html: { class: "js--chosen" }, label: Statement.human_attribute_name(:account_admins)
+      = f.input :account_admins, collection: @search_form.available_account_admins, as: :transaction_chosen, input_html: { class: "js--chosen" }, label: Statement.human_attribute_name(:account_admins), hint: text("account_admins_hint")
     %fieldset.span2
       = f.input :status, collection: @search_form.available_statuses
       = f.input :date_range_start, input_html: { class: "datepicker__data" }

--- a/app/views/facility_statements/index.html.haml
+++ b/app/views/facility_statements/index.html.haml
@@ -11,7 +11,7 @@
       - if @search_form.facility_filter?
         = f.input :facilities, collection: @search_form.available_facilities, as: :transaction_chosen, input_html: { class: "js--chosen" }
       = f.input :accounts, collection: @search_form.available_accounts, as: :transaction_chosen, input_html: { class: "js--chosen" }, label_method: :account_list_item
-      = f.input :sent_to, collection: @search_form.available_sent_to, as: :transaction_chosen, input_html: { class: "js--chosen" }, label: Statement.human_attribute_name(:sent_to)
+      = f.input :account_admins, collection: @search_form.available_account_admins, as: :transaction_chosen, input_html: { class: "js--chosen" }, label: Statement.human_attribute_name(:account_admins)
     %fieldset.span2
       = f.input :status, collection: @search_form.available_statuses
       = f.input :date_range_start, input_html: { class: "datepicker__data" }

--- a/app/views/global_search/_statements.html.haml
+++ b/app/views/global_search/_statements.html.haml
@@ -7,7 +7,7 @@
       %th= Statement.human_attribute_name(:created_at)
       %th= Facility.model_name.human
       %th= Account.model_name.human
-      %th= Statement.human_attribute_name(:sent_to)
+      %th= Statement.human_attribute_name(:account_admins)
       %th= "# of #{Order.model_name.human.pluralize}"
       %th= Statement.human_attribute_name(:total_cost)
       %th= Statement.human_attribute_name(:status)

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -6,7 +6,7 @@
       %tr
         %th= Statement.human_attribute_name(:invoice_number)
         %th= Statement.human_attribute_name(:created_at)
-        %th= Statement.human_attribute_name(:sent_to)
+        %th= Statement.human_attribute_name(:account_admins)
         - unless @account
           %th= Account.model_name.human
         - if current_facility&.cross_facility?

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -398,7 +398,7 @@ en:
         created_at: Created At
         invoice_number: "Invoice #"
         reconcile_note: Reconcile Note
-        sent_to: Sent To
+        account_admins: Account Admins
         total_cost: Total
       account:
         account_number: Account Number

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1035,6 +1035,8 @@ en:
       preference_value_header: Selected
 
   facility_statements:
+    index:
+      account_admins_hint: Account owners and business admins receive statements by email.
     new:
       no_transactions: There are no transactions requiring statements matching the search parameters.
 

--- a/spec/system/admin/facility_statements_spec.rb
+++ b/spec/system/admin/facility_statements_spec.rb
@@ -62,14 +62,14 @@ RSpec.describe "Facility Statement Admin" do
       expect(page).to have_content(statement1.invoice_number)
       expect(page).to have_content(statement2.invoice_number)
 
-      select statement1.account.owner_user.full_name, from: "Sent To"
+      select statement1.account.owner_user.full_name, from: "Account Admins"
       click_button "Filter"
 
       expect(page).to have_content(statement1.invoice_number)
       expect(page).not_to have_content(statement2.invoice_number)
 
-      unselect statement1.account.owner_user.full_name, from: "Sent To"
-      select statement2.account.owner_user.full_name, from: "Sent To"
+      unselect statement1.account.owner_user.full_name, from: "Account Admins"
+      select statement2.account.owner_user.full_name, from: "Account Admins"
       click_button "Filter"
 
       expect(page).not_to have_content(statement1.invoice_number)


### PR DESCRIPTION
# Release Notes

There is a column and filter on the Statement History page which is named "Sent To", but it is actually listing account admins.  This could potentially cause confusion, especially with the newly added feature allowing statements to be re-sent.