### PR TITLE
[#157154] Refactor Form.io survey data handling

### DIFF
--- a/app/assets/javascripts/form_io_submission.js
+++ b/app/assets/javascripts/form_io_submission.js
@@ -1,0 +1,33 @@
+/***
+ * Logic for handling submitting forms to Form.io
+ * Shared by new and edit views
+ *
+ * form - Formio form object
+ * surveyUrl - url of the form within Form.io (not NUCore)
+ * surveyCompleteUrl - NUCore url to post to after data has been submitted to Form.io
+ * prefillData - only be set for new form submissions (not editing)
+***/
+
+function handleFormioSubmission(form, surveyUrl, surveyCompleteUrl, prefillData) {
+  if (prefillData) {
+    form.submission = { data: prefillData };
+  }
+
+  form.on('submitDone', function(submission) {
+    if (prefillData) {
+      surveyUrl = surveyUrl + submission._id;
+    }
+    var orderDetailData = {
+      order_detail: submission.data,
+      survey_url: surveyUrl,
+      survey_edit_url: surveyUrl
+    }
+
+    jQuery.ajax({
+      type: "post",
+      data: orderDetailData,
+      url:  surveyCompleteUrl,
+      timeout: 25000
+    });
+  });
+};

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -41,6 +41,9 @@ class SurveysController < ApplicationController
       # send the supplied string to the browser with a MIME type of text/javascript
       render :js => "window.location = '#{params[:referer]}'"
     else
+      # TO DO: Remove logging when the other consumers of this code path are better understood.
+      # This action should not be available via GET, but we need to know more before making that change.
+      Rails.logger.info("Non-Form.io survey completed for Order detail: #{params[:receiver_id]}, external service: #{params[:external_service_id]}")
       redirect_to params[:referer]
     end
   end

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -37,7 +37,12 @@ class SurveysController < ApplicationController
       Rails.logger.error("Could not save external surveyor response! #{e.message}\n#{e.backtrace.join("\n")}")
     end
 
-    redirect_to params[:referer]
+    if request.xhr?
+      # send the supplied string to the browser with a MIME type of text/javascript
+      render :js => "window.location = '#{params[:referer]}'"
+    else
+      redirect_to params[:referer]
+    end
   end
 
   private

--- a/app/models/external_service/survey_response.rb
+++ b/app/models/external_service/survey_response.rb
@@ -21,6 +21,9 @@ class SurveyResponse
         receiver.manages_quantity = true
         od.quantity = params[:quantity].to_i
       end
+      if params[:order_detail].present?
+        od.assign_attributes(sanitized_order_detail_params)
+      end
       receiver.save!
       od.save!
       receiver
@@ -33,6 +36,12 @@ class SurveyResponse
     # old survey services (i.e. Surveyor) have the edit URL inferred
     edit_url = params[:survey_edit_url] || "#{show_url}/take"
     { show_url: show_url, edit_url: edit_url }.to_json
+  end
+
+  def sanitized_order_detail_params
+    params[:order_detail].keep_if { |k| k.starts_with?("orderDetail") }
+    params[:order_detail].transform_keys! { |k| k.sub("orderDetail", "").underscore }
+    params[:order_detail].permit(:note, :reference_id, :quantity)
   end
 
 end

--- a/app/views/formio/submissions/edit.html.haml
+++ b/app/views/formio/submissions/edit.html.haml
@@ -12,7 +12,7 @@
           }
 
           jQuery.ajax({
-            type: "get",
+            type: "post",
             data: orderDetailData,
             url:  "#{raw @redirect_url}",
             timeout: 25000

--- a/app/views/formio/submissions/edit.html.haml
+++ b/app/views/formio/submissions/edit.html.haml
@@ -3,21 +3,9 @@
     Formio
       .createForm(document.getElementById('formio'), '#{@formio_url}')
       .then(function(form) {
-        form.on('submitDone', function(submission) {
-          var surveyUrl = encodeURIComponent('#{@formio_url}');
-          var orderDetailData = {
-            order_detail: submission.data,
-            survey_url: surveyUrl,
-            survey_edit_url: surveyUrl
-          }
-
-          jQuery.ajax({
-            type: "post",
-            data: orderDetailData,
-            url:  "#{raw @redirect_url}",
-            timeout: 25000
-          });
-
-        });
-      });
+        var surveyUrl = "#{raw @formio_url}"
+        var surveyCompleteUrl = "#{raw @redirect_url}"
+        var prefillData
+        handleFormioSubmission(form, surveyUrl, surveyCompleteUrl, prefillData)
+      })
   };

