### PR TITLE
[#160958] Sets a minimum width of the status column on the order details table

### DIFF
--- a/app/assets/stylesheets/app/tables.scss
+++ b/app/assets/stylesheets/app/tables.scss
@@ -25,16 +25,8 @@ table {
   }
 }
 
-/*
- * This makes sure the status column, in particular the "Status.." dropdown menu,
- * is clearly visible on the FacilityReservationsController#index page
-**/
-table.reservations {
-  tr {
-    td:nth-last-child(2) {
-      min-width: 84px;
-    }
-  }
+table.reservations select.status_dropdown {
+  min-width: 84px;
 }
 
 .table-user-accounts {

--- a/app/assets/stylesheets/app/tables.scss
+++ b/app/assets/stylesheets/app/tables.scss
@@ -25,6 +25,18 @@ table {
   }
 }
 
+/*
+ * This makes sure the status column, in particular the "Status.." dropdown menu,
+ * is clearly visible on the FacilityReservationsController#index page
+**/
+table.reservations {
+  tr {
+    td:nth-last-child(2) {
+      min-width: 84px;
+    }
+  }
+}
+
 .table-user-accounts {
   thead {
     th {

--- a/app/views/shared/_order_detail_action_form.html.haml
+++ b/app/views/shared/_order_detail_action_form.html.haml
@@ -11,7 +11,7 @@
     options_for_select(assigned_user_options), class: "sync_select", id: nil
 
 %td.action-form
-  %select{ name: "order_status_id", class: "sync_select", id: nil }
+  %select{ name: "order_status_id", class: "sync_select status_dropdown", id: nil }
     = options_for_select([["Status...", nil]])
     - OrderStatus.non_protected_statuses(current_facility).each do |order_status|
       = options_for_select([[order_status.name_with_level, order_status.id]])


### PR DESCRIPTION
# Release Notes

At smaller viewport widths, the Status column of the order details table is too narrow. This sets a minimum width for that column

# Screenshot

![Screen Shot 2022-11-02 at 5 45 24 PM](https://user-images.githubusercontent.com/624487/199616614-3b450654-9ecd-4055-92f8-ec37a204c410.png)
