### PR TITLE
[#145122] allow CC expiration date to be edited

### DIFF
--- a/spec/system/admin/managing_payment_sources_spec.rb
+++ b/spec/system/admin/managing_payment_sources_spec.rb
@@ -54,4 +54,22 @@ RSpec.describe "Managing accounts" do
       end
     end
   end
+
+  describe "editing credit cards" do
+    let!(:account) { FactoryBot.create(:credit_card_account, :with_account_owner, owner: owner, facility: facility) }
+
+    it "can edit a credit_cards expiration date", :aggregate_failures do
+      visit facility_accounts_path(facility)
+      fill_in "search_term", with: account.account_number
+      click_on "Search"
+      click_on account.to_s
+      click_on "Edit"
+      expect(page).to have_content("Expiration month")
+      expect(page).to have_content("Expiration year")
+      select "5", from: "Expiration month"
+      select "#{Time.zone.today.year + 5}", from: "Expiration year"
+      click_on "Save"
+      expect(page).to have_content("Expiration\n05/31/#{Time.zone.today.year + 5}")
+    end
+  end
 end

--- a/vendor/engines/c2po/app/services/credit_card_account_builder.rb
+++ b/vendor/engines/c2po/app/services/credit_card_account_builder.rb
@@ -27,11 +27,18 @@ class CreditCardAccountBuilder < AccountBuilder
       :affiliate_id,
       :affiliate_other,
       :remittance_information,
+      :expiration_month,
+      :expiration_year,
     ]
   end
 
   # Hooks into superclass's `build` method.
   def after_build
+    set_expires_at
+  end
+
+  # Hooks into superclass's `build` method.
+  def after_update
     set_expires_at
   end
 

--- a/vendor/engines/c2po/app/views/facility_accounts/account_fields/_credit_card_account.html.haml
+++ b/vendor/engines/c2po/app/views/facility_accounts/account_fields/_credit_card_account.html.haml
@@ -1,7 +1,7 @@
 - if local_assigns[:is_new]
   = f.input :name_on_card, label: t('facility_accounts.account_fields.label.cc_name'), required: true
-  = f.input :expiration_month, required: true, collection: (1..12).to_a
-  = f.input :expiration_year, required: true, collection: (Time.zone.now.year..(Time.zone.now.year + 10)).to_a
+= f.input :expiration_month, required: true, collection: (1..12).to_a
+= f.input :expiration_year, required: true, collection: (Time.zone.now.year..(Time.zone.now.year + 10)).to_a
 
 = f.input :description, required: true, hint: t('facility_accounts.account_fields.label.all_instruct'), hint_html: { class: 'help-inline' }
 - if SettingsHelper.feature_on?(:account_reference_field)


### PR DESCRIPTION
# Release Notes
Exposes cc month and year for editing by admin role users

# Screenshot

![Screen Shot of credit card edit page](https://user-images.githubusercontent.com/7103652/139329632-f7687506-3b5a-49f3-81db-6ff1208e94b8.png)
![Screen Shot of credit card show page](https://user-images.githubusercontent.com/7103652/139329634-75bc5058-5610-48b5-8d3a-6e04114e6f80.png)
