### PR TITLE
[#158844] Updates environment cache settings & c2po loading 

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,10 +6,10 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.cache_classes = true
 
   # Do not eager load code on boot.
-  config.eager_load = false
+  config.eager_load = true
 
   # Show full error reports.
   config.consider_all_requests_local = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot.
   config.eager_load = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = false
+  config.cache_classes = true
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/vendor/engines/c2po/lib/c2po.rb
+++ b/vendor/engines/c2po/lib/c2po.rb
@@ -41,7 +41,7 @@ module C2po
 
     initializer :append_account_types, before: "set_routes_reloader_hook" do |app|
       C2PO_ACCOUNT_TYPES_APPENDER.call
-      app.reloader.to_prepare(&C2PO_ACCOUNT_TYPES_APPENDER)
+      app.reloader.to_run(&C2PO_ACCOUNT_TYPES_APPENDER)
     end
 
     initializer "model_core.factories", after: "factory_girl.set_factory_paths" do


### PR DESCRIPTION
# Release Notes

Because of the way classes and code were loaded, there was an issue with the c2po engine that caused the menu to load incorrectly, producing duplicate menu items. This was not noticed in development.

The `development` and `test` environments have been updated to better match `stage` and `production` and the issue with c2po has been corrected.

# Screenshot

On stage
![Screen Shot 2022-03-24 at 3 11 31 PM](https://user-images.githubusercontent.com/624487/160016614-7d6445e0-6394-4beb-9473-12fe8bf48770.png)

In development, now.
![Screen Shot 2022-03-24 at 5 09 14 PM](https://user-images.githubusercontent.com/624487/160018481-40690074-5a1b-49c7-a7ac-d7f7cfa262d1.png)