### PR TITLE
[#161969] Fix My Payment Sources page

### DIFF
--- a/app/views/facility_statements/index.html.haml
+++ b/app/views/facility_statements/index.html.haml
@@ -24,4 +24,4 @@
 
 - if @statements.any?
   = link_to t("reports.account_transactions.export"), url_for(format: :csv), class: "js--exportSearchResults pull-right", data: { form: ".search_form" }
-= render partial: "shared/statements_table"
+= render partial: "shared/statements_table", locals: { show_cancel_button: true }

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -26,12 +26,21 @@
               - # TODO: Refactor Statement#order_details to go through statement_rows so we can generate PDFs for canceled statements
               - path = current_facility ? statement_path(s) : account_statement_path(s.account, s, format: :pdf)
               = link_to t("statements.pdf.download"), path
-              - if SettingsHelper.feature_on?(:send_statement_emails) && current_facility
-                %br
-                = link_to(t("statements.resend"), resend_emails_facility_statement_path(current_facility, s), method: :post, class: "js--resend", data: { confirm: "You are about to re-send this invoice to the following recipients: #{s.users_to_notify.join(", ")}" })
+              - if current_facility
+                - if SettingsHelper.feature_on?(:send_statement_emails)
+                  %br
+                  - confirm = "You are about to re-send this invoice to the following recipients: #{s.users_to_notify.join(", ")}"
+                  = link_to(t("statements.resend"),
+                    resend_emails_facility_statement_path(current_facility, s),
+                    method: :post,
+                    class: "js--resend",
+                    data: { confirm: confirm })
 
-              - if s.can_cancel?
-                %span= link_to(t("statements.cancel"), cancel_facility_statement_path(current_facility, s), method: :post, class: "btn btn-danger", data: {confirm: "Are you sure you want to cancel?"})
+                - if s.can_cancel?
+                  = button_to(t("statements.cancel"),
+                    cancel_facility_statement_path(current_facility, s),
+∑                    class: "btn btn-danger",
+                    data: { confirm: "Are you sure you want to cancel?" })
           %td= format_usa_datetime(s.created_at)
           %td= s.account.notify_users.map(&:full_name).join(', ')
           - unless @account

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -36,10 +36,10 @@
                     class: "js--resend",
                     data: { confirm: confirm })
 
-                - if s.can_cancel?
+                - if s.can_cancel? && show_cancel_button
                   = button_to(t("statements.cancel"),
                     cancel_facility_statement_path(current_facility, s),
-∑                    class: "btn btn-danger",
+                    class: "btn btn-danger",
                     data: { confirm: "Are you sure you want to cancel?" })
           %td= format_usa_datetime(s.created_at)
           %td= s.account.notify_users.map(&:full_name).join(', ')

--- a/app/views/statements/index.html.haml
+++ b/app/views/statements/index.html.haml
@@ -8,4 +8,4 @@
   %h3= @account.account_number
   %p= @account.description_to_s
 
-= render "shared/statements_table"
+= render "shared/statements_table", locals: { show_cancel_button: false }

--- a/spec/system/admin/cancel_statement_spec.rb
+++ b/spec/system/admin/cancel_statement_spec.rb
@@ -5,46 +5,76 @@ require "rails_helper"
 RSpec.describe "canceling statements" do
   let(:facility) { create(:setup_facility) }
   let(:item) { create(:setup_item, facility:) }
-  let!(:order) { create(:complete_order, product: item, quantity: 3, account: create(:purchase_order_account, :with_account_owner, facility:)) }
-  let(:order_details) { order.order_details }
-  let!(:statement) { create(:statement, facility:) }
+  let(:statement) { create(:statement, account: po_account, facility:) }
   let(:director) { create(:user, :facility_director, facility:) }
-
-  before do
-    order_details.each do |od|
-      od.statement = statement
-      od.save
-    end
-
-    login_as director
-    visit facility_statements_path(facility)
+  let(:po_account) { create(:purchase_order_account, :with_account_owner, facility:) }
+  let(:account_owner) { po_account.owner_user }
+  let!(:order) do
+    create(:complete_order,
+      product: item,
+      quantity: 3,
+      account: po_account
+    )
   end
+  let(:order_detail) { order.order_details.first }
 
-  context "when an order detail is NOT reconciled" do
-    it "cancels a statement" do
-      click_on "Cancel"
-      expect(page).to have_content "#{I18n.t('Statement')} has been canceled"
-      expect(page).to have_content "Canceled"
-    end
+  before(:each) { order_detail.update(statement: statement) }
 
-    it "does not allow download or emailing of statement" do
-      click_on "Cancel"
-      expect(page).to_not have_content "Download"
-      expect(page).to_not have_content "Resend"
-      expect(page).to_not have_link "Cancel"
-    end
-  end
-
-  context "when an order detail is reconciled" do
+  context "as an admin" do
     before do
-      order_details.first.to_reconciled!
+      login_as director
       visit facility_statements_path(facility)
     end
 
-    it "does not allow statement to be canceled" do
+    context "when an order detail is NOT reconciled" do
+      it "cancels a statement" do
+        click_on "Cancel"
+        expect(page).to have_content "#{I18n.t('Statement')} has been canceled"
+        expect(page).to have_content "Canceled"
+      end
+
+      it "does not allow download or emailing of statement" do
+        click_on "Cancel"
+        expect(page).to_not have_content "Download"
+        expect(page).to_not have_content "Resend"
+        expect(page).to_not have_link "Cancel"
+      end
+    end
+
+    context "when an order detail is reconciled" do
+      before do
+        order_detail.to_reconciled!
+        visit facility_statements_path(facility)
+      end
+
+      it "does not allow statement to be canceled" do
+        expect(page).to have_content "Download"
+        expect(page).to have_content "Resend" if SettingsHelper.feature_on?(:send_statement_emails)
+        expect(page).to_not have_link "Cancel"
+      end
+    end
+
+    context "when statement is canceled" do
+      let(:statement) { create(:statement, canceled_at: 2.days.ago, facility:) }
+
+      it "does not allow statement to be canceled, downloaded, or resent" do
+        expect(page).not_to have_content "Download"
+        expect(page).not_to have_content "Resend" if SettingsHelper.feature_on?(:send_statement_emails)
+        expect(page).not_to have_link "Cancel"
+      end
+    end
+  end
+
+  context "as an account owner" do
+    before do
+      login_as account_owner
+      visit account_statements_path(po_account)
+    end
+
+    it "does not allow statement to be canceled or resent" do
       expect(page).to have_content "Download"
-      expect(page).to have_content "Resend" if SettingsHelper.feature_on?(:send_statement_emails)
-      expect(page).to_not have_link "Cancel"
+      expect(page).not_to have_content "Resend" if SettingsHelper.feature_on?(:send_statement_emails)
+      expect(page).not_to have_link "Cancel"
     end
   end
 end


### PR DESCRIPTION
Account owners and business admins will get an error when trying to access the Statements tab of the My Payment Sources - Details page - for an account that has cancelable statements.

Bug introduced in https://github.com/tablexi/nucore-open/pull/3663

Rollbar:
https://app.rollbar.com/a/tablexi/fix/item/nucore-dartmouth/364/occurrence/365890715445#detail

# TO DO
- [x] Add specs that cover this case - visit the My Payment Sources - Details page / Statements tab when there are cancelable statements.  You should not see the cancel button but the page should load with no errors.


