### PR TITLE
[#158493] Fix for_card_number search logic

### DIFF
--- a/vendor/engines/secure_rooms/app/models/secure_rooms/user_extension.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/user_extension.rb
@@ -11,7 +11,7 @@ module SecureRooms
       validates :i_class_number, uniqueness: { allow_blank: true }
 
       def self.for_card_number(card_number) 
-        find_by(card_number: [card_number, card_number.split("-").first])
+        find_by(card_number: card_number) || find_by(card_number: card_number.split("-").first)
       end
     end
 

--- a/vendor/engines/secure_rooms/spec/models/user_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/user_spec.rb
@@ -27,12 +27,33 @@ RSpec.describe User do
     end
 
     context "when 2 users have the same indala_number" do
-      let!(:user2) { create(:user, :netid, card_number: "12345") }
-      let(:card_number) { "12345-124" }
+      describe "when there is a matching indala number with NO facility code" do
+        let!(:user2) { create(:user, :netid, card_number: "12345") }
+        let(:card_number) { "12345-123" }
 
-      it "finds the user" do
-        expect(described_class.for_card_number(card_number)).to eq(user2)
+        it "finds the user with matching indala number and no facility code" do
+          expect(described_class.for_card_number("12345-789")).to eq(user2)
+        end
       end
+
+      describe "when there is a matching indala number with non-matching facility code" do
+        let!(:user2) { create(:user, :netid, card_number: "12345-456") }
+        let(:card_number) { "12345-123" }
+
+        it "deos not find a user" do
+          expect(described_class.for_card_number("12345-789")).to eq(nil)
+        end
+      end
+
+      describe "when there is an exact match" do
+        let!(:user2) { create(:user, :netid, card_number: "12345") }
+        let(:card_number) { "12345-124" }
+
+        it "finds the matching user" do
+          expect(described_class.for_card_number(card_number)).to eq(user)
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
# Release Notes

We can't depend on `find_by`'s internal logic when there are 2 users with the same indala number.
For some  reason the spec we had in place was passing in `nucore-open` and failed in `nucore-umass`.