### PR TITLE
TECH TASK: Remove `DateHelper` includes from specs

### DIFF
--- a/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
+++ b/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
@@ -42,10 +42,8 @@ RSpec.describe FacilityAccountsReconciliationController do
   end
 
   describe "update" do
-    include DateHelper
-
     before { sign_in admin }
-    let(:formatted_reconciled_at) { format_usa_date(reconciled_at) }
+    let(:formatted_reconciled_at) { SpecDateHelper.format_usa_date(reconciled_at) }
 
     def perform
       post :update, params: { facility_id: facility.url_name, account_type: "ReconciliationTestAccount",

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe FacilityJournalsController do
   let(:user) { @user }
   let(:journal) { @journal }
 
-  include DateHelper
-
   render_views
 
   def create_order_details
@@ -214,7 +212,7 @@ RSpec.describe FacilityJournalsController do
     it_should_deny_all [:staff, :senior_staff]
 
     it_should_allow_managers_only :redirect, "and respond gracefully when no order details given" do |_user|
-      journal_date = parse_usa_date(@journal_date)
+      journal_date = SpecDateHelper.parse_usa_date(@journal_date)
       expect(flash[:error]).not_to be_nil
     end
 
@@ -303,7 +301,7 @@ RSpec.describe FacilityJournalsController do
 
       context "trying to journal in the future" do
         before :each do
-          @params[:journal_date] = format_usa_date(1.day.from_now)
+          @params[:journal_date] = SpecDateHelper.format_usa_date(1.day.from_now)
         end
 
         it_behaves_like "journal error", "Journal Date may not be in the future"
@@ -313,13 +311,13 @@ RSpec.describe FacilityJournalsController do
         before :each do
           @order_detail1.update(fulfilled_at: 5.days.ago)
           @order_detail3.update(fulfilled_at: 3.days.ago)
-          @params[:journal_date] = format_usa_date(4.days.ago)
+          @params[:journal_date] = SpecDateHelper.format_usa_date(4.days.ago)
         end
 
         it_behaves_like "journal error", "Journal Date may not be before the latest fulfillment date."
 
         it "does allow to be the same day" do
-          @params[:journal_date] = format_usa_date(3.days.ago)
+          @params[:journal_date] = SpecDateHelper.format_usa_date(3.days.ago)
           do_request
           expect(assigns(:journal)).to be_persisted
         end

--- a/spec/controllers/facility_reservations_controller_spec.rb
+++ b/spec/controllers/facility_reservations_controller_spec.rb
@@ -5,8 +5,6 @@ require "controller_spec_helper"
 require "order_detail_batch_update_shared_examples"
 
 RSpec.describe FacilityReservationsController do
-  include DateHelper
-
   let(:account) { @account }
   let(:facility) { @authable }
   let(:product) { @product }

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -4,8 +4,6 @@ require "rails_helper"
 require "controller_spec_helper"
 
 RSpec.describe OrdersController do
-  include DateHelper
-
   render_views
 
   before(:all) { create_users }
@@ -542,14 +540,14 @@ RSpec.describe OrdersController do
       it "sets ordered_at to a time in the past" do
         maybe_grant_always_sign_in :director
         switch_to @staff
-        @params[:order_date] = format_usa_date(1.day.ago)
+        @params[:order_date] = SpecDateHelper.format_usa_date(1.day.ago)
         do_request
         expect(assigns[:order].order_details.map(&:ordered_at)).to all(match_date yesterday)
       end
 
       it "sets ordered_at to now if not acting_as" do
         maybe_grant_always_sign_in :director
-        @params[:order_date] = format_usa_date(1.day.ago)
+        @params[:order_date] = SpecDateHelper.format_usa_date(1.day.ago)
         do_request
         expect(assigns[:order].order_details.map(&:ordered_at)).to all(match_date Time.current)
       end
@@ -619,7 +617,7 @@ RSpec.describe OrdersController do
 
           it "sets the order_detail fulfilled dates to the order time" do
             @item_pp = @item.item_price_policies.create!(FactoryBot.attributes_for(:item_price_policy, price_group_id: @price_group.id, start_date: 1.day.ago, expire_date: 1.day.from_now))
-            @params[:order_date] = format_usa_date(1.day.ago)
+            @params[:order_date] = SpecDateHelper.format_usa_date(1.day.ago)
             do_request
             assigns[:order].reload.order_details.all? { |od| expect(od.fulfilled_at).to match_date yesterday }
           end
@@ -632,20 +630,20 @@ RSpec.describe OrdersController do
             end
 
             it "uses the current price policy if the order date falls in the policy's date range" do
-              @params[:order_date] = format_usa_date(yesterday)
+              @params[:order_date] = SpecDateHelper.format_usa_date(yesterday)
               do_request
               assigns[:order].reload.order_details.all? { |od| expect(od.price_policy).to eq(@item_pp) }
             end
 
             it "uses an old price policy if the order date falls in the old policy's date range" do
-              @params[:order_date] = format_usa_date(5.days.ago)
+              @params[:order_date] = SpecDateHelper.format_usa_date(5.days.ago)
               do_request
               assigns[:order].reload.order_details.all? { |od| expect(od.price_policy).to eq(@item_past_pp) }
             end
 
             # when backdating was initially set up, this would cause an error, but behavior changed as of ticket #51239
             it "does not error if there is no policy set for the date in the past" do
-              @params[:order_date] = format_usa_date(9.days.ago)
+              @params[:order_date] = SpecDateHelper.format_usa_date(9.days.ago)
               do_request
               assigns[:order].reload.order_details.all? do |od|
                 expect(od.price_policy).to be_nil
@@ -671,7 +669,7 @@ RSpec.describe OrdersController do
           @params[:id] = reservation.order_detail.order.id
           maybe_grant_always_sign_in :director
           switch_to @staff
-          @params[:order_date] = format_usa_date(2.days.ago)
+          @params[:order_date] = SpecDateHelper.format_usa_date(2.days.ago)
           @params[:order_time] = { hour: "2", minute: "27", ampm: "PM" }
         end
 

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -4,8 +4,6 @@ require "rails_helper"
 require "controller_spec_helper"
 
 RSpec.describe ReservationsController do
-  include DateHelper
-
   let(:facility) { @authable }
   let(:instrument) { @instrument }
   let(:order) { @order }
@@ -396,7 +394,7 @@ RSpec.describe ReservationsController do
         order_detail_id: @order_detail.id,
         order_account: @account.id,
         reservation: {
-          reserve_start_date: format_usa_date(Time.zone.now.to_date - 5.days),
+          reserve_start_date: SpecDateHelper.format_usa_date(Time.zone.now.to_date - 5.days),
           reserve_start_hour: "9",
           reserve_start_min: "0",
           reserve_start_meridian: "am",
@@ -447,7 +445,7 @@ RSpec.describe ReservationsController do
       @params.merge!(
         order_account: @account.id,
         reservation: {
-          reserve_start_date: format_usa_date(Time.zone.now.to_date + 1.day),
+          reserve_start_date: SpecDateHelper.format_usa_date(Time.zone.now.to_date + 1.day),
           reserve_start_hour: "9",
           reserve_start_min: "0",
           reserve_start_meridian: "am",
@@ -571,7 +569,7 @@ RSpec.describe ReservationsController do
 
     context "creating a reservation in the future with no price policy" do
       before :each do
-        @params[:reservation][:reserve_start_date] = format_usa_date(@price_policy.expire_date + 1.day)
+        @params[:reservation][:reserve_start_date] = SpecDateHelper.format_usa_date(@price_policy.expire_date + 1.day)
         @price_group_product.update(reservation_window: 365)
         sign_in @guest
         do_request
@@ -596,7 +594,7 @@ RSpec.describe ReservationsController do
         expect(assigns[:reservation].duration_mins).to eq(60)
       end
       it "should not lose the time" do
-        expect(assigns[:reservation].reserve_start_date).to eq(format_usa_date(Time.zone.now.to_date + 1.day))
+        expect(assigns[:reservation].reserve_start_date).to eq(SpecDateHelper.format_usa_date(Time.zone.now.to_date + 1.day))
         expect(assigns[:reservation].reserve_start_hour).to eq(9)
         expect(assigns[:reservation].reserve_start_min).to eq(0)
         expect(assigns[:reservation].reserve_start_meridian).to eq("am")
@@ -1133,10 +1131,10 @@ RSpec.describe ReservationsController do
       expect(assigns(:order_detail)).to eq(order_detail)
       expect(assigns(:instrument)).to eq(instrument)
       expect(assigns(:reservation)).to eq(reservation)
-      expect(format_usa_datetime(assigns(:reservation).reserve_start_at))
-        .to eq(format_usa_datetime(reservation.earliest_possible.reserve_start_at))
-      expect(format_usa_datetime(assigns(:reservation).reserve_end_at))
-        .to eq(format_usa_datetime(reservation.earliest_possible.reserve_end_at))
+      expect(SpecDateHelper.format_usa_datetime(assigns(:reservation).reserve_start_at))
+        .to eq(SpecDateHelper.format_usa_datetime(reservation.earliest_possible.reserve_start_at))
+      expect(SpecDateHelper.format_usa_datetime(assigns(:reservation).reserve_end_at))
+        .to eq(SpecDateHelper.format_usa_datetime(reservation.earliest_possible.reserve_end_at))
       is_expected.to set_flash
       assert_redirected_to reservations_status_path(status: "upcoming")
     end
@@ -1166,8 +1164,8 @@ RSpec.describe ReservationsController do
         expect(assigns(:order_detail)).to eq(@order_detail)
         expect(assigns(:instrument)).to eq(@instrument)
         expect(assigns(:reservation)).to eq(@reservation)
-        expect(format_usa_datetime(assigns(:reservation).reserve_start_at)).to eq(format_usa_datetime(@orig_start_at))
-        expect(format_usa_datetime(assigns(:reservation).reserve_end_at)).to eq(format_usa_datetime(@orig_end_at))
+        expect(SpecDateHelper.format_usa_datetime(assigns(:reservation).reserve_start_at)).to eq(SpecDateHelper.format_usa_datetime(@orig_start_at))
+        expect(SpecDateHelper.format_usa_datetime(assigns(:reservation).reserve_end_at)).to eq(SpecDateHelper.format_usa_datetime(@orig_end_at))
         is_expected.to set_flash
         assert_redirected_to reservations_status_path(status: "upcoming")
       end

--- a/spec/forms/add_to_order_form_spec.rb
+++ b/spec/forms/add_to_order_form_spec.rb
@@ -3,7 +3,6 @@
 require "rails_helper"
 
 RSpec.describe AddToOrderForm do
-  include DateHelper
   let(:order) { create(:complete_order, product: product, ordered_at: 1.week.ago) }
   let(:product) { create(:setup_item, :with_facility_account) }
   subject(:form) { described_class.new(order) }
@@ -103,7 +102,7 @@ RSpec.describe AddToOrderForm do
         end
 
         it "has the second order's fulfilled_at to the matching date" do
-          expect(parse_usa_date(form.fulfilled_at)).to eq(second_order_detail.fulfilled_at.beginning_of_day)
+          expect(SpecDateHelper.parse_usa_date(form.fulfilled_at)).to eq(second_order_detail.fulfilled_at.beginning_of_day)
         end
       end
     end

--- a/spec/forms/admin_reservation_form_spec.rb
+++ b/spec/forms/admin_reservation_form_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe AdminReservationForm do
-  include DateHelper
-
   let(:instrument) { create(:setup_instrument) }
   let(:start_date) { Time.zone.parse("2017-10-17 12:00:00") }
   let(:admin_reservation) { build(:admin_reservation, product: instrument, reserve_start_at: start_date, duration: 1.hour) }
@@ -13,26 +11,26 @@ RSpec.describe AdminReservationForm do
   describe "validations" do
     describe "cannot_exceed_max_end_date" do
       it "invalid past max end date" do
-        form.assign_attributes(repeats: "1", repeat_frequency: "weekly", repeat_end_date: format_usa_date(start_date + 14.weeks))
+        form.assign_attributes(repeats: "1", repeat_frequency: "weekly", repeat_end_date: SpecDateHelper.format_usa_date(start_date + 14.weeks))
         expect(form).not_to be_valid
         expect(form.errors).to be_added(:repeat_end_date, :too_far_in_future, time: "12 weeks")
       end
 
       it "valid before max end date" do
-        form.assign_attributes(repeats: "1", repeat_frequency: "weekly", repeat_end_date: format_usa_date(start_date + 12.weeks))
+        form.assign_attributes(repeats: "1", repeat_frequency: "weekly", repeat_end_date: SpecDateHelper.format_usa_date(start_date + 12.weeks))
         expect(form).to be_valid
       end
     end
 
     describe "repeat_end_date_after_initial_date" do
       it "invalid before initial date" do
-        form.assign_attributes(repeats: "1", repeat_frequency: "weekly", repeat_end_date: format_usa_date(start_date - 1.day))
+        form.assign_attributes(repeats: "1", repeat_frequency: "weekly", repeat_end_date: SpecDateHelper.format_usa_date(start_date - 1.day))
         expect(form).not_to be_valid
         expect(form.errors).to be_added(:repeat_end_date, :must_be_after_initial_reservation)
       end
 
       it "valid after initial date" do
-        form.assign_attributes(repeats: "1", repeat_frequency: "weekly", repeat_end_date: format_usa_date(start_date + 1.day))
+        form.assign_attributes(repeats: "1", repeat_frequency: "weekly", repeat_end_date: SpecDateHelper.format_usa_date(start_date + 1.day))
         expect(form).to be_valid
       end
     end
@@ -42,7 +40,7 @@ RSpec.describe AdminReservationForm do
 
     context "weekdays_only" do
       before do
-        form.assign_attributes(repeats: "1", repeat_frequency: "weekdays_only", repeat_end_date: format_usa_date(start_date + 7.days))
+        form.assign_attributes(repeats: "1", repeat_frequency: "weekdays_only", repeat_end_date: SpecDateHelper.format_usa_date(start_date + 7.days))
       end
 
       it "builds the right number of reservations" do
@@ -59,7 +57,7 @@ RSpec.describe AdminReservationForm do
     context "daily" do
       context "over daylight savings shift" do
         before do
-          form.assign_attributes(repeats: "1", repeat_frequency: "daily", repeat_end_date: format_usa_date(start_date + 30.days))
+          form.assign_attributes(repeats: "1", repeat_frequency: "daily", repeat_end_date: SpecDateHelper.format_usa_date(start_date + 30.days))
         end
 
         it "builds the right number of reservations" do
@@ -75,7 +73,7 @@ RSpec.describe AdminReservationForm do
 
     context "weekly" do
       before do
-        form.assign_attributes(repeats: "1", repeat_frequency: "weekly", repeat_end_date: format_usa_date(start_date + 7.weeks))
+        form.assign_attributes(repeats: "1", repeat_frequency: "weekly", repeat_end_date: SpecDateHelper.format_usa_date(start_date + 7.weeks))
       end
 
       it "builds the right number of reservations" do
@@ -85,7 +83,7 @@ RSpec.describe AdminReservationForm do
 
     context "monthly" do
       before do
-        form.assign_attributes(repeats: "1", repeat_frequency: "monthly", repeat_end_date: format_usa_date(start_date + 3.months))
+        form.assign_attributes(repeats: "1", repeat_frequency: "monthly", repeat_end_date: SpecDateHelper.format_usa_date(start_date + 3.months))
       end
 
       it "builds the right number of reservations" do

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe Reservation do
-  include DateHelper
-
   subject(:reservation) do
     instrument.reservations.create(
       reserve_start_date: 1.day.from_now.to_date,
@@ -683,13 +681,13 @@ RSpec.describe Reservation do
       end
 
       it "should return the earliest possible time slot" do
-        expect(human_date(@reservation1.reserve_start_at)).to eq(human_date(@morning + 1.day))
+        expect(SpecDateHelper.human_date(@reservation1.reserve_start_at)).to eq(SpecDateHelper.human_date(@morning + 1.day))
 
         earliest = nil
         travel_to_and_return(@morning) do
           earliest = @reservation1.earliest_possible
         end
-        expect(human_date(earliest.reserve_start_at)).to eq(human_date(@morning))
+        expect(SpecDateHelper.human_date(earliest.reserve_start_at)).to eq(SpecDateHelper.human_date(@morning))
 
         new_min = 0
 

--- a/spec/services/order_row_importer_spec.rb
+++ b/spec/services/order_row_importer_spec.rb
@@ -4,8 +4,6 @@ require "rails_helper"
 require "csv"
 
 RSpec.describe OrderRowImporter do
-  include DateHelper
-
   subject { OrderRowImporter.new(row, order_import) }
   let(:account) { create(:nufs_account, :with_account_owner, owner: user) }
   let(:facility) { create(:setup_facility) }
@@ -64,7 +62,7 @@ RSpec.describe OrderRowImporter do
         before { subject.import }
 
         it "has the expected ordered_at" do
-          expect(order.order_details.map(&:ordered_at)).to all(eq parse_usa_date(order_date))
+          expect(order.order_details.map(&:ordered_at)).to all(eq SpecDateHelper.parse_usa_date(order_date))
         end
 
         it "has the expected creator" do

--- a/spec/services/transaction_search/date_range_searcher_spec.rb
+++ b/spec/services/transaction_search/date_range_searcher_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe TransactionSearch::DateRangeSearcher do
-  include DateHelper
-
   let(:item) { create(:setup_item) }
   let(:orders) { create_list(:purchased_order, 2, product: item) }
   let(:order_details) { orders.flat_map(&:order_details) }
@@ -17,22 +15,22 @@ RSpec.describe TransactionSearch::DateRangeSearcher do
     end
 
     it "finds only the right ones when starting a day ago" do
-      results = searcher.search(field: :ordered_at, start: format_usa_date(1.day.ago))
+      results = searcher.search(field: :ordered_at, start: SpecDateHelper.format_usa_date(1.day.ago))
       expect(results).to eq([order_details.last])
     end
 
     it "finds only the right one when ending a day ago" do
-      results = searcher.search(field: :ordered_at, end: format_usa_date(2.days.ago))
+      results = searcher.search(field: :ordered_at, end: SpecDateHelper.format_usa_date(2.days.ago))
       expect(results).to eq([order_details.first])
     end
 
     it "finds nothing with an outside range" do
-      results = searcher.search(field: :ordered_at, start: format_usa_date(5.days.ago), end: format_usa_date(3.days.ago))
+      results = searcher.search(field: :ordered_at, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(3.days.ago))
       expect(results).to be_empty
     end
 
     it "finds all with a wide range in the ordered_at reverse chronological order" do
-      results = searcher.search(field: :ordered_at, start: format_usa_date(5.days.ago), end: format_usa_date(1.day.from_now))
+      results = searcher.search(field: :ordered_at, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(1.day.from_now))
       expect(results).to eq(order_details.reverse)
     end
   end
@@ -44,22 +42,22 @@ RSpec.describe TransactionSearch::DateRangeSearcher do
     end
 
     it "finds only the right ones when starting a day ago" do
-      results = searcher.search(field: :fulfilled_at, start: format_usa_date(1.day.ago))
+      results = searcher.search(field: :fulfilled_at, start: SpecDateHelper.format_usa_date(1.day.ago))
       expect(results).to eq([order_details.last])
     end
 
     it "finds only the right one when ending a day ago" do
-      results = searcher.search(field: :fulfilled_at, end: format_usa_date(2.days.ago))
+      results = searcher.search(field: :fulfilled_at, end: SpecDateHelper.format_usa_date(2.days.ago))
       expect(results).to eq([order_details.first])
     end
 
     it "finds nothing with an outside range" do
-      results = searcher.search(field: :fulfilled_at, start: format_usa_date(5.days.ago), end: format_usa_date(3.days.ago))
+      results = searcher.search(field: :fulfilled_at, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(3.days.ago))
       expect(results).to be_empty
     end
 
     it "finds all with a wide range in the fulfilled_at reverse chronological order" do
-      results = searcher.search(field: :fulfilled_at, start: format_usa_date(5.days.ago), end: format_usa_date(1.day.from_now))
+      results = searcher.search(field: :fulfilled_at, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(1.day.from_now))
       expect(results).to eq(order_details.reverse)
     end
   end
@@ -72,22 +70,22 @@ RSpec.describe TransactionSearch::DateRangeSearcher do
       end
 
       it "finds only the right ones when starting a day ago" do
-        results = searcher.search(field: :journal_or_statement_date, start: format_usa_date(1.day.ago))
+        results = searcher.search(field: :journal_or_statement_date, start: SpecDateHelper.format_usa_date(1.day.ago))
         expect(results).to eq([order_details.last])
       end
 
       it "finds only the right one when ending a day ago" do
-        results = searcher.search(field: :journal_or_statement_date, end: format_usa_date(2.days.ago))
+        results = searcher.search(field: :journal_or_statement_date, end: SpecDateHelper.format_usa_date(2.days.ago))
         expect(results).to eq([order_details.first])
       end
 
       it "finds nothing with an outside range" do
-        results = searcher.search(field: :journal_or_statement_date, start: format_usa_date(5.days.ago), end: format_usa_date(3.days.ago))
+        results = searcher.search(field: :journal_or_statement_date, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(3.days.ago))
         expect(results).to be_empty
       end
 
       it "finds all with a wide range in the reverse chronological order" do
-        results = searcher.search(field: :journal_or_statement_date, start: format_usa_date(5.days.ago), end: format_usa_date(1.day.from_now))
+        results = searcher.search(field: :journal_or_statement_date, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(1.day.from_now))
         expect(results).to eq(order_details.reverse)
       end
     end
@@ -99,22 +97,22 @@ RSpec.describe TransactionSearch::DateRangeSearcher do
       end
 
       it "finds only the right ones when starting a day ago" do
-        results = searcher.search(field: :journal_or_statement_date, start: format_usa_date(1.day.ago))
+        results = searcher.search(field: :journal_or_statement_date, start: SpecDateHelper.format_usa_date(1.day.ago))
         expect(results).to eq([order_details.last])
       end
 
       it "finds only the right one when ending a day ago" do
-        results = searcher.search(field: :journal_or_statement_date, end: format_usa_date(2.days.ago))
+        results = searcher.search(field: :journal_or_statement_date, end: SpecDateHelper.format_usa_date(2.days.ago))
         expect(results).to eq([order_details.first])
       end
 
       it "finds nothing with an outside range" do
-        results = searcher.search(field: :journal_or_statement_date, start: format_usa_date(5.days.ago), end: format_usa_date(3.days.ago))
+        results = searcher.search(field: :journal_or_statement_date, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(3.days.ago))
         expect(results).to be_empty
       end
 
       it "finds all with a wide range in the reverse chronological order" do
-        results = searcher.search(field: :journal_or_statement_date, start: format_usa_date(5.days.ago), end: format_usa_date(1.day.from_now))
+        results = searcher.search(field: :journal_or_statement_date, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(1.day.from_now))
         expect(results).to eq(order_details.reverse)
       end
     end
@@ -127,22 +125,22 @@ RSpec.describe TransactionSearch::DateRangeSearcher do
     end
 
     it "finds only the right ones when starting a day ago" do
-      results = searcher.search(field: :reconciled_at, start: format_usa_date(1.day.ago))
+      results = searcher.search(field: :reconciled_at, start: SpecDateHelper.format_usa_date(1.day.ago))
       expect(results).to eq([order_details.last])
     end
 
     it "finds only the right one when ending a day ago" do
-      results = searcher.search(field: :reconciled_at, end: format_usa_date(2.days.ago))
+      results = searcher.search(field: :reconciled_at, end: SpecDateHelper.format_usa_date(2.days.ago))
       expect(results).to eq([order_details.first])
     end
 
     it "finds nothing with an outside range" do
-      results = searcher.search(field: :reconciled_at, start: format_usa_date(5.days.ago), end: format_usa_date(3.days.ago))
+      results = searcher.search(field: :reconciled_at, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(3.days.ago))
       expect(results).to be_empty
     end
 
     it "finds all with a wide range in the reconciled_at reverse chronological order" do
-      results = searcher.search(field: :reconciled_at, start: format_usa_date(5.days.ago), end: format_usa_date(1.day.from_now))
+      results = searcher.search(field: :reconciled_at, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(1.day.from_now))
       expect(results).to eq(order_details.reverse)
     end
   end

--- a/spec/support/spec_date_helper.rb
+++ b/spec/support/spec_date_helper.rb
@@ -1,0 +1,19 @@
+class SpecDateHelper
+  include DateHelper
+
+  def self.format_usa_date(datetime)
+    new.format_usa_date(datetime)
+  end
+
+  def self.format_usa_datetime(datetime)
+    new.format_usa_datetime(datetime)
+  end
+
+  def self.parse_usa_date(date, time_string = nil)
+    new.parse_usa_date(date, time_string)
+  end
+
+  def self.human_date(date)
+    new.human_date(date)
+  end
+end

--- a/spec/support/spec_date_helper.rb
+++ b/spec/support/spec_date_helper.rb
@@ -1,3 +1,5 @@
+# Including `DateHelper` at the wrong spot in specs can cause hard to debug
+# problems. So, where possible, this class should be instead.
 class SpecDateHelper
   include DateHelper
 

--- a/spec/system/editing_a_reservation_spec.rb
+++ b/spec/system/editing_a_reservation_spec.rb
@@ -4,9 +4,6 @@ require "rails_helper"
 
 # TODO: Capybara deprecation
 RSpec.describe "Editing your own reservation" do
-
-  include DateHelper
-
   let!(:instrument) do
     FactoryBot.create(:setup_instrument, user_notes_field_mode: "optional", lock_window: 12, min_reserve_mins: nil)
   end
@@ -30,8 +27,8 @@ RSpec.describe "Editing your own reservation" do
       visit reservations_path
       click_link reservation.to_s
 
-      fill_in "Reserve Start", with: format_usa_date(reservation.reserve_start_at + 1.hour)
-      fill_in "Reserve End", with: format_usa_date(reservation.reserve_end_at + 1.hour)
+      fill_in "Reserve Start", with: SpecDateHelper.format_usa_date(reservation.reserve_start_at + 1.hour)
+      fill_in "Reserve End", with: SpecDateHelper.format_usa_date(reservation.reserve_end_at + 1.hour)
       fill_in "Duration", with: "30"
       click_button "Save"
 
@@ -42,8 +39,8 @@ RSpec.describe "Editing your own reservation" do
       visit reservations_path
       click_link reservation.to_s
 
-      fill_in "Reserve Start", with: format_usa_date(reservation.reserve_start_at - 1.day)
-      fill_in "Reserve End", with: format_usa_date(reservation.reserve_end_at - 1.day)
+      fill_in "Reserve Start", with: SpecDateHelper.format_usa_date(reservation.reserve_start_at - 1.day)
+      fill_in "Reserve End", with: SpecDateHelper.format_usa_date(reservation.reserve_end_at - 1.day)
       click_button "Save"
 
       expect(page).to have_content("My Reservations")


### PR DESCRIPTION
# Release Notes

Including `DateHelper` at the wrong spot in specs can cause hard to debug problems. This removes `DateHelper` includes and uses the newly created `SpecDateHelper` class instead.