### PR TITLE
[#160846] Fix fulfilled_at date setting when ordering for

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -243,8 +243,6 @@ class OrdersController < ApplicationController
 
   # PUT /orders/:id/update
   def update
-    params[:order_datetime] = build_order_date if acting_as?
-
     @order.transaction do
       @order.assign_attributes(order_params)
 

--- a/app/services/order_purchaser.rb
+++ b/app/services/order_purchaser.rb
@@ -77,7 +77,8 @@ class OrderPurchaser
       next if od.reservation # reservations should always have order_status dictated by their dates
 
       if order_status.root == OrderStatus.complete
-        od.backdate_to_complete!(od.ordered_at)
+        backdated_fulfilled_time = od.manual_fulfilled_at_time || od.ordered_at
+        od.backdate_to_complete!(backdated_fulfilled_time)
       else
         od.update_order_status!(update_by, order_status, admin: true)
       end

--- a/app/views/orders/_edit_date.html.haml
+++ b/app/views/orders/_edit_date.html.haml
@@ -16,7 +16,7 @@
       label: OrderDetail.human_attribute_name(:order_status)
 
     = f.input :fulfilled_at,
-      input_html: { class: "datepicker__data js--fulfilled_at",
+      input_html: { value: params[:fulfilled_at], class: "datepicker__data js--fulfilled_at",
           data: { max_date: ValidFulfilledAtDate.max.iso8601, min_date: ValidFulfilledAtDate.min.iso8601 } }
 
     = f.input :send_notification,

--- a/spec/system/placing_an_order_on_behalf_of_spec.rb
+++ b/spec/system/placing_an_order_on_behalf_of_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Placing an item order" do
                       price_group: PriceGroup.base,
                       product: product,
                       unit_cost: 33.25,
-                      start_date: 2.days.ago.beginning_of_day)
+                      start_date: 6.days.ago.beginning_of_day)
   end
   let!(:account_price_group_member) do
     FactoryBot.create(:account_price_group_member, account: account, price_group: price_policy.price_group)
@@ -95,8 +95,8 @@ RSpec.describe "Placing an item order" do
 
     expect(page).to have_content "Order Receipt"
     expect(page).to have_content(/Ordered For\n#{user.full_name}/i)
-    expect(page).to have_css(".currency .estimated_cost", count: 2)
-    expect(page).to have_css(".currency .actual_cost", count: 0) # Cost and Total
+    expect(page).to have_css(".currency .estimated_cost", count: 0)
+    expect(page).to have_css(".currency .actual_cost", count: 2) # Cost and Total
 
     expect(page).to have_content("Ordered Date\n#{two_days_ago}")
 

--- a/spec/system/placing_an_order_on_behalf_of_spec.rb
+++ b/spec/system/placing_an_order_on_behalf_of_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe "Placing an item order" do
 
   it "can backdate an order", :js do # js needed for More options expansion
     two_days_ago = I18n.l(2.days.ago.to_date, format: :usa)
+    three_days_ago = I18n.l(3.days.ago.to_date, format: :usa)
     visit facility_path(facility)
     click_link product.name
     click_link "Add to cart"
@@ -88,16 +89,20 @@ RSpec.describe "Placing an item order" do
     fill_in "Order date", with: two_days_ago
     select "Complete", from: "Order Status"
 
-    fill_in "Fulfilled at", with: two_days_ago
+    fill_in "Fulfilled at", with: three_days_ago
 
     click_button "Purchase"
 
     expect(page).to have_content "Order Receipt"
     expect(page).to have_content(/Ordered For\n#{user.full_name}/i)
-    expect(page).to have_css(".currency .estimated_cost", count: 0)
-    expect(page).to have_css(".currency .actual_cost", count: 2) # Cost and Total
+    expect(page).to have_css(".currency .estimated_cost", count: 2)
+    expect(page).to have_css(".currency .actual_cost", count: 0) # Cost and Total
 
-    expect(page).to have_content_i("Ordered Date\n#{two_days_ago}")
+    expect(page).to have_content("Ordered Date\n#{two_days_ago}")
+
+    click_link "Exit"
+    click_link "Billing"
+    expect(page).to have_content(three_days_ago)
   end
 
   it "can set a reference ID" do


### PR DESCRIPTION
# Release Notes

- After clicking "update", show the fulfilled date on the form
- Set the fulfilled date as expected