### PR TITLE
Tech task: Convert session strategy to symbol before using in route helper

### DIFF
--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -14,7 +14,7 @@ module RoutesHelper
 
   def sign_out_user_path
     # Allow for custom logout paths from saml or other authenticable options
-    strategy = warden.session(:user)[:strategy].to_sym
+    strategy = warden.session(:user)[:strategy]&.to_sym
     # facility_id will cause the user to be redirected to the facility's home page after logout
     [:destroy, strategy, :user_session, facility_id: current_facility&.url_name].compact
   end


### PR DESCRIPTION
See: https://github.com/tablexi/nucore-open/pull/2771
New sessions will get a symbol stored in session rather than a string, but existing sessions will still have the string stored.

I found this after releasing to UMass prod.  This change is in place on production now.
I've tested on stage to confirm this resolves the issue.