### PR TITLE
[#161771] Cancel statements

### DIFF
--- a/app/controllers/facility_statements_controller.rb
+++ b/app/controllers/facility_statements_controller.rb
@@ -82,6 +82,23 @@ class FacilityStatementsController < ApplicationController
     redirect_to action: :index
   end
 
+  # POST /facilities/:facility_id/statements/:id/cancel
+  def cancel
+    statement = Statement.find(params[:id])
+
+    statement.canceled_at = Time.current
+
+    if statement.save
+      OrderDetail.where(statement_id: statement.id).update_all(statement_id: nil)
+      LogEvent.log(statement, :closed, current_user)
+      flash[:notice] = "Statement has been canceled"
+    else
+      flash[:error] = "Unable to cancel statement"
+    end
+
+    redirect_to action: :index
+  end
+
   # GET /facilities/:facility_id/statements/:id
   def show
     @statement = Statement.find(params[:id])

--- a/app/forms/statement_search_form.rb
+++ b/app/forms/statement_search_form.rb
@@ -17,7 +17,7 @@ class StatementSearchForm
   end
 
   def available_statuses
-    [true, false].map { |v| [I18n.t(v, scope: "statements.reconciled"), v] }
+    ["Reconciled", "Unreconciled", "Canceled"]
   end
 
   def facility_filter?
@@ -41,10 +41,12 @@ class StatementSearchForm
 
   def add_reconciled_status_filter(results)
     case status
-    when "true"
+    when "Reconciled"
       results.reconciled
-    when "false"
+    when "Unreconciled"
       results.unreconciled
+    when "Canceled"
+      results.where.not(canceled_at: nil)
     else
       results
     end

--- a/app/mailers/statement_search_result_mailer.rb
+++ b/app/mailers/statement_search_result_mailer.rb
@@ -52,7 +52,7 @@ class StatementSearchResultMailer < CsvReportMailer
         statement.facility,
         statement.order_details.count,
         number_to_currency(statement.total_cost),
-        I18n.t(statement.reconciled?, scope: "statements.reconciled"),
+        statement.status,
       ]
     end
   end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -69,6 +69,16 @@ class Statement < ApplicationRecord
     order_details.reconciled.empty? && canceled_at.blank?
   end
 
+  def status
+    if canceled_at
+      "Canceled"
+    elsif reconciled?
+      "Reconciled"
+    else
+      "Unreconciled"
+    end
+  end
+
   def paid_in_full?
     payments.sum(:amount) >= total_cost
   end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -65,6 +65,10 @@ class Statement < ApplicationRecord
     order_details.unreconciled.empty?
   end
 
+  def can_cancel?
+    order_details.reconciled.empty?
+  end
+
   def paid_in_full?
     payments.sum(:amount) >= total_cost
   end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -27,8 +27,8 @@ class Statement < ApplicationRecord
     end
   }
 
-  scope :reconciled, -> { where.not(id: OrderDetail.unreconciled.where.not(statement_id: nil).select(:statement_id)) }
-  scope :unreconciled, -> { where(id: OrderDetail.unreconciled.where.not(statement_id: nil).select(:statement_id)) }
+  scope :reconciled, -> { where(canceled_at: nil).where.not(id: OrderDetail.unreconciled.where.not(statement_id: nil).select(:statement_id)) }
+  scope :unreconciled, -> { where(canceled_at: nil).where(id: OrderDetail.unreconciled.where.not(statement_id: nil).select(:statement_id)) }
 
   # Use this for restricting the the current facility
   scope :for_facility, ->(facility) { where(facility: facility) if facility.single_facility? }
@@ -62,11 +62,11 @@ class Statement < ApplicationRecord
   end
 
   def reconciled?
-    order_details.unreconciled.empty?
+    order_details.unreconciled.empty? && canceled_at.blank?
   end
 
   def can_cancel?
-    order_details.reconciled.empty?
+    order_details.reconciled.empty? && canceled_at.blank?
   end
 
   def paid_in_full?

--- a/app/presenters/statement_presenter.rb
+++ b/app/presenters/statement_presenter.rb
@@ -40,8 +40,12 @@ class StatementPresenter < SimpleDelegator
   end
 
   def status
