### PR TITLE
[#160881] Search & display account types

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -26,13 +26,7 @@ class TransactionsController < ApplicationController
       },
     )
 
-    @search = TransactionSearch::Searcher.new(TransactionSearch::FacilitySearcher,
-                                              TransactionSearch::AccountSearcher,
-                                              TransactionSearch::ProductSearcher,
-                                              TransactionSearch::DateRangeSearcher,
-                                              TransactionSearch::OrderStatusSearcher,
-                                              TransactionSearch::AccountOwnerSearcher,
-                                              TransactionSearch::OrderedForSearcher).search(order_details, @search_form)
+    @search = TransactionSearch::Searcher.billing_search(order_details, @search_form, include_facilites: true)
     @date_range_field = @search_form.date_params[:field]
     @order_details = @search.order_details.reorder(sort_clause)
 
@@ -47,13 +41,8 @@ class TransactionsController < ApplicationController
     order_details = current_user.administered_order_details.in_review
 
     @search_form = TransactionSearch::SearchForm.new(params[:search])
-    @search = TransactionSearch::Searcher.new(TransactionSearch::FacilitySearcher,
-                                              TransactionSearch::AccountSearcher,
-                                              TransactionSearch::ProductSearcher,
-                                              TransactionSearch::DateRangeSearcher,
-                                              TransactionSearch::OrderStatusSearcher,
-                                              TransactionSearch::AccountOwnerSearcher,
-                                              TransactionSearch::OrderedForSearcher).search(order_details, @search_form)
+    @search = TransactionSearch::Searcher.billing_search(order_details, @search_form, include_facilities: true)
+
     @date_range_field = @search_form.date_params[:field]
     params[:sort] = "date_range_field" if params[:sort].nil? # set default sort column
     @order_details = @search.order_details.reorder(sort_clause)

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -26,7 +26,7 @@ class TransactionsController < ApplicationController
       },
     )
 
-    @search = TransactionSearch::Searcher.billing_search(order_details, @search_form, include_facilites: true)
+    @search = TransactionSearch::Searcher.billing_search(order_details, @search_form, include_facilities: true)
     @date_range_field = @search_form.date_params[:field]
     @order_details = @search.order_details.reorder(sort_clause)
 

--- a/app/forms/transaction_search/search_form.rb
+++ b/app/forms/transaction_search/search_form.rb
@@ -8,7 +8,8 @@ module TransactionSearch
 
     attr_accessor :date_range_field, :date_range_start, :date_range_end, :allowed_date_fields
     attr_accessor :facilities, :accounts, :products, :account_owners,
-                  :order_statuses, :statements, :date_ranges, :ordered_fors
+                  :order_statuses, :statements, :date_ranges, :ordered_fors,
+                  :account_types
 
     def self.model_name
       ActiveModel::Name.new(self, nil, "Search")

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -115,8 +115,8 @@ class Account < ApplicationRecord
     false
   end
 
-  def self.type_string
-    I18n.t("activerecord.models.#{self.to_s.underscore}.one", default: self.model_name.human)
+  def self.label_name
+    I18n.t("activerecord.models.#{to_s.underscore}.one", default: model_name.human)
   end
 
   def require_affiliate?
@@ -124,7 +124,7 @@ class Account < ApplicationRecord
   end
 
   def type_string
-    self.class.type_string
+    self.class.label_name
   end
 
   def <=>(other)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -115,12 +115,16 @@ class Account < ApplicationRecord
     false
   end
 
+  def self.type_string
+    I18n.t("activerecord.models.#{self.to_s.underscore}.one", default: self.model_name.human)
+  end
+
   def require_affiliate?
     true
   end
 
   def type_string
-    I18n.t("activerecord.models.#{self.class.to_s.underscore}.one", default: self.class.model_name.human)
+    self.class.type_string
   end
 
   def <=>(other)

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -272,6 +272,7 @@ class OrderDetail < ApplicationRecord
   scope :with_in_progress_reservation, -> { new_or_inprocess.with_reservation.merge(Reservation.relay_in_progress) }
 
   scope :for_accounts, ->(accounts) { where("order_details.account_id in (?)", accounts) unless accounts.nil? || accounts.empty? }
