### PR TITLE
[#155892] Update reply_to address for product order notification emails

### DIFF
--- a/app/mailers/purchase_notifier.rb
+++ b/app/mailers/purchase_notifier.rb
@@ -14,14 +14,16 @@ class PurchaseNotifier < ApplicationMailer
     @order = order_detail.order
     @order_detail = OrderDetailPresenter.new(order_detail)
     attach_reservation_ical(order_detail.reservation) if order_detail.reservation.present?
-    send_nucore_mail recipient, text("views.purchase_notifier.product_order_notification.subject", product: order_detail.product)
+    subject = text("views.purchase_notifier.product_order_notification.subject", product: order_detail.product)
+    send_nucore_mail to: recipient, subject: subject, reply_to: @order.created_by_user.email
   end
 
   # Notifies the specified facility staff member if any order is placed within a facility
   def order_notification(order, recipient)
     @order = order
     attach_all_icals_from_order(@order)
-    send_nucore_mail recipient, text("views.purchase_notifier.order_notification.subject"), "order_receipt", @order.created_by_user.email
+    subject = text("views.purchase_notifier.order_notification.subject")
+    send_nucore_mail to: recipient, subject: subject, reply_to: @order.created_by_user.email, template_name: "order_receipt"
   end
 
   # Custom order forms send out a confirmation email when filled out by a
@@ -31,7 +33,7 @@ class PurchaseNotifier < ApplicationMailer
     @order = args[:order]
     @greeting = text("views.purchase_notifier.order_receipt.intro")
     attach_all_icals_from_order(@order)
-    send_nucore_mail args[:user].email, text("views.purchase_notifier.order_receipt.subject")
+    send_nucore_mail to: args[:user].email, subject: text("views.purchase_notifier.order_receipt.subject")
   end
 
   private
@@ -49,7 +51,7 @@ class PurchaseNotifier < ApplicationMailer
     }
   end
 
-  def send_nucore_mail(to, subject, template_name = nil, reply_to = nil)
+  def send_nucore_mail(to:, subject:, reply_to: nil, template_name: nil)
     if reply_to
       mail(subject: subject, to: to, template_name: template_name, reply_to: reply_to)
     else

--- a/app/views/purchase_notifier/product_order_notification.html.haml
+++ b/app/views/purchase_notifier/product_order_notification.html.haml
@@ -11,7 +11,7 @@
   %tr
     %td
       %strong= OrderDetail.human_attribute_name(:ordered_by)
-    %td= @order.created_by_user.full_name
+    %td= mail_to @order.created_by_user.email, @order.created_by_user.full_name
   %tr
     %td
       %strong= Account.model_name.human

--- a/spec/mailers/previews/purchase_notifier_preview.rb
+++ b/spec/mailers/previews/purchase_notifier_preview.rb
@@ -3,7 +3,7 @@
 class PurchaseNotifierPreview < ActionMailer::Preview
 
   def product_order_notification
-    order_detail = OrderDetail.last
+    order_detail = OrderDetail.purchased.last
     recipient = User.last
     PurchaseNotifier.product_order_notification(
       order_detail,
@@ -12,7 +12,7 @@ class PurchaseNotifierPreview < ActionMailer::Preview
   end
 
   def order_notification
-    order = Order.last
+    order = Order.purchased.last
     recipient = User.last
     PurchaseNotifier.order_notification(
       order,

--- a/spec/mailers/purchase_notifier_spec.rb
+++ b/spec/mailers/purchase_notifier_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe PurchaseNotifier do
       expect(email.text_part.to_s).to include(order_detail.to_s)
       expect(email.html_part.to_s).to match(/Ordered By.+#{user.full_name}/m)
       expect(email.text_part.to_s).to include("Ordered By: #{user.full_name}")
+      expect(email.reply_to).to eq [order.created_by_user.email]
       expect(email.html_part.to_s).to match(/Payment Source.+#{order.account}/m)
       expect(email.text_part.to_s).to include("Payment Source: #{order.account}")
       expect(email.html_part.to_s).not_to include("Thank you for your order")


### PR DESCRIPTION
# Release Notes

I realized there is another order notification mailer here that is sent per-product.  I think it should behave the same way as the facility-based order notification mailer.

Also made a change to make the mailer previews behave more predictably.