### PR TITLE
[#160761] Prevent double-clicks from breaking things

### DIFF
--- a/app/assets/javascripts/form_io_submission.js
+++ b/app/assets/javascripts/form_io_submission.js
@@ -15,7 +15,10 @@ function handleFormioSubmission(form, surveyUrl, surveyCompleteUrl, prefillData)
 
   form.on('submitDone', function(submission) {
     if (prefillData) {
-      surveyUrl = surveyUrl + submission._id;
+      // Prevent double-clicks from breaking things
+      if (!surveyUrl.includes(submission._id)) {
+        surveyUrl = surveyUrl + submission._id;
+      }
     }
     var orderDetailData = {
       order_detail: submission.data,


### PR DESCRIPTION
# Release Notes

If a user clicks more than once before the request is resolved, we end up with duplicated submission IDs stored for the survey URL.