### PR TITLE
[#159098] Adds "Recalculate pricing" button to order detail form

### DIFF
--- a/app/assets/javascripts/app/manage_orders.js
+++ b/app/assets/javascripts/app/manage_orders.js
@@ -228,10 +228,22 @@ class OrderDetailManagement {
 }
 OrderDetailManagement.initClass();
 
+function repricingButtonListener(orderDetailManagement) {
+  const repricingButton = document.querySelector(".js--recalculate-pricing");
+
+  if (repricingButton) {
+    repricingButton.addEventListener('click', () => orderDetailManagement.updatePricing());
+  }
+}
+
 $(function() {
   const prepareForm = function() {
     const elem = $('form.manage_order_detail');
-    if (elem.length > 0) { return new OrderDetailManagement(elem); }
+    if (elem.length > 0) {
+      const odm = new OrderDetailManagement(elem);
+      repricingButtonListener(odm);
+      return odm;
+    }
   };
 
   new AjaxModal('.manage-order-detail', '#order-detail-modal', {

--- a/app/assets/javascripts/app/manage_orders.js
+++ b/app/assets/javascripts/app/manage_orders.js
@@ -78,6 +78,12 @@ class OrderDetailManagement {
         if ($(evt.target).val().length > 0) { return this.updatePricing(evt); }
     });
 
+    const repricingButton = document.querySelector(".js--recalculate-pricing");
+
+    if (repricingButton) {
+      repricingButton.addEventListener('click', () => { this.updatePricing() });
+    }
+
     return this.$element.bind("reservation:times_changed", evt => {
       return this.updatePricing(evt);
     });
@@ -240,11 +246,7 @@ $(function() {
   const prepareForm = function() {
     const elem = $('form.manage_order_detail');
 
-    if (elem.length > 0) {
-      const odm = new OrderDetailManagement(elem);
-      repricingButtonListener(odm);
-      return odm;
-    }
+    if (elem.length > 0) { new OrderDetailManagement(elem); }
   };
 
   new AjaxModal('.manage-order-detail', '#order-detail-modal', {

--- a/app/assets/javascripts/app/manage_orders.js
+++ b/app/assets/javascripts/app/manage_orders.js
@@ -239,6 +239,7 @@ function repricingButtonListener(orderDetailManagement) {
 $(function() {
   const prepareForm = function() {
     const elem = $('form.manage_order_detail');
+
     if (elem.length > 0) {
       const odm = new OrderDetailManagement(elem);
       repricingButtonListener(odm);

--- a/app/assets/javascripts/app/manage_orders.js
+++ b/app/assets/javascripts/app/manage_orders.js
@@ -234,14 +234,6 @@ class OrderDetailManagement {
 }
 OrderDetailManagement.initClass();
 
-function repricingButtonListener(orderDetailManagement) {
-  const repricingButton = document.querySelector(".js--recalculate-pricing");
-
-  if (repricingButton) {
-    repricingButton.addEventListener('click', () => orderDetailManagement.updatePricing());
-  }
-}
-
 $(function() {
   const prepareForm = function() {
     const elem = $('form.manage_order_detail');

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -65,6 +65,11 @@
         .span7= render "costs", f: f
 
     .row
+      .span7
+      .span3
+        .btn.btn-primary.js--recalculate-pricing Recalculate pricing
+
+    .row
       .span3
         = render "assigned_user", f: f
 

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -67,7 +67,8 @@
     .row
       .span7
       .span3
-        .btn.btn-primary.js--recalculate-pricing Recalculate pricing
+        .btn.btn-primary.js--recalculate-pricing
+          = text("order_management.order_details.form.recalculate_price")
 
     .row
       .span3

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -561,6 +561,8 @@ en:
     order_details:
       shared_details:
         remove_from_journal: "Remove From Journal"
+      form:
+        recalculate_price: "Recalculate pricing"
 
   product_access_groups:
     index:


### PR DESCRIPTION
# Release Notes

To recalculate the price of an order detail, the payment source can be toggled, which is a fairly unnatural way to do that. This adds a "Recalculate pricing" button that recalculates the price.

# Screenshot

![Screen Shot 2022-09-26 at 2 08 27 PM](https://user-images.githubusercontent.com/624487/192359982-870828bf-711c-4fa0-b90d-17cab74c11bc.png)
