### PR TITLE
[#159184] Don't pass nil as a possible mime type

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -203,7 +203,8 @@ class ApplicationController < ActionController::Base
   end
 
   def formats_with_html_fallback
-    request.formats.map(&:symbol) + [:html]
+    # request.formats returns a collection of Mime::Type objects, which can have nil value for @symbol
+    request.formats.map(&:symbol).compact + [:html]
   end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -203,8 +203,9 @@ class ApplicationController < ActionController::Base
   end
 
   def formats_with_html_fallback
-    # request.formats returns a collection of Mime::Type objects, which can have nil value for @symbol
-    request.formats.map(&:symbol).compact + [:html]
+    # request.formats returns a collection of Mime::Type objects
+    # Mime::Type#ref returns a symbol or string, and string must be a valid Mime type
+    request.formats.map(&:ref) + [:html]
   end
 
 end


### PR DESCRIPTION
Addresses ArgumentError: Invalid formats: nil
Silently ignored before rails 6.0
https://github.com/rails/rails/commit/0eb9e1e51a9df554e1cf7a42ec339ca6f0120a04#

Tested locally by patching `formats_with_html_fallback`:
```
  def formats_with_html_fallback
    [nil] + [:html]
  end
```
... when clicking something I can't see while "acting as" another user:
```
  rescue_from NUCore::NotPermittedWhileActingAs, with: :render_acting_error
  def render_acting_error
    render "/acting_error", status: 403, layout: "application", formats: formats_with_html_fallback
  end
```
... the call to render raises `ArgumentError: Invalid formats: nil`.

