### PR TITLE
[#159074] Pass order_detail_id to translation helper

### DIFF
--- a/app/controllers/facility_order_details_controller.rb
+++ b/app/controllers/facility_order_details_controller.rb
@@ -39,7 +39,7 @@ class FacilityOrderDetailsController < ApplicationController
         flash[:notice] = I18n.t "controllers.facility_order_details.destroy.success"
       rescue => e
         Rails.logger.error "#{e.message}:#{e.backtrace.join("\n")}"
-        flash[:error] = I18n.t "controllers.facility_order_details.destroy.error", @order_detail.to_s
+        flash[:error] = I18n.t "controllers.facility_order_details.destroy.error", order_detail_id: @order_detail.to_s
       end
     else
       flash[:notice] = I18n.t "controllers.facility_order_details.destroy.notice"

--- a/spec/controllers/facility_order_details_controller_spec.rb
+++ b/spec/controllers/facility_order_details_controller_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe FacilityOrderDetailsController do
 
     context "merge order" do
       before :each do
+        # @clone is the original order, @order is the merge order
         @clone = @order.dup
         assert @clone.save
         @order.update_attribute :merge_with_order_id, @clone.id
@@ -57,12 +58,14 @@ RSpec.describe FacilityOrderDetailsController do
       end
 
       context "when deleting fails" do
+        let(:merge_order) { @order.dup }
         let(:journal) { FactoryBot.create(:journal) }
-        let(:order_detail) do
+        let(:service) { FactoryBot.create(:setup_service, :with_order_form) }
+        let(:complete_merge_order_detail) do
           FactoryBot.create(:order_detail,
                             :completed,
-                            order: @order,
-                            product: @product,
+                            order: merge_order,
+                            product: service,
                             price_policy: @price_policy,
                             ordered_at: Time.current,
                             fulfilled_at: Time.current,
@@ -71,14 +74,12 @@ RSpec.describe FacilityOrderDetailsController do
         end
 
         before :each do
-          JournalRowBuilder.create_for_single_order_detail!(journal, order_detail)
-          journal_order = order_detail.order
-          journal_order.update_attribute :merge_with_order_id, @clone.id
-          @params = { facility_id: @authable.url_name, order_id: journal_order.id, id: order_detail.id }
+          JournalRowBuilder.create_for_single_order_detail!(journal, complete_merge_order_detail)
+          @params = { facility_id: @authable.url_name, order_id: merge_order.id, id: complete_merge_order_detail.id }
         end
 
         it_should_allow :director, "to see an error message when destroy fails" do
-          expect(order_detail).to be_persisted
+          expect(complete_merge_order_detail).to be_persisted
           expect(flash[:error]).to be_present
           assert_redirected_to facility_order_path(@authable, @clone)
         end


### PR DESCRIPTION
Addresses:
```
An ArgumentError occurred in facility_order_details#destroy:
wrong number of arguments (given 2, expected 0..1)
app/controllers/facility_order_details_controller.rb:42:in `rescue in destroy'
```