### PR TITLE
Changes `revenue_account` in schema back to integer

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -213,7 +213,7 @@ ActiveRecord::Schema.define(version: 2022_10_10_164640) do
     t.boolean "is_active", null: false
     t.integer "created_by", null: false
     t.datetime "created_at", null: false
-    t.string "revenue_account", null: false
+    t.integer "revenue_account", null: false
     t.index ["facility_id"], name: "fk_facilities"
   end
 


### PR DESCRIPTION
# Release Notes

This was incorrectly changed in a PR (#3137) of unrelated changes. This changes the schema back