### PR TITLE
[#161847] Rake tasks for adding new PriceGroups to ScheduleRules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Because we use squash and merge, you should be able to see the changes by lookin
 at the [commit log](https://github.com/tablexi/nucore-open/commits/master). However, we have begun keeping track of breaking changes
 or optional rake tasks.
 
+### Addition of `PriceGroupDiscount` ([#3397](https://github.com/tablexi/nucore-open/pull/3397), [#3594](https://github.com/tablexi/nucore-open/pull/3594))
+
+Rather than one discount being set on a schedule rule, each global price group has its own discount (`PriceGroupDiscount`) for each schedule rule.
+
+When transitioning a school to use `PriceGroupDiscount`s, the `schedule_rule:add_price_group_discounts` rake task should be run, which adds `PriceGroupDiscount`s for every global price group to every schedule rule.
+
+When adding a new global price group, the `price_group:add_global_price_group` rake task should be run. This creates the global price group and sets up `PriceGroupDiscount`s for it for every schedule rule.
+
 ### Addition of `facility_tile_list: true` feature flag ([#3193](https://github.com/tablexi/nucore-open/pull/3193))
 
 Schools that have set the feature flag `facility_tile_list: false` are not affected by this change.

--- a/README.md
+++ b/README.md
@@ -288,22 +288,6 @@ It is possible to track deprecation warnings locally with [deprecation_toolkit](
 
 `deprecation_toolkit` is configured in [`spec/deprecation_toolkit_env.rb`](spec/deprecation_toolkit_env.rb).
 
-## Creating Global Price Groups
-
-A global price group is a price group that's accessible across all facilities, and it must be created via the Rails console.
-
-```
-pg = PriceGroup.new(name: "New Price Group Name", display_order: PriceGroup.globals.count + 1, is_internal: false)
-pg.save(validate: false)
-```
-
-Once the price group is created, the `schedule_rule:add_new_price_groups` rake task should be run to add the price group to all existing schedule rules. If you would like the discount to be something other than 0%, the task accepts the discount as a parameter. This example will set a 20% discount for all the price group it will add to all schedule rules
-
-```
-rake schedule_rule:add_new_price_groups[20]
-```
-
-
 ## Optional Modules
 
 The following modules are provided as optional features via

--- a/README.md
+++ b/README.md
@@ -288,6 +288,22 @@ It is possible to track deprecation warnings locally with [deprecation_toolkit](
 
 `deprecation_toolkit` is configured in [`spec/deprecation_toolkit_env.rb`](spec/deprecation_toolkit_env.rb).
 
+## Creating Global Price Groups
+
+A global price group is a price group that's accessible across all facilities, and it must be created via the Rails console.
+
+```
+pg = PriceGroup.new(name: "New Price Group Name", display_order: PriceGroup.globals.count + 1, is_internal: false)
+pg.save(validate: false)
+```
+
+Once the price group is created, the `schedule_rule:add_new_price_groups` rake task should be run to add the price group to all existing schedule rules. If you would like the discount to be something other than 0%, the task accepts the discount as a parameter. This example will set a 20% discount for all the price group it will add to all schedule rules
+
+```
+rake schedule_rule:add_new_price_groups[20]
+```
+
+
 ## Optional Modules
 
 The following modules are provided as optional features via

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -92,7 +92,7 @@ class PriceGroup < ApplicationRecord
       schedule_price_groups = schedule_rule.price_group_discounts.map(&:price_group)
 
       if schedule_price_groups.include? self
-        puts "price_group_discount for #{self} already exists for schedule rule #{schedule_rule.id}"
+        puts("price_group_discount for #{self} already exists for schedule rule #{schedule_rule.id}") unless Rails.env.test?
         next
       end
 
@@ -101,7 +101,7 @@ class PriceGroup < ApplicationRecord
         discount_percent:
       )
 
-      puts "Created price_group_discount for #{self} and schedule rule #{schedule_rule.id}"
+      puts("Created price_group_discount for #{self} and schedule rule #{schedule_rule.id}") unless Rails.env.test?
     end
   end
 
@@ -113,7 +113,7 @@ class PriceGroup < ApplicationRecord
     found_price_group = global_price_groups.find_by(name:)
 
     if found_price_group
-      puts "Global price group '#{name}' already exists."
+      puts("Global price group '#{name}' already exists.") unless Rails.env.test?
 
       found_price_group
     else
@@ -127,7 +127,7 @@ class PriceGroup < ApplicationRecord
 
       pg.save(validate: false)
 
-      puts "Created global price group '#{name}'"
+      puts("Created global price group '#{name}'") unless Rails.env.test?
 
       pg
     end

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -114,8 +114,7 @@ class PriceGroup < ApplicationRecord
     end
   end
 
-  # Creates price group discounts for every schedule rule that does not have a
-  # price group discount for this price group
+  # Creates price group discounts for this price group, if they do not exist
   def setup_schedule_rules(discount_percent: 0)
     ScheduleRule.all.each do |schedule_rule|
       schedule_price_groups = schedule_rule.price_group_discounts.map(&:price_group)

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -86,6 +86,25 @@ class PriceGroup < ApplicationRecord
     !is_internal?
   end
 
+  # Creates price group discounts for this price group, if they do not exist
+  def setup_schedule_rules(discount_percent: 0)
+    ScheduleRule.all.each do |schedule_rule|
+      schedule_price_groups = schedule_rule.price_group_discounts.map(&:price_group)
+
+      if schedule_price_groups.include? self
+        puts "price_group_discount for #{self} already exists for schedule rule #{schedule_rule.id}"
+        next
+      end
+
+      schedule_rule.price_group_discounts.create(
+        price_group: self,
+        discount_percent:
+      )
+
+      puts "Created price_group_discount for #{self} and schedule rule #{schedule_rule.id}"
+    end
+  end
+
   private
 
   # Find a global price group by name, or create it if it does not exist
@@ -111,25 +130,6 @@ class PriceGroup < ApplicationRecord
       puts "Created global price group '#{name}'"
 
       pg
-    end
-  end
-
-  # Creates price group discounts for this price group, if they do not exist
-  def setup_schedule_rules(discount_percent: 0)
-    ScheduleRule.all.each do |schedule_rule|
-      schedule_price_groups = schedule_rule.price_group_discounts.map(&:price_group)
-
-      if schedule_price_groups.include? self
-        puts "price_group_discount for #{self} already exists for schedule rule #{schedule_rule.id}"
-        next
-      end
-
-      schedule_rule.price_group_discounts.create(
-        price_group: self,
-        discount_percent:
-      )
-
-      puts "Created price_group_discount for #{self} and schedule rule #{schedule_rule.id}"
     end
   end
 end

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -94,10 +94,7 @@ class PriceGroup < ApplicationRecord
     found_price_group = global_price_groups.find_by(name:)
 
     if found_price_group
-      log_string = "Global price group '#{name}' already exists."
-
-      puts log_string
-      logger.info log_string
+      puts "Global price group '#{name}' already exists."
 
       found_price_group
     else
@@ -110,10 +107,8 @@ class PriceGroup < ApplicationRecord
       )
 
       pg.save(validate: false)
-      log_string = "Created global price group '#{name}'"
 
-      puts log_string
-      logger.info log_string
+      puts "Created global price group '#{name}'"
 
       pg
     end
@@ -126,11 +121,7 @@ class PriceGroup < ApplicationRecord
       schedule_price_groups = schedule_rule.price_group_discounts.map(&:price_group)
 
       if schedule_price_groups.include? self
-        log_string = "price_group_discount for #{self} already exists for schedule rule #{schedule_rule.id}"
-
-        puts log_string
-        logger.info log_string
-
+        puts "price_group_discount for #{self} already exists for schedule rule #{schedule_rule.id}"
         next
       end
 
@@ -139,10 +130,7 @@ class PriceGroup < ApplicationRecord
         discount_percent:
       )
 
-      log_string = "Created price_group_discount for #{self} and schedule rule #{schedule_rule.id}"
-
-      puts log_string
-      logger.info log_string
+      puts "Created price_group_discount for #{self} and schedule rule #{schedule_rule.id}"
     end
   end
 end

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -35,8 +35,8 @@ class PriceGroup < ApplicationRecord
 
   # Create a global price group, if it does not exist, and setup all the
   # schedule rules with price group discounts for the price group.
-  def self.setup_global(name:, is_internal: false, admin_editable: true, discount_percent: 0)
-    price_group = find_or_create_global(name:, is_internal:, admin_editable:)
+  def self.setup_global(name:, is_internal: false, admin_editable: true, discount_percent: 0, display_order: nil)
+    price_group = find_or_create_global(name:, is_internal:, admin_editable:, display_order:)
     price_group.setup_schedule_rules(discount_percent:)
     price_group
   end
@@ -108,7 +108,7 @@ class PriceGroup < ApplicationRecord
   private
 
   # Find a global price group by name, or create it if it does not exist
-  def self.find_or_create_global(name:, is_internal: false, admin_editable: true)
+  def self.find_or_create_global(name:, display_order:, is_internal: false, admin_editable: true)
     global_price_groups = PriceGroup.globals
     found_price_group = global_price_groups.find_by(name:)
 
@@ -122,7 +122,7 @@ class PriceGroup < ApplicationRecord
         is_internal:,
         admin_editable:,
         facility_id: nil,
-        display_order: global_price_groups.count + 1
+        display_order: display_order || (global_price_groups.count + 1)
       )
 
       pg.save(validate: false)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,11 +21,15 @@ Affiliate.OTHER
 PriceGroup.reset_column_information
 
 [
-  PriceGroup.create_with(is_internal: true, admin_editable: false).find_or_initialize_by(name: Settings.price_group.name.base),
-  PriceGroup.create_with(is_internal: true, admin_editable: true).find_or_initialize_by(name: Settings.price_group.name.cancer_center),
-  PriceGroup.create_with(is_internal: false, admin_editable: false).find_or_initialize_by(name: Settings.price_group.name.external),
-].each_with_index do |price_group, index|
-  next if price_group.name.blank? || price_group.persisted?
-  price_group.display_order = index + 1
-  price_group.save(validate: false)
+  { name: Settings.price_group.name.base, is_internal: true, admin_editable: false },
+  { name: Settings.price_group.name.cancer_center, is_internal: true, admin_editable: true },
+  { name: Settings.price_group.name.external, is_internal: false, admin_editable: false },
+].each do |pg_data|
+  next if pg_data[:name].blank?
+
+  PriceGroup.setup_global(
+    name: pg_data[:name],
+    is_internal: pg_data[:is_internal],
+    admin_editable: pg_data[:admin_editable]
+  )
 end

