### PR TITLE
Fixes account_price_group_members_controller_spec

### DIFF
--- a/spec/controllers/account_price_group_members_controller_spec.rb
+++ b/spec/controllers/account_price_group_members_controller_spec.rb
@@ -138,8 +138,8 @@ RSpec.describe AccountPriceGroupMembersController do
     # Ignore validation errors, e.g. number format
     before { allow(AccountValidator::ValidatorFactory).to receive(:instance).and_return(AccountValidator::ValidatorDefault.new) }
 
-    let!(:account_number) { FactoryBot.build(:nufs_account).account_number }
-    let!(:account) { FactoryBot.create(:nufs_account, :with_account_owner, account_number: account_number) }
+    let!(:account) { FactoryBot.create(:nufs_account, :with_account_owner) }
+    let!(:account_number) { account.account_number }
 
     before :each do
       @method = :get


### PR DESCRIPTION
# Release Notes

In UMass the way the `account_number` was set in the spec was generating records with duplicate account numbers, which caused a validation error. This changes how the `account_number` is set to avoid duplicate `account_number`s being generated, to avoid the validation error.