### PR TITLE
[#160881] Fix account type searcher account list

### DIFF
--- a/app/models/account_config.rb
+++ b/app/models/account_config.rb
@@ -50,7 +50,7 @@ class AccountConfig
     @creation_disabled_types ||= []
   end
 
-  def creation_endabled_types
+  def creation_enabled_types
     account_types - creation_disabled_types
   end
 

--- a/app/models/account_config.rb
+++ b/app/models/account_config.rb
@@ -50,6 +50,10 @@ class AccountConfig
     @creation_disabled_types ||= []
   end
 
+  def creation_endabled_types
+    account_types - creation_disabled_types
+  end
+
   def creation_enabled?(type)
     type.to_s.in?(account_types - creation_disabled_types)
   end

--- a/app/services/transaction_search/account_type_searcher.rb
+++ b/app/services/transaction_search/account_type_searcher.rb
@@ -5,7 +5,7 @@ module TransactionSearch
   class AccountTypeSearcher < BaseSearcher
 
     def options
-      Account.config.account_types.map(&:constantize)
+      Account.config.creation_endabled_types.map(&:constantize)
     end
 
     def search(params)

--- a/app/services/transaction_search/account_type_searcher.rb
+++ b/app/services/transaction_search/account_type_searcher.rb
@@ -5,7 +5,7 @@ module TransactionSearch
   class AccountTypeSearcher < BaseSearcher
 
     def options
-      Account.config.creation_endabled_types.map(&:constantize)
+      Account.config.creation_enabled_types.map(&:constantize)
     end
 
     def search(params)

--- a/spec/models/account_config_spec.rb
+++ b/spec/models/account_config_spec.rb
@@ -145,4 +145,11 @@ RSpec.describe AccountConfig, type: :model do
     end
   end
 
+  describe "#creation_enabled_types" do
+    it "does not included disabled account types" do
+      expect(instance.creation_endabled_types).to include("NufsAccount")
+      instance.creation_disabled_types << "NufsAccount"
+      expect(instance.creation_endabled_types).not_to include("NufsAccount")
+    end
+  end
 end

--- a/spec/models/account_config_spec.rb
+++ b/spec/models/account_config_spec.rb
@@ -147,9 +147,9 @@ RSpec.describe AccountConfig, type: :model do
 
   describe "#creation_enabled_types" do
     it "does not included disabled account types" do
-      expect(instance.creation_endabled_types).to include("NufsAccount")
+      expect(instance.creation_enabled_types).to include("NufsAccount")
       instance.creation_disabled_types << "NufsAccount"
-      expect(instance.creation_endabled_types).not_to include("NufsAccount")
+      expect(instance.creation_enabled_types).not_to include("NufsAccount")
     end
   end
 end


### PR DESCRIPTION
# Release Notes

The transaction type searcher was listing `account_types`, which could include some types that are disabled from being created.

This adds a method which list only the account types that can be created