### PR TITLE
[#161917] Allow purchasing without price rules in nonbillable mode

### DIFF
--- a/app/models/nonbillable_account.rb
+++ b/app/models/nonbillable_account.rb
@@ -31,7 +31,7 @@ class NonbillableAccount < Account
   # This insures that NonbillableAccount#price_groups isn't empty, in the case
   # the user doesn't have a price group
   def set_price_group
-    price_group_members.create(price_group: PriceGroup.base, type: "AccountPriceGroupMember")
+    price_group_members.create(price_group: PriceGroup.nonbillable, type: "AccountPriceGroupMember")
   end
 
   def set_account_number

--- a/app/models/nonbillable_account.rb
+++ b/app/models/nonbillable_account.rb
@@ -2,6 +2,7 @@
 
 class NonbillableAccount < Account
   before_validation :set_owner, :set_description, :set_created_by, :set_account_number, :set_expries_at
+  after_create :set_price_group
 
   # Since this account can be used by anyone, we only need one in the system
   # so this class method should be used to access it.
@@ -26,6 +27,10 @@ class NonbillableAccount < Account
   end
 
   private
+
+  def set_price_group
+    price_group_members.create(price_group: PriceGroup.base, type: "AccountPriceGroupMember")
+  end
 
   def set_account_number
     return if account_number

--- a/app/models/nonbillable_account.rb
+++ b/app/models/nonbillable_account.rb
@@ -28,6 +28,8 @@ class NonbillableAccount < Account
 
   private
 
+  # This insures that NonbillableAccount#price_groups isn't empty, in the case
+  # the user doesn't have a price group
   def set_price_group
     price_group_members.create(price_group: PriceGroup.base, type: "AccountPriceGroupMember")
   end

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -33,6 +33,10 @@ class PriceGroup < ApplicationRecord
     globals.find_by(name: Settings.price_group.name.external)
   end
 
+  def self.nonbillable
+    base
+  end
+
   # Create a global price group, if it does not exist, and setup all the
   # schedule rules with price group discounts for the price group.
   def self.setup_global(name:, is_internal: false, admin_editable: true, discount_percent: 0, display_order: nil)

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -25,7 +25,10 @@ class PricePolicy < ApplicationRecord
     start_date = record.start_date
     if value.present? && start_date.present?
       gen_exp_date = generate_expire_date(start_date)
-      record.errors.add(:expire_date, "must be after #{start_date.to_date} and before #{gen_exp_date.to_date}") if value <= start_date || value > gen_exp_date
+
+      if (value <= start_date || value > gen_exp_date) && !record.product.skip_order_review?
+        record.errors.add(:expire_date, "must be after #{start_date.to_date} and before #{gen_exp_date.to_date}") 
+      end
     end
   end
 

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -25,8 +25,9 @@ class PricePolicy < ApplicationRecord
     start_date = record.start_date
     if value.present? && start_date.present?
       gen_exp_date = generate_expire_date(start_date)
+      outside_fiscal_year = gen_exp_date < value || value <= start_date
 
-      if (value <= start_date || value > gen_exp_date) && !record.product.skip_order_review?
+      if outside_fiscal_year && !record.product.skip_order_review? # skip review price rules should not expire
         record.errors.add(:expire_date, "must be after #{start_date.to_date} and before #{gen_exp_date.to_date}") 
       end
     end

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -112,6 +112,25 @@ class PricePolicy < ApplicationRecord
     SettingsHelper.fiscal_year_end(start_date)
   end
 
+  def self.create_nonbillable_price_policy(product)
+    create(
+      type: "#{product.type}PricePolicy",
+      product: product,
+      start_date: 1.month.ago,
+      expire_date: 75.years.from_now,
+      price_group: PriceGroup.nonbillable,
+      usage_rate: 0,
+      minimum_cost: 0,
+      cancellation_cost: 0,
+      usage_subsidy: 0,
+      unit_cost: 0,
+      unit_subsidy: 0,
+      can_purchase: true,
+      charge_for: "reservation",
+      note: "Price rule automatically created because of billing mode"
+    )
+  end
+
   def has_subsidy?
     self[subsidy_field].to_f > 0
   end

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -112,25 +112,6 @@ class PricePolicy < ApplicationRecord
     SettingsHelper.fiscal_year_end(start_date)
   end
 
-  def self.create_nonbillable_price_policy(product)
-    create(
-      type: "#{product.type}PricePolicy",
-      product: product,
-      start_date: 1.month.ago,
-      expire_date: 75.years.from_now,
-      price_group: PriceGroup.nonbillable,
-      usage_rate: 0,
-      minimum_cost: 0,
-      cancellation_cost: 0,
-      usage_subsidy: 0,
-      unit_cost: 0,
-      unit_subsidy: 0,
-      can_purchase: true,
-      charge_for: "reservation",
-      note: "Price rule automatically created because of billing mode"
-    )
-  end
-
   def order_review_product?
     return true unless product
     !product.skip_order_review?

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -132,6 +132,7 @@ class PricePolicy < ApplicationRecord
   end
 
   def order_review_product?
+    return true unless product
     !product.skip_order_review?
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -210,7 +210,7 @@ class Product < ApplicationRecord
   end
 
   def create_nonbillable_price_policy
-    PricePolicy.create_nonbillable_price_policy(self)
+    PricePolicyBuilder.create_nonbillable_for(self)
   end
 
   def available_for_purchase?

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -214,7 +214,7 @@ class Product < ApplicationRecord
       type: "#{type}PricePolicy",
       start_date: 1.month.ago,
       expire_date: 75.years.from_now,
-      price_group: PriceGroup.base,
+      price_group: PriceGroup.nonbillable,
       usage_rate: 0,
       minimum_cost: 0,
       cancellation_cost: 0,
@@ -257,7 +257,7 @@ class Product < ApplicationRecord
 
   def can_purchase_order_detail?(order_detail)
     price_group_ids = if skip_order_review?
-                        [PriceGroup.base.id] # the skip review price policy is in PriceGroup.base
+                        [PriceGroup.nonbillable.id]
                       else
                         order_detail.price_groups.map(&:id)
                       end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -24,7 +24,7 @@ class Product < ApplicationRecord
   has_one :product_display_group, through: :product_display_group_product
 
   after_create :create_default_price_group_products
-  after_create :create_nonbillable_price_policies
+  after_create :create_nonbillable_price_policy
 
   email_list_attribute :training_request_contacts
 
@@ -209,13 +209,12 @@ class Product < ApplicationRecord
     end
   end
 
-  def create_nonbillable_price_policies
+  def create_nonbillable_price_policy
     if skip_order_review?
-      pp = PricePolicy.new(
+      price_policies.create(
         type: "#{type}PricePolicy",
         start_date: 1.month.ago,
         expire_date: 75.years.from_now,
-        product: self,
         price_group: PriceGroup.base,
         usage_rate: 0,
         minimum_cost: 0,
@@ -224,11 +223,9 @@ class Product < ApplicationRecord
         unit_cost: 0,
         unit_subsidy: 0,
         can_purchase: true,
-        charge_for: "reservation", #
+        charge_for: "reservation",
         note: "Adding default price policy"
       )
-      # binding.pry
-      pp.save
     end
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -210,21 +210,7 @@ class Product < ApplicationRecord
   end
 
   def create_nonbillable_price_policy
-    price_policies.create(
-      type: "#{type}PricePolicy",
-      start_date: 1.month.ago,
-      expire_date: 75.years.from_now,
-      price_group: PriceGroup.nonbillable,
-      usage_rate: 0,
-      minimum_cost: 0,
-      cancellation_cost: 0,
-      usage_subsidy: 0,
-      unit_cost: 0,
-      unit_subsidy: 0,
-      can_purchase: true,
-      charge_for: "reservation",
-      note: "Price rule automatically created because of billing mode"
-    )
+    price_policies << PricePolicy.create_nonbillable_price_policy(self)
   end
 
   def available_for_purchase?

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -210,7 +210,7 @@ class Product < ApplicationRecord
   end
 
   def create_nonbillable_price_policy
-    price_policies << PricePolicy.create_nonbillable_price_policy(self)
+    PricePolicy.create_nonbillable_price_policy(self)
   end
 
   def available_for_purchase?

--- a/app/models/product_for_cart.rb
+++ b/app/models/product_for_cart.rb
@@ -77,7 +77,7 @@ class ProductForCart
   def check_that_product_has_price_groups_accessible_to_user(user)
     proc do
       price_group_ids = if product.skip_order_review?
-                          [PriceGroup.base.id]
+                          [PriceGroup.nonbillable.id]
                         else
                           (user.price_groups + user.account_price_groups).flatten.uniq.map(&:id)
                         end

--- a/app/models/product_for_cart.rb
+++ b/app/models/product_for_cart.rb
@@ -76,7 +76,12 @@ class ProductForCart
 
   def check_that_product_has_price_groups_accessible_to_user(user)
     proc do
-      price_group_ids = (user.price_groups + user.account_price_groups).flatten.uniq.map(&:id)
+      price_group_ids = if product.skip_order_review?
+                          [PriceGroup.base.id]
+                        else
+                          (user.price_groups + user.account_price_groups).flatten.uniq.map(&:id)
+                        end
+
       @error_message = text(".no_price_groups", i18n_params) unless product.can_purchase?(price_group_ids)
     end
   end

--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -14,6 +14,25 @@ class PricePolicyBuilder
     new(product, start_date).new_policies_based_on_most_recent
   end
 
+  def self.create_nonbillable_for(product)
+    PricePolicy.create(
+      type: "#{product.type}PricePolicy",
+      product: product,
+      start_date: 1.month.ago,
+      expire_date: 75.years.from_now,
+      price_group: PriceGroup.nonbillable,
+      usage_rate: 0,
+      minimum_cost: 0,
+      cancellation_cost: 0,
+      usage_subsidy: 0,
+      unit_cost: 0,
+      unit_subsidy: 0,
+      can_purchase: true,
+      charge_for: "reservation",
+      note: "Price rule automatically created because of billing mode"
+    )
+  end
+
   def initialize(product, start_date)
     @product = product
     @start_date = start_date

--- a/app/views/price_policies/_table.html.haml
+++ b/app/views/price_policies/_table.html.haml
@@ -14,7 +14,7 @@
       %tr
         - if price_policies_to_show.first == price_policy
           %td.centered{ :rowspan => price_policies_to_show.length }
-            - if price_policies.all?(&:editable?) && can?(:edit, PricePolicy)
+            - if price_policies.all?(&:editable?) && can?(:edit, PricePolicy)  && !@product.skip_order_review?
               %p
                 = link_to t("shared.edit"),
                   [:edit, current_facility, product, :price_policy, id: url_date]

--- a/app/views/price_policies/index.html.haml
+++ b/app/views/price_policies/index.html.haml
@@ -9,7 +9,7 @@
 
 %p= text("description")
 
-- if can?(:create, PricePolicy)
+- if can?(:create, PricePolicy) && !@product.skip_order_review?
   %ul.inline
     %li= link_to text("add"), [:new, current_facility, @product, :price_policy], class: "btn-add"
 

--- a/app/views/price_policies/index.html.haml
+++ b/app/views/price_policies/index.html.haml
@@ -12,6 +12,9 @@
 - if can?(:create, PricePolicy) && !@product.skip_order_review?
   %ul.inline
     %li= link_to text("add"), [:new, current_facility, @product, :price_policy], class: "btn-add"
+- elsif @product.skip_order_review?
+  %ul.inline
+    %b= text("skip_review_message", type: @product.type.downcase, billing_mode: @product.billing_mode)
 
 - if @current_price_policies.empty?
   %p.notice= text("none")

--- a/app/views/time_based_price_policies/_table.html.haml
+++ b/app/views/time_based_price_policies/_table.html.haml
@@ -14,7 +14,7 @@
       %tr
         - if price_policies_to_show.first == price_policy
           %td.centered{ rowspan: price_policies_to_show.length }
-            - if price_policies.all?(&:editable?) && can?(:edit, PricePolicy)
+            - if price_policies.all?(&:editable?) && can?(:edit, PricePolicy) && !@product.skip_order_review?
               %p
                 = link_to t("shared.edit"),
                   [:edit, current_facility, product, :price_policy, id: url_date]

--- a/config/locales/views/admin/en.price_policies.yml
+++ b/config/locales/views/admin/en.price_policies.yml
@@ -4,6 +4,7 @@ en:
       index:
         description: Pricing rules determine the specific rate applied to each price group.
         add: Add Pricing Rules
+        skip_review_message: "Because this %{type} is set to %{billing_mode} mode, price rules cannot be changed."
         none: You must add current pricing rules before you may bill for this item.
         current: Current Pricing Rules
         upcoming: Upcoming Pricing Rules

--- a/spec/system/admin/billing_mode_workflow_spec.rb
+++ b/spec/system/admin/billing_mode_workflow_spec.rb
@@ -37,46 +37,6 @@ RSpec.describe "Billing mode workflows" do
       end
     end
 
-    context "when a user forgets to end their reservation on an instrument that charges for actuals" do
-      let(:logged_in_user) { user }
-
-      let(:instrument) do
-        create(
-          :setup_instrument,
-          :timer,
-          :always_available,
-          charge_for: :usage,
-          facility:, problems_resolvable_by_user: true,
-          billing_mode:
-        )
-      end
-
-      let!(:old_reservation) do
-        create(
-          :purchased_reservation,
-          product: instrument,
-          reserve_start_at: 2.hours.ago,
-          reserve_end_at: 1.hour.ago,
-          actual_start_at: 1.hour.ago,
-          actual_end_at: nil
-        )
-      end
-
-      before do
-        visit facility_instrument_path(facility, instrument)
-      end
-
-      it "starts a new reservation and moves the old one to the problem queue" do
-        click_on "Create"
-        expect(page).to have_content "The instrument has been activated successfully"
-        # Check the problem reservation is in the problem queue
-        login_as director
-        visit show_problems_facility_reservations_path(facility)
-        expect(page).to have_content old_reservation.order_detail.id
-        expect(page).to have_content "Missing Actuals"
-      end
-    end
-
     context "with an invalid account" do
       let(:accepts_po) { false }
       let(:logged_in_user) { user }

--- a/spec/system/admin/creating_an_item_spec.rb
+++ b/spec/system/admin/creating_an_item_spec.rb
@@ -4,8 +4,10 @@ require "rails_helper"
 
 RSpec.describe "Creating an item" do
   let(:facility) { FactoryBot.create(:setup_facility) }
-  let(:director) { FactoryBot.create(:user, :facility_director, facility: facility) }
-  before { login_as director }
+  let(:director) { FactoryBot.create(:user, :facility_director, facility:) }
+  let(:administrator) { create(:user, :administrator) }
+  let(:logged_in_user) { director }
+  before { login_as logged_in_user }
 
   it "can create and edit an item" do
     visit facility_products_path(facility)
@@ -27,5 +29,45 @@ RSpec.describe "Creating an item" do
 
     expect(current_path).to eq(manage_facility_item_path(facility, Item.last))
     expect(page).to have_content("Some description")
+  end
+
+  context "when billing mode is Skip Review" do
+    let(:logged_in_user) { administrator }
+
+    it "can create an item, which automatically creates a price rule" do
+      visit facility_products_path(facility)
+      click_link "Items"
+      click_link "Add Item"
+
+      fill_in "Name", with: "My New Item", match: :first
+      fill_in "URL Name", with: "new-item"
+      select "Required", from: "item[user_notes_field_mode]"
+      select "Skip Review", from: "item[billing_mode]"
+
+      click_button "Create"
+      click_on "Pricing"
+
+      expect(page).to have_content "#{PriceGroup.base} (#{PriceGroup.base.type_string}) $0"
+    end
+  end
+
+  context "when billing mode is Nonbillable" do
+    let(:logged_in_user) { administrator }
+
+    it "can create an item, which automatically creates a price rule" do
+      visit facility_products_path(facility)
+      click_link "Items"
+      click_link "Add Item"
+
+      fill_in "Name", with: "My New Item", match: :first
+      fill_in "URL Name", with: "new-item"
+      select "Required", from: "item[user_notes_field_mode]"
+      select "Nonbillable", from: "item[billing_mode]"
+
+      click_button "Create"
+      click_on "Pricing"
+
+      expect(page).to have_content "#{PriceGroup.base} (#{PriceGroup.base.type_string}) $0"
+    end
   end
 end

--- a/spec/system/admin/creating_an_item_spec.rb
+++ b/spec/system/admin/creating_an_item_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Creating an item" do
       click_button "Create"
       click_on "Pricing"
 
-      expect(page).to have_content "#{PriceGroup.base} (#{PriceGroup.base.type_string}) $0"
+      expect(page).to have_content "#{PriceGroup.nonbillable} (#{PriceGroup.nonbillable.type_string}) $0"
     end
   end
 
@@ -67,7 +67,7 @@ RSpec.describe "Creating an item" do
       click_button "Create"
       click_on "Pricing"
 
-      expect(page).to have_content "#{PriceGroup.base} (#{PriceGroup.base.type_string}) $0"
+      expect(page).to have_content "#{PriceGroup.nonbillable} (#{PriceGroup.nonbillable.type_string}) $0"
     end
   end
 end

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -4,8 +4,9 @@ require "rails_helper"
 
 RSpec.describe InstrumentPricePoliciesController do
   let(:facility) { create(:setup_facility) }
-  let!(:instrument) { create(:instrument, facility: facility) }
-  let(:director) { create(:user, :facility_director, facility: facility) }
+  let(:billing_mode) { "Default" }
+  let!(:instrument) { create(:instrument, facility:, billing_mode:) }
+  let(:director) { create(:user, :facility_director, facility:) }
 
   let(:base_price_group) { PriceGroup.base }
   let(:external_price_group) { PriceGroup.external }
@@ -112,6 +113,41 @@ RSpec.describe InstrumentPricePoliciesController do
       expect(page).to have_content("$120.00\n- $60.00\n= $60.00") # Cancer Center Minimum Cost
       expect(page).not_to have_content("$15.00")
       expect(page).to have_content(PricePolicy.human_attribute_name(:full_price_cancellation), count: 3)
+    end
+  end
+
+  describe "with 'Nonbillable' billing mode enabled" do
+    let(:billing_mode) { "Nonbillable" }
+
+    it "does not allow adding, editing, or removing of price policies" do
+      visit facility_instruments_path(facility, instrument)
+      click_link instrument.name
+      click_link "Pricing"
+      expect(page).not_to have_content "Add Pricing Rules"
+
+      expect(page).to have_content "Edit"
+      expect(page).to have_no_link "Edit"
+
+      expect(page).to have_content "Remove"
+      expect(page).to have_no_link "Remove"
+    end
+  end
+
+  describe "with 'Skip Review' billing mode enabled" do
+    let(:billing_mode) { "Skip Review" }
+
+    it "does not allow adding, editing, or removing of price policies" do
+      visit facility_instruments_path(facility, instrument)
+      click_link instrument.name
+      click_link "Pricing"
+
+      expect(page).not_to have_content "Add Pricing Rules"
+
+      expect(page).to have_content "Edit"
+      expect(page).to have_no_link "Edit"
+
+      expect(page).to have_content "Remove"
+      expect(page).to have_no_link "Remove"
     end
   end
 end


### PR DESCRIPTION
# Release Notes

This automatically sets up $0 price policies for products that skip order review (Skip Review, and Nonbillable modes).

# Screenshot

![Screen Shot 2023-09-05 at 2 43 06 PM](https://github.com/tablexi/nucore-open/assets/624487/c9f33b6f-4cc3-49cf-ba89-ed0a2683d3d9)

# Additional notes

It may be necessary to call `create_nonbillable_price_policy` on `skip_order_review?` products that already exist