### PR TITLE
[#159346] Adds optional reply-to address to ResultsFileNotifierMailer

### DIFF
--- a/app/mailers/results_file_notifier_mailer.rb
+++ b/app/mailers/results_file_notifier_mailer.rb
@@ -4,7 +4,8 @@ class ResultsFileNotifierMailer < ApplicationMailer
 
   def file_uploaded(file)
     @order_detail = file.order_detail
-    mail(to: @order_detail.user.email, subject: text("results_file_notifier_mailer.file_uploaded.subject"))
+    reply_to = SettingsHelper.setting("email.results_file_notifier.reply_to") || SettingsHelper.setting("email.from")
+    mail(reply_to: reply_to, to: @order_detail.user.email, subject: text("results_file_notifier_mailer.file_uploaded.subject"))
   end
 
 end

--- a/app/mailers/results_file_notifier_mailer.rb
+++ b/app/mailers/results_file_notifier_mailer.rb
@@ -4,7 +4,10 @@ class ResultsFileNotifierMailer < ApplicationMailer
 
   def file_uploaded(file)
     @order_detail = file.order_detail
-    reply_to = SettingsHelper.setting("email.results_file_notifier.reply_to") || SettingsHelper.setting("email.from")
+    product = @order_detail.product
+    product_email = product.email
+    reply_to = product_email || SettingsHelper.setting("email.from")
+
     mail(reply_to: reply_to, to: @order_detail.user.email, subject: text("results_file_notifier_mailer.file_uploaded.subject"))
   end
 

--- a/spec/mailers/previews/results_file_notifier_preview.rb
+++ b/spec/mailers/previews/results_file_notifier_preview.rb
@@ -3,7 +3,7 @@
 class ResultsFileNotifierPreview < ActionMailer::Preview
 
   def file_uploaded
-    file = StoredFile.sample_result.last
+    file = FactoryBot.build(:stored_file, order_detail: OrderDetail.first)
     ResultsFileNotifierMailer.file_uploaded(file)
   end
 

--- a/spec/mailers/previews/results_file_notifier_preview.rb
+++ b/spec/mailers/previews/results_file_notifier_preview.rb
@@ -3,7 +3,13 @@
 class ResultsFileNotifierPreview < ActionMailer::Preview
 
   def file_uploaded
-    file = FactoryBot.build(:stored_file, order_detail: OrderDetail.first)
+    file = FactoryBot.build(
+      :stored_file,
+      :results,
+      creator: User.first,
+      order_detail: OrderDetail.first
+    )
+
     ResultsFileNotifierMailer.file_uploaded(file)
   end
 


### PR DESCRIPTION
# Release Notes

The reply-to email address for every file upload notification email was the same. The changes the reply-to email address to the product's contact address, or the facility's address, if they exist.

# Screenshot

![Screen Shot 2022-11-04 at 12 18 25 PM](https://user-images.githubusercontent.com/624487/200037101-c0a55cd2-48fa-4235-bf9a-0204e063cf89.png)