-    return "Canceled" if canceled_at
-
-    reconciled? ? "Reconciled" : "Unreconciled"
+    if canceled_at
+      "Canceled"
+    elsif reconciled?
+      "Reconciled"
+    else
+      "Unreconciled"
+    end
   end
 end

--- a/app/presenters/statement_presenter.rb
+++ b/app/presenters/statement_presenter.rb
@@ -39,13 +39,4 @@ class StatementPresenter < SimpleDelegator
     @closed_events ||= LogEvent.where(loggable_type: "Statement", loggable_id: id, event_type: "closed")
   end
 
-  def status
-    if canceled_at
-      "Canceled"
-    elsif reconciled?
-      "Reconciled"
-    else
-      "Unreconciled"
-    end
-  end
 end

--- a/app/presenters/statement_presenter.rb
+++ b/app/presenters/statement_presenter.rb
@@ -39,4 +39,9 @@ class StatementPresenter < SimpleDelegator
     @closed_events ||= LogEvent.where(loggable_type: "Statement", loggable_id: id, event_type: "closed")
   end
 
+  def status
+    return "Canceled" if canceled_at
+
+    reconciled? ? "Reconciled" : "Unreconciled"
+  end
 end

--- a/app/views/global_search/_statements.html.haml
+++ b/app/views/global_search/_statements.html.haml
@@ -34,4 +34,4 @@
         %td.currency
           = number_to_currency(statement.total_cost)
         %td
-          = t("statements.reconciled.#{statement.reconciled?}")
+          = statement.status

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -23,6 +23,7 @@
             = "##{s.invoice_number}"
             - unless s.canceled_at
               %br
+              - # TODO: Refactor Statement#order_details to go through statement_rows so we can generate PDFs for canceled statements
               - path = current_facility ? statement_path(s) : account_statement_path(s.account, s, format: :pdf)
               = link_to t("statements.pdf.download"), path
               - if SettingsHelper.feature_on?(:send_statement_emails) && current_facility
@@ -30,7 +31,7 @@
                 = link_to(t("statements.resend"), resend_emails_facility_statement_path(current_facility, s), method: :post, class: "js--resend", data: { confirm: "You are about to re-send this invoice to the following recipients: #{s.users_to_notify.join(", ")}" })
 
                 - if s.can_cancel?
-                  %span= link_to("Cancel", cancel_facility_statement_path(current_facility, s), method: :post, class: "btn btn-danger", data: {confirm: "Are you sure you want to cancel?"})
+                  %span= link_to(t("statements.cancel"), cancel_facility_statement_path(current_facility, s), method: :post, class: "btn btn-danger", data: {confirm: "Are you sure you want to cancel?"})
           %td= format_usa_datetime(s.created_at)
           %td= s.account.notify_users.map(&:full_name).join(', ')
           - unless @account

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -21,12 +21,16 @@
         %tr
           %td.centered
             = "##{s.invoice_number}"
-            %br
-            - path = current_facility ? statement_path(s) : account_statement_path(s.account, s, format: :pdf)
-            = link_to t("statements.pdf.download"), path
-            - if SettingsHelper.feature_on?(:send_statement_emails) && current_facility
+            - unless s.canceled_at
               %br
-              = link_to(t("statements.resend"), resend_emails_facility_statement_path(current_facility, s), method: :post, class: "js--resend", data: { confirm: "You are about to re-send this invoice to the following recipients: #{s.users_to_notify.join(", ")}" })
+              - path = current_facility ? statement_path(s) : account_statement_path(s.account, s, format: :pdf)
+              = link_to t("statements.pdf.download"), path
+              - if SettingsHelper.feature_on?(:send_statement_emails) && current_facility
+                %br
+                = link_to(t("statements.resend"), resend_emails_facility_statement_path(current_facility, s), method: :post, class: "js--resend", data: { confirm: "You are about to re-send this invoice to the following recipients: #{s.users_to_notify.join(", ")}" })
+
+                - if s.can_cancel?
+                  %span= link_to("Cancel", cancel_facility_statement_path(current_facility, s), method: :post, class: "btn btn-danger", data: {confirm: "Are you sure you want to cancel?"})
           %td= format_usa_datetime(s.created_at)
           %td= s.account.notify_users.map(&:full_name).join(', ')
           - unless @account
