### PR TITLE
[#161053] PurchaseOrder & Account updates from OSU

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -131,6 +131,7 @@ feature:
   revenue_account_editable: false
   active_storage: false
   facility_tile_list: false
+  require_affiliate_account: true
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -364,7 +364,9 @@ RSpec.describe Account do
         @facility2_accounts = [@nufs_account]
 
         Account.config.facility_account_types.each do |class_name|
-          class_sym = class_name.underscore.split("/").last.to_sym # ensures OsuRelms::NonPurchaseOrderAccount doesn't turn into :"osu_relms/non_purchase_order_account"
+          # ensures namespaced accounts like OsuRelms::NonPurchaseOrderAccount 
+          # don't turn into :"osu_relms/non_purchase_order_account"
+          class_sym = class_name.underscore.split("/").last.to_sym
           @facility1_accounts << FactoryBot.create(class_sym, account_users_attributes: account_users_attributes_hash(user: @user), facility: @facility1)
           @facility2_accounts << FactoryBot.create(class_sym, account_users_attributes: account_users_attributes_hash(user: @user), facility: @facility2)
         end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -364,7 +364,7 @@ RSpec.describe Account do
         @facility2_accounts = [@nufs_account]
 
         Account.config.facility_account_types.each do |class_name|
-          class_sym = class_name.underscore.to_sym
+          class_sym = class_name.underscore.split("/").last.to_sym # ensures OsuRelms::NonPurchaseOrderAccount doesn't turn into :"osu_relms/non_purchase_order_account"
           @facility1_accounts << FactoryBot.create(class_sym, account_users_attributes: account_users_attributes_hash(user: @user), facility: @facility1)
           @facility2_accounts << FactoryBot.create(class_sym, account_users_attributes: account_users_attributes_hash(user: @user), facility: @facility2)
         end

--- a/vendor/engines/c2po/app/models/purchase_order_account.rb
+++ b/vendor/engines/c2po/app/models/purchase_order_account.rb
@@ -2,8 +2,11 @@
 
 class PurchaseOrderAccount < Account
 
-  include AffiliateAccount
   extend ReconcilableAccount
+
+  if SettingsHelper.feature_on? :require_affiliate_account
+    include AffiliateAccount
+  end
 
   validates_presence_of :account_number
 

--- a/vendor/engines/c2po/app/views/facility_accounts/account_fields/_affiliate.html.haml
+++ b/vendor/engines/c2po/app/views/facility_accounts/account_fields/_affiliate.html.haml
@@ -2,7 +2,6 @@
   collection: select_affiliate_options,
   input_html: { class: "js--affiliate" },
   include_blank: true,
-  required: true,
   label: text("facility_accounts.account_fields.label.affiliate_display_name")
 
 .js--affiliate_other

--- a/vendor/engines/c2po/app/views/facility_accounts/account_fields/_purchase_order_account.html.haml
+++ b/vendor/engines/c2po/app/views/facility_accounts/account_fields/_purchase_order_account.html.haml
@@ -1,8 +1,7 @@
-= f.input :account_number, label: text("account_number"), required: true
+= f.input :account_number, required: true
 
 = f.input :formatted_expires_at, required: true,
-  input_html: { class: "datepicker" },
-  label: Account.human_attribute_name(:expires_at)
+  input_html: { class: "datepicker" }
 
 = f.input :description, required: true
 
@@ -19,7 +18,6 @@
   hint_html: { class: "help-inline" }
 
 = f.input :ar_number,
-  label: text("ar_number_label"),
   hint: text("ar_number_hint"),
   hint_html: { class: "help-inline" }
 

--- a/vendor/engines/c2po/config/locales/en.yml
+++ b/vendor/engines/c2po/config/locales/en.yml
@@ -23,7 +23,6 @@ en:
       account_fields:
         purchase_order_account:
           account_number: Account Number
-          ar_number_label: Account Receivable Number
           ar_number_hint: if applicable
           outside_contact_label: Outside Contact Info
           outside_contact_hint: Contact information (phone number, email, fax, etc.)

--- a/vendor/engines/c2po/config/locales/en.yml
+++ b/vendor/engines/c2po/config/locales/en.yml
@@ -46,6 +46,7 @@ en:
     attributes:
       purchase_order_account:
         account_number: Payment Source
+        ar_number: Account Receivable Number
       credit_card_account:
         account_number: Payment Source
         name_on_card: Name On Card


### PR DESCRIPTION
# Release Notes

Some changes from https://github.com/Oregon-State/nucore-osu/pull/225

This PR:
* Creates a feature flag to include `AffiliateAccount` in purchase order or not. This allows an affiliate account to be optional if false.
* Updates views to depend on `PurchaseOrderAccount`'s attribute names rather than field names in the translation file.
* Adjusts account_spec to properly work with name-spaced facility accounts