### PR TITLE
Tech task - Use .bashrc to determine which servers should run recurring_tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Because we use squash and merge, you should be able to see the changes by lookin
 at the [commit log](https://github.com/tablexi/nucore-open/commits/master). However, we have begun keeping track of breaking changes
 or optional rake tasks.
 
+### Use `secrets.yml` to determine which servers should run recurring tasks ([#2994](https://github.com/tablexi/nucore-open/pull/2994))
+
+The `recurring_tasks` process should only run on one server per environment.  Using `eye` to manage this did not work as expected. Set the value of `recurring_tasks` in `secrets.yml` to configure which servers should run these tasks.
+
 ### Rename `auto_cancel` daemon to `recurring_tasks` and consolidate recurring tasks there ([#2957](https://github.com/tablexi/nucore-open/pull/2957))
 
 The `recurring_tasks` process should only run on one server per environment.  This is managed via `eye` now.  If you user another deployment process and have multiple servers running in production, you will need to ensure this daemon only runs on one server.  Setting `run_auto_cancel: false` in `secrets.yml` will no longer have an impact.  The list of recurring jobs is listed in `RecurringTaskConfig`.  You can add or remove items from the list from your school-specific engine like so:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ or optional rake tasks.
 
 ### Use `secrets.yml` to determine which servers should run recurring tasks ([#2994](https://github.com/tablexi/nucore-open/pull/2994))
 
-The `recurring_tasks` process should only run on one server per environment.  Using `eye` to manage this did not work as expected. Set the value of `recurring_tasks` in `secrets.yml` to configure which servers should run these tasks.
+The `recurring_tasks` process should only run on one server per environment.   Set `RECURRING=true` in the environment (`.bashrc` for example) to configure which servers should run these tasks.  Attempting to set this via `capistrano` only works on deploy.
 
 ### Rename `auto_cancel` daemon to `recurring_tasks` and consolidate recurring tasks there ([#2957](https://github.com/tablexi/nucore-open/pull/2957))
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -14,13 +14,3 @@ set :linked_files, fetch(:linked_files, []).concat(
 set :linked_dirs, fetch(:linked_dirs, []).concat(
   %w(bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/files),
 )
-
-namespace :eye do
-  task :set_recurring_tasks do
-    on roles :db do |host|
-      set :eye_env, -> { { rails_env: fetch(:rails_env), recurring: true } }
-    end
-  end
-end
-
-before "eye:load_config", "eye:set_recurring_tasks"

--- a/config/eye.yml.erb
+++ b/config/eye.yml.erb
@@ -21,7 +21,7 @@ notifications:
     type: datadog
     level: error
     config:
-      api_key: <%= ENV['DATADOG_API_KEY'] %>
+      api_key: <%= ENV["DATADOG_API_KEY"] %>
 
 # You can also set up notifications via email:
 # notifications:
@@ -57,7 +57,6 @@ processes:
         rotate: "kill -USR1 {PID}"
 
   # This should only run on 1 instance.
-  <% if ENV["RECURRING"] == "true" %>
   - name: recurring_tasks
     config:
       start_command: ruby lib/daemons/recurring_tasks.rb start -- --no-monitor
@@ -74,7 +73,6 @@ processes:
           times: 3
           every: 20 seconds
           below: 256 megabytes
-  <% end %>
 
   - name: delayed_job
     config:

--- a/config/eye.yml.erb
+++ b/config/eye.yml.erb
@@ -57,6 +57,7 @@ processes:
         rotate: "kill -USR1 {PID}"
 
   # This should only run on 1 instance.
+  <% if ENV["RECURRING"] == "true" %>
   - name: recurring_tasks
     config:
       start_command: ruby lib/daemons/recurring_tasks.rb start -- --no-monitor
@@ -73,6 +74,7 @@ processes:
           times: 3
           every: 20 seconds
           below: 256 megabytes
+  <% end %>
 
   - name: delayed_job
     config:

--- a/config/secrets.yml.template
+++ b/config/secrets.yml.template
@@ -1,7 +1,6 @@
 defaults: &defaults
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   rollbar: <%= ENV["ROLLBAR_ACCESS_TOKEN"] %>
-  run_recurring_tasks: true
 
   # You should change this if you want to be able to access the API
   api:

--- a/config/secrets.yml.template
+++ b/config/secrets.yml.template
@@ -1,6 +1,7 @@
 defaults: &defaults
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   rollbar: <%= ENV["ROLLBAR_ACCESS_TOKEN"] %>
+  run_recurring_tasks: true
 
   # You should change this if you want to be able to access the API
   api:

--- a/doc/HOWTO_recurring_tasks.md
+++ b/doc/HOWTO_recurring_tasks.md
@@ -1,6 +1,10 @@
 # Recurring Tasks
 
-There are some tasks that need to happen regularly, at 1 or 5 minute intervals.  These are currently all related to reservation management.  The list of recurring tasks is listed in `RecurringTaskConfig`, and managed by a daemon process (see [**HOWTO_daemons.txt**](./HOWTO_daemons.txt) for more information).  You can add or remove items from the list from your school-specific engine like so:
+There are some tasks that need to happen regularly, at 1 or 5 minute intervals.  These are currently all related to reservation management.  The list of recurring tasks is listed in `RecurringTaskConfig`, and managed by a daemon process (see [**HOWTO_daemons.txt**](./HOWTO_daemons.txt) for more information).
+
+The `recurring_tasks` process should only run on one server per environment.   Set `RECURRING=true` in the environment (`.bashrc` for example) to configure which servers should run these tasks.
+
+You can add or remove items from the list from your school-specific engine like so:
 ```ruby
 RecurringTaskConfig.recurring_tasks << [SecureRooms::AutoOrphanOccupancy, :perform, 5]
 ```

--- a/lib/daemons/recurring_tasks.rb
+++ b/lib/daemons/recurring_tasks.rb
@@ -2,15 +2,16 @@
 
 require File.expand_path("base", File.dirname(__FILE__))
 
-Daemons::Base.new("recurring_tasks").start do
-  start_time = Time.now
-  RecurringTaskConfig.each do |recurring_task|
-    recurring_task.invoke!(start_time)
+if Rails.application.secrets.run_recurring_tasks
+  Daemons::Base.new("recurring_tasks").start do
+    start_time = Time.now
+    RecurringTaskConfig.each do |recurring_task|
+      recurring_task.invoke!(start_time)
+    end
+
+    run_time = Time.now - start_time
+    interval = 1.minute.to_i - run_time
+
+    sleep(interval) if interval > 0
   end
-
-  run_time = Time.now - start_time
-  interval = 1.minute.to_i - run_time
-
-  sleep(interval) if interval > 0
 end
-

--- a/lib/daemons/recurring_tasks.rb
+++ b/lib/daemons/recurring_tasks.rb
@@ -2,16 +2,12 @@
 
 require File.expand_path("base", File.dirname(__FILE__))
 
-if Rails.application.secrets.run_recurring_tasks
-  Daemons::Base.new("recurring_tasks").start do
-    start_time = Time.now
-    RecurringTaskConfig.each do |recurring_task|
-      recurring_task.invoke!(start_time)
-    end
-
-    run_time = Time.now - start_time
-    interval = 1.minute.to_i - run_time
-
-    sleep(interval) if interval > 0
+Daemons::Base.new("recurring_tasks").start do
+  start_time = Time.now
+  RecurringTaskConfig.each do |recurring_task|
+    recurring_task.invoke!(start_time)
   end
+  run_time = Time.now - start_time
+  interval = 1.minute.to_i - run_time
+  sleep(interval) if interval > 0
 end


### PR DESCRIPTION
# Release Notes

I've discovered 2 problems with the implementation for managing which servers run recurring tasks:
1) capistrano sets the ENV variable during deployment, but restarting the application manually with `eye-patch load config/eye.yml.erb` will not have the variable set, so recurring_tasks will not be reloaded
2) The recurring_tasks are running on both UMass production servers
Rather than debug the current approach, I'm using `.bashrc` to control the behavior.  
This is explicit, easy to reason about, and it works.

# Additional Context

I've updated `.bashrc` on UMass and TXI servers