### PR TITLE
Tech task - Add txi digital to allow list

### DIFF
--- a/app/lib/staging_mail_interceptor.rb
+++ b/app/lib/staging_mail_interceptor.rb
@@ -32,12 +32,12 @@ class StagingMailInterceptor
   def process
     message.subject = subject
 
-    return if all_addresses_whitelisted?
+    return if all_addresses_allow_listed?
 
     message.html_part.body = html_body if message.html_part
     message.text_part.body = text_body if message.text_part
 
-    message.to = whitelisted_addresses
+    message.to = allow_listed_addresses
     message.cc = nil
     message.bcc = nil
   end
@@ -74,32 +74,32 @@ class StagingMailInterceptor
     "Intercepted email:\n  to: #{message.to}\n  cc: #{message.cc}\n  bcc: #{message.bcc}"
   end
 
-  # Internal: Is the passed recipient whitelisted for communication? Permits
+  # Internal: Is the passed recipient allow_listed for communication? Permits
   # communication only with either Table XI employees or emails listed in
   # secrets in the staging environment.
   #
   # Returns a Boolean.
-  def whitelisted?(recipient)
+  def allow_listed?(recipient)
     recipient = Mail::Address.new(recipient)
     recipient.domain == "tablexi.com" ||
-      full_whitelist.map(&:downcase).include?(recipient.address.downcase)
+      full_allow_list.map(&:downcase).include?(recipient.address.downcase)
   end
 
-  # Internal: Get a list of the whitelisted email addresses for this message.
-  # If no email addresses are whitelisted, defaults to the configured exception
+  # Internal: Get a list of the allow_listed email addresses for this message.
+  # If no email addresses are allow_listed, defaults to the configured exception
   # notification email address.
   #
   # Returns a String or Array of Strings.
-  def whitelisted_addresses
-    message.to.select { |recipient| whitelisted?(recipient) }.presence ||
+  def allow_listed_addresses
+    message.to.select { |recipient| allow_listed?(recipient) }.presence ||
       send_to_addresses
   end
 
-  # Internal: Are all target email addresses whitelisted?
+  # Internal: Are all target email addresses allow_listed?
   #
   # Returns a Boolean.
-  def all_addresses_whitelisted?
-    message.to.all? { |recipient| whitelisted?(recipient) } &&
+  def all_addresses_allow_listed?
+    message.to.all? { |recipient| allow_listed?(recipient) } &&
       message.cc.blank? &&
       message.bcc.blank?
   end
@@ -107,16 +107,16 @@ class StagingMailInterceptor
   # Internal: The list of all users that will be able to receive emails
   #
   # Returns an Array of strings
-  def full_whitelist
-    send_to_addresses + whitelist + exception_recipients
+  def full_allow_list
+    send_to_addresses + allow_list + exception_recipients
   end
 
   def send_to_addresses
     Array(settings[:to])
   end
 
-  def whitelist
-    Array(settings[:whitelist])
+  def allow_list
+    Array(settings[:allow_list])
   end
 
   def exception_recipients

--- a/app/lib/staging_mail_interceptor.rb
+++ b/app/lib/staging_mail_interceptor.rb
@@ -82,6 +82,7 @@ class StagingMailInterceptor
   def allow_listed?(recipient)
     recipient = Mail::Address.new(recipient)
     recipient.domain == "tablexi.com" ||
+      recipient.domain == "txidigital.com" ||
       full_allow_list.map(&:downcase).include?(recipient.address.downcase)
   end
 

--- a/config/eye.yml.erb
+++ b/config/eye.yml.erb
@@ -28,9 +28,9 @@ notifications:
 #   - name: monitoring
 #     type: ses
 #     level: info
-#     contact: nucore+open@tablexi.com
+#     contact: nucore+open@txidigital.com
 #     config:
-#       from: nucore+open@tablexi.com
+#       from: nucore+open@txidigital.com
 #       access_key_id: ~
 #       secret_access_key: ~
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -46,7 +46,7 @@ email:
   fake:
     enabled: false
     to:
-    whitelist:
+    allow_list:
   exceptions:
     sender: 'noreply@example.com'
     recipients: [ 'warn@example.com', 'error@example.com' ]

--- a/config/settings/stage.yml
+++ b/config/settings/stage.yml
@@ -3,8 +3,8 @@ email:
   fake:
     enabled: true
     to:
-      - nucore@tablexi.com
-    whitelist: []
+      - nucore@txidigital.com
+    allow_list: []
 
 # paperclip:
 #   storage: s3

--- a/spec/lib/staging_mail_interceptor_spec.rb
+++ b/spec/lib/staging_mail_interceptor_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe StagingMailInterceptor do
     end
   end
 
