### PR TITLE
[#159074] Prevent completing order details that are missing a form or survey

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -733,6 +733,7 @@ class OrderDetail < ApplicationRecord
   # If this +OrderDetail+ is #complete? and either:
   #   A) Does not have a +PricePolicy+ or
   #   B) Has a reservation with missing usage information
+  #   C) Has a service with missing order form or survey
   # the method will return true, otherwise false
   def problem_order?
     problem
@@ -879,8 +880,9 @@ class OrderDetail < ApplicationRecord
 
     time_data_problem_key = time_data.problem_description_key
     price_policy_problem_key = :missing_price_policy if price_policy.blank?
+    missing_form_problem_key = :missing_form if missing_form?
 
-    [time_data_problem_key, price_policy_problem_key].compact
+    [time_data_problem_key, price_policy_problem_key, missing_form_problem_key].compact
   end
 
   def requires_but_missing_actuals?

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -366,7 +366,7 @@ class OrderDetail < ApplicationRecord
     end
 
     event :to_complete do
-      transitions to: :complete, from: [:new, :inprocess], guard: :completeable?
+      transitions to: :complete, from: [:new, :inprocess], guard: :time_data_completeable?
     end
 
     event :to_reconciled do
@@ -915,12 +915,6 @@ class OrderDetail < ApplicationRecord
   private
 
   # Is there enough information to move an associated order to complete/problem?
-  def completeable?
-    return false if missing_form?
-
-    time_data_completeable?
-  end
-
   def time_data_completeable?
     canceled_at.present? || time_data.order_completable?
   end

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -11,6 +11,7 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
 
     statuses << Notice.new(:in_review) if in_review?
     statuses << Notice.new(:in_dispute) if in_dispute?
+    statuses << Notice.new(:missing_form) if missing_form? && !problem?
     statuses << Notice.new(:can_reconcile) if can_reconcile_journaled?
     statuses << Notice.new(:in_open_journal) if in_open_journal?
     statuses << Notice.new(:ready_for_statement) if ready_for_statement?

--- a/app/views/shared/_problem_order_details.html.haml
+++ b/app/views/shared/_problem_order_details.html.haml
@@ -19,11 +19,16 @@
   %tbody
     - @order_details.each do |order_detail|
       %tr{ class: row_class(order_detail) }
-        %td.centered= link_to order_detail.order_id,
-          facility_order_path(current_facility, order_detail.order)
-        %td.centered= link_to order_detail.id,
-          manage_order_detail_path(order_detail),
-          class: "manage-order-detail"
+        - if order_detail.missing_form? && order_detail.order.merge_with_order_id
+          %td.centered= link_to order_detail.order.merge_with_order_id,
+            facility_order_path(current_facility, order_detail.order.merge_order)
+          %td.centered= order_detail.id
+        - else
+          %td.centered= link_to order_detail.order_id,
+            facility_order_path(current_facility, order_detail.order)
+          %td.centered= link_to order_detail.id,
+            manage_order_detail_path(order_detail),
+            class: "manage-order-detail"
         %td= problem_order_date(order_detail, local_assigns[:show_reservation_start_at])
         %td= order_detail.order.user
         %td.centered= order_detail.quantity

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -713,6 +713,9 @@ en:
       missing_actuals:
         badge: Missing Actuals
         alert: This order's reservation does not have an actual end time. Please ensure that actual times are set and there is a price policy for the date this order was fulfilled.
+      missing_form:
+        badge: Missing Order Form
+        alert: This order is missing a required order form or survey.
       missing_price_policy:
         badge: Missing Price Policy
         alert: This order does not have a price policy assigned. Please ensure that there is a price policy for the date this order was fulfilled. Saving will attempt to assign a price policy.

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -346,6 +346,19 @@ RSpec.describe OrderDetail do
       expect(@order_detail.valid_service_meta?).to be true
     end
 
+    it "should not transition to complete if there is no upladed result" do
+      # add service file template
+      @file1      = "#{Rails.root}/spec/files/template1.txt"
+      @template1  = @service.stored_files.create(name: "Template 1", file: File.open(@file1), file_type: "template",
+                                                 created_by: @user.id)
+      expect(@order_detail.valid_service_meta?).to be false
+
+      @order_detail.to_inprocess!
+      expect { @order_detail.to_complete! }.to raise_error(AASM::InvalidTransition)
+      expect(@order_detail.state).to eq("inprocess")
+      expect(@order_detail.versions.size).to eq(3)
+    end
+
     it "should not validate_extras for a service file template upload with no template results" do
       # add service file template
       @file1      = "#{Rails.root}/spec/files/template1.txt"

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -346,19 +346,6 @@ RSpec.describe OrderDetail do
       expect(@order_detail.valid_service_meta?).to be true
     end
 
-    it "should not transition to complete if there is no upladed result" do
-      # add service file template
-      @file1      = "#{Rails.root}/spec/files/template1.txt"
-      @template1  = @service.stored_files.create(name: "Template 1", file: File.open(@file1), file_type: "template",
-                                                 created_by: @user.id)
-      expect(@order_detail.valid_service_meta?).to be false
-
-      @order_detail.to_inprocess!
-      expect { @order_detail.to_complete! }.to raise_error(AASM::InvalidTransition)
-      expect(@order_detail.state).to eq("inprocess")
-      expect(@order_detail.versions.size).to eq(3)
-    end
-
     it "should not validate_extras for a service file template upload with no template results" do
       # add service file template
       @file1      = "#{Rails.root}/spec/files/template1.txt"


### PR DESCRIPTION
# Release Notes

Prevents order details from getting reconciled when they are missing required form or survey results.