### PR TITLE
[#161672] Add secondary outlet to relays

### DIFF
--- a/app/controllers/instrument_relays_controller.rb
+++ b/app/controllers/instrument_relays_controller.rb
@@ -60,6 +60,7 @@ class InstrumentRelaysController < ApplicationController
           .permit(:ip,
                   :ip_port,
                   :outlet,
+                  :secondary_outlet,
                   :username,
                   :password,
                   :type,

--- a/app/models/power_relay.rb
+++ b/app/models/power_relay.rb
@@ -12,6 +12,7 @@ module PowerRelay
     validates_presence_of :ip, :outlet, :username, :password
     validates :auto_logout_minutes, presence: { if: :auto_logout }
     validates :outlet, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: MAXIMUM_OUTLETS }
+    validates :secondary_outlet, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: MAXIMUM_OUTLETS, allow_nil: true }
     validates :ip_port, numericality: { only_integer: true, greater_than: 0, allow_nil: true }
   end
 

--- a/app/models/power_relay.rb
+++ b/app/models/power_relay.rb
@@ -29,16 +29,42 @@ module PowerRelay
     options
   end
 
+  # Returns:
+  # boolean - The new on/off status of the outlet (and secondary outlet, if configured).
   def toggle(status)
     log_power_relay_connection(:toggle) do
-      relay_connection.toggle(outlet, status)
+      toggled_status = relay_connection.toggle(outlet, status)
+      if secondary_outlet
+        secondary_toggled_status = relay_connection.toggle(secondary_outlet, status)
+        handle_mismatch_status(status, toggled_status) if toggled_status != secondary_toggled_status
+      end
+      toggled_status
     end
   end
 
+  # Returns:
+  # boolean - The current on/off status of the outlet (and secondary outlet, if configured).
   def query_status
     log_power_relay_connection(:status) do
-      relay_connection.status(outlet)
+      relay_status = relay_connection.status(outlet)
+      if secondary_outlet
+        secondary_outlet_status = relay_connection.status(secondary_outlet)
+        handle_mismatch_status if relay_status != secondary_outlet_status
+      end
+      relay_status
     end
+  end
+
+  # Returns:
+  # string - an error
+  def handle_mismatch_status(requested_status=nil, primary_status=nil)
+    event = if requested_status.present?
+      "toggling relays (#{requested_status ? "on" : "off"})"
+    else
+      "querying status"
+    end
+    msg = "Outlet statuses don't match after #{event} for relay #{id} - outlet #{outlet} is (#{primary_status ? "on" : "off"}), outlet #{secondary_outlet} is (#{primary_status ? "off" : "on"})"
+    Rollbar.error(msg, relay: id)
   end
 
   def relay_connection
@@ -56,6 +82,7 @@ module PowerRelay
       ip,
       ip_port,
       outlet,
+      secondary_outlet,
       # Include username/password so that if one of the shared schedule is right and
       # the other is wrong we still do multiple queries: one gets an error and the other
       # doesn't.
@@ -86,6 +113,7 @@ module PowerRelay
         host: host,
         ip_port: ip_port,
         outlet: outlet,
+        secondary_outlet: secondary_outlet,
       }.merge(connection_options.except(:username, :password))
     }
   end

--- a/app/views/instrument_relays/_form.html.haml
+++ b/app/views/instrument_relays/_form.html.haml
@@ -18,6 +18,8 @@
       hint: text("instruments.instrument_fields.relay.instruct.ip_port")
     = f.input :outlet, required: true,
       hint: text("instruments.instrument_fields.relay.instruct.outlet")
+    = f.input :secondary_outlet,
+      hint: text("instruments.instrument_fields.relay.instruct.secondary_outlet")
     = f.input :username, required: true
     = f.input :password, as: :string, required: true
     = f.input :auto_logout do

--- a/app/views/instrument_relays/index.html.haml
+++ b/app/views/instrument_relays/index.html.haml
@@ -21,6 +21,7 @@
       = r.input :ip_port,
         label: text("instruments.instrument_fields.relay.label.ip_port")
       = r.input :outlet
