### PR TITLE
[#158143] Change hourly rate precision

### DIFF
--- a/app/views/time_based_price_policies/_table.html.haml
+++ b/app/views/time_based_price_policies/_table.html.haml
@@ -38,7 +38,8 @@
                 %strong= "= #{number_to_currency price_policy.subsidized_hourly_usage_cost}"
 
               %p.per-minute-show
-                = number_to_currency (price_policy.subsidized_hourly_usage_cost / 60).truncate(4), precision: 4
+                - price_per_minute = (price_policy.subsidized_hourly_usage_cost / 60).truncate(4)
+                = number_to_currency price_per_minute, precision: 4
                 \/ minute
 
 

--- a/app/views/time_based_price_policies/_table.html.haml
+++ b/app/views/time_based_price_policies/_table.html.haml
@@ -38,7 +38,7 @@
                 %strong= "= #{number_to_currency price_policy.subsidized_hourly_usage_cost}"
 
               %p.per-minute-show
-                = number_to_currency price_policy.subsidized_hourly_usage_cost / 60, precision: 4
+                = number_to_currency (price_policy.subsidized_hourly_usage_cost / 60).truncate(4), precision: 4
                 \/ minute
 
 

--- a/db/migrate/20220209233321_adjust_price_policy_usage_rate_precision.rb
+++ b/db/migrate/20220209233321_adjust_price_policy_usage_rate_precision.rb
@@ -1,5 +1,9 @@
 class AdjustPricePolicyUsageRatePrecision < ActiveRecord::Migration[6.0]
-  def change
+  def up
     change_column :price_policies, :usage_rate, :decimal, precision: 16, scale: 8
+  end
+
+  def down
+    change_column :price_policies, :usage_rate, :decimal, precision: 12, scale: 4
   end
 end

--- a/db/migrate/20220209233321_adjust_price_policy_usage_rate_precision.rb
+++ b/db/migrate/20220209233321_adjust_price_policy_usage_rate_precision.rb
@@ -1,0 +1,5 @@
+class AdjustPricePolicyUsageRatePrecision < ActiveRecord::Migration[6.0]
+  def change
+    change_column :price_policies, :usage_rate, :decimal, precision: 16, scale: 8
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_19_094923) do
+ActiveRecord::Schema.define(version: 2022_02_09_233321) do
 
   create_table "account_facility_joins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "facility_id", null: false
@@ -469,7 +469,7 @@ ActiveRecord::Schema.define(version: 2021_11_19_094923) do
     t.datetime "start_date", null: false
     t.decimal "unit_cost", precision: 10, scale: 2
     t.decimal "unit_subsidy", precision: 10, scale: 2
-    t.decimal "usage_rate", precision: 12, scale: 4
+    t.decimal "usage_rate", precision: 16, scale: 8
     t.decimal "minimum_cost", precision: 10, scale: 2
     t.decimal "cancellation_cost", precision: 10, scale: 2
     t.decimal "usage_subsidy", precision: 12, scale: 4

--- a/spec/models/instrument_price_policy_calculations_spec.rb
+++ b/spec/models/instrument_price_policy_calculations_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe InstrumentPricePolicyCalculations do
       reservation.actual_start_at = reservation.reserve_start_at
       reservation.actual_end_at = reservation.reserve_end_at + 10.minutes
       new_costs = policy.calculate_cost_and_subsidy reservation
-      expect(new_costs[:cost]).to eq(29.169.to_d)
+      expect(new_costs[:cost]).to eq(29.1666669.to_d)
       expect(new_costs[:subsidy]).to eq(8.169.to_d)
     end
 

--- a/spec/services/price_policies/time_based_price_calculator_spec.rb
+++ b/spec/services/price_policies/time_based_price_calculator_spec.rb
@@ -84,13 +84,13 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
       describe "with no discount" do
         let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) } # Thursday
         let(:end_at) { start_at + 13.minutes }
-        it { is_expected.to eq(cost: 6.7171, subsidy: 3.6829) }
+        it { is_expected.to eq(cost: 6.71666671, subsidy: 3.6829) }
       end
 
       describe "with the weekend discount of 25%" do
         let(:start_at) { Time.zone.local(2017, 4, 29, 12, 0) } # Saturday
         let(:end_at) { start_at + 13.minutes }
-        it { is_expected.to eq(cost: 5.037825, subsidy: 2.762175) }
+        it { is_expected.to eq(cost: 5.0375000325, subsidy: 2.762175) }
       end
     end
 


### PR DESCRIPTION
# Release Notes

Change the hourly rate precision to 8 decimal places (from 4). Ensure that displayed price is truncated to 4 digits (not rounded).