### PR TITLE
[#161858] Skip Review billing mode

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -377,7 +377,7 @@ class OrderDetail < ApplicationRecord
     end
 
     event :to_reconciled do
-      transitions to: :reconciled, from: :complete
+      transitions to: :reconciled, from: :complete, guard: :actual_total
     end
 
     event :to_canceled do
@@ -386,7 +386,8 @@ class OrderDetail < ApplicationRecord
   end
 
   def reconcile_if_skip_review
-    change_status!(OrderStatus.reconciled) if complete? && product.billing_mode == "Skip Review"
+    should_change_status = complete? && product.billing_mode == "Skip Review"
+    change_status!(OrderStatus.reconciled) if should_change_status
   end
 
   # block will be called after the transition, but before the save

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -386,11 +386,13 @@ class OrderDetail < ApplicationRecord
   end
 
   def reconcile_if_skip_review
-    should_change_status = actual_total &&
-                           complete? &&
-                           product.billing_mode == "Skip Review"
+    change_status!(OrderStatus.reconciled) if skip_review?
+  end
 
-    change_status!(OrderStatus.reconciled) if should_change_status
+  def skip_review?
+    actual_total &&
+      complete? &&
+      product.billing_mode == "Skip Review"
   end
 
   # block will be called after the transition, but before the save

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -386,7 +386,10 @@ class OrderDetail < ApplicationRecord
   end
 
   def reconcile_if_skip_review
-    should_change_status = complete? && product.billing_mode == "Skip Review"
+    should_change_status = actual_total &&
+                           complete? &&
+                           product.billing_mode == "Skip Review"
+
     change_status!(OrderStatus.reconciled) if should_change_status
   end
 

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -370,7 +370,7 @@ class OrderDetail < ApplicationRecord
       transitions to: :inprocess, from: :new
     end
 
-    event :to_complete do
+    event :to_complete, after: :reconcile_if_skip_review do
       transitions to: :complete, from: [:new, :inprocess], guard: :time_data_completeable?
     end
 
@@ -381,6 +381,10 @@ class OrderDetail < ApplicationRecord
     event :to_canceled do
       transitions to: :canceled, from: CANCELABLE_STATES, guard: :cancelable?
     end
+  end
+
+  def reconcile_if_skip_review
+    to_reconciled! if product.billing_mode == "Skip Review"
   end
 
   # block will be called after the transition, but before the save

--- a/lib/tasks/demo_seed.rake
+++ b/lib/tasks/demo_seed.rake
@@ -85,6 +85,19 @@ namespace :demo do
       example_item.facility_account_id = fa.id
     end
 
+    skip_review_item = Item.find_or_create_by!(url_name: "skip-review-example-item") do |example_item|
+      example_item.facility_id = facility.id
+      example_item.account = Settings.accounts.product_default
+      example_item.name = "Skip Review Example Item"
+      example_item.description = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus non ipsum id odio cursus euismod eu bibendum nisl. Sed nec.</p>"
+      example_item.requires_approval = false
+      example_item.initial_order_status_id = new_status.id
+      example_item.is_archived = false
+      example_item.is_hidden = false
+      example_item.facility_account_id = fa.id
+      example_item.billing_mode = "Skip Review"
+    end
+
     service = Service.find_or_create_by!(url_name: "example-service") do |example_service|
       example_service.facility_id = facility.id
       example_service.account = Settings.accounts.product_default
@@ -95,6 +108,19 @@ namespace :demo do
       example_service.is_archived = false
       example_service.is_hidden = false
       example_service.facility_account_id = fa.id
+    end
+
+    skip_review_service = Service.find_or_create_by!(url_name: "skip-review-example-service") do |example_service|
+      example_service.facility_id = facility.id
+      example_service.account = Settings.accounts.product_default
+      example_service.name = "Example Service"
+      example_service.description = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus non ipsum id odio cursus euismod eu bibendum nisl. Sed nec.</p>"
+      example_service.requires_approval = false
+      example_service.initial_order_status_id = in_process.id
+      example_service.is_archived = false
+      example_service.is_hidden = false
+      example_service.facility_account_id = fa.id
+      example_service.billing_mode = "Skip Review"
     end
 
     instrument = Instrument.find_or_create_by!(url_name: "example-instrument") do |example_instrument|
@@ -108,6 +134,20 @@ namespace :demo do
       example_instrument.is_hidden = false
       example_instrument.facility_account_id = fa.id
       example_instrument.reserve_interval = 5
+    end
+
+    skip_review_instrument = Instrument.find_or_create_by!(url_name: "skip-review-example-instrument") do |example_instrument|
+      example_instrument.facility_id = facility.id
+      example_instrument.account = Settings.accounts.product_default
+      example_instrument.name = "Skip Review Example Instrument"
+      example_instrument.description = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus non ipsum id odio cursus euismod eu bibendum nisl. Sed nec.</p>"
+      example_instrument.initial_order_status_id = new_status.id
+      example_instrument.requires_approval = false
+      example_instrument.is_archived = false
+      example_instrument.is_hidden = false
+      example_instrument.facility_account_id = fa.id
+      example_instrument.reserve_interval = 5
+      example_instrument.billing_mode = "Skip Review"
     end
 
     RelaySynaccessRevB.find_or_create_by!(instrument_id: instrument.id) do |relay_instrument|

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -2034,7 +2034,7 @@ RSpec.describe OrderDetail do
       expect(order_detail.state).to eq "reconciled"
     end
 
-    it "does not reconcile if produce billing mode is 'Default'" do
+    it "does not reconcile if product billing mode is 'Default'" do
       order_detail.reconcile_if_skip_review
       expect(order_detail.reconciled?).to be false
       expect(order_detail.state).to eq "complete"

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -2017,4 +2017,27 @@ RSpec.describe OrderDetail do
     end
 
   end
+
+  describe "#reconcile_if_skip_review" do
+    before do
+      order_detail.actual_cost = 10
+      order_detail.actual_subsidy = 0
+      order_detail.state = "complete"
+    end
+
+    it "reconciles if product billing mode is 'Skip Review'" do
+      item.billing_mode = "Skip Review"
+      item.save
+      order_detail.product.reload
+      order_detail.reconcile_if_skip_review
+      expect(order_detail.reconciled?).to be true
+      expect(order_detail.state).to eq "reconciled"
+    end
+
+    it "does not reconcile if produce billing mode is 'Default'" do
+      order_detail.reconcile_if_skip_review
+      expect(order_detail.reconciled?).to be false
+      expect(order_detail.state).to eq "complete"
+    end
+  end
 end

--- a/spec/system/admin/billing_mode_workflow_spec.rb
+++ b/spec/system/admin/billing_mode_workflow_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe "Billing mode workflows" do
         visit facility_transactions_path(facility)
 
         expect(page).to have_selector("tr td.nowrap", text: "Reconciled")
-        expect(order_detail.reload.reconciled?).to be true
       end
     end
 

--- a/spec/system/admin/billing_mode_workflow_spec.rb
+++ b/spec/system/admin/billing_mode_workflow_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Billing mode workflows" do
     let(:billing_mode) { "Skip Review" }
 
     context "valid account" do
-      it "is reconciled when complete" do
+      it "automatically moves an order detail from complete to reconciled" do
         order._validate_order!
         order.purchase!
         visit manage_facility_order_order_detail_path(facility, order, order_detail)

--- a/spec/system/admin/billing_mode_workflow_spec.rb
+++ b/spec/system/admin/billing_mode_workflow_spec.rb
@@ -22,13 +22,17 @@ RSpec.describe "Billing mode workflows" do
     let(:billing_mode) { "Skip Review" }
 
     context "valid account" do
-      it "automatically moves an order detail from complete to reconciled" do
+      it "automatically moves an order detail from complete to reconciled", :js do
         order._validate_order!
         order.purchase!
         visit manage_facility_order_order_detail_path(facility, order, order_detail)
 
         select "Complete", from: "Order Status"
+
         click_button "Save"
+        visit facility_transactions_path(facility)
+
+        expect(page).to have_selector("tr td.nowrap", text: "Reconciled")
         expect(order_detail.reload.reconciled?).to be true
       end
     end

--- a/spec/system/admin/billing_mode_workflow_spec.rb
+++ b/spec/system/admin/billing_mode_workflow_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Billing mode workflows" do
   describe "'Skip Review' billing mdoe" do
     let(:billing_mode) { "Skip Review" }
 
-    context "valid account" do
+    context "with a valid account" do
       let(:logged_in_user) { director }
 
       it "automatically moves an order detail from complete to reconciled", :js do
@@ -79,11 +79,11 @@ RSpec.describe "Billing mode workflows" do
       end
     end
 
-    context "invalid account" do
+    context "with an invalid account" do
       let(:accepts_po) { false }
       let(:logged_in_user) { user }
 
-      it "should not have a valid cart" do
+      it "does not allow the product to be ordered" do
         visit facility_item_path(facility, item)
         expect(page).to have_content("Sorry, but we could not find a valid payment source that you can use to purchase this item")
       end

--- a/spec/system/admin/billing_mode_workflow_spec.rb
+++ b/spec/system/admin/billing_mode_workflow_spec.rb
@@ -8,23 +8,15 @@ RSpec.describe "Billing mode workflows" do
   let(:billing_mode) { "Default" }
   let(:item) { create(:setup_item, facility:, billing_mode:) }
   let(:order) { create(:setup_order, product: item) }
+  let(:order_detail) { order.order_details.first }
   let(:nufs_account) { order.account }
   let(:account) { nufs_account }
-  let(:administrator) { create(:user, :administrator) }
-  let(:director) { create(:user, :facility_director, facility:) }
-  let(:logged_in_user) { director }
+  let(:logged_in_user) { create(:user, :facility_director, facility:) }
 
   let(:po_account) do
     po = create(:purchase_order_account, account_users: nufs_account.account_users)
     create(:account_price_group_member, account: po, price_group: item.price_groups.last)
     po
-  end
-
-  let(:order_detail) do
-    od = order.order_details.first
-    od.account_id = order.account_id
-    od.save
-    od
   end
 
   before do

--- a/spec/system/admin/billing_mode_workflow_spec.rb
+++ b/spec/system/admin/billing_mode_workflow_spec.rb
@@ -7,21 +7,12 @@ RSpec.describe "Billing mode workflows" do
   let(:accepts_po) { true }
   let(:billing_mode) { "Default" }
   let(:item) { create(:setup_item, facility:, billing_mode:) }
-  let(:order) { create(:setup_order, product: item) }
+  let(:order) { create(:setup_order, product: item, account: create(:purchase_order_account, :with_account_owner)) }
   let(:order_detail) { order.order_details.first }
   let(:nufs_account) { order.account }
-  let(:account) { nufs_account }
   let(:logged_in_user) { create(:user, :facility_director, facility:) }
 
-  let(:po_account) do
-    po = create(:purchase_order_account, account_users: nufs_account.account_users)
-    create(:account_price_group_member, account: po, price_group: item.price_groups.last)
-    po
-  end
-
   before do
-    order.account = account
-    order_detail.account_id = order.account_id # needed for cart validation
     login_as logged_in_user
   end
 
@@ -44,7 +35,6 @@ RSpec.describe "Billing mode workflows" do
 
     context "invalid account" do
       let(:accepts_po) { false }
-      let(:account) { po_account }
 
       it "should not have a valid cart" do
         expect(order.cart_valid?).to be false

--- a/spec/system/admin/billing_mode_workflow_spec.rb
+++ b/spec/system/admin/billing_mode_workflow_spec.rb
@@ -17,8 +17,6 @@ RSpec.describe "Billing mode workflows" do
     login_as logged_in_user
   end
 
-  describe "'Default' billing mode"
-
   describe "'Skip Review' billing mdoe" do
     let(:billing_mode) { "Skip Review" }
 

--- a/spec/system/admin/billing_mode_workflow_spec.rb
+++ b/spec/system/admin/billing_mode_workflow_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Billing mode workflows" do
+  let(:facility) { create(:setup_facility) }
+  let(:billing_mode) { "Default" }
+  let!(:account) { create(:setup_account, :with_account_owner, facility: order_detail.facility, owner: order_detail.user) }
+  let(:instrument) { create(:setup_instrument, facility:, billing_mode:) }
+  let(:item) { create(:setup_item, facility:, billing_mode:) }
+  let(:now) { Time.now }
+  let(:reservation) { create(:purchased_reservation, product: instrument, reserve_start_at: 1.hour.ago, reserve_end_at: now, actual_start_at: 1.hour.ago, actual_end_at: now) }
+  # let(:order_detail) { reservation.order_detail }
+  let(:order) { create(:setup_order, product: item) }
+  let(:order_detail) { order.order_details.first }
+  let(:administrator) { create(:user, :administrator) }
+  let(:director) { create(:user, :facility_director, facility:) }
+  let(:logged_in_user) { director }
+
+  before do
+    order._validate_order!
+    order.purchase!
+    login_as logged_in_user
+    visit manage_facility_order_order_detail_path(facility, order, order_detail)
+  end
+
+  context "'Default' billing mode"
+
+  context "'Skip Review' billing mdoe" do
+    let(:billing_mode) { "Skip Review" }
+
+    it "is reconciled when complete" do
+      select "Complete", from: "Order Status"
+      click_button "Save"
+      expect(order_detail.reload.reconciled?).to be true
+    end
+  end
+
+  context "'Nonbillable' billing mode"
+end

--- a/spec/system/admin/billing_mode_workflow_spec.rb
+++ b/spec/system/admin/billing_mode_workflow_spec.rb
@@ -3,38 +3,62 @@
 require "rails_helper"
 
 RSpec.describe "Billing mode workflows" do
-  let(:facility) { create(:setup_facility) }
+  let(:facility) { create(:setup_facility, accepts_po:) }
+  let(:accepts_po) { true }
   let(:billing_mode) { "Default" }
-  let!(:account) { create(:setup_account, :with_account_owner, facility: order_detail.facility, owner: order_detail.user) }
-  let(:instrument) { create(:setup_instrument, facility:, billing_mode:) }
   let(:item) { create(:setup_item, facility:, billing_mode:) }
-  let(:now) { Time.now }
-  let(:reservation) { create(:purchased_reservation, product: instrument, reserve_start_at: 1.hour.ago, reserve_end_at: now, actual_start_at: 1.hour.ago, actual_end_at: now) }
-  # let(:order_detail) { reservation.order_detail }
   let(:order) { create(:setup_order, product: item) }
-  let(:order_detail) { order.order_details.first }
+  let(:nufs_account) { order.account }
+  let(:account) { nufs_account }
   let(:administrator) { create(:user, :administrator) }
   let(:director) { create(:user, :facility_director, facility:) }
   let(:logged_in_user) { director }
 
-  before do
-    order._validate_order!
-    order.purchase!
-    login_as logged_in_user
-    visit manage_facility_order_order_detail_path(facility, order, order_detail)
+  let(:po_account) do
+    po = create(:purchase_order_account, account_users: nufs_account.account_users)
+    create(:account_price_group_member, account: po, price_group: item.price_groups.last)
+    po
   end
 
-  context "'Default' billing mode"
+  let(:order_detail) do
+    od = order.order_details.first
+    od.account_id = order.account_id
+    od.save
+    od
+  end
 
-  context "'Skip Review' billing mdoe" do
+  before do
+    order.account = account
+    order_detail.account_id = order.account_id # needed for cart validation
+    login_as logged_in_user
+  end
+
+  describe "'Default' billing mode"
+
+  describe "'Skip Review' billing mdoe" do
     let(:billing_mode) { "Skip Review" }
 
-    it "is reconciled when complete" do
-      select "Complete", from: "Order Status"
-      click_button "Save"
-      expect(order_detail.reload.reconciled?).to be true
+    context "valid account" do
+      it "is reconciled when complete" do
+        order._validate_order!
+        order.purchase!
+        visit manage_facility_order_order_detail_path(facility, order, order_detail)
+
+        select "Complete", from: "Order Status"
+        click_button "Save"
+        expect(order_detail.reload.reconciled?).to be true
+      end
+    end
+
+    context "invalid account" do
+      let(:accepts_po) { false }
+      let(:account) { po_account }
+
+      it "should not have a valid cart" do
+        expect(order.cart_valid?).to be false
+      end
     end
   end
 
-  context "'Nonbillable' billing mode"
+  describe "'Nonbillable' billing mode"
 end


### PR DESCRIPTION
# Release Notes

This implements the "Skip Review" billing mode, which will reconcile an order detail whenever it goes into the "complete" state, rather than going through the billing workflow. This is done for order details of products that are in the "Skip Review" billing mode.