### PR TITLE
Account spec changes from OSU

### DIFF
--- a/spec/controllers/account_price_group_members_controller_spec.rb
+++ b/spec/controllers/account_price_group_members_controller_spec.rb
@@ -138,12 +138,13 @@ RSpec.describe AccountPriceGroupMembersController do
     # Ignore validation errors, e.g. number format
     before { allow(AccountValidator::ValidatorFactory).to receive(:instance).and_return(AccountValidator::ValidatorDefault.new) }
 
-    let!(:account) { FactoryBot.create(:nufs_account, :with_account_owner, account_number: "TESTING123") }
+    let!(:account_number) { FactoryBot.build(:nufs_account).account_number }
+    let!(:account) { FactoryBot.create(:nufs_account, :with_account_owner, account_number: account_number) }
 
     before :each do
       @method = :get
       @action = :search_results
-      @params = { facility_id: facility.url_name, price_group_id: price_group.id, search_term: "TESTING123" }
+      @params = { facility_id: facility.url_name, price_group_id: price_group.id, search_term: account_number }
     end
 
     it_should_require_login

--- a/vendor/engines/c2po/spec/controllers/account_price_group_members_controller_spec.rb
+++ b/vendor/engines/c2po/spec/controllers/account_price_group_members_controller_spec.rb
@@ -9,17 +9,18 @@ RSpec.describe AccountPriceGroupMembersController do
     # Ignore validation errors, e.g. number format
     before { allow(AccountValidator::ValidatorFactory).to receive(:instance).and_return(AccountValidator::ValidatorDefault.new) }
 
+    let(:partial_account_number) { build(:nufs_account).account_number[0..-5] }
     let(:price_group) { create(:price_group, facility: facility) }
-    let!(:global_account) { create(:nufs_account, :with_account_owner, account_number: "TESTING123") }
-    let!(:facility_purchase_order) { create(:purchase_order_account, :with_account_owner, account_number: "TESTING1234", facility: facility) }
-    let!(:other_facility_purchase_order) { create(:purchase_order_account, :with_account_owner, account_number: "TESTING4321", facility: create(:facility)) }
+    let!(:global_account) { create(:nufs_account, :with_account_owner, account_number: "#{partial_account_number}1234") }
+    let!(:facility_purchase_order) { create(:purchase_order_account, :with_account_owner, account_number: "#{partial_account_number}7894", facility: facility) }
+    let!(:other_facility_purchase_order) { create(:purchase_order_account, :with_account_owner, account_number: "#{partial_account_number}6542", facility: create(:facility)) }
 
     let(:user) { create(:user, :facility_administrator, facility: facility) }
 
     it "limits the results to global and the facility" do
       sign_in user
 
-      get :search_results, params: { facility_id: facility.url_name, price_group_id: price_group.id, search_term: "TESTING" }
+      get :search_results, params: { facility_id: facility.url_name, price_group_id: price_group.id, search_term: partial_account_number }
       expect(assigns[:accounts]).to contain_exactly(global_account, facility_purchase_order)
     end
   end


### PR DESCRIPTION
# Release Notes

Since account number formats and validations may be different across schools, this uses account numbers from factories instead of hardcoding them. This prevents spec failures from invalid account formats.

Changes are from https://github.com/Oregon-State/nucore-osu/pull/125/commits/f4649c2b52d2fb8394756328727c66ec1112baf8