### PR TITLE
Tech task: Fix typo in canceled_statuses_for_facility and add spec coverage

### DIFF
--- a/app/models/order_status.rb
+++ b/app/models/order_status.rb
@@ -55,7 +55,7 @@ class OrderStatus < ApplicationRecord
   end
 
   def self.canceled_statuses_for_facility(facility)
-    canceled.self_and_descendants.for_facility(current_facility).sorted
+    canceled.self_and_descendants.for_facility(facility).sorted
   end
 
   def self.sorted

--- a/spec/system/admin/manage_order_detail_spec.rb
+++ b/spec/system/admin/manage_order_detail_spec.rb
@@ -87,6 +87,10 @@ RSpec.describe "Managing an order detail" do
 
         expect(page).to have_content("Canceled")
         expect(page).to have_css("tfoot .currency", text: "$0.00", count: 3)
+
+        # Happy path coverage for canceled items in the order detail form
+        click_link order_detail.to_s
+        expect(page).to have_content("Canceled")
       end
     end
 


### PR DESCRIPTION
# Release Notes

Addresses https://rollbar.com/tablexi/nucore-nu/items/823/.
```
NameError: undefined local variable or method `current_facility' for #<Class:0x000000000adb9610>
```

introduced in [this](https://github.com/tablexi/nucore-open/pull/3156/files#diff-ef96217bf42a44cb4eba3a75f27db3dbe91e46dc9d9486b60a649f37fb2164b8R58) commit