### PR TITLE
[#160950] Fixes the kiosk refresh

### DIFF
--- a/app/controllers/kiosk_reservations_controller.rb
+++ b/app/controllers/kiosk_reservations_controller.rb
@@ -25,7 +25,7 @@ class KioskReservationsController < ApplicationController
     @reservations_by_instrument = todays_reservations.group_by(&:product)
 
     if params[:refresh]
-      render partial: "reservations_table", locals: { reservations: @reservations }
+      render partial: "reservations_table", locals: { reservations: @actionable_reservations }
     end
   end
 

--- a/spec/system/admin/launch_kiosk_view_spec.rb
+++ b/spec/system/admin/launch_kiosk_view_spec.rb
@@ -20,12 +20,22 @@ RSpec.describe "Launching Kiosk View", feature_setting: { kiosk_view: true } do
       # user should be logged out
       expect(page).to have_content("Login")
     end
+
+    it "does not raise an error when refreshing" do
+      visit facility_kiosk_reservations_path(facility, refresh: true)
+      expect(page).to have_content(instrument.name)
+    end
   end
 
   context "with no active reservations" do
     it "cannot launch the Kiosk View" do
       visit timeline_facility_reservations_path(facility)
       expect(page).not_to have_content("Launch Kiosk View")
+    end
+
+    it "does not raise an error when refreshing" do
+      visit facility_kiosk_reservations_path(facility, refresh: true)
+      expect(page).to have_content("No currently actionable reservations found")
     end
   end
 


### PR DESCRIPTION
# Release Notes

Refreshing the kiosk was returning a 500 error. This corrects that by passing the correct variable to the view, and adds a couple of specs to test.