### PR TITLE
Fix order row importer translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,8 @@ en:
   facility_downcase: facility
   facilities_downcase: facilities
 
+  # When updating sso, chart string, or statement, check override/en.yml for
+  # additional changes that are necessary
   Sso_id: NetID
   sso_id_downcase: NetID
   name_or_sso_id: name, NetID, or username

--- a/config/locales/override/en.yml
+++ b/config/locales/override/en.yml
@@ -11,7 +11,9 @@ en:
   # The sections below are provided as a starting point for customizing
   # the preferred term for "statment" and "Chart String" in places where
   # it is not easy to use the text_helpers `text` method instead of `I18n.t`
-  # To use, simply uncomment and update the terms here as needed.
+  # To use, simply uncomment and update the terms here as needed. In addition
+  # to these, you may need to create an order upload template (and update
+  # `order_import_template_name`) if your changes affect the headers in that file
   
   # activerecord:
   #   models:
@@ -44,6 +46,11 @@ en:
   #       journal_or_statement_date: "Journal/Statement"
   #     actions:
   #       reassign_chart_strings: "Reassign Chart Strings"
+  #
+  # order_row_importer:
+  #   headers:
+  #      user: Netid / Email
+  #      chart_string: Chart String
 
   testing: # DO NOT DELETE: these are used to verify proper file loading in the specs
     locale_loading: This is here to verify the file is loaded in the specs

--- a/config/locales/services/en.order_row_importer.yml
+++ b/config/locales/services/en.order_row_importer.yml
@@ -5,6 +5,7 @@ en:
       order_number: Order
       notes: Note
       reference_id: Reference ID
+      chart_string: Chart String
     errors:
       blank: All fields are empty
       purchase_fail: Couldn't purchase order

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -59,6 +59,7 @@ support_email: ~
 order_details:
   list_transformer: SplitAccounts::OrderDetailListTransformer
 
+# Make sure to update order_row_importers/headers keys in override/en.yml
 order_import_template_name: bulk_import_template.csv
 
 reservations:

--- a/doc/coding_standards.md
+++ b/doc/coding_standards.md
@@ -41,6 +41,7 @@ and controller locales. Use the standard [Rails I18n](http://guides.rubyonrails.
 * When including references to "facility" and "facilities", within a longer string,
   use text-helper's interpolation features with `facility_downcase`/`facilities_downcase`
   e.g. `text("in this !facility_downcase!"). _We haven't found a better way to do this yet_
+* Varitations of "chart string", "statement", and "NetID" need to be changed in multiple places in order to be changed application wide. In addition to changes in `en.yml` (see `Sso_id:`, `Chart_string`, `Statement`) and `override/en.yml` (see the comments), a new order import template needs to be created and set in `settings.yml` (the `order_import_template_name` setting).
 
 ## Rubocop
 

--- a/spec/services/order_row_importer_spec.rb
+++ b/spec/services/order_row_importer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe OrderRowImporter do
   let(:row) do
     ref = {
       "Netid / Email" => username,
-      "Chart String" => chart_string,
+      I18n.t("Chart_string") => chart_string,
       "Product Name" => product_name,
       "Quantity" => quantity,
       "Order Date" => order_date,
@@ -505,7 +505,7 @@ RSpec.describe OrderRowImporter do
       end
 
       it_behaves_like "an order was not created"
-      it_behaves_like "it has an error message", "Missing headers: Chart String"
+      it_behaves_like "it has an error message", "Missing headers: #{I18n.t('Chart_string')}"
     end
 
     context "when the note field is invalid" do
@@ -591,7 +591,7 @@ RSpec.describe OrderRowImporter do
     let(:row) do
       {
         "Netid / Email" => username,
-        "Chart String" => chart_string,
+        I18n.t("Chart_string") => chart_string,
         "Product Name" => product_name,
         "Quantity" => quantity,
         "Order Date" => order_date,
@@ -603,7 +603,7 @@ RSpec.describe OrderRowImporter do
       expect(subject.row_with_errors.headers).to eq(
         [
           "Netid / Email",
-          "Chart String",
+          I18n.t("Chart_string"),
           "Product Name",
           "Quantity",
           "Order Date",


### PR DESCRIPTION
# Release Notes

Some needed translation changes for chart string and netid were missed. This addresses that.

In particular, the OrderRowImporter was missed, so this adds to the comments in override/en.yml, and updates specs and documentation.
