### PR TITLE
[#157969] After User Creation Screen changes

### DIFF
--- a/app/controllers/concerns/user_controller_flash_text.rb
+++ b/app/controllers/concerns/user_controller_flash_text.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module UserControllerFlashText
+
+  extend ActiveSupport::Concern
+
+  # Builds the text for the creation success flash notice
+  def creation_success_flash_text(user, facility)
+    user_type = user.email_user? ? "external" : "internal"
+
+    html(
+      "create.success.#{user_type}",
+      user_info: "#{user.full_name} (#{user.email})",
+      user_link: facility_user_path(facility, user),
+      price_group: price_group_name(user_type),
+      app_name: t("app_name"),
+      support_contact: support_contact
+    )
+  end
+
+  def price_group_name(user_type)
+    if user_type == "internal"
+      Settings.price_group.name.base
+    else
+      Settings.price_group.name.external
+    end
+  end
+
+  def support_contact
+    if Settings.support_email.blank?
+      ""
+    else
+      email = Settings.support_email
+      " at [#{email}](mailto:#{email})"
+    end
+  end
+
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,6 +12,7 @@ class UsersController < ApplicationController
   end
 
   include Overridable
+  include UserControllerFlashText
   include TextHelpers::Translation
 
   customer_tab :password
@@ -236,7 +237,7 @@ class UsersController < ApplicationController
   end
 
   def save_user_success(user)
-    flash[:notice] = creation_success_text(user)
+    flash[:notice] = creation_success_flash_text(user, current_facility)
 
     Notifier.new_user(user: user, password: user.password).deliver_later
     redirect_to facility_users_path(user: user.id)
@@ -247,36 +248,6 @@ class UsersController < ApplicationController
       flash[key] += " #{message}"
     else
       flash[key] = message
-    end
-  end
-
-  # Builds the text for the creation success flash notice
-  def creation_success_text(user)
-    user_type = user.email_user? ? "external" : "internal"
-
-    html(
-      "create.success.#{user_type}",
-      user_info: "#{user.full_name} (#{user.email})",
-      user_link: facility_user_path(current_facility, user),
-      price_group: price_group_name(user_type),
-      app_name: t("app_name"),
-      support_contact: support_contact
-    )
-  end
-
-  def price_group_name(user_type)
-    if user_type == "internal"
-      Settings.price_group.name.base
-    else
-      Settings.price_group.name.external
-    end
-  end
-
-  def support_contact
-    if Settings.support_email.blank?
-      ""
-    else
-      " at #{Settings.support_email}"
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -237,7 +237,9 @@ class UsersController < ApplicationController
   end
 
   def save_user_success(user)
-    flash[:notice] = text("create.success")
+    user_type = user.email_user? ? "external" : "internal"
+    flash[:notice] = creation_success_text(user_type)
+
     if session_user.manager_of?(current_facility)
       add_role = html("create.add_role", link: facility_facility_user_map_user_path(current_facility, user), inline: true)
       flash[:notice].safe_concat(add_role)
@@ -251,6 +253,34 @@ class UsersController < ApplicationController
       flash[key] += " #{message}"
     else
       flash[key] = message
+    end
+  end
+
+  # Builds the text for the creation success flash notice
+  #
+  # +user_type+ A string which specifies if the user is "internal" or "external"
+  def creation_success_text(user_type)
+    text(
+      "create.success.#{user_type}",
+      price_group: price_group_name(user_type),
+      app_name: t("app_name"),
+      support_contact: support_contact
+    )
+  end
+
+  def price_group_name(user_type)
+    if user_type == "internal"
+      Settings.price_group.name.internal
+    else
+      Settings.price_group.name.external
+    end
+  end
+
+  def support_contact
+    if Settings.support_email.blank?
+      ""
+    else
+      " at #{Settings.support_email}"
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
   end
 
   include Overridable
-  include UserControllerFlashText
+  include UsersHelper
   include TextHelpers::Translation
 
   customer_tab :password

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
-module UserControllerFlashText
-
-  extend ActiveSupport::Concern
+module UsersHelper
 
   # Builds the text for the creation success flash notice
   def creation_success_flash_text(user, facility)
     user_type = user.email_user? ? "external" : "internal"
 
     html(
-      "create.success.#{user_type}",
+      "controllers.users.create.success.#{user_type}",
       user_info: "#{user.full_name} (#{user.email})",
       user_link: facility_user_path(facility, user),
       price_group: price_group_name(user_type),
@@ -17,6 +15,8 @@ module UserControllerFlashText
       support_contact: support_contact
     )
   end
+
+	private
 
   def price_group_name(user_type)
     if user_type == "internal"
@@ -34,5 +34,4 @@ module UserControllerFlashText
       " at [#{email}](mailto:#{email})"
     end
   end
-
 end

--- a/app/views/users/_new_user.html.haml
+++ b/app/views/users/_new_user.html.haml
@@ -1,3 +1,0 @@
-.notice
-  %p= "#{t('users.new_user.success')} #{link_to "#{@new_user} (#{@new_user.username})", facility_user_path(current_facility, @new_user)}.".html_safe
-  %p= link_to t('users.new_user.add_to_payment_source'), facility_accounts_path(current_facility)

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -4,8 +4,6 @@
 = content_for :sidebar do
   = render "admin/shared/sidenav_users", sidenav_tab: "users"
 
-= render "new_user" if @new_user
-
 = render "search_form"
 
 #result

--- a/config/locales/views/admin/en.users.yml
+++ b/config/locales/views/admin/en.users.yml
@@ -21,13 +21,13 @@ en:
         error: There was an error creating the user. %{message}
         success:
           internal: |
-            The default Price Group for this user is "%{price_group}" (internal rates).
-            Please notify %{app_name} support%{support_contact} if this is an External User. 
-            The user must be added to a Payment Source before they can make a purchase.
+            You just created a new user, [%{user_info}](%{user_link}).
+
+            The default Price Group for this user is "%{price_group}" (internal rates). Please notify %{app_name} support%{support_contact} if this is an External User.
           external: |
-            The default Price Group for this user is "%{price_group}."
-            Please notify %{app_name} support%{support_contact} if this user is entitled to internal rates.
-            The user must be added to a Payment Source before they can make a purchase.
+            You just created a new user, [%{user_info}](%{user_link}).
+
+            The default Price Group for this user is "%{price_group}." Please notify %{app_name} support%{support_contact} if this user is entitled to internal rates.
         add_role: |
           You may wish to [add a !facility_downcase! role](%{link}) for this user.
       update:

--- a/config/locales/views/admin/en.users.yml
+++ b/config/locales/views/admin/en.users.yml
@@ -19,7 +19,15 @@ en:
     users:
       create:
         error: There was an error creating the user. %{message}
-        success: The user has been added successfully.
+        success:
+          internal: |
+            The default Price Group for this user is "%{price_group}" (internal rates).
+            Please notify %{app_name} support%{support_contact} if this is an External User. 
+            The user must be added to a Payment Source before they can make a purchase.
+          external: |
+            The default Price Group for this user is "%{price_group}."
+            Please notify %{app_name} support%{support_contact} if this user is entitled to internal rates.
+            The user must be added to a Payment Source before they can make a purchase.
         add_role: |
           You may wish to [add a !facility_downcase! role](%{link}) for this user.
       update:

--- a/config/locales/views/admin/en.users.yml
+++ b/config/locales/views/admin/en.users.yml
@@ -23,7 +23,7 @@ en:
           internal: |
             You just created a new user, [%{user_info}](%{user_link}).
 
-            The default Price Group for this user is "%{price_group}" (internal rates). Please notify %{app_name} support%{support_contact} if this is an External User.
+            The default Price Group for this user is "%{price_group}" (internal rates). Please notify %{app_name} support%{support_contact} if this is an external user.
           external: |
             You just created a new user, [%{user_info}](%{user_link}).
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -36,16 +36,6 @@ RSpec.describe UsersController do
       expect(assigns[:users]).to include @active_user
     end
 
-    context "with newly created user" do
-      before :each do
-        @user = FactoryBot.create(:user)
-        @params.merge!(user: @user.id)
-      end
-      it_should_allow_operators_only :success, "set the user" do
-        expect(assigns[:new_user]).to eq(@user)
-      end
-    end
-
   end
 
   describe "GET #edit", feature_setting: { create_users: true, reload_routes: true } do

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "text_helpers/contexts"
+
+RSpec.describe UsersHelper, controller: true do
+  let(:facility) { FactoryBot.create(:facility) }
+  let(:external_user) { FactoryBot.create(:user, :external) }
+  let(:internal_user) { FactoryBot.create(:user) }
+
+  initial_support_email = Settings.support_email
+
+  after(:all) do
+    Settings.support_email = initial_support_email
+  end
+
+  describe "creation_success_flash_text" do
+    context "with support email" do
+      before(:all) do
+        Settings.support_email = "help@example.com"
+      end
+
+      it "gives text for external user" do
+        test_string = "<p>The default Price Group for this user is &ldquo;#{Settings.price_group.name.external}.&rdquo; Please notify #{t('app_name')} support at <a href=\"mailto:help@example.com\">help@example.com</a> if this user is entitled to internal&nbsp;rates.</p>"
+
+        expect(creation_success_flash_text(external_user, facility)).to include test_string
+      end
+
+      it "gives text for internal user" do
+        test_string = "<p>The default Price Group for this user is &ldquo;#{Settings.price_group.name.base}&rdquo; (internal rates). Please notify #{t('app_name')} support at <a href=\"mailto:help@example.com\">help@example.com</a> if this is an external&nbsp;user.</p>"
+
+        expect(creation_success_flash_text(internal_user, facility)).to include test_string
+      end
+    end
+
+    context "without support email" do
+      before(:all) do
+        Settings.support_email = nil
+      end
+
+      it "gives text for external user" do
+        test_string = "<p>The default Price Group for this user is &ldquo;#{Settings.price_group.name.external}.&rdquo; Please notify #{t('app_name')} support if this user is entitled to internal&nbsp;rates.</p>"
+
+        expect(creation_success_flash_text(external_user, facility)).to include test_string
+      end
+
+      it "gives text for internal user" do
+        test_string = "<p>The default Price Group for this user is &ldquo;#{Settings.price_group.name.base}&rdquo; (internal rates). Please notify #{t('app_name')} support if this is an external&nbsp;user.</p>"
+
+        expect(creation_success_flash_text(internal_user, facility)).to include test_string
+      end
+    end
+  end
+end

--- a/spec/system/admin/managing_user_spec.rb
+++ b/spec/system/admin/managing_user_spec.rb
@@ -5,14 +5,36 @@ require "rails_helper"
 RSpec.describe "Managing User Details", :aggregate_failures, feature_setting: { create_users: true, user_based_price_groups: true, reload_routes: true } do
 
   let(:facility) { FactoryBot.create(:facility) }
+  let(:admin) { FactoryBot.create(:user, :netid, :administrator) }
+
+  before do
+    login_as admin
+  end
+
+  describe "create", js: true do
+    let(:user) { FactoryBot.build(:user, :netid, username: "user123") }
+
+    it "creates an external user" do
+      visit new_external_facility_users_path(facility)
+
+      fill_in "First name", with: user.first_name
+      fill_in "Last name", with: user.last_name
+      fill_in "Email", with: user.email
+
+      click_on "Create"
+
+      expect(page).to have_content("You just created a new user, #{user.full_name} (#{user.email})")
+
+      expect(page).to have_content("if this user is entitled to internal rates.")
+    end
+
+  end
 
   describe "edit" do
     describe "as a facility admin" do
-      let(:admin) { FactoryBot.create(:user, :netid, :administrator) }
       let(:user) { FactoryBot.create(:user, :netid, username: "user123") }
 
       before do
-        login_as admin
         visit facility_user_path(facility, user)
       end
 


### PR DESCRIPTION
# Release Notes

When a user is created, there are some helpful things the admin should be reminded of.

This puts information about price group and payment source in the flash message that appears after successful user creation.

# Screenshot

![Screen Shot 2022-05-24 at 3 47 40 PM](https://user-images.githubusercontent.com/624487/170297732-bc034e26-c926-49ce-8168-4001962a847f.png)

