### PR TITLE
[#161308] Updates rake task to add missing template to order detail

### DIFF
--- a/lib/tasks/order_details.rake
+++ b/lib/tasks/order_details.rake
@@ -66,7 +66,7 @@ namespace :order_details do
         file: StringIO.new("Placeholder text for missing template."),
         file_type: "template_result",
         name: "placeholder.csv",
-        created_by: "order_detail.user.id"
+        created_by: order_detail.user.id
       )
 
       order_detail.save

--- a/lib/tasks/order_details.rake
+++ b/lib/tasks/order_details.rake
@@ -69,6 +69,8 @@ namespace :order_details do
         created_by: order_detail.user.id
       )
 
+      puts "File added to order detail #{order_detail.id}"
+
       order_detail.save
     end
   end

--- a/lib/tasks/order_details.rake
+++ b/lib/tasks/order_details.rake
@@ -59,6 +59,8 @@ namespace :order_details do
   task :add_template_result, [:ids] => :environment do |_t, args|
     order_details = OrderDetail.where id: args[:ids].split
 
+    puts "Attempting to add missing files to order details..."
+
     order_details.each do |order_detail|
       next unless order_detail.missing_form?
 
@@ -69,7 +71,7 @@ namespace :order_details do
         created_by: order_detail.user.id
       )
 
-      puts "File added to order detail #{order_detail.id}"
+      puts "...missing file added to order detail #{order_detail.id}"
 
       order_detail.save
     end


### PR DESCRIPTION
# Release Notes

This updates the rake task that adds a missing template to order details.

Now it will only add a file if the form is missing, a file is created instead of using the product's file. And it's now possible to pass multiple ids to the rake task.