### PR TITLE
[#161859] Create non-billable account type

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -185,7 +185,7 @@ class OrdersController < ApplicationController
 
     redirect_to(cart_path) && return unless @product
 
-    add_account_to_order(NonbillableAccount.account) if @product.nonbillable?
+    add_account_to_order(NonbillableAccount.singleton_instance) if @product.nonbillable_mode?
 
     @accounts = AvailableAccountsFinder.new(acting_user, @product.facility).accounts
     @errors   = {}

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -185,10 +185,7 @@ class OrdersController < ApplicationController
 
     redirect_to(cart_path) && return unless @product
 
-    if @product.nonbillable?
-      account = NonbillableAccount.account
-      add_account_to_order(account)
-    end
+    add_account_to_order(NonbillableAccount.account) if @product.nonbillable?
 
     @accounts = AvailableAccountsFinder.new(acting_user, @product.facility).accounts
     @errors   = {}

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -116,7 +116,7 @@ class OrdersController < ApplicationController
         rescue NUCore::MixedFacilityCart
           @order.errors.add(:base, "You can not add a product from another facility; please clear your cart or place a separate order.")
         rescue NUCore::MixedBillingMode
-          @order.errors.add(:base, "You can mix billing modes with a non-billable product")
+          @order.errors.add(:base, "You can not mix billing modes with a non-billable product")
         rescue => e
           if !@order.has_valid_payment?
             @order.errors.add(:base, invalid_for_orderer_message)

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -116,7 +116,15 @@ class OrdersController < ApplicationController
         rescue NUCore::MixedFacilityCart
           @order.errors.add(:base, "You can not add a product from another facility; please clear your cart or place a separate order.")
         rescue NUCore::MixedBillingMode
-          @order.errors.add(:base, "You can not mix billing modes with a non-billable product")
+          email = @order.facility.email
+
+          msg = if email
+                  "Mixing billing modes not allowed; please contact the facility administrator <#{email}> for assistance"
+                else
+                  "Mixing billing modes not allowed; please contact the facility administrator for assistance"
+                end
+
+          @order.errors.add(:base, msg)
         rescue => e
           if !@order.has_valid_payment?
             @order.errors.add(:base, invalid_for_orderer_message)

--- a/app/lib/nucore.rb
+++ b/app/lib/nucore.rb
@@ -11,6 +11,9 @@ module NUCore
   class MixedFacilityCart < NUCore::Error
   end
 
+  class MixedBillingMode < NUCore::Error
+  end
+
   class NotPermittedWhileActingAs < NUCore::Error
   end
 

--- a/app/models/nonbillable_account.rb
+++ b/app/models/nonbillable_account.rb
@@ -5,15 +5,15 @@ class NonbillableAccount < Account
 
   # Since this account can be used by anyone, we only need one in the system
   # so this class method should be used to access it.
-  def self.account
-    @account ||= first || create
+  def self.singleton_instance
+    @singleton_instance ||= first || create
   end
 
-  def account_open?(_)
+  def account_open?(_account_number)
     true
   end
 
-  def can_be_used_by?(_)
+  def can_be_used_by?(_user)
     true
   end
 

--- a/app/models/nonbillable_account.rb
+++ b/app/models/nonbillable_account.rb
@@ -3,8 +3,10 @@
 class NonbillableAccount < Account
   before_validation :set_owner, :set_description, :set_created_by, :set_account_number, :set_expries_at
 
+  # Since this account can be used by anyone, we only need one in the system
+  # so this class method should be used to access it.
   def self.account
-    first
+    @account ||= first || create
   end
 
   def account_open?(_)

--- a/app/models/nonbillable_account.rb
+++ b/app/models/nonbillable_account.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class NonbillableAccount < Account
+  before_validation :set_owner, :set_description, :set_created_by, :set_account_number, :set_expries_at
+
+  def account_open?(_)
+    true
+  end
+
+  private
+
+  def set_account_number
+    return if account_number
+    self.account_number = "non-billable-account"
+  end
+
+  def set_description
+    return if description
+    self.description = "Nonbillable Account"
+  end
+
+  def set_expries_at
+    return if expires_at
+    self.expires_at = 75.years.from_now
+  end
+
+  def set_created_by
+    reutnr if created_by
+    self.created_by = User.nonbillable_account_owner.id
+  end
+
+  def set_owner
+    return if owner
+
+    account_users << AccountUser.new(
+      user_role: AccountUser::ACCOUNT_OWNER,
+      user: User.nonbillable_account_owner,
+      created_by_user: User.nonbillable_account_owner,
+    )
+  end
+end

--- a/app/models/nonbillable_account.rb
+++ b/app/models/nonbillable_account.rb
@@ -6,7 +6,7 @@ class NonbillableAccount < Account
   # Since this account can be used by anyone, we only need one in the system
   # so this class method should be used to access it.
   def self.singleton_instance
-    @singleton_instance ||= first || create
+    first || create
   end
 
   def account_open?(_account_number)

--- a/app/models/nonbillable_account.rb
+++ b/app/models/nonbillable_account.rb
@@ -17,6 +17,14 @@ class NonbillableAccount < Account
     true
   end
 
+  # with_facility is only used in PurchaseOrderAccount#to_s
+  def to_s(with_owner = false, flag_suspended = true, with_facility: false)
+    desc = description
+    desc += " / #{owner_user_name}" if with_owner && owner_user.present?
+    desc += " (#{display_status.upcase})" if flag_suspended && suspended?
+    desc
+  end
+
   private
 
   def set_account_number

--- a/app/models/nonbillable_account.rb
+++ b/app/models/nonbillable_account.rb
@@ -3,7 +3,15 @@
 class NonbillableAccount < Account
   before_validation :set_owner, :set_description, :set_created_by, :set_account_number, :set_expries_at
 
+  def self.account
+    first
+  end
+
   def account_open?(_)
+    true
+  end
+
+  def can_be_used_by?(_)
     true
   end
 
@@ -25,7 +33,7 @@ class NonbillableAccount < Account
   end
 
   def set_created_by
-    reutnr if created_by
+    return if created_by
     self.created_by = User.nonbillable_account_owner.id
   end
 

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -521,7 +521,7 @@ class OrderDetail < ApplicationRecord
     return unless order && account_id
     return if product.nonbillable? && account.is_a?(NonbillableAccount)
 
-    errors.add("account_id", "is not valid for the orderer") unless AccountUser.find_by(user_id: order.user_id, account_id: account_id, deleted_at: nil) #
+    errors.add("account_id", "is not valid for the orderer") unless AccountUser.find_by(user_id: order.user_id, account_id: account_id, deleted_at: nil)
   end
 
   def customer_account_changeable?

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -519,7 +519,7 @@ class OrderDetail < ApplicationRecord
 
   def account_usable_by_order_owner?
     return unless order && account_id
-    return if product.nonbillable? && account.is_a?(NonbillableAccount)
+    return if product.nonbillable_mode? && account.is_a?(NonbillableAccount)
 
     errors.add("account_id", "is not valid for the orderer") unless AccountUser.find_by(user_id: order.user_id, account_id: account_id, deleted_at: nil)
   end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -392,7 +392,7 @@ class OrderDetail < ApplicationRecord
   def skip_review?
     actual_total &&
       complete? &&
-      product.billing_mode == "Skip Review"
+      product.skip_order_review?
   end
 
   # block will be called after the transition, but before the save

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -519,7 +519,9 @@ class OrderDetail < ApplicationRecord
 
   def account_usable_by_order_owner?
     return unless order && account_id
-    errors.add("account_id", "is not valid for the orderer") unless AccountUser.find_by(user_id: order.user_id, account_id: account_id, deleted_at: nil)
+    return if product.nonbillable? && account.is_a?(NonbillableAccount)
+
+    errors.add("account_id", "is not valid for the orderer") unless AccountUser.find_by(user_id: order.user_id, account_id: account_id, deleted_at: nil) #
   end
 
   def customer_account_changeable?

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -118,6 +118,10 @@ class Product < ApplicationRecord
     order(:type, :name).group_by { |product| product.class.model_name.human }
   end
 
+  def nonbillable?
+    billing_mode == "Nonbillable"
+  end
+
   def initial_order_status
     self[:initial_order_status_id] ? OrderStatus.find(self[:initial_order_status_id]) : OrderStatus.default_order_status
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -118,6 +118,10 @@ class Product < ApplicationRecord
     order(:type, :name).group_by { |product| product.class.model_name.human }
   end
 
+  def skip_order_review?
+    nonbillable_mode? || skip_review_mode?
+  end
+
   def nonbillable_mode?
     billing_mode == "Nonbillable"
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -118,8 +118,16 @@ class Product < ApplicationRecord
     order(:type, :name).group_by { |product| product.class.model_name.human }
   end
 
-  def nonbillable?
+  def nonbillable_mode?
     billing_mode == "Nonbillable"
+  end
+
+  def skip_review_mode?
+    billing_mode == "Skip Review"
+  end
+
+  def default_mode?
+    billing_mode == "Default"
   end
 
   def initial_order_status

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,6 +56,15 @@ class User < ApplicationRecord
   scope :with_recent_orders, ->(facility) { distinct.joins(:order_details).merge(OrderDetail.recent.for_facility(facility)) }
   scope :sort_last_first, -> { order(Arel.sql("LOWER(users.last_name), LOWER(users.first_name)")) }
 
+  def self.nonbillable_account_owner
+    find_or_create_by!(
+      username: "nonbillableuser",
+      first_name: "Nonbillable",
+      last_name: "User",
+      email: "nonbillableuser@example.com",
+    )
+  end
+
   # This method is only used by devise-security to determine
   # whether or not password validations should run.
   # A better name would be password_validations_required?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -167,6 +167,7 @@ class User < ApplicationRecord
   # purchasing that product
   def accounts_for_product(product)
     return [NonbillableAccount.singleton_instance] if product.nonbillable_mode?
+
     acts = accounts.active.for_facility(product.facility).to_a
     acts.reject! { |acct| !acct.validate_against_product(product, self).nil? }
     acts

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,10 +58,10 @@ class User < ApplicationRecord
 
   def self.nonbillable_account_owner
     find_or_create_by!(
-      username: "nonbillableuser",
+      username: "None (Nonbillable)",
       first_name: "Nonbillable",
       last_name: "User",
-      email: "nonbillableuser@example.com",
+      email: (Settings.support_email || Settings.email.from),
     )
   end
 
@@ -166,6 +166,7 @@ class User < ApplicationRecord
   # Given a +Product+ returns all valid accounts this user has for
   # purchasing that product
   def accounts_for_product(product)
+    return [NonbillableAccount.singleton_instance] if product.nonbillable_mode?
     acts = accounts.active.for_facility(product.facility).to_a
     acts.reject! { |acct| !acct.validate_against_product(product, self).nil? }
     acts

--- a/lib/tasks/demo_seed.rake
+++ b/lib/tasks/demo_seed.rake
@@ -98,6 +98,19 @@ namespace :demo do
       example_item.billing_mode = "Skip Review"
     end
 
+    nonbillable_item = Item.find_or_create_by!(url_name: "nonbillable-example-item") do |example_item|
+      example_item.facility_id = facility.id
+      example_item.account = Settings.accounts.product_default
+      example_item.name = "Nonbillable Example Item"
+      example_item.description = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus non ipsum id odio cursus euismod eu bibendum nisl. Sed nec.</p>"
+      example_item.requires_approval = false
+      example_item.initial_order_status_id = new_status.id
+      example_item.is_archived = false
+      example_item.is_hidden = false
+      example_item.facility_account_id = fa.id
+      example_item.billing_mode = "Nonbillable"
+    end
+
     service = Service.find_or_create_by!(url_name: "example-service") do |example_service|
       example_service.facility_id = facility.id
       example_service.account = Settings.accounts.product_default
@@ -121,6 +134,19 @@ namespace :demo do
       example_service.is_hidden = false
       example_service.facility_account_id = fa.id
       example_service.billing_mode = "Skip Review"
+    end
+
+    nonbillable_review_service = Service.find_or_create_by!(url_name: "nonbillable-review-example-service") do |example_service|
+      example_service.facility_id = facility.id
+      example_service.account = Settings.accounts.product_default
+      example_service.name = "Nonbillable Example Service"
+      example_service.description = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus non ipsum id odio cursus euismod eu bibendum nisl. Sed nec.</p>"
+      example_service.requires_approval = false
+      example_service.initial_order_status_id = in_process.id
+      example_service.is_archived = false
+      example_service.is_hidden = false
+      example_service.facility_account_id = fa.id
+      example_service.billing_mode = "Nonbillable"
     end
 
     instrument = Instrument.find_or_create_by!(url_name: "example-instrument") do |example_instrument|
@@ -148,6 +174,20 @@ namespace :demo do
       example_instrument.facility_account_id = fa.id
       example_instrument.reserve_interval = 5
       example_instrument.billing_mode = "Skip Review"
+    end
+
+    nonbillable_review_instrument = Instrument.find_or_create_by!(url_name: "nonbillable-example-instrument") do |example_instrument|
+      example_instrument.facility_id = facility.id
+      example_instrument.account = Settings.accounts.product_default
+      example_instrument.name = "Nonbillable Example Instrument"
+      example_instrument.description = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus non ipsum id odio cursus euismod eu bibendum nisl. Sed nec.</p>"
+      example_instrument.initial_order_status_id = new_status.id
+      example_instrument.requires_approval = false
+      example_instrument.is_archived = false
+      example_instrument.is_hidden = false
+      example_instrument.facility_account_id = fa.id
+      example_instrument.reserve_interval = 5
+      example_instrument.billing_mode = "Nonbillable"
     end
 
     RelaySynaccessRevB.find_or_create_by!(instrument_id: instrument.id) do |relay_instrument|

--- a/lib/tasks/demo_seed.rake
+++ b/lib/tasks/demo_seed.rake
@@ -113,7 +113,7 @@ namespace :demo do
     skip_review_service = Service.find_or_create_by!(url_name: "skip-review-example-service") do |example_service|
       example_service.facility_id = facility.id
       example_service.account = Settings.accounts.product_default
-      example_service.name = "Example Service"
+      example_service.name = "Skip Example Service"
       example_service.description = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus non ipsum id odio cursus euismod eu bibendum nisl. Sed nec.</p>"
       example_service.requires_approval = false
       example_service.initial_order_status_id = in_process.id

--- a/spec/system/admin/billing_mode_workflow_spec.rb
+++ b/spec/system/admin/billing_mode_workflow_spec.rb
@@ -88,5 +88,21 @@ RSpec.describe "Billing mode workflows" do
     end
   end
 
-  describe "'Nonbillable' billing mode"
+  describe "'Nonbillable' billing mode" do
+    let(:billing_mode) { "Nonbillable" }
+    let(:logged_in_user) { director }
+
+    it "automatically moves an order detail from complete to reconciled", :js do
+      order._validate_order!
+      order.purchase!
+      visit manage_facility_order_order_detail_path(facility, order, order_detail)
+
+      select "Complete", from: "Order Status"
+
+      click_button "Save"
+      visit facility_transactions_path(facility)
+
+      expect(page).to have_selector("tr td.nowrap", text: "Reconciled")
+    end
+  end
 end

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -16,6 +16,26 @@ RSpec.describe "Adding products with different billing modes to cart" do
     login_as user
   end
 
+  context "when a user has no account" do
+    let(:user) do
+      u = account.owner.user
+      u.account_users.each { |au| au.destroy }
+      u.save
+      u.reload
+    end
+
+    it "allows a user without any accounts to add a nonbillable product to cart" do
+      visit facility_item_path(facility, nonbillable_item)
+      click_on "Add to cart"
+      expect(page).to have_content(nonbillable_item.name)
+    end
+
+    it "does not allow a user without any accounts to add a default product to cart" do
+      visit facility_item_path(facility, default_item)
+      expect(page).to have_content("Sorry, but we could not find a valid payment source that you can use to purchase this item")
+    end
+  end
+
   context "when a nonbillable product is added first" do
     before do
       visit facility_item_path(facility, nonbillable_item)

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -16,28 +16,43 @@ RSpec.describe "Adding products with different billing modes to cart" do
     login_as user
   end
 
-  context "when nonbillable product is added first" do
+  context "when a nonbillable product is added first" do
     before do
       visit facility_item_path(facility, nonbillable_item)
       click_on "Add to cart"
     end
 
-    it "allows user to add another nonbillable product" do
+    it "allows a user to add another nonbillable product" do
       visit facility_item_path(facility, nonbillable_item)
       click_on "Add to cart"
-      # save_and_open_page
-      # binding.pry
       expect(page).to have_content(nonbillable_item.name).twice
     end
 
-    it "does not allow user to add a default billing mode product" do
+    it "does not allow a user to add a default billing mode product" do
       visit facility_item_path(facility, default_item)
       click_on "Add to cart"
-      # save_and_open_page
       expect(page).to have_content("You can not mix billing modes with a non-billable product")
     end
   end
 
-  context "when default product is added first" do
+  context "when a default product is added first" do
+    before do
+      visit facility_item_path(facility, default_item)
+      click_on "Add to cart"
+      choose account.description
+      click_on "Continue"
+    end
+
+    it "allows a user to add another default product" do
+      visit facility_item_path(facility, default_item)
+      click_on "Add to cart"
+      expect(page).to have_content(default_item.name).twice
+    end
+
+    it "does not allow a user to add another nonbillable product" do
+      visit facility_item_path(facility, nonbillable_item)
+      click_on "Add to cart"
+      expect(page).to have_content("There were errors adding to your cart")
+    end
   end
 end

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Adding products with different billing modes to cart" do
     it "does not allow a user to add a default billing mode product" do
       visit facility_item_path(facility, default_item)
       click_on "Add to cart"
-      expect(page).to have_content("You can not mix billing modes with a non-billable product")
+      expect(page).to have_content("Mixing billing modes not allowed; please contact the facility administrator for assistance")
     end
   end
 
@@ -52,7 +52,7 @@ RSpec.describe "Adding products with different billing modes to cart" do
     it "does not allow a user to add another nonbillable product" do
       visit facility_item_path(facility, nonbillable_item)
       click_on "Add to cart"
-      expect(page).to have_content("There were errors adding to your cart")
+      expect(page).to have_content("Mixing billing modes not allowed; please contact the facility administrator for assistance")
     end
   end
 end

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Adding products with different billing modes to cart" do
     it "does not allow a user to add a default billing mode product" do
       visit facility_item_path(facility, default_item)
       click_on "Add to cart"
-      expect(page).to have_content("Mixing billing modes not allowed; please contact the facility administrator for assistance")
+      expect(page).to have_content("#{default_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
     end
   end
 
@@ -72,7 +72,7 @@ RSpec.describe "Adding products with different billing modes to cart" do
     it "does not allow a user to add another nonbillable product" do
       visit facility_item_path(facility, nonbillable_item)
       click_on "Add to cart"
-      expect(page).to have_content("Mixing billing modes not allowed; please contact the facility administrator for assistance")
+      expect(page).to have_content("#{nonbillable_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
     end
   end
 end


### PR DESCRIPTION
# Release Notes

This creates a Nonbillable account type, which allows users to not use an account when purchases nonbillable products