### PR TITLE
[adhoc] Fix CI failure by separating error class.

### DIFF
--- a/app/services/order_purchase_validator.rb
+++ b/app/services/order_purchase_validator.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 class OrderPurchaseValidator
@@ -35,7 +34,4 @@ class OrderPurchaseValidator
     !valid?
   end
 
-end
-
-class OrderPurchaseValidatorError < ActiveRecord::RecordInvalid
 end

--- a/app/services/order_purchase_validator_error.rb
+++ b/app/services/order_purchase_validator_error.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class OrderPurchaseValidatorError < ActiveRecord::RecordInvalid
+end


### PR DESCRIPTION
Otherwise, the specs might fail if they didn't require the containing-file
before using the error class.

This way, the auto-loader can find the error class when appropriate

