### PR TITLE
[#158344] Remove global banner view hook

### DIFF
--- a/app/models/concerns/products/relay_support.rb
+++ b/app/models/concerns/products/relay_support.rb
@@ -5,7 +5,7 @@ module Products::RelaySupport
   extend ActiveSupport::Concern
 
   included do
-    has_one  :relay, inverse_of: :instrument, dependent: :destroy
+    has_one :relay, inverse_of: :instrument, dependent: :destroy
     has_many :instrument_statuses, foreign_key: "instrument_id", inverse_of: :instrument
 
     accepts_nested_attributes_for :relay

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,6 @@
   %body{ class: SettingsHelper.feature_on?(:use_manage) && manage_mode? ? "manage-mode" : "" }
     %header
       = render "/shared/acting_as"
-      = render_view_hook("banner")
       = yield(:banner)
       = render "/shared/header"
     %nav


### PR DESCRIPTION
Only used for Dartmouth's login deprecation warning for non SSO users,
which is removed in https://github.com/tablexi/nucore-dartmouth/pull/379