--- a/lib/tasks/demo_seed.rake
+++ b/lib/tasks/demo_seed.rake
@@ -51,24 +51,18 @@ namespace :demo do
       end
     end
 
-    order = 1
     pgnu = pgex = nil
 
     Settings.price_group.name.to_hash.each do |k, v|
-      price_group = PriceGroup.find_or_initialize_by(name: v) do |pg|
-        pg.is_internal = (k == :base || k == :cancer_center)
-        pg.display_order = order
-      end
-
-      price_group.save(validate: false) # override facility validator
+      price_group = PriceGroup.setup_global(
+        name: v, is_internal: (k == :base || k == :cancer_center)
+      )
 
       if k == :base
         pgnu = price_group
       elsif k == :external
         pgex = price_group
       end
-
-      order += 1
     end
 
     fa = FacilityAccount.find_or_initialize_by(facility_id: facility.id) do |facility_account|

--- a/lib/tasks/pirce_groups.rake
+++ b/lib/tasks/pirce_groups.rake
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+namespace :price_group do
+  # This creates a new global price group, if it does not exist, and adds
+  # a PriceGroupDiscount for it to every ScheduleRule. If the price group
+  # already exists, this will just add PriceGroupDiscounts for it to ScheduleRules
+  # that are missing then.
+  #
+  # rake price_group:add_global_price_group["new group",true,false,15]
+  desc "Create a new global price group and/or setup schedule rules for it"
+  task :add_global_price_group, [:name, :internal, :admin_editable, :discount] => :environment do |_t, args|
+    name = args[:name]
+    is_internal = args[:internal].casecmp("true").zero?
+    admin_editable = args[:admin_editable].casecmp("true").zero?
+    discount_percent = args[:discount] || 0
+
+    PriceGroup.setup_global(name:, is_internal:, admin_editable:, discount_percent:)
+  end
+end

