### PR TITLE
[#155286] Fix split calculations for order detail table

### DIFF
--- a/app/assets/javascripts/app/manage_orders.js
+++ b/app/assets/javascripts/app/manage_orders.js
@@ -120,32 +120,31 @@ class OrderDetailManagement {
       const row = $(this).closest('.cost-table');
       const total = row.find('.cost input').val() - row.find('.subsidy input').val();
       row.find('.total input').val(total.toFixed(2));
-      // update split values
-      const splitUpdateData = []
-      for (let field of $('.split-cost')) {
-        splitUpdateData.push({
-          field: field,
-          // round down to handle remainders
-          total: Math.floor(total * field.dataset.percent) / 100,
-          applyRemainder: field.dataset.applyRemainder
-        })
-      };
 
-      // Add up each split accounts' total;
-      // Any difference with the original total is applied to the "Apply Remainder" acct
-      const newTotal = splitUpdateData.reduce((prev, splitData) => prev + splitData.total, 0)
-      const remainder = total - newTotal
-      splitUpdateData.forEach(function(splitData) {
-        var newSplitTotal = splitData.total
+      // update split table values
+      self.updateSplitValues(total);
 
-        if (splitData.applyRemainder === 'true' && remainder != 0) {
-          newSplitTotal += remainder
-        }
-        splitData.field.innerHTML = '$' + (newSplitTotal).toFixed(2)
-      });
       // notify page of changes
-      self.notifyOfUpdate($('.split-table'))
+      self.notifyOfUpdate($('.split-table'));
       return self.notifyOfUpdate($(row).find('input[name*=total]'));
+    });
+  }
+
+  updateSplitValues(total) {
+    const splitUpdateFields = $('.split-cost').toArray();
+    const splitTotal = (percent) => Math.floor(total * percent) / 100;
+    const reducer = (prev, splitField) => prev + splitTotal(splitField.dataset.percent);
+    // Add up each split accounts' total
+    const splitsTotalAmount = splitUpdateFields.reduce(reducer, 0);
+    // Any remaining pennies are added to the "Apply Remainder" account.
+    const remainder = total - splitsTotalAmount;
+
+    splitUpdateFields.forEach(function(splitField) {
+      var newSplitAmount = splitTotal(splitField.dataset.percent);
+      if (splitField.dataset.applyRemainder === 'true' && remainder != 0) {
+        newSplitAmount += remainder;
+      }
+      splitField.innerHTML = '$' + (newSplitAmount).toFixed(2);
     });
   }
 