+      = r.input :secondary_outlet
       = r.input :username
       = r.input :password
       = r.input :auto_logout

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1162,7 +1162,7 @@ en:
         instruct:
           ip_port: "Leave blank unless your device is on a non-standard port"
           outlet: "e.g. 1 or 2"
-          secondary_outlet: "will be toggled in sync with the outlet above"
+          secondary_outlet: "turned on/off in sync with the outlet above (Synaccess only)"
       reservation:
         instruct:
           reserve_interval: "The minutes of an hour on which a reservation is allowed to begin (e.g. if 5 reservations can be scheduled every 5 minutes)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1162,6 +1162,7 @@ en:
         instruct:
           ip_port: "Leave blank unless your device is on a non-standard port"
           outlet: "e.g. 1 or 2"
+          secondary_outlet: "will be toggled in sync with the outlet above"
       reservation:
         instruct:
           reserve_interval: "The minutes of an hour on which a reservation is allowed to begin (e.g. if 5 reservations can be scheduled every 5 minutes)"

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -15,6 +15,7 @@ en:
         ip: "IP Address"
         ip_port: "IP Port"
         outlet: "Device Outlet"
+        secondary_outlet: "Secondary Device Outlet"
         username: "Username"
         password: "Password"
     hints:

--- a/db/migrate/20230519154410_add_secondary_outlet_to_relays.rb
+++ b/db/migrate/20230519154410_add_secondary_outlet_to_relays.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSecondaryOutletToRelays < ActiveRecord::Migration[6.1]
+  def change
+    add_column :relays, :secondary_outlet, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_05_222132) do
+ActiveRecord::Schema.define(version: 2023_05_19_154410) do
 
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
@@ -676,6 +676,7 @@ ActiveRecord::Schema.define(version: 2023_05_05_222132) do
     t.string "building_room_number"
     t.string "circuit_number"
     t.string "ethernet_port_number"
+    t.integer "secondary_outlet"
     t.index ["instrument_id"], name: "index_relays_on_instrument_id"
   end
 

