### PR TITLE
[#159255] Give time data inputs more space

### DIFF
--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -3,8 +3,7 @@
 module AccountsHelper
 
   def account_input(form)
-    hint = t("facility_order_details.edit.label.account_owner_html", owner: @order_detail.account.owner_user)
-    form.input :account_id, hint: hint, label: OrderDetail.human_attribute_name(:account) do
+    form.input :account_id, label: OrderDetail.human_attribute_name(:account) do
       form.select :account_id, available_accounts_options, include_blank: false, disabled: edit_disabled?
     end
   end

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -11,6 +11,9 @@
     .row
       .span3.js--pricingUpdate
         = account_input(f)
+      .span3
+        %strong= t("facility_order_details.edit.label.account_owner")
+        .account-owner= @order_detail.account.owner_user
 
       .span3
         - if @order_statuses
@@ -48,14 +51,18 @@
         - if f.object.account.try(:splits).try(:present?)
           = render "split_costs", order_detail: @order_detail
 
-    .row
-      - if @order_detail.time_data.present?
-        .span3= render "order_management/order_details/#{@order_detail.time_data.class.name.underscore}", f: f
-      - else
+    - if @order_detail.time_data.present?
+      .row
+        .span3
+        .span7= render "costs", f: f
+      .row
+        .span3
+        .span7= render "order_management/order_details/#{@order_detail.time_data.class.name.underscore}", f: f
+    - else
+      .row
         .span3.js--pricingUpdate
           = f.input :quantity, as: :order_detail_quantity, hint_html: { class: "help-inline" }
-      .span7
-        = render "costs", f: f
+        .span7= render "costs", f: f
 
     .row
       .span3

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -475,7 +475,7 @@ en:
         dispute_information: Dispute Information
         h3-5: "Bundle Summary"
       label:
-        account_owner_html: "<strong>Owner: </strong><span class='account-owner'>%{owner}</span>"
+        account_owner: Account Owner
         ordered:
           at: "Ordered At"
           for: "Ordered For"


### PR DESCRIPTION
# Release Notes

Reservation order details can have date and time inputs in some cases, and they need more space on the page.

# Screenshots
## With date/time inputs + split account
![Screen Shot 2022-02-16 at 9 14 08 AM](https://user-images.githubusercontent.com/30355046/154297018-aef9e53a-1861-4f8a-9184-a0c415ae37b5.png)

## No date inputs, no split account
![Screen Shot 2022-02-16 at 9 15 25 AM](https://user-images.githubusercontent.com/30355046/154297026-1d76c0e9-981e-4534-b05f-880764c167e5.png)
