### PR TITLE
[#157534] Change Order on Behalf of Screen

### DIFF
--- a/app/assets/javascripts/app/orders_edit_date.js
+++ b/app/assets/javascripts/app/orders_edit_date.js
@@ -1,33 +1,39 @@
+/** 
+ * Show and require the "Fulfilled at" field only if the "Order Status" is 
+ * "Complete", this is currently done in the _edit_date partial.
+ * 
+ * TODO: The SetFulfilledOnComplete class does something similar to this,
+ *       so it may be a good idea to generalize this function to replace
+ *       that class.
+**/
+function toggleFulfilledAtSection(orderStatusSelectElem) {
+  const fulfilledAtSection = document.querySelector(".backdate_fulfilled_at");
+  const fulfilledAtElement = document.querySelector(".js--fulfilled_at");
+  let selectedIndex = orderStatusSelectElem.selectedIndex;
+  let selectedText = orderStatusSelectElem.options[selectedIndex].text; 
+  let displayStyle;
+  let required;
+
+  if (selectedText === "Complete") {
+    displayStyle = "";
+    required = true;
+  }
+  else {
+    displayStyle = "none";
+    required = false;
+    fulfilledAtElement.value = null;
+  }
+
+  fulfilledAtSection.style.display = displayStyle;
+  fulfilledAtElement.required = required;
+}
+
+
 window.addEventListener("DOMContentLoaded", () => {
-  const orderStatusSelect = document.querySelector("#order_status_id");
+  const orderStatusSelect = document.querySelector(".js--order_status");
 
   if (orderStatusSelect) {
-    toggleFulfilledAt();
-  
-    orderStatusSelect.addEventListener("change", () => toggleFulfilledAt());
-
-    // In the _edit_date partial, show the "Fulfilled at" field only if 
-    // the "Order Status" is "Complete"
-    function toggleFulfilledAt() {
-      const fulfilledAtSection = document.querySelector(".backdate_fulfilled_at");
-      const fulfilledAtElement = document.querySelector("#fulfilled_at");
-      let selectedIndex = orderStatusSelect.selectedIndex;
-      let selectedText = orderStatusSelect.options[selectedIndex].text; 
-      let displayStyle;
-      let required;
-
-      if (selectedText === "Complete") {
-        displayStyle = "";
-        required = true;
-      }
-      else {
-        displayStyle = "none";
-        required = false;
-        fulfilledAtElement.value = null;
-      }
-  
-      fulfilledAtSection.style.display = displayStyle;
-      fulfilledAtElement.required = required;
-    }
+    toggleFulfilledAtSection(orderStatusSelect);
+    orderStatusSelect.addEventListener("change", () => toggleFulfilledAtSection(orderStatusSelect));
   }
 });

--- a/app/assets/javascripts/app/orders_edit_date.js
+++ b/app/assets/javascripts/app/orders_edit_date.js
@@ -1,26 +1,26 @@
 window.addEventListener("DOMContentLoaded", function() {
-	const orderStatusSelect = document.querySelector("#order_status_id");
-
-	// In the _edit_date partial, show the "Fulfilled at" field only if 
-	// the "Order Status" is "Complete"
-	if (orderStatusSelect) {
-		const fulfilledAt = document.querySelector(".backdate_fulfilled_at");
-		let displayStyle = "none";
-
-		fulfilledAt.style.display = displayStyle;
-
-		orderStatusSelect.addEventListener("change", function() {
-			const selectedValue = orderStatusSelect.value;
-
-			// "Complete" is the 4th item in the dropdown
-			if (selectedValue === "4") {
-				displayStyle = "";
-			}
-			else {
-				displayStyle = "none";
-			}
-
-			fulfilledAt.style.display = displayStyle;
-		});
-	}
+  const orderStatusSelect = document.querySelector("#order_status_id");
+  
+  // In the _edit_date partial, show the "Fulfilled at" field only if 
+  // the "Order Status" is "Complete"
+  if (orderStatusSelect) {
+    const fulfilledAt = document.querySelector(".backdate_fulfilled_at");
+    let displayStyle = "none";
+  
+    fulfilledAt.style.display = displayStyle;
+  
+    orderStatusSelect.addEventListener("change", function() {
+      const selectedValue = orderStatusSelect.value;
+  
+      // "Complete" is the 4th item in the dropdown
+      if (selectedValue === "4") {
+        displayStyle = "";
+      }
+      else {
+        displayStyle = "none";
+      }
+  
+      fulfilledAt.style.display = displayStyle;
+    });
+  }
 });

--- a/app/assets/javascripts/app/orders_edit_date.js
+++ b/app/assets/javascripts/app/orders_edit_date.js
@@ -1,17 +1,18 @@
-window.addEventListener("DOMContentLoaded", function() {
+window.addEventListener("DOMContentLoaded", () => {
   const orderStatusSelect = document.querySelector("#order_status_id");
-  
-  // In the _edit_date partial, show the "Fulfilled at" field only if 
-  // the "Order Status" is "Complete"
+
   if (orderStatusSelect) {
-    const fulfilledAt = document.querySelector(".backdate_fulfilled_at");
-    let displayStyle = "none";
+    toggleFulfilledAt();
   
-    fulfilledAt.style.display = displayStyle;
-  
-    orderStatusSelect.addEventListener("change", function() {
-      const selectedValue = orderStatusSelect.value;
-  
+    orderStatusSelect.addEventListener("change", () => toggleFulfilledAt());
+
+    // In the _edit_date partial, show the "Fulfilled at" field only if 
+    // the "Order Status" is "Complete"
+	  function toggleFulfilledAt() {
+    	const fulfilledAt = document.querySelector(".backdate_fulfilled_at");
+      let selectedValue = orderStatusSelect.value;
+		  let displayStyle;
+
       // "Complete" is the 4th item in the dropdown
       if (selectedValue === "4") {
         displayStyle = "";
@@ -21,6 +22,6 @@ window.addEventListener("DOMContentLoaded", function() {
       }
   
       fulfilledAt.style.display = displayStyle;
-    });
+	  }
   }
 });

--- a/app/assets/javascripts/app/orders_edit_date.js
+++ b/app/assets/javascripts/app/orders_edit_date.js
@@ -9,19 +9,25 @@ window.addEventListener("DOMContentLoaded", () => {
     // In the _edit_date partial, show the "Fulfilled at" field only if 
     // the "Order Status" is "Complete"
     function toggleFulfilledAt() {
-      const fulfilledAt = document.querySelector(".backdate_fulfilled_at");
+      const fulfilledAtSection = document.querySelector(".backdate_fulfilled_at");
+      const fulfilledAtElement = document.querySelector("#fulfilled_at");
       let selectedValue = orderStatusSelect.value;
       let displayStyle;
+      let required;
 
       // "Complete" is the 4th item in the dropdown
       if (selectedValue === "4") {
         displayStyle = "";
+        required = true;
       }
       else {
         displayStyle = "none";
+        required = false;
+        fulfilledAtElement.value = null;
       }
   
-      fulfilledAt.style.display = displayStyle;
+      fulfilledAtSection.style.display = displayStyle;
+      fulfilledAtElement.required = required;
     }
   }
 });

--- a/app/assets/javascripts/app/orders_edit_date.js
+++ b/app/assets/javascripts/app/orders_edit_date.js
@@ -8,8 +8,8 @@ window.addEventListener("DOMContentLoaded", () => {
 
     // In the _edit_date partial, show the "Fulfilled at" field only if 
     // the "Order Status" is "Complete"
-	  function toggleFulfilledAt() {
-    	const fulfilledAt = document.querySelector(".backdate_fulfilled_at");
+    function toggleFulfilledAt() {
+      const fulfilledAt = document.querySelector(".backdate_fulfilled_at");
       let selectedValue = orderStatusSelect.value;
 		  let displayStyle;
 

--- a/app/assets/javascripts/app/orders_edit_date.js
+++ b/app/assets/javascripts/app/orders_edit_date.js
@@ -11,7 +11,7 @@ window.addEventListener("DOMContentLoaded", () => {
     function toggleFulfilledAt() {
       const fulfilledAt = document.querySelector(".backdate_fulfilled_at");
       let selectedValue = orderStatusSelect.value;
-		  let displayStyle;
+      let displayStyle;
 
       // "Complete" is the 4th item in the dropdown
       if (selectedValue === "4") {
@@ -22,6 +22,6 @@ window.addEventListener("DOMContentLoaded", () => {
       }
   
       fulfilledAt.style.display = displayStyle;
-	  }
+    }
   }
 });

--- a/app/assets/javascripts/app/orders_edit_date.js
+++ b/app/assets/javascripts/app/orders_edit_date.js
@@ -1,0 +1,26 @@
+window.addEventListener("DOMContentLoaded", function() {
+	const orderStatusSelect = document.querySelector("#order_status_id");
+
+	// In the _edit_date partial, show the "Fulfilled at" field only if 
+	// the "Order Status" is "Complete"
+	if (orderStatusSelect) {
+		const fulfilledAt = document.querySelector(".backdate_fulfilled_at");
+		let displayStyle = "none";
+
+		fulfilledAt.style.display = displayStyle;
+
+		orderStatusSelect.addEventListener("change", function() {
+			const selectedValue = orderStatusSelect.value;
+
+			// "Complete" is the 4th item in the dropdown
+			if (selectedValue === "4") {
+				displayStyle = "";
+			}
+			else {
+				displayStyle = "none";
+			}
+
+			fulfilledAt.style.display = displayStyle;
+		});
+	}
+});

--- a/app/assets/javascripts/app/orders_edit_date.js
+++ b/app/assets/javascripts/app/orders_edit_date.js
@@ -11,12 +11,12 @@ window.addEventListener("DOMContentLoaded", () => {
     function toggleFulfilledAt() {
       const fulfilledAtSection = document.querySelector(".backdate_fulfilled_at");
       const fulfilledAtElement = document.querySelector("#fulfilled_at");
-      let selectedValue = orderStatusSelect.value;
+      let selectedIndex = orderStatusSelect.selectedIndex;
+      let selectedText = orderStatusSelect.options[selectedIndex].text; 
       let displayStyle;
       let required;
 
-      // "Complete" is the 4th item in the dropdown
-      if (selectedValue === "4") {
+      if (selectedText === "Complete") {
         displayStyle = "";
         required = true;
       }

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -327,8 +327,8 @@ class OrdersController < ApplicationController
   private
 
   def build_order_date
-    if params[:order_date].present? && params[:order_time].present?
-      parse_usa_date(params[:order_date], join_time_select_values(params[:order_time]))
+    if params[:order_date].present?
+      parse_usa_date(params[:order_date])
     end
   end
 
@@ -372,7 +372,7 @@ class OrdersController < ApplicationController
   end
 
   def ordering_on_behalf_with_date_params?
-    params[:order_date].present? && params[:order_time].present? && acting_as?
+    params[:order_date].present? && acting_as?
   end
 
   def single_reservation?

--- a/app/services/order_detail_update_param_hash_extractor.rb
+++ b/app/services/order_detail_update_param_hash_extractor.rb
@@ -17,20 +17,17 @@ class OrderDetailUpdateParamHashExtractor
   #   { 123 => { quantity: 2, note: "Noted" } }
   def to_h
     # TODO: clean up this and _cart_row.html.haml
-    od_params = params.permit!.to_h.each_with_object({}) do |(key, value), memo|
+    fulfilled_at = params.permit!.to_h[:fulfilled_at] if params.permit!.to_h[:fulfilled_at]
+
+    params.permit!.to_h.each_with_object({}) do |(key, value), memo|
       match = key.match(/\A(note|quantity|reference_id)(\d+)\z/) || next
       property = match[1].to_sym
       id = match[2].to_i
       next if property.in?([:note, :reference_id]) && !value
 
       (memo[id] ||= {})[property] = value
+      memo[id][:manual_fulfilled_at] = fulfilled_at if fulfilled_at.presence
     end
-
-    if params.permit!.to_h[:fulfilled_at]
-      od_params.each_value { |inner_hash| inner_hash[:manual_fulfilled_at] = params.permit!.to_h[:fulfilled_at] }
-    end
-
-    od_params
   end
 
 end

--- a/app/services/order_detail_update_param_hash_extractor.rb
+++ b/app/services/order_detail_update_param_hash_extractor.rb
@@ -17,7 +17,7 @@ class OrderDetailUpdateParamHashExtractor
   #   { 123 => { quantity: 2, note: "Noted" } }
   def to_h
     # TODO: clean up this and _cart_row.html.haml
-    params.permit!.to_h.each_with_object({}) do |(key, value), memo|
+    od_params = params.permit!.to_h.each_with_object({}) do |(key, value), memo|
       match = key.match(/\A(note|quantity|reference_id)(\d+)\z/) || next
       property = match[1].to_sym
       id = match[2].to_i
@@ -25,6 +25,12 @@ class OrderDetailUpdateParamHashExtractor
 
       (memo[id] ||= {})[property] = value
     end
+
+    if params.permit!.to_h[:fulfilled_at]
+      od_params.each_value { |inner_hash| inner_hash[:manual_fulfilled_at] = params.permit!.to_h[:fulfilled_at] }
+    end
+
+    od_params
   end
 
 end

--- a/app/services/order_detail_update_param_hash_extractor.rb
+++ b/app/services/order_detail_update_param_hash_extractor.rb
@@ -17,7 +17,8 @@ class OrderDetailUpdateParamHashExtractor
   #   { 123 => { quantity: 2, note: "Noted" } }
   def to_h
     # TODO: clean up this and _cart_row.html.haml
-    fulfilled_at = params.permit!.to_h[:fulfilled_at] if params.permit!.to_h[:fulfilled_at]
+
+    fulfilled_at = params[:fulfilled_at].presence
 
     params.permit!.to_h.each_with_object({}) do |(key, value), memo|
       match = key.match(/\A(note|quantity|reference_id)(\d+)\z/) || next
@@ -26,7 +27,7 @@ class OrderDetailUpdateParamHashExtractor
       next if property.in?([:note, :reference_id]) && !value
 
       (memo[id] ||= {})[property] = value
-      memo[id][:manual_fulfilled_at] = fulfilled_at if fulfilled_at.presence
+      memo[id][:manual_fulfilled_at] = fulfilled_at if fulfilled_at
     end
   end
 

--- a/app/views/orders/_edit_date.html.haml
+++ b/app/views/orders/_edit_date.html.haml
@@ -8,16 +8,15 @@
           class: "datepicker__data",
           data: { max_date: Time.current.iso8601 } }
 
-    = label_tag :order_time
-    .time-select= time_select_tag :order_time, params[:order_datetime] || default_time 
-
     = f.input :order_status_id,
       collection: @order_statuses,
       label_method: :name_with_level,
       selected:  params[:order_status_id] || @order_statuses.first.try(:id),
       label: OrderDetail.human_attribute_name(:order_status)
 
-    = f.input :fulfilled_at
+    = f.input :fulfilled_at,
+      input_html: { class: "datepicker__data",
+          data: { max_date: ValidFulfilledAtDate.max.iso8601, min_date: ValidFulfilledAtDate.min.iso8601 } }
 
     = f.input :send_notification,
       as: :boolean,

--- a/app/views/orders/_edit_date.html.haml
+++ b/app/views/orders/_edit_date.html.haml
@@ -1,30 +1,27 @@
-- classes = ['collapsable']
-- classes << 'collapsed' if params['backdate_order'].blank?
-%fieldset#backdate-orders{ class: classes }
-  %label.legend= t("orders.show.more_options")
+%fieldset#backdate-orders
   = hidden_field_tag :backdate_order, true
   - default_time = time_floor(Time.zone.now)
+
   = simple_fields_for :backdate, builder: ModelLessFormBuilder, defaults: { required: false } do |f|
     = f.input :order_date,
       input_html: { value: params[:order_date] || format_usa_date(default_time),
           class: "datepicker__data",
-          data: { max_date: Time.current.iso8601 } },
-          disabled: true
+          data: { max_date: Time.current.iso8601 } }
+
+    = f.input :fulfilled_at
 
     = label_tag :order_time
-    .time-select= time_select_tag :order_time, params[:order_datetime] || default_time, disabled: true
+    .time-select= time_select_tag :order_time, params[:order_datetime] || default_time 
 
     = f.input :order_status_id,
       collection: @order_statuses,
       label_method: :name_with_level,
       selected:  params[:order_status_id] || @order_statuses.first.try(:id),
-      label: OrderDetail.human_attribute_name(:order_status),
-      disabled: true
+      label: OrderDetail.human_attribute_name(:order_status)
 
     = f.input :send_notification,
       as: :boolean,
       input_html: { value: 1 },
       default: params[:send_notification],
       label: false,
-      inline_label: true,
-      disabled: true
+      inline_label: true

--- a/app/views/orders/_edit_date.html.haml
+++ b/app/views/orders/_edit_date.html.haml
@@ -8,8 +8,6 @@
           class: "datepicker__data",
           data: { max_date: Time.current.iso8601 } }
 
-    = f.input :fulfilled_at
-
     = label_tag :order_time
     .time-select= time_select_tag :order_time, params[:order_datetime] || default_time 
 
@@ -18,6 +16,8 @@
       label_method: :name_with_level,
       selected:  params[:order_status_id] || @order_statuses.first.try(:id),
       label: OrderDetail.human_attribute_name(:order_status)
+
+    = f.input :fulfilled_at
 
     = f.input :send_notification,
       as: :boolean,

--- a/app/views/orders/_edit_date.html.haml
+++ b/app/views/orders/_edit_date.html.haml
@@ -11,11 +11,12 @@
     = f.input :order_status_id,
       collection: @order_statuses,
       label_method: :name_with_level,
+      input_html: { class: "js--order_status"},
       selected:  params[:order_status_id] || @order_statuses.first.try(:id),
       label: OrderDetail.human_attribute_name(:order_status)
 
     = f.input :fulfilled_at,
-      input_html: { class: "datepicker__data",
+      input_html: { class: "datepicker__data js--fulfilled_at",
           data: { max_date: ValidFulfilledAtDate.max.iso8601, min_date: ValidFulfilledAtDate.min.iso8601 } }
 
     = f.input :send_notification,

--- a/app/views/orders/_form.html.haml
+++ b/app/views/orders/_form.html.haml
@@ -1,4 +1,4 @@
-= simple_form_for order, url: { action: :update_or_purchase } do |f|
+= simple_form_for order, html: { novalidate: false }, url: { action: :update_or_purchase } do |f|
   %table.table.table-striped.table-hover.js--cart.js--responsive_table#cart{ class: order.has_valid_payment? ? "" : " invalid" }
     %thead
       %tr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -677,7 +677,6 @@ en:
         account: "Payment Source"
       link:
         change_account: "Change Payment Source"
-      more_options: More options
       order_form:
         edit: "Edit Online Order Form"
         new: "Complete Online Order Form"

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -541,9 +541,8 @@ RSpec.describe OrdersController do
         maybe_grant_always_sign_in :director
         switch_to @staff
         @params[:order_date] = format_usa_date(1.day.ago)
-        @params[:order_time] = { hour: "10", minute: "12", ampm: "AM" }
         do_request
-        expect(assigns[:order].order_details.map(&:ordered_at)).to all(match_date 1.day.ago.change(hour: 10, min: 12))
+        expect(assigns[:order].order_details.map(&:ordered_at)).to all(match_date 1.day.ago.beginning_of_day)
       end
 
       it "sets ordered_at to now if not acting_as" do
@@ -619,21 +618,19 @@ RSpec.describe OrdersController do
           it "sets the order_detail fulfilled dates to the order time" do
             @item_pp = @item.item_price_policies.create!(FactoryBot.attributes_for(:item_price_policy, price_group_id: @price_group.id, start_date: 1.day.ago, expire_date: 1.day.from_now))
             @params[:order_date] = format_usa_date(1.day.ago)
-            @params[:order_time] = { hour: "10", minute: "13", ampm: "AM" }
             do_request
-            assigns[:order].reload.order_details.all? { |od| expect(od.fulfilled_at).to match_date 1.day.ago.change(hour: 10, min: 13) }
+            assigns[:order].reload.order_details.all? { |od| expect(od.fulfilled_at).to match_date 1.day.ago.beginning_of_day }
           end
 
           context "price policies" do
             before :each do
               @item.item_price_policies.clear
-              @item_pp = @item.item_price_policies.create!(FactoryBot.attributes_for(:item_price_policy, price_group_id: @price_group.id, start_date: 1.day.ago, expire_date: 1.day.from_now))
-              @item_past_pp = @item.item_price_policies.create!(FactoryBot.attributes_for(:item_price_policy, price_group_id: @price_group.id, start_date: 7.days.ago, expire_date: 1.day.ago))
-              @params.merge!(order_time: { hour: "10", minute: "00", ampm: "AM" })
+              @item_pp = @item.item_price_policies.create!(FactoryBot.attributes_for(:item_price_policy, price_group_id: @price_group.id, start_date: 1.day.ago.beginning_of_day, expire_date: 1.day.from_now.beginning_of_day))
+              @item_past_pp = @item.item_price_policies.create!(FactoryBot.attributes_for(:item_price_policy, price_group_id: @price_group.id, start_date: 7.days.ago.beginning_of_day, expire_date: 1.day.ago.beginning_of_day))
             end
 
             it "uses the current price policy if the order date falls in the policy's date range" do
-              @params[:order_date] = format_usa_date(1.day.ago)
+              @params[:order_date] = format_usa_date(1.day.ago.beginning_of_day)
               do_request
               assigns[:order].reload.order_details.all? { |od| expect(od.price_policy).to eq(@item_pp) }
             end

--- a/spec/system/placing_an_order_on_behalf_of_spec.rb
+++ b/spec/system/placing_an_order_on_behalf_of_spec.rb
@@ -84,7 +84,6 @@ RSpec.describe "Placing an item order" do
     choose account.to_s
     click_button "Continue"
 
-    find("label", text: /More options/i).click
     fill_in "Order date", with: I18n.l(2.days.ago.to_date, format: :usa)
     select "Complete", from: "Order Status"
 

--- a/spec/system/placing_an_order_on_behalf_of_spec.rb
+++ b/spec/system/placing_an_order_on_behalf_of_spec.rb
@@ -78,16 +78,17 @@ RSpec.describe "Placing an item order" do
   end
 
   it "can backdate an order", :js do # js needed for More options expansion
+    two_days_ago = I18n.l(2.days.ago.to_date, format: :usa)
     visit facility_path(facility)
     click_link product.name
     click_link "Add to cart"
     choose account.to_s
     click_button "Continue"
 
-    fill_in "Order date", with: I18n.l(2.days.ago.to_date, format: :usa)
+    fill_in "Order date", with: two_days_ago
     select "Complete", from: "Order Status"
 
-    fill_in "Fulfilled at", with: I18n.l(2.days.ago.to_date, format: :usa)
+    fill_in "Fulfilled at", with: two_days_ago
 
     click_button "Purchase"
 
@@ -96,7 +97,7 @@ RSpec.describe "Placing an item order" do
     expect(page).to have_css(".currency .estimated_cost", count: 0)
     expect(page).to have_css(".currency .actual_cost", count: 2) # Cost and Total
 
-    expect(page).to have_content_i("Ordered Date\n#{I18n.l(2.days.ago.to_date, format: :usa)}")
+    expect(page).to have_content_i("Ordered Date\n#{two_days_ago}")
   end
 
   it "can set a reference ID" do

--- a/spec/system/placing_an_order_on_behalf_of_spec.rb
+++ b/spec/system/placing_an_order_on_behalf_of_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Placing an item order" do
                       price_group: PriceGroup.base,
                       product: product,
                       unit_cost: 33.25,
-                      start_date: 2.days.ago)
+                      start_date: 3.days.ago)
   end
   let!(:account_price_group_member) do
     FactoryBot.create(:account_price_group_member, account: account, price_group: price_policy.price_group)
@@ -86,6 +86,8 @@ RSpec.describe "Placing an item order" do
 
     fill_in "Order date", with: I18n.l(2.days.ago.to_date, format: :usa)
     select "Complete", from: "Order Status"
+
+    fill_in "Fulfilled at", with: I18n.l(2.days.ago.to_date, format: :usa)
 
     click_button "Purchase"
 

--- a/spec/system/placing_an_order_on_behalf_of_spec.rb
+++ b/spec/system/placing_an_order_on_behalf_of_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Placing an item order" do
                       price_group: PriceGroup.base,
                       product: product,
                       unit_cost: 33.25,
-                      start_date: 3.days.ago)
+                      start_date: 2.days.ago.beginning_of_day)
   end
   let!(:account_price_group_member) do
     FactoryBot.create(:account_price_group_member, account: account, price_group: price_policy.price_group)


### PR DESCRIPTION
# Release Notes

This separates the order date from the completion date on the orders show page. The fulfilled at date is manually set.

# Screenshot 
![Screen Shot 2022-07-18 at 2 17 53 PM](https://user-images.githubusercontent.com/624487/179600233-6810b2dc-0446-49b7-ad32-7162ed1198d1.png)
