### PR TITLE
[#155264] Handle validation errors when updating from SAML

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1254,6 +1254,7 @@ en:
       invalid: "Invalid username or password."
       not_found_in_database: "Invalid username or password."
       inactive: "Invalid username or password."
+      saml_update_failed: "Login failed, please contact an administrator."
       saml_invalid: "Invalid username or password."
     mailer:
       # TODO

--- a/vendor/engines/saml_authentication/app/controllers/saml_authentication/sessions_controller.rb
+++ b/vendor/engines/saml_authentication/app/controllers/saml_authentication/sessions_controller.rb
@@ -7,6 +7,16 @@ module SamlAuthentication
     before_action :store_logging_out_username, only: :destroy
     after_action :store_winning_strategy, only: :create
 
+    # See https://github.com/apokalipto/devise_saml_authenticatable/issues/181#issuecomment-696904192
+    rescue_from ActiveRecord::RecordInvalid, with: :handle_validation_error
+
+    def handle_validation_error(exception)
+      ::Rails.logger.warn "There was an error trying to log in the SAML user '#{exception}'"
+
+      flash[:alert] = I18n.t("devise.failure.saml_update_failed").html_safe
+      redirect_to new_user_session_path
+    end
+
     # Overrides SamlSessionsController.
     #
     # The default behavior for IdP-initiated signout uses a database-backed


### PR DESCRIPTION
If updating from SAML data fails, we want to show the user a helpful message.

Coming from work on https://github.com/tablexi/nucore-umass/pull/337