--- a/lib/tasks/schedule_rules.rake
+++ b/lib/tasks/schedule_rules.rake
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 namespace :schedule_rule do
+  # This task is useful for switching a school over to PriceGroupDiscounts. If a
+  # school is already using price group discounts on all its schedule rules, this
+  # task will do nothing
   desc "Adds PriceGroupDiscounts for existing global price groups to every schedule rule"
   task add_price_group_discounts: :environment do |_t, _args|
     price_groups = PriceGroup.globals
@@ -21,7 +24,13 @@ namespace :schedule_rule do
     end
   end
 
-  desc "Adds PriceGroupDiscounts for new global price groups to every schedule rule"
+  # Add missing global price groups to schedule rules.
+  #
+  # Run this whenever a new global price group is created. You can set a discount
+  # percent for all schedule rules. The below example will set a 20% discount
+  #
+  # `rake schedule_rule:add_new_price_groups[20]`
+  desc "Adds PriceGroupDiscounts for global price groups that have yet to be associated with schedule rules"
   task :add_new_price_groups, [:discount] => :environment do |_t, args|
     price_groups = PriceGroup.globals
     discount_percent = args[:discount] || 0
@@ -30,7 +39,10 @@ namespace :schedule_rule do
       schedule_price_groups = schedule_rule.price_group_discounts.map(&:price_group)
 
       price_groups.each do |price_group|
