### PR TITLE
[#142306] Allow admins to reserve on holidays when ordering on behalf of other users

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -120,7 +120,8 @@ class ReservationsController < ApplicationController
       end
     else
       @reservation = creator.reservation
-      flash.now[:error] = creator.error.html_safe
+      # validation errors are handled by simple form
+      flash.now[:error] = creator.error.html_safe if creator.error.present?
       set_windows
       render :new
     end

--- a/app/controllers/single_reservations_controller.rb
+++ b/app/controllers/single_reservations_controller.rb
@@ -30,7 +30,8 @@ class SingleReservationsController < ApplicationController
       redirect_to purchase_order_path(@order, params.permit(:send_notification))
     else
       @reservation = creator.reservation
-      flash.now[:error] = creator.error.html_safe
+      # validation errors are handled by simple form
+      flash.now[:error] = creator.error.html_safe if creator.error.present?
       set_windows
       render "reservations/new"
     end

--- a/app/services/order_purchase_validator.rb
+++ b/app/services/order_purchase_validator.rb
@@ -36,3 +36,6 @@ class OrderPurchaseValidator
   end
 
 end
+
+class OrderPurchaseValidatorError < ActiveRecord::RecordInvalid
+end

--- a/app/services/reservation_creator.rb
+++ b/app/services/reservation_creator.rb
@@ -28,7 +28,7 @@ class ReservationCreator
         raise ActiveRecord::RecordInvalid, @order_detail unless reservation_and_order_valid?(session_user)
 
         validator = OrderPurchaseValidator.new(@order_detail)
-        raise ActiveRecord::RecordInvalid, @order_detail if validator.invalid?
+        raise OrderPurchaseValidatorError, @order_detail if validator.invalid?
 
         save_reservation_and_order_detail(session_user)
 
@@ -42,6 +42,9 @@ class ReservationCreator
         else
           @success = :default
         end
+      rescue OrderPurchaseValidatorError => e
+        @error = e.message
+        raise ActiveRecord::Rollback
       rescue ActiveRecord::RecordInvalid => e
         raise ActiveRecord::Rollback
       rescue StandardError => e

--- a/app/services/reservation_creator.rb
+++ b/app/services/reservation_creator.rb
@@ -43,7 +43,6 @@ class ReservationCreator
           @success = :default
         end
       rescue ActiveRecord::RecordInvalid => e
-        @error = e.message
         raise ActiveRecord::Rollback
       rescue StandardError => e
         @error = I18n.t("orders.purchase.error", message: e.message).html_safe

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -207,7 +207,7 @@ module Reservations::Validations
   end
 
   def holiday_access
-    return if Holiday.allow_access?(order.created_by_user, product, reserve_start_at)
+    return if Holiday.allow_access?(order&.created_by_user, product, reserve_start_at)
 
     errors.add(:reserve_start_at, :holiday_access_restricted)
   end

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -207,7 +207,7 @@ module Reservations::Validations
   end
 
   def holiday_access
-    return if Holiday.allow_access?(user, product, reserve_start_at)
+    return if Holiday.allow_access?(order.created_by_user, product, reserve_start_at)
 
     errors.add(:reserve_start_at, :holiday_access_restricted)
   end

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -564,8 +564,7 @@ RSpec.describe ReservationsController do
       end
 
       it_should_allow_all [:guest], "to receive an error that they are trying to reserve outside of the window" do
-        expect(assigns[:reservation].errors).not_to be_empty
-        expect(flash[:error]).to include("The reservation is too far in advance")
+        expect(assigns[:reservation].errors[:base]).to include("The reservation is too far in advance")
         expect(response).to render_template(:new)
       end
     end

--- a/spec/system/holiday_reservation_access_spec.rb
+++ b/spec/system/holiday_reservation_access_spec.rb
@@ -30,12 +30,26 @@ RSpec.describe "Reserving an instrument on a holiday" do
   end
 
   context "as a member of a restricted group" do
-    it "does NOT allow making a reservation" do
-      click_link instrument.name
-      select user.accounts.first.description, from: "Payment Source"
-      fill_in "Reserve Start", with: 2.days.from_now
-      click_button "Create"
-      expect(page).to have_content("Reserve Start cannot be on a holiday because you do not have holiday access")
+    context "non-admin" do
+      it "does NOT allow making a reservation" do
+        click_link instrument.name
+        select user.accounts.first.description, from: "Payment Source"
+        fill_in "Reserve Start", with: 2.days.from_now
+        click_button "Create"
+        expect(page).to have_content("Reserve Start cannot be on a holiday because you do not have holiday access")
+      end
+    end
+
+    context "as an admin" do
+      let(:user) { create(:user, :administrator) }
+
+      it "allows making a reservation" do
+        click_link instrument.name
+        select user.accounts.first.description, from: "Payment Source"
+        fill_in "Reserve Start", with: 2.days.from_now
+        click_button "Create"
+        expect(page).to have_content("Reservation created successfully")
+      end
     end
   end
 

--- a/spec/system/purchasing_a_reservation_on_behalf_of_spec.rb
+++ b/spec/system/purchasing_a_reservation_on_behalf_of_spec.rb
@@ -88,6 +88,22 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
     end
   end
 
+  describe "when the reservation is on a holiday" do
+    before do
+      instrument.update!(restrict_holiday_access: true)
+      Holiday.create(date: Time.current)
+    end
+
+    it "can purchase" do
+      click_link instrument.name
+      select user.accounts.first.description, from: "Payment Source"
+
+      click_button "Create"
+
+      expect(page).to have_content("Order Receipt")
+    end
+  end
+
   describe "creating multiple reservations" do
     it "can create reservations in the future" do
       fill_in "order[order_details][][quantity]", with: "2"


### PR DESCRIPTION
# Release Notes

Admins should be able to reserve on holidays when ordering for other users- even if the user doesn't have holiday access.

Also, reservations that fail validation have two error messages.  This removes the one at the top of the page that just says: "Validation failed: " with no further details.

# Screenshot
An example of the problem:
![image](https://user-images.githubusercontent.com/30355046/131379725-ea39406e-c65b-401b-a0b3-c7a08ca6073e.png)

Resolved:
![Screen Shot 2021-08-30 at 12 29 43 PM](https://user-images.githubusercontent.com/30355046/131380029-c165bafc-6dd4-49e3-a5eb-5abce9b3d3c5.png)
