### PR TITLE
Tech task: Use the explicit label for PO account number

### DIFF
--- a/vendor/engines/c2po/app/views/facility_accounts/account_fields/_purchase_order_account.html.haml
+++ b/vendor/engines/c2po/app/views/facility_accounts/account_fields/_purchase_order_account.html.haml
@@ -1,4 +1,4 @@
-= f.input :account_number, required: true
+= f.input :account_number, label: text("account_number"), required: true
 
 = f.input :formatted_expires_at, required: true,
   input_html: { class: "datepicker" }


### PR DESCRIPTION
# Release Notes

Reverts a change made in https://github.com/tablexi/nucore-open/pull/3266 to support an over-ride for OSU.
This restores the label of "Account Number" for PO accounts, which had been inadvertently changed to "Payment Source".

## NOTE
When merging this into OSU we will need to update the way the over-ride is done.