### PR TITLE
[#161811] Adds auto-dispute setup code from UMass

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -56,7 +56,6 @@ class Account < ApplicationRecord
 
   validate { errors.add(:base, :missing_owner) if missing_owner? }
 
-  delegate :administrators, to: :account_users
   delegate :global?, :per_facility?, to: :class
 
   # The @@config class variable stores account configuration details via a
@@ -129,6 +128,21 @@ class Account < ApplicationRecord
 
   def <=>(other)
     account_number <=> other.account_number
+  end
+
+  # A collection of users to be notified when transaction notifications are sent.
+  def administrators
+    account_users.administrators
+  end
+
+  # If desired, override this in a subclass with the `User` who auto-disputes
+  # transactions of the given account type. For example, this happens with
+  # UMass' UmassCorum::SubsidyAccount. If this is not set, transactions
+  # will not be auto-disputed. If the method returns a truthy value &
+  # NotificationSender#auto_dispute_order_details is implemented, all
+  # transactions for this account will be auto-disputed.
+  def auto_dispute_by
+    nil
   end
 
   def owner_user_name

--- a/app/services/notification_sender.rb
+++ b/app/services/notification_sender.rb
@@ -25,6 +25,7 @@ class NotificationSender
     OrderDetail.transaction do
       account_ids_to_notify # needs to be memoized before order_details get reviewed
       mark_order_details_as_reviewed
+      auto_dispute_order_details
       notify_accounts
     end
   end
@@ -42,6 +43,13 @@ class NotificationSender
                                   .need_notification
                                   .where_ids_in(@order_detail_ids)
                                   .includes(:product, :order, :price_policy, :reservation)
+  end
+
+  # If desired, override this method to automatically dispute order details,
+  # during NotificationSender#perform. As an example, UMass overrides this
+  # method in UmassCorum::NotificationSenderExtension
+  def auto_dispute_order_details
+    nil
   end
 
   private


### PR DESCRIPTION
# Release Notes

This pulls into Open some non-engine changes from UMass that are needed to enable auto-disputing transactions. This does not enable auto-disputing, but sets up some methods to override in the case auto-disputing is desired.