### PR TITLE
[#158778] improve payment source search

### DIFF
--- a/app/controllers/account_price_group_members_controller.rb
+++ b/app/controllers/account_price_group_members_controller.rb
@@ -13,7 +13,9 @@ class AccountPriceGroupMembersController < ApplicationController
     searcher = AccountSearcher.new(params[:search_term], scope: Account.for_facility(current_facility))
 
     if searcher.valid?
-      @accounts = searcher.results
+      @search_results = searcher.results
+      @count = @search_results.count
+      @accounts = @search_results.limit(@limit)
     else
       flash.now[:errors] = "Search terms must be 3 or more characters."
     end

--- a/app/helpers/account_price_group_members_helper.rb
+++ b/app/helpers/account_price_group_members_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module AccountPriceGroupMembersHelper
+  # Provides a notice, if the number of search results found is above the
+  # limit.
+  #
+  # +count+ The total number of accounts there were found in the search
+  #
+  # +limit+ The maximum number of accounts that will be displayed
+  def additional_results_notice(count:, limit:)
+    # This ensures that count and limit exist before attemtping to use 
+    # them, and will silently exit if they don't.
+    #
+    # This should never happen, so this method is mainly here to handle
+    # the case that one of these has been inappropriately deleted.
+    if count.nil? || limit.nil?
+      if defined?(Rollbar)
+        Rollbar.info("Argument missing in additional_results_notice", count: count, limit: limit)
+      end
+    elsif count > limit
+      t("account_price_group_members.search_results.notice_html", count: count - limit)
+    end
+  end
+end

--- a/app/views/account_price_group_members/search_results.html.haml
+++ b/app/views/account_price_group_members/search_results.html.haml
@@ -20,7 +20,6 @@
             %td= link_to account, facility_price_group_account_price_group_members_path(current_facility, @price_group, account_id: account.id), method: :post
             %td= account.owner_user.full_name if account.owner_user
             %td= human_date(account.expires_at)
-    - if @accounts.count > @limit
-      %p.notice= t(".notice", count: @count - @limit)
+    = additional_results_notice(count: @count, limit: @limit)
 - else
   %p.error= t(".error.noterm")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -804,7 +804,7 @@ en:
       head: "Select an Existing Payment Source"
       main: "Can't find the payment source you're looking for?"
       create: "Create a new payment source"
-      notice: "%{count} more payment sources exist, try refining your search."
+      notice_html: "<p class='notice'>%{count} more payment sources exist, try refining your search.</p>"
       error:
         noterm: "Please enter a search term"
         notfound: "No existing payment sources found."

--- a/spec/helpers/account_price_group_members_helper_spec.rb
+++ b/spec/helpers/account_price_group_members_helper_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AccountPriceGroupMembersHelper do
+  describe "additional_results_notice" do
+    it "returns nil if an input is missing" do
+      expect(additional_results_notice(count: nil, limit: 25)).to be_nil
+      expect(additional_results_notice(count: 14, limit: nil)).to be_nil
+      expect(additional_results_notice(count: 14, limit: 25)).to be_nil
+    end
+
+    it "returns nil if the accounts_count isn't over the limit" do
+      expect(additional_results_notice(count: 12, limit: 25)).to be_nil
+	end
+
+    it "returns a notice if accounts_count is over the limit" do
+	  count = 120
+	  limit = 25
+	  text = "<p class='notice'>#{count - limit} more payment sources exist, try refining your search.</p>"
+
+      expect(additional_results_notice(count: 120, limit: 25)).to eq text
+	end
+  end
+end


### PR DESCRIPTION
# Release Notes

`@count` was erroneously removed, which caused an error when the
search_results template was rendered and the number of results was over
the limit.

This adds an `additional_results_notice` helper which checks its inputs
before they are used.