### PR TITLE
[#161905] Invalid image format uploads

### DIFF
--- a/app/models/concerns/downloadable_files/image.rb
+++ b/app/models/concerns/downloadable_files/image.rb
@@ -16,7 +16,7 @@ module DownloadableFiles
       before_validation { delete_file if remove_file }
 
       if SettingsHelper.feature_on?(:active_storage_for_images_only)
-        validates :file, content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"]
+        validates :file, content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"], processable_image: true
       else
         validates_attachment :file, content_type: { content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"] }
       end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -30,7 +30,7 @@ en:
         schedule: You may share a schedule with other products. Choose an existing schedule or use an unshared schedule.
         control_mechanism: Time management options for the Instrument. 'Reservation' tracks reserved time only. Both 'Timer' settings track actual usage time.
         problems_resolvable_by_user: Allow users to update their usage time if they forget to sign out
-      image_dimensions: Image will be resized to 400x200
+      image_dimensions: Image will be resized to 400x200. Valid formats include JPG, JPEG, PNG, & GIF
     # Labels and hints examples
     # labels:
     #   defaults:


### PR DESCRIPTION
# Release Notes

It was possible to upload an unprocessable image format (e.g. JFIJ) without getting any sort of error in the UI.

This adds `processable_image` to the validation, which will provide an error in the UI, and it lists the valid image formats

# Screenshot

![Screen Shot 2023-08-11 at 5 39 51 PM](https://github.com/tablexi/nucore-open/assets/624487/e23ab930-aeeb-4226-9db6-ab70a519b52b)