--- a/doc/coding_standards.md
+++ b/doc/coding_standards.md
@@ -41,7 +41,7 @@ and controller locales. Use the standard [Rails I18n](http://guides.rubyonrails.
 * When including references to "facility" and "facilities", within a longer string,
   use text-helper's interpolation features with `facility_downcase`/`facilities_downcase`
   e.g. `text("in this !facility_downcase!"). _We haven't found a better way to do this yet_
-* Varitations of "chart string", "statement", and "NetID" need to be changed in multiple places in order to be changed application wide. In addition to changes in `en.yml` (see `Sso_id:`, `Chart_string:`, `Statement:`) and `override/en.yml` (see the comments), a new order import template needs to be created and set in `settings.yml` (the `order_import_template_name` setting).
+* Variations of "chart string", "statement", and "NetID" need to be changed in multiple places in order to be changed application wide. In addition to changes in `en.yml` (see `Sso_id:`, `Chart_string:`, `Statement:`) and `override/en.yml` (see the comments), a new order import template needs to be created and set in `settings.yml` (the `order_import_template_name` setting).
 
 ## Rubocop
 

--- a/spec/controllers/relays_activations_controller_spec.rb
+++ b/spec/controllers/relays_activations_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe RelaysActivationsController do
   let(:instrument) { FactoryBot.create(:setup_instrument) }
   let(:user) { FactoryBot.create(:user, :facility_director, facility: instrument.facility) }
-  let(:relay) { build_stubbed(:relay) }
+  let(:relay) { build_stubbed(:relay, secondary_outlet: 2) }
 
   before do
     allow_any_instance_of(Instrument).to receive(:has_real_relay?).and_return true

--- a/spec/models/power_relay_spec.rb
+++ b/spec/models/power_relay_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe SomeRelay do
   it { is_expected.to validate_presence_of :username }
   it { is_expected.to validate_presence_of :password }
   it { is_expected.not_to validate_presence_of :auto_logout_minutes }
+  it { is_expected.not_to validate_presence_of :secondary_outlet }
 
   describe "outlet range" do
     let(:relay) { SomeRelay.new(ip: "123", username: "nucore", password: "password") }

--- a/spec/models/power_relay_spec.rb
+++ b/spec/models/power_relay_spec.rb
@@ -57,6 +57,16 @@ RSpec.describe SomeRelay do
     end
   end
 
+  describe "secondary outlet" do
+    let(:relay) { SomeRelay.new(ip: "123", username: "nucore", password: "password", outlet: 1, instrument_id: 1) }
+
+    it "allows a secondary outlet allocation" do
+      relay.secondary_outlet = 3
+
+      expect(relay).to be_valid
+    end
+  end
+
   context "with auto logout" do
     before { subject.auto_logout = true }
     it { is_expected.to validate_presence_of :auto_logout_minutes }

--- a/spec/system/admin/instrument_relay_tab_spec.rb
+++ b/spec/system/admin/instrument_relay_tab_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "Instrument Relay Tab" do
         fill_in "relay_ip", with: "123.456.789"
         fill_in "relay_ip_port", with: "1234"
         fill_in "relay_outlet", with: "1"
+        fill_in "relay_secondary_outlet", with: "2"
         fill_in "relay_username", with: "root"
         fill_in "relay_password", with: "root"
         fill_in "relay_mac_address", with: "123abc456"
@@ -45,6 +46,7 @@ RSpec.describe "Instrument Relay Tab" do
         expect(instrument.relay.ip).to eq("123.456.789")
         expect(instrument.relay.ip_port).to eq(1234)
         expect(instrument.relay.outlet).to eq(1)
+        expect(instrument.relay.secondary_outlet).to eq(2)
         expect(instrument.relay.username).to eq("root")
         expect(instrument.relay.password).to eq("root")
         expect(instrument.relay.mac_address).to eq("123abc456")
@@ -95,6 +97,7 @@ RSpec.describe "Instrument Relay Tab" do
           fill_in "relay_ip", with: "123.456.789"
           fill_in "relay_ip_port", with: "1234"
           fill_in "relay_outlet", with: "1"
+          fill_in "relay_secondary_outlet", with: "2"
           fill_in "relay_username", with: "root"
           fill_in "relay_password", with: "root"
           fill_in "relay_mac_address", with: "123abc456"
@@ -108,6 +111,7 @@ RSpec.describe "Instrument Relay Tab" do
           expect(instrument.relay.ip).to eq("123.456.789")
           expect(instrument.relay.ip_port).to eq(1234)
           expect(instrument.relay.outlet).to eq(1)
+          expect(instrument.relay.secondary_outlet).to eq(2)
           expect(instrument.relay.username).to eq("root")
           expect(instrument.relay.password).to eq("root")
           expect(instrument.relay.mac_address).to eq("123abc456")
@@ -170,6 +174,7 @@ RSpec.describe "Instrument Relay Tab" do
       fill_in "relay_ip", with: "123.456.789"
       fill_in "relay_ip_port", with: "1234"
       fill_in "relay_outlet", with: "1"
+      fill_in "relay_secondary_outlet", with: "2"
       fill_in "relay_username", with: "root"
       fill_in "relay_password", with: "root"
       fill_in "relay_mac_address", with: "123abc456"
@@ -182,6 +187,7 @@ RSpec.describe "Instrument Relay Tab" do
       expect(instrument.relay.ip).to eq("123.456.789")
       expect(instrument.relay.ip_port).to eq(1234)
       expect(instrument.relay.outlet).to eq(1)
+      expect(instrument.relay.secondary_outlet).to eq(2)
       expect(instrument.relay.username).to eq("root")
       expect(instrument.relay.password).to eq("root")
       expect(instrument.relay.mac_address).to eq("123abc456")


### PR DESCRIPTION
# Release Notes

Allows specifying a secondary outlet for relays.
If specified for Synaccess A and B relays, the secondary outlet will be switched along with the primary outlet.

Use case is something like 2 monitors for a single instrument.