### PR TITLE
[#161733] Allow skipping form.io forms with missing form response

### DIFF
--- a/app/controllers/order_details_controller.rb
+++ b/app/controllers/order_details_controller.rb
@@ -75,23 +75,8 @@ class OrderDetailsController < ApplicationController
   end
 
   def add_missing_form
-    # Eventually, the issue of an admin addressing a missing form should probably be done via
-    # a field on the OderDetail allowing the form validation to be skipped. But, given the
-    # complexity of OderDetail, this approach is simpler for now. This code is adopted from
-    # the  order_details:add_template_result rake task
     if @order_detail.missing_form?
-      file_text = "This order was missing a template file, so an administrator " \
-                  "(#{current_user.full_name} <#{current_user.email}>) added this " \
-                  "place holder file at #{format_usa_datetime(Time.zone.now)} so " \
-                  "that it could be processed."
-
-      @order_detail.stored_files << StoredFile.new(
-        file: StringIO.new(file_text),
-        file_type: "template_result",
-        name: "missing_form.txt",
-        created_by: current_user.id
-      )
-
+      @order_detail.skip_missing_form = true
       if @order_detail.save
         flash[:notice] = text("add_missing_file.success")
       else

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -582,6 +582,8 @@ class OrderDetail < ApplicationRecord
     templates = product.stored_files.template
     if templates.empty?
       nil # no file templates
+    elsif skip_missing_form?
+      nil # admin users can over-ride a missing template result file
     else
       # check for a template result
       results = stored_files.template_result
@@ -594,6 +596,8 @@ class OrderDetail < ApplicationRecord
       nil # no active survey
     elsif product.active_survey? && survey_completed?
       nil # active survey with a completed response set
+    elsif skip_missing_form?
+      nil # admin users can over-ride a missing response set
     else
       # active survey but no response
       "Please complete the online order form"

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -100,9 +100,9 @@ en:
         success: The order has been updated
         error: There was a problem updating the order
       add_missing_file:
-        success: Placeholder file successfully added
-        saving_error: Failed to add file
-        file_not_missing: No file added, order detail already has template file
+        success: Missing form successfully skipped
+        saving_error: Failed to skip missing form
+        file_not_missing: No missing form found
 
     price_groups:
       create:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -570,7 +570,7 @@ en:
       form:
         recalculate_price: "Recalculate pricing"
       warnings:
-        missing_form_button: Add missing form
+        missing_form_button: Skip missing form
 
   product_access_groups:
     index:

--- a/db/migrate/20230505222132_add_skip_missing_form_to_order_details.rb
+++ b/db/migrate/20230505222132_add_skip_missing_form_to_order_details.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddSkipMissingFormToOrderDetails < ActiveRecord::Migration[6.1]
+  def change
+    # The order_details table has ~1.4m records for NU,
+    # so adding default values is a little tricky:
+    # https://dev.to/lucasprag/how-to-add-columns-with-default-to-large-tables-8mc
+    # We are only setting the value to true in rare cases
+    # so it didn't seem worth the added risk/trouble.
+    add_column :order_details, :skip_missing_form, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_23_221431) do
+ActiveRecord::Schema.define(version: 2023_05_05_222132) do
 
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
@@ -374,6 +374,7 @@ ActiveRecord::Schema.define(version: 2023_02_23_221431) do
     t.timestamp "problem_resolved_at"
     t.integer "problem_resolved_by_id"
     t.string "reference_id"
+    t.boolean "skip_missing_form"
     t.index ["account_id"], name: "fk_od_accounts"
     t.index ["assigned_user_id"], name: "index_order_details_on_assigned_user_id"
     t.index ["bundle_product_id"], name: "fk_bundle_prod_id"


### PR DESCRIPTION
# Release Notes

This adds a boolean column to order details to allow admins to mark transactions where the missing order form - template file or form.io - can be safely skipped.

NU Stage has ~1.2m order detail records and should be a good testing place for the migration.