### PR TITLE
[#159906] Update reservation cost terminology

### DIFF
--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -310,8 +310,8 @@ en:
         can_purchase: Can Purchase?
         minimum_cost: Minimum Cost
         hourly_usage_rate: Rate Per Hour
-        cancellation_cost: Reservation Fee
-        full_price_cancellation: Full reservation fee
+        cancellation_cost: Reservation Cost
+        full_price_cancellation: Full reservation cost
         unit_cost: Unit Cost
         unit_adjustment: Unit Adjustment
         unit_net_cost: Unit Net Cost

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -490,7 +490,7 @@ en:
           resolve: "Resolution Notes"
         resolved: "Resolved At"
         reconcile: "Reconciliation Note:"
-        with_cancel_fee: Add reservation fee
+        with_cancel_fee: Add reservation cost
         updating: Calculating Price
         unreconcile: Unreconcile
       instruct:
@@ -578,7 +578,7 @@ en:
     delete:
       confirm: Are you sure you wish to cancel this reservation?
       confirm_with_fee: "Canceling this reservation will incur a %{fee} fee.  Are you sure you wish to cancel this reservation?"
-      confirm_with_full_price: Canceling this reservation incur the full reservation fee of %{fee}. Are you sure you wish to cancel this reservation?
+      confirm_with_full_price: Canceling this reservation incur the full reservation cost of %{fee}. Are you sure you wish to cancel this reservation?
       link: Cancel
     finished: Reservation Ended
     moving_up:
@@ -1128,7 +1128,7 @@ en:
           reserve_interval: "The minutes of an hour on which a reservation is allowed to begin (e.g. if 5 reservations can be scheduled every 5 minutes)"
           min_reserve: "Minimum amount of time for a reservation (optional; must be a multiple of the reservation interval)"
           max_reserve: "Maximum amount of time for a reservation (optional)"
-          cancel_hours: "The number of hours before a reservation begins that marks the start of the Reservation Fee Window. Cancelations after the Reservation Fee Window has started will be charged a reservation fee. When blank or set to 0, no reservation fees will be charged."
+          cancel_hours: "The number of hours before a reservation begins that a user may cancel a reservation without invoking the Reservation Cost. When blank or set to 0, the Reservation Cost will not be charged."
           auto_cancel: |
             The number of minutes the system will wait before automatically
             canceling an unstarted reservation.
@@ -1141,7 +1141,7 @@ en:
           reserve_interval: "Interval (minutes)"
           min_reserve: "Minimum (minutes)"
           max_reserve: "Maximum (minutes)"
-          cancel_hours: "Reservation Fee Window (hours)"
+          cancel_hours: "Reservation Cost Window (hours)"
           auto_cancel: "Automatic Cancelation (minutes)"
           lock_window: "Reservation Lock Window (hours)"
           cutoff_hours: "Cutoff Time (hours)"


### PR DESCRIPTION
# Release Notes

A few minor changes to terminology around Reservation costs.  Goal here is to make the connection between "Reservation Cost" and "Reservation Cost Window" more clear to the user.  This PR incorporates feedback to align the language with compliance requirements.

1. When setting pricing rules, the header "Reservation Cost" should remain "Reservation Cost"
2. When editing an instrument, the field "Cancelation Minimum (hours)" should be renamed to "Reservation Cost Window (hours)"
3. For the helper text when editing an instrument:
“The number of hours before a reservation begins that a user may cancel a reservation without invoking the Reservation Cost. When blank or set to 0, the Reservation Cost will not be charged.”