### PR TITLE
[#161991] [Shared dev] Duration based pricing - Select pricing mode

### DIFF
--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -118,7 +118,8 @@ class ProductsCommonController < ApplicationController
       :schedule_id, :reserve_interval,
       :min_reserve_mins, :max_reserve_mins, :min_cancel_hours,
       :auto_cancel_mins, :lock_window, :cutoff_hours,
-      :problems_resolvable_by_user, :restrict_holiday_access, :billing_mode
+      :problems_resolvable_by_user, :restrict_holiday_access, :billing_mode,
+      :pricing_mode
     ]
   end
 

--- a/app/models/concerns/products/schedule_rule_support.rb
+++ b/app/models/concerns/products/schedule_rule_support.rb
@@ -9,8 +9,6 @@ module Products::ScheduleRuleSupport
     has_many :product_access_groups, foreign_key: :product_id, inverse_of: :product
   end
 
-  PRICING_MODES = ["Schedule Rule", "Duration"].freeze
-
   def can_purchase?(group_ids = nil)
     return false if schedule_rules.empty?
     super

--- a/app/models/concerns/products/schedule_rule_support.rb
+++ b/app/models/concerns/products/schedule_rule_support.rb
@@ -9,6 +9,8 @@ module Products::ScheduleRuleSupport
     has_many :product_access_groups, foreign_key: :product_id, inverse_of: :product
   end
 
+  PRICING_MODES = ["Schedule Rule", "Duration"].freeze
+
   def can_purchase?(group_ids = nil)
     return false if schedule_rules.empty?
     super

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -8,6 +8,7 @@ class Instrument < Product
   include EmailListAttribute
 
   RESERVE_INTERVALS = [1, 5, 10, 15, 30, 60].freeze
+  PRICING_MODES = ["Schedule Rule", "Duration"].freeze
 
   with_options foreign_key: "product_id" do |instrument|
     instrument.has_many :admin_reservations
@@ -35,6 +36,8 @@ class Instrument < Product
            :maximum_reservation_is_multiple_of_interval,
            :max_reservation_not_less_than_min
 
+  validates :pricing_mode, presence: true, inclusion: { in: PRICING_MODES }
+
   # Callbacks
   # --------
 
@@ -48,7 +51,6 @@ class Instrument < Product
     joins("LEFT OUTER JOIN relays ON relays.instrument_id = products.id")
       .where("relays.instrument_id IS NULL")
   end
-
   # Instance methods
   # -------
 

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -8,6 +8,7 @@ class Instrument < Product
   include EmailListAttribute
 
   RESERVE_INTERVALS = [1, 5, 10, 15, 30, 60].freeze
+  PRICING_MODES = ["Schedule Rule", "Duration"].freeze
 
   with_options foreign_key: "product_id" do |instrument|
     instrument.has_many :admin_reservations

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -8,7 +8,6 @@ class Instrument < Product
   include EmailListAttribute
 
   RESERVE_INTERVALS = [1, 5, 10, 15, 30, 60].freeze
-  PRICING_MODES = ["Schedule Rule", "Duration"].freeze
 
   with_options foreign_key: "product_id" do |instrument|
     instrument.has_many :admin_reservations

--- a/app/views/instruments/_instrument_fields.html.haml
+++ b/app/views/instruments/_instrument_fields.html.haml
@@ -12,7 +12,7 @@
 
 = f.input :problems_resolvable_by_user, as: :boolean, label: false, inline_label: true
 
-= f.label :pricing_mode
+= f.label :pricing_mode, "Set Pricing By"
 - Instrument::PRICING_MODES.each do |option|
   - field_id = "pricing_mode_#{option.parameterize.underscore}".to_sym
   = f.label field_id do

--- a/app/views/instruments/_instrument_fields.html.haml
+++ b/app/views/instruments/_instrument_fields.html.haml
@@ -12,7 +12,7 @@
 
 = f.input :problems_resolvable_by_user, as: :boolean, label: false, inline_label: true
 
-= f.input :pricing_mode, as: :radio_buttons, collection: Instrument::PRICING_MODES, "Set Pricing By", item_wrapper_class: :radio, item_wrapper_tag: :div
+= f.input :pricing_mode, as: :radio_buttons, collection: Instrument::PRICING_MODES, label: text("instruments.instrument_fields.schedule.pricing_mode"), item_wrapper_class: :radio, item_wrapper_tag: :div
 
 .well
   %h3= text("instruments.instrument_fields.reservation.label.restrict")

