### PR TITLE
[#161053] Pulls in affiliate fixes from OSU

### DIFF
--- a/app/lib/affiliate_account.rb
+++ b/app/lib/affiliate_account.rb
@@ -4,7 +4,7 @@
 module AffiliateAccount
 
   def self.included(base)
-    base.validates_presence_of :affiliate_id
+    base.validates_presence_of :affiliate_id, if: :require_affiliate?
     base.validates_length_of :affiliate_other,
                              minimum: 1,
                              if: proc { |cc| cc.affiliate.try(:subaffiliates_enabled?) }

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -115,6 +115,10 @@ class Account < ApplicationRecord
     false
   end
 
+  def require_affiliate?
+    true
+  end
+
   def type_string
     I18n.t("activerecord.models.#{self.class.to_s.underscore}.one", default: self.class.model_name.human)
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -131,7 +131,7 @@ feature:
   revenue_account_editable: false
   active_storage: false
   facility_tile_list: false
-  require_affiliate_account: true
+  po_require_affiliate_account: true
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/doc/HOWTO_feature_flags.md
+++ b/doc/HOWTO_feature_flags.md
@@ -27,6 +27,7 @@
 * `facility_payment_urls` Store a payment url for each facility (can be used on statement PDFs to direct users to pay via CC)
 * `default_journal_cutoff_time` Journal cutoff time
 * `statement_pdf:class_name` PDF Statement formatting
+* `po_require_affiliate_account` Whether or not Purchase Order accounts will be required to have affiliates
 
 ## Billing and Pricing
 

--- a/spec/support/shared_examples/affiliate_account_shared_examples.rb
+++ b/spec/support/shared_examples/affiliate_account_shared_examples.rb
@@ -3,26 +3,49 @@
 # These shared examples require a `let(:account)`
 
 RSpec.shared_examples_for "AffiliateAccount" do
-
   let(:affiliate) { FactoryBot.create(:affiliate) }
-  it { is_expected.to validate_presence_of(:affiliate_id) }
 
-  it "requires affiliate_other if affiliate is 'Other'" do
-    account.affiliate = Affiliate.OTHER
-    account.affiliate_other = nil
-    expect(account).to be_invalid
-    expect(account)
-      .to validate_length_of(:affiliate_other).is_at_least(1)
+  context "with the :po_require_affiliate_account flag set to true", feature_setting: { po_require_affiliate_account: true } do
+    it { is_expected.to validate_presence_of(:affiliate_id) }
+
+    it "requires affiliate_other if affiliate is 'Other'" do
+      account.affiliate = Affiliate.OTHER
+      account.affiliate_other = nil
+      expect(account).to be_invalid
+      expect(account)
+        .to validate_length_of(:affiliate_other).is_at_least(1)
+    end
+
+    it "does not require affiliate_other if affiliate is not 'Other'" do
+      account.affiliate = affiliate
+      account.affiliate_other = nil
+      expect(account.affiliate).to be_present
+      expect(account.affiliate).not_to be_other
+      account.valid?
+      expect(account)
+        .not_to validate_length_of(:affiliate_other).is_at_least(1)
+    end
   end
 
-  it "does not require affiliate_other if affiliate is not 'Other'" do
-    account.affiliate = affiliate
-    account.affiliate_other = nil
-    expect(account.affiliate).to be_present
-    expect(account.affiliate).not_to be_other
-    account.valid?
-    expect(account)
-      .not_to validate_length_of(:affiliate_other).is_at_least(1)
-  end
+  context "with the :po_require_affiliate_account flag set to false", feature_setting: { po_require_affiliate_account: false } do
+    it { is_expected.not_to validate_presence_of(:affiliate_id) }
 
+    it "requires affiliate_other if affiliate is 'Other'" do
+      account.affiliate = Affiliate.OTHER
+      account.affiliate_other = nil
+      expect(account).to be_invalid
+      expect(account)
+        .to validate_length_of(:affiliate_other).is_at_least(1)
+    end
+
+    it "does not require affiliate_other if affiliate is not 'Other'" do
+      account.affiliate = affiliate
+      account.affiliate_other = nil
+      expect(account.affiliate).to be_present
+      expect(account.affiliate).not_to be_other
+      account.valid?
+      expect(account)
+        .not_to validate_length_of(:affiliate_other).is_at_least(1)
+    end
+  end
 end

--- a/spec/support/shared_examples/affiliate_account_shared_examples.rb
+++ b/spec/support/shared_examples/affiliate_account_shared_examples.rb
@@ -28,7 +28,7 @@ RSpec.shared_examples_for "AffiliateAccount" do
   end
 
   context "with the :po_require_affiliate_account flag set to false", feature_setting: { po_require_affiliate_account: false } do
-    it { is_expected.not_to validate_presence_of(:affiliate_id) }
+    it { is_expected.not_to validate_presence_of(:affiliate_id) if account.is_a? PurchaseOrderAccount }
 
     it "requires affiliate_other if affiliate is 'Other'" do
       account.affiliate = Affiliate.OTHER

--- a/vendor/engines/c2po/app/models/purchase_order_account.rb
+++ b/vendor/engines/c2po/app/models/purchase_order_account.rb
@@ -4,9 +4,7 @@ class PurchaseOrderAccount < Account
 
   extend ReconcilableAccount
 
-  if SettingsHelper.feature_on? :require_affiliate_account
-    include AffiliateAccount
-  end
+  include AffiliateAccount
 
   validates_presence_of :account_number
 
@@ -15,6 +13,10 @@ class PurchaseOrderAccount < Account
     desc += " / #{facility_description}" if with_facility && facilities.present?
     desc += " (#{display_status.upcase})" if flag_suspended && suspended?
     desc
+  end
+
+  def require_affiliate?
+    SettingsHelper.feature_on? :po_require_affiliate_account
   end
 
   private


### PR DESCRIPTION
# Release Notes

When the change was pulled into OSU, spec failures occurred. This cherry picks the fixes for those failures.

It adjusts how the `po_require_affiliate_account` feature flag works. It removes the `affiliate_id` validation instead of removing the `AffiliateAccount` include. And it insures the validation test only runs for `PurchaseOrderAccount`