### PR TITLE
Add patch for oracle-enhanced adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "rack-utf8_sanitizer"
 ## database
 gem "mysql2"
 # To use Oracle, remove the mysql2 gem above and uncomment these lines
+# TODO - remove patch in oracle.rb when we upgrade to rails 6.1
 # gem "activerecord-oracle_enhanced-adapter", "~> 6.0.0"
 # gem "ruby-oci8" # only for CRuby users
 

--- a/app/assets/javascripts/power_relay.js
+++ b/app/assets/javascripts/power_relay.js
@@ -1,4 +1,4 @@
-// Used on the instrument manage page
+// Used on the instrument Relays tab
 $(function() {
   var power_relay_section = $('#power-relay')
     , instrument_control_mechanism = $('#relay_control_mechanism');

--- a/config/initializers/oracle.rb
+++ b/config/initializers/oracle.rb
@@ -18,3 +18,52 @@ if defined?(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
   # tell it what to do.
   OCI8::BindType::Mapping["ActiveSupport::SafeBuffer"] = OCI8::BindType::String
 end
+
+# TODO - Remove patch after upgrading to rails 6.1
+# Jason's fix didn't make it into 6.0
+# https://githubmemory.com/repo/rsim/oracle-enhanced/issues/1985
+# https://github.com/rsim/oracle-enhanced/commit/b88deba791f0e00b6ab0f252cb3662aaa9536465
+# https://github.com/jhanggi/oracle-enhanced/pull/1
+if defined?(ActiveRecord::ConnectionAdapters::OracleEnhanced::SchemaDumper)
+  ActiveRecord::ConnectionAdapters::OracleEnhanced::SchemaDumper.class_eval do
+    def _indexes(table, stream)
+      if (indexes = @connection.indexes(table)).any?
+        add_index_statements = indexes.map do |index|
+          case index.type
+          when nil
+            # do nothing here. see indexes_in_create
+            statement_parts = []
+          when "CTXSYS.CONTEXT"
+            if index.statement_parameters
+              statement_parts = [ ("add_context_index " + remove_prefix_and_suffix(table).inspect) ]
+              statement_parts << index.statement_parameters
+            else
+              statement_parts = [ ("add_context_index " + remove_prefix_and_suffix(table).inspect) ]
+              statement_parts << index.columns.inspect
+              statement_parts << ("sync: " + $1.inspect) if index.parameters =~ /SYNC\((.*?)\)/
+              statement_parts << ("name: " + index.name.inspect)
+            end
+          else
+            # unrecognized index type
+            statement_parts = ["# unrecognized index #{index.name.inspect} with type #{index.type.inspect}"]
+          end
+          "  " + statement_parts.join(", ") unless statement_parts.empty?
+        end.compact
+
+        return if add_index_statements.empty?
+
+        stream.puts add_index_statements.sort.join("\n")
+        stream.puts
+      end
+    end
+
+    def indexes_in_create(table, stream)
+      if (indexes = @connection.indexes(table)).any?
+        index_statements = indexes.map do |index|
+          "    t.index #{index_parts(index).join(', ')}" unless index.type == "CTXSYS.CONTEXT"
+        end
+        stream.puts index_statements.compact.sort.join("\n")
+      end
+    end
+  end
+end


### PR DESCRIPTION
@jhanggi fixed some issues that were merged in to 6.1:
https://github.com/jhanggi/oracle-enhanced/pull/1

This is just adding those changes in as a patch.  This is only in use by NU:
https://github.com/tablexi/nucore-nu/pull/771