### PR TITLE
[#161102] Sets ActiveStorage's variant processor to vips

### DIFF
--- a/app/models/concerns/downloadable_files/image.rb
+++ b/app/models/concerns/downloadable_files/image.rb
@@ -30,9 +30,9 @@ module DownloadableFiles
       @remove_file = !value.to_i.zero?
     end
 
-    def padded_image(width: 400, height: 200, background_color: "rgb(231, 231, 231)")
+    def padded_image(width: 400, height: 200, background_color: 231)
       if SettingsHelper.feature_on?(:active_storage_for_images_only)
-        download_url.variant(resize_and_pad: [width, height, { background: background_color }])
+        download_url.variant(resize_and_pad: [width, height, { background: [background_color] }])
       else
         download_url
       end

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,6 +64,8 @@ module Nucore
 
     # Prevent invalid (usually malicious) URLs from causing exceptions/issues
     config.middleware.insert 0, Rack::UTF8Sanitizer
+
+    config.active_storage.variant_processor = :vips
   end
 
 end


### PR DESCRIPTION
# Release Notes

This sets `ActiveStorage`'s variant processor to vips.

Take care to verify this works correctly in OSU.