### PR TITLE
[#161102] Adds `active_storage_for_images_only` feature flag

### DIFF
--- a/app/lib/settings_helper.rb
+++ b/app/lib/settings_helper.rb
@@ -29,6 +29,10 @@ module SettingsHelper
     setting "relays.#{Rails.env}.reservation_enabled"
   end
 
+  def self.active_storage_enabled?
+    feature_on?(:active_storage) || feature_on?(:active_storage_for_images_only)
+  end
+
   #
   # Used to query the +Settings+ under feature:
   # [_feature_]

--- a/app/lib/settings_helper.rb
+++ b/app/lib/settings_helper.rb
@@ -29,10 +29,6 @@ module SettingsHelper
     setting "relays.#{Rails.env}.reservation_enabled"
   end
 
-  def self.active_storage_enabled?
-    feature_on?(:active_storage) || feature_on?(:active_storage_for_images_only)
-  end
-
   #
   # Used to query the +Settings+ under feature:
   # [_feature_]

--- a/app/models/concerns/active_storage_file.rb
+++ b/app/models/concerns/active_storage_file.rb
@@ -9,12 +9,10 @@ module ActiveStorageFile
     has_one_attached :file
 
     def assign_attributes(new_attributes)
-      if SettingsHelper.active_storage_enabled?
-        # Ensure the file name and file_type are set first when attaching a StringIO
-        # see #file= method below
-        assign_first = new_attributes.extract!(:name, :file_type)
-        super(assign_first) unless assign_first.empty?
-      end
+      # Ensure the file name and file_type are set first when attaching a StringIO
+      # see #file= method below
+      assign_first = new_attributes.extract!(:name, :file_type)
+      # super(assign_first) unless assign_first.empty?
       super(new_attributes)
     end
   end

--- a/app/models/concerns/active_storage_file.rb
+++ b/app/models/concerns/active_storage_file.rb
@@ -12,6 +12,8 @@ module ActiveStorageFile
       # Ensure the file name and file_type are set first when attaching a StringIO
       # see #file= method below
       assign_first = new_attributes.extract!(:name, :file_type)
+
+      super(assign_first) unless assign_first.empty?
       super(new_attributes)
     end
   end

--- a/app/models/concerns/active_storage_file.rb
+++ b/app/models/concerns/active_storage_file.rb
@@ -9,7 +9,7 @@ module ActiveStorageFile
     has_one_attached :file
 
     def assign_attributes(new_attributes)
-      if SettingsHelper.feature_on?(:active_storage)
+      if SettingsHelper.feature_on?(:active_storage) || SettingsHelper.feature_on?(:active_storage_for_images)
         # Ensure the file name and file_type are set first when attaching a StringIO
         # see #file= method below
         assign_first = new_attributes.extract!(:name, :file_type)

--- a/app/models/concerns/active_storage_file.rb
+++ b/app/models/concerns/active_storage_file.rb
@@ -9,7 +9,7 @@ module ActiveStorageFile
     has_one_attached :file
 
     def assign_attributes(new_attributes)
-      if SettingsHelper.feature_on?(:active_storage) || SettingsHelper.feature_on?(:active_storage_for_images)
+      if SettingsHelper.active_storage_enabled?
         # Ensure the file name and file_type are set first when attaching a StringIO
         # see #file= method below
         assign_first = new_attributes.extract!(:name, :file_type)

--- a/app/models/concerns/active_storage_file.rb
+++ b/app/models/concerns/active_storage_file.rb
@@ -12,7 +12,6 @@ module ActiveStorageFile
       # Ensure the file name and file_type are set first when attaching a StringIO
       # see #file= method below
       assign_first = new_attributes.extract!(:name, :file_type)
-      # super(assign_first) unless assign_first.empty?
       super(new_attributes)
     end
   end

--- a/app/models/concerns/downloadable_files/image.rb
+++ b/app/models/concerns/downloadable_files/image.rb
@@ -3,18 +3,27 @@ module DownloadableFiles
   module Image
 
     extend ActiveSupport::Concern
-    include DownloadableFile
+
+    if SettingsHelper.feature_on?(:active_storage_for_images)
+      include ActiveStorageFile
+    else
+      include PaperclipFile
+    end
 
     included do
       attr_reader :remove_file
 
       before_validation { delete_file if remove_file }
 
-      if SettingsHelper.feature_on?(:active_storage)
+      if SettingsHelper.feature_on?(:active_storage_for_images)
         validates :file, content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"]
       else
         validates_attachment :file, content_type: { content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"] }
       end
+    end
+
+    def file_present?
+      file.present?
     end
 
     def remove_file=(value)
@@ -22,7 +31,7 @@ module DownloadableFiles
     end
 
     def padded_image(width: 400, height: 200, background_color: "rgb(231, 231, 231)")
-      if SettingsHelper.feature_on?(:active_storage)
+      if SettingsHelper.feature_on?(:active_storage_for_images)
         download_url.variant(resize_and_pad: [width, height, { background: background_color }])
       else
         download_url

--- a/app/models/concerns/downloadable_files/image.rb
+++ b/app/models/concerns/downloadable_files/image.rb
@@ -4,7 +4,7 @@ module DownloadableFiles
 
     extend ActiveSupport::Concern
 
-    if SettingsHelper.active_storage_enabled?
+    if SettingsHelper.feature_on?(:active_storage_for_images_only) 
       include ActiveStorageFile
     else
       include PaperclipFile
@@ -15,7 +15,7 @@ module DownloadableFiles
 
       before_validation { delete_file if remove_file }
 
-      if SettingsHelper.active_storage_enabled?
+      if SettingsHelper.feature_on?(:active_storage_for_images_only)
         validates :file, content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"]
       else
         validates_attachment :file, content_type: { content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"] }
@@ -31,7 +31,7 @@ module DownloadableFiles
     end
 
     def padded_image(width: 400, height: 200, background_color: "rgb(231, 231, 231)")
-      if SettingsHelper.active_storage_enabled?
+      if SettingsHelper.feature_on?(:active_storage_for_images_only)
         download_url.variant(resize_and_pad: [width, height, { background: background_color }])
       else
         download_url

--- a/app/models/concerns/downloadable_files/image.rb
+++ b/app/models/concerns/downloadable_files/image.rb
@@ -4,7 +4,7 @@ module DownloadableFiles
 
     extend ActiveSupport::Concern
 
-    if SettingsHelper.feature_on?(:active_storage_for_images)
+    if SettingsHelper.active_storage_enabled?
       include ActiveStorageFile
     else
       include PaperclipFile
@@ -15,7 +15,7 @@ module DownloadableFiles
 
       before_validation { delete_file if remove_file }
 
-      if SettingsHelper.feature_on?(:active_storage_for_images)
+      if SettingsHelper.active_storage_enabled?
         validates :file, content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"]
       else
         validates_attachment :file, content_type: { content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"] }
@@ -31,7 +31,7 @@ module DownloadableFiles
     end
 
     def padded_image(width: 400, height: 200, background_color: "rgb(231, 231, 231)")
-      if SettingsHelper.feature_on?(:active_storage_for_images)
+      if SettingsHelper.active_storage_enabled?
         download_url.variant(resize_and_pad: [width, height, { background: background_color }])
       else
         download_url

--- a/app/models/stored_file.rb
+++ b/app/models/stored_file.rb
@@ -13,7 +13,7 @@ class StoredFile < ApplicationRecord
   validates_inclusion_of  :file_type, in: %w(info user_info template template_result sample_result import_error import_upload)
   validates :name, uniqueness: { scope: :order_detail_id, case_sensitive: false }, if: :order_detail_id?
   if SettingsHelper.feature_on?(:active_storage)
-    validates :file, size: { between: 1.kilobyte..10.megabytes }, if: ->(o) { o.file_type == "user_info" }
+    validates :file, size: { less_than: 10.megabytes }, if: ->(o) { o.file_type == "user_info" }
   else
     validates_with AttachmentSizeValidator, attributes: :file, less_than: 10.megabytes, if: ->(o) { o.file_type == "user_info" }
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -130,7 +130,7 @@ feature:
   bypass_kiosk_auth: false
   revenue_account_editable: false
   active_storage: false
-  active_storage_for_images: true
+  active_storage_for_images_only: false
   facility_tile_list: <%= ENV.fetch("FACILITY_TILE_LIST", false) %>  
   facility_tile_list_admin: false
   po_require_affiliate_account: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -130,7 +130,8 @@ feature:
   bypass_kiosk_auth: false
   revenue_account_editable: false
   active_storage: false
-  facility_tile_list: false
+  active_storage_for_images: true
+  facility_tile_list: <%= ENV.fetch("FACILITY_TILE_LIST", false) %>  
   facility_tile_list_admin: false
   po_require_affiliate_account: true
 

--- a/doc/HOWTO_feature_flags.md
+++ b/doc/HOWTO_feature_flags.md
@@ -56,3 +56,4 @@
 * `kiosk_view` Kiosk mode - display a list of actionable reservations without logging in (optionally allow acting w/o auth)
 * `reservations: grace_period`, `reservations: timeout_period`, `occupancies: timeout_period`, `billing: review_period` various grace periods, time periods, and review periods
 * `active_storage` use `ActiveStorage` if `true`, or `Paperclip` if `false`
+* `active_storage_for_images_only` enables `ActiveStorage` for the `DownloadableFiles::Image` module. This flag does not need to be enabled if `active_storage` is

--- a/doc/HOWTO_feature_flags.md
+++ b/doc/HOWTO_feature_flags.md
@@ -56,4 +56,4 @@
 * `kiosk_view` Kiosk mode - display a list of actionable reservations without logging in (optionally allow acting w/o auth)
 * `reservations: grace_period`, `reservations: timeout_period`, `occupancies: timeout_period`, `billing: review_period` various grace periods, time periods, and review periods
 * `active_storage` use `ActiveStorage` if `true`, or `Paperclip` if `false`
-* `active_storage_for_images_only` enables `ActiveStorage` for the `DownloadableFiles::Image` module. This flag does not need to be enabled if `active_storage` is
+* `active_storage_for_images_only` enables `ActiveStorage` for the `DownloadableFiles::Image` module. This flag needs to be enabled even if `active_storage` is

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -123,7 +123,7 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-core/v/3-0/docs/configuration/global-namespace-dsl
   config.expose_dsl_globally = false
 
-  # for testing paperclip attachments
+  # for testing attachment validations
   config.include Paperclip::Shoulda::Matchers
   config.include ActiveStorageValidations::Matchers
 end

--- a/spec/system/facility_list_tile_spec.rb
+++ b/spec/system/facility_list_tile_spec.rb
@@ -2,11 +2,11 @@
 
 require "rails_helper"
 
-RSpec.describe "Facility list tile", feature_setting: { facility_tile_list: true } do
+RSpec.describe "Facility list tile", feature_setting: { facility_tile_list_admin: true, facility_tile_list: true } do
   # This spec requires that Facility have an attachement. Currently that can be done using
   # either Paperclip or ActiveStorage. Because Paperclip requires a migration that may or
   # may not have occurred, these specs are only set to run if ActiveStorage is being used.
-  if SettingsHelper.feature_on?(:active_storage)
+  if SettingsHelper.feature_on?(:active_storage_for_images_only)
     Facility.include DownloadableFiles::Image
 
     let(:admin_user) { create(:user, :administrator) }


### PR DESCRIPTION
# Release Notes

This adds the `active_storage_for_images_only` feature flag to allow for the use of `ActiveStorage` just for `DownloadableFiles::Image`.

Since UMass would like to use images but is using Paperclip otherwise, this will allow them to add images via `ActiveStorage` so there's less to migrate over to `ActiveStorage` when the time comes.