### PR TITLE
Fix external user and nonbillable instrument bug

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -503,6 +503,8 @@ class OrderDetail < ApplicationRecord
   end
 
   def price_groups
+    return [PriceGroup.nonbillable] if product.nonbillable_mode?
+
     groups = user.price_groups
     groups += account.price_groups if account
     groups.uniq

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -110,11 +110,11 @@ class PriceGroup < ApplicationRecord
     end
   end
 
-  # Creates price rules for all Skip Review products.
+  # Creates a new price rule for all Skip Review products.
   # Price rules should not prevent any user from purchasing
   def setup_skip_review_price_policies
     Product.where(billing_mode: "Skip Review").each do |product|
-      product.create_skip_review_price_policies([self])
+      PricePolicyBuilder.create_skip_review_for(product, [self])
     end
   end
 

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -42,6 +42,7 @@ class PriceGroup < ApplicationRecord
   def self.setup_global(name:, is_internal: false, admin_editable: true, discount_percent: 0, display_order: nil)
     price_group = find_or_create_global(name:, is_internal:, admin_editable:, display_order:)
     price_group.setup_schedule_rules(discount_percent:)
+    price_group.setup_skip_review_price_policies
     price_group
   end
 
@@ -106,6 +107,14 @@ class PriceGroup < ApplicationRecord
       )
 
       puts("Created price_group_discount for #{self} and schedule rule #{schedule_rule.id}") unless Rails.env.test?
+    end
+  end
+
+  # Creates price rules for all Skip Review products.
+  # Price rules should not prevent any user from purchasing
+  def setup_skip_review_price_policies
+    Product.where(billing_mode: "Skip Review").each do |product|
+      product.create_skip_review_price_policies([self])
     end
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -24,7 +24,7 @@ class Product < ApplicationRecord
   has_one :product_display_group, through: :product_display_group_product
 
   after_create :create_default_price_group_products
-  after_create :create_nonbillable_price_policy, if: :skip_order_review?
+  after_create :create_skip_review_price_policies, if: :skip_order_review?
 
   email_list_attribute :training_request_contacts
 
@@ -209,8 +209,8 @@ class Product < ApplicationRecord
     end
   end
 
-  def create_nonbillable_price_policy
-    PricePolicyBuilder.create_nonbillable_for(self)
+  def create_skip_review_price_policies
+    PricePolicyBuilder.create_skip_review_for(self)
   end
 
   def available_for_purchase?

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -24,7 +24,8 @@ class Product < ApplicationRecord
   has_one :product_display_group, through: :product_display_group_product
 
   after_create :create_default_price_group_products
-  after_create :create_skip_review_price_policies, if: :skip_order_review?
+  after_create :create_skip_review_price_policies, if: :skip_review_mode?
+  after_create :create_nonbillable_price_policy, if: :nonbillable_mode?
 
   email_list_attribute :training_request_contacts
 
@@ -211,6 +212,10 @@ class Product < ApplicationRecord
 
   def create_skip_review_price_policies
     PricePolicyBuilder.create_skip_review_for(self)
+  end
+
+  def create_nonbillable_price_policy
+    PricePolicyBuilder.create_nonbillable_for(self)
   end
 
   def available_for_purchase?

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -210,8 +210,8 @@ class Product < ApplicationRecord
     end
   end
 
-  def create_skip_review_price_policies(price_groups = nil)
-    PricePolicyBuilder.create_skip_review_for(self, price_groups)
+  def create_skip_review_price_policies
+    PricePolicyBuilder.create_skip_review_for(self)
   end
 
   def create_nonbillable_price_policy

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -242,13 +242,7 @@ class Product < ApplicationRecord
   end
 
   def can_purchase_order_detail?(order_detail)
-    price_group_ids = if skip_order_review?
-                        [PriceGroup.nonbillable.id]
-                      else
-                        order_detail.price_groups.map(&:id)
-                      end
-
-    can_purchase? price_group_ids
+    can_purchase? order_detail.price_groups.map(&:id)
   end
 
   def cheapest_price_policy(order_detail, date = Time.zone.now)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -210,8 +210,8 @@ class Product < ApplicationRecord
     end
   end
 
-  def create_skip_review_price_policies
-    PricePolicyBuilder.create_skip_review_for(self)
+  def create_skip_review_price_policies(price_groups = nil)
+    PricePolicyBuilder.create_skip_review_for(self, price_groups)
   end
 
   def create_nonbillable_price_policy

--- a/app/models/product_for_cart.rb
+++ b/app/models/product_for_cart.rb
@@ -76,7 +76,7 @@ class ProductForCart
 
   def check_that_product_has_price_groups_accessible_to_user(user)
     proc do
