### PR TITLE
Tech task: Use a generic account instead of nufs_account

### DIFF
--- a/spec/system/admin/facility_reservations_tooltip_spec.rb
+++ b/spec/system/admin/facility_reservations_tooltip_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe "Reservation Tooltips", :js do
   let(:reserve_start) { Time.current.change(hour: 12, min: 30) }
   let!(:reservation) { create(:purchased_reservation, reserve_start_at: reserve_start, product: instrument, order_detail: order_detail) }
   let(:instrument) { create(:setup_instrument, facility: facility) }
-  let(:order) { create(:setup_order, product: instrument, order_detail_attributes: { note: "This is an order detail note" } ) }
+  let(:account) { create(:account, :with_account_owner, owner: director) }
+  let(:order) { create(:setup_order, account: account, product: instrument, order_detail_attributes: { note: "This is an order detail note" } ) }
   let(:order_detail) { order.order_details.first }
 
   before(:each) { login_as director }


### PR DESCRIPTION
The `nufs_account` factory is over-ridden by individual schools, and some of them have date validations.  
This spec doesn't need to care about that.