### PR TITLE
[#142305] Add import for adding approved users

### DIFF
--- a/app/controllers/product_user_imports_controller.rb
+++ b/app/controllers/product_user_imports_controller.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class ProductUserImportsController < ApplicationController
+
+  include ActionView::Helpers::TextHelper
+
+  admin_tab     :all
+  before_action :authenticate_user!
+  before_action :check_acting_as
+  before_action :init_current_facility
+  before_action :init_product
+
+  def create
+    begin
+      import = create_product_user_import!
+      import.process_upload!
+      if import.succeeded?
+        flash[:notice] = import_success_alert(import)
+      else
+        flash[:error] = import_failed_alert(import)
+      end
+    rescue => e
+      import_exception_alert(e)
+    end
+
+    redirect_to url_for([current_facility, @product, :users])
+  end
+
+  private
+
+  def create_params
+    params.require(:product_user_import).permit(:file)
+  end
+
+  def create_product_user_import!
+    raise "Please upload a valid import file" if file.blank?
+
+    ProductUserImport.create!(
+      create_params.merge(
+        creator: session_user,
+        product: @product,
+      )
+    )
+  end
+
+  def import_exception_alert(exception)
+    Rails.logger.error "#{exception.message}\n#{exception.backtrace.join("\n")}"
+    flash[:error] = text("controllers.product_user_imports.create.error", error: exception.message)
+
+  end
+
+  def import_success_alert(import)
+    if import.skipped.present?
+      html("controllers.product_user_imports.create.success", count: import.successes.count, added: import.successes.join) +
+      html("controllers.product_user_imports.create.skips", skipped: import.skipped.join)
+    else
+      html("controllers.product_user_imports.create.success", count: import.successes.count, added: import.successes.join)
+    end
+  end
+
+  def import_failed_alert(import)
+    html("controllers.product_user_imports.create.failure", count: import.failures.count, errors: import.failures.join)
+  end
+
+  def file
+    params.fetch(:product_user_import, {}).fetch(:file, nil)
+  end
+
+  def init_product
+    @product = current_facility.products.find_by!(url_name: params[:product_id])
+  end
+
+end

--- a/app/controllers/product_user_imports_controller.rb
+++ b/app/controllers/product_user_imports_controller.rb
@@ -14,7 +14,7 @@ class ProductUserImportsController < ApplicationController
     begin
       import = create_product_user_import!
       import.process_upload!
-      if import.succeeded?
+      if !import.failed?
         flash[:notice] = import_success_alert(import)
       else
         flash[:error] = import_failed_alert(import)
@@ -35,7 +35,7 @@ class ProductUserImportsController < ApplicationController
   def create_product_user_import!
     raise "Please upload a valid import file" if file.blank?
 
-    ProductUserImport.create!(
+    ProductUserImport.new(
       create_params.merge(
         creator: session_user,
         product: @product,

--- a/app/models/product_user.rb
+++ b/app/models/product_user.rb
@@ -10,7 +10,7 @@ class ProductUser < ApplicationRecord
   belongs_to :approved_by_user, class_name: "User", foreign_key: "approved_by", inverse_of: false
   delegate :facility, to: :product
 
-  validates_numericality_of :product_id, :user_id, :approved_by, only_integer: true
+  validates_numericality_of :product_id, :user_id, :approved_by, only_integer: true, message: "not found"
   validates_uniqueness_of :user_id, scope: :product_id, message: "is already approved"
 
   before_create ->(product_user) { product_user.approved_at = Time.zone.now }

--- a/app/models/product_user_import.rb
+++ b/app/models/product_user_import.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "csv"
+
+class ProductUserImport < ApplicationRecord
+
+  include DownloadableFile
+
+  belongs_to :product
+  belongs_to :creator, class_name: "User", foreign_key: :created_by_id
+
+  validates_presence_of :file, :creator
+
+  attr_accessor :successes, :failures, :skipped
+
+  def process_upload!
+    self.successes = []
+    self.skipped = []
+    self.failures = []
+    ProductUser.transaction do
+      begin
+        CSV.parse(Paperclip.io_adapters.for(file).read, headers: true, skip_lines: /^,*$/).each do |row|
+          import_row(row)
+        end
+      end
+
+      raise ActiveRecord::Rollback if failed?
+    end
+
+    self.processed_at = Time.zone.now
+    save!
+
+    if succeeded?
+      successes.map! do |product_user|
+        LogEvent.log(product_user, :create, creator)
+        "* #{product_user.user.username}\n"
+      end
+    end
+  end
+
+  def processed?
+    processed_at.present?
+  end
+
+  def failed?
+    failures.count > 0
+  end
+
+  def succeeded?
+    !failed?
+  end
+
+  private
+
+  def import_row(row)
+    row_username = row["Username"]
+    user = User.find_by(username: row_username)
+    new_product_user = ProductUserCreator.create(user: user, product: product, approver: creator)
+
+    if new_product_user.persisted?
+      successes << new_product_user
+    elsif new_product_user.errors.full_messages.to_sentence == "User is already approved"
+      skipped << "* #{row_username}\n"
+    else
+      failures << "* #{row_username}: #{new_product_user.errors.full_messages.to_sentence}\n\n"
+    end
+  rescue => e
+    failures << "* #{row_username}: #{e.message}\n\n"
+  end
+
+  def upload_file_path
+    @upload_file_path ||= upload_file.file.path
+  end
+
+end

--- a/app/models/product_user_import.rb
+++ b/app/models/product_user_import.rb
@@ -18,7 +18,7 @@ class ProductUserImport < ApplicationRecord
     self.skipped = []
     self.failures = []
 
-    if parsed_import_file.headers.include?('Username')
+    if parsed_import_file.headers.include?("Username")
       ProductUser.transaction do
         parsed_import_file.each { |row| import_row(row) }
         raise ActiveRecord::Rollback if failed?
@@ -26,7 +26,7 @@ class ProductUserImport < ApplicationRecord
 
       self.processed_at = Time.zone.now
     else
-      failures << "Uploaded CSV file must include a Username Column.  Please try again."
+      failures << "Uploaded CSV file must include a 'Username' column.  Please try again."
     end
 
 

--- a/app/views/product_users/index.html.haml
+++ b/app/views/product_users/index.html.haml
@@ -13,8 +13,7 @@
 
 %p= text("explanation", product_type: @product.model_name.human.downcase)
 
-%p
-  = link_to text("add"), [:new, current_facility, @product, :user], class: "btn-add"
+%p= link_to text("add"), [:new, current_facility, @product, :user], class: "btn-add"
 
 .well.well-small
   = simple_form_for :product_user_import, url: facility_product_product_user_imports_path(current_facility, @product), html: { multipart: true } do |f|

--- a/app/views/product_users/index.html.haml
+++ b/app/views/product_users/index.html.haml
@@ -23,7 +23,6 @@
       = text("import_button")
       %span{ style:"display:none" }= f.file_field :file, onchange: "form.submit()"
 
-
 - if @product_users.nil?
 - elsif @product_users.empty?
   %p.notice= text("none")

--- a/app/views/product_users/index.html.haml
+++ b/app/views/product_users/index.html.haml
@@ -14,19 +14,16 @@
 %p= text("explanation", product_type: @product.model_name.human.downcase)
 
 %p
+  = link_to text("add"), [:new, current_facility, @product, :user], class: "btn-add"
+
+.well.well-small
   = simple_form_for :product_user_import, url: facility_product_product_user_imports_path(current_facility, @product), html: { multipart: true } do |f|
-    = link_to text("add"), [:new, current_facility, @product, :user], class: "btn-add"
+    %h4= text("import_header")
+    %p= text("import_hint")
     %label.btn.btn-primary
-      = "Import Approved Users"
-      %span{ style:"display:none" }= f.file_field :file
-    = submit_tag "Submit", class: ["btn", "btn-primary"], data: { disable_with: "Submit" }
+      = text("import_button")
+      %span{ style:"display:none" }= f.file_field :file, onchange: "form.submit()"
 
-
-.well.well-small#bulk-import-fields
-  %p= "You can import a CSV with a list of emails/usernames in the first column." #html("upload_file_hint")
-  %p= "The import process will not remove any approved users."
-  %p= "Users that already have access will not be affected by the import."
-  %p= "Any errors will cause the import to be aborted."
 
 - if @product_users.nil?
 - elsif @product_users.empty?

--- a/app/views/product_users/index.html.haml
+++ b/app/views/product_users/index.html.haml
@@ -13,7 +13,20 @@
 
 %p= text("explanation", product_type: @product.model_name.human.downcase)
 
-%p= link_to text("add"), [:new, current_facility, @product, :user], class: "btn-add"
+%p
+  = simple_form_for :product_user_import, url: facility_product_product_user_imports_path(current_facility, @product), html: { multipart: true } do |f|
+    = link_to text("add"), [:new, current_facility, @product, :user], class: "btn-add"
+    %label.btn.btn-primary
+      = "Import Approved Users"
+      %span{ style:"display:none" }= f.file_field :file
+    = submit_tag "Submit", class: ["btn", "btn-primary"], data: { disable_with: "Submit" }
+
+
+.well.well-small#bulk-import-fields
+  %p= "You can import a CSV with a list of emails/usernames in the first column." #html("upload_file_hint")
+  %p= "The import process will not remove any approved users."
+  %p= "Users that already have access will not be affected by the import."
+  %p= "Any errors will cause the import to be aborted."
 
 - if @product_users.nil?
 - elsif @product_users.empty?

--- a/app/views/shared/_flashes.html.haml
+++ b/app/views/shared/_flashes.html.haml
@@ -7,4 +7,4 @@
 - if flash[:alert]
   .alert.alert-error= flash[:alert]
 
-#js--flash= # for us in AJAXY flashes
+#js--flash= # for use in AJAXY flashes

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -162,7 +162,27 @@ en:
       update_restrictions:
         success: "The users' scheduling groups have been updated."
 
+    product_user_imports:
+      create:
+        error: "Our apologies, but an error occurred while importing: %{error}"
+        failure: |
+          %{count} error(s) occurred while importing:
 
+          %{errors}
+        success:
+          zero: No new approved users were added.
+          one: |
+            %{count} new approved user imported successfully:
+
+            %{added}
+          other: |
+            %{count} new approved users imported successfully:
+
+            %{added}
+        skips: |
+          The following user(s) already had access:
+
+          %{skipped}
 
     orders:
       purchase:

--- a/config/locales/views/admin/en.product_users.yml
+++ b/config/locales/views/admin/en.product_users.yml
@@ -9,6 +9,13 @@ en:
           purchase the %{product_type}.
         none: No users are currently approved.
         update: Update %{plural_label}
+        import_button: Import Approved Users
+        import_header: Approved User Import
+        import_hint: |
+          Click the button below to import a CSV file with a list of emails
+          or NetId's in the 'Username' column.  All other columns will be
+          ignored. Users that already have access will not be affected.
+
       table:
         confirm_removal: |
           Are you sure you wish to remove this user from this %{product_type}?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Rails.application.routes.draw do
 
       resource :product_notification, only: [:show, :edit, :update], path: "notifications", as: "notifications"
       resources :product_research_safety_certification_requirements, only: [:index, :create, :destroy], path: "certification_requirements"
+      resources :product_user_imports, only: :create
     end
 
     resources :product_display_groups do

--- a/db/migrate/20210706192338_create_product_user_imports.rb
+++ b/db/migrate/20210706192338_create_product_user_imports.rb
@@ -1,0 +1,11 @@
+class CreateProductUserImports < ActiveRecord::Migration[5.2]
+  def change
+    create_table :product_user_imports do |t|
+      t.attachment :file
+      t.integer :created_by_id, null: false, foreign_key: { to_table: "users" }
+      t.references :product, null: false
+      t.datetime :processed_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_08_225403) do
+ActiveRecord::Schema.define(version: 2021_07_06_192338) do
 
   create_table "account_facility_joins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "facility_id", null: false
@@ -511,6 +511,19 @@ ActiveRecord::Schema.define(version: 2021_06_08_225403) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["facility_id"], name: "index_product_display_groups_on_facility_id"
+  end
+
+  create_table "product_user_imports", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "file_file_name"
+    t.string "file_content_type"
+    t.bigint "file_file_size"
+    t.datetime "file_updated_at"
+    t.integer "created_by_id", null: false
+    t.bigint "product_id", null: false
+    t.datetime "processed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_product_user_imports_on_product_id"
   end
 
   create_table "product_users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/files/product_user_imports/existing_users.csv
+++ b/spec/files/product_user_imports/existing_users.csv
@@ -1,0 +1,3 @@
+Username
+ddavidson
+jjacobson

--- a/spec/files/product_user_imports/user_not_found.csv
+++ b/spec/files/product_user_imports/user_not_found.csv
@@ -1,0 +1,4 @@
+Username
+ddavidson
+jjacobson
+whoami

--- a/spec/models/product_user_import_spec.rb
+++ b/spec/models/product_user_import_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe ProductUserImport do
   end
 
   context "validations" do
+    it { is_expected.to belong_to :product }
     it { is_expected.to belong_to :creator }
     it { is_expected.to validate_presence_of :file }
     it { is_expected.to validate_presence_of :creator }
@@ -43,7 +44,7 @@ RSpec.describe ProductUserImport do
       it { is_expected.not_to be_persisted }
 
       it "includes a failure message" do
-        expect(import.failures).to include("Uploaded CSV file must include a Username Column.  Please try again.")
+        expect(import.failures).to include("Uploaded CSV file must include a 'Username' column.  Please try again.")
       end
     end
 

--- a/spec/models/product_user_import_spec.rb
+++ b/spec/models/product_user_import_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProductUserImport do
+
+  let(:admin) { create(:user, :administrator) }
+  let(:product) { create(:setup_item) }
+  let(:file) { StringIO.new(body) }
+  let(:body) do
+    <<~CSV
+      Username
+      admin
+      director
+      user123
+    CSV
+  end
+
+  subject(:import) do
+    ProductUserImport.new(
+      creator: admin,
+      file: file,
+      product: product
+    )
+  end
+
+  context "validations" do
+    it { is_expected.to belong_to :creator }
+    it { is_expected.to validate_presence_of :file }
+    it { is_expected.to validate_presence_of :creator }
+  end
+
+  describe "#process_upload!" do
+    context "when no Username column exists" do
+      let(:body) do
+        <<~CSV
+          Wrong Column Name
+          admin
+          director
+          user123
+        CSV
+      end
+
+      before { import.process_upload! }
+
+      it { is_expected.to be_failed }
+      it { is_expected.not_to be_persisted }
+
+      it "includes a failure message" do
+        expect(import.failures).to include("Uploaded CSV file must include a Username Column.  Please try again.")
+      end
+    end
+  end
+end

--- a/spec/models/product_user_import_spec.rb
+++ b/spec/models/product_user_import_spec.rb
@@ -4,17 +4,13 @@ require "rails_helper"
 
 RSpec.describe ProductUserImport do
 
-  let(:admin) { create(:user, :administrator) }
+  let!(:admin) { create(:user, :administrator) }
+  let!(:user_1) { create(:user) }
+  let!(:user_2) { create(:user) }
+  let!(:product_user) { create(:product_user, product: product, user: admin) }
   let(:product) { create(:setup_item) }
   let(:file) { StringIO.new(body) }
-  let(:body) do
-    <<~CSV
-      Username
-      admin
-      director
-      user123
-    CSV
-  end
+  let(:body) { "c,s,v" }
 
   subject(:import) do
     ProductUserImport.new(
@@ -31,6 +27,8 @@ RSpec.describe ProductUserImport do
   end
 
   describe "#process_upload!" do
+    before(:each) { import.process_upload! }
+
     context "when no Username column exists" do
       let(:body) do
         <<~CSV
@@ -41,13 +39,49 @@ RSpec.describe ProductUserImport do
         CSV
       end
 
-      before { import.process_upload! }
 
       it { is_expected.to be_failed }
       it { is_expected.not_to be_persisted }
 
       it "includes a failure message" do
         expect(import.failures).to include("Uploaded CSV file must include a Username Column.  Please try again.")
+      end
+    end
+
+    context "when all usernames are found (some are skipped)" do
+      let(:body) do
+        <<~CSV
+          Username
+          #{admin.username}
+          #{user_1.username}
+          #{user_2.username}
+        CSV
+      end
+
+      it { is_expected.to be_new_product_users_added }
+      it { is_expected.to be_persisted }
+
+      it "includes a list of added users" do
+        expect(import.skipped).to include("* #{admin.username}\n")
+        expect(import.successes).to include("* #{user_1.username}\n", "* #{user_2.username}\n")
+      end
+    end
+
+    context "when some usernames are found and some are not" do
+      let(:body) do
+        <<~CSV
+          Username
+          #{admin.username}
+          #{user_1.username}
+          admin
+        CSV
+      end
+
+      it { is_expected.to be_failed }
+      it { is_expected.not_to be_persisted }
+
+      it "includes a failure message" do
+        expect(import.failures).to include("* admin: User not found\n")
       end
     end
   end

--- a/spec/models/product_user_import_spec.rb
+++ b/spec/models/product_user_import_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe ProductUserImport do
         CSV
       end
 
-
       it { is_expected.to be_failed }
       it { is_expected.not_to be_persisted }
 

--- a/spec/system/admin/import_product_users_spec.rb
+++ b/spec/system/admin/import_product_users_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe "Importing Approved Users", :js do
       create(:product_user, product: instrument, user: user_2)
     end
 
-    it "can launch the Kiosk View" do
+    it "displays the correct message" do
       visit facility_instrument_users_path(facility, instrument)
       page.attach_file(Rails.root + 'spec/files/product_user_imports/existing_users.csv', visible: false)
 
       expect(page.current_path).to eq facility_instrument_users_path(facility, instrument)
-      expect(page).to have_content("The following user(s) already had access:\n#{user_1.username}\n#{user_2.username}\n")
+      expect(page).to have_content("No new approved users were added.\nThe following user(s) already had access:\n#{user_1.username}\n#{user_2.username}\n")
       expect(page).not_to have_content("imported successfully")
     end
   end
@@ -32,7 +32,7 @@ RSpec.describe "Importing Approved Users", :js do
       create(:product_user, product: instrument, user: user_1)
     end
 
-    it "can launch the Kiosk View" do
+    it "displays the correct message" do
       visit facility_instrument_users_path(facility, instrument)
       page.attach_file(Rails.root + 'spec/files/product_user_imports/existing_users.csv', visible: false)
 
@@ -47,7 +47,7 @@ RSpec.describe "Importing Approved Users", :js do
       create(:product_user, product: instrument, user: user_1)
     end
 
-    it "can launch the Kiosk View" do
+    it "displays the correct message" do
       visit facility_instrument_users_path(facility, instrument)
       page.attach_file(Rails.root + 'spec/files/product_user_imports/user_not_found.csv', visible: false)
 

--- a/spec/system/admin/import_product_users_spec.rb
+++ b/spec/system/admin/import_product_users_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Importing Approved Users", :js do
 
     it "displays the correct message" do
       visit facility_instrument_users_path(facility, instrument)
-      page.attach_file(Rails.root + 'spec/files/product_user_imports/existing_users.csv', visible: false)
+      page.attach_file("#{Rails.root}/spec/files/product_user_imports/existing_users.csv", visible: false)
 
       expect(page.current_path).to eq facility_instrument_users_path(facility, instrument)
       expect(page).to have_content("No new approved users were added.\nThe following user(s) already had access:\n#{user_1.username}\n#{user_2.username}\n")
@@ -34,7 +34,7 @@ RSpec.describe "Importing Approved Users", :js do
 
     it "displays the correct message" do
       visit facility_instrument_users_path(facility, instrument)
-      page.attach_file(Rails.root + 'spec/files/product_user_imports/existing_users.csv', visible: false)
+      page.attach_file("#{Rails.root}/spec/files/product_user_imports/existing_users.csv", visible: false)
 
       expect(page.current_path).to eq facility_instrument_users_path(facility, instrument)
       expect(page).to have_content("The following user(s) already had access:\n#{user_1.username}\n")
@@ -42,14 +42,14 @@ RSpec.describe "Importing Approved Users", :js do
     end
   end
 
-  context "when some usernames are not found and some are imported" do
+  context "when some usernames are found and some are not found" do
     before(:each) do
       create(:product_user, product: instrument, user: user_1)
     end
 
     it "displays the correct message" do
       visit facility_instrument_users_path(facility, instrument)
-      page.attach_file(Rails.root + 'spec/files/product_user_imports/user_not_found.csv', visible: false)
+      page.attach_file("#{Rails.root}/spec/files/product_user_imports/user_not_found.csv", visible: false)
 
       expect(page.current_path).to eq facility_instrument_users_path(facility, instrument)
       expect(page).to have_content("1 error(s) occurred while importing:\nwhoami: User not found")

--- a/spec/system/admin/import_product_users_spec.rb
+++ b/spec/system/admin/import_product_users_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Importing Approved Users", :js do
+  let(:facility) { create(:setup_facility, kiosk_enabled: true) }
+  let(:director) { create(:user, :facility_director, facility: facility) }
+  let(:instrument) { create(:instrument_requiring_approval, facility: facility) }
+  let!(:user_1) { create(:user, username: "ddavidson") }
+  let!(:user_2) { create(:user, username: "jjacobson") }
+
+  before { login_as director }
+
+  context "when all usernames are skipped" do
+    before(:each) do
+      create(:product_user, product: instrument, user: user_1)
+      create(:product_user, product: instrument, user: user_2)
+    end
+
+    it "can launch the Kiosk View" do
+      visit facility_instrument_users_path(facility, instrument)
+      page.attach_file(Rails.root + 'spec/files/product_user_imports/existing_users.csv', visible: false)
+
+      expect(page.current_path).to eq facility_instrument_users_path(facility, instrument)
+      expect(page).to have_content("The following user(s) already had access:\n#{user_1.username}\n#{user_2.username}\n")
+      expect(page).not_to have_content("imported successfully")
+    end
+  end
+
+  context "when some usernames are skipped and some are imported" do
+    before(:each) do
+      create(:product_user, product: instrument, user: user_1)
+    end
+
+    it "can launch the Kiosk View" do
+      visit facility_instrument_users_path(facility, instrument)
+      page.attach_file(Rails.root + 'spec/files/product_user_imports/existing_users.csv', visible: false)
+
+      expect(page.current_path).to eq facility_instrument_users_path(facility, instrument)
+      expect(page).to have_content("The following user(s) already had access:\n#{user_1.username}\n")
+      expect(page).to have_content("1 new approved user imported successfully:\n#{user_2.username}")
+    end
+  end
+
+  context "when some usernames are not found and some are imported" do
+    before(:each) do
+      create(:product_user, product: instrument, user: user_1)
+    end
+
+    it "can launch the Kiosk View" do
+      visit facility_instrument_users_path(facility, instrument)
+      page.attach_file(Rails.root + 'spec/files/product_user_imports/user_not_found.csv', visible: false)
+
+      expect(page.current_path).to eq facility_instrument_users_path(facility, instrument)
+      expect(page).to have_content("1 error(s) occurred while importing:\nwhoami: User not found")
+      expect(page).not_to have_content("The following user(s) already had access")
+      expect(page).not_to have_content("imported successfully")
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

The import process should only add new approved users when no errors occur.
Any error should prevent the import from adding new approved users.

# Screenshots

Import includes one existing user and one new one:
<img width="1362" alt="Screen Shot 2021-07-11 at 4 40 12 PM" src="https://user-images.githubusercontent.com/30355046/125210656-d4395200-e266-11eb-9347-83cd99ee9d76.png">

All users already have access:
<img width="1286" alt="Screen Shot 2021-07-11 at 4 39 40 PM" src="https://user-images.githubusercontent.com/30355046/125210657-d4d1e880-e266-11eb-96f1-281d34b48df2.png">

One username is not found:
<img width="1338" alt="Screen Shot 2021-07-11 at 4 39 20 PM" src="https://user-images.githubusercontent.com/30355046/125210658-d56a7f00-e266-11eb-8926-b3150e02b9bb.png">
