### PR TITLE
Fix: Adds translations to order import specs

### DIFF
--- a/spec/models/order_import_csv_spec.rb
+++ b/spec/models/order_import_csv_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe OrderImport, feature_setting: { user_based_price_groups: true } d
     describe "happy path" do
       let(:body) do
         <<~CSV
-          Netid / Email,Chart String,Product Name,Quantity,Order Date,Fulfillment Date,Note,Order,Reference ID
+          #{I18n.t("order_row_importer.headers.user")},#{I18n.t("Chart_string")},Product Name,Quantity,Order Date,Fulfillment Date,Note,Order,Reference ID
           sst123@example.com,#{account.account_number},Example Item,1,02/15/2020,02/15/2020,Add to 1,#{order.id},123456789
           sst123@example.com,#{account2.account_number},Example Item,1,02/15/2020,02/15/2020,Add to 2,#{order.id},123456000
           sst123@example.com,#{account2.account_number},Example Item,1,02/15/2020,02/15/2020,Add to other,#{order2.id},abc123

--- a/spec/models/order_import_spec.rb
+++ b/spec/models/order_import_spec.rb
@@ -8,8 +8,8 @@ require "stringio"
 RSpec.describe OrderImport, :time_travel do
 
   CSV_HEADERS = [
-    "Netid / Email",
-    "Chart String",
+    I18n.t("order_row_importer.headers.user"),
+    I18n.t("Chart_string"),
     "Product Name",
     "Quantity",
     "Order Date",


### PR DESCRIPTION
# Release Notes

Some order importer specs were missing the use of translations. This adds those in.