-        next if schedule_price_groups.include? price_group
+        if schedule_price_groups.include? price_group
+          puts "price_group_discount for #{price_group} already exists for schedule rule #{schedule_rule.id}"
+          next
+        end
 
         schedule_rule.price_group_discounts.create(
           price_group:,

--- a/lib/tasks/schedule_rules.rake
+++ b/lib/tasks/schedule_rules.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :schedule_rule do
-  desc "Adds PriceGroupDiscounts for global price groups to every schedule rule"
+  desc "Adds PriceGroupDiscounts for existing global price groups to every schedule rule"
   task add_price_group_discounts: :environment do |_t, _args|
     price_groups = PriceGroup.globals
 
@@ -17,6 +17,27 @@ namespace :schedule_rule do
         end
 
         puts "Created price_group_discounts for #{schedule_rule.id}"
+      end
+    end
+  end
+
+  desc "Adds PriceGroupDiscounts for new global price groups to every schedule rule"
+  task :add_new_price_groups, [:discount] => :environment do |_t, args|
+    price_groups = PriceGroup.globals
+    discount_percent = args[:discount] || 0
+
+    ScheduleRule.all.each do |schedule_rule|
+      schedule_price_groups = schedule_rule.price_group_discounts.map(&:price_group)
+
+      price_groups.each do |price_group|
+        next if schedule_price_groups.include? price_group
+
+        schedule_rule.price_group_discounts.create(
+          price_group:,
+          discount_percent:
+        )
+
+        puts "Created price_group_discount for #{price_group} and schedule rule #{schedule_rule.id}"
       end
     end
   end

--- a/lib/tasks/schedule_rules.rake
+++ b/lib/tasks/schedule_rules.rake
@@ -23,34 +23,4 @@ namespace :schedule_rule do
       end
     end
   end
-
-  # Add missing global price groups to schedule rules.
-  #
-  # Run this whenever a new global price group is created. You can set a discount
-  # percent for all schedule rules. The below example will set a 20% discount
-  #
-  # `rake schedule_rule:add_new_price_groups[20]`
-  desc "Adds PriceGroupDiscounts for global price groups that have yet to be associated with schedule rules"
-  task :add_new_price_groups, [:discount] => :environment do |_t, args|
-    price_groups = PriceGroup.globals
-    discount_percent = args[:discount] || 0
-
-    ScheduleRule.all.each do |schedule_rule|
-      schedule_price_groups = schedule_rule.price_group_discounts.map(&:price_group)
-
-      price_groups.each do |price_group|
-        if schedule_price_groups.include? price_group
-          puts "price_group_discount for #{price_group} already exists for schedule rule #{schedule_rule.id}"
-          next
-        end
-
-        schedule_rule.price_group_discounts.create(
-          price_group:,
-          discount_percent:
-        )
-
-        puts "Created price_group_discount for #{price_group} and schedule rule #{schedule_rule.id}"
-      end
-    end
-  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -132,7 +132,7 @@ RSpec.configure do |config|
     Affiliate.OTHER
 
     # initialize price groups
-    PriceGroup.setup_global(name: Settings.price_group.name.base, is_internal: true)
+    @nupg = PriceGroup.setup_global(name: Settings.price_group.name.base, is_internal: true)
     PriceGroup.setup_global(name: Settings.price_group.name.external, is_internal: false)
 
     # Because many specs rely on not crossing a fiscal year boundary we lock the

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -132,8 +132,8 @@ RSpec.configure do |config|
     Affiliate.OTHER
 
     # initialize price groups
-    @nupg = PriceGroup.setup_global(name: Settings.price_group.name.base, is_internal: true)
-    PriceGroup.setup_global(name: Settings.price_group.name.external, is_internal: false)
+    @nupg = PriceGroup.setup_global(name: Settings.price_group.name.base, is_internal: true, display_order: 1)
+    PriceGroup.setup_global(name: Settings.price_group.name.external, is_internal: false, display_order: 3)
 
     # Because many specs rely on not crossing a fiscal year boundary we lock the
     # time globally. Rails's `travel_to` helper does not work well with nesting, so

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -132,9 +132,8 @@ RSpec.configure do |config|
     Affiliate.OTHER
 
     # initialize price groups
-    @nupg = PriceGroup.find_or_create_by(name: Settings.price_group.name.base, is_internal: true, display_order: 1)
-    @nupg.save(validate: false)
-    PriceGroup.find_or_create_by(name: Settings.price_group.name.external, is_internal: false, display_order: 3).save(validate: false)
+    PriceGroup.setup_global(name: Settings.price_group.name.base, is_internal: true)
+    PriceGroup.setup_global(name: Settings.price_group.name.external, is_internal: false)
 
     # Because many specs rely on not crossing a fiscal year boundary we lock the
     # time globally. Rails's `travel_to` helper does not work well with nesting, so


### PR DESCRIPTION
# Release Notes

When a global price group is created, it needs to be added to all the schedule rules for it to appear on the UI for each product.

This created a rake tasks which does that.