### PR TITLE
[#157835] Make Devise lock_strategy configurable via settings.yml

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -65,7 +65,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :lockable
   # Number of authentication tries before locking an account.
-  config.lock_strategy = :failed_attempts
+  config.lock_strategy = Settings.devise.lock_strategy
   config.maximum_attempts = 5
 
   # Defines which strategy will be used to unlock an account.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -161,3 +161,6 @@ price_policy_note_options: ~
 order_detail_price_change_reason_options: ~
 
 google_analytics_key: ~
+
+devise:
+  lock_strategy: :failed_attempts


### PR DESCRIPTION
# Release Notes

Make Devise lock_strategy configurable via settings.yml

# Additional Context

Currently, the locking behavior in Devise uses a hard-coded configuration, which does not allow for easy overriding in a school-specific fork. This PR moves the configuration to the `settings.yml` facility, so that we can selectively disable locking for a school. The method I am using for opting out of locking is based on [this line of code](https://github.com/heartcombo/devise/blob/v4.8.0/lib/devise/models/lockable.rb#L103), which should short-circuit the Lockable method and just call `super` without any of the locking functionality when the `lock_strategy` is not `:failed_attempts`. Per https://github.com/heartcombo/devise/blob/v4.8.0/lib/devise/models/lockable.rb#L19, `:none` is also a valid option for the lock strategy, so my plan is to use this value in school-specific forks to opt out of the locking module.