### PR TITLE
[#156659] Update text styling for problem order email

### DIFF
--- a/app/views/problem_order_mailer/notify_user_with_resolution_option.html.haml
+++ b/app/views/problem_order_mailer/notify_user_with_resolution_option.html.haml
@@ -1,6 +1,7 @@
 = html("body",
   user: @user,
   facility: @order_detail.facility.name,
+  facility_email: @order_detail.facility.email,
   product: @order_detail.product.name,
   order_detail: @order_detail,
   order_detail_link: edit_problem_reservation_url(@order_detail.reservation),

--- a/app/views/problem_order_mailer/notify_user_with_resolution_option.text.erb
+++ b/app/views/problem_order_mailer/notify_user_with_resolution_option.text.erb
@@ -1,6 +1,7 @@
 <%= text("body",
   user: @user,
   facility: @order_detail.facility.name,
+  facility_email: @order_detail.facility.email,
   product: @order_detail.product.name,
   order_detail: @order_detail,
   order_detail_link: order_order_detail_url(@order_detail.order, @order_detail),

--- a/config/locales/views/en.problem_order_mailer.yml
+++ b/config/locales/views/en.problem_order_mailer.yml
@@ -18,15 +18,17 @@ en:
 
           %{facility}
       notify_user_with_resolution_option:
+        subject: "User Amendable !app_name! Problem Order Alert: %{facility}"
         body: |
           Hello %{user},
 
           !app_name! is missing log off information from your recent use of the %{product}
-          at the %{facility} on %{fulfillment_date}. Please click on the link below
-          to enter the End Time or Actual Duration for your instrument reservation
-          and to add any applicable accessories:
+          at the %{facility} on %{fulfillment_date}.
 
-          [#%{order_detail}](%{order_detail_link})
+          **Please click on the link below** to enter the End Time or Actual Duration
+          for your instrument reservation, and to add any applicable accessories:
+
+          **[Add your logout time to #%{order_detail}](%{order_detail_link})**
 
           Thank you,
 

--- a/config/locales/views/en.problem_order_mailer.yml
+++ b/config/locales/views/en.problem_order_mailer.yml
@@ -2,23 +2,25 @@ en:
   views:
     problem_order_mailer:
       notify_user:
-        subject: "!app_name! Problem Order Alert: %{facility}"
+        subject: "!app_name! Problem Order Alert"
         body: |
           Hello %{user},
 
           !app_name! is missing information regarding your recent use of the %{product}
-          at the %{facility} on %{fulfillment_date}. Please [contact the facility](mailto:%{facility_email})
+          at the %{facility} on %{fulfillment_date}.
+
+          **Please [contact the facility](mailto:%{facility_email})**
           to let them know your reservation's actual start time and total duration,
           or your entry and exit times through the facility's secure door, referencing
           the following !app_name! Order Number:
 
-          [#%{order_detail}](%{order_detail_link})
+          **[#%{order_detail}](%{order_detail_link})**
 
           Thank you,
 
           %{facility}
       notify_user_with_resolution_option:
-        subject: "User Amendable !app_name! Problem Order Alert: %{facility}"
+        subject: "User Input Required -- !app_name! Problem Order Alert"
         body: |
           Hello %{user},
 
@@ -29,6 +31,8 @@ en:
           for your instrument reservation, and to add any applicable accessories:
 
           **[Add your logout time to #%{order_detail}](%{order_detail_link})**
+
+          If you need assistance providing this information, please [contact the facility](mailto:%{facility_email}).
 
           Thank you,
 


### PR DESCRIPTION
# Release Notes

This PR updates the email for problem orders to have more clarity, and use styling to inform the actions that should be taken by the user.  Includes changes to both problem order mailers (some facilities allow users to resolve these orders on their own).

# Screenshots

User resolvable:
![Screen Shot of the user resolvable problem order email with new styling](https://user-images.githubusercontent.com/30355046/135908021-4464c71c-79e8-49c5-8746-b3e0edd825ce.png)

Facility staff resolvable:
![Screen Shot of the staff resolved problem order email with new styling](https://user-images.githubusercontent.com/30355046/135908023-e73ebf2c-a316-469d-bdd5-603067c7f5ad.png)

