### PR TITLE
[#160950] Kiosk Mode enhancements from OSU

### DIFF
--- a/app/views/kiosk_reservations/_instrument.html.haml
+++ b/app/views/kiosk_reservations/_instrument.html.haml
@@ -1,0 +1,12 @@
+.timeline_instrument[instrument]
+  %h4
+    = instrument
+    = warning_if_instrument_is_offline_or_partially_available(instrument)
+
+  .timeline
+    .unit_container
+      = render partial: "reservation",
+        collection: (@reservations_by_instrument.fetch(instrument, []) + instrument.blackout_reservations(@display_datetime)),
+        locals: { product: instrument }
+
+      .current_time{style: "left: #{datetime_left_position(@display_datetime, Time.current)}"}

--- a/app/views/kiosk_reservations/_reservation.html.haml
+++ b/app/views/kiosk_reservations/_reservation.html.haml
@@ -1,0 +1,5 @@
+%div{ style: "width: #{reservation_width(@display_datetime, reservation)}; left: #{reservation_left_position(@display_datetime, reservation)}; z-index: #{reservation_counter};", class: reservation_classes(reservation, product) }[reservation, :block]
+
+- unless reservation.blackout?
+  %div[reservation, :tooltip]
+    %span= reservation_date_range_display(@display_datetime, reservation)

--- a/app/views/kiosk_reservations/_schedule.html.haml
+++ b/app/views/kiosk_reservations/_schedule.html.haml
@@ -1,0 +1,7 @@
+- if schedule.public_instruments.size > 1
+  .timeline-schedule
+    %h3= schedule.name
+    = render partial: "instrument", collection: schedule.public_instruments, as: :instrument
+- else
+  .timeline-single
+    = render partial: "instrument", collection: schedule.public_instruments, as: :instrument

--- a/app/views/kiosk_reservations/index.html.haml
+++ b/app/views/kiosk_reservations/index.html.haml
@@ -1,8 +1,14 @@
 = content_for :head_content do
+  = javascript_include_tag "tooltipsy"
+  = javascript_include_tag "timeline"
   = javascript_include_tag "dashboard_refresh"
 
 = content_for :h1 do
   = text("title", facility: current_facility)
 
 .js--dashboardRefresh{ data: { refresh_interval: 5.minutes } }
-  = render partial: "reservations_table", locals: { reservations: @reservations }
+  = render partial: "reservations_table", locals: { reservations: @actionable_reservations }
+
+.row
+  .span12.timeline-wrapper
+    = render partial: "schedule", collection: @schedules, as: :schedule

--- a/spec/system/kiosk_view_spec.rb
+++ b/spec/system/kiosk_view_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Launching Kiosk View", :js, feature_setting: { kiosk_view: true,
   shared_examples "kiosk_actions" do |login_label, password|
 
     context "with an admin reservation" do
-      let!(:admin_reservation) { create(:admin_reservation, reserve_start_at: 15.minutes.ago, actual_start_at: 10.minutes.ago, product: instrument) }
+      let!(:admin_reservation) { create(:admin_reservation, reserve_start_at: 15.minutes.ago, product: instrument) }
       let!(:accessory) { create(:accessory, parent: instrument) }
 
       it "does not error" do
@@ -26,7 +26,7 @@ RSpec.describe "Launching Kiosk View", :js, feature_setting: { kiosk_view: true,
     end
 
     context "with an offline reservation" do
-      let!(:offline_reservation) { create(:offline_reservation, reserve_start_at: 15.minutes.ago, actual_start_at: 10.minutes.ago, product: instrument) }
+      let!(:offline_reservation) { create(:offline_reservation, reserve_start_at: 15.minutes.ago, product: instrument) }
 
       it "does not error" do
         visit facility_kiosk_reservations_path(facility)


### PR DESCRIPTION
# Release Notes

The kiosk only shows actionable reservations. This adds the ability to see all of the day's reservations below the actionable ones.

This is cherry picked from OSU

# Screenshot

![Screen Shot 2022-12-09 at 3 25 44 PM](https://user-images.githubusercontent.com/624487/206798679-aed9541a-7713-469f-a929-80640e3f6632.png)