### PR TITLE
[#155215] Specify a stable version and use cdn.form.io

### DIFF
--- a/app/views/layouts/formio.html.haml
+++ b/app/views/layouts/formio.html.haml
@@ -3,9 +3,10 @@
   %head
     %meta{ "http-equiv" => "content-type", "content" => "text/html; charset=UTF-8" }
     = render_view_hook "head"
-    = stylesheet_link_tag "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css", media: "all"
-    = stylesheet_link_tag "https://unpkg.com/formiojs@3.28.0/dist/formio.full.min.css", media: "all"
-    = javascript_include_tag "https://unpkg.com/formiojs@3.28.0/dist/formio.full.min.js"
+    - # using resource links based on https://github.com/formio/formio.js#form-building
+    = stylesheet_link_tag "https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css", media: "all"
+    = stylesheet_link_tag "https://cdn.form.io/formiojs@4.13.8/dist/formio.full.min.css", media: "all"
+    = javascript_include_tag "https://cdn.form.io/formiojs@4.13.8/dist/formio.full.min.js"
     = javascript_include_tag "jquery"
     = javascript_include_tag "jquery_ujs"
     = javascript_include_tag "form_io_submission"

--- a/app/views/layouts/formio.html.haml
+++ b/app/views/layouts/formio.html.haml
@@ -3,7 +3,7 @@
   %head
     %meta{ "http-equiv" => "content-type", "content" => "text/html; charset=UTF-8" }
     = render_view_hook "head"
-    - # using resource links based on https://github.com/formio/formio.js#form-building
+    -# using resource links based on https://github.com/formio/formio.js#form-building
     = stylesheet_link_tag "https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css", media: "all"
     = stylesheet_link_tag "https://cdn.form.io/formiojs@4.13.8/dist/formio.full.min.css", media: "all"
     = javascript_include_tag "https://cdn.form.io/formiojs@4.13.8/dist/formio.full.min.js"


### PR DESCRIPTION
As recommended by form.io support team