### PR TITLE
TECH TASK: Updates creating a journal spec to get account from Settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,6 +44,10 @@ validator:
     factory: # relative to Rails.root
     helper: 'spec/validator_helper' # relative to Rails.root
 
+testing:
+  account_factory: "nufs_account"
+  api_account_factory: ~
+
 email:
   from: 'noreply@example.com'
   fake:

--- a/doc/coding_standards.md
+++ b/doc/coding_standards.md
@@ -85,6 +85,7 @@ multiple places. See the following section for more information.
 
 * A factory configured in settings (e.g. `AccountValidator::ValidatorFactory`, `StatementPdfFactory`
 * Adding a module onto an existing class in the engine initializer (see `vendor/engines/c2po/lib/c2po.rb`)
+* A spec configured in settings (e.g. `spec/system/creating_a_journal_spec.rb`)
 * Other things we haven't thought of
 
 ## Extending views within engines

--- a/spec/system/creating_a_journal_spec.rb
+++ b/spec/system/creating_a_journal_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe "Creating a journal" do
   let(:admin) { FactoryBot.create(:user, :administrator) }
   let(:user) { FactoryBot.create(:user) }
   let(:facility) { FactoryBot.create(:facility) }
-  let(:account) { FactoryBot.create(:nufs_account, :with_account_owner, owner: user, facility: facility) }
+  let(:account) { FactoryBot.create(Settings.testing.account_factory.to_sym, :with_account_owner, owner: user, facilities: [facility]) }
+  let!(:account_api_record) { create(Settings.testing.api_account_factory.to_sym, account_number: account.account_number) } if Settings.testing.api_account_factory
   let!(:reviewed_order_detail) { place_and_complete_item_order(user, facility, account, true) }
   let!(:unreviewed_order_detail) { place_and_complete_item_order(user, facility, account) }
   let(:expiry_date) { 1.year.ago }
-  let(:expired_payment_source) { FactoryBot.create(:nufs_account, :with_account_owner, owner: user, expires_at: expiry_date, facility: facility) }
+  let(:expired_payment_source) { FactoryBot.create(Settings.testing.account_factory.to_sym, :with_account_owner, owner: user, expires_at: expiry_date, facilities: [facility]) }
   let!(:problem_order_detail) { place_and_complete_item_order(user, facility, expired_payment_source, true) }
 
   before do


### PR DESCRIPTION
# Release Notes

Different schools have different account types. This allows the account type used in `spec/system/creating_a_journal_spec.rb` to be specified in `config/settings.yml` 