### PR TITLE
[#160761] formio order date issue

### DIFF
--- a/app/controllers/formio/submissions_controller.rb
+++ b/app/controllers/formio/submissions_controller.rb
@@ -45,7 +45,7 @@ module Formio
         accountOwnerName: order_detail.account.owner_user.full_name,
         accountOwnerUsername: order_detail.account.owner_user.username,
         nucoreOrderNumber: order_detail.order_number,
-        orderedAtDate: order_detail.created_at.to_date.to_s,
+        orderedAtDate: order_detail.created_at.to_s,
         orderedForEmail: order_detail.user.email,
         orderedForName: order_detail.user.full_name,
         orderedForUsernname: order_detail.user.username,


### PR DESCRIPTION
# Release Notes

This removes the `to_date` conversion on the `OderDetails`'s `created_at`.

Converting this from a DateTime to a Date seems to result in form.io turning it back into a DateTime, probably at 12:00 AM UTC of the given date. Then converting it into to CST, resulting in the date being yesterday rather than today.