### PR TITLE
[#155286] Adjust split cost table for view in modal

### DIFF
--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -50,7 +50,7 @@
         .span5.js--pricingUpdate
           = f.input :quantity, as: :order_detail_quantity, hint_html: { class: "help-inline" }
 
-      .span6
+      .span5
         = render "costs", f: f
 
     .row


### PR DESCRIPTION
I recently made the costs partial wider without realizing it needed to be span5 for modal viewing.

# Screenshot

Before (span6):
<img width="1118" alt="Screen Shot 2022-01-06 at 1 01 43 PM" src="https://user-images.githubusercontent.com/30355046/148436824-8027e486-0c9a-40b2-ac69-c162c734cb9a.png">

Fixed (span5):
<img width="1191" alt="Screen Shot 2022-01-06 at 1 03 30 PM" src="https://user-images.githubusercontent.com/30355046/148437041-924b5efc-cd14-4337-8148-15632614a29c.png">
