### PR TITLE
[#153891] Adds dynamic hint logic to new bundle product view

### DIFF
--- a/app/assets/javascripts/app/bundle_products.js
+++ b/app/assets/javascripts/app/bundle_products.js
@@ -1,34 +1,42 @@
-// On bundle_products#new, switch between a regular quantity field and a time
-// quantity field based on the type of product selected.
-$(function() {
-  $productSelect = $(".js--bundleProducts__productSelect");
-  const hints = document.querySelectorAll('.hint');
+/**
+ * Show/hide helpful hint text on the bundle new page based on which kind of product
+ * is selected. The hint text is meant to give the user helpful information about
+ * the product type (e.g. Item, Timed Service, etc).
+ * 
+ * To add a hint, add an element with the .hint and .js--<camel cased product type> 
+ * classes to the page. E.g. the "Timed Services" hint is put in an element with the
+ * .js--timedServices, and .hint classes.
+ */
+(function() {
+  window.addEventListener("DOMContentLoaded", function() {
+    const productSelect = document.querySelector(".js--bundleProducts__productSelect");
 
-  hideElements(hints);
+    if (productSelect) {
+      const hints = document.querySelectorAll(".hint");
 
-  if ($productSelect.length) {
-
-    $productSelect.bind("change", function(evt) {
       hideElements(hints);
 
-      let selectedType = $(evt.target).find(":selected").closest("optgroup").attr("label");
+      productSelect.addEventListener("change", function(evt) {
+        hideElements(hints);
 
-      if (selectedType) {
-        let className = ".js--" + capitalizedToCamelCase(selectedType);
-        document.querySelector(className).hidden = false;
-      }
+        let selectedType = $(evt.target).find(":selected").closest("optgroup").attr("label");
 
-    }).trigger("change");
+        if (selectedType) {
+          let className = ".js--" + capitalizedToCamelCase(selectedType);
+          document.querySelector(className).hidden = false;
+        }
 
-  }
+      });
+    }
 
-  function capitalizedToCamelCase(str) {
-    return (str[0].toLowerCase() + str.slice(1)).replaceAll(" ", "");
-  }
+    function capitalizedToCamelCase(str) {
+      return (str[0].toLowerCase() + str.slice(1)).replaceAll(" ", "");
+    }
 
-  function hideElements(elements) {
-    elements.forEach(function(element) {
-      element.hidden = true;
-    });
-  }
-});
+    function hideElements(elements) {
+      elements.forEach(function(element) {
+        element.hidden = true;
+      });
+    }
+  });
+})();

--- a/app/assets/javascripts/app/bundle_products.js
+++ b/app/assets/javascripts/app/bundle_products.js
@@ -2,29 +2,33 @@
 // quantity field based on the type of product selected.
 $(function() {
   $productSelect = $(".js--bundleProducts__productSelect");
+  const hints = document.querySelectorAll('.hint');
+
+  hideElements(hints);
 
   if ($productSelect.length) {
-    var timeQuantityTypes = $productSelect.data("timed-quantity-types").split(", ")
-    var $quantityField = $(".js--bundleProducts__quantityField");
-    var $timedQuantityField = $(".js--bundleProducts__timedQuantityField");
 
     $productSelect.bind("change", function(evt) {
-      var selectedType = $(evt.target).find(":selected").closest("optgroup").attr("label");
-      var isTimeSelected = timeQuantityTypes.includes(selectedType);
+      hideElements(hints);
 
-      // Show/hide and Enable/Disable the regular quantity vs time quantit fields
-      $quantityField.toggle(!isTimeSelected).find("input").prop("disabled", isTimeSelected);
-      $timedQuantityField.toggle(isTimeSelected).find("input").prop("disabled", !isTimeSelected);
+      let selectedType = $(evt.target).find(":selected").closest("optgroup").attr("label");
+
+      if (selectedType) {
+        let className = ".js--" + capitalizedToCamelCase(selectedType);
+        document.querySelector(className).hidden = false;
+      }
+
     }).trigger("change");
 
-    // Keep the two fields synchronized. In the time input field, there is a visible
-    // field, which is the formatted (H:MM) version and the hidden is a raw quantity.
-    $quantityField.on("change", function(evt) {
-      $timedQuantityField.find("input[type=hidden]").val($(evt.target).val()).trigger("change");
-    });
+  }
 
-    $timedQuantityField.on("change", "input[type=hidden]", function(evt) {
-      $quantityField.find("input").val($(evt.target).val())
+  function capitalizedToCamelCase(str) {
+    return (str[0].toLowerCase() + str.slice(1)).replaceAll(" ", "");
+  }
+
+  function hideElements(elements) {
+    elements.forEach(function(element) {
+      element.hidden = true;
     });
   }
 });

--- a/app/views/bundle_products/new.html.haml
+++ b/app/views/bundle_products/new.html.haml
@@ -24,7 +24,7 @@
       = f.input :quantity, required: true
 
     %p.js--timedServices.hint
-      The number of timed services, not time per service. Time can be adjusted in cart.
+      = t("timed_service_hint")
 
   %ul.inline
     %li= f.submit t("shared.create"), class: "btn"

--- a/app/views/bundle_products/new.html.haml
+++ b/app/views/bundle_products/new.html.haml
@@ -18,12 +18,13 @@
       required: true,
       collection: @bundle.products_for_group_select,
       group_method: :last,
-      input_html: { class: "js--bundleProducts__productSelect", data: { timed_quantity_types: '' } }
+      input_html: { class: "js--bundleProducts__productSelect" }
 
     .js--bundleProducts__quantityField
       = f.input :quantity, required: true
-    .js--bundleProducts__timedQuantityField
-      = f.input :quantity, required: true, input_html: { class: "timeinput" }
+
+    %p.js--timedServices.hint
+      The number of timed services, not time per service. Time can be adjusted in cart.
 
   %ul.inline
     %li= f.submit t("shared.create"), class: "btn"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1269,3 +1269,5 @@ en:
     calendar_tooltip: Calendar file download
     summary: "%{facility}: %{product}"
     description: "%{facility} reservation for %{product}. Order number %{order_number}."
+  
+  timed_service_hint: The number of timed services, not time per service. Time can be adjusted in cart.


### PR DESCRIPTION
# Release Notes

For Timed Services, the quantity field may be confusing for some users, since its meaning has recently changed.

This adds some informational hint text that dynamically appears when a Timed Service is being added to the bundle. It also makes it trivial to add hints for other product types.

# Screenshot

![Screen Shot 2022-07-06 at 4 23 03 PM](https://user-images.githubusercontent.com/624487/177647660-f3c08780-8291-4754-8767-05c837e7c3d9.png)

