### PR TITLE
[#159023] Fix bulk note checkbox

### DIFF
--- a/app/assets/javascripts/bulk_note.js
+++ b/app/assets/javascripts/bulk_note.js
@@ -1,5 +1,5 @@
 $(document).ready(function() {
-  var bulkNoteCheckbox = $('#bulk-note-checkbox');
+  var bulkNoteCheckbox = $('#bulk_note_checkbox');
   var bulkNoteInput = $('#bulk-note-input');
   bulkNoteInput.hide()
   var rowNoteInputs = $('.row-note-input')

--- a/app/assets/javascripts/bulk_note.js
+++ b/app/assets/javascripts/bulk_note.js
@@ -1,8 +1,8 @@
 $(document).ready(function() {
-  var bulkNoteCheckbox = $('#bulk_note_checkbox');
-  var bulkNoteInput = $('#bulk-note-input');
+  var bulkNoteCheckbox = $("#bulk_note_checkbox");
+  var bulkNoteInput = $("#bulk-note-input");
   bulkNoteInput.hide()
-  var rowNoteInputs = $('.row-note-input')
+  var rowNoteInputs = $(".row-note-input")
 
   bulkNoteCheckbox.change(function(e){
     if (bulkNoteCheckbox[0].checked === true){

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,9 +48,9 @@ RSpec.configure do |config|
   # Based on https://medium.com/@coorasse/catch-javascript-errors-in-your-system-tests-89c2fe6773b1
   config.after(:each, type: :system, js: true) do |example|
     unless ENV['DOCKER']
-      # Must call page.driver.browser.manage.logs.get(:browser) after every run,
+      # Must call page.driver.browser.logs.get(:browser) after every run,
       # otherwise the logs don't get cleared and leak into other specs.
-      js_errors = page.driver.browser.manage.logs.get(:browser)
+      js_errors = page.driver.browser.logs.get(:browser)
       # Some forms using remote: true return a 406 that is expected
       unless example.metadata[:ignore_js_errors]
         js_errors.each do |error|

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -2,13 +2,13 @@
 
 # Allow running system specs with JS enabled and still access 'chosen' select inputs
 def select_from_chosen(item_text, options)
-    field = find_field(options[:from], visible: false)
-    option_value = page.evaluate_script("$(\"##{field[:id]} option:contains('#{item_text}')\").val()")
-    page.execute_script("value = ['#{option_value}']\; if ($('##{field[:id]}').val()) {$.merge(value, $('##{field[:id]}').val())}")
-    option_value = page.evaluate_script("value")
-    page.execute_script("$('##{field[:id]}').val(#{option_value})")
-    page.execute_script("$('##{field[:id]}').trigger('chosen:updated')")
-  end
+  field = find_field(options[:from], visible: false)
+  option_value = page.evaluate_script("$(\"##{field[:id]} option:contains('#{item_text}')\").val()")
+  page.execute_script("value = ['#{option_value}']\; if ($('##{field[:id]}').val()) {$.merge(value, $('##{field[:id]}').val())}")
+  option_value = page.evaluate_script("value")
+  page.execute_script("$('##{field[:id]}').val(#{option_value})")
+  page.execute_script("$('##{field[:id]}').trigger('chosen:updated')")
+end
 
 #
 # Asserts that the model +var+

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# Allow running system specs with JS enabled and still access 'chosen' select inputs
+def select_from_chosen(item_text, options)
+    field = find_field(options[:from], visible: false)
+    option_value = page.evaluate_script("$(\"##{field[:id]} option:contains('#{item_text}')\").val()")
+    page.execute_script("value = ['#{option_value}']\; if ($('##{field[:id]}').val()) {$.merge(value, $('##{field[:id]}').val())}")
+    option_value = page.evaluate_script("value")
+    page.execute_script("$('##{field[:id]}').val(#{option_value})")
+    page.execute_script("$('##{field[:id]}').trigger('chosen:updated')")
+  end
+
 #
 # Asserts that the model +var+
 # no longer exists in the DB

--- a/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
+++ b/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Account Reconciliation" do
+RSpec.describe "Account Reconciliation", js: true do
   let(:facility) { create(:setup_facility) }
   let(:item) { create(:setup_item, facility: facility) }
   let(:orders) do
@@ -39,19 +39,19 @@ RSpec.describe "Account Reconciliation" do
       expect(page).to have_content(order_number)
       expect(page).to have_content(other_order_number)
 
-      select accounts.first.account_list_item, from: "Payment Sources"
+      select_from_chosen accounts.first.account_list_item, from: "Payment Sources"
       click_button "Filter"
       expect(page).to have_content(order_number)
       expect(page).not_to have_content(other_order_number)
 
       visit credit_cards_facility_accounts_path(facility)
-      select accounts.first.owner_user.full_name, from: "Owners"
+      select_from_chosen accounts.first.owner_user.full_name, from: "Owners"
       click_button "Filter"
       expect(page).to have_content(order_number)
       expect(page).not_to have_content(other_order_number)
 
       visit credit_cards_facility_accounts_path(facility)
-      select statements.first.invoice_number, from: "Statements"
+      select_from_chosen statements.first.invoice_number, from: "Statements"
       click_button "Filter"
       expect(page).to have_content(order_number)
       expect(page).not_to have_content(other_order_number)
@@ -115,7 +115,7 @@ RSpec.describe "Account Reconciliation" do
       expect(page).to have_content(order_number)
       expect(page).to have_content(other_order_number)
 
-      select accounts.first.account_list_item, from: "Payment Sources"
+      select_from_chosen accounts.first.account_list_item, from: "Payment Sources"
       click_button "Filter"
       expect(page).to have_content(order_number)
       expect(page).not_to have_content(other_order_number)


### PR DESCRIPTION
# Release Notes

Use the correct selector to hide/show bulk note input.

Also:
- Enable JS for system spec
- Address capybara deprecation message `WARN Selenium [DEPRECATION] Manager#logs is deprecated. Use Chrome::Driver#logs instead.`
- Add a `select_from_chosen` helper method