### PR TITLE
[#159818] Add matrix gem because prawn hasn't had a new release in 2 years

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,8 @@ gem "rubyzip"
 
 ## PDF generation
 gem "prawn-rails"
+# https://github.com/prawnpdf/prawn/issues/1195
+gem "matrix"
 
 ## other
 gem "delayed_job_active_record"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -720,6 +720,7 @@ DEPENDENCIES
   kt-paperclip
   ldap_authentication!
   letter_opener
+  matrix
   mysql2
   nested_form_fields
   net-imap


### PR DESCRIPTION
https://github.com/prawnpdf/prawn/issues/1195
https://github.com/prawnpdf/prawn/discussions/1210

Discovered while attempting a stage release:
```
SSHKit::Runner::ExecuteError: Exception while executing as nucore@tablexi-shared02.txihosting.com: rake exit status: 1
rake stdout: Nothing written
rake stderr: rake aborted!
LoadError: cannot load such file -- matrix
/home/nucore/nucore.stage.tablexi.com/shared/bundle/ruby/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:29:in `require'
/home/nucore/nucore.stage.tablexi.com/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:332:in `block in require'
/home/nucore/nucore.stage.tablexi.com/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:299:in `load_dependency'
/home/nucore/nucore.stage.tablexi.com/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:332:in `require'
/home/nucore/nucore.stage.tablexi.com/shared/bundle/ruby/3.1.0/gems/prawn-2.4.0/lib/prawn/transformation_stack.rb:10:in `<main>'
```