@@ -37,6 +41,6 @@
           %td.currency= number_to_currency(s.total_cost)
           %td= s.closed_by_times
           %td= s.closed_by_user_full_names
-          %td= t("statements.reconciled.#{s.reconciled?}")
+          %td= s.status
 
   = will_paginate(@statements)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -664,9 +664,6 @@ en:
     pdf:
       filename: "%{facility}-%{invoice_number}-%{date}.pdf"
       download: Download
-    reconciled:
-      "true": Reconciled
-      "false": Unreconciled
     resend: Resend
     closed_at: Closed At
     closed_by: Closed By

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -665,6 +665,7 @@ en:
       filename: "%{facility}-%{invoice_number}-%{date}.pdf"
       download: Download
     resend: Resend
+    cancel: Cancel
     closed_at: Closed At
     closed_by: Closed By
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
   # front-end accounts
   resources :accounts, only: [:index, :show] do
     resources :statements, only: [:show, :index]
+
     member do
       get "user_search"
     end
@@ -312,6 +313,7 @@ Rails.application.routes.draw do
 
     resources :statements, controller: "facility_statements", only: [:index, :new, :show, :create] do
       post "resend_emails", on: :member
+      post "cancel", on: :member
     end
 
     get "general_reports/raw", to: "reports/export_raw_reports#export_all", as: "export_raw_reports"

--- a/db/migrate/20230907173215_add_cancelation_date_to_statements.rb
+++ b/db/migrate/20230907173215_add_cancelation_date_to_statements.rb
@@ -1,0 +1,5 @@
+class AddCancelationDateToStatements < ActiveRecord::Migration[6.1]
+  def change
+    add_column :statements, :canceled_at, :datetime
+  end
+end

--- a/db/migrate/20230907173215_add_cancelation_date_to_statements.rb
+++ b/db/migrate/20230907173215_add_cancelation_date_to_statements.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddCancelationDateToStatements < ActiveRecord::Migration[6.1]
   def change
     add_column :statements, :canceled_at, :datetime

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_24_224847) do
+ActiveRecord::Schema.define(version: 2023_09_07_173215) do
 
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
@@ -857,6 +857,7 @@ ActiveRecord::Schema.define(version: 2023_07_24_224847) do
     t.integer "created_by", null: false
     t.datetime "created_at", null: false
     t.integer "account_id", null: false
+    t.datetime "canceled_at"
     t.index ["account_id"], name: "index_statements_on_account_id"
     t.index ["facility_id"], name: "fk_statement_facilities"
   end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -36,6 +36,26 @@ RSpec.describe Statement do
     end
   end
 
+  context "when canceled" do
+    subject(:statement) { create(:statement, account: account, created_by: user.id, facility: facility, canceled_at: Time.current) }
+
+    it "should not be reconciled" do
+      expect(statement).to_not be_reconciled
+    end
+
+    it "is not in the reconciled scope" do
+      expect(described_class.reconciled).not_to include(statement)
+    end
+
+    it "is not in the unreconciled scope" do
+      expect(described_class.unreconciled).to_not include(statement)
+    end
+
+    it "should not be cancelable" do
+      expect(statement).to_not be_can_cancel
+    end
+  end
+
   context "with order details" do
     before :each do
       @order_details = []
@@ -74,9 +94,17 @@ RSpec.describe Statement do
       expect(described_class.unreconciled).to include(statement)
     end
 
+    it "should be cancelable" do
+      expect(statement).to be_can_cancel
+    end
+
     context "with one order detail reconciled" do
       before :each do
         @order_details.first.to_reconciled!
+      end
+
+      it "should not be cancelable" do
+        expect(statement).to_not be_can_cancel
       end
 
       it "should not be reconciled" do
@@ -95,6 +123,10 @@ RSpec.describe Statement do
     context "with all order_details reconciled" do
       before :each do
         @order_details.each(&:to_reconciled!)
