### PR TITLE
[#161992] [Shared dev] Duration based pricing - (2) Set discounts

### DIFF
--- a/app/controllers/instrument_duration_rates_controller.rb
+++ b/app/controllers/instrument_duration_rates_controller.rb
@@ -53,5 +53,7 @@ class InstrumentDurationRatesController < ApplicationController
     (MAX_DURATION_RATES - @product_duration_rates.length).times do
       @product_duration_rates.build
     end
+
+    @product_duration_rates = @product_duration_rates.select(&:min_duration).sort_by(&:min_duration) + @product_duration_rates.reject(&:min_duration)
   end
 end

--- a/app/controllers/instrument_duration_rates_controller.rb
+++ b/app/controllers/instrument_duration_rates_controller.rb
@@ -17,7 +17,7 @@ class InstrumentDurationRatesController < ApplicationController
 
   def update
     params[:duration_rates_attributes].reject! do |key, duration_rate|
-      duration_rate['min_duration'].blank? && duration_rate['rate'].blank?
+      duration_rate["min_duration"].blank? && duration_rate["rate"].blank?
     end
 
     @product.transaction do
@@ -57,6 +57,6 @@ class InstrumentDurationRatesController < ApplicationController
       @product_duration_rates.build
     end
 
-    @product_duration_rates = @product_duration_rates.select(&:min_duration).sort_by(&:min_duration) + @product_duration_rates.reject(&:min_duration)
+    @product_duration_rates = @product_duration_rates.sort_by { |dr| dr.min_duration || 1_000 }
   end
 end

--- a/app/controllers/instrument_duration_rates_controller.rb
+++ b/app/controllers/instrument_duration_rates_controller.rb
@@ -20,9 +20,12 @@ class InstrumentDurationRatesController < ApplicationController
       duration_rate['min_duration'].blank? && duration_rate['rate'].blank?
     end
 
-    @product.duration_rates = @product.duration_rates.reject { |dr| dr.rate.blank? && dr.min_duration.blank? }
+    @product.transaction do
+      @product.duration_rates.destroy_all
+      @product.update(instrument_duration_rate_params)
+    end
 
-    if @product.update(instrument_duration_rate_params)
+    if @product.errors
       flash[:notice] = text("controllers.instrument_duration_rates.success")
     end
 
@@ -33,7 +36,7 @@ class InstrumentDurationRatesController < ApplicationController
   private
 
   def instrument_duration_rate_params
-    params.permit(duration_rates_attributes: [:id, :min_duration, :rate])
+    params.permit(duration_rates_attributes: [:min_duration, :rate])
   end
 
   def manage

--- a/app/controllers/instrument_duration_rates_controller.rb
+++ b/app/controllers/instrument_duration_rates_controller.rb
@@ -25,7 +25,7 @@ class InstrumentDurationRatesController < ApplicationController
       @product.update(instrument_duration_rate_params)
     end
 
-    if @product.errors
+    if @product.errors.blank?
       flash[:notice] = text("controllers.instrument_duration_rates.success")
     end
 

--- a/app/controllers/instrument_duration_rates_controller.rb
+++ b/app/controllers/instrument_duration_rates_controller.rb
@@ -23,6 +23,10 @@ class InstrumentDurationRatesController < ApplicationController
     @product.duration_rates = @product.duration_rates.reject { |dr| dr.rate.blank? && dr.min_duration.blank? }
 
     @product.update! instrument_duration_rate_params
+
+    set_product_duration_rates
+
+    render :edit
   end
 
   private
@@ -39,6 +43,10 @@ class InstrumentDurationRatesController < ApplicationController
   def init_instrument_duration_rates
     @product = Product.find_by!(url_name: params[:id])
 
+    set_product_duration_rates
+  end
+
+  def set_product_duration_rates
     @product_duration_rates = @product.duration_rates
 
     (MAX_DURATION_RATES - @product_duration_rates.length).times do

--- a/app/controllers/instrument_duration_rates_controller.rb
+++ b/app/controllers/instrument_duration_rates_controller.rb
@@ -22,10 +22,11 @@ class InstrumentDurationRatesController < ApplicationController
 
     @product.duration_rates = @product.duration_rates.reject { |dr| dr.rate.blank? && dr.min_duration.blank? }
 
-    @product.update! instrument_duration_rate_params
+    if @product.update(instrument_duration_rate_params)
+      flash[:notice] = text("controllers.instrument_duration_rates.success")
+    end
 
     set_product_duration_rates
-
     render :edit
   end
 

--- a/app/controllers/instrument_duration_rates_controller.rb
+++ b/app/controllers/instrument_duration_rates_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class InstrumentDurationRatesController < ApplicationController
+
+  admin_tab :all
+  before_action :authenticate_user!
+  before_action :check_acting_as
+  before_action :init_instrument_duration_rates
+  before_action :manage
+
+  layout "two_column"
+
+  MAX_DURATION_RATES = 4
+
+  def edit
+  end
+
+  def update
+    params[:duration_rates_attributes].reject! do |key, duration_rate|
+      duration_rate['min_duration'].blank? && duration_rate['rate'].blank?
+    end
+
+    @product.duration_rates = @product.duration_rates.reject { |dr| dr.rate.blank? && dr.min_duration.blank? }
+
+    @product.update! instrument_duration_rate_params
+  end
+
+  private
+
+  def instrument_duration_rate_params
+    params.permit(duration_rates_attributes: [:id, :min_duration, :rate])
+  end
+
+  def manage
+    authorize! :view_details, @product
+    @active_tab = "admin_products"
+  end
+
+  def init_instrument_duration_rates
+    @product = Product.find_by!(url_name: params[:id])
+
+    @product_duration_rates = @product.duration_rates
+
+    (MAX_DURATION_RATES - @product_duration_rates.length).times do
+      @product_duration_rates.build
+    end
+  end
+end

--- a/app/models/duration_rate.rb
+++ b/app/models/duration_rate.rb
@@ -4,6 +4,8 @@ class DurationRate < ApplicationRecord
 
   belongs_to :instrument, foreign_key: :product_id
 
-  validates :min_duration, numericality: { greater_than_or_equal_to: 0 }
-  validates :rate, numericality: { greater_than_or_equal_to: 0 }
+  validates :min_duration, presence: true
+  validates :min_duration, numericality: { greater_than_or_equal_to: 0, allow_blank: true }
+  validates :rate, presence: true
+  validates :rate, numericality: { greater_than_or_equal_to: 0, allow_blank: true }
 end

--- a/app/models/duration_rate.rb
+++ b/app/models/duration_rate.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DurationRate < ApplicationRecord
+
+  belongs_to :instrument, foreign_key: :product_id
+
+end

--- a/app/models/duration_rate.rb
+++ b/app/models/duration_rate.rb
@@ -6,5 +6,4 @@ class DurationRate < ApplicationRecord
 
   validates :min_duration, numericality: { greater_than_or_equal_to: 0 }
   validates :rate, numericality: { greater_than_or_equal_to: 0 }
-
 end

--- a/app/models/duration_rate.rb
+++ b/app/models/duration_rate.rb
@@ -4,4 +4,7 @@ class DurationRate < ApplicationRecord
 
   belongs_to :instrument, foreign_key: :product_id
 
+  validates :min_duration, numericality: { greater_than_or_equal_to: 0 }
+  validates :rate, numericality: { greater_than_or_equal_to: 0 }
+
 end

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -106,6 +106,10 @@ class Instrument < Product
     end
   end
 
+  def duration_pricing_mode?
+    pricing_mode == "Duration"
+  end
+
   private
 
   def minimum_reservation_is_multiple_of_interval

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -38,6 +38,10 @@ class Instrument < Product
 
   validates :pricing_mode, presence: true, inclusion: { in: PRICING_MODES }
 
+  validate :duration_rates_only_for_duration_pricing_mode
+  validate :unique_duration_rates
+  validates :duration_rates, length: { maximum: 4 }
+
   # Callbacks
   # --------
 
@@ -122,6 +126,20 @@ class Instrument < Product
   def max_reservation_not_less_than_min
     if max_reserve_mins && min_reserve_mins && max_reserve_mins < min_reserve_mins
       errors.add :max_reserve_mins, :max_less_than_min
+    end
+  end
+
+  def unique_duration_rates
+    return unless duration_pricing_mode?
+
+    if duration_rates.pluck(:min_duration).uniq.length < duration_rates.length
+      errors.add(:duration_rates, "Reservations longer than values must be unique")
+    end
+  end
+
+  def duration_rates_only_for_duration_pricing_mode
+    if !duration_pricing_mode? && duration_rates.present?
+      errors.add(:duration_rates, "Can only be set for Instruments with Duration pricing mode")
     end
   end
 

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -140,13 +140,13 @@ class Instrument < Product
     return unless duration_pricing_mode?
 
     if duration_rates.pluck(:min_duration).uniq.length < duration_rates.length
-      errors.add(:duration_pricing_rules, "Minimum duration values must be unique")
+      errors.add(:base, "Minimum duration values must be unique")
     end
   end
 
   def duration_rates_only_for_duration_pricing_mode
     if !duration_pricing_mode? && duration_rates.present?
-      errors.add(:duration_pricing_rules, "Can only be set for Instruments with Duration pricing mode")
+      errors.add(:base, "Can only be set for Instruments with Duration pricing mode")
     end
   end
 

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -15,8 +15,11 @@ class Instrument < Product
     instrument.has_many :instrument_price_policies
     instrument.has_many :offline_reservations
     instrument.has_many :current_offline_reservations, -> { current }, class_name: "OfflineReservation"
+    instrument.has_many :duration_rates
   end
   has_one :alert, dependent: :destroy, class_name: "InstrumentAlert"
+
+  accepts_nested_attributes_for :duration_rates
 
   email_list_attribute :cancellation_email_recipients
   email_list_attribute :issue_report_recipients

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -140,13 +140,13 @@ class Instrument < Product
     return unless duration_pricing_mode?
 
     if duration_rates.pluck(:min_duration).uniq.length < duration_rates.length
-      errors.add(:duration_rates, "Reservations longer than values must be unique")
+      errors.add(:duration_pricing_rules, "Minimum duration values must be unique")
     end
   end
 
   def duration_rates_only_for_duration_pricing_mode
     if !duration_pricing_mode? && duration_rates.present?
-      errors.add(:duration_rates, "Can only be set for Instruments with Duration pricing mode")
+      errors.add(:duration_pricing_rules, "Can only be set for Instruments with Duration pricing mode")
     end
   end
 

--- a/app/views/admin/shared/_tabnav_product.html.haml
+++ b/app/views/admin/shared/_tabnav_product.html.haml
@@ -16,6 +16,7 @@
       = tab "Pricing", [current_facility, @product, PricePolicy], (secondary_tab == "pricing_rules")
   - if @product.is_a?(Instrument)
     = tab "Restrictions", edit_facility_price_group_product_path(current_facility, @product), (secondary_tab == "restrictions")
+    = tab "Duration Pricing", edit_facility_instrument_duration_rate_path(current_facility, @product), (secondary_tab == "duration_pricing")
     = tab "Reservations", facility_instrument_schedule_path(current_facility, @product), (secondary_tab == "reservations")
   = tab "Docs",
     [current_facility, @product, :file_uploads, file_type: "info"],

--- a/app/views/admin/shared/_tabnav_product.html.haml
+++ b/app/views/admin/shared/_tabnav_product.html.haml
@@ -16,7 +16,8 @@
       = tab "Pricing", [current_facility, @product, PricePolicy], (secondary_tab == "pricing_rules")
   - if @product.is_a?(Instrument)
     = tab "Restrictions", edit_facility_price_group_product_path(current_facility, @product), (secondary_tab == "restrictions")
-    = tab "Duration Pricing", edit_facility_instrument_duration_rate_path(current_facility, @product), (secondary_tab == "duration_pricing")
+    - if @product.duration_pricing_mode?
+      = tab "Duration Pricing", edit_facility_instrument_duration_rate_path(current_facility, @product), (secondary_tab == "duration_pricing")
     = tab "Reservations", facility_instrument_schedule_path(current_facility, @product), (secondary_tab == "reservations")
   = tab "Docs",
     [current_facility, @product, :file_uploads, file_type: "info"],

--- a/app/views/admin/shared/_tabnav_product.html.haml
+++ b/app/views/admin/shared/_tabnav_product.html.haml
@@ -1,32 +1,32 @@
 - return nil if @product.nil? || @product.id.nil?
 %ul.nav.nav-tabs
-  = tab "Details", [:manage, current_facility, @product], (secondary_tab == "details")
+  = tab t("views.admin.products.tabnav.details"), [:manage, current_facility, @product], (secondary_tab == "details")
   - if @product.is_a?(Instrument)
-    = tab "Timers & Relays", [current_facility, @product, Relay], (secondary_tab == "relays")
+    = tab t("views.admin.products.tabnav.relays"), [current_facility, @product, Relay], (secondary_tab == "relays")
   - if @product.requires_approval? && @product.respond_to?(:product_access_groups)
     = tab ProductAccessGroup.model_name.human.pluralize, facility_instrument_product_access_groups_path(current_facility, @product), (secondary_tab == "restriction_levels")
   - if @product.respond_to?(:schedule_rules)
-    = tab "Scheduling", [current_facility, @product, ScheduleRule], (secondary_tab == "schedule_rules")
+    = tab t("views.admin.products.tabnav.schedule_rules"), [current_facility, @product, ScheduleRule], (secondary_tab == "schedule_rules")
   - if @product.requires_approval?
-    = tab "Access List", [current_facility, @product, :users], (secondary_tab == "users")
+    = tab t("views.admin.products.tabnav.users"), [current_facility, @product, :users], (secondary_tab == "users")
   - if @product.is_a?(Bundle)
-    = tab "Bundled Products", facility_bundle_bundle_products_path(current_facility, @product), (secondary_tab == "products")
+    = tab t("views.admin.products.tabnav.products"), facility_bundle_bundle_products_path(current_facility, @product), (secondary_tab == "products")
   - else
     - if can? :index, PricePolicy
-      = tab "Pricing", [current_facility, @product, PricePolicy], (secondary_tab == "pricing_rules")
+      = tab t("views.admin.products.tabnav.pricing_rules"), [current_facility, @product, PricePolicy], (secondary_tab == "pricing_rules")
   - if @product.is_a?(Instrument)
-    = tab "Restrictions", edit_facility_price_group_product_path(current_facility, @product), (secondary_tab == "restrictions")
+    = tab t("views.admin.products.tabnav.restrictions"), edit_facility_price_group_product_path(current_facility, @product), (secondary_tab == "restrictions")
     - if @product.duration_pricing_mode?
-      = tab "Duration Pricing", edit_facility_instrument_duration_rate_path(current_facility, @product), (secondary_tab == "duration_pricing")
-    = tab "Reservations", facility_instrument_schedule_path(current_facility, @product), (secondary_tab == "reservations")
-  = tab "Docs",
+      = tab t("views.admin.products.tabnav.duration_pricing"), edit_facility_instrument_duration_rate_path(current_facility, @product), (secondary_tab == "duration_pricing")
+    = tab t("views.admin.products.tabnav.reservations"), facility_instrument_schedule_path(current_facility, @product), (secondary_tab == "reservations")
+  = tab t("views.admin.products.tabnav.documentation"),
     [current_facility, @product, :file_uploads, file_type: "info"],
     (secondary_tab == "documentation")
   - if @product.respond_to?(:reservations)
-    = tab "Accessories", facility_product_product_accessories_path(current_facility, @product), (secondary_tab == "accessories")
+    = tab t("views.admin.products.tabnav.accessories"), facility_product_product_accessories_path(current_facility, @product), (secondary_tab == "accessories")
   - if @product.is_a?(Service)
-    = tab "Order Forms", product_survey_path(current_facility, @product.parameterize, @product.url_name), (secondary_tab == "surveys")
-  = tab "Notifications", facility_product_notifications_path(current_facility, @product), (secondary_tab == "notifications")
+    = tab t("views.admin.products.tabnav.surveys"), product_survey_path(current_facility, @product.parameterize, @product.url_name), (secondary_tab == "surveys")
+  = tab t("views.admin.products.tabnav.notifications"), facility_product_notifications_path(current_facility, @product), (secondary_tab == "notifications")
   - unless @product.is_a?(Bundle)
     - if ResearchSafetyCertificate.any?
       = tab ProductResearchSafetyCertificationRequirement.model_name.human.pluralize, facility_product_product_research_safety_certification_requirements_path(current_facility, @product), secondary_tab == "certification_reqs"

--- a/app/views/instrument_duration_rates/edit.html.haml
+++ b/app/views/instrument_duration_rates/edit.html.haml
@@ -9,7 +9,7 @@
 
 %h2= @product
 
--# TODO-161992: Tab explanation
+= t("views.instrument_duration_rates.edit.explanation")
 
 = form_for @product, url: facility_instrument_duration_rate_path(current_facility, @product), method: :put do |f|
   = error_messages_for @product

--- a/app/views/instrument_duration_rates/edit.html.haml
+++ b/app/views/instrument_duration_rates/edit.html.haml
@@ -17,8 +17,8 @@
   %table.table.table-striped.table-hover
     %thead
       %tr
-        %th Reservations longer than (hrs)
-        %th Hourly rate ($)
+        %th= t("views.instrument_duration_rates.edit.min_duration")
+        %th= t("views.instrument_duration_rates.edit.rate")
     %tbody
       - @product_duration_rates.each_with_index do |product_duration_rate, index|
         = fields_for :duration_rates_attributes, product_duration_rate, index: index do |pdr|
@@ -27,4 +27,4 @@
             %td= pdr.text_field :rate, value: number_to_currency(product_duration_rate.rate, unit: "", delimiter: ""), size: 8
             %td= pdr.hidden_field :id
 
-  = submit_tag "Save", class: :btn
+  = submit_tag t("views.instrument_duration_rates.edit.submit"), class: :btn

--- a/app/views/instrument_duration_rates/edit.html.haml
+++ b/app/views/instrument_duration_rates/edit.html.haml
@@ -13,8 +13,6 @@
 
 = form_for @product, url: facility_instrument_duration_rate_path(current_facility, @product), method: :put do |f|
   = error_messages_for @product
-  - @product_duration_rates.each do |product_duration_rate|
-    = error_messages_for product_duration_rate
 
   %table.table.table-striped.table-hover
     %thead

--- a/app/views/instrument_duration_rates/edit.html.haml
+++ b/app/views/instrument_duration_rates/edit.html.haml
@@ -1,0 +1,30 @@
+= content_for :h1 do
+  = current_facility
+
+= content_for :sidebar do
+  = render "admin/shared/sidenav_product", sidenav_tab: @product.product_type
+
+= content_for :tabnav do
+  = render "admin/shared/tabnav_product", secondary_tab: "duration_pricing"
+
+%h2= @product
+
+-# TODO: Tab explanation
+
+-# TODO: Use translations
+
+= form_for @product, url: facility_instrument_duration_rate_path(current_facility, @product), method: :put do |f|
+  %table.table.table-striped.table-hover
+    %thead
+      %tr
+        %th Reservations longer than (hrs)
+        %th Hourly rate ($)
+    %tbody
+      - @product_duration_rates.each_with_index do |product_duration_rate, index|
+        = fields_for :duration_rates_attributes, product_duration_rate, index: index do |pdr|
+          %tr
+            %td= pdr.number_field :min_duration, min: 0
+            %td= pdr.text_field :rate, value: number_to_currency(product_duration_rate.rate, unit: "", delimiter: ""), size: 8
+            %td= pdr.hidden_field :id
+
+  = submit_tag "Save", class: :btn

--- a/app/views/instrument_duration_rates/edit.html.haml
+++ b/app/views/instrument_duration_rates/edit.html.haml
@@ -25,6 +25,5 @@
           %tr
             %td= pdr.number_field :min_duration, min: 0
             %td= pdr.text_field :rate, value: number_to_currency(product_duration_rate.rate, unit: "", delimiter: ""), size: 8
-            %td= pdr.hidden_field :id
 
   = submit_tag t("views.instrument_duration_rates.edit.submit"), class: :btn

--- a/app/views/instrument_duration_rates/edit.html.haml
+++ b/app/views/instrument_duration_rates/edit.html.haml
@@ -9,11 +9,13 @@
 
 %h2= @product
 
--# TODO: Tab explanation
-
--# TODO: Use translations
+-# TODO-161992: Tab explanation
 
 = form_for @product, url: facility_instrument_duration_rate_path(current_facility, @product), method: :put do |f|
+  = error_messages_for @product
+  - @product_duration_rates.each do |product_duration_rate|
+    = error_messages_for product_duration_rate
+
   %table.table.table-striped.table-hover
     %thead
       %tr

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -303,6 +303,9 @@ en:
         max_reserve_mins: Maximum Reservation Minutes
         min_cancel_hours: Reservation Cost Window (hours)
         auto_cancel_mins: Automatic Cancellation Minutes
+      instrument/duration_rates:
+        min_duration: Minimum duration
+        rate: Hourly rate
       price_group:
         is_internal: Is Internal?
       price_policy:

--- a/config/locales/views/admin/en.instrument_duration_rates.yml
+++ b/config/locales/views/admin/en.instrument_duration_rates.yml
@@ -1,12 +1,12 @@
 en:
   controllers:
     instrument_duration_rates:
-      success: The duration rates have been updated
+      success: The duration pricing rules have been updated
 
   views:
     instrument_duration_rates:
       edit:
-        explanation: "Duration pricing rules determine the specific rate applied when using Duration pricing mode. You may define up to 4 duration rates, as long as the Reservations longer than are unique."
-        min_duration: Reservations longer than (hrs)
+        explanation: "Duration pricing rules determine the specific rate applied when using Duration pricing mode. You may define up to 4 duration pricing rules, as long as Duration minimum are unique."
+        min_duration: Minimum duration (hrs)
         rate: Hourly rate ($)
         submit: Save

--- a/config/locales/views/admin/en.instrument_duration_rates.yml
+++ b/config/locales/views/admin/en.instrument_duration_rates.yml
@@ -6,7 +6,7 @@ en:
   views:
     instrument_duration_rates:
       edit:
-        explanation: "Duration pricing rules determine the specific rate applied when using Duration pricing mode. You may define up to 4 duration pricing rules, as long as Duration minimum are unique."
+        explanation: "Duration pricing rules determine the specific rate applied when using Duration pricing mode. You may define up to 4 duration pricing rules."
         min_duration: Minimum duration (hrs)
         rate: Hourly rate ($)
         submit: Save

--- a/config/locales/views/admin/en.instrument_duration_rates.yml
+++ b/config/locales/views/admin/en.instrument_duration_rates.yml
@@ -1,4 +1,8 @@
 en:
+  controllers:
+    instrument_duration_rates:
+      success: The duration rates have been updated
+
   views:
     instrument_duration_rates:
       edit:

--- a/config/locales/views/admin/en.instrument_duration_rates.yml
+++ b/config/locales/views/admin/en.instrument_duration_rates.yml
@@ -6,6 +6,7 @@ en:
   views:
     instrument_duration_rates:
       edit:
+        explanation: "Duration pricing rules determine the specific rate applied when using Duration pricing mode. You may define up to 4 duration rates, as long as the Reservations longer than are unique."
         min_duration: Reservations longer than (hrs)
         rate: Hourly rate ($)
         submit: Save

--- a/config/locales/views/admin/en.instrument_duration_rates.yml
+++ b/config/locales/views/admin/en.instrument_duration_rates.yml
@@ -1,0 +1,7 @@
+en:
+  views:
+    instrument_duration_rates:
+      edit:
+        min_duration: Reservations longer than (hrs)
+        rate: Hourly rate ($)
+        submit: Save

--- a/config/locales/views/admin/en.products.yml
+++ b/config/locales/views/admin/en.products.yml
@@ -31,6 +31,20 @@ en:
             is_archived: "Inactivate the product, disallowing purchase and viewing"
             is_hidden: "Hide %{field} from end users; visible to staff when \"ordering on behalf\" of another user"
             billing_mode: "<b>Default</b>: Standard billing workflow, payment source required.<br><b>Skip Review</b>: Reconciled on completion, payment source required.<br><b>Nonbillable</b>: Reconciled on completion, NO payment source required."
+        tabnav:
+          details: "Details"
+          relays: "Timers & Relays"
+          schedule_rules: "Scheduling"
+          users: "Access List"
+          products: "Bundled Products"
+          pricing_rules: "Pricing"
+          restrictions: "Restrictions"
+          duration_pricing: "Duration Pricing"
+          reservations: "Reservations"
+          documentation: "Docs"
+          accessories: "Accessories"
+          surveys: "Order Forms"
+          notifications: "Notifications"
 
       services:
         index:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,6 +144,8 @@ Rails.application.routes.draw do
 
     resources :price_group_products, only: [:edit, :update]
 
+    resources :instrument_duration_rates, only: [:edit, :update]
+
     resources :order_statuses, except: [:show]
 
     resources :facility_users, controller: "facility_users", only: [:index, :destroy], path: "#{I18n.t('facility_downcase')}_users" do

--- a/db/migrate/20231012210150_create_duration_rates.rb
+++ b/db/migrate/20231012210150_create_duration_rates.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateDurationRates < ActiveRecord::Migration[7.0]
+  def change
+    create_table :duration_rates do |t|
+      t.integer  "min_duration"
+      t.decimal  "rate", precision: 16, scale: 8
+      t.references :product, type: :integer, foreign_key: true, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_11_195736) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_12_210150) do
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
     t.integer "account_id", null: false
