### PR TITLE
Tech task - Update template and readme to use port 636 instead of 389 for LDAP

### DIFF
--- a/config/ldap.yml.template
+++ b/config/ldap.yml.template
@@ -2,12 +2,12 @@
 #
 # Required settings:
 #   'host' => Host of local LDAP server
-#   'port'  => Port of local LDAP server (usually port 389)
+#   'port'  => Port of local LDAP server (usually port 636)
 #   'base' => Base Distinguished Name (Base DN)
 #
 development:
   host: <%= ENV.fetch("LDAP_HOST", "localhost") %>
-  port: <%= ENV.fetch("LDAP_PORT", 389) %>
+  port: <%= ENV.fetch("LDAP_PORT", 636) %>
   base: dc=example,dc=org
   username_attribute: uid
   admin_user: "cn=admin,dc=example,dc=org"

--- a/vendor/engines/ldap_authentication/README.md
+++ b/vendor/engines/ldap_authentication/README.md
@@ -20,7 +20,7 @@ The example config file provided with NUcore is enough to get started:
 cp config/ldap.yml.template config/ldap.yml
 ```
 
-The default settings are for an LDAP server running on `localhost` port 389,
+The default settings are for an LDAP server running on `localhost` port 636,
 which should work for the test LDAP server described below.
 
 Change the `host:` value if you are using an external LDAP server.
@@ -60,7 +60,7 @@ The easiest thing to do is add an LDAP server in `docker-compose`.
     image: osixia/openldap
     command: "--copy-service"
     ports:
-      - "389:389"
+      - "636:636"
     volumes:
       - "ldap-data:/var/lib/ldap"
       - "slapd-config:/etc/ldap/slapd.d"


### PR DESCRIPTION
# Release Notes

We should use port 636 in development, this is what NU is using.