### PR TITLE
[#160830] Limit quantity to 10 for times service products in bundles

### DIFF
--- a/app/models/bundle_product.rb
+++ b/app/models/bundle_product.rb
@@ -9,6 +9,7 @@ class BundleProduct < ApplicationRecord
 
   validates_presence_of     :bundle_product_id, :product_id
   validates_numericality_of :quantity, only_integer: true, greater_than: 0
+  validates_numericality_of :quantity, less_than: 10, if: :timed_service_product?
   validates_uniqueness_of   :product_id, scope: [:bundle_product_id]
 
   scope :alphabetized, -> { joins(:product).order(Arel.sql("LOWER(products.name)")) }
@@ -16,6 +17,10 @@ class BundleProduct < ApplicationRecord
   # TODO: favor the alphabetized scope over relying on Array#sort
   def <=>(other)
     product.name <=> other.product.name
+  end
+
+  def timed_service_product?
+    product.is_a?(TimedService)
   end
 
 end

--- a/spec/factories/bundle_products.rb
+++ b/spec/factories/bundle_products.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :bundle_product do
+    product
+  end
+end

--- a/spec/models/bundle_product_spec.rb
+++ b/spec/models/bundle_product_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BundleProduct do
+  subject(:bundle_product) { FactoryBot.build(:bundle_product, product: product) }
+
+  describe "#quantity" do
+    context "with a non-TimedService" do
+      let(:product) { FactoryBot.build(:item) }
+
+      it "is an integer greater than 0" do
+        is_expected.to validate_numericality_of(:quantity).is_greater_than(0).only_integer
+      end
+
+      it "can be greater than 10" do
+        bundle_product.quantity = 11
+        is_expected.to have(0).errors_on(:quantity)
+      end
+    end
+
+    context "with a TimedService" do
+      let(:product) { FactoryBot.build(:timed_service) }
+
+      it "is an integer greater than 0" do
+        is_expected.to validate_numericality_of(:quantity).is_greater_than(0).only_integer
+      end
+
+      it "is less than 10" do
+        is_expected.to validate_numericality_of(:quantity).is_less_than(10)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

It would be a good idea to check if we have any bundles that will be made invalid by this change:
```
Bundle.all.select do |b| 
  b.bundle_products.any? do |bp| 
    bp.product.type == "TimedService" && bp.quantity > 9
  end
end.count
```
# Additional Context

Previously, this `quantity` field was used to indicate quantity of minutes, now it is quantity of products.