### PR TITLE
[#153891] TimedServices adjustment in product bundles

### DIFF
--- a/app/support/orders/item_adder.rb
+++ b/app/support/orders/item_adder.rb
@@ -99,6 +99,8 @@ class Orders::ItemAdder
       case bundle_product.product
       when Instrument
         add_instruments(bundle_product.product, bundle_product.quantity, { bundle: product, group_id: group_id }.merge(attributes))
+      when TimedService
+        add_timed_services(bundle_product.product, bundle_product.quantity, nil, { bundle: product, group_id: group_id }.merge(attributes))
       else
         create_order_detail(
           {

--- a/app/support/orders/item_adder.rb
+++ b/app/support/orders/item_adder.rb
@@ -100,7 +100,7 @@ class Orders::ItemAdder
       when Instrument
         add_instruments(bundle_product.product, bundle_product.quantity, { bundle: product, group_id: group_id }.merge(attributes))
       when TimedService
-        add_timed_services(bundle_product.product, bundle_product.quantity, nil, { bundle: product, group_id: group_id }.merge(attributes))
+        add_timed_services(bundle_product.product, bundle_product.quantity, DEFAULT_TIMED_SERVICES_DURATION, { bundle: product, group_id: group_id }.merge(attributes))
       else
         create_order_detail(
           {

--- a/app/views/bundle_products/edit.html.haml
+++ b/app/views/bundle_products/edit.html.haml
@@ -11,7 +11,7 @@
 = simple_form_for([current_facility, @bundle, @bundle_product]) do |f|
   = f.error_messages
   .form-inputs
-    = f.input :quantity, as: :quantity, required: true
+    = f.input :quantity, required: true
   %ul.inline
     %li= f.submit text("shared.save"), class: "btn btn-primary"
     %li= link_to text("shared.cancel"), facility_bundle_bundle_products_path

--- a/app/views/bundle_products/index.html.haml
+++ b/app/views/bundle_products/index.html.haml
@@ -32,7 +32,7 @@
         %tr
           %td.centered= link_to text("shared.remove"), facility_bundle_bundle_product_path(current_facility, @bundle, bundle_product), method: :delete if can? :delete, bundle_product
           %td= link_to product.to_s_with_status, [:manage, current_facility, product]
-          - if product.is_a?(Instrument) or cannot? :edit, bundle_product
+          - if product.is_a?(Instrument) or product.is_a?(TimedService) or cannot? :edit, bundle_product
             %td= bundle_product.quantity
           - else
             - quantity = QuantityPresenter.new(bundle_product, bundle_product.quantity)

--- a/app/views/bundle_products/new.html.haml
+++ b/app/views/bundle_products/new.html.haml
@@ -18,7 +18,7 @@
       required: true,
       collection: @bundle.products_for_group_select,
       group_method: :last,
-      input_html: { class: "js--bundleProducts__productSelect", data: { timed_quantity_types: TimedService.model_name.human(count: 2) } }
+      input_html: { class: "js--bundleProducts__productSelect", data: { timed_quantity_types: '' } }
 
     .js--bundleProducts__quantityField
       = f.input :quantity, required: true

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -25,6 +25,15 @@
 
       - if order_detail.product.is_a?(Instrument)
         %td
+      - elsif order_detail.product.is_a?(TimedService)
+        %td.centered
+          = odf.input :quantity,
+            disabled: order_detail.quantity_locked_by_survey?,
+            input_html: { name: "quantity#{order_detail.id}",
+            aria: { label: "#{order_detail.product} #{OrderDetail.human_attribute_name(:quantity)}" },
+            id: "quantity#{order_detail.id}",
+            class: "cart__quantityField" },
+            label: false
       - elsif order_detail.bundle
         %td.centered= QuantityPresenter.new(order_detail.product, order_detail.quantity)
       - else

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -25,16 +25,7 @@
 
       - if order_detail.product.is_a?(Instrument)
         %td
-      - elsif order_detail.product.is_a?(TimedService)
-        %td.centered
-          = odf.input :quantity,
-            disabled: order_detail.quantity_locked_by_survey?,
-            input_html: { name: "quantity#{order_detail.id}",
-            aria: { label: "#{order_detail.product} #{OrderDetail.human_attribute_name(:quantity)}" },
-            id: "quantity#{order_detail.id}",
-            class: "cart__quantityField" },
-            label: false
-      - elsif order_detail.bundle
+      - elsif order_detail.bundle && !order_detail.product.is_a?(TimedService)
         %td.centered= QuantityPresenter.new(order_detail.product, order_detail.quantity)
       - else
         %td.centered

--- a/spec/system/placing_an_order_spec.rb
+++ b/spec/system/placing_an_order_spec.rb
@@ -107,15 +107,20 @@ RSpec.describe "Placing an item order" do
 
     describe "that has a timed service" do
       let(:timed_service) { FactoryBot.create(:setup_timed_service) }
+      let(:quantity) { 3 }
+
       before do
         FactoryBot.create(:timed_service_price_policy, price_group: PriceGroup.base, product: timed_service)
-        bundle.bundle_products.create!(product: timed_service, quantity: 90)
+        bundle.bundle_products.create!(product: timed_service, quantity: quantity)
       end
 
-      it "adds the item as a single line item" do
+      it "adds one editable line item per quantity" do
         add_to_cart
-        expect(page).to have_content(timed_service.name)
-        expect(page).to have_content("90")
+        ele = find_all(".timeinput").first
+        ele.fill_in with: "10"
+        click_button "Update"
+        expect(page).to have_content(timed_service.name, count: quantity)
+        expect(page).to have_content("$12.00")
       end
     end
 

--- a/spec/system/placing_an_order_spec.rb
+++ b/spec/system/placing_an_order_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe "Placing an item order" do
 
       it "adds the item as a single line item" do
         add_to_cart
-        expect(page).to have_content(timed_service.name).once
+        expect(page).to have_content(timed_service.name)
         expect(page).to have_content("90")
       end
     end

--- a/spec/system/placing_an_order_spec.rb
+++ b/spec/system/placing_an_order_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "Placing an item order" do
       it "adds the item as a single line item" do
         add_to_cart
         expect(page).to have_content(timed_service.name).once
-        expect(page).to have_content("1:30")
+        expect(page).to have_content("90")
       end
     end
 


### PR DESCRIPTION
# Release Notes

When TimedServices are part of a bundle, the time is preset, it's not possible for a user to adjust the amount of time they'd like.

This updates the behavior of bundled TimedServices so that the time can be adjusted by the user on checkout.

# Screenshot

![Screen Shot 2022-05-31 at 12 48 56 PM](https://user-images.githubusercontent.com/624487/171267634-043f3c62-7162-4fe7-9bf5-3bc36e840a50.png)
