### PR TITLE
[#160840] Hide unused revenue_account inputs (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Because we use squash and merge, you should be able to see the changes by lookin
 at the [commit log](https://github.com/tablexi/nucore-open/commits/master). However, we have begun keeping track of breaking changes
 or optional rake tasks.
 
+### Change in behavior of feature flag `expense_accounts: false` ([#3153](https://github.com/tablexi/nucore-open/pull/3153))
+
+Schools that have set the feature flag `expense_accounts: true` are not affected by this change.
+Schools that have set the feature flag `expense_accounts: false` typically include the `revenue_account` as part of the chart string account number.
+This changes expands the scope of the feature flag, so that when it is set to `false`:
+- The `revenue_account` value is not displayed in parentheses as part of the account number
+- The input for `revenue_account` is hidden, but the value is still set to `Settings.accounts.revenue_account_default`
+- You can determine what value to include in journal exports by over-riding the `FacilityAccount#revenue_account_for_journal` method.  The default is `revenue_account`.
+
 ### Use `.bashrc` to determine which servers should run recurring tasks ([#2994](https://github.com/tablexi/nucore-open/pull/2994))
 
 The `recurring_tasks` process should only run on one server per environment.   Set `RECURRING=true` in the environment (`.bashrc` for example) to configure which servers should run these tasks.  Attempting to set this via `capistrano` only works on deploy.

--- a/app/controllers/facility_facility_accounts_controller.rb
+++ b/app/controllers/facility_facility_accounts_controller.rb
@@ -66,7 +66,12 @@ class FacilityFacilityAccountsController < ApplicationController
   private
 
   def create_params
-    params.require(:facility_account).permit(:revenue_account, :account_number, :is_active, account_number_parts: FacilityAccount.account_number_field_names)
+    strong_params = params.require(:facility_account).permit(:revenue_account, :account_number, :is_active, account_number_parts: FacilityAccount.account_number_field_names)
+    if SettingsHelper.feature_on?(:expense_accounts)
+      strong_params
+    else
+      strong_params.merge(revenue_account: Settings.accounts.revenue_account_default)
+    end
   end
 
   def update_params

--- a/app/models/facility_account.rb
+++ b/app/models/facility_account.rb
@@ -32,7 +32,16 @@ class FacilityAccount < ApplicationRecord
   end
 
   def to_s
-    "#{account_number} (#{revenue_account})"
+    if SettingsHelper.feature_on?(:expense_accounts)
+      "#{account_number} (#{revenue_account})"
+    else
+      account_number
+    end
+  end
+
+  # Over-rideable from school-specific engines that don't use the expense_accounts feature flag
+  def revenue_account_for_journal
+    revenue_account
   end
 
   def method_missing(method_sym, *arguments, &block)

--- a/app/services/converters/double_entry_order_detail_to_journal_row_attributes.rb
+++ b/app/services/converters/double_entry_order_detail_to_journal_row_attributes.rb
@@ -46,7 +46,7 @@ module Converters
     def default_revenue_attributes
       {
         amount: total * -1,
-        account: order_detail.product.facility_account.revenue_account,
+        account: order_detail.product.facility_account.revenue_account_for_journal,
         journal: journal,
         description: order_detail.product.to_s,
       }

--- a/app/services/converters/product_to_journal_row_attributes.rb
+++ b/app/services/converters/product_to_journal_row_attributes.rb
@@ -14,7 +14,7 @@ module Converters
 
     def convert
       {
-        account: product.facility_account.revenue_account,
+        account: product.facility_account.revenue_account_for_journal,
         amount: total * -1,
         description: product.to_s,
         journal_id: journal.try(:id),

--- a/app/views/facility_facility_accounts/_facility_account_fields.html.haml
+++ b/app/views/facility_facility_accounts/_facility_account_fields.html.haml
@@ -1,7 +1,7 @@
 - revenue_acct_readonly = local_assigns[:readonly] && !FacilityAccount.revenue_account_editable_by_user?(current_user)
 .well
   = render "shared/account_fields", f: f, account_class: FacilityAccount, readonly: local_assigns[:readonly]
-  = f.input :revenue_account, readonly: revenue_acct_readonly, required: true, input_html: { maxlength: Settings.accounts.revenue_account_default.to_s.length, size: 10 }
+  = f.input :revenue_account, readonly: revenue_acct_readonly, required: true, input_html: { maxlength: Settings.accounts.revenue_account_default.to_s.length, size: 10 } if SettingsHelper.feature_on?(:expense_accounts)
 
   = f.label :is_active do
     = f.check_box :is_active

--- a/spec/services/converters/product_to_journal_row_attributes_spec.rb
+++ b/spec/services/converters/product_to_journal_row_attributes_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Converters::ProductToJournalRowAttributes, type: :service do
   let(:journal) { build_stubbed(:journal) }
   let(:product) do
     build_stubbed(:product).tap do |product|
-      allow(product).to receive_message_chain(:facility_account, :revenue_account) { "revenue_account" }
+      allow(product).to receive_message_chain(:facility_account, :revenue_account_for_journal) { "revenue_account" }
     end
   end
   let(:total) { 100 }
@@ -31,7 +31,7 @@ RSpec.describe Converters::ProductToJournalRowAttributes, type: :service do
     context "for the journal row attributes" do
 
       it "sets account" do
-        expect(returned[:account]).to eq(product.facility_account.revenue_account)
+        expect(returned[:account]).to eq(product.facility_account.revenue_account_for_journal)
       end
 
       it "sets amount" do

--- a/vendor/engines/split_accounts/spec/services/journal_row_builder_spec.rb
+++ b/vendor/engines/split_accounts/spec/services/journal_row_builder_spec.rb
@@ -45,12 +45,12 @@ RSpec.describe JournalRowBuilder, :enable_split_accounts, :default_journal_row_c
     end
 
     it "2 negative rows for the facility accounts" do
-      rows = builder.build.journal_rows.select { |row| row.account.to_i == facility_account.revenue_account.to_i }
+      rows = builder.build.journal_rows.select { |row| row.account.to_i == facility_account.revenue_account_for_journal.to_i }
       expect(rows.length).to eq(1)
       expect(rows.first.amount).to eq(-20)
       expect(rows.first.order_detail_id).to be_blank
 
-      rows2 = builder.journal_rows.select { |row| row.account.to_i == facility_account2.revenue_account.to_i }
+      rows2 = builder.journal_rows.select { |row| row.account.to_i == facility_account2.revenue_account_for_journal.to_i }
       expect(rows2.length).to eq(1)
       expect(rows2.first.amount).to eq(-3)
       expect(rows2.first.order_detail_id).to be_blank


### PR DESCRIPTION
I have confirmed this approach with UConn - the only other school besides OSU that currently has `expense_accounts: false`.