### PR TITLE
[#160883] Set scishield_endpoint in spec environment

### DIFF
--- a/config/secrets.yml.template
+++ b/config/secrets.yml.template
@@ -41,6 +41,8 @@ development:
 test:
   <<: *defaults
   secret_key_base: value_needed_for_ci
+  scishield:
+    scishield_endpoint: "https://test-university.scishield.com/jsonapi/raft_training_record/raft_training_record"
 
 stage:
   <<: *defaults

--- a/spec/services/scishield_api_adapter_spec.rb
+++ b/spec/services/scishield_api_adapter_spec.rb
@@ -5,16 +5,7 @@ require "rails_helper"
 RSpec.describe ResearchSafetyAdapters::ScishieldApiAdapter do
   subject(:adapter) { described_class.new(user) }
   let(:user) { build(:user, email: "research@osu.edu") }
-  let(:test_endpoint) { "https://test-university.scishield.com/jsonapi/raft_training_record/raft_training_record" }
   let(:api_endpoint) { adapter.client.api_endpoint(user.email) }
-
-  before(:each) {
-    allow(Rails.application.secrets).to receive(:dig).with(:scishield, :key).and_return(nil)
-    allow(Rails.application.secrets).to receive(:dig).with(:scishield, :key_id).and_return(nil)
-    allow(Rails.application.secrets).to receive(:dig).with(:scishield, :rsa_private_key).and_return(nil)
-    allow(Rails.application.secrets).to receive(:dig).with(:scishield, :scishield_endpoint).and_return(test_endpoint)
-
-  }
 
   describe "with a successful response" do
     let(:response) { File.expand_path("../fixtures/scishield/success.json", __dir__) }


### PR DESCRIPTION
# Release Notes

For some reason, mocking the value for `scishield_endpoint` in the spec file is [flaky](https://app.circleci.com/pipelines/github/tablexi/nucore-open/3196/workflows/c4589d9f-581d-44a2-a858-4a04654bc7c1/jobs/11447/parallel-runs/2?filterBy=FAILED):
`Absolute URI missing hierarchical segment: 'http://?include=course_id&filter[status]=1&filter[user][condition][path]=user_id.mail&filter[user][condition][operator]=%3D&filter[user][condition][value]=research%40osu.edu'`

I tried debugging by SSHing into the active CI run, and the specs that sometimes fail in CI were passing.  They also pass when run locally.  And also sometimes they pass in CI as well.

Rather than dig further into the cause, I'd like to try reading the value from the secrets file for testing environment instead.