### PR TITLE
[#161763] Excess Chart String account validation errors

### DIFF
--- a/app/validators/account_validator/account_number_format_error.rb
+++ b/app/validators/account_validator/account_number_format_error.rb
@@ -15,8 +15,9 @@ class  AccountValidator::AccountNumberFormatError < AccountValidator::ValidatorE
   #
   # This error is only raised in `NucsValidator#chart_string``
   def apply_to_model(model)
-    errors.each do |error|
-      model.errors.add(error.attribute, error.type, message: error.message)
+    errors.group_by_attribute.each do |attribute, errors|
+      error = errors.first
+      model.errors.add(attribute, error.type, message: error.message)
     end
   end
 


### PR DESCRIPTION
# Release Notes

This corrects an error in `apply_to_model` which happened during the Ruby 3 upgrade, which adds more errors to the model than are necessary.