### PR TITLE
Tech task - Improve system spec handling of JS errors

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,9 +34,11 @@ RSpec.configure do |config|
   # Gives more verbose output for JS errors, fails any spec with SEVERE errors
   # Based on https://medium.com/@coorasse/catch-javascript-errors-in-your-system-tests-89c2fe6773b1
   config.after(:each, type: :system, js: true) do |example|
+    # Must call page.driver.browser.manage.logs.get(:browser) after every run,
+    # otherwise the logs don't get cleared and leak into other specs.
+    js_errors = page.driver.browser.manage.logs.get(:browser)
     # Some forms using remote: true return a 406 that is expected
     unless example.metadata[:ignore_js_errors]
-      js_errors = page.driver.browser.manage.logs.get(:browser)
       js_errors.each do |error|
         if error.level == "SEVERE" || error.level == "WARNING"
           STDERR.puts "JS error detected (#{error.level}): #{error.message}"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,14 +33,17 @@ RSpec.configure do |config|
 
   # Gives more verbose output for JS errors, fails any spec with SEVERE errors
   # Based on https://medium.com/@coorasse/catch-javascript-errors-in-your-system-tests-89c2fe6773b1
-  config.after(:each, type: :system, js: true) do
-    js_errors = page.driver.browser.manage.logs.get(:browser)
-    js_errors.each do |error|
-      if error.level == "SEVERE" || error.level == "WARNING"
-        STDERR.puts "JS error detected (#{error.level}): #{error.message}"
+  config.after(:each, type: :system, js: true) do |example|
+    # Some forms using remote: true return a 406 that is expected
+    unless example.metadata[:ignore_js_errors]
+      js_errors = page.driver.browser.manage.logs.get(:browser)
+      js_errors.each do |error|
+        if error.level == "SEVERE" || error.level == "WARNING"
+          STDERR.puts "JS error detected (#{error.level}): #{error.message}"
+        end
       end
+      expect(js_errors.map(&:level)).not_to include "SEVERE"
     end
-    expect(js_errors.map(&:level)).not_to include "SEVERE"
   end
 
   Capybara.server = :webrick

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,18 @@ RSpec.configure do |config|
     driven_by :selenium, using: :headless_chrome, screen_size: [1366, 768]
   end
 
+  # Gives more verbose output for JS errors, fails any spec with SEVERE errors
+  # Based on https://medium.com/@coorasse/catch-javascript-errors-in-your-system-tests-89c2fe6773b1
+  config.after(:each, type: :system, js: true) do
+    js_errors = page.driver.browser.manage.logs.get(:browser)
+    js_errors.each do |error|
+      if error.level == "SEVERE" || error.level == "WARNING"
+        STDERR.puts "JS error detected (#{error.level}): #{error.message}"
+      end
+    end
+    expect(js_errors.map(&:level)).not_to include "SEVERE"
+  end
+
   Capybara.server = :webrick
   require "capybara/email/rspec"
   Capybara.enable_aria_label = true

--- a/spec/system/kiosk_view_spec.rb
+++ b/spec/system/kiosk_view_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe "Launching Kiosk View", :js, feature_setting: { kiosk_view: true,
     end
   end
 
-  context "with an LDAP authenticated user", :ldap, feature_setting: { kiosk_view: true, bypass_kiosk_auth: false, uses_ldap_authentication: true } do
+  context "with an LDAP authenticated user", :ldap, ignore_js_errors: true, feature_setting: { kiosk_view: true, bypass_kiosk_auth: false, uses_ldap_authentication: true } do
     let(:user) { create(:user, :netid, :purchaser, account: account, email: "internal@example.org", username: "netid") }
 
     before(:each) do
@@ -178,13 +178,13 @@ RSpec.describe "Launching Kiosk View", :js, feature_setting: { kiosk_view: true,
     it_behaves_like "kiosk_actions", "Login", "netidpassword"
   end
 
-  context "with a locally authenticated user" do
+  context "with a locally authenticated user", ignore_js_errors: true do
     let(:user) { create(:user, :external, :purchaser, account: account) }
 
     it_behaves_like "kiosk_actions", "Login", "P@ssw0rd!!"
   end
 
-  context "with a locally authenticated user who is signed in" do
+  context "with a locally authenticated user who is signed in", ignore_js_errors: true do
     let(:user) { create(:user, :external, :purchaser, account: account) }
 
     before { login_as(user) }
@@ -192,7 +192,7 @@ RSpec.describe "Launching Kiosk View", :js, feature_setting: { kiosk_view: true,
     it_behaves_like "kiosk_actions", "Logout", "P@ssw0rd!!"
   end
 
-  context "with an SSO authenticated user", feature_setting: { kiosk_view: true, bypass_kiosk_auth: true } do
+  context "with an SSO authenticated user", ignore_js_errors: true, feature_setting: { kiosk_view: true, bypass_kiosk_auth: true } do
     let(:user) { create(:user, :netid, :purchaser, account: account, email: "internal@example.org", username: "netid") }
 
     context "with an active reservation that hasn't been started" do
@@ -211,10 +211,10 @@ RSpec.describe "Launching Kiosk View", :js, feature_setting: { kiosk_view: true,
       end
     end
 
-    context "with an active reservation that is running" do
+    context "with an active reservation that is running", ignore_js_errors: true do
       let!(:reservation) { create(:purchased_reservation, reserve_start_at: 15.minutes.ago, actual_start_at: 10.minutes.ago, product: instrument, user: user) }
 
-      it "can end reservations  (no password field)" do
+      it "can end reservations (no password field)" do
         visit facility_kiosk_reservations_path(facility)
         expect(page).to have_content("Login")
         expect(page).not_to have_content("Add Accessories")
@@ -248,7 +248,7 @@ RSpec.describe "Launching Kiosk View", :js, feature_setting: { kiosk_view: true,
         expect(page).to have_content("Login")
       end
 
-      it "can add accessories when ending reservations  (no password field)" do
+      it "can add accessories when ending reservations (no password field)", ignore_js_errors: true do
         visit facility_kiosk_reservations_path(facility)
         expect(page).to have_content("Login")
         click_link "End Reservation"
@@ -265,7 +265,7 @@ RSpec.describe "Launching Kiosk View", :js, feature_setting: { kiosk_view: true,
     end
   end
 
-  context "with a facility that has disabled the kiosk view" do
+  context "with a facility that has disabled the kiosk view", ignore_js_errors: true do
     let(:user) { create(:user, :external, :purchaser, account: account) }
     let(:facility) { create(:setup_facility, kiosk_enabled: false) }
     let!(:reservation) { create(:purchased_reservation, reserve_start_at: 15.minutes.ago, product: instrument, user: user) }


### PR DESCRIPTION
SEVERE errors will now explicitly cause a spec to fail
SEVERE and WARNING level errors will get sent to STDERR