### PR TITLE
[#158518] Use updated version of activerecord-oracle_enhanced-adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,7 @@ gem "rack-utf8_sanitizer"
 ## database
 gem "mysql2"
 # To use Oracle, remove the mysql2 gem above and uncomment these lines
-# There are fixes for fulltext indexing in the 6.0 master of the gem, but we need
-# to backport them to support 5.2.
-# gem "activerecord-oracle_enhanced-adapter", git: "https://github.com/jhanggi/oracle-enhanced", branch: "release52"
+# gem "activerecord-oracle_enhanced-adapter", "~> 6.0.0"
 # gem "ruby-oci8" # only for CRuby users
 
 


### PR DESCRIPTION
# Release Notes

Migration failed when merging in the rails 6.0 branch to NU.

Addresses:
```
bundle exec rake db:create db:schema:load

Created database '//localhost:1521/ORCLCDB.localdomain'
rake aborted!
ArgumentError: wrong number of arguments (given 4, expected 2)
/home/circleci/project/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract/schema_definitions.rb:266:in `initialize'
```

Supports https://github.com/tablexi/nucore-nu/pull/760