### PR TITLE
[#159611] Configure capistrano to clean up old assets on deploy

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -16,5 +16,9 @@ require "whenever/capistrano"
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
 
+# Only keep the 3 most recent asset versions
+# See https://github.com/capistrano/rails#usage
+set :keep_assets, 3
+
 require "capistrano/scm/git"
 install_plugin Capistrano::SCM::Git


### PR DESCRIPTION
# Release Notes

Discovered this gap while debugging the issue with missing ckeditor icons.
This cleans up old assets while still keeping a few recent versions around to support rolling deploys and for ease of rolling back.

This should prevent an issue such as:
* `sprockets-rails` has a bug which breaks asset references
* capistrano runs `assets:precompile` against sym-linked `assets/` directory
* future deploys will reference the broken assets unless manually cleaned up