### PR TITLE
[#157244] Don't clean up reconciled order details

### DIFF
--- a/lib/tasks/order_details.rake
+++ b/lib/tasks/order_details.rake
@@ -14,7 +14,7 @@ namespace :order_details do
 
   desc "task to remove merge orders that have been abandoned. See Task #48377"
   task remove_merge_orders: :environment do
-    stale_merge_orders = Order.where("merge_with_order_id IS NOT NULL AND created_at <= ?", Time.zone.now - 4.weeks).all
+    stale_merge_orders = Order.joins(:order_details).where("orders.merge_with_order_id IS NOT NULL AND order_details.state != 'reconciled' AND orders.created_at <= ?", Time.zone.now - 4.weeks).all
     stale_merge_orders.each(&:destroy)
   end
 


### PR DESCRIPTION
# Release Notes

It is possible to add a service product to an existing order and mark it Complete at the same time.
If this service requires a survey or order form it will not be added to the existing order, but will appear as a transaction and can be reconciled.

This has only happened once, so for now we are just going to exclude reconciled order details from the cleanup task.
I manually merged the order detail that was in this odd state.