### PR TITLE
[#160914 ] Add label to split accounts

### DIFF
--- a/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
+++ b/vendor/engines/split_accounts/app/models/split_accounts/split_account.rb
@@ -21,6 +21,10 @@ module SplitAccounts
       errors.add(:splits, :percent_total) if percent_total != 100
     end
 
+    def account_number_to_s
+      "(SPLIT) #{super}"
+    end
+
     def percent_total
       splits.reduce(0) do |sum, split|
         split.percent.present? ? sum + split.percent : sum


### PR DESCRIPTION
# Release Notes

When looking at lists of accounts, it can sometimes be helpful to quickly identify which ones are split accounts.

This adds "(SPLIT)" in front of split accounts account numbers to make them easier to identify.

# Screenshot

![Screen Shot 2022-11-16 at 3 11 33 PM](https://user-images.githubusercontent.com/624487/202297119-0ea75481-80c7-4e48-a40a-734cf9af5508.png)

![Screen Shot 2022-11-16 at 3 12 22 PM](https://user-images.githubusercontent.com/624487/202297140-1560e2f9-392a-438b-b2d0-f497f3f9b630.png)