### PR TITLE
[#160217] Make home page welcome message optional

### DIFF
--- a/app/views/facilities/index.html.haml
+++ b/app/views/facilities/index.html.haml
@@ -1,7 +1,8 @@
 - if SettingsHelper.feature_on?(:equipment_list)
   = render "shared/nav/equipment_list_nav"
 
-.alert.alert-info= html("welcome")
+- unless html("welcome").blank?
+  .alert.alert-info= html("welcome")
 
 - if azlist_on?
   .az_list_container


### PR DESCRIPTION
# Release Notes

This adjusts the home page such that the wlecome `.alert-info` paragraph is not rendered if the welcome text is blank.

# Screenshot

![Screen Shot 2023-02-09 at 4 58 13 PM](https://user-images.githubusercontent.com/624487/217959532-71f0cb2d-0708-45fc-98f4-09a40b7bae55.png)