### PR TITLE
[#161283] Optional BCC on invoice emails

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -47,7 +47,7 @@ class Notifier < ActionMailer::Base
                        end
 
     @accounts_grouped_by_owner = accounts.group_by(&:owner_user)
-    send_nucore_mail @user.email, text("views.notifier.review_orders.subject", abbreviation: @facility.abbreviation)
+    send_nucore_mail @user.email, text("views.notifier.review_orders.subject", abbreviation: @facility.abbreviation), nil, Settings.email.invoice_bcc
   end
 
   # Billing sends out the statement for the month. Appropriate users get
@@ -85,8 +85,8 @@ class Notifier < ActionMailer::Base
     @statement_pdf ||= StatementPdfFactory.instance(@statement)
   end
 
-  def send_nucore_mail(to, subject, template_name = nil)
-    mail(subject: subject, to: to, template_name: template_name)
+  def send_nucore_mail(to, subject, template_name = nil, bcc = nil)
+    mail(subject: subject, to: to, template_name: template_name, bcc: bcc)
   end
 
 end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -47,7 +47,7 @@ class Notifier < ActionMailer::Base
                        end
 
     @accounts_grouped_by_owner = accounts.group_by(&:owner_user)
-    send_nucore_mail @user.email, text("views.notifier.review_orders.subject", abbreviation: @facility.abbreviation), nil, Settings.email.invoice_bcc
+    send_nucore_mail @user.email, text("views.notifier.review_orders.subject", abbreviation: @facility.abbreviation)
   end
 
   # Billing sends out the statement for the month. Appropriate users get
@@ -59,7 +59,7 @@ class Notifier < ActionMailer::Base
     @account = args[:account]
     @statement = args[:statement]
     attach_statement_pdf
-    send_nucore_mail args[:user].email, text("views.notifier.statement.subject", facility: @facility)
+    send_nucore_mail args[:user].email, text("views.notifier.statement.subject", facility: @facility), nil, Settings.email.invoice_bcc
   end
 
   def order_detail_status_changed(order_detail)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,6 +50,7 @@ testing:
 
 email:
   from: 'noreply@example.com'
+  invoice_bcc: 'invoice.bcc@example.com'
   fake:
     enabled: false
     to:

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe Notifier do
         expect(email.subject).to include(I18n.t(".Statement"))
         expect(email_html).to include(statement.account.to_s)
         expect(email_text).to include(statement.account.to_s)
+
+        if Settings.email.invoice_bcc
+          expect(email.bcc).to eq [Settings.email.invoice_bcc]
+        end
       end
     end
   end


### PR DESCRIPTION
# Release Notes

This adds an optional BCC to the statement email which can be set in `settings.yml`