### PR TITLE
[#161993] Duration based pricing - (3) Create duration and schedule tabs

### DIFF
--- a/app/controllers/instrument_duration_rates_controller.rb
+++ b/app/controllers/instrument_duration_rates_controller.rb
@@ -47,6 +47,8 @@ class InstrumentDurationRatesController < ApplicationController
   def init_instrument_duration_rates
     @product = Product.find_by!(url_name: params[:id])
 
+    return unless @product.is_a?(Instrument)
+
     set_product_duration_rates
   end
 

--- a/app/views/admin/shared/_tabnav_product.html.haml
+++ b/app/views/admin/shared/_tabnav_product.html.haml
@@ -16,8 +16,7 @@
       = tab t("views.admin.products.tabnav.pricing_rules"), [current_facility, @product, PricePolicy], (secondary_tab == "pricing_rules")
   - if @product.is_a?(Instrument)
     = tab t("views.admin.products.tabnav.restrictions"), edit_facility_price_group_product_path(current_facility, @product), (secondary_tab == "restrictions")
-    - if @product.duration_pricing_mode?
-      = tab t("views.admin.products.tabnav.duration_pricing"), edit_facility_instrument_duration_rate_path(current_facility, @product), (secondary_tab == "duration_pricing")
+    = tab t("views.admin.products.tabnav.duration_pricing"), edit_facility_instrument_duration_rate_path(current_facility, @product), (secondary_tab == "duration_pricing")
     = tab t("views.admin.products.tabnav.reservations"), facility_instrument_schedule_path(current_facility, @product), (secondary_tab == "reservations")
   = tab t("views.admin.products.tabnav.documentation"),
     [current_facility, @product, :file_uploads, file_type: "info"],

--- a/app/views/instrument_duration_rates/edit.html.haml
+++ b/app/views/instrument_duration_rates/edit.html.haml
@@ -9,21 +9,24 @@
 
 %h2= @product
 
-= t("views.instrument_duration_rates.edit.explanation")
+- if @product.duration_pricing_mode?
+  = t("views.instrument_duration_rates.edit.explanation")
 
-= form_for @product, url: facility_instrument_duration_rate_path(current_facility, @product), method: :put do |f|
-  = error_messages_for @product
+  = form_for @product, url: facility_instrument_duration_rate_path(current_facility, @product), method: :put do |f|
+    = error_messages_for @product
 
-  %table.table.table-striped.table-hover
-    %thead
-      %tr
-        %th= t("views.instrument_duration_rates.edit.min_duration")
-        %th= t("views.instrument_duration_rates.edit.rate")
-    %tbody
-      - @product_duration_rates.each_with_index do |product_duration_rate, index|
-        = fields_for :duration_rates_attributes, product_duration_rate, index: index do |pdr|
-          %tr
-            %td= pdr.number_field :min_duration, min: 0
-            %td= pdr.text_field :rate, value: number_to_currency(product_duration_rate.rate, unit: "", delimiter: ""), size: 8
+    %table.table.table-striped.table-hover
+      %thead
+        %tr
+          %th= t("views.instrument_duration_rates.edit.min_duration")
+          %th= t("views.instrument_duration_rates.edit.rate")
+      %tbody
+        - @product_duration_rates.each_with_index do |product_duration_rate, index|
+          = fields_for :duration_rates_attributes, product_duration_rate, index: index do |pdr|
+            %tr
+              %td= pdr.number_field :min_duration, min: 0
+              %td= pdr.text_field :rate, value: number_to_currency(product_duration_rate.rate, unit: "", delimiter: ""), size: 8
 
-  = submit_tag t("views.instrument_duration_rates.edit.submit"), class: :btn
+    = submit_tag t("views.instrument_duration_rates.edit.submit"), class: :btn
+- else
+  %p.notice= t("views.instrument_duration_rates.edit.message_for_non_duration_pricing_mode")

--- a/app/views/schedule_rules/_schedule_rule_fields.html.haml
+++ b/app/views/schedule_rules/_schedule_rule_fields.html.haml
@@ -15,24 +15,25 @@
       = f.label :end_time
       = time_select24(f, :end, hours: (0..24), minute_step: @product.reserve_interval)
 
-%h3= t("views.schedule_rules.discount")
+- if !@product.duration_pricing_mode?
+  %h3= t("views.schedule_rules.discount")
 
-%p= t("views.schedule_rules.discount_hint")
+  %p= t("views.schedule_rules.discount_hint")
 
-- if @highlighted_price_group_discounts&.present?
-  .well
-    %h4= t("views.schedule_rules.highlighted_heading")
-    = f.association :price_group_discounts, collection: @highlighted_price_group_discounts do |pgd|
-      = render partial: "price_group_discount", locals: { pgd: pgd }
+  - if @highlighted_price_group_discounts&.present?
+    .well
+      %h4= t("views.schedule_rules.highlighted_heading")
+      = f.association :price_group_discounts, collection: @highlighted_price_group_discounts do |pgd|
+        = render partial: "price_group_discount", locals: { pgd: pgd }
 
-- unless @non_highlighted_price_group_discounts&.empty?
-  .well
-    - if @highlighted_price_group_discounts.blank?
-      %h4= t("views.schedule_rules.price_groups_heading")
-    - else
-      %h4= t("views.schedule_rules.non_highlighted_heading")
-    = f.association :price_group_discounts, collection: @non_highlighted_price_group_discounts do |pgd|
-      = render partial: "price_group_discount", locals: { pgd: pgd }
+  - unless @non_highlighted_price_group_discounts&.empty?
+    .well
+      - if @highlighted_price_group_discounts.blank?
+        %h4= t("views.schedule_rules.price_groups_heading")
+      - else
+        %h4= t("views.schedule_rules.non_highlighted_heading")
+      = f.association :price_group_discounts, collection: @non_highlighted_price_group_discounts do |pgd|
+        = render partial: "price_group_discount", locals: { pgd: pgd }
 
-- if @product.has_product_access_groups?
-  = f.association :product_access_groups, as: :check_boxes, collection: @product.product_access_groups, wrapper_html: { class: "inline-checkbox-list" }
+  - if @product.has_product_access_groups?
+    = f.association :product_access_groups, as: :check_boxes, collection: @product.product_access_groups, wrapper_html: { class: "inline-checkbox-list" }

--- a/app/views/schedule_rules/index.html.haml
+++ b/app/views/schedule_rules/index.html.haml
@@ -27,10 +27,11 @@
         %th Days of Week
         %th Start Time
         %th End Time
-        - PriceGroup.globals.each do |price_group|
-          %th.currency= "#{price_group.name} Discount (%)"
-        - if @product.product_access_groups.to_a.any?
-          %th Scheduling Groups
+        - if !@product.duration_pricing_mode?
+          - PriceGroup.globals.each do |price_group|
+            %th.currency= "#{price_group.name} Discount (%)"
+          - if @product.product_access_groups.to_a.any?
+            %th Scheduling Groups
     %tbody
       - @schedule_rules.each do |schedule_rule|
         %tr{:class => cycle("odd", "even")}
@@ -46,11 +47,12 @@
           %td= schedule_rule.days_string
           %td= human_time(Time.zone.parse(schedule_rule.start_time))
           %td= human_time(Time.zone.parse(schedule_rule.end_time))
-          - PriceGroup.globals.each do |price_group|
-            - discount = schedule_rule.discount_for_price_group(price_group)
-            %td.currency= number_to_percentage(discount, strip_insignificant_zeros: true)
-          - if @product.product_access_groups.any?
-            %td= schedule_rule.product_access_groups.join(", ")
+          - if !@product.duration_pricing_mode?
+            - PriceGroup.globals.each do |price_group|
+              - discount = schedule_rule.discount_for_price_group(price_group)
+              %td.currency= number_to_percentage(discount, strip_insignificant_zeros: true)
+            - if @product.product_access_groups.any?
+              %td= schedule_rule.product_access_groups.join(", ")
 - else
   %br
   %p.notice No Schedule Rules exist yet.

--- a/config/locales/views/admin/en.instrument_duration_rates.yml
+++ b/config/locales/views/admin/en.instrument_duration_rates.yml
@@ -7,6 +7,7 @@ en:
     instrument_duration_rates:
       edit:
         explanation: "Duration pricing rules determine the specific rate applied when using Duration pricing mode. You may define up to 4 duration pricing rules."
+        message_for_non_duration_pricing_mode: Duration pricing is disabled for this instrument.
         min_duration: Minimum duration (hrs)
         rate: Hourly rate ($)
         submit: Save

--- a/spec/system/admin/instrument_duration_pricing_tab_spec.rb
+++ b/spec/system/admin/instrument_duration_pricing_tab_spec.rb
@@ -11,52 +11,75 @@ RSpec.describe "Instrument Duration Pricing Tab" do
     visit edit_facility_instrument_duration_rate_path(facility, instrument)
   end
 
-  context "the instrument has no duration pricing rules" do
+  context "when the instrument has duration pricing mode" do
     let!(:instrument) do
       FactoryBot.create(:setup_instrument, pricing_mode: "Duration")
     end
 
-    it "renders the page" do
-      expect(page).to have_content("Duration pricing rules determine the specific rate applied when using Duration pricing mode. You may define up to 4 duration pricing rules.")
-    end
-
-    context "adding new duration pricing rules" do
-      it "shows 4 group of fields for duration rates" do
-        expect(page).to have_field("duration_rates_attributes_0_min_duration")
-        expect(page).to have_field("duration_rates_attributes_1_min_duration")
-        expect(page).to have_field("duration_rates_attributes_2_min_duration")
-        expect(page).to have_field("duration_rates_attributes_3_min_duration")
-        expect(page).to have_field("duration_rates_attributes_0_rate")
-        expect(page).to have_field("duration_rates_attributes_1_rate")
-        expect(page).to have_field("duration_rates_attributes_2_rate")
-        expect(page).to have_field("duration_rates_attributes_3_rate")
+    context "the instrument has no duration pricing rules" do
+      it "renders the page" do
+        expect(page).to have_content("Duration pricing rules determine the specific rate applied when using Duration pricing mode. You may define up to 4 duration pricing rules.")
       end
 
-      it "saves new duration pricing rules" do
-        fill_in "duration_rates_attributes_0_min_duration", with: "3"
-        fill_in "duration_rates_attributes_0_rate", with: "10.00"
+      context "adding new duration pricing rules" do
+        it "shows 4 group of fields for duration rates" do
+          expect(page).to have_field("duration_rates_attributes_0_min_duration")
+          expect(page).to have_field("duration_rates_attributes_1_min_duration")
+          expect(page).to have_field("duration_rates_attributes_2_min_duration")
+          expect(page).to have_field("duration_rates_attributes_3_min_duration")
+          expect(page).to have_field("duration_rates_attributes_0_rate")
+          expect(page).to have_field("duration_rates_attributes_1_rate")
+          expect(page).to have_field("duration_rates_attributes_2_rate")
+          expect(page).to have_field("duration_rates_attributes_3_rate")
+        end
 
-        click_button "Save"
-        instrument.reload
-        expect(instrument.duration_rates).to be_present
-        expect(instrument.duration_rates.length).to eq(1)
-        expect(instrument.duration_rates.first.min_duration).to eq(3)
-        expect(instrument.duration_rates.first.rate).to eq(10.00)
-
-        expect(page).to have_content("The duration pricing rules have been updated")
-      end
-
-      context "two duration pricing with the same minimum duration" do
-        it "shows an error" do
+        it "saves new duration pricing rules" do
           fill_in "duration_rates_attributes_0_min_duration", with: "3"
           fill_in "duration_rates_attributes_0_rate", with: "10.00"
-          fill_in "duration_rates_attributes_1_min_duration", with: "3"
-          fill_in "duration_rates_attributes_1_rate", with: "11.00"
 
           click_button "Save"
-          expect(page).to have_content("Minimum duration values must be unique")
+          instrument.reload
+          expect(instrument.duration_rates).to be_present
+          expect(instrument.duration_rates.length).to eq(1)
+          expect(instrument.duration_rates.first.min_duration).to eq(3)
+          expect(instrument.duration_rates.first.rate).to eq(10.00)
+
+          expect(page).to have_content("The duration pricing rules have been updated")
+        end
+
+        context "two duration pricing with the same minimum duration" do
+          it "shows an error" do
+            fill_in "duration_rates_attributes_0_min_duration", with: "3"
+            fill_in "duration_rates_attributes_0_rate", with: "10.00"
+            fill_in "duration_rates_attributes_1_min_duration", with: "3"
+            fill_in "duration_rates_attributes_1_rate", with: "11.00"
+
+            click_button "Save"
+            expect(page).to have_content("Minimum duration values must be unique")
+          end
         end
       end
+    end
+  end
+
+  context "when the instrument has schedule pricing mode" do
+    let!(:instrument) do
+      FactoryBot.create(:setup_instrument, pricing_mode: "Schedule Rule")
+    end
+
+    it "shows a notice message saying it's disabled" do
+      expect(page).to have_content("Duration pricing is disabled for this instrument.")
+    end
+
+    it "doesn't show duration pricing rules fields" do
+      expect(page).not_to have_field("duration_rates_attributes_0_min_duration")
+      expect(page).not_to have_field("duration_rates_attributes_1_min_duration")
+      expect(page).not_to have_field("duration_rates_attributes_2_min_duration")
+      expect(page).not_to have_field("duration_rates_attributes_3_min_duration")
+      expect(page).not_to have_field("duration_rates_attributes_0_rate")
+      expect(page).not_to have_field("duration_rates_attributes_1_rate")
+      expect(page).not_to have_field("duration_rates_attributes_2_rate")
+      expect(page).not_to have_field("duration_rates_attributes_3_rate")
     end
   end
 

--- a/spec/system/admin/instrument_scheduling_tab_spec.rb
+++ b/spec/system/admin/instrument_scheduling_tab_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe "Instrument Scheduling Tab" do
       it "shows all Schedule rule fields" do
         expect(page).to have_content("Editing Schedule Rule")
         expect(page).to have_content("Price Group Discounts")
+        # As the instrument has no highlighted price groups, header should not be displayed
         expect(page).not_to have_content("Highlighted Price Groups")
         expect(page).to have_content("Price Groups")
       end

--- a/spec/system/admin/instrument_scheduling_tab_spec.rb
+++ b/spec/system/admin/instrument_scheduling_tab_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Instrument Scheduling Tab" do
         visit new_facility_instrument_schedule_rule_path(facility, instrument)
       end
 
-      it "shows common Schedule rule fields" do
+      it "shows all Schedule rule fields" do
         expect(page).to have_content(instrument.name)
         expect(page).to have_content("Add Schedule Rule")
         expect(page).to have_content("Price Group Discounts")

--- a/spec/system/admin/instrument_scheduling_tab_spec.rb
+++ b/spec/system/admin/instrument_scheduling_tab_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Instrument Scheduling Tab" do
+  let(:facility) { FactoryBot.create(:setup_facility) }
+  let(:user) { FactoryBot.create(:user, :administrator) }
+
+  before do
+    login_as user
+  end
+
+  context "when the instrument has duration pricing mode" do
+    let!(:instrument) do
+      FactoryBot.create(:setup_instrument, pricing_mode: "Duration", facility: facility)
+    end
+
+    context "new schedule rule" do
+      before do
+        visit new_facility_instrument_schedule_rule_path(facility, instrument)
+      end
+
+      it "shows common Schedule rule fields" do
+        expect(page).to have_content(instrument.name)
+        expect(page).to have_content("Add Schedule Rule")
+        expect(page).not_to have_content("Price Group Discounts")
+
+        check "Sun"
+
+        select "7", from: "schedule_rule_start_hour"
+        select "8", from: "schedule_rule_end_hour"
+
+        click_button "Create"
+
+        expect(page).to have_content("Days of Week")
+        expect(page).to have_content("Start Time")
+        expect(page).to have_content("End Time")
+        expect(page).not_to have_content("Discount (%)")
+      end
+    end
+
+    context "edit schedule rules" do
+      before do
+        visit edit_facility_instrument_schedule_rule_path(facility, instrument, instrument.schedule_rules.first)
+      end
+
+      it "shows common Schedule rule fields" do
+        expect(page).to have_content("Editing Schedule Rule")
+        expect(page).not_to have_content("Price Group Discounts")
+
+        check "Mon"
+
+        click_button "Update"
+
+        expect(page).to have_content("Days of Week")
+        expect(page).to have_content("Start Time")
+        expect(page).to have_content("End Time")
+        expect(page).not_to have_content("Discount (%)")
+      end
+    end
+  end
+
+  context "when the instrument has schedule pricing mode" do
+    let!(:instrument) do
+      FactoryBot.create(:setup_instrument, pricing_mode: "Schedule Rule", facility: facility)
+    end
+
+    context "new schedule rule" do
+      before do
+        visit new_facility_instrument_schedule_rule_path(facility, instrument)
+      end
+
+      it "shows common Schedule rule fields" do
+        expect(page).to have_content(instrument.name)
+        expect(page).to have_content("Add Schedule Rule")
+        expect(page).to have_content("Price Group Discounts")
+
+        check "Sun"
+
+        select "7", from: "schedule_rule_start_hour"
+        select "8", from: "schedule_rule_end_hour"
+
+        click_button "Create"
+
+        expect(page).to have_content("Days of Week")
+        expect(page).to have_content("Start Time")
+        expect(page).to have_content("End Time")
+        expect(page).to have_content("Discount (%)")
+      end
+    end
+
+    context "edit schedule rules" do
+      before do
+        visit edit_facility_instrument_schedule_rule_path(facility, instrument, instrument.schedule_rules.first)
+      end
+
+      it "shows all Schedule rule fields" do
+        expect(page).to have_content("Editing Schedule Rule")
+        expect(page).to have_content("Price Group Discounts")
+        expect(page).not_to have_content("Highlighted Price Groups")
+        expect(page).to have_content("Price Groups")
+      end
+    end
+  end
+
+end

--- a/spec/system/admin/instrument_scheduling_tab_spec.rb
+++ b/spec/system/admin/instrument_scheduling_tab_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Instrument Scheduling Tab" do
         visit edit_facility_instrument_schedule_rule_path(facility, instrument, instrument.schedule_rules.first)
       end
 
-      it "shows common Schedule rule fields" do
+      it "shows common Schedule rule fields, but NOT Price Group Discounts" do
         expect(page).to have_content("Editing Schedule Rule")
         expect(page).not_to have_content("Price Group Discounts")
 

--- a/spec/system/admin/instrument_scheduling_tab_spec.rb
+++ b/spec/system/admin/instrument_scheduling_tab_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Instrument Scheduling Tab" do
         visit new_facility_instrument_schedule_rule_path(facility, instrument)
       end
 
-      it "shows common Schedule rule fields" do
+      it "shows common Schedule rule fields, but NOT Price Group Discounts" do
         expect(page).to have_content(instrument.name)
         expect(page).to have_content("Add Schedule Rule")
         expect(page).not_to have_content("Price Group Discounts")


### PR DESCRIPTION
# Release Notes
Both Schedule Rule discounts and duration-based discounts cannot be set for the same instrument.

# Screenshot
## Instrument with Duration pricing mode
### Scheduling tab
#### View
![image](https://github.com/tablexi/nucore-open/assets/28798610/f3c78d80-5442-401d-95fc-9b6c894cbdbe)

#### New 
![image](https://github.com/tablexi/nucore-open/assets/28798610/a1405cf7-0ac8-47a3-9457-14bf81bb699f)

#### Edit
![image](https://github.com/tablexi/nucore-open/assets/28798610/ffc7e9e8-b9b1-4830-ac63-318eb595cbe4)

### Duration pricing tab
![image](https://github.com/tablexi/nucore-open/assets/28798610/c281e690-2482-4773-bb59-c6b22d17374b)

## Instrument with Schedule Rule pricing mode
### Scheduling tab
![image](https://github.com/tablexi/nucore-open/assets/28798610/bf2a4e0e-6fb4-490a-835f-c6cd74849f36)

### Duration pricing tab
![image](https://github.com/tablexi/nucore-open/assets/28798610/a6763ac7-3b1d-4cf5-afaf-278b0debc599)

# Additional Context