### PR TITLE
[#161107] Ports some changes to the products controller & view from OSU

### DIFF
--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -101,14 +101,20 @@ class ProductsCommonController < ApplicationController
   private
 
   def resource_params
-    params.require(:"#{singular_object_name}").permit(:name, :url_name, :contact_email, :description,
-                                                      :facility_account_id, :account, :initial_order_status_id,
-                                                      :requires_approval, :allows_training_requests, :is_archived, :is_hidden, :email_purchasers_on_order_status_changes,
-                                                      :user_notes_field_mode, :user_notes_label, :show_details,
-                                                      :schedule_id, :reserve_interval,
-                                                      :min_reserve_mins, :max_reserve_mins, :min_cancel_hours,
-                                                      :auto_cancel_mins, :lock_window, :cutoff_hours,
-                                                      :problems_resolvable_by_user, :restrict_holiday_access)
+    params.require(:"#{singular_object_name}").permit(*permitted_params)
+  end
+
+  def permitted_params
+    [
+      :name, :url_name, :contact_email, :description,
+      :facility_account_id, :account, :initial_order_status_id,
+      :requires_approval, :allows_training_requests, :is_archived, :is_hidden, :email_purchasers_on_order_status_changes,
+      :user_notes_field_mode, :user_notes_label, :show_details,
+      :schedule_id, :reserve_interval,
+      :min_reserve_mins, :max_reserve_mins, :min_cancel_hours,
+      :auto_cancel_mins, :lock_window, :cutoff_hours,
+      :problems_resolvable_by_user, :restrict_holiday_access
+    ]
   end
 
   def current_facility_products

--- a/app/views/admin/products/_account_fields.html.haml
+++ b/app/views/admin/products/_account_fields.html.haml
@@ -7,6 +7,8 @@
   collection: current_facility.facility_accounts.active,
   hint: text("hints.deposit_account")
 
+= render_view_hook("after_facility_account", { f: f })
+
 %p= link_to text("deposit_account.add"), :facility_facility_accounts
 
 - if SettingsHelper.feature_on? :expense_accounts

--- a/app/views/products_common/manage.html.haml
+++ b/app/views/products_common/manage.html.haml
@@ -18,6 +18,8 @@
     = f.input :facility_account,
       input_html: { value: @product.facility_account.account_number + (@product.facility_account.is_active? ? "" : " (inactive)") }
 
+    = render_view_hook("after_facility_account", { f: f })
+
     = f.input :initial_order_status
     = f.input :requires_approval
     - if f.object.requires_approval?


### PR DESCRIPTION
# Release Notes

To enable an instrument to have an external revenue account in https://github.com/Oregon-State/nucore-osu/pull/233, some changes were made to the `Product` controller and views.

This ports over the changes that should be in Open.