### PR TITLE
[#161895] Only show highlighted price groups if present

### DIFF
--- a/app/views/schedule_rules/_schedule_rule_fields.html.haml
+++ b/app/views/schedule_rules/_schedule_rule_fields.html.haml
@@ -19,7 +19,7 @@
 
 %p= t("views.schedule_rules.discount_hint")
 
-- unless @highlighted_price_group_discounts&.empty?
+- if @highlighted_price_group_discounts&.present?
   .well
     %h4= t("views.schedule_rules.highlighted_heading")
     = f.association :price_group_discounts, collection: @highlighted_price_group_discounts do |pgd|


### PR DESCRIPTION
# Release Notes
Fixes price groups being duplicated when editing an instrument's schedule rules.

# Screenshot
<img width="1271" alt="image" src="https://github.com/tablexi/nucore-open/assets/28798610/4f1c3333-0d6b-45af-9c52-19f01548e6de">


# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".
