### PR TITLE
[#160949] change ethernet port to string

### DIFF
--- a/db/migrate/20221010164640_adjust_relays_ethernet_port_number.rb
+++ b/db/migrate/20221010164640_adjust_relays_ethernet_port_number.rb
@@ -1,0 +1,9 @@
+class AdjustRelaysEthernetPortNumber < ActiveRecord::Migration[6.1]
+  def up
+    change_column :relays, :ethernet_port_number, :string
+  end
+
+  def down
+    change_column :relays, :ethernet_port_number, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,34 +55,6 @@ ActiveRecord::Schema.define(version: 2022_10_10_164640) do
     t.index ["affiliate_id"], name: "index_accounts_on_affiliate_id"
   end
 
-  create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
-    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
-  end
-
-  create_table "active_storage_blobs", charset: "utf8mb3", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
-    t.bigint "byte_size", null: false
-    t.string "checksum", null: false
-    t.datetime "created_at", null: false
-    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
-  end
-
-  create_table "active_storage_variant_records", charset: "utf8mb3", force: :cascade do |t|
-    t.bigint "blob_id", null: false
-    t.string "variation_digest", null: false
-    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
-  end
-
   create_table "affiliates", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -213,7 +185,7 @@ ActiveRecord::Schema.define(version: 2022_10_10_164640) do
     t.boolean "is_active", null: false
     t.integer "created_by", null: false
     t.datetime "created_at", null: false
-    t.string "revenue_account", null: false
+    t.integer "revenue_account", null: false
     t.index ["facility_id"], name: "fk_facilities"
   end
 
@@ -960,8 +932,10 @@ ActiveRecord::Schema.define(version: 2022_10_10_164640) do
     t.index ["versioned_id", "versioned_type"], name: "index_vestal_versions_on_versioned_id_and_versioned_type"
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "account_facility_joins", "accounts"
+  add_foreign_key "account_facility_joins", "facilities"
+  add_foreign_key "account_users", "accounts", name: "fk_accounts"
+  add_foreign_key "account_users", "users"
   add_foreign_key "bulk_email_jobs", "facilities"
   add_foreign_key "bulk_email_jobs", "users"
   add_foreign_key "bundle_products", "products", column: "bundle_product_id", name: "fk_bundle_prod_prod"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_19_183819) do
+ActiveRecord::Schema.define(version: 2022_10_10_164640) do
 
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
@@ -664,7 +664,7 @@ ActiveRecord::Schema.define(version: 2022_08_19_183819) do
     t.string "mac_address"
     t.string "building_room_number"
     t.string "circuit_number"
-    t.integer "ethernet_port_number"
+    t.string "ethernet_port_number"
     t.index ["instrument_id"], name: "index_relays_on_instrument_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_16_233321) do
+ActiveRecord::Schema.define(version: 2022_08_19_183819) do
 
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
@@ -53,6 +53,34 @@ ActiveRecord::Schema.define(version: 2022_02_16_233321) do
     t.string "outside_contact_info"
     t.string "ar_number"
     t.index ["affiliate_id"], name: "index_accounts_on_affiliate_id"
+  end
+
+  create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", charset: "utf8mb3", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
   create_table "affiliates", id: :integer, charset: "utf8mb3", force: :cascade do |t|
@@ -185,7 +213,7 @@ ActiveRecord::Schema.define(version: 2022_02_16_233321) do
     t.boolean "is_active", null: false
     t.integer "created_by", null: false
     t.datetime "created_at", null: false
-    t.integer "revenue_account", null: false
+    t.string "revenue_account", null: false
     t.index ["facility_id"], name: "fk_facilities"
   end
 
@@ -932,10 +960,8 @@ ActiveRecord::Schema.define(version: 2022_02_16_233321) do
     t.index ["versioned_id", "versioned_type"], name: "index_vestal_versions_on_versioned_id_and_versioned_type"
   end
 
-  add_foreign_key "account_facility_joins", "accounts"
-  add_foreign_key "account_facility_joins", "facilities"
-  add_foreign_key "account_users", "accounts", name: "fk_accounts"
-  add_foreign_key "account_users", "users"
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "bulk_email_jobs", "facilities"
   add_foreign_key "bulk_email_jobs", "users"
   add_foreign_key "bundle_products", "products", column: "bundle_product_id", name: "fk_bundle_prod_prod"

--- a/spec/system/admin/instrument_relay_tab_spec.rb
+++ b/spec/system/admin/instrument_relay_tab_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Instrument Relay Tab" do
         expect(instrument.relay.mac_address).to eq("123abc456")
         expect(instrument.relay.building_room_number).to eq("1a")
         expect(instrument.relay.circuit_number).to eq("1")
-        expect(instrument.relay.ethernet_port_number).to eq(2000)
+        expect(instrument.relay.ethernet_port_number).to eq("2000")
       end
 
       it "raises an error if there's no outlet entered" do
@@ -113,7 +113,7 @@ RSpec.describe "Instrument Relay Tab" do
           expect(instrument.relay.mac_address).to eq("123abc456")
           expect(instrument.relay.building_room_number).to eq("1a")
           expect(instrument.relay.circuit_number).to eq("1")
-          expect(instrument.relay.ethernet_port_number).to eq(2000)
+          expect(instrument.relay.ethernet_port_number).to eq("2000")
         end
       end
 
@@ -187,7 +187,7 @@ RSpec.describe "Instrument Relay Tab" do
       expect(instrument.relay.mac_address).to eq("123abc456")
       expect(instrument.relay.building_room_number).to eq("1a")
       expect(instrument.relay.circuit_number).to eq("1")
-      expect(instrument.relay.ethernet_port_number).to eq(2000)
+      expect(instrument.relay.ethernet_port_number).to eq("2000")
     end
   end
 


### PR DESCRIPTION
# Release Notes

This changes the `ethernet_port_number` on Relays from an integer to a string