-      price_group_ids = if product.skip_order_review?
+      price_group_ids = if product.nonbillable_mode?
                           [PriceGroup.nonbillable.id]
                         else
                           (user.price_groups + user.account_price_groups).flatten.uniq.map(&:id)

--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -14,8 +14,9 @@ class PricePolicyBuilder
     new(product, start_date).new_policies_based_on_most_recent
   end
 
-  def self.create_skip_review_for(product)
-    PriceGroup.globals.each do |price_group|
+  def self.create_skip_review_for(product, price_groups = nil)
+    groups = price_groups || PriceGroup.globals
+    groups.each do |price_group|
       PricePolicy.create(
         type: "#{product.type}PricePolicy",
         product:,

--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -35,6 +35,25 @@ class PricePolicyBuilder
     end
   end
 
+  def self.create_nonbillable_for(product)
+    PricePolicy.create(
+      type: "#{product.type}PricePolicy",
+      product:,
+      start_date: 1.month.ago,
+      expire_date: 75.years.from_now,
+      price_group: PriceGroup.nonbillable,
+      usage_rate: 0,
+      minimum_cost: 0,
+      cancellation_cost: 0,
+      usage_subsidy: 0,
+      unit_cost: 0,
+      unit_subsidy: 0,
+      can_purchase: true,
+      charge_for: "reservation",
+      note: "Price rule automatically created because of billing mode"
+    )
+  end
+
   def initialize(product, start_date)
     @product = product
     @start_date = start_date

--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -14,23 +14,25 @@ class PricePolicyBuilder
     new(product, start_date).new_policies_based_on_most_recent
   end
 
-  def self.create_nonbillable_for(product)
-    PricePolicy.create(
-      type: "#{product.type}PricePolicy",
-      product: product,
-      start_date: 1.month.ago,
-      expire_date: 75.years.from_now,
-      price_group: PriceGroup.nonbillable,
-      usage_rate: 0,
-      minimum_cost: 0,
-      cancellation_cost: 0,
-      usage_subsidy: 0,
-      unit_cost: 0,
-      unit_subsidy: 0,
-      can_purchase: true,
-      charge_for: "reservation",
-      note: "Price rule automatically created because of billing mode"
-    )
+  def self.create_skip_review_for(product)
+    PriceGroup.globals.each do |price_group|
+      PricePolicy.create(
+        type: "#{product.type}PricePolicy",
+        product:,
+        start_date: 1.month.ago,
+        expire_date: 75.years.from_now,
+        price_group:,
+        usage_rate: 0,
+        minimum_cost: 0,
+        cancellation_cost: 0,
+        usage_subsidy: 0,
+        unit_cost: 0,
+        unit_subsidy: 0,
+        can_purchase: true,
+        charge_for: "reservation",
+        note: "Price rule automatically created because of billing mode"
+      )
+    end
   end
 
   def initialize(product, start_date)

--- a/app/services/reservation_window.rb
+++ b/app/services/reservation_window.rb
@@ -7,13 +7,7 @@ class ReservationWindow
   def max_window
     return 365 if operator?
 
-    price_groups = if @reservation.product.skip_order_review?
-                     [PriceGroup.nonbillable]
-                   else
-                     @reservation.order_detail.price_groups
-                   end
-
-    @reservation.longest_reservation_window(price_groups)
+    @reservation.longest_reservation_window(@reservation.order_detail.price_groups)
   end
 
   def max_days_ago

--- a/app/services/reservation_window.rb
+++ b/app/services/reservation_window.rb
@@ -6,7 +6,14 @@ class ReservationWindow
 
   def max_window
     return 365 if operator?
-    @reservation.longest_reservation_window(@reservation.order_detail.price_groups)
+
+    price_groups = if @reservation.product.skip_order_review?
+                     [PriceGroup.nonbillable]
+                   else
+                     @reservation.order_detail.price_groups
+                   end
+
+    @reservation.longest_reservation_window(price_groups)
   end
 
   def max_days_ago

--- a/app/services/reservation_window.rb
+++ b/app/services/reservation_window.rb
@@ -6,7 +6,6 @@ class ReservationWindow
 
   def max_window
     return 365 if operator?
-
     @reservation.longest_reservation_window(@reservation.order_detail.price_groups)
   end
 

--- a/app/views/price_policies/_table.html.haml
+++ b/app/views/price_policies/_table.html.haml
@@ -14,7 +14,7 @@
       %tr
         - if price_policies_to_show.first == price_policy
           %td.centered{ :rowspan => price_policies_to_show.length }
-            - if price_policies.all?(&:editable?) && can?(:edit, PricePolicy)  && !@product.skip_order_review?
+            - if price_policies.all?(&:editable?) && can?(:edit, PricePolicy) && !@product.skip_order_review?
               %p
                 = link_to t("shared.edit"),
                   [:edit, current_facility, product, :price_policy, id: url_date]

--- a/lib/tasks/price_policies.rake
+++ b/lib/tasks/price_policies.rake
@@ -45,4 +45,25 @@ namespace :price_policies do
     puts "DONE"
   end
 
+  # bundle exec rake 'price_policies:update_skip_review'
+  # bundle exec rake 'price_policies:update_skip_review[commit]'
+  desc "Update current price policies existing Skip Review products"
+  task :update_skip_review, [:commit] => :environment do |_t, args|
+    commit = args[:commit].to_s == "commit"
+
+    # We already have a price policy for PriceGroup.nonbillable
+    groups = PriceGroup.globals - [PriceGroup.nonbillable]
+
+    skip_review_products = Product.where(billing_mode: "Skip Review")
+    if commit
+      skip_review_products.each do |product|
+        product.create_skip_review_price_policies(groups)
+      end
+    else
+      puts "Found #{skip_review_products.count} Skip Review products"
+      puts "Price Groups to add price policies for:"
+      puts groups
+    end
+  end
+
 end

--- a/lib/tasks/price_policies.rake
+++ b/lib/tasks/price_policies.rake
@@ -57,7 +57,7 @@ namespace :price_policies do
     skip_review_products = Product.where(billing_mode: "Skip Review")
     if commit
       skip_review_products.each do |product|
-        product.create_skip_review_price_policies(groups)
+        PricePolicyBuilder.create_skip_review_for(product, groups)
       end
     else
       puts "Found #{skip_review_products.count} Skip Review products"

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -109,7 +109,7 @@ FactoryBot.define do
 
     factory :setup_item, class: Item do
       after(:create) do |product|
-        create(:item_price_policy, product: product, price_group: product.facility.price_groups.last)
+        create(:item_price_policy, product: product, price_group: product.facility.price_groups.last) if product.default_mode?
       end
     end
 

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -22,10 +22,7 @@ RSpec.describe "Adding products with different billing modes to cart" do
   ### SHARED EXAMPLES ###
   shared_examples "user with no accounts" do
     before(:each) do
-      u = logged_in_user
-      u.account_users.each(&:destroy)
-      u.save
-      u.reload
+      logged_in_user.account_users.each(&:destroy)
       login_as logged_in_user
     end
 

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Adding products with different billing modes to cart" do
       login_as logged_in_user
     end
 
-    it "allows a user without any accounts to add a nonbillable product to cart" do
+    it "allows a user without any accounts to add a Nonbillable product to cart" do
       visit facility_item_path(facility, nonbillable_item)
       click_on "Add to cart"
       expect(page).to have_content(nonbillable_item.name)
@@ -34,10 +34,15 @@ RSpec.describe "Adding products with different billing modes to cart" do
 
     it "does not allow a user without any accounts to add a Skip Review product to cart" do
       visit facility_item_path(facility, skip_review_item)
-      expect(page).to have_content("Sorry, but we could not find a valid payment source that you can use to purchase this")
+      price_groups_present = self.class.metadata[:feature_setting][:user_based_price_groups]
+      if price_groups_present
+        expect(page).to have_content("Sorry, but we could not find a valid payment source that you can use to purchase this")
+      else
+        expect(page).to have_content("You are not in a price group that may purchase this")
+      end
     end
 
-    it "does not allow a user without any accounts to add a default product to cart" do
+    it "does not allow a user without any accounts to add a Default product to cart" do
       visit facility_item_path(facility, default_item)
       expect(page).to have_content("You are not in a price group that may purchase this")
     end

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -34,17 +34,7 @@ RSpec.describe "Adding products with different billing modes to cart" do
   let!(:default_price_policy_2) { create(:item_price_policy, price_group: PriceGroup.globals.second, product: default_item) }
 
   let(:external_user) { create(:user, :external) }
-
-  let!(:external_account) do
-    a = build(:purchase_order_account, facility:)
-    a.account_users.build(
-      user: external_user,
-      user_role: AccountUser::ACCOUNT_OWNER,
-      created_by_user: user
-    )
-    a.save
-    a
-  end
+  let!(:external_account) { create(:purchase_order_account, :with_account_owner, owner: external_user, facility:) }
 
   let(:user) { account.owner.user }
   let(:logged_in_user) { user }
@@ -106,13 +96,13 @@ RSpec.describe "Adding products with different billing modes to cart" do
       expect(page).to have_content(nonbillable_item.name)
     end
 
-    it "can add a default item to cart" do
-      visit facility_item_path(facility, default_item)
-      click_on "Add to cart"
-      choose account_used.to_s
-      click_button "Continue"
-      expect(page).to have_content(default_item.name)
-    end
+    # it "can add a default item to cart" do
+    #   visit facility_item_path(facility, default_item)
+    #   click_on "Add to cart"
+    #   choose account_used.to_s
+    #   click_button "Continue"
+    #   expect(page).to have_content(default_item.name)
+    # end
   end
 
   ### SPEC CONTEXTS ###
@@ -151,6 +141,13 @@ RSpec.describe "Adding products with different billing modes to cart" do
       it_behaves_like "adding item to cart" do
         let(:user_used) { user }
         let(:account_used) { account }
+      end
+    end
+
+    context "external user and external account" do
+      it_behaves_like "adding item to cart" do
+        let(:user_used) { external_user }
+        let(:account_used) { external_account }
       end
     end
   end

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -14,13 +14,6 @@ RSpec.describe "Adding products with different billing modes to cart" do
   let(:internal_user) { internal_account.owner.user }
   let(:external_user) { create(:user, :external) }
 
-  # not sure we should be doing these
-  let!(:internal_account_price_group_member) { create(:account_price_group_member, account: internal_account, price_group: PriceGroup.base) }
-  let!(:internal_account_price_group_member_2) { create(:account_price_group_member, account: internal_account, price_group: PriceGroup.external) }
-
-  let!(:default_price_policy) { create(:item_price_policy, price_group: PriceGroup.base, product: default_item) }
-  let!(:default_price_policy_2) { create(:item_price_policy, price_group: PriceGroup.external, product: default_item) }
-
   before do
     create(:account_user, :purchaser, account: internal_account, user: external_user)
     create(:account_user, :purchaser, account: external_account, user: internal_user)
@@ -52,11 +45,7 @@ RSpec.describe "Adding products with different billing modes to cart" do
 
     it "does not allow a user without any accounts to add a default product to cart" do
       visit facility_item_path(facility, default_item)
-      if price_groups_present
-        expect(page).to have_content("Sorry, but we could not find a valid payment source that you can use to purchase this")
-      else
-        expect(page).to have_content("You are not in a price group that may purchase this")
-      end
+      expect(page).to have_content("You are not in a price group that may purchase this")
     end
   end
 
@@ -93,14 +82,12 @@ RSpec.describe "Adding products with different billing modes to cart" do
     context "when a user has no price groups (or no account with price groups)" do
       it_behaves_like "user with no accounts" do
         let(:logged_in_user) { internal_user }
-        let(:price_groups_present) { false }
       end
     end
 
     context "with an external user that has no account" do
       it_behaves_like "user with no accounts" do
         let(:logged_in_user) { external_user }
-        let(:price_groups_present) { false }
       end
     end
   end
@@ -109,14 +96,12 @@ RSpec.describe "Adding products with different billing modes to cart" do
     context "with an internal that has no account" do
       it_behaves_like "user with no accounts" do
         let(:logged_in_user) { internal_user }
-        let(:price_groups_present) { true }
       end
     end
 
     context "with an external user that has no account" do
       it_behaves_like "user with no accounts" do
         let(:logged_in_user) { external_user }
-        let(:price_groups_present) { true }
       end
     end
 

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -45,7 +45,37 @@ RSpec.describe "Adding products with different billing modes to cart" do
 
   shared_examples "adding items to the cart" do
     before(:each) do
+      # The setup_item factory creates a price_policy
+      # for a facility-based price group.
+      # This allows purchasing the default_item with the internal_account.
+      create(:item_price_policy, price_group: PriceGroup.base, product: default_item)
       login_as logged_in_user
+    end
+
+    context "when a nonbillable product is added first" do
+      before do
+        visit facility_item_path(facility, nonbillable_item)
+        click_on "Add to cart"
+        expect(page).to have_content(nonbillable_item.name)
+      end
+
+      it "can add another Nonbillable product" do
+        visit facility_item_path(facility, nonbillable_item)
+        click_on "Add to cart"
+        expect(page).to have_content(nonbillable_item.name).twice
+      end
+
+      it "cannot add Skip Review item to cart" do
+        visit facility_item_path(facility, skip_review_item)
+        click_on "Add to cart"
+        expect(page).to have_content("#{skip_review_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
+      end
+
+      it "cannot add a default billing mode product" do
+        visit facility_item_path(facility, default_item)
+        click_on "Add to cart"
+        expect(page).to have_content("#{default_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
+      end
     end
 
     it "can add Skip Review item to cart" do
@@ -56,11 +86,6 @@ RSpec.describe "Adding products with different billing modes to cart" do
       expect(page).to have_content(skip_review_item.name)
     end
 
-    it "can add Nonbillable item to cart" do
-      visit facility_item_path(facility, nonbillable_item)
-      click_on "Add to cart"
-      expect(page).to have_content(nonbillable_item.name)
-    end
   end
 
   ### SPEC CONTEXTS ###

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -21,25 +21,22 @@ RSpec.describe "Adding products with different billing modes to cart" do
   let!(:default_price_policy) { create(:item_price_policy, price_group: PriceGroup.base, product: default_item) }
   let!(:default_price_policy_2) { create(:item_price_policy, price_group: PriceGroup.external, product: default_item) }
 
-  let(:logged_in_user) { internal_user }
-
   before do
     create(:account_user, :purchaser, account: internal_account, user: external_user)
     create(:account_user, :purchaser, account: external_account, user: internal_user)
-    login_as logged_in_user
   end
 
   ### SHARED EXAMPLES ###
   shared_examples "user with no accounts" do
     before(:each) do
-      u = user_used
+      u = logged_in_user
       u.account_users.each(&:destroy)
       u.save
       u.reload
     end
 
     before do
-      login_as user_used
+      login_as logged_in_user
     end
 
     it "allows a user without any accounts to add a nonbillable product to cart" do
@@ -65,7 +62,7 @@ RSpec.describe "Adding products with different billing modes to cart" do
 
   shared_examples "adding item to cart" do
     before do
-      login_as user_used
+      login_as logged_in_user
     end
 
     it "can add Skip Review item to cart" do
@@ -95,14 +92,14 @@ RSpec.describe "Adding products with different billing modes to cart" do
   context "with user-based price groups disabled", feature_setting: { user_based_price_groups: false } do
     context "when a user has no price groups (or no account with price groups)" do
       it_behaves_like "user with no accounts" do
-        let(:user_used) { internal_user }
+        let(:logged_in_user) { internal_user }
         let(:price_groups_present) { false }
       end
     end
 
     context "with an external user that has no account" do
       it_behaves_like "user with no accounts" do
-        let(:user_used) { external_user }
+        let(:logged_in_user) { external_user }
         let(:price_groups_present) { false }
       end
     end
@@ -111,42 +108,42 @@ RSpec.describe "Adding products with different billing modes to cart" do
   context "with user-based price groups enabled", feature_setting: { user_based_price_groups: true } do
     context "with an internal that has no account" do
       it_behaves_like "user with no accounts" do
-        let(:user_used) { internal_user }
+        let(:logged_in_user) { internal_user }
         let(:price_groups_present) { true }
       end
     end
 
     context "with an external user that has no account" do
       it_behaves_like "user with no accounts" do
-        let(:user_used) { external_user }
+        let(:logged_in_user) { external_user }
         let(:price_groups_present) { true }
       end
     end
 
     context "internal user and internal account" do
       it_behaves_like "adding item to cart" do
-        let(:user_used) { internal_user }
+        let(:logged_in_user) { internal_user }
         let(:account_used) { internal_account }
       end
     end
 
     context "internal user and external account" do
       it_behaves_like "adding item to cart" do
-        let(:user_used) { internal_user }
+        let(:logged_in_user) { internal_user }
         let(:account_used) { external_account }
       end
     end
 
     context "external user and external account" do
       it_behaves_like "adding item to cart" do
-        let(:user_used) { external_user }
+        let(:logged_in_user) { external_user }
         let(:account_used) { external_account }
       end
     end
 
     context "external user and internal account" do
       it_behaves_like "adding item to cart" do
-        let(:user_used) { external_user }
+        let(:logged_in_user) { external_user }
         let(:account_used) { internal_account }
       end
     end

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe "Adding products with different billing modes to cart" do
   let(:logged_in_user) { user }
 
   before do
+    create(:account_user, :purchaser, account:, user: external_user)
+    create(:account_user, :purchaser, account: external_account, user:)
     login_as logged_in_user
   end
 
@@ -144,10 +146,24 @@ RSpec.describe "Adding products with different billing modes to cart" do
       end
     end
 
+    context "internal user and external account" do
+      it_behaves_like "adding item to cart" do
+        let(:user_used) { user }
+        let(:account_used) { external_account }
+      end
+    end
+
     context "external user and external account" do
       it_behaves_like "adding item to cart" do
         let(:user_used) { external_user }
         let(:account_used) { external_account }
+      end
+    end
+
+    context "external user and internal account" do
+      it_behaves_like "adding item to cart" do
+        let(:user_used) { external_user }
+        let(:account_used) { account }
       end
     end
   end

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -4,24 +4,9 @@ require "rails_helper"
 
 RSpec.describe "Adding products with different billing modes to cart" do
   let(:facility) { create(:setup_facility) }
-  let(:billing_mode) { "Default" }
   let!(:nonbillable_item) { create(:setup_item, facility:, billing_mode: "Nonbillable") }
   let!(:default_item) { create(:setup_item, facility:, billing_mode: "Default") }
-
-  let(:skip_review_item) do
-    # Do not want the facotry to add price policies, so not using
-    # :setup_item
-    FactoryBot.create(:item,
-                      facility:,
-                      facility_account: facility.facility_accounts.first,
-                      billing_mode: "Skip Review",
-                      name: "Skip Review Item",
-                      url_name: "skip-review-item",
-                      description: "Product description",
-                      account: 71_234,
-                      initial_order_status: FactoryBot.create(:order_status, name: "New"),
-                     )
-  end
+  let(:skip_review_item) { create(:setup_item, facility:, billing_mode: "Skip Review") }
 
   let!(:account) { create(:purchase_order_account, :with_account_owner, facility:) }
   let!(:account_price_group_member) { create(:account_price_group_member, account:, price_group: PriceGroup.base) }

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -128,6 +128,12 @@ RSpec.describe "Adding products with different billing modes to cart" do
         expect(page).to have_content(default_item.name).twice
       end
 
+      it "can add a Skip Review item to cart" do
+        visit facility_item_path(facility, skip_review_item)
+        click_on "Add to cart"
+        expect(page).to have_content(skip_review_item.name)
+      end
+
       it "can add a Nonbillable product" do
         visit facility_item_path(facility, nonbillable_item)
         click_on "Add to cart"

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Adding products with different billing modes to cart" do
   let(:internal_user) { internal_account.owner.user }
   let(:external_user) { create(:user, :external) }
 
-  before do
+  before(:each) do
     create(:account_user, :purchaser, account: internal_account, user: external_user)
     create(:account_user, :purchaser, account: external_account, user: internal_user)
   end
@@ -26,9 +26,6 @@ RSpec.describe "Adding products with different billing modes to cart" do
       u.account_users.each(&:destroy)
       u.save
       u.reload
-    end
-
-    before do
       login_as logged_in_user
     end
 
@@ -49,8 +46,8 @@ RSpec.describe "Adding products with different billing modes to cart" do
     end
   end
 
-  shared_examples "adding item to cart" do
-    before do
+  shared_examples "adding items to the cart" do
+    before(:each) do
       login_as logged_in_user
     end
 
@@ -67,14 +64,6 @@ RSpec.describe "Adding products with different billing modes to cart" do
       click_on "Add to cart"
       expect(page).to have_content(nonbillable_item.name)
     end
-
-    # it "can add a default item to cart" do
-    #   visit facility_item_path(facility, default_item)
-    #   click_on "Add to cart"
-    #   choose account_used.to_s
-    #   click_button "Continue"
-    #   expect(page).to have_content(default_item.name)
-    # end
   end
 
   ### SPEC CONTEXTS ###
@@ -106,28 +95,28 @@ RSpec.describe "Adding products with different billing modes to cart" do
     end
 
     context "internal user and internal account" do
-      it_behaves_like "adding item to cart" do
+      it_behaves_like "adding items to the cart" do
         let(:logged_in_user) { internal_user }
         let(:account_used) { internal_account }
       end
     end
 
     context "internal user and external account" do
-      it_behaves_like "adding item to cart" do
+      it_behaves_like "adding items to the cart" do
         let(:logged_in_user) { internal_user }
         let(:account_used) { external_account }
       end
     end
 
     context "external user and external account" do
-      it_behaves_like "adding item to cart" do
+      it_behaves_like "adding items to the cart" do
         let(:logged_in_user) { external_user }
         let(:account_used) { external_account }
       end
     end
 
     context "external user and internal account" do
-      it_behaves_like "adding item to cart" do
+      it_behaves_like "adding items to the cart" do
         let(:logged_in_user) { external_user }
         let(:account_used) { internal_account }
       end

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe "Adding products with different billing modes to cart" do
     it "can add a default item to cart" do
       visit facility_item_path(facility, default_item)
       click_on "Add to cart"
+      choose account_used.to_s
       click_button "Continue"
       expect(page).to have_content(default_item.name)
     end

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -52,14 +52,14 @@ RSpec.describe "Adding products with different billing modes to cart" do
       login_as logged_in_user
     end
 
-    context "when a nonbillable product is added first" do
+    context "when a Nonbillable product is added first" do
       before do
         visit facility_item_path(facility, nonbillable_item)
         click_on "Add to cart"
-        expect(page).to have_content(nonbillable_item.name)
       end
 
       it "can add another Nonbillable product" do
+        expect(page).to have_content(nonbillable_item.name)
         visit facility_item_path(facility, nonbillable_item)
         click_on "Add to cart"
         expect(page).to have_content(nonbillable_item.name).twice
@@ -71,21 +71,40 @@ RSpec.describe "Adding products with different billing modes to cart" do
         expect(page).to have_content("#{skip_review_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
       end
 
-      it "cannot add a default billing mode product" do
+      it "cannot add a Default billing mode product" do
         visit facility_item_path(facility, default_item)
         click_on "Add to cart"
         expect(page).to have_content("#{default_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
       end
     end
 
-    it "can add Skip Review item to cart" do
-      visit facility_item_path(facility, skip_review_item)
-      click_on "Add to cart"
-      choose account_used.to_s
-      click_button "Continue"
-      expect(page).to have_content(skip_review_item.name)
-    end
+    context "when a Skip Review product is added first" do
+      before do
+        visit facility_item_path(facility, skip_review_item)
+        click_on "Add to cart"
+        choose account_used.to_s
+        click_button "Continue"
+      end
 
+      it "can add another Skip Review item to cart" do
+        expect(page).to have_content(skip_review_item.name)
+        visit facility_item_path(facility, skip_review_item)
+        click_on "Add to cart"
+        expect(page).to have_content(skip_review_item.name).twice
+      end
+
+      it "can add a Nonbillable product" do
+        visit facility_item_path(facility, nonbillable_item)
+        click_on "Add to cart"
+        expect(page).to have_content(nonbillable_item.name)
+      end
+
+      it "can add Default item to cart" do
+        visit facility_item_path(facility, default_item)
+        click_on "Add to cart"
+        expect(page).to have_content(default_item.name)
+      end
+    end
   end
 
   ### SPEC CONTEXTS ###

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe "Adding products with different billing modes to cart" do
   let!(:default_item) { create(:setup_item, facility:, billing_mode: "Default") }
   let(:skip_review_item) { create(:setup_item, facility:, billing_mode: "Skip Review") }
 
-  let!(:account) { create(:purchase_order_account, :with_account_owner, facility:) }
-  let!(:account_price_group_member) { create(:account_price_group_member, account:, price_group: PriceGroup.base) }
-  let!(:account_price_group_member_2) { create(:account_price_group_member, account:, price_group: PriceGroup.external) }
+  let!(:internal_account) { create(:purchase_order_account, :with_account_owner, facility:) }
+  let!(:internal_account_price_group_member) { create(:account_price_group_member, account: internal_account, price_group: PriceGroup.base) }
+  let!(:internal_account_price_group_member_2) { create(:account_price_group_member, account: internal_account, price_group: PriceGroup.external) }
 
   let!(:nonbillable_price_policy) { create(:item_price_policy, price_group: PriceGroup.globals.first, product: nonbillable_item) }
   let!(:nonbillable_price_policy_2) { create(:item_price_policy, price_group: PriceGroup.globals.second, product: nonbillable_item) }
@@ -21,11 +21,11 @@ RSpec.describe "Adding products with different billing modes to cart" do
   let(:external_user) { create(:user, :external) }
   let!(:external_account) { create(:purchase_order_account, :with_account_owner, owner: external_user, facility:) }
 
-  let(:user) { account.owner.user }
+  let(:user) { internal_account.owner.user }
   let(:logged_in_user) { user }
 
   before do
-    create(:account_user, :purchaser, account:, user: external_user)
+    create(:account_user, :purchaser, account: internal_account, user: external_user)
     create(:account_user, :purchaser, account: external_account, user:)
     login_as logged_in_user
   end
@@ -127,7 +127,7 @@ RSpec.describe "Adding products with different billing modes to cart" do
     context "internal user and internal account" do
       it_behaves_like "adding item to cart" do
         let(:user_used) { user }
-        let(:account_used) { account }
+        let(:account_used) { internal_account }
       end
     end
 
@@ -148,7 +148,7 @@ RSpec.describe "Adding products with different billing modes to cart" do
     context "external user and internal account" do
       it_behaves_like "adding item to cart" do
         let(:user_used) { external_user }
-        let(:account_used) { account }
+        let(:account_used) { internal_account }
       end
     end
   end

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -4,12 +4,12 @@ require "rails_helper"
 
 RSpec.describe "Adding products with different billing modes to cart" do
   let(:facility) { create(:setup_facility) }
-  let!(:nonbillable_item) { create(:setup_item, facility:, billing_mode: "Nonbillable") }
-  let!(:default_item) { create(:setup_item, facility:, billing_mode: "Default") }
+  let(:nonbillable_item) { create(:setup_item, facility:, billing_mode: "Nonbillable") }
+  let(:default_item) { create(:setup_item, facility:, billing_mode: "Default") }
   let(:skip_review_item) { create(:setup_item, facility:, billing_mode: "Skip Review") }
 
-  let!(:internal_account) { create(:purchase_order_account, :with_account_owner, facility:) }
-  let!(:external_account) { create(:purchase_order_account, :with_account_owner, owner: external_user, facility:) }
+  let(:internal_account) { create(:purchase_order_account, :with_account_owner, facility:) }
+  let(:external_account) { create(:purchase_order_account, :with_account_owner, owner: external_user, facility:) }
 
   let(:internal_user) { internal_account.owner.user }
   let(:external_user) { create(:user, :external) }

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -96,18 +96,18 @@ RSpec.describe "Adding products with different billing modes to cart" do
       expect(page).to have_content(nonbillable_item.name)
     end
 
-    it "allows a user to add another default product" do
+    it "can add a default item to cart" do
       visit facility_item_path(facility, default_item)
       click_on "Add to cart"
-      expect(page).to have_content(default_item.name).twice
-    end
-
-    it "allows a user to add another nonbillable product" do
-      visit facility_item_path(facility, nonbillable_item)
-      click_on "Add to cart"
+      click_button "Continue"
       expect(page).to have_content(default_item.name)
-      expect(page).to have_content(nonbillable_item.name)
-      expect(page).not_to have_content("#{nonbillable_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
+    end
+  end
+
+  context "internal user and internal account" do
+    it_behaves_like "adding item to cart" do
+      let(:user_used) { user }
+      let(:account_used) { account }
     end
   end
 

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -132,13 +132,6 @@ RSpec.describe "Adding products with different billing modes to cart" do
     end
   end
 
-  context "internal user and internal account" do
-    it_behaves_like "adding item to cart" do
-      let(:user_used) { user }
-      let(:account_used) { account }
-    end
-  end
-
   context "with user-based price groups enabled", feature_setting: { user_based_price_groups: true } do
     context "with an internal that has no account" do
       it_behaves_like "user with no accounts" do
@@ -154,61 +147,10 @@ RSpec.describe "Adding products with different billing modes to cart" do
       end
     end
 
-    describe "multi-item cart" do
-      context "when a nonbillable product is added first" do
-        before do
-          visit facility_item_path(facility, nonbillable_item)
-          click_on "Add to cart"
-        end
-
-        it "allows a user to add another nonbillable product" do
-          visit facility_item_path(facility, nonbillable_item)
-          click_on "Add to cart"
-          expect(page).to have_content(nonbillable_item.name).twice
-        end
-
-        it "does not allow a user to add a default billing mode product" do
-          visit facility_item_path(facility, default_item)
-          click_on "Add to cart"
-          expect(page).to have_content("#{default_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
-        end
-      end
-
-      context "when a default product is added first" do
-        before do
-          visit facility_item_path(facility, default_item)
-          click_on "Add to cart"
-          choose account.description
-          click_on "Continue"
-        end
-
-        it "allows a user to add another default product" do
-          visit facility_item_path(facility, default_item)
-          click_on "Add to cart"
-          expect(page).to have_content(default_item.name).twice
-        end
-
-        it "allows a user to add another nonbillable product" do
-          visit facility_item_path(facility, nonbillable_item)
-          click_on "Add to cart"
-          expect(page).to have_content(default_item.name)
-          expect(page).to have_content(nonbillable_item.name)
-          expect(page).not_to have_content("#{nonbillable_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
-        end
-      end
-
-      context "when an external user is used" do
-        let(:logged_in_user) { external_user }
-
-        it "Adds skip review item to cart" do
-          external_account
-          visit facility_item_path(facility, skip_review_item)
-
-          click_on "Add to cart"
-          choose external_account.to_s
-          click_button "Continue"
-          expect(page).to have_content(skip_review_item.name)
-        end
+    context "internal user and internal account" do
+      it_behaves_like "adding item to cart" do
+        let(:user_used) { user }
+        let(:account_used) { account }
       end
     end
   end


### PR DESCRIPTION
# Release Notes

- Addresses this Rollbar error: https://app.rollbar.com/a/oregonstate/fix/item/RELMS/38/occurrence/365621698022#detail
- Allows external users to reserve or purchase any Nonbillable product
- Requires a payment source selection for Skip Review products
- Updates the setup_global method
- Big improvement in improved spec coverage

## Manual Tasks

This adds a new `after_create` callback on `Product`. Instead of creating a price policy for just the base price group, it creates one for all global price groups. For existing `skip_review_mode?` products to work correctly, they will need to have these price policies added manually:
`bundle exec rake 'price_policies:update_skip_review[commit]'`