### PR TITLE
Disables class caching in the development environment

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -111,6 +111,10 @@ class Account < ApplicationRecord
     for_user(order_detail.user).for_facility(order_detail.facility)
   end
 
+  def self.reconcilable?
+    false
+  end
+
   def type_string
     I18n.t("activerecord.models.#{self.class.to_s.underscore}.one", default: self.class.model_name.human)
   end

--- a/app/models/account_config.rb
+++ b/app/models/account_config.rb
@@ -30,7 +30,7 @@ class AccountConfig
   end
 
   def reconcilable_account_types
-    @reconcilable_account_types ||= statement_account_types.map(&:constantize).select(&:reconcilable?).map(&:to_s)
+    statement_account_types.uniq.map(&:constantize).select(&:reconcilable?).map(&:to_s)
   end
 
   # Returns an array of subclassed Account object names that support affiliates.

--- a/app/models/account_config.rb
+++ b/app/models/account_config.rb
@@ -23,8 +23,8 @@ class AccountConfig
     @facility_account_types ||= []
   end
 
-  # Returns a set of subclassed Account object names that support statements.
-  # Engines can append to this list using `add_statement_account_types`
+  # Returns an array of subclassed Account object names that support statements.
+  # Engines can append to this list.
   def statement_account_types
     @statement_account_types ||= []
   end

--- a/app/models/account_config.rb
+++ b/app/models/account_config.rb
@@ -26,15 +26,11 @@ class AccountConfig
   # Returns a set of subclassed Account object names that support statements.
   # Engines can append to this list using `add_statement_account_types`
   def statement_account_types
-    @statement_account_types ||= Set[]
-  end
-
-  def add_statement_account_types(statement_types)
-    statement_types.each { |type| statement_account_types.add type }
+    @statement_account_types ||= []
   end
 
   def reconcilable_account_types
-    statement_account_types.map(&:constantize).select { |t| t < ReconcilableAccount }.map(&:to_s)
+    @reconcilable_account_types ||= statement_account_types.map(&:constantize).select(&:reconcilable?).map(&:to_s)
   end
 
   # Returns an array of subclassed Account object names that support affiliates.

--- a/app/models/account_config.rb
+++ b/app/models/account_config.rb
@@ -29,8 +29,12 @@ class AccountConfig
     @statement_account_types ||= []
   end
 
+  def statement_account_types_uniq
+    statement_account_types.uniq
+  end
+
   def reconcilable_account_types
-    statement_account_types.map(&:constantize).select { |t| t < ReconcilableAccount }.map(&:to_s)
+    statement_account_types_uniq.map(&:constantize).select { |t| t < ReconcilableAccount }.map(&:to_s)
   end
 
   # Returns an array of subclassed Account object names that support affiliates.
@@ -84,7 +88,7 @@ class AccountConfig
   # Returns true if statements are enabled. Some downstream repositories may
   # not use statements anywhere in the app.
   def statements_enabled?
-    statement_account_types.present?
+    statement_account_types_uniq.present?
   end
 
   # Returns true if affiliates are enabled. Some downstream repositories may
@@ -110,7 +114,7 @@ class AccountConfig
 
   # Returns true if this account type supports statements.
   def using_statements?(account_type)
-    statement_account_types.include?(account_type.to_s.classify)
+    statement_account_types_uniq.include?(account_type.to_s.classify)
   end
 
   # Returns true if this account type supports journal.

--- a/app/models/account_config.rb
+++ b/app/models/account_config.rb
@@ -23,18 +23,18 @@ class AccountConfig
     @facility_account_types ||= []
   end
 
-  # Returns an array of subclassed Account object names that support statements.
-  # Engines can append to this list.
+  # Returns a set of subclassed Account object names that support statements.
+  # Engines can append to this list using `add_statement_account_types`
   def statement_account_types
-    @statement_account_types ||= []
+    @statement_account_types ||= Set[]
   end
 
-  def statement_account_types_uniq
-    statement_account_types.uniq
+  def add_statement_account_types(statement_types)
+    statement_types.each { |type| statement_account_types.add type }
   end
 
   def reconcilable_account_types
-    statement_account_types_uniq.map(&:constantize).select { |t| t < ReconcilableAccount }.map(&:to_s)
+    statement_account_types.map(&:constantize).select { |t| t < ReconcilableAccount }.map(&:to_s)
   end
 
   # Returns an array of subclassed Account object names that support affiliates.
@@ -88,7 +88,7 @@ class AccountConfig
   # Returns true if statements are enabled. Some downstream repositories may
   # not use statements anywhere in the app.
   def statements_enabled?
-    statement_account_types_uniq.present?
+    statement_account_types.present?
   end
 
   # Returns true if affiliates are enabled. Some downstream repositories may
@@ -114,7 +114,7 @@ class AccountConfig
 
   # Returns true if this account type supports statements.
   def using_statements?(account_type)
-    statement_account_types_uniq.include?(account_type.to_s.classify)
+    statement_account_types.include?(account_type.to_s.classify)
   end
 
   # Returns true if this account type supports journal.

