### PR TITLE
[#152051] Fail gracefully when replacing account owner with existing member

### DIFF
--- a/app/controllers/facility_account_users_controller.rb
+++ b/app/controllers/facility_account_users_controller.rb
@@ -7,7 +7,6 @@ class FacilityAccountUsersController < ApplicationController
   before_action :check_acting_as
   before_action :init_current_facility
   before_action :init_account
-  before_action :init_user, only: :create
 
   load_and_authorize_resource class: AccountUser
 
@@ -34,25 +33,31 @@ class FacilityAccountUsersController < ApplicationController
 
   # POST /facilities/:facility_id/accounts/:account_id/account_users
   def create
-    @account_user = AccountUser.grant(@user, create_params[:user_role], @account, by: session_user)
-
-    if @account_user.persisted?
-      flash[:notice] = text("create.success", user: @user.full_name, account_type: @account.type_string)
-      LogEvent.log(@account_user, :create, current_user)
-
-      [@account.owner_user.email, @account.business_admin_users.map(&:email)].flatten.compact.each do |email|
-        Notifier.user_update(
-          account: @account,
-          user: @user,
-          created_by: session_user,
-          role: create_params[:user_role],
-          send_to: email,
-        ).deliver_later
-      end
+    @user = User.find(params[:user_id])
+    
+    if existing_member_becoming_owner?
+      flash[:error] = text("create.existing_member_error", user: @user.full_name)
       redirect_to facility_account_members_path(current_facility, @account)
     else
-      flash.now[:error] = text("create.error", user: @user.full_name, account_type: @account.type_string)
-      render(action: "new")
+      @account_user = AccountUser.grant(@user, create_params[:user_role], @account, by: session_user)
+      if @account_user.persisted?
+        flash[:notice] = text("create.success", user: @user.full_name, account_type: @account.type_string)
+        LogEvent.log(@account_user, :create, current_user)
+
+        [@account.owner_user.email, @account.business_admin_users.map(&:email)].flatten.compact.each do |email|
+          Notifier.user_update(
+            account: @account,
+            user: @user,
+            created_by: session_user,
+            role: create_params[:user_role],
+            send_to: email,
+          ).deliver_later
+        end
+        redirect_to facility_account_members_path(current_facility, @account)
+      else
+        flash.now[:error] = text("create.error", user: @user.full_name, account_type: @account.type_string)
+        render(action: "new")
+      end
     end
   end
 
@@ -86,14 +91,8 @@ class FacilityAccountUsersController < ApplicationController
     @account.owner_user == @user
   end
 
-  def init_user
-    @user = User.find(params[:user_id])
-    return unless create_params[:user_role] == AccountUser::ACCOUNT_OWNER
-
-    if @account.account_users.map(&:user_id).include?(@user.id)
-      flash[:error] = text("create.existing_member_error", user: @user.full_name)
-      redirect_to facility_account_members_path(current_facility, @account)
-    end
+  def existing_member_becoming_owner?
+    create_params[:user_role] == AccountUser::ACCOUNT_OWNER && @account.account_users.map(&:user_id).include?(@user.id)
   end
 
 end

--- a/config/locales/views/admin/en.facility_account_users.yml
+++ b/config/locales/views/admin/en.facility_account_users.yml
@@ -4,6 +4,7 @@ en:
       create:
         success: "%{user} was added to the %{account_type} Account"
         error: An error was encountered while trying to add %{user} to the %{account_type} Account
+        existing_member_error: "%{user} is already a member. Please remove %{user} before adding them as the new Owner."
       destroy:
         success: The user was successfully removed from the payment method
         error: An error was encountered while attempting to remove the user from the payment method

--- a/spec/controllers/facility_account_users_controller_spec.rb
+++ b/spec/controllers/facility_account_users_controller_spec.rb
@@ -215,36 +215,6 @@ RSpec.describe FacilityAccountUsersController, if: SettingsHelper.feature_on?(:e
             do_request
           end
         end
-
-        context "from anything to owner" do
-          let(:existing_user) { FactoryBot.create(:user) }
-          let!(:user_role) do
-            FactoryBot.create(:account_user, account: @account, user: existing_user, user_role: AccountUser::ACCOUNT_PURCHASER)
-          end
-
-          before :each do
-            @params[:user_id]                  = existing_user.id
-            @params[:account_user][:user_role] = AccountUser::ACCOUNT_OWNER
-            expect(@account.account_users.owners.map(&:user)).to eq([@owner])
-            expect(@account.account_users.purchasers.map(&:user)).to eq([existing_user])
-          end
-
-          it "should be prevented" do
-            do_request
-            expect(assigns(:account)).to eq(@account)
-            expect(assigns(:account).owner_user).to eq(@owner)
-            expect(@account.account_users.owners.map(&:user)).to eq([@owner])
-            expect(@account.account_users.purchasers.map(&:user)).to eq([existing_user])
-
-            expect(flash[:error]).to be_present
-            expect(response).to redirect_to facility_account_members_path(@authable, @account)
-          end
-
-          it "should not send an email" do
-            expect(Notifier).not_to receive(:user_update)
-            do_request
-          end
-        end
       end
     end
 

--- a/spec/controllers/facility_account_users_controller_spec.rb
+++ b/spec/controllers/facility_account_users_controller_spec.rb
@@ -215,6 +215,36 @@ RSpec.describe FacilityAccountUsersController, if: SettingsHelper.feature_on?(:e
             do_request
           end
         end
+
+        context "from anything to owner" do
+          let(:existing_user) { FactoryBot.create(:user) }
+          let!(:user_role) do
+            FactoryBot.create(:account_user, account: @account, user: existing_user, user_role: AccountUser::ACCOUNT_PURCHASER)
+          end
+
+          before :each do
+            @params[:user_id]                  = existing_user.id
+            @params[:account_user][:user_role] = AccountUser::ACCOUNT_OWNER
+            expect(@account.account_users.owners.map(&:user)).to eq([@owner])
+            expect(@account.account_users.purchasers.map(&:user)).to eq([existing_user])
+          end
+
+          it "should be prevented" do
+            do_request
+            expect(assigns(:account)).to eq(@account)
+            expect(assigns(:account).owner_user).to eq(@owner)
+            expect(@account.account_users.owners.map(&:user)).to eq([@owner])
+            expect(@account.account_users.purchasers.map(&:user)).to eq([existing_user])
+
+            expect(flash[:error]).to be_present
+            expect(response).to redirect_to facility_account_members_path(@authable, @account)
+          end
+
+          it "should not send an email" do
+            expect(Notifier).not_to receive(:user_update)
+            do_request
+          end
+        end
       end
     end
 

--- a/spec/system/admin/managing_payment_sources_spec.rb
+++ b/spec/system/admin/managing_payment_sources_spec.rb
@@ -27,4 +27,31 @@ RSpec.describe "Managing accounts" do
       expect(page).to have_content("Description\nNew description")
     end
   end
+
+  describe "changing a user's role" do
+    let(:account_factory) { Account.config.account_types.first.demodulize.underscore }
+    let!(:account) { create(account_factory, :with_account_owner, owner: owner) }
+
+    context "from anything to owner" do
+      let(:other_user) { create(:user) }
+      let!(:user_role) do
+        create(:account_user, account: account, user: other_user, user_role: AccountUser::ACCOUNT_PURCHASER)
+      end
+
+      it "fails gracefully" do
+        visit facility_accounts_path(facility)
+        fill_in "search_term", with: account.account_number
+        click_on "Search"
+        click_on account.to_s
+        click_on "Members"
+        click_on "Add Access"
+        fill_in "search_term", with: other_user.first_name
+        click_on "Search"
+        click_on other_user.last_first_name
+        select "Owner", from: "Role"
+        click_on "Create"
+        expect(page).to have_content("#{other_user.full_name} is already a member. Please remove #{other_user.full_name} before adding them as the new Owner.")
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Release Notes

This PR adds error handling for attempts to replace an account owner with a user that is already an account member.

# Screenshot

![Screen Shot 2021-08-18 at 12 20 26 PM](https://user-images.githubusercontent.com/35459081/129947696-db83ec40-e3ed-468b-b912-fb652af6fab9.png)
