### PR TITLE
Downgrade jquery UI rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,8 +53,7 @@ gem "dynamic_form", git: "https://github.com/payrollhero/dynamic_form"
 # 5.0 has breaking changes based which need to be addressed before we can upgrade
 gem "ckeditor", "< 5"
 gem "jquery-rails"
-# https://github.com/jquery-ui-rails/jquery-ui-rails/issues/146#issuecomment-1655225232
-gem "jquery-ui-rails", git: "https://github.com/jquery-ui-rails/jquery-ui-rails.git"
+gem "jquery-ui-rails", "~> 6.0"
 gem "vuejs-rails", "~> 1.0.26" # 2.0 introduces breaking changes
 gem "clockpunch"
 gem "simple_form"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: https://github.com/jquery-ui-rails/jquery-ui-rails.git
-  revision: c7460b447589eb04aa948ecaf0d1245c88f6ff45
-  specs:
-    jquery-ui-rails (7.0.0)
-      railties (>= 3.2.16)
-
-GIT
   remote: https://github.com/payrollhero/dynamic_form
   revision: 072a58fb706ef65ea2e2eeddd12cacf47e77ae76
   specs:
@@ -396,6 +389,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (6.0.1)
+      railties (>= 3.2.16)
     json (2.6.3)
     jwt (2.7.1)
     kgio (2.11.4)
@@ -770,7 +765,7 @@ DEPENDENCIES
   ice_cube
   image_processing (>= 1.2)
   jquery-rails
-  jquery-ui-rails!
+  jquery-ui-rails (~> 6.0)
   jwt
   kt-paperclip
   ldap_authentication!


### PR DESCRIPTION
# Release Notes

jquery-ui-rails v7 caused an issue with the `datepicker` where some of the HTML is not rendered

# Screenshot

jquery-ui-rails v7

![Screen Shot 2023-10-09 at 1 46 54 PM](https://github.com/tablexi/nucore-open/assets/624487/3999fb71-7517-4dc4-bb04-b6b2fdaefb92)

jquery-ui-rails v6

![Screen Shot 2023-10-09 at 1 47 47 PM](https://github.com/tablexi/nucore-open/assets/624487/ccc4e189-45b2-4c6c-bbf5-2a119e1e1318)