### PR TITLE
Security update for jquery-ui-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,8 @@ gem "dynamic_form", git: "https://github.com/payrollhero/dynamic_form"
 # 5.0 has breaking changes based which need to be addressed before we can upgrade
 gem "ckeditor", "< 5"
 gem "jquery-rails"
-gem "jquery-ui-rails"
+# https://github.com/jquery-ui-rails/jquery-ui-rails/issues/146#issuecomment-1655225232
+gem "jquery-ui-rails", git: "https://github.com/jquery-ui-rails/jquery-ui-rails.git"
 gem "vuejs-rails", "~> 1.0.26" # 2.0 introduces breaking changes
 gem "clockpunch"
 gem "simple_form"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/jquery-ui-rails/jquery-ui-rails.git
+  revision: c7460b447589eb04aa948ecaf0d1245c88f6ff45
+  specs:
+    jquery-ui-rails (7.0.0)
+      railties (>= 3.2.16)
+
+GIT
   remote: https://github.com/payrollhero/dynamic_form
   revision: 072a58fb706ef65ea2e2eeddd12cacf47e77ae76
   specs:
@@ -367,8 +374,6 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-ui-rails (6.0.1)
-      railties (>= 3.2.16)
     json (2.6.3)
     jwt (2.7.1)
     kgio (2.11.4)
@@ -678,7 +683,7 @@ GEM
     will_paginate (4.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.11)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   aarch64-linux
@@ -731,7 +736,7 @@ DEPENDENCIES
   ice_cube
   image_processing (>= 1.2)
   jquery-rails
-  jquery-ui-rails
+  jquery-ui-rails!
   jwt
   kt-paperclip
   ldap_authentication!


### PR DESCRIPTION
https://github.com/jquery-ui-rails/jquery-ui-rails/issues/146#issuecomment-1655225232

This gem does not appear to be actively maintained...

We should probably use something else

https://github.com/tablexi/nucore-open/security/dependabot/43
https://github.com/tablexi/nucore-open/security/dependabot/44
https://github.com/tablexi/nucore-open/security/dependabot/45