@@ -133,6 +133,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_11_195736) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
+
+  create_table "duration_rates", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "min_duration"
+    t.decimal "rate", precision: 16, scale: 8
+    t.integer "product_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_duration_rates_on_product_id"
   end
 
   create_table "email_events", id: :integer, charset: "utf8mb3", force: :cascade do |t|
@@ -986,6 +995,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_11_195736) do
   add_foreign_key "bulk_email_jobs", "users"
   add_foreign_key "bundle_products", "products", column: "bundle_product_id", name: "fk_bundle_prod_prod"
   add_foreign_key "bundle_products", "products", name: "fk_bundle_prod_bundle"
+  add_foreign_key "duration_rates", "products"
   add_foreign_key "email_events", "users"
   add_foreign_key "facility_accounts", "facilities", name: "fk_facilities"
   add_foreign_key "instrument_statuses", "products", column: "instrument_id", name: "fk_int_stats_product"

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -133,6 +133,7 @@ FactoryBot.define do
     end
 
     reserve_interval { 1 }
+    pricing_mode { "Schedule Rule" }
 
     schedule { create :schedule, facility: facility }
 

--- a/spec/system/admin/instrument_duration_pricing_tab_spec.rb
+++ b/spec/system/admin/instrument_duration_pricing_tab_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Instrument Duration Pricing Tab" do
+  let(:facility) { FactoryBot.create(:setup_facility) }
+  let(:user) { FactoryBot.create(:user, :administrator) }
+
+  before do
+    login_as user
+    visit edit_facility_instrument_duration_rate_path(facility, instrument)
+  end
+
+  context "the instrument has no duration pricing rules" do
+    let!(:instrument) do
+      FactoryBot.create(:setup_instrument, pricing_mode: "Duration")
+    end
+
+    it "renders the page" do
+      expect(page).to have_content("Duration pricing rules determine the specific rate applied when using Duration pricing mode. You may define up to 4 duration pricing rules, as long as Duration minimum are unique.")
+    end
+
+    context "adding new duration pricing rules" do
+      it "shows 4 group of fields for duration rates" do
+        expect(page).to have_field("duration_rates_attributes_0_min_duration")
+        expect(page).to have_field("duration_rates_attributes_1_min_duration")
+        expect(page).to have_field("duration_rates_attributes_2_min_duration")
+        expect(page).to have_field("duration_rates_attributes_3_min_duration")
+        expect(page).to have_field("duration_rates_attributes_0_rate")
+        expect(page).to have_field("duration_rates_attributes_1_rate")
+        expect(page).to have_field("duration_rates_attributes_2_rate")
+        expect(page).to have_field("duration_rates_attributes_3_rate")
+      end
+
+      it "saves new duration pricing rules" do
+        fill_in "duration_rates_attributes_0_min_duration", with: "3"
+        fill_in "duration_rates_attributes_0_rate", with: "10.00"
+
+        click_button "Save"
+        instrument.reload
+        expect(instrument.duration_rates).to be_present
+        expect(instrument.duration_rates.length).to eq(1)
+        expect(instrument.duration_rates.first.min_duration).to eq(3)
+        expect(instrument.duration_rates.first.rate).to eq(10.00)
+
+        expect(page).to have_content("The duration pricing rules have been updated")
+      end
+
+      context "two duration pricing with the same minimum duration" do
+        it "shows an error" do
+          fill_in "duration_rates_attributes_0_min_duration", with: "3"
+          fill_in "duration_rates_attributes_0_rate", with: "10.00"
+          fill_in "duration_rates_attributes_1_min_duration", with: "3"
+          fill_in "duration_rates_attributes_1_rate", with: "11.00"
+
+          click_button "Save"
+          expect(page).to have_content("Minimum duration values must be unique")
+        end
+      end
+    end
+  end
+
+end

--- a/spec/system/admin/instrument_duration_pricing_tab_spec.rb
+++ b/spec/system/admin/instrument_duration_pricing_tab_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Instrument Duration Pricing Tab" do
     end
 
     it "renders the page" do
-      expect(page).to have_content("Duration pricing rules determine the specific rate applied when using Duration pricing mode. You may define up to 4 duration pricing rules, as long as Duration minimum are unique.")
+      expect(page).to have_content("Duration pricing rules determine the specific rate applied when using Duration pricing mode. You may define up to 4 duration pricing rules.")
     end
 
     context "adding new duration pricing rules" do


### PR DESCRIPTION
# Release Notes
For Instruments with Duration pricing mode there's a new Duration Pricing tab, where users can set their duration pricing rules. Rules are sorted by minimum duration.

# Screenshot

<img width="1390" alt="image" src="https://github.com/tablexi/nucore-open/assets/28798610/6d861d1b-7b80-4b5a-a774-e671fb6a5f7a">

# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".
