### PR TITLE
[#160767] Adds NetID as a term in the translation file

### DIFF
--- a/app/views/account_price_group_members/new.html.haml
+++ b/app/views/account_price_group_members/new.html.haml
@@ -8,7 +8,7 @@
 %h2 Add Price Group Member
 %fieldset
   = form_tag url_for(action: "search_results"), id: "ajax_form", method: :get do
-    = label_tag :search_term, t(".label.search_term")
+    = label_tag :search_term, text("account_price_group_members.new.label.search_term")
     %br
     = text_field_tag :search_term, nil, size: 30, class: "search-query"
     = submit_tag "Search", class: "btn"

--- a/app/views/account_users/user_search.html.haml
+++ b/app/views/account_users/user_search.html.haml
@@ -8,7 +8,7 @@
   %p= @account.description_to_s
 
 = form_tag user_search_results_path, id: "ajax_form", method: :get do
-  = label_tag :search_term, t(".label.search")
+  = label_tag :search_term, text("account_users.user_search.label.search")
   = text_field_tag :search_term, nil, size: 30, class: "search-query"
   = submit_tag "Search", class: "btn"
   = hidden_field_tag :account_id, @account.id

--- a/app/views/clone_account_memberships/index.html.haml
+++ b/app/views/clone_account_memberships/index.html.haml
@@ -13,7 +13,7 @@
 %p= text("instructions")
 
 = form_tag url_for(action: :search), id: "ajax_form", method: :get do
-  = label_tag :search_term, text("search_term")
+  = label_tag :search_term, text("clone_account_memberships.index.search_term")
   = text_field_tag :search_term, nil, size: 30, class: "search-query"
   = submit_tag text("shared.search"), class: "btn"
   = hidden_field_tag :user_id, @user.id

--- a/app/views/clone_account_memberships/index.html.haml
+++ b/app/views/clone_account_memberships/index.html.haml
@@ -13,7 +13,7 @@
 %p= text("instructions")
 
 = form_tag url_for(action: :search), id: "ajax_form", method: :get do
-  = label_tag :search_term, text("clone_account_memberships.index.search_term")
+  = label_tag :search_term, text("views.clone_account_memberships.index.search_term")
   = text_field_tag :search_term, nil, size: 30, class: "search-query"
   = submit_tag text("shared.search"), class: "btn"
   = hidden_field_tag :user_id, @user.id

--- a/app/views/facility_account_users/user_search.html.haml
+++ b/app/views/facility_account_users/user_search.html.haml
@@ -12,7 +12,7 @@
 %h3= t(".head")
 
 = form_tag user_search_results_path, id: "ajax_form", method: :get do
-  = label_tag :search_term, t(".label.search_term")
+  = label_tag :search_term, text("facility_account_users.user_search.label.search_term")
   %br
   = text_field_tag :search_term, nil, size: 30, class: "search-query"
   = submit_tag "Search", class: "btn"

--- a/app/views/facility_accounts/index.html.haml
+++ b/app/views/facility_accounts/index.html.haml
@@ -6,7 +6,7 @@
 %h2= t(".head")
 
 = form_tag search_results_facility_accounts_path, id: "ajax_form", method: :get, class: "js--searchForm" do
-  = label_tag :search_term, t(".label.search_term")
+  = label_tag :search_term, text("facility_accounts.index.label.search_term")
   = hidden_field_tag :email, current_user.email, disabled: true
   = hidden_field_tag :format, params[:format], disabled: true
   %br

--- a/app/views/facility_accounts/new_account_user_search.html.haml
+++ b/app/views/facility_accounts/new_account_user_search.html.haml
@@ -7,7 +7,7 @@
 %h2= t(".head")
 %p= t(".instruct")
 = form_tag user_search_results_path, id: "ajax_form", method: :get do
-  = label_tag :search_term, t(".label.search_term")
+  = label_tag :search_term, text("facility_accounts.new_account_user_search.label.search_term")
   %br
   = text_field_tag :search_term, nil, size: 30, class: "search-query"
   = submit_tag "Search", class: "btn"

--- a/app/views/facility_users/search.html.haml
+++ b/app/views/facility_users/search.html.haml
@@ -5,7 +5,7 @@
 
 %h2 Add a User
 = form_tag user_search_results_path, id: "ajax_form", method: "get" do
-  %p.instructions= t(".instruct")
+  %p.instructions= text("facility_users.search.instruct")
   = text_field_tag :search_term, nil, size: 30, class: "search-query"
   = submit_tag "Search", class: "btn"
   = hidden_field_tag :facility_id, current_facility.id

--- a/app/views/global_user_roles/search.html.haml
+++ b/app/views/global_user_roles/search.html.haml
@@ -7,7 +7,7 @@
 %h2= t(".h2")
 = form_tag user_search_results_path, id: "ajax_form", method: :get do
   %p.instructions
-    = t(".instructions.search")
+    = text("global_user_roles.search.instructions.search")
     - if can_create_users?
       = t(".instructions.add_user")
 

--- a/app/views/order_imports/new.html.haml
+++ b/app/views/order_imports/new.html.haml
@@ -6,7 +6,7 @@
 
   #bulk-import
     %h2= text(".h2")
-    - link = link_to text("download_link_here"), "#{root_path}templates/bulk_import_template.csv"
+    - link = link_to text("download_link_here"), "#{root_path}templates/#{Settings.order_import_template_name}"
     = html("instructions", importable_products: OrderRowImporter.importable_products, optional_fields: OrderRowImporter.optional_fields, link: link)
     = simple_form_for [:facility, @order_import], html: { multipart: true } do |f|
       .well.well-small#bulk-import-fields

--- a/app/views/product_users/index.html.haml
+++ b/app/views/product_users/index.html.haml
@@ -13,7 +13,7 @@
 
 .well.well-small
   = simple_form_for :product_user_import, url: facility_product_product_user_imports_path(current_facility, @product), html: { multipart: true } do |f|
-    %p= text("import_hint", product_type: @product.model_name.human.downcase)
+    %p= text("product_users.index.import_hint", product_type: @product.model_name.human.downcase)
     .row
       %p.span2= link_to text("add"), [:new, current_facility, @product, :user], class: "btn-add"
       %label.span2.btn.btn-primary

--- a/app/views/product_users/index.html.haml
+++ b/app/views/product_users/index.html.haml
@@ -13,7 +13,7 @@
 
 .well.well-small
   = simple_form_for :product_user_import, url: facility_product_product_user_imports_path(current_facility, @product), html: { multipart: true } do |f|
-    %p= text("product_users.index.import_hint", product_type: @product.model_name.human.downcase)
+    %p= text("import_hint", product_type: @product.model_name.human.downcase)
     .row
       %p.span2= link_to text("add"), [:new, current_facility, @product, :user], class: "btn-add"
       %label.span2.btn.btn-primary

--- a/app/views/product_users/new.html.haml
+++ b/app/views/product_users/new.html.haml
@@ -9,7 +9,7 @@
 
 %fieldset
   = form_tag user_search_results_path, id: "ajax_form", method: :get do
-    = label_tag :search_term, t(".label.search_term")
+    = label_tag :search_term, text("product_users.new.label.search_term")
     %br
     = text_field_tag :search_term, nil, size: 30, class: "search-query"
     = submit_tag text("shared.search"), class: "btn"

--- a/app/views/user_price_group_members/new.html.haml
+++ b/app/views/user_price_group_members/new.html.haml
@@ -9,7 +9,7 @@
 
 %fieldset
   = form_tag user_search_results_path, id: "ajax_form", method: :get do
-    = label_tag :search_term, t(".label.search_term")
+    = label_tag :search_term, text("user_price_group_members.new.label.search_term")
     %br
     = text_field_tag :search_term, nil, size: 30, class: "search-query"
     = submit_tag "Search", class: "btn"

--- a/app/views/users/_search_form.html.haml
+++ b/app/views/users/_search_form.html.haml
@@ -1,6 +1,6 @@
 %h2= t(".head.h2")
 = form_tag user_search_results_path, id: "ajax_form", method: :get do
-  = label_tag :search_term, t(".label.search_term")
+  = label_tag :search_term, text("users.search_form.label.search_term")
   %br
   = text_field_tag :search_term, nil, size: 30, class: "search-query"
   = submit_tag "Search", class: "btn"

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -21,9 +21,9 @@
 
         function has_netid_change() {
           if ($('#has_netid').val() == 'yes')
-            changeUsernameLookupText('#{t(".js.email")}', '#{t(".js.id")}');
+            changeUsernameLookupText('#{t(".js.email")}', '#{text("users.new.js.id")}');
           else
-            changeUsernameLookupText('#{t(".js.id")}', '#{t(".js.email")}');
+            changeUsernameLookupText('#{text("users.new.js.id")}', '#{t(".js.email")}');
         }
 
         $('#has_netid').change(function(e) {
@@ -52,7 +52,7 @@
               submit.attr("disabled", false);
             },
             error: function() {
-              error_div.html('<p class="error">#{t('.js.error')}</p>');
+              error_div.html('<p class="error">#{text('users.new.js.error')}</p>');
               submit.val(submit_val);
               submit.attr("disabled", false);
             }
@@ -64,13 +64,13 @@
 = simple_form_for :search, :url => search_facility_users_path, :html => { :id => 'username_search_form', :class => 'form-inline' }, :defaults => { :required => false } do |f|
   #error_result
 
-  %p= t('.intro')
+  %p= text('users.new.intro')
 
-  = f.input :has_netid, :collection => [['Yes','yes'],['No','no']], :selected => params[:hidden_has_netid] || 'yes', :label => t('.label.have_id'), :input_html => { :id => 'has_netid', :name => 'has_netid' }
+  = f.input :has_netid, :collection => [['Yes','yes'],['No','no']], :selected => params[:hidden_has_netid] || 'yes', :label => text('users.new.label.have_id'), :input_html => { :id => 'has_netid', :name => 'has_netid' }
 
   #username_lookup
-    = f.input :username_lookup, :label => t('.label.id'), :hint => t('.instruct'), :input_html => { :name => 'username_lookup' }
-    = submit_tag t('.submit'), :class => 'btn'
+    = f.input :username_lookup, :label => text('users.new.label.id'), :hint => text('users.new.instruct'), :input_html => { :name => 'username_lookup' }
+    = submit_tag text('users.new.submit'), :class => 'btn'
 
 
 #search_results

--- a/config/locales/en.notifier.yml
+++ b/config/locales/en.notifier.yml
@@ -10,7 +10,7 @@ en:
 
           A !app_name! account has been created for you. You may log in at [%{login_url}](%{login_url})."
         only_username: |
-          Log in using your !online_id_downcase! and password.
+          Log in using your !sso_id_downcase! and password.
         username_and_password: |
           You may log in with your username and password.
 

--- a/config/locales/en.notifier.yml
+++ b/config/locales/en.notifier.yml
@@ -10,7 +10,7 @@ en:
 
           A !app_name! account has been created for you. You may log in at [%{login_url}](%{login_url})."
         only_username: |
-          Log in using your NetID and password.
+          Log in using your !online_id_downcase! and password.
         username_and_password: |
           You may log in with your username and password.
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -230,7 +230,7 @@ en:
   facility_users:
     title: "!Facility! Staff"
     search:
-      instruct: "Search for an existing user by name,!online_id_username!.  Click on the name of the user you wish to grant access to.  If the search does not return any acceptable matches, you may create a new user."
+      instruct: "Search for an existing user by name,!online_id_downcase!.  Click on the name of the user you wish to grant access to.  If the search does not return any acceptable matches, you may create a new user."
 
   facility_account_orders:
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,9 +29,9 @@ en:
   facility_downcase: facility
   facilities_downcase: facilities
 
-  Online_id: NetID
-  online_id_downcase: NetID
-  online_id_or_username: NetID, or username
+  sso_id_upcase: NetID
+  sso_id_downcase: NetID
+  sso_id_or_username: NetID, or username
 
   admin:
     shared:
@@ -169,13 +169,13 @@ en:
       head: "Recent Payment Sources"
       add_account: "Add Payment Source"
       label:
-        search_term: "Search by payment source number, description, accounts receivable number, or payment source owner's name, !online_id_or_username!"
+        search_term: "Search by payment source number, description, accounts receivable number, or payment source owner's name, !sso_id_or_username!"
       search: Search
     new_account_user_search:
       head: "Add Payment Source"
       instruct: "To add a payment source, first search for the user you would like to create the payment source for."
       label:
-        search_term: "Search by name, !online_id_or_username!"
+        search_term: "Search by name, !sso_id_or_username!"
     account_fields:
       label:
         owner_user: "Owner User"
@@ -230,7 +230,7 @@ en:
   facility_users:
     title: "!Facility! Staff"
     search:
-      instruct: "Search for an existing user by name,!online_id_downcase!.  Click on the name of the user you wish to grant access to.  If the search does not return any acceptable matches, you may create a new user."
+      instruct: "Search for an existing user by name,!sso_id_downcase!.  Click on the name of the user you wish to grant access to.  If the search does not return any acceptable matches, you may create a new user."
 
   facility_account_orders:
     index:
@@ -248,7 +248,7 @@ en:
     user_search:
       head: "Add Payment Source User"
       label:
-        search_term: "Search by name, !online_id_or_username!"
+        search_term: "Search by name, !sso_id_or_username!"
     new:
       head: "Add Payment Source User"
       messages:
@@ -433,7 +433,7 @@ en:
       h2: Grant global roles to a user
       instructions:
         search: |
-          Search for an existing user by name, !online_id_or_username!.
+          Search for an existing user by name, !sso_id_or_username!.
           Click on the name of the user you wish to grant global roles to.
         add_user: |
           If the search does not return any acceptable matches,
@@ -773,7 +773,7 @@ en:
   product_users:
     new:
       label:
-        search_term: "Search by name, !online_id_or_username!"
+        search_term: "Search by name, !sso_id_or_username!"
     table:
       date_added: "Date Added"
 
@@ -781,7 +781,7 @@ en:
     new:
       head: "Add Price Group Member"
       label:
-        search_term: "Search by name, !online_id_or_username!"
+        search_term: "Search by name, !sso_id_or_username!"
 
   search:
     results_table:
@@ -803,7 +803,7 @@ en:
   account_price_group_members:
     new:
       label:
-        search_term: "Search by payment source number, description, accounts receivable number, or payment source owner's name, !online_id_or_username!"
+        search_term: "Search by payment source number, description, accounts receivable number, or payment source owner's name, !sso_id_or_username!"
     search_results:
       head: "Select an Existing Payment Source"
       main: "Can't find the payment source you're looking for?"
@@ -827,7 +827,7 @@ en:
       head: "Add Payment Source Member"
       instruct: "Search for a user to add to the %{account_type}, (%{account})"
       label:
-        search: "Search by name, !online_id_or_username!"
+        search: "Search by name, !sso_id_or_username!"
 
   accounts:
     role:
@@ -1009,16 +1009,16 @@ en:
       main: "You may use this to grant !app_name! access to users."
     new:
       js:
-        id: "!Online_id!"
+        id: "!sso_id_upcase!"
         email: "Email Address"
-        error: "An error was encountered while looking up the !online_id_downcase!"
+        error: "An error was encountered while looking up the !sso_id_downcase!"
       head: "Add User"
-      intro: "Some information about this user may already exist in university databases.  Please choose whether the user you wish to add has a !online_id_downcase! and enter the requested information.  If the user exists already, you will be able to add her with a single click."
-      instruct: "Enter the user's !online_id_downcase!"
-      submit: "Look up !online_id_downcase!"
+      intro: "Some information about this user may already exist in university databases.  Please choose whether the user you wish to add has a !sso_id_downcase! and enter the requested information.  If the user exists already, you will be able to add her with a single click."
+      instruct: "Enter the user's !sso_id_downcase!"
+      submit: "Look up !sso_id_downcase!"
       label:
-        id: "!Online_id!"
-        have_id: "Does the new user have a !Online_id!?"
+        id: "!sso_id_upcase!"
+        have_id: "Does the new user have a !sso_id_upcase!?"
     orders:
       none: "%{name} has not placed any orders."
     reservations:
@@ -1037,7 +1037,7 @@ en:
 
     search:
       main_html: "You may add a new external user by clicking <a href=\"%{link}\">Add a new external user</a>."
-      netid_not_found: "The user could not be located in the university database.  Please make sure you typed the !online_id_downcase! correctly."
+      netid_not_found: "The user could not be located in the university database.  Please make sure you typed the !sso_id_downcase! correctly."
       email_not_found: "No user information was found in the university databases."
       found: "The following user was found.  Click \"Add User\" to allow this user access to !app_name!."
       user_already_exists: "The user %{username} already exists in !app_name!"
@@ -1045,7 +1045,7 @@ en:
       head:
         h2: "Search Users"
       label:
-        search_term: "Search by name, !online_id_or_username!"
+        search_term: "Search by name, !sso_id_or_username!"
 
   user_accounts:
     show:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,10 @@ en:
   facility_downcase: facility
   facilities_downcase: facilities
 
+  Online_id: NetID
+  online_id_downcase: NetID
+  online_id_or_username: NetID, or username
+
   admin:
     shared:
       add: "Add %{model}"
@@ -165,13 +169,13 @@ en:
       head: "Recent Payment Sources"
       add_account: "Add Payment Source"
       label:
-        search_term: "Search by payment source number, description, accounts receivable number, or payment source owner's name, NetID, or username"
+        search_term: "Search by payment source number, description, accounts receivable number, or payment source owner's name, !online_id_or_username!"
       search: Search
     new_account_user_search:
       head: "Add Payment Source"
       instruct: "To add a payment source, first search for the user you would like to create the payment source for."
       label:
-        search_term: "Search by name, NetID, or username"
+        search_term: "Search by name, !online_id_or_username!"
     account_fields:
       label:
         owner_user: "Owner User"
@@ -226,7 +230,7 @@ en:
   facility_users:
     title: "!Facility! Staff"
     search:
-      instruct: "Search for an existing user by name, NetID, or username.  Click on the name of the user you wish to grant access to.  If the search does not return any acceptable matches, you may create a new user."
+      instruct: "Search for an existing user by name,!online_id_username!.  Click on the name of the user you wish to grant access to.  If the search does not return any acceptable matches, you may create a new user."
 
   facility_account_orders:
     index:
@@ -244,7 +248,7 @@ en:
     user_search:
       head: "Add Payment Source User"
       label:
-        search_term: "Search by name, NetID, or username"
+        search_term: "Search by name, !online_id_or_username!"
     new:
       head: "Add Payment Source User"
       messages:
@@ -429,7 +433,7 @@ en:
       h2: Grant global roles to a user
       instructions:
         search: |
-          Search for an existing user by name, NetID, or username.
+          Search for an existing user by name, !online_id_or_username!.
           Click on the name of the user you wish to grant global roles to.
         add_user: |
           If the search does not return any acceptable matches,
@@ -769,7 +773,7 @@ en:
   product_users:
     new:
       label:
-        search_term: "Search by name, NetID, or username"
+        search_term: "Search by name, !online_id_or_username!"
     table:
       date_added: "Date Added"
 
@@ -777,7 +781,7 @@ en:
     new:
       head: "Add Price Group Member"
       label:
-        search_term: "Search by name, NetID, or username"
+        search_term: "Search by name, !online_id_or_username!"
 
   search:
     results_table:
@@ -799,7 +803,7 @@ en:
   account_price_group_members:
     new:
       label:
-        search_term: "Search by payment source number, description, accounts receivable number, or payment source owner's name, NetID, or username"
+        search_term: "Search by payment source number, description, accounts receivable number, or payment source owner's name, !online_id_or_username!"
     search_results:
       head: "Select an Existing Payment Source"
       main: "Can't find the payment source you're looking for?"
@@ -823,7 +827,7 @@ en:
       head: "Add Payment Source Member"
       instruct: "Search for a user to add to the %{account_type}, (%{account})"
       label:
-        search: "Search by name, NetID, or username"
+        search: "Search by name, !online_id_or_username!"
 
   accounts:
     role:
@@ -1005,16 +1009,16 @@ en:
       main: "You may use this to grant !app_name! access to users."
     new:
       js:
-        id: "NetID"
+        id: "!Online_id!"
         email: "Email Address"
-        error: "An error was encountered while looking up the NetID"
+        error: "An error was encountered while looking up the !online_id_downcase!"
       head: "Add User"
-      intro: "Some information about this user may already exist in university databases.  Please choose whether the user you wish to add has a NetID and enter the requested information.  If the user exists already, you will be able to add her with a single click."
-      instruct: "Enter the user's NetID"
-      submit: "Look up NetID"
+      intro: "Some information about this user may already exist in university databases.  Please choose whether the user you wish to add has a !online_id_downcase! and enter the requested information.  If the user exists already, you will be able to add her with a single click."
+      instruct: "Enter the user's !online_id_downcase!"
+      submit: "Look up !online_id_downcase!"
       label:
-        id: "NetID"
-        have_id: "Does the new user have a NetID?"
+        id: "!Online_id!"
+        have_id: "Does the new user have a !Online_id!?"
     orders:
       none: "%{name} has not placed any orders."
     reservations:
@@ -1033,7 +1037,7 @@ en:
 
     search:
       main_html: "You may add a new external user by clicking <a href=\"%{link}\">Add a new external user</a>."
-      netid_not_found: "The user could not be located in the university database.  Please make sure you typed the NetID correctly."
+      netid_not_found: "The user could not be located in the university database.  Please make sure you typed the !online_id_downcase! correctly."
       email_not_found: "No user information was found in the university databases."
       found: "The following user was found.  Click \"Add User\" to allow this user access to !app_name!."
       user_already_exists: "The user %{username} already exists in !app_name!"
@@ -1041,7 +1045,7 @@ en:
       head:
         h2: "Search Users"
       label:
-        search_term: "Search by name, NetID, or username"
+        search_term: "Search by name, !online_id_or_username!"
 
   user_accounts:
     show:

--- a/config/locales/views/admin/en.clone_account_memberships.yml
+++ b/config/locales/views/admin/en.clone_account_memberships.yml
@@ -6,7 +6,7 @@ en:
   views:
     clone_account_memberships:
       index:
-        search_term: "Search by name, !online_id_or_username!"
+        search_term: "Search by name, !sso_id_or_username!"
         header: "Clone Payment Source Memberships"
         instructions: |
           You may clone payment source access from another user to this user. Search below to

--- a/config/locales/views/admin/en.clone_account_memberships.yml
+++ b/config/locales/views/admin/en.clone_account_memberships.yml
@@ -6,7 +6,7 @@ en:
   views:
     clone_account_memberships:
       index:
-        search_term: "Search by name, NetID, or username"
+        search_term: "Search by name, !online_id_or_username!"
         header: "Clone Payment Source Memberships"
         instructions: |
           You may clone payment source access from another user to this user. Search below to

--- a/config/locales/views/admin/en.order_imports.yml
+++ b/config/locales/views/admin/en.order_imports.yml
@@ -16,7 +16,7 @@ en:
           <p>Only %{importable_products} product types can be imported.</p>
           <p>Rows containing an existing Order Number will be added to that order.</p>
           <p>Rows without an Order Number will be added as new order(s).</p>
-          <p>Rows sharing the same !Online_id!/Email, Chart String, and Order Date will be added to a single new order.</p>
+          <p>Rows sharing the same !sso_id_upcase!/Email, Chart String, and Order Date will be added to a single new order.</p>
         upload_file_hint: |
           <p>Click “Browse…” to select a bulk import file. Next, select error-handling and receipt options (below), then click “Import” to upload the orders.</p>
         fail_on_error_hint:

--- a/config/locales/views/admin/en.order_imports.yml
+++ b/config/locales/views/admin/en.order_imports.yml
@@ -16,7 +16,7 @@ en:
           <p>Only %{importable_products} product types can be imported.</p>
           <p>Rows containing an existing Order Number will be added to that order.</p>
           <p>Rows without an Order Number will be added as new order(s).</p>
-          <p>Rows sharing the same NetID/Email, Chart String, and Order Date will be added to a single new order.</p>
+          <p>Rows sharing the same !Online_id!/Email, Chart String, and Order Date will be added to a single new order.</p>
         upload_file_hint: |
           <p>Click “Browse…” to select a bulk import file. Next, select error-handling and receipt options (below), then click “Import” to upload the orders.</p>
         fail_on_error_hint:

--- a/config/locales/views/admin/en.product_users.yml
+++ b/config/locales/views/admin/en.product_users.yml
@@ -11,7 +11,7 @@ en:
           This %{product_type} requires a user to be approved before they can make a 
           reservation or purchase. Users can be approved individually or a list can be imported. 
           When importing, create a CSV file with a single column titled ‘Username’ 
-          (NETID or email). New users are added to the existing access list.
+          (!online_id_downcase! or email). New users are added to the existing access list.
 
       table:
         confirm_removal: |

--- a/config/locales/views/admin/en.product_users.yml
+++ b/config/locales/views/admin/en.product_users.yml
@@ -11,7 +11,7 @@ en:
           This %{product_type} requires a user to be approved before they can make a 
           reservation or purchase. Users can be approved individually or a list can be imported. 
           When importing, create a CSV file with a single column titled ‘Username’ 
-          (!online_id_downcase! or email). New users are added to the existing access list.
+          (!sso_id_downcase! or email). New users are added to the existing access list.
 
       table:
         confirm_removal: |

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -56,6 +56,8 @@ support_email: ~
 order_details:
   list_transformer: SplitAccounts::OrderDetailListTransformer
 
+order_import_template_name: bulk_import_template.csv
+
 reservations:
   grace_period: <%= 5.minutes %>
   timeout_period: <%= 12.hours %>


### PR DESCRIPTION
# Release Notes

Not every school calls their online SSO account "NetID". This reorganizes the translation files so that "NetID" is easy to change to something else.

The order import template contains "Netid" and is a static file. So this also adds `order_import_template_name` to the `settngs.yml` file, in case a school would like to change to its own template with school specific language.