### PR TITLE
[#161107] Updates recharge accounts for products

### DIFF
--- a/app/models/facility_account.rb
+++ b/app/models/facility_account.rb
@@ -39,6 +39,10 @@ class FacilityAccount < ApplicationRecord
     end
   end
 
+  def display_account_number
+    account_number + (is_active? ? "" : " (inactive)")
+  end
+
   # Over-rideable from school-specific engines that don't use the expense_accounts feature flag
   def revenue_account_for_journal
     revenue_account

--- a/app/views/admin/products/_account_fields.html.haml
+++ b/app/views/admin/products/_account_fields.html.haml
@@ -1,7 +1,7 @@
 -# Use `label_text` to add * marking the field as required because
 -# `include_blank: false` gets ignored if you use `required: true`
 = f.input :facility_account_id,
-  label: FacilityAccount.model_name.human,
+  label: text("facility_accounts.account_fields.label.recharge_account"),
   label_text: -> (label, _required, _) { "* #{label}" },
   include_blank: false,
   collection: current_facility.facility_accounts.active,

--- a/app/views/products_common/manage.html.haml
+++ b/app/views/products_common/manage.html.haml
@@ -16,7 +16,8 @@
 
   - unless @product.is_a?(Bundle)
     = f.input :facility_account,
-      input_html: { value: @product.facility_account.account_number + (@product.facility_account.is_active? ? "" : " (inactive)") }
+      input_html: { value: @product.facility_account.display_account_number },
+      label: text("facility_accounts.account_fields.label.recharge_account")
 
     = f.input :initial_order_status
     = f.input :requires_approval

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,6 +195,7 @@ en:
         affiliate: "Name" # used for labeling affiliate_other field in forms
         remit: "Bill To"
         all_instruct: "Enter a text description to help you and the user identify this payment source."
+        recharge_account: "!activerecord.models.facility_account.one!"
     account_table:
       notice: "No payment sources found."
       foot: "* Includes transactions for which the user has not been sent a !statement_downcase! or that are in the user review period."


### PR DESCRIPTION
# Release Notes

Adjusts label on views to make it easier to change the name on the account label. This is helpful to OSU, who can have 2 recharge accounts for each product

Refactors value of `facility_account` field