### PR TITLE
[#161764] Fix order import for ruby upgrade

### DIFF
--- a/app/models/reports/order_import.rb
+++ b/app/models/reports/order_import.rb
@@ -19,9 +19,9 @@ class Reports::OrderImport
     when @order_import.result.blank?
       I18n.t("reports.order_import.blank")
     when @order_import.result.failed?
-      I18n.t(failure_message_key, @order_import.result.to_h)
+      I18n.t(failure_message_key, **@order_import.result.to_h)
     else
-      I18n.t("reports.order_import.success", @order_import.result.to_h)
+      I18n.t("reports.order_import.success", **@order_import.result.to_h)
     end
   end
 

--- a/spec/models/reports/order_import_spec.rb
+++ b/spec/models/reports/order_import_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Reports::OrderImport do
+  let(:order_import) { OrderImport.new }
+  let(:report_import) { described_class.new(order_import) }
+
+  describe "#text_content" do
+    it "displays a success message if successful" do
+      order_import.result.successes = 1
+      expect(report_import.text_content).to include "The import completed successfully"
+    end
+
+    it "displays a blank message if blank" do
+      expect(report_import.text_content).to eq I18n.t("reports.order_import.blank")
+    end
+
+    it "displays a failure message if there are failures" do
+      order_import.result.failures = 1
+      expect(report_import.text_content).to include "The import failed."
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

The parameters passed into `I18n.t` needed to be updated for Ruby 3.