### PR TITLE
Small translation fix.

### DIFF
--- a/config/locales/views/admin/en.transaction_search.yml
+++ b/config/locales/views/admin/en.transaction_search.yml
@@ -4,7 +4,7 @@ en:
       date_range_fields:
         ordered_at: Ordered
         fulfilled_at: Fulfilled
-        journal_or_statement_date: "Journal/Statement"
+        journal_or_statement_date: "Journaled/Statement"
         reconciled_at: Reconciled
       actions:
         reassign_chart_strings: Reassign Chart Strings


### PR DESCRIPTION
# Release Notes

In `transaction_search`, the value of `journal_or_statement_date` was changed incorrectly. This changes it back.