### PR TITLE
prevent dependabot from auto-requesting code review from owners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,11 @@
 # Each line is a file pattern followed by one or more owners.
 
 * @tablexi/nucore
+
+# Ignore changes to the Gemfile + Gemfile.lock
+# by assigning the review to @ghost, which is
+# NOT a a collaborator on this project,
+# and thus not assigned for review.
+Gemfile* @ghost
+package.json @ghost
+yarn.lock @ghost


### PR DESCRIPTION
this should reduce the noise, and allow the code-owners to review dependabot
PRs on their schedule