+      end
+
+      it "should not be cancelable" do
+        expect(statement).to_not be_can_cancel
       end
 
       it "should be reconciled" do

--- a/spec/system/admin/cancel_statement_spec.rb
+++ b/spec/system/admin/cancel_statement_spec.rb
@@ -32,14 +32,14 @@ RSpec.describe "canceling statements" do
     expect(page).to_not have_content "Resend"
   end
 
-	context "when an order detail is reconciled" do
-		before do
-			order_details.first.to_reconciled!
-			visit facility_statements_path(facility)
-		end
+  context "when an order detail is reconciled" do
+    before do
+      order_details.first.to_reconciled!
+      visit facility_statements_path(facility)
+    end
 
-		it "does not allow statement to be canceled" do
-			expect(page).to_not have_content "Cancel"
-		end
-	end
+    it "does not allow statement to be canceled" do
+      expect(page).to_not have_content "Cancel"
+    end
+  end
 end

--- a/spec/system/admin/cancel_statement_spec.rb
+++ b/spec/system/admin/cancel_statement_spec.rb
@@ -20,16 +20,19 @@ RSpec.describe "canceling statements" do
     visit facility_statements_path(facility)
   end
 
-  it "cancels a statement" do
-    click_on "Cancel"
-    expect(page).to have_content "#{I18n.t('Statement')} has been canceled"
-    expect(page).to have_content "Canceled"
-  end
+  context "when an order detail is NOT reconciled" do
+    it "cancels a statement" do
+      click_on "Cancel"
+      expect(page).to have_content "#{I18n.t('Statement')} has been canceled"
+      expect(page).to have_content "Canceled"
+    end
 
-  it "does not allow download or emailing of statement" do
-    click_on "Cancel"
-    expect(page).to_not have_content "Download"
-    expect(page).to_not have_content "Resend"
+    it "does not allow download or emailing of statement" do
+      click_on "Cancel"
+      expect(page).to_not have_content "Download"
+      expect(page).to_not have_content "Resend"
+      expect(page).to_not have_link "Cancel"
+    end
   end
 
   context "when an order detail is reconciled" do
@@ -39,7 +42,9 @@ RSpec.describe "canceling statements" do
     end
 
     it "does not allow statement to be canceled" do
-      expect(page).to_not have_content "Cancel"
+      expect(page).to have_content "Download"
+      expect(page).to have_content "Resend"
+      expect(page).to_not have_link "Cancel"
     end
   end
 end

--- a/spec/system/admin/cancel_statement_spec.rb
+++ b/spec/system/admin/cancel_statement_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "canceling statements" do
+  let(:facility) { create(:setup_facility) }
+  let(:item) { create(:setup_item, facility:) }
+  let!(:order) { create(:complete_order, product: item, quantity: 3, account: create(:purchase_order_account, :with_account_owner, facility:)) }
+  let(:order_details) { order.order_details }
+  let!(:statement) { create(:statement, facility:) }
+  let(:director) { create(:user, :facility_director, facility:) }
+
+  before do
+    order_details.each do |od|
+      od.statement = statement
+      od.save
+    end
+
+    login_as director
+    visit facility_statements_path(facility)
+  end
+
+  it "cancels a statement" do
+    click_on "Cancel"
+    expect(page).to have_content "#{I18n.t('Statement')} has been canceled"
+    expect(page).to have_content "Canceled"
+  end
+
+  it "does not allow download or emailing of statement" do
+    click_on "Cancel"
+    expect(page).to_not have_content "Download"
+    expect(page).to_not have_content "Resend"
+  end
+
+	context "when an order detail is reconciled" do
+		before do
+			order_details.first.to_reconciled!
+			visit facility_statements_path(facility)
+		end
+
+		it "does not allow statement to be canceled" do
+			expect(page).to_not have_content "Cancel"
+		end
+	end
+end


### PR DESCRIPTION
# Release Notes

This allows statements that do not have any associated reconciled order details to be canceled.

# Screenshot

![Screen Shot 2023-09-07 at 4 54 21 PM](https://github.com/tablexi/nucore-open/assets/624487/71338155-f1db-466d-94a0-c1a0004c196a)