--- a/app/views/instruments/_instrument_fields.html.haml
+++ b/app/views/instruments/_instrument_fields.html.haml
@@ -12,12 +12,7 @@
 
 = f.input :problems_resolvable_by_user, as: :boolean, label: false, inline_label: true
 
-= f.label :pricing_mode, "Set Pricing By"
-- Instrument::PRICING_MODES.each do |option|
-  - field_id = "pricing_mode_#{option.parameterize.underscore}".to_sym
-  = f.label field_id do
-    = f.radio_button :pricing_mode, option, checked: option == f.object.pricing_mode
-    = option
+= f.input :pricing_mode, as: :radio_buttons, collection: Instrument::PRICING_MODES, "Set Pricing By", item_wrapper_class: :radio, item_wrapper_tag: :div
 
 .well
   %h3= text("instruments.instrument_fields.reservation.label.restrict")

--- a/app/views/instruments/_instrument_fields.html.haml
+++ b/app/views/instruments/_instrument_fields.html.haml
@@ -12,6 +12,13 @@
 
 = f.input :problems_resolvable_by_user, as: :boolean, label: false, inline_label: true
 
+= f.label :pricing_mode
+- Instrument::PRICING_MODES.each do |option|
+  - field_id = "pricing_mode_#{option.parameterize.underscore}".to_sym
+  = f.label field_id do
+    = f.radio_button :pricing_mode, option, checked: option == f.object.pricing_mode
+    = option
+
 .well
   %h3= text("instruments.instrument_fields.reservation.label.restrict")
 

--- a/app/views/instruments/_instrument_manage_fields.html.haml
+++ b/app/views/instruments/_instrument_manage_fields.html.haml
@@ -4,6 +4,8 @@
 
 = f.input :problems_resolvable_by_user, as: :boolean, hint: false
 
+= f.input :pricing_mode
+
 = f.input :reserve_interval, value_method: :to_i, label: "Reservation Interval"
 = f.input :min_reserve_mins, value_method: :to_i
 = f.input :max_reserve_mins, default_value: "None"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1196,6 +1196,7 @@ en:
           auto_cancel_mins:
             zero: Automatic cancellation will be disabled for this instrument
       schedule:
+        pricing_mode: Set Pricing By
         unshared: Unshared schedule
         shared: Shared schedule
       hints:

--- a/db/migrate/20231011195736_add_pricing_mode_to_products.rb
+++ b/db/migrate/20231011195736_add_pricing_mode_to_products.rb
@@ -1,0 +1,5 @@
+class AddPricingModeToProducts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :products, :pricing_mode, :string, null: false, default: "Schedule Rule"
+  end
+end

--- a/db/migrate/20231011195736_add_pricing_mode_to_products.rb
+++ b/db/migrate/20231011195736_add_pricing_mode_to_products.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPricingModeToProducts < ActiveRecord::Migration[7.0]
   def change
     add_column :products, :pricing_mode, :string, null: false, default: "Schedule Rule"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_09_192347) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_11_195736) do
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
     t.integer "account_id", null: false
@@ -640,6 +640,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_09_192347) do
     t.integer "tablet_port_number"
     t.text "tablet_location_description"
     t.string "billing_mode", default: "Default", null: false
+    t.string "pricing_mode", default: "Schedule Rule", null: false
     t.index ["dashboard_token"], name: "index_products_on_dashboard_token"
     t.index ["facility_account_id"], name: "fk_facility_accounts"
     t.index ["facility_id"], name: "fk_rails_0c9fa1afbe"


### PR DESCRIPTION
# Release Notes
Add pricing mode to instrument. It can either be Schedule Rule or Duration (defaults to the first one). For new/edit, user sees a radio button. Also, it's in the Details tab.

# Screenshots
## Form
<img width="711" alt="image" src="https://github.com/tablexi/nucore-open/assets/28798610/c74d17b2-5496-47a1-909d-d9f2400a8349">

## View
<img width="895" alt="image" src="https://github.com/tablexi/nucore-open/assets/28798610/66057049-a5d7-44e9-951f-3c1ac18988a8">



# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".
