### PR TITLE
[Tech task] Fix heroku deployments

### DIFF
--- a/.github/workflows/nucore-heroku-auto-deploy-staging.yml
+++ b/.github/workflows/nucore-heroku-auto-deploy-staging.yml
@@ -4,7 +4,8 @@ name: Staging heroku auto deployment
 on:
   workflow_run:
     workflows: [ "Run test suite" ]
-    # branches: [ master ]
+    branches: [ master ]
+    types: [ completed ]
 
   # Allow manually triggering this workflow by visiting
   # https://github.com/tablexi/nucore-open/actions/workflows/nucore-heroku-auto-deploy-staging.yml

--- a/.github/workflows/nucore-heroku-auto-deploy-staging.yml
+++ b/.github/workflows/nucore-heroku-auto-deploy-staging.yml
@@ -2,9 +2,10 @@ name: Staging heroku auto deployment
 
 # When this action will be executed
 on:
-  push:
-    branches:
-      - "master"
+  workflow_run:
+    workflows: [ "Run test suite" ]
+    # branches: [ master ]
+    types: [ completed ]
 
   # Allow manually triggering this workflow by visiting
   # https://github.com/tablexi/nucore-open/actions/workflows/nucore-heroku-auto-deploy-staging.yml

--- a/.github/workflows/nucore-heroku-auto-deploy-staging.yml
+++ b/.github/workflows/nucore-heroku-auto-deploy-staging.yml
@@ -5,7 +5,6 @@ on:
   workflow_run:
     workflows: [ "Run test suite" ]
     # branches: [ master ]
-    types: [ completed ]
 
   # Allow manually triggering this workflow by visiting
   # https://github.com/tablexi/nucore-open/actions/workflows/nucore-heroku-auto-deploy-staging.yml


### PR DESCRIPTION
Triggering on a push to the master branch means
we cannot check if the test were succesful or not.

This has been broken since we switched over to heroku.
https://github.com/tablexi/nucore-open/actions/workflows/nucore-heroku-auto-deploy-staging.yml

The deploys are being skipped because there is not any `github.event.workflow_run.conclusion` to check:

```
jobs:
  deploy-staging-heroku:
    if: ${{ github.event.workflow_run.conclusion == 'success' }}
```