### PR TITLE
[#161123] Allow handling custom root order statuses

### DIFF
--- a/app/models/order_status.rb
+++ b/app/models/order_status.rb
@@ -19,7 +19,10 @@ class OrderStatus < ApplicationRecord
 
   scope :for_facility, ->(facility) { where(facility_id: [nil, facility&.id]) }
 
-  STATUS_ORDER = ["New", "In Process", "Canceled", "Complete", "Reconciled"].freeze
+  ROOT_STATUS_ORDER = ["New", "In Process", "Canceled", "Complete", "Reconciled"].freeze
+
+  # Needs to be overridable by engines
+  cattr_accessor(:ordered_root_statuses) { ROOT_STATUS_ORDER.dup }
 
   # This one is different because `new` is a reserved keyword
   def self.new_status
@@ -79,7 +82,7 @@ class OrderStatus < ApplicationRecord
   end
 
   def position
-    [STATUS_ORDER.index(root.name), id]
+    [ordered_root_statuses.index(root.name), id]
   end
 
   def name_with_level

--- a/spec/models/order_status_spec.rb
+++ b/spec/models/order_status_spec.rb
@@ -21,6 +21,17 @@ RSpec.describe OrderStatus do
 
   let!(:facility) { create(:facility) }
 
+  describe ".ordered_root_statuses" do
+    let(:ordered_roots) { root_statuses.values.map(&:name) }
+
+    it "allows adding and removing root order statuses" do
+      OrderStatus.ordered_root_statuses << "TEST"
+      expect(described_class.ordered_root_statuses).to eq(ordered_roots + ["TEST"])
+      OrderStatus.ordered_root_statuses.pop
+      expect(described_class.ordered_root_statuses).to eq(ordered_roots)
+    end
+  end
+
   describe ".new_status" do
     let!(:new_order_status) { create(:order_status, name: "New") }
 


### PR DESCRIPTION
# Release Notes

Some schools have a custom root order status.  This change allows handling that with the newly refactored approach to order statuses (we don't use awesome nested set any more).