### PR TITLE
Tech task - Fix recharge spec

### DIFF
--- a/spec/system/admin/recharge_accounts_spec.rb
+++ b/spec/system/admin/recharge_accounts_spec.rb
@@ -36,11 +36,9 @@ RSpec.describe "Managing recharge accounts (FacilityFacilityAccountsController)"
       click_link facility_account.to_s
 
       dummy_account.account_number_fields.each do |field, _values|
-        expect(page).to have_field(
-          I18n.t(field, scope: "facility_account.account_fields.label.account_number"),
-          readonly: true,
-          with: facility_account.account_number_part_value_or_default(field)
-        )
+        field_label = I18n.t(field, scope: "facility_account.account_fields.label.account_number")
+        field_value = find_field(field_label, readonly: true).value.to_s
+        expect(field_value).to eq facility_account.account_number_part_value_or_default(field).to_s
       end
 
       uncheck "Is Active?"


### PR DESCRIPTION
the have_field matcher doesn't handle nil/empty string value checking:
https://github.com/teamcapybara/capybara/pull/1169#issuecomment-44575123