--- a/app/views/formio/submissions/edit.html.haml
+++ b/app/views/formio/submissions/edit.html.haml
@@ -5,7 +5,19 @@
       .then(function(form) {
         form.on('submitDone', function(submission) {
           var surveyUrl = encodeURIComponent('#{@formio_url}');
-          window.location = '#{raw @redirect_url}&survey_url=' + surveyUrl + '&survey_edit_url=' + surveyUrl;
+          var orderDetailData = {
+            order_detail: submission.data,
+            survey_url: surveyUrl,
+            survey_edit_url: surveyUrl
+          }
+
+          jQuery.ajax({
+            type: "get",
+            data: orderDetailData,
+            url:  "#{raw @redirect_url}",
+            timeout: 25000
+          });
+
         });
       });
   };

--- a/app/views/formio/submissions/new.html.haml
+++ b/app/views/formio/submissions/new.html.haml
@@ -14,7 +14,7 @@
           }
 
           jQuery.ajax({
-            type: "get",
+            type: "post",
             data: orderDetailData,
             url:  "#{raw @redirect_url}",
             timeout: 25000

--- a/app/views/formio/submissions/new.html.haml
+++ b/app/views/formio/submissions/new.html.haml
@@ -3,22 +3,9 @@
     Formio
       .createForm(document.getElementById('formio'), '#{@formio_url}')
       .then(function(form) {
-        form.submission = { data: #{raw @prefill_data.to_json} };
-
-        form.on('submitDone', function(submission) {
-          var surveyUrl = "#{raw @formio_url}/submission/" + submission._id;
-          var orderDetailData = {
-            order_detail: submission.data,
-            survey_url: surveyUrl,
-            survey_edit_url: surveyUrl
-          }
-
-          jQuery.ajax({
-            type: "post",
-            data: orderDetailData,
-            url:  "#{raw @redirect_url}",
-            timeout: 25000
-          });
-        });
-      });
+        var surveyUrl = "#{raw @formio_url}/submission/"
+        var surveyCompleteUrl = "#{raw @redirect_url}"
+        var prefillData = #{raw @prefill_data.to_json}
+        handleFormioSubmission(form, surveyUrl, surveyCompleteUrl, prefillData)
+      })
   };

--- a/app/views/formio/submissions/new.html.haml
+++ b/app/views/formio/submissions/new.html.haml
@@ -6,8 +6,19 @@
         form.submission = { data: #{raw @prefill_data.to_json} };
 
         form.on('submitDone', function(submission) {
-          var surveyUrl = encodeURIComponent('#{@formio_url}/submission/' + submission._id);
-          window.location = '#{raw @redirect_url}&survey_url=' + surveyUrl + '&survey_edit_url=' + surveyUrl;
+          var surveyUrl = "#{raw @formio_url}/submission/" + submission._id;
+          var orderDetailData = {
+            order_detail: submission.data,
+            survey_url: surveyUrl,
+            survey_edit_url: surveyUrl
+          }
+
+          jQuery.ajax({
+            type: "get",
+            data: orderDetailData,
+            url:  "#{raw @redirect_url}",
+            timeout: 25000
+          });
         });
       });
   };

--- a/app/views/layouts/formio.html.haml
+++ b/app/views/layouts/formio.html.haml
@@ -6,6 +6,9 @@
     = stylesheet_link_tag "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css", media: "all"
     = stylesheet_link_tag "https://unpkg.com/formiojs@3.28.0/dist/formio.full.min.css", media: "all"
     = javascript_include_tag "https://unpkg.com/formiojs@3.28.0/dist/formio.full.min.js"
+    = javascript_include_tag "jquery"
+    = javascript_include_tag "jquery_ujs"
+
     :css
       #formio {
         margin: 2em auto;

--- a/app/views/layouts/formio.html.haml
+++ b/app/views/layouts/formio.html.haml
@@ -8,6 +8,8 @@
     = javascript_include_tag "https://unpkg.com/formiojs@3.28.0/dist/formio.full.min.js"
     = javascript_include_tag "jquery"
     = javascript_include_tag "jquery_ujs"
+    = javascript_include_tag "form_io_submission"
+    = csrf_meta_tag
 
     :css
       #formio {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -405,7 +405,7 @@ Rails.application.routes.draw do
 
   put   "/#{I18n.t('facilities_downcase')}/:facility_id/services/:service_id/surveys/:external_service_passer_id/activate",   to: "surveys#activate",                 as: "activate_survey"
   put   "/#{I18n.t('facilities_downcase')}/:facility_id/services/:service_id/surveys/:external_service_passer_id/deactivate", to: "surveys#deactivate",               as: "deactivate_survey"
