### PR TITLE
[#158849] Fix card number and iclass indexes for mysql

### DIFF
--- a/vendor/engines/secure_rooms/app/models/secure_rooms/user_extension.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/user_extension.rb
@@ -7,11 +7,19 @@ module SecureRooms
     extend ActiveSupport::Concern
 
     included do
+      NULL_ATTRS = %w(card_number i_class_number)
+
+      before_save :nil_if_blank
+
       validates :card_number, uniqueness: { allow_blank: true, case_sensitive: false }
       validates :i_class_number, uniqueness: { allow_blank: true, case_sensitive: false }
 
       def self.for_card_number(card_number)
         find_by(card_number: card_number) || find_by(card_number: card_number.split("-").first)
+      end
+
+      def nil_if_blank
+        NULL_ATTRS.each { |attr| self[attr] = nil if self[attr].blank? }
       end
     end
 

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/user_extension.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/user_extension.rb
@@ -7,9 +7,6 @@ module SecureRooms
     extend ActiveSupport::Concern
 
     included do
-      NULL_ATTRS = %w(card_number i_class_number)
-
-      before_save :nil_if_blank
 
       validates :card_number, uniqueness: { allow_blank: true, case_sensitive: false }
       validates :i_class_number, uniqueness: { allow_blank: true, case_sensitive: false }
@@ -18,9 +15,15 @@ module SecureRooms
         find_by(card_number: card_number) || find_by(card_number: card_number.split("-").first)
       end
 
-      def nil_if_blank
-        NULL_ATTRS.each { |attr| self[attr] = nil if self[attr].blank? }
+      # MySQL uniqueness constraints don't apply to NULL values
+      def card_number=(value)
+        super value.presence
       end
+
+      def i_class_number=(value)
+        super value.presence
+      end
+
     end
 
   end

--- a/vendor/engines/secure_rooms/spec/models/user_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/user_spec.rb
@@ -6,8 +6,17 @@ RSpec.describe User do
   subject!(:user) { create(:user, :netid, card_number: card_number) }
   let(:card_number) { "abcXYZ" }
 
-  it { is_expected.to validate_uniqueness_of(:card_number).case_insensitive }
-  it { is_expected.to validate_uniqueness_of(:i_class_number).case_insensitive }
+
+  describe "validations" do
+    let!(:other_user) { create(:user, :netid, card_number: "", i_class_number: "") }
+
+    it { is_expected.to validate_uniqueness_of(:card_number).case_insensitive }
+    it { is_expected.to validate_uniqueness_of(:i_class_number).case_insensitive }
+
+    it "doesn't error on empty string" do
+      expect{ create(:user, :netid, card_number: "", i_class_number: "") }.not_to raise_error
+    end
+  end
 
   describe ".for_card_number" do
     context "when user's card number has facility number" do


### PR DESCRIPTION
Oracle doesn't consider an empty string when enforcing uniqueness, but MySQL does
https://decipherinfosys.wordpress.com/2007/11/30/multiple-null-values-in-a-unique-index-in-sql-serverdb2-luw/

This prevents saving empty strings to the database, since MySQL enforces uniqueness to non-NULL values.