### PR TITLE
Remove capistrano lock directive.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-lock "~> 3.16.0"
-
 set :application, "nucore"
 set :eye_config, "config/eye.yml.erb"
 set :eye_env, -> { { rails_env: fetch(:rails_env) } }


### PR DESCRIPTION
If we don't remove this, Dependabot might accidentally upgrade capistrano,
and it won't fail until we try to do a deploy.

We have not found this lock entry to ever be useful in preventing capsitrano-config-inconsistency

