### PR TITLE
[#158793] Check the connection every 6 hours

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -10,6 +10,10 @@ require File.expand_path(File.dirname(__FILE__) + "/environment")
 # still sent via email to sysadmins
 job_type :rake, "cd :path && :environment_variable=:environment bundle exec rake :task :output"
 
+every 6.hours, roles: [:db] do
+  rake "check_connection"
+end
+
 every 5.minutes, roles: [:db] do
   command "curl --silent -X POST #{Rails.application.routes.url_helpers.admin_services_process_five_minute_tasks_url}"
 end

--- a/lib/tasks/check_connection.rake
+++ b/lib/tasks/check_connection.rake
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Every 1 and 5 minutes the system sends itself a curl command.
+# If curl commands from the server to itself are failing, we want to know.
+# See config/schedule.rb
+desc "confirm HTTP calls are getting through to the server"
+task check_connection: :environment do
+  root_url = Rails.application.routes.url_helpers.root_url
+  uri = URI(root_url)
+  begin
+    response = Net::HTTP.get_response(uri)
+  rescue => e
+    if defined?(Rollbar)
+      Rollbar.error("Connection check failed, are the 1 and 5 minute tasks running?", message: e.message)
+    else
+      Rails.logger.error("Connection check failed, are the 1 and 5 minute tasks running?", message: e.message)
+    end
+  end
+end


### PR DESCRIPTION
Gives us early warning if something goes wrong with curl commands from the server to itself
For UMass this currently fails with:
`SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)`

NOTE:
Instances hosted on k8s don't use the `whenever` gem.  
I think the `CronJob` objects will complain if they fail, but haven't looked into it or tested.