### PR TITLE
[#160499] Change revenue_account to string on FacilityAccount

### DIFF
--- a/app/models/facility_account.rb
+++ b/app/models/facility_account.rb
@@ -11,7 +11,7 @@ class FacilityAccount < ApplicationRecord
 
   belongs_to :facility
 
-  validates :revenue_account, numericality: { only_integer: true }
+  validates :revenue_account, presence: true
   validates :account_number, presence: true, uniqueness: { scope: [:revenue_account, :facility_id], case_sensitive: false }
 
   scope :active, -> { where(is_active: true) }

--- a/app/views/facility_facility_accounts/_facility_account_fields.html.haml
+++ b/app/views/facility_facility_accounts/_facility_account_fields.html.haml
@@ -1,7 +1,7 @@
 - revenue_acct_readonly = local_assigns[:readonly] && !FacilityAccount.revenue_account_editable_by_user?(current_user)
 .well
   = render "shared/account_fields", f: f, account_class: FacilityAccount, readonly: local_assigns[:readonly]
-  = f.input :revenue_account, readonly: revenue_acct_readonly, required: true, input_html: { maxlength: Settings.accounts.revenue_account_default.to_s.length, size: 10 }
+  = f.input :revenue_account, readonly: revenue_acct_readonly, required: true, input_html: { maxlength: Settings.accounts.revenue_account_default.length, size: 10 }
 
   = f.label :is_active do
     = f.check_box :is_active

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,7 +13,7 @@ time_zone: "Central Time (US & Canada)"
 accounts:
   # Most frequently used account by NU
   product_default: 75340
-  revenue_account_default: 50617
+  revenue_account_default: "50617"
 
 financial:
   # in the format MM-DD

--- a/db/migrate/20220819183819_change_revenue_account_to_string_in_facility_accounts.rb
+++ b/db/migrate/20220819183819_change_revenue_account_to_string_in_facility_accounts.rb
@@ -1,0 +1,9 @@
+class ChangeRevenueAccountToStringInFacilityAccounts < ActiveRecord::Migration[6.1]
+  def up
+    change_column :facility_accounts, :revenue_account, :string
+  end
+
+  def down
+    change_column :facility_accounts, :revenue_account, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_16_233321) do
+ActiveRecord::Schema.define(version: 2022_08_19_183819) do
 
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
@@ -185,7 +185,7 @@ ActiveRecord::Schema.define(version: 2022_02_16_233321) do
     t.boolean "is_active", null: false
     t.integer "created_by", null: false
     t.datetime "created_at", null: false
-    t.integer "revenue_account", null: false
+    t.string "revenue_account", null: false
     t.index ["facility_id"], name: "fk_facilities"
   end
 

--- a/spec/models/facility_account_spec.rb
+++ b/spec/models/facility_account_spec.rb
@@ -4,8 +4,10 @@ require "rails_helper"
 
 RSpec.describe FacilityAccount do
   describe "#revenue_account" do
-    it "is an integer" do
-      is_expected.to validate_numericality_of(:revenue_account).only_integer
+    it "is required" do
+      facility_account = build(:facility_account, revenue_account: nil)
+      expect(facility_account.valid?).to be false
+      expect(facility_account.errors[:revenue_account]).to include("may not be blank")
     end
   end
 end

--- a/vendor/engines/split_accounts/spec/services/journal_row_builder_spec.rb
+++ b/vendor/engines/split_accounts/spec/services/journal_row_builder_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe JournalRowBuilder, :enable_split_accounts, :default_journal_row_c
   end
 
   let(:facility) { create(:facility) }
-  let(:facility_account) { create(:facility_account, facility: facility, revenue_account: 51_234) }
+  let(:facility_account) { create(:facility_account, facility: facility, revenue_account: "51234") }
   let(:product) { create(:setup_item, facility: facility, facility_account: facility_account) }
-  let(:facility_account2) { create(:facility_account, facility: facility, revenue_account: 51_235) }
+  let(:facility_account2) { create(:facility_account, facility: facility, revenue_account: "51235") }
   let(:product2) { create(:setup_item, facility: facility, facility_account: facility_account2) }
 
   let(:journal) { build_stubbed(:journal, facility: facility) }
@@ -45,12 +45,12 @@ RSpec.describe JournalRowBuilder, :enable_split_accounts, :default_journal_row_c
     end
 
     it "2 negative rows for the facility accounts" do
-      rows = builder.build.journal_rows.select { |row| row.account.to_i == facility_account.revenue_account }
+      rows = builder.build.journal_rows.select { |row| row.account == facility_account.revenue_account }
       expect(rows.length).to eq(1)
       expect(rows.first.amount).to eq(-20)
       expect(rows.first.order_detail_id).to be_blank
 
-      rows2 = builder.journal_rows.select { |row| row.account.to_i == facility_account2.revenue_account }
+      rows2 = builder.journal_rows.select { |row| row.account == facility_account2.revenue_account }
       expect(rows2.length).to eq(1)
       expect(rows2.first.amount).to eq(-3)
       expect(rows2.first.order_detail_id).to be_blank


### PR DESCRIPTION
# Release Notes

Some revenue accounts start with a leading 0. However, since `revenue_account` on `FacilityAccount` is an integer, it's not possible to save those. This changes `revenue_account` from an integer to a string, which will allow accounts with leading 0s.