### PR TITLE
[#161290] Fix: implement dataprobe relay port configuration option

### DIFF
--- a/app/models/power_relay.rb
+++ b/app/models/power_relay.rb
@@ -49,7 +49,7 @@ module PowerRelay
   # fetch the status once.
   # Note that if one has nil (e.g. default) and the other has "80", it will still do two
   # network queries. This is so this model can be agnostic about the actual relay's default port
-  # (e.g. Synaccess is 80 while Dataprobe is 9200).
+  # (e.g. Synaccess is 80 while Dataprobe is 9100).
   def status_cache_key
     [
       ip,

--- a/vendor/engines/dataprobe/lib/dataprobe/ipio.rb
+++ b/vendor/engines/dataprobe/lib/dataprobe/ipio.rb
@@ -44,7 +44,9 @@ module Dataprobe
       sequence_number[0] += 1
       block.call(socket, sequence_number.pack("s<"))
     ensure
-      raise Dataprobe::Error.new("Network error while communicating with relay") unless socket&.close
+      raise Dataprobe::Error.new("Network error while communicating with relay") if socket.nil?
+
+      socket.close
     end
 
     def write(socket, string)

--- a/vendor/engines/dataprobe/lib/dataprobe/ipio.rb
+++ b/vendor/engines/dataprobe/lib/dataprobe/ipio.rb
@@ -13,7 +13,7 @@ module Dataprobe
 
     def initialize(host, options = {})
       @ip = host
-      @port = 9100
+      @port = set_port(options[:port])
       @username = (options[:username].presence || "user").ljust(21, "\x00")
       @password = (options[:password].presence || "user").ljust(21, "\x00")
     end
@@ -44,7 +44,7 @@ module Dataprobe
       sequence_number[0] += 1
       block.call(socket, sequence_number.pack("s<"))
     ensure
-      socket.close
+      raise Dataprobe::Error.new("Network error while communicating with relay") unless socket&.close
     end
 
     def write(socket, string)
@@ -67,6 +67,15 @@ module Dataprobe
 
     def hex_s(int)
       [int].pack "C"
+    end
+
+    # restrict port to valid range
+    def set_port(port_string)
+      return 9100 if port_string.blank?
+      return 1 if port_string.to_i < 1
+      return 65535 if port_string.to_i > 65535
+
+      port_string.to_i
     end
 
   end

--- a/vendor/engines/dataprobe/spec/lib/dataprobe/ipio_spec.rb
+++ b/vendor/engines/dataprobe/spec/lib/dataprobe/ipio_spec.rb
@@ -23,6 +23,22 @@ RSpec.describe Dataprobe::Ipio do
       expect(described_class.new(ip).port).to eq 9100
     end
 
+    it "defaults port to 9100" do
+      expect(described_class.new(ip, options = {:port => ""}).port).to eq 9100
+    end
+
+    it "sets port to 9101" do
+      expect(described_class.new(ip, options = {:port => "9101"}).port).to eq 9101
+    end
+
+    it "sets port to 1 when out of range < 1" do
+      expect(described_class.new(ip, options = {:port => "0"}).port).to eq 1
+    end
+
+    it "sets port to 65535 when out of range > 65535" do
+      expect(described_class.new(ip, options = {:port => "65536"}).port).to eq 65535
+    end
+
     it "sets username from the passed-in options and encodes it" do
       expect(described_class.new(ip, username: "alice").username).to eq "alice".ljust(21, "\x00")
     end


### PR DESCRIPTION
Compliments of @stevens101:
The TCP port field available on the product relay page is incorrectly hard-coded to 9100, which is the factory default port for this relay. This patch should be more useful, so that any valid user-defined integer will be used to report the status and to toggle the outlet for the product.