### PR TITLE
[#161811] Only global admins can resolve auto-disputed transactions

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -131,6 +131,10 @@ class Account < ApplicationRecord
     account_number <=> other.account_number
   end
 
+  def global_admin_must_resolve_disputes?
+    false
+  end
+
   def owner_user_name
     owner_user.try(:name) || ""
   end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -753,10 +753,10 @@ class OrderDetail < ApplicationRecord
   end
 
   def in_dispute?
-    dispute_at.present? && dispute_resolved_at.nil? && !canceled? && !auto_disputed?
+    dispute_at.present? && dispute_resolved_at.nil? && !canceled? && !global_admin_must_resolve?
   end
 
-  def auto_disputed?
+  def global_admin_must_resolve?
     account&.global_admin_must_resolve_disputes?
   end
 

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -757,7 +757,7 @@ class OrderDetail < ApplicationRecord
   end
 
   def auto_disputed?
-    account.auto_dispute_by.present?
+    account&.global_admin_must_resolve_disputes?
   end
 
   def in_review?

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -753,7 +753,7 @@ class OrderDetail < ApplicationRecord
   end
 
   def in_dispute?
-    dispute_at.present? && dispute_resolved_at.nil? && !canceled? && !global_admin_must_resolve?
+    dispute_at.present? && dispute_resolved_at.nil? && !canceled?
   end
 
   def global_admin_must_resolve?

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -753,7 +753,11 @@ class OrderDetail < ApplicationRecord
   end
 
   def in_dispute?
-    dispute_at.present? && dispute_resolved_at.nil? && !canceled?
+    dispute_at.present? && dispute_resolved_at.nil? && !canceled? && !auto_disputed?
+  end
+
+  def auto_disputed?
+    account.auto_dispute_by.present?
   end
 
   def in_review?

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -11,6 +11,7 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
 
     statuses << Notice.new(:in_review) if in_review?
     statuses << Notice.new(:in_dispute) if in_dispute?
+    statuses << Notice.new(:auto_disputed) if auto_disputed?
     statuses << Notice.new(:missing_form) if missing_form? && !problem?
     statuses << Notice.new(:can_reconcile) if can_reconcile_journaled?
     statuses << Notice.new(:in_open_journal) if in_open_journal?

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -10,8 +10,8 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
     statuses = []
 
     statuses << Notice.new(:in_review) if in_review?
-    statuses << Notice.new(:in_dispute) if in_dispute?
-    statuses << Notice.new(:global_admin_must_resolve) if global_admin_must_resolve?
+    statuses << Notice.new(:in_dispute) if in_dispute? && !global_admin_must_resolve?
+    statuses << Notice.new(:global_admin_must_resolve) if in_dispute? && global_admin_must_resolve?
     statuses << Notice.new(:missing_form) if missing_form? && !problem?
     statuses << Notice.new(:can_reconcile) if can_reconcile_journaled?
     statuses << Notice.new(:in_open_journal) if in_open_journal?

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -11,7 +11,7 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
 
     statuses << Notice.new(:in_review) if in_review?
     statuses << Notice.new(:in_dispute) if in_dispute?
-    statuses << Notice.new(:auto_disputed) if auto_disputed?
+    statuses << Notice.new(:global_admin_must_resolve) if global_admin_must_resolve?
     statuses << Notice.new(:missing_form) if missing_form? && !problem?
     statuses << Notice.new(:can_reconcile) if can_reconcile_journaled?
     statuses << Notice.new(:in_open_journal) if in_open_journal?

--- a/app/views/order_management/order_details/_dispute.html.haml
+++ b/app/views/order_management/order_details/_dispute.html.haml
@@ -6,7 +6,7 @@
     = banner_date_label @order_detail, :dispute_resolved_at
     = banner_label      @order_detail, :dispute_resolved_reason
 - # only global admins can resolve auto-disputed transactions
-- elsif !@order_detail.auto_disputed? || current_ability.can?(:manage, :all)
+- if !@order_detail.auto_disputed? || current_ability.can?(:manage, :all)
   .span10
     .well.well-small
       %h4= t('facility_order_details.edit.head.resolve_dispute')

--- a/app/views/order_management/order_details/_dispute.html.haml
+++ b/app/views/order_management/order_details/_dispute.html.haml
@@ -20,4 +20,4 @@
         .span4
           = f.input :dispute_resolved_reason, input_html: { class: 'note' }
 - else
-  = "Only Global Admins can resolve"
+  = t("facility_order_details.edit.instruct.admin_resolution_notice")

--- a/app/views/order_management/order_details/_dispute.html.haml
+++ b/app/views/order_management/order_details/_dispute.html.haml
@@ -5,8 +5,7 @@
     = banner_label      @order_detail, :dispute_reason
     = banner_date_label @order_detail, :dispute_resolved_at
     = banner_label      @order_detail, :dispute_resolved_reason
-- # only global admins can resolve auto-disputed transactions
-- if !@order_detail.auto_disputed? || current_ability.can?(:manage, :all)
+- elsif !@order_detail.global_admin_must_resolve? || current_ability.can?(:manage, :all)
   .span10
     .well.well-small
       %h4= t('facility_order_details.edit.head.resolve_dispute')

--- a/app/views/order_management/order_details/_dispute.html.haml
+++ b/app/views/order_management/order_details/_dispute.html.haml
@@ -5,7 +5,8 @@
     = banner_label      @order_detail, :dispute_reason
     = banner_date_label @order_detail, :dispute_resolved_at
     = banner_label      @order_detail, :dispute_resolved_reason
-- else
+- # only global admins can resolve auto-disputed transactions
+- elsif !@order_detail.auto_disputed? || current_ability.can?(:manage, :all)
   .span10
     .well.well-small
       %h4= t('facility_order_details.edit.head.resolve_dispute')
@@ -19,3 +20,5 @@
           = f.input :dispute_reason, as: :readonly
         .span4
           = f.input :dispute_resolved_reason, input_html: { class: 'note' }
+- else
+  = "Only Global Admins can resolve"

--- a/app/views/order_management/order_details/_dispute.html.haml
+++ b/app/views/order_management/order_details/_dispute.html.haml
@@ -20,4 +20,4 @@
         .span4
           = f.input :dispute_resolved_reason, input_html: { class: 'note' }
 - else
-  = t("facility_order_details.edit.instruct.admin_resolution_notice")
+  = t("order_details.notices.global_admin_must_resolve.alert")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -759,8 +759,8 @@ en:
         badge: In Dispute
         alert: 'To resolve the dispute, please make the necessary changes, including entering in Resolution Notes, and click "Resolve Dispute".'
       global_admin_must_resolve:
-        badge: Auto Dispute
-        alert: 'Only global administrators can resolve disputes with this account type.'
+        badge: In Dispute (Admin)
+        alert: Only global administrators can resolve disputes with this account type.
       in_open_journal:
         badge: Open Journal
         alert: You are unable to edit all aspects of this order because it is part of a pending journal. Please close the journal first.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -758,7 +758,7 @@ en:
       in_dispute:
         badge: In Dispute
         alert: 'To resolve the dispute, please make the necessary changes, including entering in Resolution Notes, and click "Resolve Dispute".'
-      auto_disputed:
+      global_admin_must_resolve:
         badge: Auto Dispute
         alert: 'Only global administrators can resolve disputes with this account type.'
       in_open_journal:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -760,7 +760,7 @@ en:
         alert: 'To resolve the dispute, please make the necessary changes, including entering in Resolution Notes, and click "Resolve Dispute".'
       auto_disputed:
         badge: Auto Dispute
-        alert: 'Stuff here'
+        alert: 'Only global administrators can resolve disputes with this account type.'
       in_open_journal:
         badge: Open Journal
         alert: You are unable to edit all aspects of this order because it is part of a pending journal. Please close the journal first.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -758,6 +758,9 @@ en:
       in_dispute:
         badge: In Dispute
         alert: 'To resolve the dispute, please make the necessary changes, including entering in Resolution Notes, and click "Resolve Dispute".'
+      auto_disputed:
+        badge: Auto Dispute
+        alert: 'Stuff here'
       in_open_journal:
         badge: Open Journal
         alert: You are unable to edit all aspects of this order because it is part of a pending journal. Please close the journal first.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -524,7 +524,6 @@ en:
       instruct:
         dispute: "To resolve the dispute, please make the necessary changes and click \"Resolve Dispute\"."
         bundle: "This order is part of a bundle.  Below is a summary of related bundle order line items."
-        admin_resolution_notice: Only Global Admins can resolve
       notice:
         no_results: "No results have been uploaded yet."
         no_time: "You must enter actual start/end reservation times."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -524,6 +524,7 @@ en:
       instruct:
         dispute: "To resolve the dispute, please make the necessary changes and click \"Resolve Dispute\"."
         bundle: "This order is part of a bundle.  Below is a summary of related bundle order line items."
+        admin_resolution_notice: Only Global Admins can resolve
       notice:
         no_results: "No results have been uploaded yet."
         no_time: "You must enter actual start/end reservation times."

--- a/spec/presenters/order_detail_notice_presenter_spec.rb
+++ b/spec/presenters/order_detail_notice_presenter_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe OrderDetailNoticePresenter do
       expect(presenter.badges_to_html).to have_badge("In Dispute")
     end
 
+    it "shows in dispute" do
+      allow(order_detail).to receive(:in_dispute?).and_return(true)
+      allow(order_detail).to receive(:global_admin_must_resolve?).and_return(true)
+      expect(presenter.badges_to_html).to have_badge("In Dispute (Admin)")
+    end
+
     it "shows can reconcile" do
       allow(order_detail).to receive(:can_reconcile_journaled?).and_return(true)
       expect(presenter.badges_to_html).to have_badge("Can Reconcile")

--- a/spec/system/resolving_a_disputed_order_spec.rb
+++ b/spec/system/resolving_a_disputed_order_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Resolving a disputed order" do
+  class OrderDetail < ApplicationRecord
+    def global_admin_must_resolve?
+      true
+    end
+  end
+
+  let(:item) { create(:setup_item) }
+  let(:facility) { item.facility }
+  let(:owner) { create(:user) }
+  let(:administrator) { create(:user, :administrator) }
+  let(:facility_admin) { create(:user, :facility_director, facility:) }
+  let(:account) { create(:account, :with_account_owner, owner:) }
+  let(:order) { create(:complete_order, product: item, account:) }
+  let(:logged_in_user) { nil }
+
+  let(:order_detail) do
+    od = order.order_details.first
+    od.update(
+      reviewed_at: 5.days.ago,
+      dispute_at: 3.days.ago,
+      dispute_by: owner,
+      dispute_reason: "Testing, testing"
+    )
+    od
+  end
+
+  before do
+    login_as logged_in_user
+    visit facility_disputed_orders_path facility
+    click_link order_detail.id.to_s
+  end
+
+  context "logged in as global administrator" do
+    let(:logged_in_user) { administrator }
+
+    it "allows global admins to resolve a disputed order" do
+      expect(page).to have_content "Resolution Notes"
+    end
+  end
+
+  context "logged in as user who is not a global administrator" do
+    let(:logged_in_user) { facility_admin }
+
+    it "does not allow non-global admins to resolve a disputed order" do
+      expect(page).to have_content I18n.t("order_details.notices.global_admin_must_resolve.alert")
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

This only allows global admins to resolve disputed transactions, if they are associated with an account type that only allows global admins to resolve disputes.