### PR TITLE
[#161941] Removes `sudo` from Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@ ENV BUNDLE_PATH /gems
 # Install NodeJS based on https://github.com/nodesource/distributions#installation-instructions
 RUN apt-get update && \
  # Installs the node repository
-  sudo apt-get install -y ca-certificates curl gnupg && \
-  sudo mkdir -p /etc/apt/keyrings && \
-  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  apt-get install -y ca-certificates curl gnupg && \
+  mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
   NODE_MAJOR=16 && \
-  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list && \
-  sudo apt-get update && \
-  sudo apt-get install nodejs -y && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
+  apt-get install nodejs -y && \
  # Installs libvips and the node repository
  apt-get install --yes libvips42 nodejs && \
  npm install --global yarn && \

--- a/Dockerfile.github-actions
+++ b/Dockerfile.github-actions
@@ -15,13 +15,13 @@ ARG NODE_VERSION=setup_16.x
 ENV NODE_VERISON ${NODE_VERSION}
 RUN apt-get update && \
  # Installs the node repository
-  sudo apt-get install -y ca-certificates curl gnupg && \
-  sudo mkdir -p /etc/apt/keyrings && \
-  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  apt-get install -y ca-certificates curl gnupg && \
+  mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
   NODE_MAJOR=16 && \
-  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list && \
-  sudo apt-get update && \
-  sudo apt-get install nodejs -y && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
+  apt-get install nodejs -y && \
  # Installs libvips and the node repository
  apt-get install --yes libvips42 nodejs && \
  npm install --global yarn && \


### PR DESCRIPTION
# Release Notes

In the build process on Github, there was a `sudo: not found` error. This PR removes `sudo` from the Dockerfiles