### PR TITLE
[#159023] Only apply bulk reconcile note when the bulk note checkbox has been checked

### DIFF
--- a/app/controllers/facility_accounts_reconciliation_controller.rb
+++ b/app/controllers/facility_accounts_reconciliation_controller.rb
@@ -32,7 +32,13 @@ class FacilityAccountsReconciliationController < ApplicationController
 
   def update
     reconciled_at = parse_usa_date(params[:reconciled_at])
-    reconciler = OrderDetails::Reconciler.new(unreconciled_details, params[:order_detail], reconciled_at, params[:bulk_reconcile_note])
+    reconciler = OrderDetails::Reconciler.new(
+      unreconciled_details,
+      params[:order_detail],
+      reconciled_at,
+      params[:bulk_reconcile_note],
+      params[:bulk_note_checkbox],
+    )
 
     if reconciler.reconcile_all > 0
       count = reconciler.count

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -12,11 +12,11 @@ module OrderDetails
     validate :reconciliation_must_be_in_past
     validate :all_journals_and_statements_must_be_before_reconciliation_date
 
-    def initialize(order_detail_scope, params, reconciled_at, bulk_reconcile_note = nil)
+    def initialize(order_detail_scope, params, reconciled_at, bulk_reconcile_note = nil, bulk_reconcile_checkbox = nil)
       @params = params || ActionController::Parameters.new
       @order_details = order_detail_scope.readonly(false).find_ids(to_be_reconciled.keys)
       @reconciled_at = reconciled_at
-      @bulk_reconcile_note = bulk_reconcile_note
+      @bulk_reconcile_note = bulk_reconcile_note if bulk_reconcile_checkbox == "1"
     end
 
     def reconcile_all

--- a/app/views/facility_accounts_reconciliation/_action_row.html.haml
+++ b/app/views/facility_accounts_reconciliation/_action_row.html.haml
@@ -10,9 +10,9 @@
         = text_field_tag :reconciled_at, format_usa_date(Time.current), class: :datepicker__data, data: { min_date: unreconciled_order_details.map(&:journal_or_statement_date).min.iso8601, max_date: Time.current.iso8601 }
   .row.table-actions.form-horizontal
     .span3.control-group.fields
-      %label.control-label{ for: "bulk-note-checkbox" }= t("facility_accounts_reconciliation.index.bulk_note_checkbox")
+      %label.control-label{ for: "bulk_note_checkbox" }= t("facility_accounts_reconciliation.index.bulk_note_checkbox")
       .controls
-        = check_box_tag :bulk_note_checkbox, 0, false, id: "bulk-note-checkbox"
+        = check_box_tag :bulk_note_checkbox
     #bulk-note-input.span5.control-group.fields
       %label.control-label{ for: :bulk_reconcile_note }= t("facility_accounts_reconciliation.index.bulk_note")
       .controls

--- a/spec/services/order_details/reconciler_spec.rb
+++ b/spec/services/order_details/reconciler_spec.rb
@@ -23,12 +23,25 @@ RSpec.describe OrderDetails::Reconciler do
     end
 
     context "with a bulk note" do
-      let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "this is a bulk note" ) }
+      context "bulk note checkbox checked" do
+        let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "this is a bulk note", "1") }
 
-      it "adds the note to all order details" do
-        reconciler.reconcile_all
-        order_details.each do |od|
-          expect(od.reload.reconciled_note).to eq("this is a bulk note")
+        it "adds the note to all order details" do
+          reconciler.reconcile_all
+          order_details.each do |od|
+            expect(od.reload.reconciled_note).to eq("this is a bulk note")
+          end
+        end
+      end
+
+      context "bulk note checkbox UNchecked" do
+        let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "this is a bulk note") }
+
+        it "does NOT add the note to the order details" do
+          reconciler.reconcile_all
+          order_details.each do |od|
+            expect(od.reload.reconciled_note).to eq(nil)
+          end
         end
       end
     end

--- a/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
+++ b/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
@@ -67,19 +67,37 @@ RSpec.describe "Account Reconciliation" do
       expect(order_detail.reconciled_at).to eq(1.day.ago.beginning_of_day)
     end
 
-    it "can take a bulk reconciliation note" do
-      visit credit_cards_facility_accounts_path(facility)
-      click_link "Reconcile Credit Cards"
+    context "with bulk reconciliation note" do
+      it "sets the note when checkbox is checked" do
+        visit credit_cards_facility_accounts_path(facility)
+        click_link "Reconcile Credit Cards"
 
-      check "Use Bulk Note"
-      fill_in "Bulk Reconciliation Note", with: "this is the bulk note"
-      check "order_detail_#{order_detail.id}_reconciled"
-      check "order_detail_#{orders.last.order_details.first.id}_reconciled"
-      fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
-      click_button "Reconcile Orders", match: :first
+        check "Use Bulk Note"
+        fill_in "Bulk Reconciliation Note", with: "this is the bulk note"
+        check "order_detail_#{order_detail.id}_reconciled"
+        check "order_detail_#{orders.last.order_details.first.id}_reconciled"
+        fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
+        click_button "Reconcile Orders", match: :first
 
-      expect(order_detail.reload.reconciled_note).to eq("this is the bulk note")
-      expect(orders.last.order_details.first.reload.reconciled_note).to eq("this is the bulk note")
+        expect(order_detail.reload.reconciled_note).to eq("this is the bulk note")
+        expect(orders.last.order_details.first.reload.reconciled_note).to eq("this is the bulk note")
+      end
+
+      it "does NOT set the note when checkbox is NOT checked" do
+        visit credit_cards_facility_accounts_path(facility)
+        click_link "Reconcile Credit Cards"
+
+        check "Use Bulk Note"
+        fill_in "Bulk Reconciliation Note", with: "this is the bulk note"
+        uncheck "Use Bulk Note"
+        check "order_detail_#{order_detail.id}_reconciled"
+        check "order_detail_#{orders.last.order_details.first.id}_reconciled"
+        fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
+        click_button "Reconcile Orders", match: :first
+
+        expect(order_detail.reload.reconciled_note).to eq("")
+        expect(orders.last.order_details.first.reload.reconciled_note).to eq("")
+      end
     end
   end
 


### PR DESCRIPTION
# Release Notes
This PR adds logic to account for the bulk note checkbox value when determining how to update order detail records.  
Also changes the bulk note checkbox checked value from `"0"` to `"1"`.  The value is not sent in params when unchecked.

Handles the following edge case:
- User checks the bulk note checkbox
- User enters a bulk note
- User unchecks the bulk note checkbox
- User reconciles transactions

In this case the bulk note will not be applied, which is the expected behavior. 