### PR TITLE
Tech task: Revert "Changing AccountConfig's data structures to sets (#3188)"

### DIFF
--- a/app/models/account_config.rb
+++ b/app/models/account_config.rb
@@ -2,55 +2,52 @@
 
 class AccountConfig
 
-  # Returns a set of all subclassed Account object names - including global,
+  # Returns an array of all subclassed Account object names - including global,
   # per-facility, and statement account types.
   # Engines can append to this list.
   def account_types
-    @account_types ||= Set["NufsAccount"]
+    @account_types ||= ["NufsAccount"]
   end
 
-  # Returns a set of subclassed Account object names that are available
+  # Returns an array of subclassed Account object names that are available
   # across facilities. Derived from other lists.
   # Engines should NOT append to this list.
   def global_account_types
     account_types - facility_account_types
   end
 
-  # Returns a set of subclassed Account object names that are only available
+  # Returns an array of subclassed Account object names that are only available
   # on a per-facility basis.
   # Engines can append to this list.
   def facility_account_types
-    @facility_account_types ||= Set[]
+    @facility_account_types ||= []
   end
 
-  # Returns a set of subclassed Account object names that support statements.
+  # Returns an array of subclassed Account object names that support statements.
   # Engines can append to this list.
   def statement_account_types
-    @statement_account_types ||= Set[]
+    @statement_account_types ||= []
   end
 
   def reconcilable_account_types
-    statement_account_types.map(&:constantize)
-                           .select(&:reconcilable?)
-                           .map(&:to_s)
-                           .to_set
+    statement_account_types.uniq.map(&:constantize).select(&:reconcilable?).map(&:to_s)
   end
 
-  # Returns a set of subclassed Account object names that support affiliates.
+  # Returns an array of subclassed Account object names that support affiliates.
   # Engines can append to this list.
   def affiliate_account_types
-    @affiliate_account_types ||= Set[]
+    @affiliate_account_types ||= []
   end
 
-  # Returns a set of subclassed Account object names that support journal.
+  # Returns an array of subclassed Account object names that support journal.
   # Engines can append to this list.
   def journal_account_types
-    @journal_account_types ||= Set["NufsAccount"]
+    @journal_account_types ||= ["NufsAccount"]
   end
 
-  # A set of account types where creation should be disabled
+  # An array of account types where creation should be disabled
   def creation_disabled_types
-    @creation_disabled_types ||= Set[]
+    @creation_disabled_types ||= []
   end
 
   def creation_enabled?(type)
@@ -69,12 +66,12 @@ class AccountConfig
     account_type_to_param(class_string).sub(/_account\z/, "").pluralize
   end
 
-  # Returns a set of subclassed Account objects given a facility.
+  # Returns an array of subclassed Account objects given a facility.
   # Facility can be a NullObject (used when not in the context of a facility)
   # and the NullObject always returns `true` for cross_facility?.
   def account_types_for_facility(facility, action)
     types = account_types
-    types = types.select { |type| type.constantize.global? }.to_set if facility.try(:cross_facility?)
+    types = types.select { |type| type.constantize.global? } if facility.try(:cross_facility?)
     types -= creation_disabled_types if action == :create
     types
   end

--- a/vendor/engines/c2po/lib/c2po.rb
+++ b/vendor/engines/c2po/lib/c2po.rb
@@ -2,13 +2,13 @@
 
 module C2po
 
-  C2PO_ACCOUNT_TYPES = Set["CreditCardAccount", "PurchaseOrderAccount"]
+  C2PO_ACCOUNT_TYPES = %w(CreditCardAccount PurchaseOrderAccount).freeze
 
   C2PO_ACCOUNT_TYPES_APPENDER = proc do
-    Account.config.account_types.merge(C2po::C2PO_ACCOUNT_TYPES)
-    Account.config.facility_account_types.merge(C2po::C2PO_ACCOUNT_TYPES)
-    Account.config.statement_account_types.merge(C2po::C2PO_ACCOUNT_TYPES)
-    Account.config.affiliate_account_types.merge(C2po::C2PO_ACCOUNT_TYPES)
+    Account.config.account_types.concat C2po::C2PO_ACCOUNT_TYPES
+    Account.config.facility_account_types.concat C2po::C2PO_ACCOUNT_TYPES
+    Account.config.statement_account_types.concat C2po::C2PO_ACCOUNT_TYPES
+    Account.config.affiliate_account_types.concat C2po::C2PO_ACCOUNT_TYPES
   end.freeze
 
   class Engine < Rails::Engine


### PR DESCRIPTION
This reverts commit dc521a2d754b5343afb7abccece54eae6ef013fc.

Account config collections have order dependencies.
We can handle uniqueness more easily with arrays (vs handling ordering with sets)