### PR TITLE
[ #161840] Adds Global column to price group table

### DIFF
--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -49,10 +49,6 @@ class PriceGroup < ApplicationRecord
     facility.nil?
   end
 
-  def price_group_scope
-    global? ? "Global" : "Local"
-  end
-
   def can_manage_price_group_members?
     is_not_global? || SettingsHelper.feature_on?(:can_manage_global_price_groups)
   end

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -49,6 +49,10 @@ class PriceGroup < ApplicationRecord
     facility.nil?
   end
 
+  def price_group_scope
+    global? ? "Global" : "Local"
+  end
+
   def can_manage_price_group_members?
     is_not_global? || SettingsHelper.feature_on?(:can_manage_global_price_groups)
   end

--- a/app/views/price_groups/index.html.haml
+++ b/app/views/price_groups/index.html.haml
@@ -20,7 +20,7 @@
         %th
         %th= t(".th.pg")
         %th= t(".th.type")
-        %th= t(".th.scope")
+        %th= t(".th.global")
         %th= t(".th.users")
         %th= t(".th.accounts")
     %tbody
@@ -38,7 +38,7 @@
               facility_price_group_path(current_facility, price_group)
 
           %td= price_group.type_string
-          %td= price_group.price_group_scope
+          %td= t(".#{price_group.global?.to_s}")
           - if price_group.admin_editable?
             %td= price_group.user_price_group_members.count
           - else

--- a/app/views/price_groups/index.html.haml
+++ b/app/views/price_groups/index.html.haml
@@ -20,6 +20,7 @@
         %th
         %th= t(".th.pg")
         %th= t(".th.type")
+        %th= t(".th.scope")
         %th= t(".th.users")
         %th= t(".th.accounts")
     %tbody
@@ -37,6 +38,7 @@
               facility_price_group_path(current_facility, price_group)
 
           %td= price_group.type_string
+          %td= price_group.price_group_scope
           - if price_group.admin_editable?
             %td= price_group.user_price_group_members.count
           - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -936,10 +936,12 @@ en:
       link:
         add: "Add Price Group"
       notice: "No price groups exist yet."
+      true: "Yes"
+      false: "No"
       th:
         pg: "Price Group"
         type: "Type"
-        scope: "Scope"
+        global: "Global"
         users: "Number of Users"
         accounts: "Number of Payment Sources"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -939,6 +939,7 @@ en:
       th:
         pg: "Price Group"
         type: "Type"
+        scope: "Scope"
         users: "Number of Users"
         accounts: "Number of Payment Sources"
 


### PR DESCRIPTION
# Release Notes

This adds a "Global" column to the facility price group table, to indicate if a price group is global or local.

# Screenshot

![Screen Shot 2023-08-10 at 3 41 36 PM](https://github.com/tablexi/nucore-open/assets/624487/a1d3f1a2-0d76-408c-8b61-3ace26b8c2f4)