### PR TITLE
[#160776] Include username and email when NETID login fails

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1254,7 +1254,7 @@ en:
       not_found_in_database: "Invalid username or password."
       inactive: "Invalid username or password."
       saml_update_failed: "Login failed, please contact an administrator."
-      saml_invalid: "Invalid username or password."
+      saml_invalid: "Invalid username or password for %{username}/%{email}"
     mailer:
       # TODO
       reset_password_instructions:

--- a/vendor/engines/saml_authentication/lib/saml_authentication/saml_authenticatable_with_custom_error.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/saml_authenticatable_with_custom_error.rb
@@ -22,7 +22,7 @@ module Devise
       # authentication to call fail!(:saml_invalid), which allows us to specify a separate
       # failure message for authentication via SAML.
       def failed_auth(msg)
-        Rollbar.warn(msg, attributes: failed_auth_user_attributes) if defined?(Rollbar)
+        log_to_rollbar(msg) if defined?(Rollbar)
         DeviseSamlAuthenticatable::Logger.send(msg)
         fail!(error_message.html_safe)
         Devise.saml_failed_callback.new.handle(@response, self) if Devise.saml_failed_callback # rubocop:disable Style/SafeNavigation
@@ -40,6 +40,10 @@ module Devise
           username: failed_auth_user_attributes[:username]&.first,
           email: failed_auth_user_attributes[:email]&.first
         )
+      end
+
+      def log_to_rollbar(msg)
+        Rollbar.warn(msg, attributes: failed_auth_user_attributes) unless msg == "Resource could not be found"
       end
 
     end

--- a/vendor/engines/saml_authentication/lib/saml_authentication/saml_authenticatable_with_custom_error.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/saml_authenticatable_with_custom_error.rb
@@ -22,9 +22,24 @@ module Devise
       # authentication to call fail!(:saml_invalid), which allows us to specify a separate
       # failure message for authentication via SAML.
       def failed_auth(msg)
+        Rollbar.warn(msg, attributes: failed_auth_user_attributes) if defined?(Rollbar)
         DeviseSamlAuthenticatable::Logger.send(msg)
-        fail!(I18n.t("devise.failure.saml_invalid").html_safe)
+        fail!(error_message.html_safe)
         Devise.saml_failed_callback.new.handle(@response, self) if Devise.saml_failed_callback # rubocop:disable Style/SafeNavigation
+      end
+
+      def failed_auth_user_attributes
+        attribute_map = Devise.saml_attribute_map_resolver.new("").attribute_map
+        saml_response = ::SamlAuthenticatable::SamlResponse.new(@response.attributes, attribute_map)
+        SamlAuthentication::SamlAttributes.new(saml_response).to_h
+      end
+
+      def error_message
+        I18n.t(
+          "devise.failure.saml_invalid",
+          username: failed_auth_user_attributes[:username].first,
+          email: failed_auth_user_attributes[:email].first
+        )
       end
 
     end

--- a/vendor/engines/saml_authentication/lib/saml_authentication/saml_authenticatable_with_custom_error.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/saml_authenticatable_with_custom_error.rb
@@ -37,8 +37,8 @@ module Devise
       def error_message
         I18n.t(
           "devise.failure.saml_invalid",
-          username: failed_auth_user_attributes[:username].first,
-          email: failed_auth_user_attributes[:email].first
+          username: failed_auth_user_attributes[:username]&.first,
+          email: failed_auth_user_attributes[:email]&.first
         )
       end
 

--- a/vendor/engines/saml_authentication/spec/controllers/saml_authentication/sessions_controller_spec.rb
+++ b/vendor/engines/saml_authentication/spec/controllers/saml_authentication/sessions_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe SamlAuthentication::SessionsController, type: :controller do
 
       it "sets a user-friendly error message in the flash" do
         post :create, params: { SAMLResponse: saml_response }
-        expect(flash[:alert]).to eq(I18n.t("devise.failure.saml_invalid"))
+        expect(flash[:alert]).to eq(I18n.t("devise.failure.saml_invalid", username: "sst123", email: "sst123@example.com"))
       end
 
       it "marks the message in :saml_invalid as html_safe to allow including links" do


### PR DESCRIPTION
# Release Notes

To help clarify/confirm for the user and assist in debugging, it would be helpful to include the username and email that is returned from the SAML response when SSO fails.
Also logs a warning to rollbar with the complete user attributes.