### PR TITLE
[#161267] Changes statement email subject to use `!Statement!`

### DIFF
--- a/config/locales/en.notifier.yml
+++ b/config/locales/en.notifier.yml
@@ -48,7 +48,7 @@ en:
         outro: Please log in to [!app_name!](%{login_url}) and review these charges.
 
       statement:
-        subject: "!app_name! Statement"
+        subject: "!app_name! !Statement!"
         body: |
           Thank you for using %{facility}.
 


### PR DESCRIPTION
# Release Notes

This changes the statement email subject to use `!Statement!` instead of "Statement", so that it will changed based on what `Statement` is set to in the translation file

# Screenshot

![Screen Shot 2023-01-04 at 11 35 15 AM](https://user-images.githubusercontent.com/624487/210615552-1c61861a-b924-4470-8007-88c22d979623.png)