-  get "/#{I18n.t('facilities_downcase')}/:facility_id/services/:service_id/surveys/:external_service_id/complete", to: "surveys#complete", as: "complete_survey"
+  match "/#{I18n.t('facilities_downcase')}/:facility_id/services/:service_id/surveys/:external_service_id/complete", to: "surveys#complete", as: "complete_survey", via: [:get, :post]
 
   namespace :admin do
     namespace :services do

--- a/doc/HOWTO_external_services.md
+++ b/doc/HOWTO_external_services.md
@@ -1,18 +1,22 @@
 # External Services — Order Forms
 
-Services can require a completed order form which can be hosted through an external service. By default, NUCore uses Surveyor as its external service, but it should be simple to integrate another service.
+Services can require a completed order form which can be hosted through an external service. By default, NUCore uses Form.io as its external service, but it should be simple to integrate another service.
 
-Currently, you can only use one external service at a time.
+Currently, you can only use one external service class at a time.
 
 ## Default (and only): UrlService
 
-You can change the default external service by creating a new class that extends from [`ExternalService`](../app/models/external_service.rb) and changing the value of external_services.survey in settings.yml. The current implementation, [`UrlService`](../app/models/url_service.rb), provides the majority of functionality.
+You can change the default external service by creating a new class that extends from [`ExternalService`](../app/models/external_service.rb). The current implementation, [`UrlService`](../app/models/url_service.rb), provides the majority of functionality.
+
+There may be other gems or companion applications that utilize `UrlService`.
+For example, NU is using `acgt`, `sanger_sequencing`, and the IMSERC application (https://github.com/tablexi/nucore-imserc).
 
 ## Process
 
 1. Add the URL to the product under Products > Services > Order Forms and activate the form. This should be the URL for taking a new survey
 
-    For Surveyor, this link is `http://[yourdomain.com]/surveys/[survey-path]`
+    For Form.io, this link can be found by logging into Form.io and selecting the "Embed" tab for the form you wish to use.
+    The link will look like this: `https://[form-io-stage-path].form.io/[survey-path]`
 
 2. User adds the service to their cart
    
@@ -22,7 +26,7 @@ You can change the default external service by creating a new class that extends
 
    `success_url` The URL that the external service should redirect to upon completion of the survey.
     e.g. `http://[yourdomain.com]/facilities/[facility_url]/services/[service_url]/surveys/[external_service_id]/complete?receiver_id=[order_detail_id]`
-   
+
    `receiver_id` The OrderDetail ID
 
 4. Once the user completes the survey, the external service should redirect the user to `success_url`. The URL should have the following additional parameters:
@@ -35,13 +39,15 @@ You can change the default external service by creating a new class that extends
     
     ![Screenshot](images/edit-online-order-form.png)
     
-    The link to this will be the `survey_url` passed back unless you have overridden `edit_url` in a subclass of `UrlService`. For example, Surveyor appends "/take" to the end of the URL for editing.
+    The link to this will be the `survey_url` passed back unless you have overridden `edit_url` in a subclass of `UrlService`.
 
 6. Once the user has purchased the product, administrators will see a link to "View Order Form" under the order. This links to the `survey_url` that was passed back. 
 
 ## Developer Notes
 
-Your new service must extend from `ExternalService` and contain the following methods. `receiver` in this case will be the OrderDetail object.
+Your new service must extend from `ExternalService` and contain the following methods:
+
+`receiver` in this case will be the OrderDetail object.
 
 `new_url(receiver)` Returns the URL for filling out a new survey. This URL should contain the `success_url` parameter for where the external service should return after the user completes the survey. The main part of the URL will likely be the `location` field from the database.
 
@@ -49,6 +55,4 @@ Your new service must extend from `ExternalService` and contain the following me
 
 `show_url(receiver)` Used on the administrative side to link to viewing a completed survey
 
-The easiest way to set up an external service is to extend the `UrlService` class, which contains basic functionality for these three methods. The `Surveyor` class does this.
-
-   
+The easiest way to set up an external service is to extend the `UrlService` class, which contains basic functionality for these three methods.

--- a/spec/support/contexts/external_service_context.rb
+++ b/spec/support/contexts/external_service_context.rb
@@ -6,7 +6,7 @@ RSpec.shared_context "external service" do
   let(:external_service) { external_service_passer.external_service }
   let(:external_service_receiver) { create :external_service_receiver, external_service: external_service }
 
-  let :params do
+  let :params_hash do
     {
       receiver_id: external_service_receiver.receiver.id,
       external_service_id: external_service.id,
@@ -18,4 +18,5 @@ RSpec.shared_context "external service" do
     }
   end
 
+  let(:params) { ActionController::Parameters.new(params_hash) }
 end


### PR DESCRIPTION
# Release Notes

Use ajax POST calls to store data coming back from form.io instead of a GET/query string.
Also updates some documentation that still references the Surveyor application (which is no longer in use).