### PR TITLE
[#155892] Udates order notification with reply-to email

### DIFF
--- a/app/mailers/purchase_notifier.rb
+++ b/app/mailers/purchase_notifier.rb
@@ -21,7 +21,7 @@ class PurchaseNotifier < ApplicationMailer
   def order_notification(order, recipient)
     @order = order
     attach_all_icals_from_order(@order)
-    send_nucore_mail recipient, text("views.purchase_notifier.order_notification.subject"), "order_receipt"
+    send_nucore_mail recipient, text("views.purchase_notifier.order_notification.subject"), "order_receipt", @order.created_by_user.email
   end
 
   # Custom order forms send out a confirmation email when filled out by a
@@ -49,8 +49,12 @@ class PurchaseNotifier < ApplicationMailer
     }
   end
 
-  def send_nucore_mail(to, subject, template_name = nil)
-    mail(subject: subject, to: to, template_name: template_name)
+  def send_nucore_mail(to, subject, template_name = nil, reply_to = nil)
+    if reply_to
+      mail(subject: subject, to: to, template_name: template_name, reply_to: reply_to)
+    else
+      mail(subject: subject, to: to, template_name: template_name)
+    end
   end
 
 end

--- a/app/views/purchase_notifier/order_receipt.html.haml
+++ b/app/views/purchase_notifier/order_receipt.html.haml
@@ -14,7 +14,7 @@
   %tr
     %td
       %strong= OrderDetail.human_attribute_name(:ordered_by)
-    %td= @order.created_by_user.full_name
+    %td= mail_to @order.created_by_user.email, @order.created_by_user.full_name
   %tr
     %td
       %strong= Account.model_name.human

--- a/app/views/purchase_notifier/order_receipt.text.haml
+++ b/app/views/purchase_notifier/order_receipt.text.haml
@@ -4,7 +4,7 @@
 
 #{Order.human_attribute_name(:ordered_at)}: #{l(@order.initial_ordered_at, format: :receipt)}
 #{Facility.model_name.human}: #{@order.facility}
-#{OrderDetail.human_attribute_name(:ordered_by)}: #{@order.created_by_user.full_name}
+#{OrderDetail.human_attribute_name(:ordered_by)}: #{@order.created_by_user.full_name}, #{@order.created_by_user.email}
 #{Account.model_name.human}: #{@order.account}
 ==
 = OrderDetail.model_name.to_s.titleize.pluralize

--- a/spec/mailers/purchase_notifier_spec.rb
+++ b/spec/mailers/purchase_notifier_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe PurchaseNotifier do
       expect(email.to).to eq [recipient]
       expect(email.subject).to include("Order Notification")
       expect(email.html_part.to_s).to match(/Ordered By.+#{user.full_name}/m)
+      expect(email.reply_to).to eq [order.created_by_user.email]
       expect(email.text_part.to_s).to include("Ordered By: #{user.full_name}")
       expect(email.html_part.to_s).to match(/Payment Source.+#{order.account}/m)
       expect(email.text_part.to_s).to include("Payment Source: #{order.account}")


### PR DESCRIPTION
# Release Notes

This PR Updates the order notification email to show a reply-to and a mailto link for the orders user, for the administrators to have access to. 