### PR TITLE
[#161859] Adds feature flagged specs for cart billing mode

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -4,6 +4,9 @@ class Account < ApplicationRecord
 
   module Overridable
 
+    # Consider creating a default price gorup, when `user_based_price_groups` is
+    # set to `false`. Currently Dartmouth is the only school with this feature 
+    # flag set to false, and they do this in their account_extension.rb
     def price_groups
       (price_group_members.collect(&:price_group) + (owner_user ? owner_user.price_groups : [])).uniq
     end

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -8,71 +8,144 @@ RSpec.describe "Adding products with different billing modes to cart" do
   let!(:nonbillable_item) { create(:setup_item, facility:, billing_mode: "Nonbillable") }
   let!(:default_item) { create(:setup_item, facility:, billing_mode: "Default") }
   let!(:account) { create(:purchase_order_account, :with_account_owner, facility:) }
+  let!(:account_price_group_member) { create(:account_price_group_member, account: account, price_group: PriceGroup.globals.first) }
+  let!(:account_price_group_member_2) { create(:account_price_group_member, account: account, price_group: PriceGroup.globals.second) }
+
   let!(:nonbillable_price_policy) { create(:item_price_policy, price_group: PriceGroup.globals.first, product: nonbillable_item) }
+  let!(:nonbillable_price_policy_2) { create(:item_price_policy, price_group: PriceGroup.globals.second, product: nonbillable_item) }
+
   let!(:default_price_policy) { create(:item_price_policy, price_group: PriceGroup.globals.first, product: default_item) }
+  let!(:default_price_policy_2) { create(:item_price_policy, price_group: PriceGroup.globals.second, product: default_item) }
+
   let(:user) { account.owner.user }
 
   before do
     login_as user
   end
 
-  context "when a user has no account" do
-    let(:user) do
-      u = account.owner.user
-      u.account_users.each { |au| au.destroy }
-      u.save
-      u.reload
+  context "with user-based price groups disabled", feature_setting: { user_based_price_groups: false } do
+    # These specs currently fail, but should behave differently once price groups
+    # are automatically handled with Nonbillable products
+    context "when a user has no price groups (or no account with price groups)" do
+      let(:user) do
+        u = account.owner.user
+        u.account_users.each(&:destroy)
+        u.save
+        u.reload
+      end
+
+      xit "allows a user without any accounts to add a nonbillable product to cart" do
+        visit facility_item_path(facility, nonbillable_item)
+        click_on "Add to cart"
+        expect(page).to have_content(nonbillable_item.name)
+      end
+
+      xit "does not allow a user without any accounts to add a default product to cart" do
+        visit facility_item_path(facility, default_item)
+        expect(page).to have_content("Sorry, but we could not find a valid payment source that you can use to purchase this item")
+      end
     end
 
-    it "allows a user without any accounts to add a nonbillable product to cart" do
-      visit facility_item_path(facility, nonbillable_item)
-      click_on "Add to cart"
-      expect(page).to have_content(nonbillable_item.name)
+    context "when a nonbillable product is added first" do
+      before do
+        visit facility_item_path(facility, nonbillable_item)
+        click_on "Add to cart"
+      end
+
+      it "allows a user to add another nonbillable product" do
+        visit facility_item_path(facility, nonbillable_item)
+        click_on "Add to cart"
+        expect(page).to have_content(nonbillable_item.name).twice
+      end
+
+      it "does not allow a user to add a default billing mode product" do
+        visit facility_item_path(facility, default_item)
+        click_on "Add to cart"
+        expect(page).to have_content("#{default_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
+      end
     end
 
-    it "does not allow a user without any accounts to add a default product to cart" do
-      visit facility_item_path(facility, default_item)
-      expect(page).to have_content("Sorry, but we could not find a valid payment source that you can use to purchase this item")
+    context "when a default product is added first" do
+      before do
+        visit facility_item_path(facility, default_item)
+        click_on "Add to cart"
+        choose account.description
+        click_on "Continue"
+      end
+
+      it "allows a user to add another default product" do
+        visit facility_item_path(facility, default_item)
+        click_on "Add to cart"
+        expect(page).to have_content(default_item.name).twice
+      end
+
+      it "does not allow a user to add another nonbillable product" do
+        visit facility_item_path(facility, nonbillable_item)
+        click_on "Add to cart"
+        expect(page).to have_content("#{nonbillable_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
+      end
     end
   end
 
-  context "when a nonbillable product is added first" do
-    before do
-      visit facility_item_path(facility, nonbillable_item)
-      click_on "Add to cart"
+  context "with user-based price groups enabled", feature_setting: { user_based_price_groups: true } do
+    context "when a user has no account" do
+      let(:user) do
+        u = account.owner.user
+        u.account_users.each(&:destroy)
+        u.save
+        u.reload
+      end
+
+      it "allows a user without any accounts to add a nonbillable product to cart" do
+        visit facility_item_path(facility, nonbillable_item)
+        click_on "Add to cart"
+        expect(page).to have_content(nonbillable_item.name)
+      end
+
+      it "does not allow a user without any accounts to add a default product to cart" do
+        visit facility_item_path(facility, default_item)
+        expect(page).to have_content("Sorry, but we could not find a valid payment source that you can use to purchase this item")
+      end
     end
 
-    it "allows a user to add another nonbillable product" do
-      visit facility_item_path(facility, nonbillable_item)
-      click_on "Add to cart"
-      expect(page).to have_content(nonbillable_item.name).twice
+    context "when a nonbillable product is added first" do
+      before do
+        visit facility_item_path(facility, nonbillable_item)
+        click_on "Add to cart"
+      end
+
+      it "allows a user to add another nonbillable product" do
+        visit facility_item_path(facility, nonbillable_item)
+        click_on "Add to cart"
+        expect(page).to have_content(nonbillable_item.name).twice
+      end
+
+      it "does not allow a user to add a default billing mode product" do
+        visit facility_item_path(facility, default_item)
+        click_on "Add to cart"
+        expect(page).to have_content("#{default_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
+      end
     end
 
-    it "does not allow a user to add a default billing mode product" do
-      visit facility_item_path(facility, default_item)
-      click_on "Add to cart"
-      expect(page).to have_content("#{default_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
-    end
-  end
+    context "when a default product is added first" do
+      before do
+        visit facility_item_path(facility, default_item)
+        click_on "Add to cart"
+        choose account.description
+        click_on "Continue"
+      end
 
-  context "when a default product is added first" do
-    before do
-      visit facility_item_path(facility, default_item)
-      click_on "Add to cart"
-      choose account.description
-      click_on "Continue"
-    end
+      it "allows a user to add another default product" do
+        visit facility_item_path(facility, default_item)
+        click_on "Add to cart"
+        expect(page).to have_content(default_item.name).twice
+      end
 
-    it "allows a user to add another default product" do
-      visit facility_item_path(facility, default_item)
-      click_on "Add to cart"
-      expect(page).to have_content(default_item.name).twice
-    end
-
-    it "does not allow a user to add another nonbillable product" do
-      visit facility_item_path(facility, nonbillable_item)
-      click_on "Add to cart"
-      expect(page).to have_content("#{nonbillable_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
+      it "does not allow a user to add another nonbillable product" do
+        visit facility_item_path(facility, nonbillable_item)
+        click_on "Add to cart"
+        expect(page).to have_content("#{nonbillable_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
+      end
     end
   end
 end

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "Adding products with different billing modes to cart" do
   let!(:nonbillable_item) { create(:setup_item, facility:, billing_mode: "Nonbillable") }
   let!(:default_item) { create(:setup_item, facility:, billing_mode: "Default") }
   let!(:account) { create(:purchase_order_account, :with_account_owner, facility:) }
-  let!(:account_price_group_member) { create(:account_price_group_member, account: account, price_group: PriceGroup.globals.first) }
-  let!(:account_price_group_member_2) { create(:account_price_group_member, account: account, price_group: PriceGroup.globals.second) }
+  let!(:account_price_group_member) { create(:account_price_group_member, account: account, price_group: PriceGroup.base) }
+  let!(:account_price_group_member_2) { create(:account_price_group_member, account: account, price_group: PriceGroup.external) }
 
   let!(:nonbillable_price_policy) { create(:item_price_policy, price_group: PriceGroup.globals.first, product: nonbillable_item) }
   let!(:nonbillable_price_policy_2) { create(:item_price_policy, price_group: PriceGroup.globals.second, product: nonbillable_item) }
@@ -96,13 +96,13 @@ RSpec.describe "Adding products with different billing modes to cart" do
         u.reload
       end
 
-      it "allows a user without any accounts to add a nonbillable product to cart" do
+      it "allows adding a nonbillable product to cart" do
         visit facility_item_path(facility, nonbillable_item)
         click_on "Add to cart"
         expect(page).to have_content(nonbillable_item.name)
       end
 
-      it "does not allow a user without any accounts to add a default product to cart" do
+      it "does not allow adding a default product to cart" do
         visit facility_item_path(facility, default_item)
         expect(page).to have_content("Sorry, but we could not find a valid payment source that you can use to purchase this item")
       end


### PR DESCRIPTION
# Release Notes

Dartmouth has `user_based_price_groups` disabled, which changes the behavior of the cart. So specs were added with that flag disabled