### PR TITLE
[#161859] Moves nonbillable user creation to the NonbillableAccount class

### DIFF
--- a/app/models/nonbillable_account.rb
+++ b/app/models/nonbillable_account.rb
@@ -44,7 +44,7 @@ class NonbillableAccount < Account
 
   def set_created_by
     return if created_by
-    self.created_by = User.nonbillable_account_owner.id
+    self.created_by = nonbillable_account_owner.id
   end
 
   def set_owner
@@ -52,8 +52,21 @@ class NonbillableAccount < Account
 
     account_users << AccountUser.new(
       user_role: AccountUser::ACCOUNT_OWNER,
-      user: User.nonbillable_account_owner,
-      created_by_user: User.nonbillable_account_owner,
+      user: nonbillable_account_owner,
+      created_by_user: nonbillable_account_owner,
     )
+  end
+
+  def nonbillable_account_owner
+    User.find_or_create_by!(nonbillable_account_owner_attrs)
+  end
+
+  def nonbillable_account_owner_attrs
+    {
+      username: "none (nonbillable)",
+      first_name: "Nonbillable",
+      last_name: "User",
+      email: (Settings.support_email || Settings.email.from),
+    }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,15 +56,6 @@ class User < ApplicationRecord
   scope :with_recent_orders, ->(facility) { distinct.joins(:order_details).merge(OrderDetail.recent.for_facility(facility)) }
   scope :sort_last_first, -> { order(Arel.sql("LOWER(users.last_name), LOWER(users.first_name)")) }
 
-  def self.nonbillable_account_owner
-    find_or_create_by!(
-      username: "None (Nonbillable)",
-      first_name: "Nonbillable",
-      last_name: "User",
-      email: (Settings.support_email || Settings.email.from),
-    )
-  end
-
   # This method is only used by devise-security to determine
   # whether or not password validations should run.
   # A better name would be password_validations_required?


### PR DESCRIPTION
# Release Notes

Creating the user who owns the Nonbillable account is more at home in the NonbillableAccount class than it is in the User class.