### PR TITLE
[#161857] Add new dropdown for Billing Mode when creating new products

### DIFF
--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -113,7 +113,7 @@ class ProductsCommonController < ApplicationController
       :schedule_id, :reserve_interval,
       :min_reserve_mins, :max_reserve_mins, :min_cancel_hours,
       :auto_cancel_mins, :lock_window, :cutoff_hours,
-      :problems_resolvable_by_user, :restrict_holiday_access
+      :problems_resolvable_by_user, :restrict_holiday_access, :billing_mode
     ]
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -55,6 +55,11 @@ class Product < ApplicationRecord
     errors.add(:contact_email, text("errors.models.product.attributes.contact_email.required")) unless email.present?
   end
 
+  def self.billing_modes
+    ["Default", "Skip Review", "Nonbillable"]
+  end
+  validates :billing_mode, inclusion: Product.billing_modes
+
   scope :active, -> { where(is_archived: false, is_hidden: false) }
   scope :alphabetized, -> { order(Arel.sql("LOWER(products.name)")) }
   scope :archived, -> { where(is_archived: true) }
@@ -66,11 +71,6 @@ class Product < ApplicationRecord
   scope :without_display_group, -> {
     left_outer_joins(:product_display_group_product).where(product_display_group_products: { id: nil })
   }
-
-  def self.billing_modes
-    ["Default", "Skip Review", "Nonbillable"]
-  end
-  validates :billing_mode, inclusion: Product.billing_modes
 
   # All product types. This cannot be a cattr_accessor because the block is evaluated
   # at definition time (not lazily as I expected) and this causes a circular dependency

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -67,6 +67,11 @@ class Product < ApplicationRecord
     left_outer_joins(:product_display_group_product).where(product_display_group_products: { id: nil })
   }
 
+  def self.billing_modes
+    ["Default", "Skip Review", "Nonbillable"]
+  end
+  validates :billing_mode, inclusion: Product.billing_modes
+
   # All product types. This cannot be a cattr_accessor because the block is evaluated
   # at definition time (not lazily as I expected) and this causes a circular dependency
   # in some schools.

--- a/app/views/admin/products/_product_fields.html.haml
+++ b/app/views/admin/products/_product_fields.html.haml
@@ -5,6 +5,9 @@
 
   = f.input :initial_order_status_id, collection: OrderStatus.initial_statuses(current_facility).collect {|cf| [cf.name_with_level, cf.id] }, hint: text("hints.initial_order_status"), include_blank: false
 
+  - if @product.id.blank? && current_user.administrator?
+    = f.input :billing_mode, collection: ["Default", "Skip Review", "Nonbillable"], include_blank: false, hint: text("hints.billing_mode")
+
   %fieldset.well
     = f.input :requires_approval, as: :boolean, label: false, inline_label: text("hints.requires_approval"), input_html: { data: { disables: ".#{f.object.class.model_name.to_s.underscore}_allows_training_requests, .instrument_restrict_holiday_access"} }
     - if SettingsHelper.feature_on?(:training_requests)

--- a/app/views/admin/products/_product_fields.html.haml
+++ b/app/views/admin/products/_product_fields.html.haml
@@ -6,7 +6,7 @@
   = f.input :initial_order_status_id, collection: OrderStatus.initial_statuses(current_facility).collect {|cf| [cf.name_with_level, cf.id] }, hint: text("hints.initial_order_status"), include_blank: false
 
   - if @product.id.blank? && current_user.administrator?
-    = f.input :billing_mode, collection: ["Default", "Skip Review", "Nonbillable"], include_blank: false, hint: text("hints.billing_mode")
+    = f.input :billing_mode, collection: Product.billing_modes, include_blank: false, hint: text("hints.billing_mode")
 
   %fieldset.well
     = f.input :requires_approval, as: :boolean, label: false, inline_label: text("hints.requires_approval"), input_html: { data: { disables: ".#{f.object.class.model_name.to_s.underscore}_allows_training_requests, .instrument_restrict_holiday_access"} }

--- a/app/views/products_common/manage.html.haml
+++ b/app/views/products_common/manage.html.haml
@@ -22,6 +22,7 @@
     = render_view_hook("after_facility_account", { f: f })
 
     = f.input :initial_order_status
+    = f.input :billing_mode
     = f.input :requires_approval
     - if f.object.requires_approval?
       = f.input :allows_training_requests

--- a/config/locales/views/admin/en.products.yml
+++ b/config/locales/views/admin/en.products.yml
@@ -30,7 +30,7 @@ en:
             initial_order_status: "Default status for new orders"
             is_archived: "Inactivate the product, disallowing purchase and viewing"
             is_hidden: "Hide %{field} from end users; visible to staff when \"ordering on behalf\" of another user"
-            billing_mode: "Default: Standard billing workflow, and payment source required.<br>Skip Review: Reconciled on completion, and payment source required<br>Nonbillable: Reconciled on completion, and NO payment source is required"
+            billing_mode: "<b>Default</b>: Standard billing workflow, and payment source required.<br><b>Skip Review</b>: Reconciled on completion, and payment source required<br><b>Nonbillable</b>: Reconciled on completion, and NO payment source is required"
 
       services:
         index:

