### PR TITLE
Fix reconcile note bug, add specs

### DIFF
--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -46,7 +46,7 @@ module OrderDetails
     def reconcile(order_detail, params)
       order_detail.reconciled_at = @reconciled_at
       order_detail.assign_attributes(allowed(params))
-      order_detail.reconciled_note = @bulk_reconcile_note if @bulk_reconcile_note
+      order_detail.reconciled_note = @bulk_reconcile_note if @bulk_reconcile_note.present?
       order_detail.change_status!(OrderStatus.reconciled)
       @count += 1
     rescue => e

--- a/spec/services/order_details/reconciler_spec.rb
+++ b/spec/services/order_details/reconciler_spec.rb
@@ -32,6 +32,47 @@ RSpec.describe OrderDetails::Reconciler do
         end
       end
     end
+
+    context "with NO bulk note" do
+      context "with reconciled note set" do
+        let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "" ) }
+        let(:params) { order_details.each_with_object({}) { |od, h| h[od.id.to_s] = ActionController::Parameters.new(reconciled: "1", reconciled_note: "note #{od.id}") } }
+
+        it "adds the note to the appropriate order details" do
+          reconciler.reconcile_all
+          order_details.each do |od|
+            expect(od.reload.reconciled_note).to eq("note #{od.id}")
+          end
+        end
+      end
+
+      context "with NO reconciled note set" do
+        let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "" ) }
+
+        it "does not set a value" do
+          reconciler.reconcile_all
+          order_details.each do |od|
+            expect(od.reload.reconciled_note).to eq(nil)
+          end
+        end
+      end
+
+      context "with previous reconciled note value, no new value set" do
+        let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "" ) }
+        before(:each) do
+          order_details.each do |od|
+            od.update!(reconciled_note: "rec note #{od.id}")
+          end
+        end
+
+        it "does not change the reconciled note" do
+          reconciler.reconcile_all
+          order_details.each do |od|
+            expect(od.reload.reconciled_note).to eq("rec note #{od.id}")
+          end
+        end
+      end
+    end
   end
 
   # describe "reconciling more than 1000 order details (because of oracle)" do

--- a/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
+++ b/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
@@ -59,9 +59,11 @@ RSpec.describe "Account Reconciliation" do
       check "order_detail_#{order_detail.id}_reconciled"
 
       fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
+      fill_in "order_detail_#{order_detail.id}_reconciled_note", with: "this is a note!"
       click_button "Reconcile Orders", match: :first
 
       expect(order_detail.reload).to be_reconciled
+      expect(order_detail.reconciled_note).to eq("this is a note!")
       expect(order_detail.reconciled_at).to eq(1.day.ago.beginning_of_day)
     end
 
@@ -88,7 +90,7 @@ RSpec.describe "Account Reconciliation" do
     let(:order_number) { "##{orders.first.id} - #{orders.first.order_details.first.id}" }
     let(:other_order_number) { "##{orders.last.id} - #{orders.last.order_details.first.id}" }
 
-    it "can search and then reconcile a credit card order" do
+    it "can search and then reconcile a PO order" do
       visit facility_notifications_path(facility)
       click_link "Reconcile Purchase Orders"
 
@@ -102,9 +104,11 @@ RSpec.describe "Account Reconciliation" do
 
       check "order_detail_#{order_detail.id}_reconciled"
       fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
+      fill_in "order_detail_#{order_detail.id}_reconciled_note", with: "this is a note!"
       click_button "Reconcile Orders", match: :first
 
       expect(order_detail.reload).to be_reconciled
+      expect(order_detail.reconciled_note).to eq("this is a note!")
       expect(order_detail.reconciled_at).to eq(1.day.ago.beginning_of_day)
     end
 


### PR DESCRIPTION
# Release Notes

In [#142337] Implements bulk reconcile note (tablexi/nucore-open#2710) we introduced a regression that causes individually applied reconcile notes to not be saved to the db.