+  scope :for_account_types, ->(account_types) { where("accounts.type in (?)", account_types) unless account_types.blank? }
   scope :for_facilities, ->(facilities) { joins(:order).where("orders.facility_id in (?)", facilities) unless facilities.nil? || facilities.empty? }
   scope :for_products, ->(products) { where("order_details.product_id in (?)", products) unless products.blank? }
   scope :for_users, ->(user_ids) { joins(:order).where(orders: { user_id: user_ids }) unless user_ids.blank? }

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -271,9 +271,9 @@ class OrderDetail < ApplicationRecord
   }
   scope :with_in_progress_reservation, -> { new_or_inprocess.with_reservation.merge(Reservation.relay_in_progress) }
 
-  scope :for_accounts, ->(accounts) { where("order_details.account_id in (?)", accounts) unless accounts.nil? || accounts.empty? }
+  scope :for_accounts, ->(accounts) { where("order_details.account_id in (?)", accounts) unless accounts.blank? }
   scope :for_account_types, ->(account_types) { where("accounts.type in (?)", account_types) unless account_types.blank? }
-  scope :for_facilities, ->(facilities) { joins(:order).where("orders.facility_id in (?)", facilities) unless facilities.nil? || facilities.empty? }
+  scope :for_facilities, ->(facilities) { joins(:order).where("orders.facility_id in (?)", facilities) unless facilities.blank? }
   scope :for_products, ->(products) { where("order_details.product_id in (?)", products) unless products.blank? }
   scope :for_users, ->(user_ids) { joins(:order).where(orders: { user_id: user_ids }) unless user_ids.blank? }
   scope :for_owners, lambda { |owners|

--- a/app/services/transaction_search/account_type_searcher.rb
+++ b/app/services/transaction_search/account_type_searcher.rb
@@ -9,7 +9,7 @@ module TransactionSearch
     end
 
     def search(params)
-      order_details.where("accounts.type" => params).includes(:account)
+      order_details.for_account_types(params).includes(:account)
     end
 
     def label_method
@@ -17,7 +17,7 @@ module TransactionSearch
     end
 
     def label
-      "Account Type"
+      "Account Types"
     end
 
   end

--- a/app/services/transaction_search/account_type_searcher.rb
+++ b/app/services/transaction_search/account_type_searcher.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module TransactionSearch
+
+  class AccountTypeSearcher < BaseSearcher
+
+    def options
+      Account.config.account_types.map(&:constantize)
+    end
+
+    def search(params)
+      order_details.where("accounts.type" => params).includes(:account)
+    end
+
+    def label_method
+      :type_string
+    end
+
+    def label
+      "Account Type"
+    end
+
+  end
+
+end

--- a/app/services/transaction_search/account_type_searcher.rb
+++ b/app/services/transaction_search/account_type_searcher.rb
@@ -9,7 +9,7 @@ module TransactionSearch
     end
 
     def search(params)
-      order_details.for_account_types(params).includes(:account)
+      order_details.for_account_types(params).references(:account).includes(:account)
     end
 
     def label_method

--- a/app/services/transaction_search/account_type_searcher.rb
+++ b/app/services/transaction_search/account_type_searcher.rb
@@ -17,7 +17,7 @@ module TransactionSearch
     end
 
     def label
-      "Account Types"
+      "Payment Source Type"
     end
 
   end

--- a/app/services/transaction_search/account_type_searcher.rb
+++ b/app/services/transaction_search/account_type_searcher.rb
@@ -13,11 +13,11 @@ module TransactionSearch
     end
 
     def label_method
-      :type_string
+      :label_name
     end
 
     def label
-      "Payment Source Type"
+      Account.human_attribute_name(:type_string)
     end
 
   end

--- a/app/services/transaction_search/searcher.rb
+++ b/app/services/transaction_search/searcher.rb
@@ -10,6 +10,7 @@ module TransactionSearch
     cattr_accessor(:default_searchers) do
       [
         TransactionSearch::AccountSearcher,
+        TransactionSearch::AccountTypeSearcher,
         TransactionSearch::ProductSearcher,
         TransactionSearch::AccountOwnerSearcher,
         TransactionSearch::OrderedForSearcher,

--- a/app/views/facility_accounts/_account_table.html.haml
+++ b/app/views/facility_accounts/_account_table.html.haml
@@ -6,6 +6,7 @@
     %thead
       %tr
         %th= t(".th.account")
+        %th= t(".th.account_type")
         %th= t(".th.owner")
         %th= Account.human_attribute_name(:expires_at)
         - if current_facility.cross_facility?
@@ -14,6 +15,7 @@
       - @accounts.each do |account|
         %tr{ class: account.expired? ? "expired--js" : "" }
           %td= payment_source_link_or_text(account)
+          %td= account.type_string
           %td= account.owner_user.full_name if account.owner_user
           %td{ class: account.expired? ? "expired" : "" }
             = human_date(account.expires_at)

--- a/app/views/user_accounts/show.html.haml
+++ b/app/views/user_accounts/show.html.haml
@@ -21,12 +21,14 @@
     %thead
       %tr
         %th= Account.model_name.human
+        %th= t("views.facility_accounts.account_table.account_type")
         %th.centered= Facility.model_name.human
         %th= Account.human_attribute_name(:expires_at)
     %tbody.user_accounts
       - @accounts.each do |account|
         %tr{ class: account.expired? ? "expired--js" : "" }
           %td= payment_source_link_or_text(account)
+          %td= account.type_string
           %td= account.per_facility? ? account.facilities.join(", ") :  content_tag(:i, t("shared.all"))
           %td{ class: account.expired? ? "expired" : "" }
             = human_date(account.expires_at)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -204,6 +204,7 @@ en:
       foot: "* Includes transactions for which the user has not been sent a !statement_downcase! or that are in the user review period."
       th:
         account: "Payment Source"
+        account_type: "Type"
         owner: "Owner"
     accounts:
       th:

--- a/config/locales/views/en.facility_accounts.yml
+++ b/config/locales/views/en.facility_accounts.yml
@@ -2,6 +2,7 @@ en:
   views:
     facility_accounts:
       account_table:
+        account_type: Type
         all: "!views.accounts.index.all!"
         show_text: Show Expired Accounts
         hide_text: Hide Expired Accounts

--- a/spec/services/transaction_search/searcher_spec.rb
+++ b/spec/services/transaction_search/searcher_spec.rb
@@ -50,8 +50,13 @@ RSpec.describe TransactionSearch::Searcher, type: :service do
       end
 
       it "does not find it with a different account type" do
-        result = searcher.search(scope, accounts: ["FakeAccountType"])
+        result = searcher.search(scope, account_types: ["FakeAccountType"])
         expect(result.order_details).to be_empty
+      end
+
+      it "returns the scope when passed nil" do
+        result = searcher.search(scope, account_types: nil)
+        expect(result.order_details).to match_array scope
       end
     end
 

--- a/spec/services/transaction_search/searcher_spec.rb
+++ b/spec/services/transaction_search/searcher_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TransactionSearch::Searcher, type: :service do
     let(:order) { create(:purchased_order, product: item) }
     let(:order_detail) { order.order_details.first }
     let(:account) { order.account }
-    let(:searcher) { described_class.new(TransactionSearch::AccountSearcher, TransactionSearch::DateRangeSearcher) }
+    let(:searcher) { described_class.new(TransactionSearch::AccountSearcher, TransactionSearch::DateRangeSearcher, TransactionSearch::AccountTypeSearcher) }
     let(:scope) { OrderDetail.all.joins(:order) }
     before do
       order_detail.to_complete!
@@ -34,6 +34,23 @@ RSpec.describe TransactionSearch::Searcher, type: :service do
 
       it "does not find it with a different account" do
         result = searcher.search(scope, accounts: [account.id + 1])
+        expect(result.order_details).to be_empty
+      end
+    end
+
+    describe "account type searching" do
+      it "can search by the account type" do
+        result = searcher.search(scope, account_types: [account.type])
+        expect(result.order_details).to include(order_detail)
+      end
+
+      it "can search by the account type with a blank" do
+        result = searcher.search(scope, account_types: ["", account.type])
+        expect(result.order_details).to include(order_detail)
+      end
+
+      it "does not find it with a different account type" do
+        result = searcher.search(scope, accounts: ["FakeAccountType"])
         expect(result.order_details).to be_empty
       end
     end


### PR DESCRIPTION
# Release Notes

This allows users to filter search by account type, and it displays account types in tables to make the type of the account easier to see.

# Screenshot

![Screen Shot 2023-05-18 at 11 21 14 AM](https://github.com/tablexi/nucore-open/assets/624487/3730ad91-fe3c-470e-9a53-25350ed87c9d)

![Screen Shot 2023-05-18 at 11 20 12 AM](https://github.com/tablexi/nucore-open/assets/624487/cb773771-2ab0-4acc-a211-b4bd5897fc53)

![Screen Shot 2023-05-18 at 11 19 30 AM](https://github.com/tablexi/nucore-open/assets/624487/ec90e836-f5fe-4fee-ad0b-c171d82da050)