### PR TITLE
[#160400] Simplify logic for user type (internal/external)

### DIFF
--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -42,7 +42,7 @@ class UserForm < SimpleDelegator
   end
 
   def admin_editable?
-    user.email_user?
+    user.authenticated_locally?
   end
 
   def username_editable?

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -4,7 +4,7 @@ module UsersHelper
 
   # Builds the text for the creation success flash notice
   def creation_success_flash_text(user, facility)
-    user_type = user.email_user? ? "external" : "internal"
+    user_type = user.authenticated_locally? ? "external" : "internal"
 
     html(
       "controllers.users.create.success.#{user_type}",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,14 +85,8 @@ class User < ApplicationRecord
     encrypted_password.present? && password_salt.present?
   end
 
-  #
-  # Returns true if this user uses Devise's authenticatable module
-  def email_user?
-    username.casecmp(email.downcase).zero?
-  end
-
   def password_updatable?
-    email_user?
+    authenticated_locally?
   end
 
   # Runs various validation checks and then saves the new password.

--- a/app/services/users/convert_external_to_internal_user.rb
+++ b/app/services/users/convert_external_to_internal_user.rb
@@ -22,7 +22,7 @@ module Users
 
     def convert!
       existing_user = User.find_by!(email: @email)
-      raise "Is already an internal user" unless existing_user.email_user?
+      raise "Is already an internal user" unless existing_user.authenticated_locally?
 
       existing_user.assign_attributes(find_attributes)
 

--- a/app/services/users/convert_internal_to_external_user.rb
+++ b/app/services/users/convert_internal_to_external_user.rb
@@ -15,7 +15,7 @@ module Users
     def convert!
       user = User.find_by!(username: @username)
 
-      raise "#{@username} is already an external user" if user.email_user?
+      raise "#{@username} is already an external user" if user.authenticated_locally?
 
       user.assign_attributes(
         username: user.email,

--- a/app/services/users/default_price_group_selector.rb
+++ b/app/services/users/default_price_group_selector.rb
@@ -5,7 +5,7 @@ module Users
   class DefaultPriceGroupSelector
 
     def call(user)
-      user.email_user? ? PriceGroup.external : PriceGroup.base
+      user.authenticated_locally? ? PriceGroup.external : PriceGroup.base
     end
 
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -99,11 +99,6 @@ RSpec.describe User do
     expect(user).not_to be_email_user
   end
 
-  it "is an email user when the username is the same as the email" do
-    user.username = user.email
-    expect(user).to be_email_user
-  end
-
   describe ".with_global_roles" do
     subject(:users_with_global_roles) { described_class.with_global_roles }
     let!(:unprivileged_users) { create_list(:user, 2) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -94,11 +94,6 @@ RSpec.describe User do
 
   it { is_expected.to be_respond_to(:ldap_attributes) }
 
-  it "is not an email user when the username and email differ" do
-    expect(user.username).not_to eq(user.email)
-    expect(user).not_to be_email_user
-  end
-
   describe ".with_global_roles" do
     subject(:users_with_global_roles) { described_class.with_global_roles }
     let!(:unprivileged_users) { create_list(:user, 2) }


### PR DESCRIPTION
# Release Notes

We currently have 2 ways to determine if a user is internal or external - checking for a stored password or comparing username and email.  We'd like to be able to support SSO that uses email as username, and this allows that while also moving to a single way of checking user type.  

I've confirmed this change with all the schools.  Some schools will benefit from a little user record cleanup after this is released.