### PR TITLE
[#161924] Journal 90 day popup bug

### DIFF
--- a/app/assets/javascripts/facility_journal.js
+++ b/app/assets/javascripts/facility_journal.js
@@ -1,9 +1,11 @@
 document.addEventListener("DOMContentLoaded", function() {
+  const selectAllLink = document.querySelector(".js--select_all");
   const table = document.querySelector("table.js--transactions-table");
   const submitDiv = document.querySelector(".submit");
   let earliestFulfilledAtDate;
-  
+
   table.addEventListener("click", setEarliestFulfilledAtDate);
+  selectAllLink.addEventListener("click", setEarliestFulfilledAtDate);
   submitDiv.addEventListener("click", handleModals);
   
   function setEarliestFulfilledAtDate(event) {
@@ -26,6 +28,7 @@ document.addEventListener("DOMContentLoaded", function() {
   
     const dateDiff = moment(journalDate).diff(earliestFulfilledAtDate, "days");
     const atLeastOneRowChecked = typeof(earliestFulfilledAtDate) === "object" && earliestFulfilledAtDate !== null
+
     if (atLeastOneRowChecked && dateDiff >= 90) {
       event.preventDefault();
       $("#journal-date-popup").modal("show");

--- a/spec/system/creating_a_journal_spec.rb
+++ b/spec/system/creating_a_journal_spec.rb
@@ -78,7 +78,15 @@ RSpec.describe "Creating a journal" do
           visit new_facility_journal_path(facility)
         end
 
-        it "has a 90 day pop up" do
+        it "has a 90 day pop up when 'Select All' is clicked" do
+          click_on "Select All"
+          click_button "Create"
+          expect(page).to have_content "90-Day Justification"
+          click_button "OK"
+          expect(page).to have_content "The journal file has been created successfully", wait: 3
+        end
+
+        it "has a 90 day pop up when the check box is clicked" do
           check "order_detail_ids_"
           click_button "Create"
           expect(page).to have_content "90-Day Justification"

--- a/spec/system/creating_a_journal_spec.rb
+++ b/spec/system/creating_a_journal_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Creating a journal" do
           expect(page).to have_content "The journal file has been created successfully", wait: 3
         end
 
-        it "has a 90 day pop up when the check box is clicked" do
+        it "has a 90 day pop up when the check box is checked" do
           check "order_detail_ids_"
           click_button "Create"
           expect(page).to have_content "90-Day Justification"


### PR DESCRIPTION
# Release Notes

The "Select All" link does not have an event listener on it. So when transactions are selected using that link, the  Journal 90 day popup is not setup correctly.

This adds a listener to the "Select All" link