### PR TITLE
[#160506] Add unlock strategy and timing to settings file

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -75,7 +75,7 @@ Devise.setup do |config|
   config.unlock_strategy = Settings.devise.unlock_strategy
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  config.unlock_in = Settings.devise.unlock_in.to_i.minutes
+  config.unlock_in = Settings.devise.minutes_to_unlock_in.to_i.minutes
 
   config.reset_password_within = 1.day
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -72,10 +72,10 @@ Devise.setup do |config|
   # :email = Sends an unlock link to the user email
   # :time  = Reanables login after a certain ammount of time (see :unlock_in below)
   # :both  = enables both strategies
-  config.unlock_strategy = :email
+  config.unlock_strategy = Settings.devise.unlock_strategy
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  # config.unlock_in = 5.minutes
+  config.unlock_in = Settings.devise.unlock_in.to_i.minutes
 
   config.reset_password_within = 1.day
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -175,3 +175,5 @@ google_analytics_key: ~
 
 devise:
   lock_strategy: :failed_attempts
+  unlock_strategy: :email
+  unlock_in: 5 minutes

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -176,4 +176,4 @@ google_analytics_key: ~
 devise:
   lock_strategy: :failed_attempts
   unlock_strategy: :email
-  unlock_in: 5 minutes
+  minutes_to_unlock_in: 5


### PR DESCRIPTION
# Release Notes

Some schools want a different unlock strategy and a different lock period. This adds those configurations to the settings file.