--- a/app/support/reconcilable_account.rb
+++ b/app/support/reconcilable_account.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 module ReconcilableAccount
+
+  # This is used as a class method on account classes that extend this module.
+  # Reconcilable statement accounts are collected by AccountConfig
   def reconcilable?
     true
   end
+
 end

--- a/app/support/reconcilable_account.rb
+++ b/app/support/reconcilable_account.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 module ReconcilableAccount
-
+  def reconcilable?
+    true
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot.
   config.eager_load = true

--- a/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
+++ b/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FacilityAccountsReconciliationController do
 
   class ReconciliationTestAccount < Account
 
-    include ReconcilableAccount
+    extend ReconcilableAccount
 
   end
 

--- a/vendor/engines/c2po/app/models/credit_card_account.rb
+++ b/vendor/engines/c2po/app/models/credit_card_account.rb
@@ -3,7 +3,7 @@
 class CreditCardAccount < Account
 
   include AffiliateAccount
-  include ReconcilableAccount
+  extend ReconcilableAccount
 
   attr_readonly :account_number
   before_validation :setup_false_credit_card_number

--- a/vendor/engines/c2po/app/models/purchase_order_account.rb
+++ b/vendor/engines/c2po/app/models/purchase_order_account.rb
@@ -3,7 +3,7 @@
 class PurchaseOrderAccount < Account
 
   include AffiliateAccount
-  include ReconcilableAccount
+  extend ReconcilableAccount
 
   validates_presence_of :account_number
 

--- a/vendor/engines/c2po/lib/c2po.rb
+++ b/vendor/engines/c2po/lib/c2po.rb
@@ -41,7 +41,7 @@ module C2po
 
     initializer :append_account_types, before: "set_routes_reloader_hook" do |app|
       C2PO_ACCOUNT_TYPES_APPENDER.call
-      app.reloader.to_run(&C2PO_ACCOUNT_TYPES_APPENDER)
+      app.reloader.to_prepare(&C2PO_ACCOUNT_TYPES_APPENDER)
     end
 
     initializer "model_core.factories", after: "factory_girl.set_factory_paths" do

--- a/vendor/engines/c2po/lib/c2po.rb
+++ b/vendor/engines/c2po/lib/c2po.rb
@@ -7,7 +7,7 @@ module C2po
   C2PO_ACCOUNT_TYPES_APPENDER = proc do
     Account.config.account_types.concat C2po::C2PO_ACCOUNT_TYPES
     Account.config.facility_account_types.concat C2po::C2PO_ACCOUNT_TYPES
-    Account.config.statement_account_types.concat C2po::C2PO_ACCOUNT_TYPES
+    Account.config.add_statement_account_types C2po::C2PO_ACCOUNT_TYPES
     Account.config.affiliate_account_types.concat C2po::C2PO_ACCOUNT_TYPES
   end.freeze
 

--- a/vendor/engines/c2po/lib/c2po.rb
+++ b/vendor/engines/c2po/lib/c2po.rb
@@ -7,7 +7,7 @@ module C2po
   C2PO_ACCOUNT_TYPES_APPENDER = proc do
     Account.config.account_types.concat C2po::C2PO_ACCOUNT_TYPES
     Account.config.facility_account_types.concat C2po::C2PO_ACCOUNT_TYPES
-    Account.config.add_statement_account_types C2po::C2PO_ACCOUNT_TYPES
+    Account.config.statement_account_types.concat C2po::C2PO_ACCOUNT_TYPES
     Account.config.affiliate_account_types.concat C2po::C2PO_ACCOUNT_TYPES
   end.freeze
 
@@ -31,6 +31,7 @@ module C2po
       ViewHook.add_hook "facilities.facility_fields", "before_is_active", "c2po/facilities/facility_fields"
       ViewHook.add_hook "facility_accounts.show", "additional_account_fields", "c2po/facility_accounts/show/additional_account_fields"
       ViewHook.add_hook "facility_accounts.show", "after_end_of_form", "c2po/facility_accounts/show/remittance_information"
+      C2PO_ACCOUNT_TYPES_APPENDER.call
     end
 
     initializer :append_migrations do |app|
@@ -40,8 +41,7 @@ module C2po
     end
 
     initializer :append_account_types, before: "set_routes_reloader_hook" do |app|
-      C2PO_ACCOUNT_TYPES_APPENDER.call
-      app.reloader.to_prepare(&C2PO_ACCOUNT_TYPES_APPENDER)
+      app.reloader.to_run(&C2PO_ACCOUNT_TYPES_APPENDER)
     end
 
     initializer "model_core.factories", after: "factory_girl.set_factory_paths" do


### PR DESCRIPTION
# Release Notes

Cached classes requires a lot of server restarts when developing. This disables class caching.

It also adjusts some loading behavior of the `C2po` engine so the application works correctly with respect to the caching. The way `C2po` was setup to load, `AccountConfig`'s reconcilable accounts would disappear. This make the reconcilable account code a bit more clear.