-  describe "whitelisting" do
-    let(:whitelist) { ["allowed@example.org", "allowed2@example.org", "allowed3@example.org"] }
+  describe "allow_listing" do
+    let(:allow_list) { ["allowed@example.org", "allowed2@example.org", "allowed3@example.org"] }
     let(:send_to) { ["sendto@example.org"] }
 
     before do
-      allow(interceptor).to receive(:whitelist) { whitelist }
+      allow(interceptor).to receive(:allow_list) { allow_list }
       allow(interceptor).to receive(:send_to_addresses) { send_to }
       interceptor.process
     end
@@ -39,7 +39,7 @@ RSpec.describe StagingMailInterceptor do
       end
 
       describe "multiple addresses" do
-        let(:to) { whitelist.first(2) }
+        let(:to) { allow_list.first(2) }
 
         it "lets the email through" do
           expect(message.to).to eq(to)
@@ -58,7 +58,7 @@ RSpec.describe StagingMailInterceptor do
     describe "when the email is not on the list" do
       let(:to) { ["notallowed@example.org"] }
 
-      it "sends to the whitelist" do
+      it "sends to the allow_list" do
         expect(message.to).to eq(send_to)
       end
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -661,8 +661,8 @@ RSpec.describe Product do
     end
 
     describe "invalid emails" do
-      let(:contacts) { "valid@tablexi.com, invalid@ " }
-      it { is_expected.to eq ["valid@tablexi.com", "invalid@"] }
+      let(:contacts) { "valid@txidigital, invalid@ " }
+      it { is_expected.to eq ["valid@txidigital", "invalid@"] }
       it "is invalid" do
         expect(product).to be_invalid
         expect(product.errors).to include(:training_request_contacts)

--- a/spec/services/log_event_searcher_spec.rb
+++ b/spec/services/log_event_searcher_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe LogEventSearcher do
     let!(:log_2) { create(:log_event, loggable: account_user, event_type: :create) }
     let!(:log_3) { create(:log_event, loggable: user, event_type: :create) }
 
-    it "whitelists event type" do
+    it "allow-lists event type" do
       search = LogEventSearcher.new(events: ["user.create", "cheeseburger.create", "user.update"])
       expect(search.events).to contain_exactly("user.create")
     end

--- a/vendor/engines/bulk_email/bulk_email.gemspec
+++ b/vendor/engines/bulk_email/bulk_email.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.name    = "bulk_email"
   s.version = BulkEmail::VERSION
   s.authors  = ["Table XI"]
-  s.email    = "devs@tablexi.com"
+  s.email    = "devs@txidigital.com"
   s.homepage = "https://github.com/tablexi/nucore-open"
   s.summary = "Bulk email feature"
   s.description = ""

--- a/vendor/engines/c2po/c2po.gemspec
+++ b/vendor/engines/c2po/c2po.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name    = "c2po"
   s.version = "1.0.0"
   s.authors  = ["Table XI"]
-  s.email    = "devs@tablexi.com"
+  s.email    = "devs@txidigital.com"
   s.homepage = "https://github.com/tablexi/nucore-open"
   s.summary = "Provides credit card and purchase order accounts for nucore apps"
 

--- a/vendor/engines/dataprobe/dataprobe.gemspec
+++ b/vendor/engines/dataprobe/dataprobe.gemspec
@@ -5,6 +5,6 @@ Gem::Specification.new do |gem|
   gem.version = "1.0.0"
   gem.summary = "Provides interfacing with Dataprobe iPIO-8 relay monitor"
   gem.authors  = ["Table XI"]
-  gem.email    = "chris@tablexi.com"
+  gem.email    = "devs@txidigital.com"
   gem.homepage = "https://github.com/tablexi/nucore-open"
 end

--- a/vendor/engines/fine_uploader/fine_uploader.gemspec
+++ b/vendor/engines/fine_uploader/fine_uploader.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.name        = "fine_uploader"
   s.version     = FineUploader::VERSION
   s.authors     = ["Jason Hanggi"]
-  s.email       = ["jason@tablexi.com"]
+  s.email       = ["devs@txidigital.com"]
   s.homepage    = "http://fineuploader.com/"
   s.summary     = "FineUploader for Rails Asset Pipeline"
   s.description = "FineUploader for Rails Asset Pipeline."

--- a/vendor/engines/fullcalendar/fullcalendar.gemspec
+++ b/vendor/engines/fullcalendar/fullcalendar.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.name        = "fullcalendar"
   s.version     = Fullcalendar::VERSION
   s.authors     = ["Jason Hanggi"]
