### PR TITLE
Tech task - Add Dockerfile for Github Actions testing

### DIFF
--- a/Dockerfile.github-actions
+++ b/Dockerfile.github-actions
@@ -1,0 +1,76 @@
+# To build with specific versions of bundler or node, pass in a build arg.
+# You can set these explicitly:
+# `--build-arg NODE_VERSION=setup_18.x`
+# Also, if the variable is already set in your local environment, you can just pass in:
+# `--build-arg BUNDLER_VERSION`
+# ... and `docker build` will pick up the local value.
+#
+# Example usage:
+# build . -f Dockerfile.github-actions --build-arg NODE_VERSION=setup_18.x --build-arg BUNDLER_VERSION
+FROM ubuntu:18.04
+
+# Update & upgrade
+RUN apt-get update && apt-get -y upgrade
+
+# Install Ruby on Rails dependencies
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get -y install build-essential zlib1g-dev libssl-dev \
+  libreadline6-dev libyaml-dev git libcurl4-openssl-dev libpq-dev \
+  libxslt-dev libsqlite3-dev curl \
+  wget zip unzip cmake libmagic-dev tzdata xvfb libxi6 libgconf-2-4 \
+  ghostscript libxml2-dev libglib2.0-dev libbz2-dev libsodium-dev
+
+# install missing libpng12-dev
+RUN mkdir /tmp/libpng && cd /tmp/libpng && \
+  wget -O libpng12-0_1.2.54-1ubuntu1.1_amd64.deb https://launchpad.net/~ubuntu-security/+archive/ubuntu/ppa/+build/15108504/+files/libpng12-0_1.2.54-1ubuntu1.1_amd64.deb && \
+  dpkg -i libpng12-*.deb
+
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get -y install libmagickwand-dev \
+  imagemagick libmagickcore-dev libmagickwand-dev \
+  libjpeg-dev checkinstall libx11-dev \
+  libxext-dev libfreetype6-dev
+
+# Fix Ghostscript issues with PDFs
+RUN wget -O /usr/local/bin/imagemagick-enable-pdf https://raw.githubusercontent.com/RobertKaczmarek/ubuntu-scripts/master/image/imagemagick-enable-pdf
+RUN chmod +x /usr/local/bin/imagemagick-enable-pdf
+RUN /usr/local/bin/imagemagick-enable-pdf
+
+# Install node
+ARG NODE_VERSION=setup_16.x
+ENV NODE_VERISON ${NODE_VERSION}
+RUN curl -sL https://deb.nodesource.com/$NODE_VERISON | bash -
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get -y install nodejs
+RUN npm install -g yarn
+
+# Install ruby
+ENV RUBY_DOWNLOAD_SHA256 2755b900a21235b443bb16dadd9032f784d4a88f143d852bc5d154f22b8781f1
+ADD https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.5.tar.gz /tmp/
+
+RUN \
+  cd /tmp && \
+  echo "$RUBY_DOWNLOAD_SHA256 *ruby-2.7.5.tar.gz" | sha256sum -c - && \
+  tar -xzf ruby-2.7.5.tar.gz && \
+  cd ruby-2.7.5 && \
+  ./configure --enable-shared && \
+  make && \
+  make install && \
+  cd .. && \
+  rm -rf ruby-2.7.5 && \
+  rm -f ruby-2.7.5.tar.gz
+
+ARG BUNDLER_VERSION=2.3.11
+ENV BUNDLER_VERSION=${BUNDLER_VERSION}
+RUN gem install bundler -v $BUNDLER_VERSION --no-document
+
+# Install Google Chrome
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub |  apt-key add -
+RUN echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' |  tee /etc/apt/sources.list.d/google-chrome.list
+RUN apt-get update && apt-get install -y google-chrome-stable
+
+# Install chromedriver
+RUN CHROMEDRIVER_VERSION=$(curl -s 'https://chromedriver.storage.googleapis.com/LATEST_RELEASE'); \
+  wget https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
+RUN unzip chromedriver_linux64.zip
+RUN rm -f chromedriver_linux64.zip
+RUN mv chromedriver /usr/bin/chromedriver
+RUN chown root:root /usr/bin/chromedriver
+RUN chmod +x /usr/bin/chromedriver

--- a/README.md
+++ b/README.md
@@ -209,6 +209,31 @@ NUcore uses [Rspec](http://rspec.info) to run tests. Try any of the following fr
     rake spec:controllers
     ```
 
+#### Github Actions
+
+To use Github Actions for CI testing you may need to maintain a testing image with spcific versions of dependencies set.  Do to this:
+```
+# Set your desired version of node and bundler
+export NODE_VERSION=setup_16.x
+export BUNDLER_VERSION=2.3.11
+
+# Build the image
+docker build . -f Dockerfile.github-actions --build-arg NODE_VERSION=$NODE_VERSION --build-arg BUNDLER_VERSION
+
+# Check the IMAGE ID
+docker image ls
+
+# Tag the image with the appropriate ruby version
+docker tag {IMAGE ID} nucoretxi/ruby-node-chrome-pack:2.7.5
+
+# Check the image was tagged correctly
+docker image ls
+
+# login and push the new tag
+docker login -u nucoretxi
+docker push nucoretxi/ruby-node-chrome-pack:2.7.5
+```
+
 #### Parallel Tests
 
 You can run specs in parallel during local development using the [`parallel_tests`](https://github.com/grosser/parallel_tests) gem.

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ NUcore uses [Rspec](http://rspec.info) to run tests. Try any of the following fr
 
 #### Github Actions
 
-To use Github Actions for CI testing you may need to maintain a testing image with spcific versions of dependencies set.  To do this:
+To use Github Actions for CI testing you may need to maintain a testing image with specific versions of dependencies set.  To do this:
 ```
 # Set your desired version of node and bundler
 export NODE_VERSION=setup_16.x

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ NUcore uses [Rspec](http://rspec.info) to run tests. Try any of the following fr
 
 #### Github Actions
 
-To use Github Actions for CI testing you may need to maintain a testing image with spcific versions of dependencies set.  Do to this:
+To use Github Actions for CI testing you may need to maintain a testing image with spcific versions of dependencies set.  To do this:
 ```
 # Set your desired version of node and bundler
 export NODE_VERSION=setup_16.x


### PR DESCRIPTION
# Release Notes

As we prepare to move away from CircleCI this will be helpful to have here in nucore-open.
I used [prograils' ruby image](https://github.com/prograils/docker-ruby-node-chrome-pack/blob/2.7.5/Dockerfile) as a base and added in ENV variables to control node version and bundler version.  This allows CI testing to run in an environment that matches production more closely.