### PR TITLE
[#156336] Support email link updates

### DIFF
--- a/app/views/file_uploads/product_survey.html.haml
+++ b/app/views/file_uploads/product_survey.html.haml
@@ -14,7 +14,7 @@
 %p= t(".intro")
 .box_no_fill.margin_bottom
   %h3= t(".order_form.head")
-  %p= text("file_uploads.product_survey.order_form.main", email: Settings.support_email)
+  %p= html("file_uploads.product_survey.order_form.main", email: Settings.support_email)
 
   = simple_form_for(@survey, url: create_product_survey_path(current_facility, @product.parameterize, @product), html: { multipart: true }) do |f|
     = f.error_messages

--- a/app/views/shared/_support.html.haml
+++ b/app/views/shared/_support.html.haml
@@ -1,3 +1,3 @@
 - if Settings.support_email.present?
-  %li= mail_to Settings.support_email, t('pages.support')
+  %li= mail_to Settings.support_email, t('pages.support'), subject: Settings.support_email_subject
   %li.divider-vertical

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -960,7 +960,7 @@ en:
       intro: "You may provide an Online Order Form and/or an Order File Template.  If provided, the user must complete one before placing an order."
       order_form:
         head: "Online Order Form"
-        main: "Please contact !app_name! Support (%{email}) for more information."
+        main: "Please contact !app_name! Support ([%{email}](mailto:%{email})) for more information."
         notice: "No Online Order Forms have been added."
       download_form:
         head: "Downloadable Order Form"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -54,7 +54,10 @@ email:
     sender: 'noreply@example.com'
     recipients: [ 'warn@example.com', 'error@example.com' ]
 
+# email subject is only applied on the Support header link
+# this will be encoded by the mail_to helper, so use standard spaces (not %20)
 support_email: ~
+support_email_subject: ~
 
 order_details:
   list_transformer: SplitAccounts::OrderDetailListTransformer


### PR DESCRIPTION
# Release Notes

- Allows setting a default subject for support email link in the header nav
- Makes the support email a clickable link in the order form tab