### PR TITLE
[#152780] Handle orders with invalid Payment Source

### DIFF
--- a/app/assets/stylesheets/app/order_details.scss
+++ b/app/assets/stylesheets/app/order_details.scss
@@ -7,3 +7,7 @@
     font-style: italic;
   }
 }
+
+.invalid {
+  opacity: 0.5;
+}

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -1,5 +1,7 @@
 = f.simple_fields_for order_detail do |odf|
-  %tr{ class: order_detail_iteration.first? ? "first-in-bundle" : "" }
+  - row_class = "#{ order_detail_iteration.first? ? "first-in-bundle" : "" }"
+  - row_class += "#{ order_detail.order.has_valid_payment? ? "" : " invalid" }"
+  %tr{ class: row_class }
     %td
       - if order_detail_iteration.first?
         = link_to text("shared.remove"), remove_order_path(f.object, order_detail), method: :put

--- a/app/views/orders/_form.html.haml
+++ b/app/views/orders/_form.html.haml
@@ -41,11 +41,21 @@
       .backdate_fields= render "edit_date", f: f
 
     %ul.inline{ style: "float: left" }
-      %li
-        = f.submit t("shared.update"),
-          class: "btn"
-      - if order.validated?
+      - if @order.has_valid_payment?
         %li
-          = f.submit t("shared.purchase"),
-            class: %w(btn btn-primary),
-            data: { disable_with: t("shared.purchase") }
+          = f.submit t("shared.update"),
+            class: "btn"
+        - if order.validated?
+          %li
+            = f.submit t("shared.purchase"),
+              class: %w(btn btn-primary),
+              data: { disable_with: t("shared.purchase") }
+      - else
+        - alert_error = "Please Change Payment Source or remove any invalid products from the Cart before continuing"
+        %li
+          %a{ class: "btn disabled", data: { toggle: "tooltip" }, title: "#{alert_error}" }
+            = t("shared.update")
+        - if order.validated?
+          %li
+            %a{ class: "btn btn-primary disabled", data: { toggle: "tooltip" }, title: "#{alert_error}" }
+              = t("shared.purchase")

--- a/app/views/orders/_product_description.html.haml
+++ b/app/views/orders/_product_description.html.haml
@@ -1,5 +1,6 @@
 - unless order_detail.order.validated?
   .label.label-warning= order_detail.validate_for_purchase
-
+- unless order_detail.order.has_valid_payment?
+  .label.label-warning= "Invalid"
 
 = order_detail.product

--- a/spec/system/placing_an_order_spec.rb
+++ b/spec/system/placing_an_order_spec.rb
@@ -139,4 +139,34 @@ RSpec.describe "Placing an item order" do
       end
     end
   end
+
+  describe "when the order's account payment source is invalid" do
+    let(:other_user) { FactoryBot.create(:user) }
+    let(:account) { FactoryBot.create(:nufs_account, :with_account_owner, owner: other_user) }
+    let!(:account_user) { FactoryBot.create(:account_user, :purchaser, account: account, user: user) }
+    let!(:other_account) { FactoryBot.create(:nufs_account, :with_account_owner, owner: other_user) }
+    let!(:other_account_user) { FactoryBot.create(:account_user, :purchaser, account: other_account, user: user) }
+    let!(:other_account_price_group_member) do
+      FactoryBot.create(:account_price_group_member, account: other_account, price_group: price_policy.price_group)
+    end
+
+    def add_to_cart(payment_source)
+      visit "/"
+      click_link facility.name
+      click_link product.name
+      click_link "Add to cart"
+      choose payment_source.to_s
+      click_button "Continue"
+    end
+
+    before do
+      add_to_cart(account)
+      account_user.destroy!
+    end
+
+    it "shows error in cart" do
+      visit "/orders/cart"
+      expect(page).to have_content("Account is not valid for the orderer")
+    end
+  end
 end


### PR DESCRIPTION
# Release Notes

This PR handles orders with invalid Payment Sources, making it explicit to the user how they should proceed in order to continue with their orders

# Screenshot


