### PR TITLE
[#157527] Add feature flag to allow global admins to edit revenue account 

### DIFF
--- a/app/controllers/facility_facility_accounts_controller.rb
+++ b/app/controllers/facility_facility_accounts_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Controller for managing recharge chart string accounts.
 class FacilityFacilityAccountsController < ApplicationController
 
   admin_tab     :all

--- a/app/models/facility_account.rb
+++ b/app/models/facility_account.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# A model representing a recharge chart string account.
+# These are the accounts that are "recharged" when purchases are made.
+#
+# account_number - chart string for the account
+# revenue_account - an account code that signals the type of transaction expected
 class FacilityAccount < ApplicationRecord
 
   include Accounts::AccountNumberSectionable
@@ -13,6 +18,18 @@ class FacilityAccount < ApplicationRecord
   scope :inactive, -> { where(is_active: false) }
 
   alias_attribute :active, :is_active
+
+  def self.editable_attributes(user)
+    if revenue_account_editable_by_user?(user)
+      [:is_active, :revenue_account]
+    else
+      [:is_active]
+    end
+  end
+
+  def self.revenue_account_editable_by_user?(user)
+    SettingsHelper.feature_on?(:revenue_account_editable) && user.administrator?
+  end
 
   def to_s
     "#{account_number} (#{revenue_account})"

--- a/app/views/facility_facility_accounts/_facility_account_fields.html.haml
+++ b/app/views/facility_facility_accounts/_facility_account_fields.html.haml
@@ -1,6 +1,7 @@
+- revenue_acct_readonly = local_assigns[:readonly] && !FacilityAccount.revenue_account_editable_by_user?(current_user)
 .well
   = render "shared/account_fields", f: f, account_class: FacilityAccount, readonly: local_assigns[:readonly]
-  = f.input :revenue_account, readonly: local_assigns[:readonly], required: true, input_html: { maxlength: Settings.accounts.revenue_account_default.to_s.length, size: 10 }
+  = f.input :revenue_account, readonly: revenue_acct_readonly, required: true, input_html: { maxlength: Settings.accounts.revenue_account_default.to_s.length, size: 10 }
 
   = f.label :is_active do
     = f.check_box :is_active

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -121,6 +121,7 @@ feature:
   uses_ldap_authentication: false
   kiosk_view: true
   bypass_kiosk_auth: false
+  revenue_account_editable: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts


### PR DESCRIPTION
# Release Notes

This adds a feature flag that makes it possible for global admins to self-correct if an error has been made.
In support of https://github.com/tablexi/nucore-dartmouth/pull/356.