### PR TITLE
[#158778] improve payment source search

### DIFF
--- a/app/controllers/account_price_group_members_controller.rb
+++ b/app/controllers/account_price_group_members_controller.rb
@@ -42,9 +42,12 @@ class AccountPriceGroupMembersController < ApplicationController
   end
 
   def search_conditions
+    search_term = generate_multipart_like_search_term(params[:search_term])
+
     @search_conditions ||= [
-      "LOWER(account_number) LIKE ?",
-      generate_multipart_like_search_term(params[:search_term]),
+      "LOWER(accounts.account_number) LIKE ? or LOWER(accounts.description) LIKE ?",
+      search_term,
+      search_term
     ]
   end
 

--- a/app/controllers/account_price_group_members_controller.rb
+++ b/app/controllers/account_price_group_members_controller.rb
@@ -10,7 +10,14 @@ class AccountPriceGroupMembersController < ApplicationController
   # GET /facilities/:facility_id/price_groups/:price_group_id/account_price_group_members/search_results
   def search_results
     @limit = 25
-    set_search_conditions if params[:search_term].present?
+    searcher = AccountSearcher.new(params[:search_term], scope: Account.for_facility(current_facility))
+
+    if searcher.valid?
+      @accounts = searcher.results
+    else
+      flash.now[:errors] = "Search terms must be 3 or more characters."
+    end
+
     render layout: false
   end
 
@@ -39,23 +46,6 @@ class AccountPriceGroupMembersController < ApplicationController
     @account_price_group_member.account ||= account
     @account_price_group_member.price_group ||= @price_group
     @account_price_group_member
-  end
-
-  def search_conditions
-    search_term = generate_multipart_like_search_term(params[:search_term])
-
-    @search_conditions ||= [
-      "LOWER(accounts.account_number) LIKE ? or LOWER(accounts.description) LIKE ?",
-      search_term,
-      search_term
-    ]
-  end
-
-  def set_search_conditions
-    @accounts = Account.for_facility(current_facility)
-                       .where(search_conditions)
-                       .order(:account_number)
-                       .limit(@limit)
   end
 
   def authorize_account_price_group_member!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -799,7 +799,7 @@ en:
   account_price_group_members:
     new:
       label:
-        search_term: "Search by payment source"
+        search_term: "Search by payment source number or description, or payment source owner's name, NetID, or username"
     search_results:
       head: "Select an Existing Payment Source"
       main: "Can't find the payment source you're looking for?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -799,7 +799,7 @@ en:
   account_price_group_members:
     new:
       label:
-        search_term: "Search by payment source number or description, or payment source owner's name, NetID, or username"
+        search_term: "Search by payment source number, accounts receivable number, or description, or payment source owner's name, NetID, or username"
     search_results:
       head: "Select an Existing Payment Source"
       main: "Can't find the payment source you're looking for?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,7 +164,7 @@ en:
       head: "Recent Payment Sources"
       add_account: "Add Payment Source"
       label:
-        search_term: "Search by payment source number or payment source owner's name, NetID, or username"
+        search_term: "Search by payment source number, description, accounts receivable number, or payment source owner's name, NetID, or username"
       search: Search
     new_account_user_search:
       head: "Add Payment Source"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -799,7 +799,7 @@ en:
   account_price_group_members:
     new:
       label:
-        search_term: "Search by payment source number, accounts receivable number, or description, or payment source owner's name, NetID, or username"
+        search_term: "Search by payment source number, description, accounts receivable number, or payment source owner's name, NetID, or username"
     search_results:
       head: "Select an Existing Payment Source"
       main: "Can't find the payment source you're looking for?"

--- a/spec/system/admin/price_group_management_spec.rb
+++ b/spec/system/admin/price_group_management_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "Managing Price Groups", :aggregate_failures do
     end
   end
 
-  describe "searcing to add price group member", js: true do
+  describe "searching to add price group member", js: true do
     let(:user) { FactoryBot.create(:user, :facility_director, facility: facility) }
     let!(:account1) { FactoryBot.create(:account, :with_account_owner, account_number: "135711", description: "first account", facilities: [facility], owner: user) }
     let!(:account2) { FactoryBot.create(:account, :with_account_owner, account_number: "246810", description: "second account", facilities: [facility], owner: user) }
@@ -115,8 +115,7 @@ RSpec.describe "Managing Price Groups", :aggregate_failures do
     before do
       allow(Account.config).to receive(:facility_account_types).and_return(["Account"])
       login_as user
-      price_group = FactoryBot.create(:price_group, facility_id: facility.id )
-      visit "/facilities/#{facility.url_name}/price_groups/#{price_group.id}/account_price_group_members/new"
+      visit new_facility_price_group_account_price_group_member_path(facility, price_group)
     end
 
     it "searches for accounts by partial description" do

--- a/spec/system/admin/price_group_management_spec.rb
+++ b/spec/system/admin/price_group_management_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe "Managing Price Groups", :aggregate_failures do
 
   describe "searching to add price group member", js: true do
     let(:user) { FactoryBot.create(:user, :facility_director, facility: facility) }
+    let(:price_group) { FactoryBot.create(:price_group, facility_id: facility.id ) }
     let!(:account1) { FactoryBot.create(:account, :with_account_owner, account_number: "135711", description: "first account", facilities: [facility], owner: user) }
     let!(:account2) { FactoryBot.create(:account, :with_account_owner, account_number: "246810", description: "second account", facilities: [facility], owner: user) }
 

--- a/spec/system/admin/price_group_management_spec.rb
+++ b/spec/system/admin/price_group_management_spec.rb
@@ -106,5 +106,33 @@ RSpec.describe "Managing Price Groups", :aggregate_failures do
       end
     end
   end
+
+  describe "searcing to add price group member", js: true do
+    let(:user) { FactoryBot.create(:user, :facility_director, facility: facility) }
+    let!(:account1) { FactoryBot.create(:account, :with_account_owner, account_number: "135711", description: "first account", facilities: [facility], owner: user) }
+    let!(:account2) { FactoryBot.create(:account, :with_account_owner, account_number: "246810", description: "second account", facilities: [facility], owner: user) }
+
+    before do
+      allow(Account.config).to receive(:facility_account_types).and_return(["Account"])
+      login_as user
+      price_group = FactoryBot.create(:price_group, facility_id: facility.id )
+      visit "/facilities/#{facility.url_name}/price_groups/#{price_group.id}/account_price_group_members/new"
+    end
+
+    it "searches for accounts by partial description" do
+      fill_in "search_term", with: account1.description[0,5]
+      click_button "Search"
+      expect(page).to have_content(account1.description)
+      expect(page).to_not have_content(account2.description)
+    end
+
+    it "searches for accounts by partial account number" do
+      fill_in "search_term", with: account2.account_number[1,3]
+      click_button "Search"
+      expect(page).to have_content(account2.description)
+      expect(page).to_not have_content(account1.description)
+    end
+  end
+
   # TODO: Move tests out of price_groups_controller_spec.rb
 end


### PR DESCRIPTION
# Release Notes

The search box for adding a price group member to a facility only executes a search of accounts by account number, this is a bit difficult since the account number is not particularly memorable.

This PR updates the search to `AccountSearcher` to execute the search, allowing searches for account by account number, accounts receivable number, description, or owner's name, NetID, or username.