### PR TITLE
[#161863] Instrument quantity on reconciled statements

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -358,7 +358,7 @@ class Reservation < ApplicationRecord
   end
 
   def update_billable_minutes
-    update_column(:billable_minutes, calculated_billable_minutes)
+    update_column(:billable_minutes, calculated_billable_minutes) if set_billable_minutes?
   end
 
   private
@@ -384,7 +384,9 @@ class Reservation < ApplicationRecord
   end
 
   def set_billable_minutes
-    self.billable_minutes = calculated_billable_minutes if set_billable_minutes?
+    if set_billable_minutes?
+      self.billable_minutes = calculated_billable_minutes
+    end
   end
 
   def set_billable_minutes?
@@ -392,6 +394,7 @@ class Reservation < ApplicationRecord
   end
 
   def calculated_billable_minutes
+    # binding.pry
     case price_policy.charge_for
     when InstrumentPricePolicy::CHARGE_FOR.fetch(:reservation)
       TimeRange.new(reserve_start_at, reserve_end_at).duration_mins

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -358,7 +358,7 @@ class Reservation < ApplicationRecord
   end
 
   def update_billable_minutes
-    update_column(:billable_minutes, calculated_billable_minutes) if set_billable_minutes?
+    update_column(:billable_minutes, calculated_billable_minutes)
   end
 
   private
@@ -384,9 +384,7 @@ class Reservation < ApplicationRecord
   end
 
   def set_billable_minutes
-    if set_billable_minutes?
-      self.billable_minutes = calculated_billable_minutes
-    end
+    self.billable_minutes = calculated_billable_minutes
   end
 
   def set_billable_minutes?
@@ -394,15 +392,16 @@ class Reservation < ApplicationRecord
   end
 
   def calculated_billable_minutes
-    # binding.pry
-    case price_policy.charge_for
-    when InstrumentPricePolicy::CHARGE_FOR.fetch(:reservation)
-      TimeRange.new(reserve_start_at, reserve_end_at).duration_mins
-    when InstrumentPricePolicy::CHARGE_FOR.fetch(:usage)
-      TimeRange.new(actual_start_at, actual_end_at).duration_mins
-    when InstrumentPricePolicy::CHARGE_FOR.fetch(:overage)
-      end_time = [reserve_end_at, actual_end_at].max
-      TimeRange.new(reserve_start_at, end_time).duration_mins
+    if set_billable_minutes?
+      case price_policy.charge_for
+      when InstrumentPricePolicy::CHARGE_FOR.fetch(:reservation)
+        TimeRange.new(reserve_start_at, reserve_end_at).duration_mins
+      when InstrumentPricePolicy::CHARGE_FOR.fetch(:usage)
+        TimeRange.new(actual_start_at, actual_end_at).duration_mins
+      when InstrumentPricePolicy::CHARGE_FOR.fetch(:overage)
+        end_time = [reserve_end_at, actual_end_at].max
+        TimeRange.new(reserve_start_at, end_time).duration_mins
+      end
     end
   end
 

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -388,7 +388,7 @@ class Reservation < ApplicationRecord
   end
 
   def calculated_billable_minutes
-    if order_detail&.complete? && order_detail&.canceled_at.blank? && price_policy.present?
+    if (order_detail&.complete? || order_detail&.reconciled?) && order_detail&.canceled_at.blank? && price_policy.present?
       case price_policy.charge_for
       when InstrumentPricePolicy::CHARGE_FOR.fetch(:reservation)
         TimeRange.new(reserve_start_at, reserve_end_at).duration_mins

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -391,8 +391,7 @@ class Reservation < ApplicationRecord
     order_detail&.complete? && order_detail&.canceled_at.blank? && price_policy.present?
   end
 
-  def calculated_billable_minutes
-    if set_billable_minutes?
+  def billable_duration_mins
       case price_policy.charge_for
       when InstrumentPricePolicy::CHARGE_FOR.fetch(:reservation)
         TimeRange.new(reserve_start_at, reserve_end_at).duration_mins
@@ -402,7 +401,10 @@ class Reservation < ApplicationRecord
         end_time = [reserve_end_at, actual_end_at].max
         TimeRange.new(reserve_start_at, end_time).duration_mins
       end
-    end
+  end
+
+  def calculated_billable_minutes
+    set_billable_minutes? ? billable_duration_mins : nil
   end
 
 end

--- a/app/support/price_displayment.rb
+++ b/app/support/price_displayment.rb
@@ -72,14 +72,22 @@ module PriceDisplayment
   private
 
   def build_quantity_presenter
-    quantity_to_display = if time_data.try(:actual_duration_mins) && time_data.actual_duration_mins.to_i > 0
-                            time_data.actual_duration_mins
+    quantity_to_display = if time_data.try(:billable_minutes) && time_data.billable_minutes.to_i > 0
+                            calculated_billable_minutes
                           elsif time_data.try(:duration_mins)
                             time_data.duration_mins
                           else
                             quantity
                           end
     QuantityPresenter.new(product, quantity_to_display)
+  end
+
+  def calculated_billable_minutes
+    if time_data.present? && time_data.respond_to?(:billable_minutes)
+      time_data.billable_minutes
+    else
+      quantity
+    end
   end
 
   def empty_display

--- a/app/support/price_displayment.rb
+++ b/app/support/price_displayment.rb
@@ -76,8 +76,8 @@ module PriceDisplayment
   private
 
   def build_statement_quantity_presenter
-    quantity_to_display = if calculated_billable_minutes > 0
-                            calculated_billable_minutes
+    quantity_to_display = if reservation.billable_duration_mins > 0
+                            reservation.billable_duration_mins
                           elsif time_data.try(:duration_mins)
                             time_data.duration_mins
                           else
@@ -95,18 +95,6 @@ module PriceDisplayment
                             quantity
                           end
     QuantityPresenter.new(product, quantity_to_display)
-  end
-
-  def calculated_billable_minutes
-    case reservation.price_policy.charge_for
-    when InstrumentPricePolicy::CHARGE_FOR.fetch(:reservation)
-      TimeRange.new(reservation.reserve_start_at, reservation.reserve_end_at).duration_mins
-    when InstrumentPricePolicy::CHARGE_FOR.fetch(:usage)
-      TimeRange.new(reservation.actual_start_at, reservation.actual_end_at).duration_mins
-    when InstrumentPricePolicy::CHARGE_FOR.fetch(:overage)
-      end_time = [reservation.reserve_end_at, reservation.actual_end_at].max
-      TimeRange.new(reservation.reserve_start_at, reservation.end_time).duration_mins
-    end
   end
 
   def empty_display


### PR DESCRIPTION
# Release Notes

Reservations for reconciled order details have their `billable_minutes` set to `nil`. OSU and UMass use this attribute in their statements, which means the purchased quantity is blank. Dartmouth and NU use `PriceDisplayment#wrapped_quanity` to display the quantity on the statement. This method relies on `actual_duration_mins` and `duration_mins` instead of `billable_minutes`

This PR makes `PriceDisplayment#wrapped_statement_quanity`, which uses a calculated value of, instead of the saved value for `billable_minutes`.

This method can be used by OSU and UMass to address the blank quantity on statements.