### PR TITLE
Update winning strategy to use symbol instead of string

### DIFF
--- a/vendor/engines/saml_authentication/app/controllers/saml_authentication/sessions_controller.rb
+++ b/vendor/engines/saml_authentication/app/controllers/saml_authentication/sessions_controller.rb
@@ -70,7 +70,7 @@ module SamlAuthentication
     # This will be used to choose which Logout link is shown to the user.
     # https://github.com/apokalipto/devise_saml_authenticatable/wiki/Supporting-multiple-authentication-strategies
     def store_winning_strategy
-      warden.session(resource_name)[:strategy] = "saml_authenticatable"
+      warden.session(resource_name)[:strategy] = :saml_authenticatable
     end
 
   end


### PR DESCRIPTION
Addresses- ArgumentError: Please use symbols for polymorphic route arguments.

[This](https://github.com/tablexi/nucore-open/blob/master/app/helpers/routes_helper.rb#L17) is where we actually put the symbol into a route helper.

I've hot-fixed UMass stage servers and confirmed the fix behaves as expected