--- a/app/assets/javascripts/app/manage_orders.js
+++ b/app/assets/javascripts/app/manage_orders.js
@@ -121,19 +121,28 @@ class OrderDetailManagement {
       const total = row.find('.cost input').val() - row.find('.subsidy input').val();
       row.find('.total input').val(total.toFixed(2));
       // update split values
+      const splitUpdateData = []
       for (let field of $('.split-cost')) {
-        const splitCount = 100 / field.dataset.percent
-        const totalPennies = total * 100;
-        // round down to handle remainders
-        var newSplit = Math.floor(totalPennies / splitCount);
-
-        const remainder = (totalPennies % splitCount);
-        if (remainder && field.dataset.applyRemainder === 'true') {
-          // add an extra penny
-          newSplit += 1
-        }
-        field.innerHTML = '$' + (newSplit / 100).toFixed(2)
+        splitUpdateData.push({
+          field: field,
+          // round down to handle remainders
+          total: Math.floor(total * field.dataset.percent) / 100,
+          applyRemainder: field.dataset.applyRemainder
+        })
       };
+
+      // Add up each split accounts' total;
+      // Any difference with the original total is applied to the "Apply Remainder" acct
+      const newTotal = splitUpdateData.reduce((prev, splitData) => prev + splitData.total, 0)
+      const remainder = total - newTotal
+      splitUpdateData.forEach(function(splitData) {
+        var newSplitTotal = splitData.total
+
+        if (splitData.applyRemainder === 'true' && remainder != 0) {
+          newSplitTotal += remainder
+        }
+        splitData.field.innerHTML = '$' + (newSplitTotal).toFixed(2)
+      });
       // notify page of changes
       self.notifyOfUpdate($('.split-table'))
       return self.notifyOfUpdate($(row).find('input[name*=total]'));

--- a/app/assets/javascripts/app/manage_orders.js
+++ b/app/assets/javascripts/app/manage_orders.js
@@ -122,14 +122,15 @@ class OrderDetailManagement {
       row.find('.total input').val(total.toFixed(2));
       // update split values
       for (let field of $('.split-cost')) {
-        const splitCount = Math.round(100 / field.dataset.percent)
+        const splitCount = 100 / field.dataset.percent
         const totalPennies = total * 100;
         // round down to handle remainders
         var newSplit = Math.floor(totalPennies / splitCount);
 
-        if (field.dataset.applyRemainder === 'true') {
-          const remainder = (totalPennies % splitCount);
-          newSplit += remainder
+        const remainder = (totalPennies % splitCount);
+        if (remainder && field.dataset.applyRemainder === 'true') {
+          // add an extra penny
+          newSplit += 1
         }
         field.innerHTML = '$' + (newSplit / 100).toFixed(2)
       };

--- a/app/assets/stylesheets/app/order_management.scss
+++ b/app/assets/stylesheets/app/order_management.scss
@@ -97,7 +97,7 @@
 
     th {
       text-align: left;
-      width: 88%;
+      padding-right: 0.5em;
     }
   }
 

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -17,6 +17,15 @@ module AccountsHelper
     end
   end
 
+  def split_account_link_or_text(account, percent)
+    acct_desc = "#{account.description_to_s} (#{percent}%)"
+    if current_ability.can?(:edit, account)
+      link_to acct_desc, facility_account_path(current_facility, account)
+    else
+      acct_desc
+    end
+  end
+
   def show_account_facilities_tab?(ability, account)
     SettingsHelper.feature_on?(:multi_facility_accounts) && account.per_facility? && ability.can?(:edit, AccountFacilityJoinsForm.new(account: account))
   end

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -17,8 +17,8 @@ module AccountsHelper
     end
   end
 
-  def split_account_link_or_text(account, percent)
-    acct_desc = "#{account.description_to_s} (#{percent}%)"
+  def split_account_link_or_text(account)
+    acct_desc = account.to_s(with_facility: false)
     if current_ability.can?(:edit, account)
       link_to acct_desc, facility_account_path(current_facility, account)
     else

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -234,6 +234,7 @@ class Account < ApplicationRecord
 
   delegate :to_s, to: :account_number, prefix: true
 
+  # with_facility is only used in PurchaseOrderAccount#to_s
   def to_s(with_owner = false, flag_suspended = true, with_facility: false)
     desc = "#{description} / #{account_number_to_s}"
     desc += " / #{owner_user_name}" if with_owner && owner_user.present?

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -50,7 +50,7 @@
         .span5.js--pricingUpdate
           = f.input :quantity, as: :order_detail_quantity, hint_html: { class: "help-inline" }
 
-      .span5
+      .span6
         = render "costs", f: f
 
     .row

--- a/app/views/order_management/order_details/_split_costs.html.haml
+++ b/app/views/order_management/order_details/_split_costs.html.haml
@@ -1,14 +1,18 @@
 .split-table
   %table
-    %caption= payment_source_link_or_text(order_detail.account)
+    %caption
+      == Split Account:
+      = payment_source_link_or_text(order_detail.account)
     %tbody
       %tr
         %th{scope: "col"}== Subaccounts
         %th{scope: "col"}== Amount
+        %th{scope: "col"}== Percent
       - SplitAccounts::OrderDetailSplitter.new(order_detail).split.each do |split_order_detail|
         %tr
+          %th{scope: "row"}= split_account_link_or_text(split_order_detail.account)
           - split_percent = split_order_detail.split.percent
-          %th{scope: "row"}= split_account_link_or_text(split_order_detail.account, split_percent)
           - apply_remainder = split_order_detail.split.apply_remainder.to_s
           %td.split-cost{ data: { percent: split_percent, apply_remainder: apply_remainder } }
             = number_to_currency(split_order_detail.send(cost_type))
+          %td= split_percent

--- a/app/views/order_management/order_details/_split_costs.html.haml
+++ b/app/views/order_management/order_details/_split_costs.html.haml
@@ -1,13 +1,14 @@
 .split-table
   %table
+    %caption= payment_source_link_or_text(order_detail.account)
     %tbody
       %tr
         %th{scope: "col"}== Subaccounts
         %th{scope: "col"}== Amount
       - SplitAccounts::OrderDetailSplitter.new(order_detail).split.each do |split_order_detail|
         %tr
-          %th{scope: "row"}= payment_source_link_or_text(split_order_detail.account)
           - split_percent = split_order_detail.split.percent
+          %th{scope: "row"}= split_account_link_or_text(split_order_detail.account, split_percent)
           - apply_remainder = split_order_detail.split.apply_remainder.to_s
           %td.split-cost{ data: { percent: split_percent, apply_remainder: apply_remainder } }
             = number_to_currency(split_order_detail.send(cost_type))

--- a/vendor/engines/split_accounts/README.md
+++ b/vendor/engines/split_accounts/README.md
@@ -54,9 +54,9 @@ There is a 2 cent remainder. That results in the accounts being charged the foll
     * B: $3.49
     * C: $3.49
 
-If the "Apply Remainder" flag were set on on account B, the results would be slightly
-more evenly:
+If the "Apply Remainder" flag were set on account B, the results would be slightly
+more even:
 
-    * A: $3.51
-    * B: $3.50
+    * A: $3.50
+    * B: $3.51
     * C: $3.49


### PR DESCRIPTION
# Release Notes

Addresses bounce back:
- split calculations were returning incorrect values
- Purchase order accounts included the facility in the link

Also I added a new column to show the split % and a link to the parent split account.

# Screenshot

![Screen Shot 2022-01-05 at 11 33 07 PM](https://user-images.githubusercontent.com/30355046/148333857-092e5e67-921a-426f-bda7-243e97bbd017.png)
