### PR TITLE
Tech task: Run CI testing for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
   open-pull-requests-limit: 99
   allow:
   - dependency-type: all
+
+# Check for updates to GitHub Actions every week
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -4,7 +4,7 @@ name: Run test suite
 on:
   push:
     branches:
-      - "*"
+      - "**"
 
 jobs:
   run-rspec-engines:


### PR DESCRIPTION
Use ** filter to include PRs on namespaced branches like dependabot/gem-upgrade-branch
https://stackoverflow.com/questions/64635032/github-actions-run-on-push-to-all-branches
