### PR TITLE
[#158114] Improve error handling for order import

### DIFF
--- a/app/models/order_import.rb
+++ b/app/models/order_import.rb
@@ -113,7 +113,7 @@ class OrderImport < ApplicationRecord
   def handle_save_nothing_on_error # TODO: refactor and rename
     Order.transaction do
       begin
-        CSV.parse(upload_file.read, headers: true, skip_lines: /^,*$/).each do |row|
+        csv.each do |row|
           row_importer = import_row(row)
           self.error_report += row_importer.row_with_errors.to_csv
 
@@ -178,7 +178,7 @@ class OrderImport < ApplicationRecord
 
   def rows_by_order_key # TODO: refactor
     rows = Hash.new { |hash, key| hash[key] = [] }
-    CSV.parse(upload_file.read, headers: true, skip_lines: /^,*$/).each do |row|
+    csv.each do |row|
       order_key = OrderRowImporter.order_key_for_row(row)
       rows[order_key] << row
     end
@@ -210,6 +210,10 @@ class OrderImport < ApplicationRecord
 
   def upload_file_path
     @upload_file_path ||= upload_file.file.path
+  end
+
+  def csv
+    @csv ||= CSV.parse(upload_file.read, headers: true, skip_blanks: true)
   end
 
   class Result

--- a/app/services/order_row_importer.rb
+++ b/app/services/order_row_importer.rb
@@ -193,12 +193,20 @@ class OrderRowImporter
   end
 
   def validate_fields
-    validate_fulfillment_date
-    validate_order_date
-    validate_user
-    validate_product
-    validate_account
-    validate_existing_order
+    if empty_row?
+      add_error(:blank)
+    else
+      validate_fulfillment_date
+      validate_order_date
+      validate_user
+      validate_product
+      validate_account
+      validate_existing_order
+    end
+  end
+
+  def empty_row?
+    @row.to_h.values.all?(&:blank?)
   end
 
   def validate_fulfillment_date

--- a/app/services/order_row_importer.rb
+++ b/app/services/order_row_importer.rb
@@ -205,8 +205,12 @@ class OrderRowImporter
     end
   end
 
+  # When skip_blanks is set to true, CSV will skip over empty rows,
+  # but it doesn't skip rows that contain column separators,
+  # even if the rows contain no actual data
+  # see https://ruby-doc.org/stdlib-2.6.1/libdoc/csv/rdoc/CSV.html#method-c-new
   def empty_row?
-    @row.to_h.values.all?(&:blank?)
+    @row.fields.compact.empty?
   end
 
   def validate_fulfillment_date

--- a/config/locales/services/en.order_row_importer.yml
+++ b/config/locales/services/en.order_row_importer.yml
@@ -6,6 +6,7 @@ en:
       notes: Note
       reference_id: Reference ID
     errors:
+      blank: All fields are empty
       purchase_fail: Couldn't purchase order
       validate_fail: Couldn't validate order
       invalid_date: "Invalid %{field}: Please use MM/DD/YYYY format"

--- a/spec/services/order_row_importer_spec.rb
+++ b/spec/services/order_row_importer_spec.rb
@@ -105,6 +105,29 @@ RSpec.describe OrderRowImporter do
       end
     end
 
+    context "with an empty row" do
+      let(:username) { nil }
+      let(:chart_string) { nil }
+      let(:product_name) { nil }
+      let(:quantity) { nil }
+      let(:order_date) { nil }
+      let(:fulfillment_date) { nil }
+      let(:notes) { nil }
+      let(:order_number) { nil }
+      let(:reference_id) { nil }
+
+      before(:each) do
+        allow_any_instance_of(Product).to receive(:can_purchase?).and_return(true)
+      end
+
+      it_behaves_like "an order was not created"
+
+      it "has an error message" do
+        subject.import
+        expect(subject.errors).to eq(["All fields are empty"])
+      end
+    end
+
     context "when the reference_id field is missing" do
       include_context "valid row values"
       let(:reference_id) { "" }


### PR DESCRIPTION
# Release Notes

Use `skip_blanks` instead of `skip_lines`.
For some reason `skip_lines` is more brittle, and can cause the process to stall until the DelayedJob worker times out (4 hrs).

From the [Ruby CSV documentation](https://ruby-doc.org/stdlib-2.6.1/libdoc/csv/rdoc/CSV.html#method-c-new):
"When setting a true value, CSV will skip over any empty rows. Note that this setting will not skip rows that contain column separators, even if the rows contain no actual data."