### PR TITLE
[#160368] Add image processing to DownloadableFiles::Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ENV BUNDLE_PATH /gems
 RUN apt-get update && \
  # Installs the node repository
  curl -sL https://deb.nodesource.com/setup_16.x | bash && \
- # Installs the node repository
- apt-get install --yes nodejs && \
+ # Installs libvips and the node repository
+ apt-get install --yes libvips42 nodejs && \
  npm install --global yarn && \
  apt-get autoremove -y
 

--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ gem "ice_cube"
 # gem "azure-storage-blob", "~> 2.0", require: false
 # only used when SettingsHelper.feature_on?(:active_storage) is true
 gem "active_storage_validations"
+gem "image_processing", ">= 1.2"
 
 ## custom
 gem "bulk_email", path: "vendor/engines/bulk_email"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,6 +345,9 @@ GEM
       ice_cube (~> 0.16)
     ice_cube (0.16.4)
     ice_nine (0.11.2)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jquery-rails (4.5.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -372,6 +375,7 @@ GEM
     mimemagic (0.3.10)
       nokogiri (~> 1)
       rake
+    mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.16.3)
@@ -539,6 +543,8 @@ GEM
     ruby-saml (1.14.0)
       nokogiri (>= 1.10.5)
       rexml
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     rubyzip (2.3.2)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -681,6 +687,7 @@ DEPENDENCIES
   health_check
   icalendar
   ice_cube
+  image_processing (>= 1.2)
   jquery-rails
   jquery-ui-rails
   ldap_authentication!

--- a/app/assets/stylesheets/app/facility.scss
+++ b/app/assets/stylesheets/app/facility.scss
@@ -8,12 +8,16 @@ ul.facility_list_container.tile {
     min-width: 250px;
     margin-right:10px;
     max-width: 400px;
+    img {
+      margin-bottom: 1em;
+    }
   }
 
   .thumbnailFallBackContainer {
     width: 100%;
     padding-bottom: 50%;
     position: relative;
+    margin-bottom: 1em;;
   }
 	
   .thumbnailFallback {

--- a/app/models/concerns/downloadable_files/image.rb
+++ b/app/models/concerns/downloadable_files/image.rb
@@ -21,6 +21,14 @@ module DownloadableFiles
       @remove_file = !value.to_i.zero?
     end
 
+    def padded_image400x200
+      if SettingsHelper.feature_on?(:active_storage)
+        download_url.variant(resize_and_pad: [400, 200, { background: "rgb(231, 231, 231)" }])
+      else
+        download_url
+      end
+    end
+
   end
 
 end

--- a/app/models/concerns/downloadable_files/image.rb
+++ b/app/models/concerns/downloadable_files/image.rb
@@ -21,9 +21,9 @@ module DownloadableFiles
       @remove_file = !value.to_i.zero?
     end
 
-    def padded_image400x200
+    def padded_image(width: 400, height: 200, background_color: "rgb(231, 231, 231)")
       if SettingsHelper.feature_on?(:active_storage)
-        download_url.variant(resize_and_pad: [400, 200, { background: "rgb(231, 231, 231)" }])
+        download_url.variant(resize_and_pad: [width, height, { background: background_color }])
       else
         download_url
       end

--- a/app/views/facilities/_facilities_list.html.haml
+++ b/app/views/facilities/_facilities_list.html.haml
@@ -7,7 +7,7 @@
           - if SettingsHelper.feature_on?(:facility_tile_list)
             = link_to facility_path(facility) do
               - if facility.file_present?
-                = image_tag(facility.padded_image400x200, class: "tile-image")
+                = image_tag(facility.padded_image, class: "tile-image")
               - else
                 .thumbnailFallBackContainer
                   .thumbnailFallback= facility.abbreviation

--- a/app/views/facilities/_facilities_list.html.haml
+++ b/app/views/facilities/_facilities_list.html.haml
@@ -7,7 +7,7 @@
           - if SettingsHelper.feature_on?(:facility_tile_list)
             = link_to facility_path(facility) do
               - if facility.file_present?
-                = image_tag(facility.download_url, class: "tile-image")
+                = image_tag(facility.padded_image400x200, class: "tile-image")
               - else
                 .thumbnailFallBackContainer
                   .thumbnailFallback= facility.abbreviation

--- a/app/views/facilities/_facility_fields.html.haml
+++ b/app/views/facilities/_facility_fields.html.haml
@@ -3,10 +3,11 @@
   = f.input :abbreviation, hint: text(".hints.abbreviation")
   = f.input :url_name, hint: facility_url(f.object.url_name || "url-name"), as: :string
   - if SettingsHelper.feature_on?(:facility_tile_list)
-    = f.input :file, as: :file, label: "Image"
+    = f.input :file, as: :file, label: "Image", hint: t("simple_form.hints.image_dimensions"), hint_html: { class: "help-block" }
+
     - if current_facility&.file_present?
       = f.input(:remove_file, as: :boolean, inline_label: "Remove image")
-      = image_tag(current_facility.download_url, class: "tile-image")
+      = image_tag(current_facility.padded_image, class: "tile-image")
   = f.input :short_description, input_html: { class: "wide" }, hint: text(".hints.short_description")
   = f.input :description, input_html: { class: "editor" }, hint: text(".hints.description")
 

--- a/app/views/facilities/manage.html.haml
+++ b/app/views/facilities/manage.html.haml
@@ -9,7 +9,7 @@
   = f.input :abbreviation
   = f.input :url_name
   - if SettingsHelper.feature_on?(:facility_tile_list) && current_facility.file_present?
-    = image_tag(current_facility.download_url, class: "tile-image")
+    = image_tag(current_facility.padded_image400x200, class: "tile-image")
   = f.input :short_description
   = f.input :description
   = f.input :banner_notice if SettingsHelper.feature_on?(:facility_banner_notice)

--- a/app/views/facilities/manage.html.haml
+++ b/app/views/facilities/manage.html.haml
@@ -9,7 +9,7 @@
   = f.input :abbreviation
   = f.input :url_name
   - if SettingsHelper.feature_on?(:facility_tile_list) && current_facility.file_present?
-    = image_tag(current_facility.padded_image400x200, class: "tile-image")
+    = image_tag(current_facility.padded_image, class: "tile-image")
   = f.input :short_description
   = f.input :description
   = f.input :banner_notice if SettingsHelper.feature_on?(:facility_banner_notice)

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -27,6 +27,7 @@ en:
         schedule: You may share a schedule with other products. Choose an exisiting schedule or use an unshared schedule.
         control_mechanism: Time management options for the Instrument. 'Reservation' tracks reserved time only. Both 'Timer' settings track actual usage time.
         problems_resolvable_by_user: Allow users to update their usage time if they forget to sign out
+      image_dimensions: Image will be resized to 400x200
     # Labels and hints examples
     # labels:
     #   defaults:


### PR DESCRIPTION
# Release Notes

Users can attached image files of any size and dimension to a Facility, which can make the `facility_tile_list` grid layout in unexpected ways. This uses `ActiveStroage#variant` to make images the same size and dimension, it adds colored padding if the image is the wrong aspect ratio.

This depends on `libvips` to do the image processing. That or `ImageMagick` must be installed on the server for this to work.

# Screenshot

![Screen Shot 2022-10-28 at 12 48 03 PM](https://user-images.githubusercontent.com/624487/198700197-ea3311e6-ba33-4aff-a72a-1899a28297dc.png)
