### PR TITLE
[#155885] Adjust account dropdown width

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -303,11 +303,23 @@ p.per-minute-show {
 }
 
 /* Account Fields */
-.order_account,
-.order_detail_account {
+.order_account {
   select {
     width: inherit;
     max-width: 100%;
+  }
+}
+
+.order_detail_account {
+  select {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+
+.order_detail_order_status {
+  select {
+    width: inherit;
   }
 }
 

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -3,9 +3,13 @@
 module AccountsHelper
 
   def account_input(form)
-    form.input :account_id, label: OrderDetail.human_attribute_name(:account) do
-      form.select :account_id, available_accounts_options, include_blank: false, disabled: edit_disabled?
-    end
+    form.input :account,
+      as: :select,
+      label: OrderDetail.human_attribute_name(:account),
+      collection: available_accounts_array,
+      selected: @order_detail.account_id,
+      include_blank: false,
+      disabled: edit_disabled?
   end
 
   def payment_source_link_or_text(account)
@@ -39,10 +43,6 @@ module AccountsHelper
         { "data-account-owner" => account.owner_user_name },
       ]
     end
-  end
-
-  def available_accounts_options
-    options_for_select(available_accounts_array, @order_detail.account_id)
   end
 
 end

--- a/app/views/facility_accounts/show.html.haml
+++ b/app/views/facility_accounts/show.html.haml
@@ -10,6 +10,8 @@
 
 = readonly_form_for :account, defaults: { hint: false } do |f|
 
+  = render_view_hook("top_of_readonly_form", f: f, account: @account)
+
   = f.input :owner_user
   = f.input :type_string
   = f.input :description

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -9,13 +9,13 @@
         = render "warnings"
 
     .row
-      .span3.js--pricingUpdate
+      .span5.js--pricingUpdate
         = account_input(f)
-      .span3
+      .span2
         %strong= t("facility_order_details.edit.label.account_owner")
         .account-owner= @order_detail.account.owner_user
 
-      .span3
+      .span2
         - if @order_statuses
           = f.association :order_status, collection: @order_statuses, label_method: :name_with_level, include_blank: false
           - if f.object.fulfilled_at.blank? || f.object.fulfilled_at_changed?


### PR DESCRIPTION
# Release Notes

Some payment sources have long descriptions and the account number gets pushed out of view.

Also:
- Add a view hook for the top of the payment source detail page
- Clean up an old view helper method