### PR TITLE
[#159180] Add a vertical divider after username in header

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -23,6 +23,7 @@
           %ul.nav.pull-right.hide-from-print
             - if acting_as?
               %li.navbar-text= "#{acting_user.full_name} (#{acting_user.username})"
+              %li.divider-vertical
               = render "/shared/support"
               %li= link_to "#{t('pages.cart')} (#{current_cart.order_details.count})", :cart
             - else


### PR DESCRIPTION
# Release Notes

When ordering on behalf of a user, the header menu doesn't have a vertical divider after the username, making it run into the next column. This adds a vertical divider

# Screenshot

![Screen Shot 2023-01-17 at 11 48 58 AM](https://user-images.githubusercontent.com/624487/212973976-9d96ddbd-4e25-4edf-ad6e-227bfa78274a.png)