--- a/config/locales/views/admin/en.products.yml
+++ b/config/locales/views/admin/en.products.yml
@@ -30,6 +30,7 @@ en:
             initial_order_status: "Default status for new orders"
             is_archived: "Inactivate the product, disallowing purchase and viewing"
             is_hidden: "Hide %{field} from end users; visible to staff when \"ordering on behalf\" of another user"
+            billing_mode: "Default: Standard billing workflow, and payment source required.<br>Skip Review: Reconciled on completion, and payment source required<br>Nonbillable: Reconciled on completion, and NO payment source is required"
 
       services:
         index:

--- a/db/migrate/20230724224847_add_billing_mode_to_product.rb
+++ b/db/migrate/20230724224847_add_billing_mode_to_product.rb
@@ -1,0 +1,5 @@
+class AddBillingModeToProduct < ActiveRecord::Migration[6.1]
+  def change
+    add_column :products, :billing_mode, :string
+  end
+end

--- a/db/migrate/20230724224847_add_billing_mode_to_product.rb
+++ b/db/migrate/20230724224847_add_billing_mode_to_product.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class AddBillingModeToProduct < ActiveRecord::Migration[6.1]
   def change
-    add_column :products, :billing_mode, :string
+    add_column :products, :billing_mode, :string, null: false, default: "Default"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_19_154410) do
+ActiveRecord::Schema.define(version: 2023_07_24_224847) do
 
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
@@ -639,6 +639,7 @@ ActiveRecord::Schema.define(version: 2023_05_19_154410) do
     t.string "tablet_circuit_number"
     t.integer "tablet_port_number"
     t.text "tablet_location_description"
+    t.string "billing_mode"
     t.index ["dashboard_token"], name: "index_products_on_dashboard_token"
     t.index ["facility_account_id"], name: "fk_facility_accounts"
     t.index ["facility_id"], name: "fk_rails_0c9fa1afbe"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -639,7 +639,7 @@ ActiveRecord::Schema.define(version: 2023_07_24_224847) do
     t.string "tablet_circuit_number"
     t.integer "tablet_port_number"
     t.text "tablet_location_description"
-    t.string "billing_mode"
+    t.string "billing_mode", default: "Default", null: false
     t.index ["dashboard_token"], name: "index_products_on_dashboard_token"
     t.index ["facility_account_id"], name: "fk_facility_accounts"
     t.index ["facility_id"], name: "fk_rails_0c9fa1afbe"

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     is_archived { false }
     is_hidden { false }
     initial_order_status_id { FactoryBot.create(:order_status, name: "New").id }
+    billing_mode { Product.billing_modes.first }
 
     after(:build) do |product|
       if product.facility_account.present?

--- a/spec/system/managing_product_billing_mode_spec.rb
+++ b/spec/system/managing_product_billing_mode_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe "Managing products" do
   let(:facility) { instrument.facility }
   let(:administrator) { create(:user, :administrator) }
   let(:facility_administrator) { create(:user, :facility_administrator, facility: facility) }
-  let(:user) { nil }
   let(:new_instrument) { FactoryBot.build(:instrument) }
 
   before do

--- a/spec/system/managing_product_billing_mode_spec.rb
+++ b/spec/system/managing_product_billing_mode_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Managing products" do
+  let(:instrument) { FactoryBot.create(:setup_instrument) }
+  let(:facility) { instrument.facility }
+  let(:administrator) { create(:user, :administrator) }
+  let(:facility_administrator) { create(:user, :facility_administrator, facility: facility) }
+  let(:user) { nil }
+  let(:new_instrument) { FactoryBot.build(:instrument) }
+
+  before do
+    login_as user
+    visit facility_instruments_path(facility)
+  end
+
+  context "global admin" do
+    let(:user) { administrator }
+
+    it "can select a billing mode when creating an instrument" do
+      click_link "Add Instrument"
+      fill_in "instrument[name]", with: new_instrument.name
+      fill_in "instrument[url_name]", with: new_instrument.url_name
+      select "Skip Review", from: "Billing mode"
+      select "1", from: "Interval (minutes)"
+      click_button "Create"
+      expect(page).to have_content("Instrument was successfully created.")
+      expect(page).to have_content("Skip Review")
+    end
+
+    it "cannot select a billing mode when editing an instrument" do
+      click_link instrument.name
+      expect(page).not_to have_content "Billing mode"
+    end
+  end
+
+  context "non-global admin" do
+    let(:user) { facility_administrator }
+
+    it "cannot select a billing mode when creating an instrument" do
+      click_link "Add Instrument"
+      expect(page).not_to have_content "Billing mode"
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

This adds a billing mode attribute to products that global admins can set only on creation. Users who are not global admins cannot set this attribute (it defaults to "Default").

# Screenshot

![Screen Shot 2023-07-26 at 1 28 03 PM](https://github.com/tablexi/nucore-open/assets/624487/9f6566d2-d143-4b28-9b5a-3d8b1eaa94e8)

![Screen Shot 2023-07-26 at 1 27 21 PM](https://github.com/tablexi/nucore-open/assets/624487/ee44cc15-9fa8-4733-976a-fd3911b2093c)