### PR TITLE
Fix: Add wait to flaky spec

### DIFF
--- a/app/assets/javascripts/facility_journal.js
+++ b/app/assets/javascripts/facility_journal.js
@@ -25,8 +25,8 @@ document.addEventListener("DOMContentLoaded", function() {
     const journalDate = new Date(journalDateInput.value);
   
     const dateDiff = moment(journalDate).diff(earliestFulfilledAtDate, "days");
-  
-    if (dateDiff >= 90) {
+    const atLeastOneRowChecked = typeof(earliestFulfilledAtDate) === "object" && earliestFulfilledAtDate !== null
+    if (atLeastOneRowChecked && dateDiff >= 90) {
       event.preventDefault();
       $("#journal-date-popup").modal("show");
     }

--- a/spec/system/creating_a_journal_spec.rb
+++ b/spec/system/creating_a_journal_spec.rb
@@ -129,6 +129,7 @@ RSpec.describe "Creating a journal" do
           click_button "Create"
           expect(page).to have_content "90-Day Justification"
           click_link "OK"
+          # sometimes takes longer to load and causes failures in CI
           expect(page).to have_content "We are in the year-end closing window.", wait: 4
         end
       end

--- a/spec/system/creating_a_journal_spec.rb
+++ b/spec/system/creating_a_journal_spec.rb
@@ -126,7 +126,8 @@ RSpec.describe "Creating a journal" do
 
         it "has a 90 day and journal creation reminder pop up" do
           click_button "Create"
-          expect(page).to have_content "90-Day Justification"
+          # sometimes takes longer to load and causes failures in CI
+          expect(page).to have_content "90-Day Justification", wait: 4
           click_link "OK"
           expect(page).to have_content "We are in the year-end closing window."
         end

--- a/spec/system/creating_a_journal_spec.rb
+++ b/spec/system/creating_a_journal_spec.rb
@@ -125,9 +125,9 @@ RSpec.describe "Creating a journal" do
         end
 
         it "has a 90 day and journal creation reminder pop up" do
+          check "order_detail_ids_"
           click_button "Create"
-          # sometimes takes longer to load and causes failures in CI
-          expect(page).to have_content "90-Day Justification", wait: 4
+          expect(page).to have_content "90-Day Justification"
           click_link "OK"
           expect(page).to have_content "We are in the year-end closing window."
         end

--- a/spec/system/creating_a_journal_spec.rb
+++ b/spec/system/creating_a_journal_spec.rb
@@ -132,6 +132,12 @@ RSpec.describe "Creating a journal" do
           # sometimes takes longer to load and causes failures in CI
           expect(page).to have_content "We are in the year-end closing window.", wait: 4
         end
+
+        it "has NO 90 day and journal creation reminder pop up when nothing is checked" do
+          click_button "Create"
+          expect(page).not_to have_content "90-Day Justification"
+          expect(page).to have_content "We are in the year-end closing window."
+        end
       end
     end
   end

--- a/spec/system/creating_a_journal_spec.rb
+++ b/spec/system/creating_a_journal_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "Creating a journal" do
           click_button "Create"
           expect(page).to have_content "90-Day Justification"
           click_link "OK"
-          expect(page).to have_content "We are in the year-end closing window."
+          expect(page).to have_content "We are in the year-end closing window.", wait: 4
         end
       end
     end


### PR DESCRIPTION
# Release Notes

This spec has been failing pretty frequently - I'm not sure why it ever passes actually.
Since the spec was not selecting any transactions to journal, the JS is comparing the Journal Date with `undefined`:
```
const checked = document.querySelectorAll("table.js--transactions-table tr td input[type='checkbox']:checked");
```

