### PR TITLE
Adjusts _account_fields

### DIFF
--- a/app/views/shared/_account_fields.html.haml
+++ b/app/views/shared/_account_fields.html.haml
@@ -2,6 +2,7 @@
   %ul.inline
     - fields = account_class.new.account_number_fields
     - fields.each_with_index do |(section, options), i|
+      - section_value = f.object.send(section) || options[:default]
       %li.account_number_field
         = p.label section,
           t("#{account_class.name.underscore}.account_fields.label.account_number.#{section}"),
@@ -12,6 +13,6 @@
           maxlength: options[:length] || 30,
           tabindex: i + 1,
           readonly: local_assigns[:readonly],
-          value: account_field_value(params, account_class, section, options[:default])
+          value: account_field_value(params, account_class, section, section_value)
 
         = "-&nbsp;".html_safe unless i >= fields.size - 1

--- a/spec/system/admin/recharge_accounts_spec.rb
+++ b/spec/system/admin/recharge_accounts_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe "Managing recharge accounts (FacilityFacilityAccountsController)"
         expect(page).to have_field(I18n.t(field, scope: "facility_account.account_fields.label.account_number"), readonly: true)
       end
 
+      expect(page.html).to include facility_account.account_number
       uncheck "Is Active?"
       click_button "Save"
       expect(page).to have_content("(inactive)")


### PR DESCRIPTION
# Release Notes

It did not work correctly for existing accounts. This update correctly displays the account number for existing accounts.