### PR TITLE
[#160013] Updates formatting of fulfilled_at in form

### DIFF
--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -24,6 +24,7 @@
               as: :string,
               placeholder: OrderDetail.human_attribute_name(:fulfilled_at),
               input_html: { class: "datepicker__data js--showOnCompleteStatus",
+                value: format_usa_date(f.object.fulfilled_at),
                 data: { min_date: ValidFulfilledAtDate.min.iso8601,
                   max_date: ValidFulfilledAtDate.max.iso8601,
                   complete_target: "#order_detail_order_status_id"}}

--- a/spec/system/admin/manage_order_detail_spec.rb
+++ b/spec/system/admin/manage_order_detail_spec.rb
@@ -258,14 +258,15 @@ RSpec.describe "Managing an order detail" do
 
       before do
         expect(page).to have_selector("input[name='order_detail[fulfilled_at]']")
-        fill_in "order_detail[fulfilled_at]", with: DateTime.now.to_s
+        fill_in "order_detail[fulfilled_at]", with: 1.day.ago.to_s
         click_button "Save"
         expect(page).to have_content("The order was successfully updated.")
         click_link order_detail.to_s
       end
 
       it "can update the fulfilled at date" do
-        expect(page).to have_content SpecDateHelper.format_usa_date(Date.today)
+        expect(page).to have_content(SpecDateHelper.format_usa_date(1.day.ago.to_s))
+        expect(page).to have_field("order_detail[fulfilled_at]", with: SpecDateHelper.format_usa_date(1.day.ago.to_s))
       end
 
       it "logs fulfilled at date updates" do


### PR DESCRIPTION
# Release Notes

This field is validated by JavaScript, this PR changes the date into the format the JavaScript expects, to remove the validation error message when changing the date.

# Screenshot

See https://github.com/tablexi/nucore-open/pull/3588 for original screenshots

![Screen Shot 2023-08-01 at 3 32 18 PM](https://github.com/tablexi/nucore-open/assets/624487/d66cad90-04e4-4442-9767-369890d0ca4d)