### PR TITLE
[#161966] Don't auto-reconcile problem orders

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -392,6 +392,7 @@ class OrderDetail < ApplicationRecord
   def skip_review?
     actual_total &&
       complete? &&
+      !problem_order? &&
       product.skip_order_review?
   end
 

--- a/spec/services/auto_expire_reservation_spec.rb
+++ b/spec/services/auto_expire_reservation_spec.rb
@@ -52,6 +52,44 @@ RSpec.describe AutoExpireReservation, :time_travel do
       end
     end
 
+    context "a started Nonbillable reservation" do
+      let(:instrument) { create(:setup_instrument, :timer, min_reserve_mins: 1, problems_resolvable_by_user: true, billing_mode: "Nonbillable") }
+
+      let!(:reservation) do
+        create(:purchased_reservation, :yesterday, actual_start_at: 1.hour.ago,
+                                                   product: instrument)
+      end
+
+      it "completes the reservation" do
+        expect { action.perform }.to change { order_detail.reload.state }.from("new").to("complete")
+      end
+
+      it "sets this to a problem reservation" do
+        expect { action.perform }.to change { order_detail.reload.problem }.to(true)
+      end
+
+      it "logs the problem reservation" do
+        action.perform
+        log_event = LogEvent.find_by(loggable: reservation.order_detail, event_type: :problem_queue)
+        expect(log_event).to be_present
+        expect(log_event.metadata).to eq("cause"=>"auto_expire")
+      end
+
+      it "does not assign pricing" do
+        action.perform
+        expect(order_detail.reload.price_policy).to be_nil
+      end
+
+      it "sets the reservation fulfilled at time" do
+        expect { action.perform }.to change { order_detail.reload.fulfilled_at }.to(reservation.reserve_end_at)
+      end
+
+      it "triggers an email with a link to fix it themselves" do
+        expect { action.perform }.to change(ActionMailer::Base.deliveries, :count).by(1)
+        expect(ActionMailer::Base.deliveries.last.body.encoded).to include("click on the link below")
+      end
+    end
+
     context "a started reservation that is already in the problem queue" do
       let!(:reservation) do
         create(:purchased_reservation, :yesterday, actual_start_at: 1.hour.ago,

--- a/spec/services/auto_expire_reservation_spec.rb
+++ b/spec/services/auto_expire_reservation_spec.rb
@@ -75,9 +75,10 @@ RSpec.describe AutoExpireReservation, :time_travel do
         expect(log_event.metadata).to eq("cause"=>"auto_expire")
       end
 
-      it "does not assign pricing" do
+      it "assigns a price policy" do
         action.perform
-        expect(order_detail.reload.price_policy).to be_nil
+        expect(order_detail.reload.price_policy).to be_present
+        expect(order_detail.reload.price_policy.unit_cost).to eq 0
       end
 
       it "sets the reservation fulfilled at time" do


### PR DESCRIPTION
# Release Notes

Nonbillable and Skip Review transactions should go to the problem queue like everyone else.

Before this change, Nonbillable and Skip Review transactions would get marked "Complete" as part of being moved to the problem queue, and then go automatically to "Reconciled". The system does not expect the order detail to be reconciled, so it raises an error and rolls everything back:
`raise "Trying to move Order ##{@order_detail} to problem queue, but it's not a problem" unless @order_detail.problem?`

The code's definition of "problem" is more complex than it needs to be but it requires the the order detail to be in the "complete" state:
```
  before_save :set_problem_order
  def set_problem_order
    self.problem = problem_description_key.present?
    update_fulfilled_at_on_resolve if time_data.present?
    true # problem might be false; we need the callback chain to continue
  end
# ...
  def problem_description_key
    Array(problem_description_keys).first
  end

  def problem_description_keys
    return [] unless complete?

    time_data_problem_key = time_data.problem_description_key
    price_policy_problem_key = :missing_price_policy if price_policy.blank?
    missing_form_problem_key = :missing_form if missing_form?

    [time_data_problem_key, price_policy_problem_key, missing_form_problem_key].compact
  end
```

To fix this, we just need to prevent auto-reconciling.  This allows `problem_description_keys` to return the expected values, `problem_description_key.present?` will return truthy, and `problem` will be set to `true`.