### PR TITLE
[#159884] Remove mini_racer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           - RAILS_ENV: "test"
           - MYSQL_USER: root
           - SELENIUM_DRIVER_URL: http://localhost:4444/wd/hub
-      - image: circleci/mysql:8.0.28-ram
+      - image: cimg/mysql:8.0.28
         environment:
           MYSQL_ROOT_PASSWORD: 'root'
           MYSQL_ROOT_HOST: "%"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           - RAILS_ENV: "test"
           - MYSQL_USER: root
           - SELENIUM_DRIVER_URL: http://localhost:4444/wd/hub
-      - image: circleci/mysql:5.7.22-ram
+      - image: circleci/mysql:8.0.28-ram
         environment:
           MYSQL_ROOT_PASSWORD: 'root'
           MYSQL_ROOT_HOST: "%"
@@ -17,6 +17,21 @@ jobs:
 
     steps:
       - checkout
+
+      # https://support.circleci.com/hc/en-us/articles/360051656632-Swap-node-version-on-CircleCI-convenience-image
+      - run:
+          name: Set node version
+          command: |
+            set +e
+            wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+            nvm install v16
+            nvm alias default 16.14.2
+
+            echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
+            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
 
       # Bundle
       - restore_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV BUNDLE_PATH /gems
 # Install NodeJS based on https://github.com/nodesource/distributions#installation-instructions
 RUN apt-get update && \
  # Installs the node repository
- curl -sL https://deb.nodesource.com/setup_14.x | bash && \
+ curl -sL https://deb.nodesource.com/setup_16.x | bash && \
  # Installs the node repository
  apt-get install --yes nodejs && \
  apt-get autoremove -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
  curl -sL https://deb.nodesource.com/setup_16.x | bash && \
  # Installs the node repository
  apt-get install --yes nodejs && \
+ npm install --global yarn && \
  apt-get autoremove -y
 
 # Copy just what we need in order to bundle
@@ -39,5 +40,6 @@ FROM base as deploy
 
 ENV RAILS_ENV production
 RUN bundle install --without=development test
+RUN yarn install
 # asset compile
 RUN SECRET_KEY_BASE=fake bundle exec rake assets:precompile

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,6 @@ gem "paranoia"
 gem "sass-rails"
 gem "coffee-rails"
 gem "uglifier", "= 4.1.18" # 4.1.19 has an issue https://github.com/mishoo/UglifyJS2/issues/3245
-gem "mini_racer", "~> 0.6.2"
 gem "bootstrap-sass", "~> 2.3.2" # will not upgrade
 gem "haml"
 gem "will_paginate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,9 +338,6 @@ GEM
       addressable (~> 2.7)
     letter_opener (1.8.1)
       launchy (>= 2.2, < 3)
-    libv8-node (16.10.0.0)
-    libv8-node (16.10.0.0-aarch64-linux)
-    libv8-node (16.10.0.0-x86_64-linux)
     loofah (2.16.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -357,8 +354,6 @@ GEM
       rake
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    mini_racer (0.6.2)
-      libv8-node (~> 16.10.0.0)
     minitest (5.15.0)
     momentjs-rails (2.29.1.1)
       railties (>= 3.1)
@@ -656,7 +651,6 @@ DEPENDENCIES
   jquery-ui-rails
   ldap_authentication!
   letter_opener
-  mini_racer (~> 0.6.2)
   mysql2
   nested_form_fields
   nokogiri

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ It makes a few assumptions:
 2. You have a running Oracle or MySQL instance with two brand new databases. (Oracle setup instructions [here](doc/HOWTO_oracle.md).)
 3. You have the following installed:
     * [Ruby](http://www.ruby-lang.org/en)
+    * [NodeJS](https://nodejs.org/en/)
     * [Bundler](http://gembundler.com)
     * [Git](http://git-scm.com)
     * [PhantomJS](http://phantomjs.org/)


### PR DESCRIPTION
# Release Notes

Using node instead of mini_racer, as mini_racer is failing to compile on the TXI stage server.