### PR TITLE
[#157607] Handle admin and offline reservations in kiosk view

### DIFF
--- a/app/controllers/kiosk_reservations_controller.rb
+++ b/app/controllers/kiosk_reservations_controller.rb
@@ -18,7 +18,7 @@ class KioskReservationsController < ApplicationController
     sign_out if params[:sign_out].present?
     schedules = current_facility.schedules_for_timeline(:public_instruments)
     instrument_ids = schedules.flat_map { |schedule| schedule.public_instruments.map(&:id) }
-    @reservations = Reservation.for_timeline(Time.current.beginning_of_day, instrument_ids).select(&:can_switch_instrument?)
+    @reservations = Reservation.for_timeline(Time.current.beginning_of_day, instrument_ids).select(&:kiosk?)
     if params[:refresh]
       render partial: "reservations_table", locals: { reservations: @reservations }
     end

--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -39,6 +39,10 @@ module ReservationsHelper
     safe_join(links, delimiter)
   end
 
+  def kiosk_reservation_user(reservation)
+    reservation.display_user&.full_name || text("no_user")
+  end
+
   def reservation_view_edit_link(reservation)
     ReservationUserActionPresenter.new(self, reservation).view_edit_link
   end

--- a/app/models/admin_reservation.rb
+++ b/app/models/admin_reservation.rb
@@ -16,6 +16,10 @@ class AdminReservation < Reservation
             inclusion: { in: CATEGORIES, allow_blank: true }
   validates :expires_mins_before, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
 
+  def display_user
+    created_by
+  end
+
   # TODO: Move admin parts of Reservation here
 
   def admin?

--- a/app/models/offline_reservation.rb
+++ b/app/models/offline_reservation.rb
@@ -13,6 +13,10 @@ class OfflineReservation < Reservation
 
   scope :current, -> { where(reserve_end_at: nil).where("reserve_start_at < ?", Time.current) }
 
+  def display_user
+    created_by
+  end
+
   def admin?
     true
   end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -232,6 +232,14 @@ class Reservation < ApplicationRecord
     raise ActiveRecord::RecordInvalid.new(self) unless save_as_user(user)
   end
 
+  def display_user
+    user
+  end
+
+  def kiosk?
+    admin? || can_switch_instrument?
+  end
+
   def offline?
     type == "OfflineReservation"
   end

--- a/app/presenters/reservation_user_action_presenter.rb
+++ b/app/presenters/reservation_user_action_presenter.rb
@@ -39,6 +39,9 @@ class ReservationUserActionPresenter
   end
 
   def kiosk_user_actions
+    # no actions allowed for Offline and Admin Reservations
+    return [] unless order_detail.present?
+
     actions = []
     actions << kiosk_accessories_link if accessories?
     actions << kiosk_switch_actions if can_switch_instrument?
@@ -102,9 +105,7 @@ class ReservationUserActionPresenter
   end
 
   def kiosk_switch_actions
-    if order.nil?
-      # do nothing for Offline and Admin Reservations
-    elsif can_switch_instrument_on?
+    if can_switch_instrument_on?
       link_to I18n.t("reservations.switch.start"),
               order_order_detail_reservation_kiosk_begin_path(order, order_detail, reservation),
               class: "has_accessories",

--- a/app/presenters/reservation_user_action_presenter.rb
+++ b/app/presenters/reservation_user_action_presenter.rb
@@ -3,7 +3,7 @@
 class ReservationUserActionPresenter
 
   attr_accessor :reservation, :controller
-  delegate :order_detail, :order, :facility, :product,
+  delegate :order_detail, :order, :facility, :product, :admin?,
            :can_switch_instrument?, :can_switch_instrument_on?, :can_switch_instrument_off?,
            :can_cancel?, :startable_now?, :can_customer_edit?, :started?, :ongoing?, to: :reservation
 
@@ -39,13 +39,14 @@ class ReservationUserActionPresenter
   end
 
   def kiosk_user_actions
-    # no actions allowed for Offline and Admin Reservations
-    return [] unless order_detail.present?
-
     actions = []
     actions << kiosk_accessories_link if accessories?
-    actions << kiosk_switch_actions if can_switch_instrument?
+    actions << kiosk_switch_actions if kiosk_actions?
     actions.compact
+  end
+
+  def kiosk_actions?
+    !admin? && can_switch_instrument?
   end
 
   def view_edit_link
@@ -69,7 +70,7 @@ class ReservationUserActionPresenter
   private
 
   def accessories?
-    ongoing? && order_detail.accessories?
+    ongoing? && order_detail&.accessories?
   end
 
   def accessories_link

--- a/app/presenters/reservation_user_action_presenter.rb
+++ b/app/presenters/reservation_user_action_presenter.rb
@@ -102,8 +102,9 @@ class ReservationUserActionPresenter
   end
 
   def kiosk_switch_actions
-    kiosk_path = facility_kiosk_reservations_path(reservation.facility)
-    if can_switch_instrument_on?
+    if order.nil?
+      # do nothing for Offline and Admin Reservations
+    elsif can_switch_instrument_on?
       link_to I18n.t("reservations.switch.start"),
               order_order_detail_reservation_kiosk_begin_path(order, order_detail, reservation),
               class: "has_accessories",

--- a/app/support/reservations/relay_support.rb
+++ b/app/support/reservations/relay_support.rb
@@ -20,7 +20,7 @@ module Reservations::RelaySupport
     return false if check_on && can_switch_instrument_on?(false) # mutually exclusive
     return false unless actual_end_at.nil?    # already ended
     return false if actual_start_at.nil?      # hasn't been started yet
-    return false if order_detail&.complete?   # admin/offline reservations have no order_detail
+    return false if order_detail.complete?
     true
   end
 

--- a/app/support/reservations/relay_support.rb
+++ b/app/support/reservations/relay_support.rb
@@ -20,7 +20,7 @@ module Reservations::RelaySupport
     return false if check_on && can_switch_instrument_on?(false) # mutually exclusive
     return false unless actual_end_at.nil?    # already ended
     return false if actual_start_at.nil?      # hasn't been started yet
-    return false if order_detail.complete?
+    return false if order_detail&.complete?   # admin/offline reservations have no order_detail
     true
   end
 

--- a/app/views/kiosk_reservations/_reservations_table.html.haml
+++ b/app/views/kiosk_reservations/_reservations_table.html.haml
@@ -10,8 +10,7 @@
       - reservations.each do |res|
         %tr
           %td
-            - # Admin and Offline Reservations have a created_by user and no order user
-            = res.user&.full_name || res.created_by&.full_name || text("no_user")
+            = kiosk_reservation_user(res)
           %td
             = res
           %td

--- a/app/views/kiosk_reservations/_reservations_table.html.haml
+++ b/app/views/kiosk_reservations/_reservations_table.html.haml
@@ -10,7 +10,8 @@
       - reservations.each do |res|
         %tr
           %td
-            = res.user.full_name
+            - # AdminReservation and OfflineReservation records don't belong to an order
+            = res.user&.full_name || res.created_by&.full_name || text("no_user")
           %td
             = res
           %td

--- a/app/views/kiosk_reservations/_reservations_table.html.haml
+++ b/app/views/kiosk_reservations/_reservations_table.html.haml
@@ -10,7 +10,7 @@
       - reservations.each do |res|
         %tr
           %td
-            - # AdminReservation and OfflineReservation records don't belong to an order
+            - # Admin and Offline Reservations have a created_by user and no order user
             = res.user&.full_name || res.created_by&.full_name || text("no_user")
           %td
             = res

--- a/config/locales/views/en.kiosk_reservations.yml
+++ b/config/locales/views/en.kiosk_reservations.yml
@@ -8,6 +8,7 @@ en:
         reservation: Reservation
         actions: Actions
         none: No active reservations found for today
+        no_user: No user found
       begin:
         title: Begin Reservation (%{user})
         confirm: Sign in to Confirm

--- a/spec/system/kiosk_view_spec.rb
+++ b/spec/system/kiosk_view_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Launching Kiosk View", :js, feature_setting: { kiosk_view: true,
     end
 
     context "with an offline reservation" do
-      let!(:offline_reservation) { create(:offline_reservation, reserve_start_at: 5.minutes.ago, product: instrument) }
+      let!(:offline_reservation) { create(:offline_reservation, reserve_start_at: 15.minutes.ago, actual_start_at: 10.minutes.ago, product: instrument) }
 
       it "does not error" do
         visit facility_kiosk_reservations_path(facility)

--- a/spec/system/kiosk_view_spec.rb
+++ b/spec/system/kiosk_view_spec.rb
@@ -11,6 +11,32 @@ RSpec.describe "Launching Kiosk View", :js, feature_setting: { kiosk_view: true,
   let(:instrument) { create(:setup_instrument, facility: facility, control_mechanism: "timer") }
 
   shared_examples "kiosk_actions" do |login_label, password|
+
+    context "with an admin reservation" do
+      let!(:admin_reservation) { create(:admin_reservation, reserve_start_at: 15.minutes.ago, actual_start_at: 10.minutes.ago, product: instrument) }
+      let!(:accessory) { create(:accessory, parent: instrument) }
+
+      it "does not error" do
+        visit facility_kiosk_reservations_path(facility)
+
+        expect(page.current_path).to eq facility_kiosk_reservations_path(facility)
+        expect(page).to have_content("No user found")
+        expect(page).to have_content(login_label)
+      end
+    end
+
+    context "with an offline reservation" do
+      let!(:offline_reservation) { create(:offline_reservation, reserve_start_at: 5.minutes.ago, product: instrument) }
+
+      it "does not error" do
+        visit facility_kiosk_reservations_path(facility)
+
+        expect(page.current_path).to eq facility_kiosk_reservations_path(facility)
+        expect(page).to have_content("No user found")
+        expect(page).to have_content(login_label)
+      end
+    end
+
     context "with an active reservation that hasn't been started" do
       let!(:reservation) { create(:purchased_reservation, reserve_start_at: 15.minutes.ago, product: instrument, user: user) }
 


### PR DESCRIPTION
# Release Notes

The kiosk page doesn't behave when a switchable instrument is placed offline or on an admin hold.
Resolves `NoMethodError: undefined method 'full_name' for nil:NilClass`