-  s.email       = ["jason@tablexi.com"]
+  s.email       = ["devs@txidigital.com"]
   s.homepage    = "https://fullcalendar.io/"
   s.summary     = "FullCalendar for Rails Asset Pipeline"
   s.description = "FullCalendar for Rails Asset Pipeline."

--- a/vendor/engines/ldap_authentication/ldap_authentication.gemspec
+++ b/vendor/engines/ldap_authentication/ldap_authentication.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.name        = "ldap_authentication"
   s.version     = LdapAuthentication::VERSION
   s.authors     = ["Table XI"]
-  s.email       = ["devs@tablexi.com"]
+  s.email       = ["devs@txidigital.com"]
   s.homepage = "https://github.com/tablexi/nucore-open"
   s.summary     = "LDAP Authentication for NUcore"
   s.description = ""

--- a/vendor/engines/projects/projects.gemspec
+++ b/vendor/engines/projects/projects.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.name    = "projects"
   s.version = Projects::VERSION
   s.authors  = ["Table XI"]
-  s.email    = "devs@tablexi.com"
+  s.email    = "devs@txidigital.com"
   s.homepage = "https://github.com/tablexi/nucore-open"
   s.summary = "Optional projects feature"
   s.description = ""

--- a/vendor/engines/saml_authentication/saml_authentication.gemspec
+++ b/vendor/engines/saml_authentication/saml_authentication.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.name        = "saml_authentication"
   s.version     = SamlAuthentication::VERSION
   s.authors     = ["Table XI"]
-  s.email       = ["devs@tablexi.com"]
+  s.email       = ["devs@txidigital.com"]
   s.homepage    = "https://github.com/tablexi/nucore-open"
   s.summary     = "SAML Authentication for NUcore"
   s.description = ""

--- a/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/admin/batches_controller.rb
+++ b/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/admin/batches_controller.rb
@@ -30,7 +30,7 @@ module SangerSequencing
       end
 
       def create
-        # Whitelisting should happen in the form object
+        # Allow-listing should happen in the form object
         if @batch.update_form_attributes(params[:batch].merge(created_by: current_user, facility: current_facility))
           redirect_to [current_facility, :sanger_sequencing, :admin, :batches, group: @batch.group], notice: text("create.success")
         else

--- a/vendor/engines/sanger_sequencing/sanger_sequencing.gemspec
+++ b/vendor/engines/sanger_sequencing/sanger_sequencing.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.name        = "sanger_sequencing"
   s.version     = SangerSequencing::VERSION
   s.authors     = ["Table XI"]
-  s.email       = "devs@tablexi.com"
+  s.email       = "devs@txidigital.com"
   s.homepage    = "https://github.com/tablexi/nucore-open"
   s.summary     = "Sanger Sequencing module for NUcore"
   s.description = "Sanger Sequencing module for NUcore"

--- a/vendor/engines/secure_rooms/secure_rooms.gemspec
+++ b/vendor/engines/secure_rooms/secure_rooms.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.name        = "secure_rooms"
   s.version     = SecureRooms::VERSION
   s.authors     = ["Table XI"]
-  s.email       = ["devs@tablexi.com"]
+  s.email       = ["devs@txidigital.com"]
   s.homepage    = "https://github.com/tablexi/nucore-open"
   s.summary     = "Optional Secure Room feature for NUcore"
   s.description = "Optional Secure Room feature for NUcore"

--- a/vendor/engines/split_accounts/split_accounts.gemspec
+++ b/vendor/engines/split_accounts/split_accounts.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.authors  = ["Table XI"]
   s.email    = "devs@txidigital.com"
   s.homepage = "https://github.com/tablexi/nucore-open"
-  s.summary = "Optional split a`ccounts feature"
+  s.summary = "Optional split accounts feature"
   s.description = ""
 
   s.files = Dir["{app,config,db,lib}/**/*", "spec/factories/**/*"]

--- a/vendor/engines/split_accounts/split_accounts.gemspec
+++ b/vendor/engines/split_accounts/split_accounts.gemspec
@@ -8,9 +8,9 @@ Gem::Specification.new do |s|
   s.name    = "split_accounts"
   s.version = SplitAccounts::VERSION
   s.authors  = ["Table XI"]
-  s.email    = "devs@tablexi.com"
+  s.email    = "devs@txidigital.com"
   s.homepage = "https://github.com/tablexi/nucore-open"
-  s.summary = "Optional split accounts feature"
+  s.summary = "Optional split a`ccounts feature"
   s.description = ""
 
   s.files = Dir["{app,config,db,lib}/**/*", "spec/factories/**/*"]


### PR DESCRIPTION
# Release Notes

- Use "allow_list" in place of "whitelist", a term which has a racist history
- Allow stage to send email to any address "@txidigital.com"
- Clean up references to "@tablexi.com"