### PR TITLE
[#142305] Fix Access List tab

### DIFF
--- a/app/views/product_users/index.html.haml
+++ b/app/views/product_users/index.html.haml
@@ -27,7 +27,7 @@
 - elsif @product_users.empty?
   %p.notice= text("none")
 - else
-  = form_tag facility_instrument_users_path(format: :csv), method: :get, class: "search_form" do
+  = form_tag polymorphic_path([current_facility, @product, :users], format: :csv), method: :get, class: "search_form" do
     = hidden_field_tag :email, current_user.email, disabled: true
     = hidden_field_tag :format, params[:format], disabled: true
 

--- a/spec/system/admin/access_list_tab_spec.rb
+++ b/spec/system/admin/access_list_tab_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Access List Tab for various product types", :js do
+  let(:facility) { create(:setup_facility) }
+  let(:director) { create(:user, :facility_director, facility: facility) }
+  let!(:user) { create(:user, username: "ddavidson") }
+
+  before(:each) do
+    create(:product_user, product: product, user: user)
+    login_as director
+    visit polymorphic_path([:manage, facility, product])
+    click_link "Access List"
+  end
+
+  context "with an instrument" do
+    let(:product) { create(:setup_instrument, requires_approval: true, facility: facility) }
+
+    it "renders the page" do
+      expect(page.current_path).to eq polymorphic_path([facility, product, :users])
+    end
+  end
+
+  context "with an item" do
+    let(:product) { create(:setup_item, requires_approval: true, facility: facility) }
+
+    it "renders the page" do
+      expect(page.current_path).to eq polymorphic_path([facility, product, :users])
+    end
+  end
+
+  context "with a service" do
+    let(:product) { create(:setup_service, requires_approval: true, facility: facility) }
+
+    it "renders the page" do
+      expect(page.current_path).to eq polymorphic_path([facility, product, :users])
+    end
+  end
+
+  context "with a timed service" do
+    let(:product) { create(:setup_timed_service, requires_approval: true, facility: facility) }
+
+    it "renders the page" do
+      expect(page.current_path).to eq polymorphic_path([facility, product, :users])
+    end
+  end
+end

--- a/spec/system/admin/import_product_users_spec.rb
+++ b/spec/system/admin/import_product_users_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Importing Approved Users", :js do
-  let(:facility) { create(:setup_facility, kiosk_enabled: true) }
+  let(:facility) { create(:setup_facility) }
   let(:director) { create(:user, :facility_director, facility: facility) }
   let(:instrument) { create(:instrument_requiring_approval, facility: facility) }
   let!(:user_1) { create(:user, username: "ddavidson") }


### PR DESCRIPTION
# Release Notes

Use polymorphic routes for CSV export link.  

Addresses errors like:
```
 ActionView::Template::Error: No route matches {:action=>"index", :controller=>"product_users", :facility_id=>"dartlab", :format=>:csv, :service_id=>"NonSterileSorterSetUp"}, missing required keys: [:instrument_id]
```
... which are caused when a user tries to access the "Access List" tab for a non-instrument product.