### PR TITLE
If product is not an instrument, redirect to products overview

### DIFF
--- a/app/controllers/instrument_duration_rates_controller.rb
+++ b/app/controllers/instrument_duration_rates_controller.rb
@@ -6,7 +6,7 @@ class InstrumentDurationRatesController < ApplicationController
   before_action :authenticate_user!
   before_action :check_acting_as
   before_action :init_product
-  before_action :ensure_is_intrument
+  before_action :ensure_is_instrument
   before_action :set_product_duration_rates
   before_action :manage
 
@@ -50,7 +50,7 @@ class InstrumentDurationRatesController < ApplicationController
     @product = Product.find_by!(url_name: params[:id])
   end
 
-  def ensure_is_intrument
+  def ensure_is_instrument
     redirect_to facility_instruments_path(current_facility) unless @product.is_a?(Instrument)
   end
 

--- a/app/controllers/instrument_duration_rates_controller.rb
+++ b/app/controllers/instrument_duration_rates_controller.rb
@@ -5,7 +5,9 @@ class InstrumentDurationRatesController < ApplicationController
   admin_tab :all
   before_action :authenticate_user!
   before_action :check_acting_as
-  before_action :init_instrument_duration_rates
+  before_action :init_product
+  before_action :ensure_is_intrument
+  before_action :set_product_duration_rates
   before_action :manage
 
   layout "two_column"
@@ -44,12 +46,12 @@ class InstrumentDurationRatesController < ApplicationController
     @active_tab = "admin_products"
   end
 
-  def init_instrument_duration_rates
+  def init_product
     @product = Product.find_by!(url_name: params[:id])
+  end
 
-    return unless @product.is_a?(Instrument)
-
-    set_product_duration_rates
+  def ensure_is_intrument
+    redirect_to facility_instruments_path(current_facility) unless @product.is_a?(Instrument)
   end
 
   def set_product_duration_rates


### PR DESCRIPTION
# Release Notes
When product is not an instrument, navegation to duration pricing rules ended up in errors. Now it redirects user to facility products overview.
