### PR TITLE
[#162031] [Shared dev] Duration based pricing - Move form inputs to Pricing tab

### DIFF
--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -39,6 +39,9 @@ class PricePoliciesController < ApplicationController
     raise ActiveRecord::RecordNotFound if @price_policies.blank?
 
     Instrument::MAX_RATE_STARTS.times { @product.rate_starts.build }
+    @price_policies.each do |price_policy|
+      Instrument::MAX_RATE_STARTS.times { price_policy.price_group.duration_rates.build }
+    end
   end
 
   # POST /facilities/:facility_id/{product_type}/:product_id/price_policies
@@ -66,6 +69,9 @@ class PricePoliciesController < ApplicationController
     raise ActiveRecord::RecordNotFound if @price_policies.blank?
 
     (Instrument::MAX_RATE_STARTS - @product.rate_starts.length).times { @product.rate_starts.build }
+    @price_policies.each do |price_policy|
+      (Instrument::MAX_RATE_STARTS - price_policy.price_group.duration_rates.length).times { price_policy.price_group.duration_rates.build }
+    end
   end
 
   # DELETE /facilities/:facility_id/{product_type}/:product_id/price_policies/:id

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -38,8 +38,7 @@ class PricePoliciesController < ApplicationController
     @price_policies = PricePolicyBuilder.get_new_policies_based_on_most_recent(@product, @start_date)
     raise ActiveRecord::RecordNotFound if @price_policies.blank?
 
-    build_rate_starts
-    build_duration_rates
+    build_instrument_stepped_billing_fields
   end
 
   # POST /facilities/:facility_id/{product_type}/:product_id/price_policies
@@ -47,8 +46,8 @@ class PricePoliciesController < ApplicationController
     if update_policies_from_params
       redirect_to facility_product_price_policies_path, notice: text("create.success")
     else
-      build_rate_starts
-      build_duration_rates
+      build_instrument_stepped_billing_fields
+
       flash.now[:error] = text("errors.save")
       render :new
     end
@@ -59,8 +58,8 @@ class PricePoliciesController < ApplicationController
     if update_policies_from_params
       redirect_to facility_product_price_policies_path, notice: text("update.success")
     else
-      build_rate_starts
-      build_duration_rates
+      build_instrument_stepped_billing_fields
+
       flash.now[:error] = text("errors.save")
       render :edit
     end
@@ -70,8 +69,7 @@ class PricePoliciesController < ApplicationController
   def edit
     raise ActiveRecord::RecordNotFound if @price_policies.blank?
 
-    build_rate_starts
-    build_duration_rates
+    build_instrument_stepped_billing_fields
   end
 
   # DELETE /facilities/:facility_id/{product_type}/:product_id/price_policies/:id
@@ -149,6 +147,13 @@ class PricePoliciesController < ApplicationController
   def build_duration_rates
     @price_policies.each do |price_policy|
       (Instrument::MAX_RATE_STARTS - price_policy.price_group.duration_rates.length).times { price_policy.price_group.duration_rates.build }
+    end
+  end
+
+  def build_instrument_stepped_billing_fields
+    if @product.is_a?(Instrument) && @product.duration_pricing_mode?
+      build_rate_starts
+      build_duration_rates
     end
   end
 

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -37,6 +37,8 @@ class PricePoliciesController < ApplicationController
 
     @price_policies = PricePolicyBuilder.get_new_policies_based_on_most_recent(@product, @start_date)
     raise ActiveRecord::RecordNotFound if @price_policies.blank?
+
+    Instrument::MAX_RATE_STARTS.times { @product.rate_starts.build }
   end
 
   # POST /facilities/:facility_id/{product_type}/:product_id/price_policies
@@ -62,6 +64,8 @@ class PricePoliciesController < ApplicationController
   # GET /facilities/:facility_id/{product_type}/:product_id/price_policies/:id/edit
   def edit
     raise ActiveRecord::RecordNotFound if @price_policies.blank?
+
+    (Instrument::MAX_RATE_STARTS - @product.rate_starts.length).times { @product.rate_starts.build }
   end
 
   # DELETE /facilities/:facility_id/{product_type}/:product_id/price_policies/:id
@@ -124,6 +128,7 @@ class PricePoliciesController < ApplicationController
 
   def update_policies_from_params
     PricePolicyUpdater.update_all(
+      @product,
       @price_policies,
       parse_usa_date(params[:start_date])&.beginning_of_day,
       parse_usa_date(params[:expire_date])&.end_of_day,

--- a/app/models/duration_rate.rb
+++ b/app/models/duration_rate.rb
@@ -2,10 +2,20 @@
 
 class DurationRate < ApplicationRecord
 
-  belongs_to :instrument, foreign_key: :product_id
+  belongs_to :price_group
+  belongs_to :rate_start
 
-  validates :min_duration, presence: true
-  validates :min_duration, numericality: { greater_than_or_equal_to: 0, allow_blank: true }
-  validates :rate, presence: true
+  validate :rate_or_subsidy
   validates :rate, numericality: { greater_than_or_equal_to: 0, allow_blank: true }
+  validates :subsidy, numericality: { greater_than: 0, allow_blank: true }
+
+  # TODO: Validate both rate and subsidy are lesser than or equal to base rate
+  # Question: Are all base rate price groups global? Is that the way of knowing whether a price group is the Base one?
+
+  private
+  def rate_or_subsidy
+    if rate.blank? && subsidy.blank?
+      errors.add(:base, "Either Rate or Adjustment must be provided")
+    end
+  end
 end

--- a/app/models/duration_rate.rb
+++ b/app/models/duration_rate.rb
@@ -3,7 +3,7 @@
 class DurationRate < ApplicationRecord
 
   belongs_to :price_group
-  belongs_to :rate_start
+  belongs_to :rate_start, required: true
 
   validate :rate_or_subsidy
   validates :rate, numericality: { greater_than_or_equal_to: 0, allow_blank: true }

--- a/app/models/duration_rate.rb
+++ b/app/models/duration_rate.rb
@@ -9,8 +9,14 @@ class DurationRate < ApplicationRecord
   validates :rate, numericality: { greater_than_or_equal_to: 0, allow_blank: true }
   validates :subsidy, numericality: { greater_than: 0, allow_blank: true }
 
-  # TODO: Validate both rate and subsidy are lesser than or equal to base rate
-  # Question: Are all base rate price groups global? Is that the way of knowing whether a price group is the Base one?
+  # TODO: Validate:
+  # - Rate is <= base rate (if Price group is the “base” group or external).
+  # - Subsidy is <= base rate (if Price group is internal but not the “base”).
+  # For this it looks like we'll need to link Rate Start to Price Policy, instead of Instrument.
+  # In this context we only have a Price Group (which can have N Price policies) and an Instrument (which can have N Price policies).
+  # We need a Price Policy as that's where we store the usage_rate.
+  # Also, makes sense that Steps for an Instrument can change in time but we may want to keep the historic data.
+
 
   private
   def rate_or_subsidy

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -9,6 +9,7 @@ class Instrument < Product
 
   RESERVE_INTERVALS = [1, 5, 10, 15, 30, 60].freeze
   PRICING_MODES = ["Schedule Rule", "Duration"].freeze
+  MAX_RATE_STARTS = 3
 
   with_options foreign_key: "product_id" do |instrument|
     instrument.has_many :admin_reservations
@@ -18,6 +19,8 @@ class Instrument < Product
     instrument.has_many :rate_starts
   end
   has_one :alert, dependent: :destroy, class_name: "InstrumentAlert"
+
+  accepts_nested_attributes_for :rate_starts, allow_destroy: true
 
   email_list_attribute :cancellation_email_recipients
   email_list_attribute :issue_report_recipients
@@ -41,7 +44,7 @@ class Instrument < Product
 
   validate :rate_starts_only_for_duration_pricing_mode
   validate :unique_rate_starts
-  validates :rate_starts, length: { maximum: 3 }
+  validates :rate_starts, length: { maximum: MAX_RATE_STARTS }
 
   # Callbacks
   # --------
@@ -137,7 +140,9 @@ class Instrument < Product
   def unique_rate_starts
     return unless duration_pricing_mode?
 
-    if rate_starts.pluck(:min_duration).uniq.length < rate_starts.length
+    rate_starts_with_valid_min_duration = rate_starts.select { |dr| dr.min_duration.present? }
+
+    if rate_starts_with_valid_min_duration.pluck(:min_duration).uniq.length < rate_starts_with_valid_min_duration.length
       errors.add(:base, "Rate start values must be unique")
     end
   end

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -15,11 +15,9 @@ class Instrument < Product
     instrument.has_many :instrument_price_policies
     instrument.has_many :offline_reservations
     instrument.has_many :current_offline_reservations, -> { current }, class_name: "OfflineReservation"
-    instrument.has_many :duration_rates
+    instrument.has_many :rate_starts
   end
   has_one :alert, dependent: :destroy, class_name: "InstrumentAlert"
-
-  accepts_nested_attributes_for :duration_rates
 
   email_list_attribute :cancellation_email_recipients
   email_list_attribute :issue_report_recipients
@@ -41,9 +39,9 @@ class Instrument < Product
 
   validates :pricing_mode, presence: true, inclusion: { in: PRICING_MODES }
 
-  validate :duration_rates_only_for_duration_pricing_mode
-  validate :unique_duration_rates
-  validates :duration_rates, length: { maximum: 4 }
+  validate :rate_starts_only_for_duration_pricing_mode
+  validate :unique_rate_starts
+  validates :rate_starts, length: { maximum: 3 }
 
   # Callbacks
   # --------
@@ -136,16 +134,16 @@ class Instrument < Product
     end
   end
 
-  def unique_duration_rates
+  def unique_rate_starts
     return unless duration_pricing_mode?
 
-    if duration_rates.pluck(:min_duration).uniq.length < duration_rates.length
-      errors.add(:base, "Minimum duration values must be unique")
+    if rate_starts.pluck(:min_duration).uniq.length < rate_starts.length
+      errors.add(:base, "Rate start values must be unique")
     end
   end
 
-  def duration_rates_only_for_duration_pricing_mode
-    if !duration_pricing_mode? && duration_rates.present?
+  def rate_starts_only_for_duration_pricing_mode
+    if !duration_pricing_mode? && rate_starts.present?
       errors.add(:base, "Can only be set for Instruments with Duration pricing mode")
     end
   end

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -11,10 +11,13 @@ class PriceGroup < ApplicationRecord
   has_many   :user_price_group_members, class_name: "UserPriceGroupMember"
   has_many   :account_price_group_members, class_name: "AccountPriceGroupMember"
   has_many   :price_group_discounts, dependent: :destroy
+  has_many   :duration_rates, dependent: :destroy
 
   validates_presence_of   :facility_id, unless: :global?
   validates_presence_of   :name
   validates_uniqueness_of :name, scope: :facility_id, case_sensitive: false, unless: :deleted_at?
+
+  validates :duration_rates, length: { maximum: 3 }
 
   default_scope -> { order(is_internal: :desc, display_order: :asc, name: :asc) }
 

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -13,6 +13,8 @@ class PriceGroup < ApplicationRecord
   has_many   :price_group_discounts, dependent: :destroy
   has_many   :duration_rates, dependent: :destroy
 
+  accepts_nested_attributes_for :duration_rates
+
   validates_presence_of   :facility_id, unless: :global?
   validates_presence_of   :name
   validates_uniqueness_of :name, scope: :facility_id, case_sensitive: false, unless: :deleted_at?

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -9,6 +9,9 @@ class PricePolicy < ApplicationRecord
   belongs_to :created_by, class_name: "User"
   has_many :order_details
 
+  accepts_nested_attributes_for :product
+  accepts_nested_attributes_for :price_group
+
   validates :start_date, :expire_date, presence: true
   validates :price_group_id, :type, presence: true
   validate :start_date_is_unique, if: :start_date?

--- a/app/models/rate_start.rb
+++ b/app/models/rate_start.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RateStart < ApplicationRecord
+
+  has_many :duration_rates
+  belongs_to :instrument, foreign_key: :product_id
+
+  validates :min_duration, presence: true
+  validates :min_duration, numericality: { greater_than: 0, allow_blank: true }
+
+end

--- a/app/services/price_policy_updater.rb
+++ b/app/services/price_policy_updater.rb
@@ -62,10 +62,16 @@ class PricePolicyUpdater
         end
       end
     end
+
+    @price_policies.each do |price_policy|
+      price_policy.assign_attributes(price_group_attributes(price_policy.price_group))
+    end
   end
 
   def save_for_stepped_billing
-    (save_product && assign_attributes_for_stepped_billing && @price_policies.all?(&:save)) || raise(ActiveRecord::Rollback)
+    ActiveRecord::Base.transaction do
+      (save_product && assign_attributes_for_stepped_billing && @price_policies.all?(&:save)) || raise(ActiveRecord::Rollback)
+    end
   end
 
   def save_product

--- a/app/services/price_policy_updater.rb
+++ b/app/services/price_policy_updater.rb
@@ -44,7 +44,7 @@ class PricePolicyUpdater
 
   def save
     ActiveRecord::Base.transaction do
-      (assign_attributes && @price_policies.all?(&:save)) || raise(ActiveRecord::Rollback)
+      @price_policies.all?(&:save) || raise(ActiveRecord::Rollback)
     end
   end
 

--- a/app/views/instrument_price_policies/_price_policy_fields.html.haml
+++ b/app/views/instrument_price_policies/_price_policy_fields.html.haml
@@ -1,1 +1,15 @@
 = render "time_based_price_policies/price_policy_fields", f: f, cancellation: true, minimum_cost: true, charge_for_collection: charge_for_options(@price_policies.first.product)
+
+%table.table.table-striped.table-hover.price-policy-table
+  %thead
+    %tr
+      %th= "Initial Rate"
+      %th= "Step 2"
+      %th= "Step 3"
+      %th= "Step 4"
+  %tbody
+    %tr
+      %td= 0
+      = fields_for :product, @product do |p|
+        = p.fields_for :rate_starts do |rs|
+          %td= rs.number_field :min_duration, min: 1

--- a/app/views/instrument_price_policies/_price_policy_fields.html.haml
+++ b/app/views/instrument_price_policies/_price_policy_fields.html.haml
@@ -1,1 +1,4 @@
-= render "time_based_price_policies/stepped_billing_price_policy_fields", f: f, cancellation: true, minimum_cost: true, charge_for_collection: charge_for_options(@price_policies.first.product)
+- if @product.duration_pricing_mode?
+  = render "time_based_price_policies/stepped_billing_price_policy_fields", f: f, cancellation: true, minimum_cost: true, charge_for_collection: charge_for_options(@price_policies.first.product)
+- else
+  = render "time_based_price_policies/price_policy_fields", f: f, cancellation: true, minimum_cost: true, charge_for_collection: charge_for_options(@price_policies.first.product)

--- a/app/views/instrument_price_policies/_price_policy_fields.html.haml
+++ b/app/views/instrument_price_policies/_price_policy_fields.html.haml
@@ -1,15 +1,1 @@
-= render "time_based_price_policies/price_policy_fields", f: f, cancellation: true, minimum_cost: true, charge_for_collection: charge_for_options(@price_policies.first.product)
-
-%table.table.table-striped.table-hover.price-policy-table
-  %thead
-    %tr
-      %th= "Initial Rate"
-      %th= "Step 2"
-      %th= "Step 3"
-      %th= "Step 4"
-  %tbody
-    %tr
-      %td= 0
-      = fields_for :product, @product do |p|
-        = p.fields_for :rate_starts do |rs|
-          %td= rs.number_field :min_duration, min: 1
+= render "time_based_price_policies/stepped_billing_price_policy_fields", f: f, cancellation: true, minimum_cost: true, charge_for_collection: charge_for_options(@price_policies.first.product)

--- a/app/views/time_based_price_policies/_stepped_billing_adjustment_row.html.haml
+++ b/app/views/time_based_price_policies/_stepped_billing_adjustment_row.html.haml
@@ -22,6 +22,7 @@
   = pp.hidden_field :usage_rate, value: display_usage_rate(price_group, price_policy),
     class: "js--usageRate"
   = pp.label :usage_subsidy, t("price_policies.adjustment"), class: "normal-weight"
+  %span="-"
   = pp.text_field :usage_subsidy, value: display_usage_subsidy(price_group, price_policy),
     size: 8,
     class: "usage_adjustment"

--- a/app/views/time_based_price_policies/_stepped_billing_adjustment_row.html.haml
+++ b/app/views/time_based_price_policies/_stepped_billing_adjustment_row.html.haml
@@ -1,0 +1,27 @@
+- if local_assigns[:minimum_cost]
+  %td
+    = pp.label :minimum_cost, t("price_policies.amount"), class: "normal-weight"
+    %span.js--minimumCost
+    = pp.hidden_field :minimum_cost, value: number_to_currency(price_policy.minimum_cost, unit: "", delimiter: ""),
+      size: 8,
+      class: "js--minimumCost"
+
+
+- if local_assigns[:cancellation]
+  %td
+    = pp.label :cancellation_cost, t("price_policies.amount"), class: "normal-weight"
+    %span.js--cancellationCost
+    = pp.hidden_field :cancellation_cost, value: number_to_currency(price_policy.cancellation_cost, unit: "", delimiter: ""),
+      readonly: true,
+      size: 8,
+      class: "js--cancellationCost"
+
+    = pp.hidden_field :full_price_cancellation, class: "js--fullCancellationCost", readonly: true
+
+%td
+  = pp.hidden_field :usage_rate, value: display_usage_rate(price_group, price_policy),
+    class: "js--usageRate"
+  = pp.label :usage_subsidy, t("price_policies.adjustment"), class: "normal-weight"
+  = pp.text_field :usage_subsidy, value: display_usage_subsidy(price_group, price_policy),
+    size: 8,
+    class: "usage_adjustment"

--- a/app/views/time_based_price_policies/_stepped_billing_amount_row.html.haml
+++ b/app/views/time_based_price_policies/_stepped_billing_amount_row.html.haml
@@ -1,0 +1,28 @@
+
+- if local_assigns[:minimum_cost]
+  %td
+    = pp.label :minimum_cost, t("price_policies.amount"), class: "normal-weight"
+    = pp.text_field :minimum_cost, value: number_to_currency(price_policy.minimum_cost, unit: "", delimiter: ""),
+      size: 8,
+      data: { target: ".js--minimumCost" }
+
+- if local_assigns[:cancellation]
+  %td.js--cancellationCostContainer
+    = pp.label :cancellation_cost, t("price_policies.amount"), class: "normal-weight"
+    = pp.text_field :cancellation_cost, value: number_to_currency(price_policy.cancellation_cost, unit: "", delimiter: ""),
+      size: 8,
+      class: "js--cancellationCost",
+      data: { target: ".js--cancellationCost" }
+    - if SettingsHelper.feature_on?(:charge_full_price_on_cancellation)
+      = label_tag(nil, class: "checkbox normal-weight") do
+        = pp.check_box :full_price_cancellation,
+          class: "js--fullCancellationCost"
+        = price_policy.class.human_attribute_name(:full_price_cancellation)
+        = tooltip_icon "fa fa-question-circle-o", t("price_policies.charge_full_price_on_cancellation_hint")
+
+%td
+  = pp.label :usage_rate, t("price_policies.rate"), class: "normal-weight"
+  = pp.text_field :usage_rate, value: display_usage_rate(price_group, price_policy),
+    size: 8,
+    class: "#{price_group.master_internal? ? 'master_usage_cost' : ''} usage_rate",
+    data: { target: ".js--usageRate" }

--- a/app/views/time_based_price_policies/_stepped_billing_price_policy_fields.html.haml
+++ b/app/views/time_based_price_policies/_stepped_billing_price_policy_fields.html.haml
@@ -9,6 +9,8 @@
     collection: charge_for_collection,
     selected: price_policy.charge_for
 
+%div{ style: "display: flex; flex-direction: row-reverse" }
+  %h4.half-width= "Stepped Billing Rates"
 %table.table.table-striped.table-hover.price-policy-table
   %thead
     %tr

--- a/app/views/time_based_price_policies/_stepped_billing_price_policy_fields.html.haml
+++ b/app/views/time_based_price_policies/_stepped_billing_price_policy_fields.html.haml
@@ -1,0 +1,65 @@
+= content_for :head_content do
+  = javascript_include_tag "price_policy"
+
+- price_policy = @price_policies.first
+= render "price_policies/common_fields", f: f, price_policy: price_policy
+
+- if local_assigns[:charge_for_collection]
+  = f.input :charge_for,
+    collection: charge_for_collection,
+    selected: price_policy.charge_for
+
+%div{ style: "display: flex" }
+  %table.table.table-striped.table-hover.price-policy-table
+    %thead
+      %tr
+        %th{ rowspan: "2" }= PriceGroup.model_name.human
+        %th{ rowspan: "2" }= price_policy.class.human_attribute_name(:type)
+        %th{ rowspan: "2" }= price_policy.class.human_attribute_name(:can_purchase)
+        - if local_assigns[:minimum_cost]
+          %th= price_policy.class.human_attribute_name(:minimum_cost)
+        - if local_assigns[:cancellation]
+          %th= price_policy.class.human_attribute_name(:cancellation_cost)
+        %th= "Initial Rate"
+        %th= "Step 2"
+        %th= "Step 3"
+        %th= "Step 4"
+    %tbody
+      %tr
+        %td
+        %td
+        %td
+        - if local_assigns[:minimum_cost]
+          %td
+        - if local_assigns[:cancellation]
+          %td
+        %td= 0
+        = fields_for :product, @product do |p|
+          = p.fields_for :rate_starts do |rs|
+            %td
+              = rs.label :min_duration, "Rate Start (hr):", class: "normal-weight"
+              = rs.number_field :min_duration, min: 1, class: "half-width"
+      - @price_policies.each do |price_policy|
+        - price_group = price_policy.price_group
+        = fields_for "price_policy_#{price_group.id}", price_policy do |pp|
+          - row_class = []
+          - row_class << "js--masterInternalRow" if price_group.master_internal?
+          - row_class << "js--adjustmentRow" unless price_group.external? || price_group.master_internal?
+          %tr{class: row_class}
+            %td= price_group.name
+            %td= price_group.type_string
+            %td= pp.check_box :can_purchase, class: "js--canPurchase"
+            - if price_group.external? || price_group.master_internal?
+              = render "time_based_price_policies/stepped_billing_amount_row", price_group: price_group, price_policy: price_policy, pp: pp, cancellation: cancellation, minimum_cost: minimum_cost
+            - else
+              = render "time_based_price_policies/stepped_billing_adjustment_row", price_group: price_group, price_policy: price_policy, pp: pp, cancellation: cancellation, minimum_cost: minimum_cost
+            = pp.fields_for :price_group do |pg|
+              = pg.fields_for :duration_rates do |dr|
+                - if price_group.external? || price_group.master_internal?
+                  %td
+                    = dr.label :rate, "Rate per hr:", class: "normal-weight"
+                    = dr.text_field :rate, value: number_to_currency(dr.object.rate, unit: "", delimiter: ""), size: 8
+                - else
+                  %td
+                    = dr.label :subsidy, "Adjustment:", class: "normal-weight"
+                    = dr.text_field :subsidy, value: number_to_currency(dr.object.subsidy, unit: "", delimiter: ""), size: 8

--- a/app/views/time_based_price_policies/_stepped_billing_price_policy_fields.html.haml
+++ b/app/views/time_based_price_policies/_stepped_billing_price_policy_fields.html.haml
@@ -9,57 +9,56 @@
     collection: charge_for_collection,
     selected: price_policy.charge_for
 
-%div{ style: "display: flex" }
-  %table.table.table-striped.table-hover.price-policy-table
-    %thead
-      %tr
-        %th{ rowspan: "2" }= PriceGroup.model_name.human
-        %th{ rowspan: "2" }= price_policy.class.human_attribute_name(:type)
-        %th{ rowspan: "2" }= price_policy.class.human_attribute_name(:can_purchase)
-        - if local_assigns[:minimum_cost]
-          %th= price_policy.class.human_attribute_name(:minimum_cost)
-        - if local_assigns[:cancellation]
-          %th= price_policy.class.human_attribute_name(:cancellation_cost)
-        %th= "Initial Rate"
-        %th= "Step 2"
-        %th= "Step 3"
-        %th= "Step 4"
-    %tbody
-      %tr
+%table.table.table-striped.table-hover.price-policy-table
+  %thead
+    %tr
+      %th{ rowspan: "2" }= PriceGroup.model_name.human
+      %th{ rowspan: "2" }= price_policy.class.human_attribute_name(:type)
+      %th{ rowspan: "2" }= price_policy.class.human_attribute_name(:can_purchase)
+      - if local_assigns[:minimum_cost]
+        %th= price_policy.class.human_attribute_name(:minimum_cost)
+      - if local_assigns[:cancellation]
+        %th= price_policy.class.human_attribute_name(:cancellation_cost)
+      %th= "Initial Rate"
+      %th= "Step 2"
+      %th= "Step 3"
+      %th= "Step 4"
+  %tbody
+    %tr
+      %td
+      %td
+      %td
+      - if local_assigns[:minimum_cost]
         %td
+      - if local_assigns[:cancellation]
         %td
-        %td
-        - if local_assigns[:minimum_cost]
+      %td= 0
+      = fields_for :product, @product do |p|
+        = p.fields_for :rate_starts do |rs|
           %td
-        - if local_assigns[:cancellation]
-          %td
-        %td= 0
-        = fields_for :product, @product do |p|
-          = p.fields_for :rate_starts do |rs|
-            %td
-              = rs.label :min_duration, "Rate Start (hr):", class: "normal-weight"
-              = rs.number_field :min_duration, min: 1, class: "half-width"
-      - @price_policies.each do |price_policy|
-        - price_group = price_policy.price_group
-        = fields_for "price_policy_#{price_group.id}", price_policy do |pp|
-          - row_class = []
-          - row_class << "js--masterInternalRow" if price_group.master_internal?
-          - row_class << "js--adjustmentRow" unless price_group.external? || price_group.master_internal?
-          %tr{class: row_class}
-            %td= price_group.name
-            %td= price_group.type_string
-            %td= pp.check_box :can_purchase, class: "js--canPurchase"
-            - if price_group.external? || price_group.master_internal?
-              = render "time_based_price_policies/stepped_billing_amount_row", price_group: price_group, price_policy: price_policy, pp: pp, cancellation: cancellation, minimum_cost: minimum_cost
-            - else
-              = render "time_based_price_policies/stepped_billing_adjustment_row", price_group: price_group, price_policy: price_policy, pp: pp, cancellation: cancellation, minimum_cost: minimum_cost
-            = pp.fields_for :price_group do |pg|
-              = pg.fields_for :duration_rates do |dr|
-                - if price_group.external? || price_group.master_internal?
-                  %td
-                    = dr.label :rate, "Rate per hr:", class: "normal-weight"
-                    = dr.text_field :rate, value: number_to_currency(dr.object.rate, unit: "", delimiter: ""), size: 8
-                - else
-                  %td
-                    = dr.label :subsidy, "Adjustment:", class: "normal-weight"
-                    = dr.text_field :subsidy, value: number_to_currency(dr.object.subsidy, unit: "", delimiter: ""), size: 8
+            = rs.label :min_duration, "Rate Start (hr):", class: "normal-weight"
+            = rs.number_field :min_duration, min: 1, class: "half-width"
+    - @price_policies.each do |price_policy|
+      - price_group = price_policy.price_group
+      = fields_for "price_policy_#{price_group.id}", price_policy do |pp|
+        - row_class = []
+        - row_class << "js--masterInternalRow" if price_group.master_internal?
+        - row_class << "js--adjustmentRow" unless price_group.external? || price_group.master_internal?
+        %tr{class: row_class}
+          %td= price_group.name
+          %td= price_group.type_string
+          %td= pp.check_box :can_purchase, class: "js--canPurchase"
+          - if price_group.external? || price_group.master_internal?
+            = render "time_based_price_policies/stepped_billing_amount_row", price_group: price_group, price_policy: price_policy, pp: pp, cancellation: cancellation, minimum_cost: minimum_cost
+          - else
+            = render "time_based_price_policies/stepped_billing_adjustment_row", price_group: price_group, price_policy: price_policy, pp: pp, cancellation: cancellation, minimum_cost: minimum_cost
+          = pp.fields_for :price_group do |pg|
+            = pg.fields_for :duration_rates do |dr|
+              - if price_group.external? || price_group.master_internal?
+                %td
+                  = dr.label :rate, "Rate per hr:", class: "normal-weight"
+                  = dr.text_field :rate, value: number_to_currency(dr.object.rate, unit: "", delimiter: ""), size: 8
+              - else
+                %td
+                  = dr.label :subsidy, "Adjustment:", class: "normal-weight"
+                  = dr.text_field :subsidy, value: number_to_currency(dr.object.subsidy, unit: "", delimiter: ""), size: 8

--- a/app/views/time_based_price_policies/_stepped_billing_price_policy_fields.html.haml
+++ b/app/views/time_based_price_policies/_stepped_billing_price_policy_fields.html.haml
@@ -63,4 +63,5 @@
               - else
                 %td
                   = dr.label :subsidy, "Adjustment:", class: "normal-weight"
+                  %span="-"
                   = dr.text_field :subsidy, value: number_to_currency(dr.object.subsidy, unit: "", delimiter: ""), size: 8

--- a/db/migrate/20231031155216_create_rate_starts.rb
+++ b/db/migrate/20231031155216_create_rate_starts.rb
@@ -1,0 +1,9 @@
+class CreateRateStarts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :rate_starts do |t|
+      t.integer  "min_duration"
+      t.references :product, type: :integer, foreign_key: true, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231031160639_change_duration_rates.rb
+++ b/db/migrate/20231031160639_change_duration_rates.rb
@@ -1,0 +1,23 @@
+class ChangeDurationRates < ActiveRecord::Migration[7.0]
+  def up
+    change_table :duration_rates do |t|
+      t.decimal  "subsidy", precision: 16, scale: 8
+      t.references :price_group
+      t.references :rate_start
+    end
+
+    remove_column :duration_rates, :min_duration
+    remove_column :duration_rates, :product_id
+  end
+
+  def down
+    change_table :duration_rates do |t|
+      t.integer  "min_duration"
+      t.references :product
+    end
+
+    remove_column :duration_rates, :subsidy
+    remove_column :duration_rates, :price_group_id
+    remove_column :duration_rates, :rate_start_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -136,12 +136,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_02_000551) do
   end
 
   create_table "duration_rates", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "min_duration"
     t.decimal "rate", precision: 16, scale: 8
-    t.integer "product_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["product_id"], name: "index_duration_rates_on_product_id"
+    t.decimal "subsidy", precision: 16, scale: 8
+    t.bigint "price_group_id"
+    t.bigint "rate_start_id"
+    t.index ["price_group_id"], name: "index_duration_rates_on_price_group_id"
+    t.index ["rate_start_id"], name: "index_duration_rates_on_rate_start_id"
   end
 
   create_table "email_events", id: :integer, charset: "utf8mb3", force: :cascade do |t|
@@ -672,6 +674,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_02_000551) do
     t.index ["facility_id"], name: "index_projects_on_facility_id"
   end
 
+  create_table "rate_starts", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "min_duration"
+    t.integer "product_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_rate_starts_on_product_id"
+  end
+
   create_table "relays", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "instrument_id"
     t.string "ip"
@@ -996,7 +1006,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_02_000551) do
   add_foreign_key "bulk_email_jobs", "users"
   add_foreign_key "bundle_products", "products", column: "bundle_product_id", name: "fk_bundle_prod_prod"
   add_foreign_key "bundle_products", "products", name: "fk_bundle_prod_bundle"
-  add_foreign_key "duration_rates", "products"
   add_foreign_key "email_events", "users"
   add_foreign_key "facility_accounts", "facilities", name: "fk_facilities"
   add_foreign_key "instrument_statuses", "products", column: "instrument_id", name: "fk_int_stats_product"
@@ -1047,6 +1056,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_02_000551) do
   add_foreign_key "products", "facility_accounts", name: "fk_facility_accounts"
   add_foreign_key "products", "schedules", name: "fk_instruments_schedule"
   add_foreign_key "projects", "facilities"
+  add_foreign_key "rate_starts", "products"
   add_foreign_key "reservations", "order_details"
   add_foreign_key "reservations", "products", name: "reservations_instrument_id_fk"
   add_foreign_key "reservations", "users", column: "created_by_id"

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -5,86 +5,21 @@ require "rails_helper"
 RSpec.describe InstrumentPricePoliciesController do
   let(:facility) { create(:setup_facility) }
   let(:billing_mode) { "Default" }
-  let!(:instrument) { create(:instrument, facility:, billing_mode:) }
+  let(:pricing_mode) { "Schedule Rule" }
+  let!(:instrument) { create(:instrument, facility:, billing_mode:, pricing_mode:) }
   let(:director) { create(:user, :facility_director, facility:) }
 
   let(:base_price_group) { PriceGroup.base }
   let(:external_price_group) { PriceGroup.external }
   let!(:cancer_center) { create(:price_group, :cancer_center) }
 
-  before do
-    login_as director
-    facility.price_groups.destroy_all # get rid of the price groups created by the factories
-  end
-
-  it "can set up the price policies", :js, feature_setting: { facility_directors_can_manage_price_groups: true } do
-    visit facility_instruments_path(facility, instrument)
-    click_link instrument.name
-    click_link "Pricing"
-    click_link "Add Pricing Rules"
-
-    fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "60"
-    fill_in "price_policy_#{base_price_group.id}[minimum_cost]", with: "120"
-    fill_in "price_policy_#{base_price_group.id}[cancellation_cost]", with: "15"
-
-    fill_in "price_policy_#{cancer_center.id}[usage_subsidy]", with: "30"
-
-    fill_in "price_policy_#{external_price_group.id}[usage_rate]", with: "120.11"
-    fill_in "price_policy_#{external_price_group.id}[minimum_cost]", with: "122"
-    fill_in "price_policy_#{external_price_group.id}[cancellation_cost]", with: "31"
-
-    fill_in "note", with: "This is my note"
-
-    click_button "Add Pricing Rules"
-
-    expect(page).to have_content("$60.00\n- $30.00\n= $30.00") # Cancer Center Usage Rate
-    expect(page).to have_content("$120.00\n- $60.00\n= $60.00") # Cancer Center Minimum Cost
-    expect(page).to have_content("$15.00", count: 2) # Internal and Cancer Center Reservation Costs
-
-    # External price group
-    expect(page).to have_content("$120.11")
-    expect(page).to have_content("$122.00")
-    expect(page).to have_content("$31.00")
-
-    expect(page).to have_content("This is my note")
-  end
-
-  it "can only allow some to purchase", :js, feature_setting: { facility_directors_can_manage_price_groups: true } do
-    visit facility_instruments_path(facility, instrument)
-    click_link instrument.name
-    click_link "Pricing"
-    click_link "Add Pricing Rules"
-
-    fill_in "note", with: "This is my note"
-
-    fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "60"
-    fill_in "price_policy_#{base_price_group.id}[minimum_cost]", with: "120"
-    fill_in "price_policy_#{base_price_group.id}[cancellation_cost]", with: "15"
-
-    uncheck "price_policy_#{cancer_center.id}[can_purchase]"
-    uncheck "price_policy_#{external_price_group.id}[can_purchase]"
-
-    click_button "Add Pricing Rules"
-
-    expect(page).to have_content(base_price_group.name)
-    expect(page).not_to have_content(external_price_group.name)
-    expect(page).not_to have_content(cancer_center.name)
-  end
-
-  describe "with required note enabled", feature_setting: { price_policy_requires_note: true, facility_directors_can_manage_price_groups: true } do
-    it "requires the field" do
-      visit facility_instruments_path(facility, instrument)
-      click_link instrument.name
-      click_link "Pricing"
-      click_link "Add Pricing Rules"
-
-      click_button "Add Pricing Rules"
-      expect(page).to have_content("Note may not be blank")
+  context "Schedule Rule pricing mode" do
+    before do
+      login_as director
+      facility.price_groups.destroy_all # get rid of the price groups created by the factories
     end
-  end
 
-  describe "with full cancellation cost enabled", :js, feature_setting: { charge_full_price_on_cancellation: true, facility_directors_can_manage_price_groups: true } do
-    it "can set up the price policies", :js do
+    it "can set up the price policies", :js, feature_setting: { facility_directors_can_manage_price_groups: true } do
       visit facility_instruments_path(facility, instrument)
       click_link instrument.name
       click_link "Pricing"
@@ -94,16 +29,11 @@ RSpec.describe InstrumentPricePoliciesController do
       fill_in "price_policy_#{base_price_group.id}[minimum_cost]", with: "120"
       fill_in "price_policy_#{base_price_group.id}[cancellation_cost]", with: "15"
 
-      check "price_policy_#{base_price_group.id}[full_price_cancellation]"
-      expect(page).to have_field("price_policy_#{base_price_group.id}[cancellation_cost]", disabled: true)
-
       fill_in "price_policy_#{cancer_center.id}[usage_subsidy]", with: "30"
 
       fill_in "price_policy_#{external_price_group.id}[usage_rate]", with: "120.11"
       fill_in "price_policy_#{external_price_group.id}[minimum_cost]", with: "122"
       fill_in "price_policy_#{external_price_group.id}[cancellation_cost]", with: "31"
-      check "price_policy_#{external_price_group.id}[full_price_cancellation]"
-      expect(page).to have_field("price_policy_#{external_price_group.id}[cancellation_cost]", disabled: true)
 
       fill_in "note", with: "This is my note"
 
@@ -111,43 +41,165 @@ RSpec.describe InstrumentPricePoliciesController do
 
       expect(page).to have_content("$60.00\n- $30.00\n= $30.00") # Cancer Center Usage Rate
       expect(page).to have_content("$120.00\n- $60.00\n= $60.00") # Cancer Center Minimum Cost
-      expect(page).not_to have_content("$15.00")
-      expect(page).to have_content(PricePolicy.human_attribute_name(:full_price_cancellation), count: 3)
+      expect(page).to have_content("$15.00", count: 2) # Internal and Cancer Center Reservation Costs
+
+      # External price group
+      expect(page).to have_content("$120.11")
+      expect(page).to have_content("$122.00")
+      expect(page).to have_content("$31.00")
+
+      expect(page).to have_content("This is my note")
     end
-  end
 
-  describe "with 'Nonbillable' billing mode enabled" do
-    let(:billing_mode) { "Nonbillable" }
-
-    it "does not allow adding, editing, or removing of price policies" do
+    it "can only allow some to purchase", :js, feature_setting: { facility_directors_can_manage_price_groups: true } do
       visit facility_instruments_path(facility, instrument)
       click_link instrument.name
       click_link "Pricing"
-      expect(page).not_to have_content "Add Pricing Rules"
+      click_link "Add Pricing Rules"
 
-      expect(page).to have_content "Edit"
-      expect(page).to have_no_link "Edit"
+      fill_in "note", with: "This is my note"
 
-      expect(page).to have_content "Remove"
-      expect(page).to have_no_link "Remove"
+      fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "60"
+      fill_in "price_policy_#{base_price_group.id}[minimum_cost]", with: "120"
+      fill_in "price_policy_#{base_price_group.id}[cancellation_cost]", with: "15"
+
+      uncheck "price_policy_#{cancer_center.id}[can_purchase]"
+      uncheck "price_policy_#{external_price_group.id}[can_purchase]"
+
+      click_button "Add Pricing Rules"
+
+      expect(page).to have_content(base_price_group.name)
+      expect(page).not_to have_content(external_price_group.name)
+      expect(page).not_to have_content(cancer_center.name)
+    end
+
+    describe "with required note enabled", feature_setting: { price_policy_requires_note: true, facility_directors_can_manage_price_groups: true } do
+      it "requires the field" do
+        visit facility_instruments_path(facility, instrument)
+        click_link instrument.name
+        click_link "Pricing"
+        click_link "Add Pricing Rules"
+
+        click_button "Add Pricing Rules"
+        expect(page).to have_content("Note may not be blank")
+      end
+    end
+
+    describe "with full cancellation cost enabled", :js, feature_setting: { charge_full_price_on_cancellation: true, facility_directors_can_manage_price_groups: true } do
+      it "can set up the price policies", :js do
+        visit facility_instruments_path(facility, instrument)
+        click_link instrument.name
+        click_link "Pricing"
+        click_link "Add Pricing Rules"
+
+        fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "60"
+        fill_in "price_policy_#{base_price_group.id}[minimum_cost]", with: "120"
+        fill_in "price_policy_#{base_price_group.id}[cancellation_cost]", with: "15"
+
+        check "price_policy_#{base_price_group.id}[full_price_cancellation]"
+        expect(page).to have_field("price_policy_#{base_price_group.id}[cancellation_cost]", disabled: true)
+
+        fill_in "price_policy_#{cancer_center.id}[usage_subsidy]", with: "30"
+
+        fill_in "price_policy_#{external_price_group.id}[usage_rate]", with: "120.11"
+        fill_in "price_policy_#{external_price_group.id}[minimum_cost]", with: "122"
+        fill_in "price_policy_#{external_price_group.id}[cancellation_cost]", with: "31"
+        check "price_policy_#{external_price_group.id}[full_price_cancellation]"
+        expect(page).to have_field("price_policy_#{external_price_group.id}[cancellation_cost]", disabled: true)
+
+        fill_in "note", with: "This is my note"
+
+        click_button "Add Pricing Rules"
+
+        expect(page).to have_content("$60.00\n- $30.00\n= $30.00") # Cancer Center Usage Rate
+        expect(page).to have_content("$120.00\n- $60.00\n= $60.00") # Cancer Center Minimum Cost
+        expect(page).not_to have_content("$15.00")
+        expect(page).to have_content(PricePolicy.human_attribute_name(:full_price_cancellation), count: 3)
+      end
+    end
+
+    describe "with 'Nonbillable' billing mode enabled" do
+      let(:billing_mode) { "Nonbillable" }
+
+      it "does not allow adding, editing, or removing of price policies" do
+        visit facility_instruments_path(facility, instrument)
+        click_link instrument.name
+        click_link "Pricing"
+        expect(page).not_to have_content "Add Pricing Rules"
+
+        expect(page).to have_content "Edit"
+        expect(page).to have_no_link "Edit"
+
+        expect(page).to have_content "Remove"
+        expect(page).to have_no_link "Remove"
+      end
+    end
+
+    describe "with 'Skip Review' billing mode enabled" do
+      let(:billing_mode) { "Skip Review" }
+
+      it "does not allow adding, editing, or removing of price policies" do
+        visit facility_instruments_path(facility, instrument)
+        click_link instrument.name
+        click_link "Pricing"
+
+        expect(page).not_to have_content "Add Pricing Rules"
+
+        expect(page).to have_content "Edit"
+        expect(page).to have_no_link "Edit"
+
+        expect(page).to have_content "Remove"
+        expect(page).to have_no_link "Remove"
+      end
     end
   end
 
-  describe "with 'Skip Review' billing mode enabled" do
-    let(:billing_mode) { "Skip Review" }
+  context "Duration pricing mode" do
+    let(:pricing_mode) { "Duration" }
 
-    it "does not allow adding, editing, or removing of price policies" do
+    it "can set up the price policies", :js, feature_setting: { facility_directors_can_manage_price_groups: true } do
       visit facility_instruments_path(facility, instrument)
       click_link instrument.name
       click_link "Pricing"
+      click_link "Add Pricing Rules"
 
-      expect(page).not_to have_content "Add Pricing Rules"
+      fill_in "product[rate_starts_attributes][0][min_duration]", with: "2"
+      fill_in "product[rate_starts_attributes][0][min_duration]", with: "3"
+      fill_in "product[rate_starts_attributes][0][min_duration]", with: "4"
 
-      expect(page).to have_content "Edit"
-      expect(page).to have_no_link "Edit"
+      fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "60"
+      fill_in "price_policy_#{base_price_group.id}[minimum_cost]", with: "120"
+      fill_in "price_policy_#{base_price_group.id}[cancellation_cost]", with: "15"
 
-      expect(page).to have_content "Remove"
-      expect(page).to have_no_link "Remove"
+      fill_in "price_policy_#{base_price_group.id}[price_group_attributes][duration_rates_attributes][0][rate]", with: "50"
+      fill_in "price_policy_#{base_price_group.id}[price_group_attributes][duration_rates_attributes][1][rate]", with: "40"
+      fill_in "price_policy_#{base_price_group.id}[price_group_attributes][duration_rates_attributes][2][rate]", with: "30"
+
+      fill_in "price_policy_#{cancer_center.id}[usage_subsidy]", with: "30"
+
+      fill_in "price_policy_#{external_price_group.id}[usage_rate]", with: "120.11"
+      fill_in "price_policy_#{external_price_group.id}[minimum_cost]", with: "122"
+      fill_in "price_policy_#{external_price_group.id}[cancellation_cost]", with: "31"
+
+      fill_in "price_policy_#{external_price_group.id}[price_group_attributes][duration_rates_attributes][0][rate]", with: "110"
+      fill_in "price_policy_#{external_price_group.id}[price_group_attributes][duration_rates_attributes][1][rate]", with: "100"
+      fill_in "price_policy_#{external_price_group.id}[price_group_attributes][duration_rates_attributes][2][rate]", with: "90"
+
+      fill_in "note", with: "This is my note"
+
+      click_button "Add Pricing Rules"
+
+      expect(page).to have_content("$60.00\n- $30.00\n= $30.00") # Cancer Center Usage Rate
+      expect(page).to have_content("$120.00\n- $60.00\n= $60.00") # Cancer Center Minimum Cost
+      expect(page).to have_content("$15.00", count: 2) # Internal and Cancer Center Reservation Costs
+
+      # External price group
+      expect(page).to have_content("$120.11")
+      expect(page).to have_content("$122.00")
+      expect(page).to have_content("$31.00")
+
+      expect(page).to have_content("This is my note")
     end
   end
+
 end

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe InstrumentPricePoliciesController do
   let(:external_price_group) { PriceGroup.external }
   let!(:cancer_center) { create(:price_group, :cancer_center) }
 
-  context "Schedule Rule pricing mode" do
-    before do
-      login_as director
-      facility.price_groups.destroy_all # get rid of the price groups created by the factories
-    end
+  before do
+    login_as director
+    facility.price_groups.destroy_all # get rid of the price groups created by the factories
+  end
 
+  context "Schedule Rule pricing mode" do
     it "can set up the price policies", :js, feature_setting: { facility_directors_can_manage_price_groups: true } do
       visit facility_instruments_path(facility, instrument)
       click_link instrument.name
@@ -164,8 +164,8 @@ RSpec.describe InstrumentPricePoliciesController do
       click_link "Add Pricing Rules"
 
       fill_in "product[rate_starts_attributes][0][min_duration]", with: "2"
-      fill_in "product[rate_starts_attributes][0][min_duration]", with: "3"
-      fill_in "product[rate_starts_attributes][0][min_duration]", with: "4"
+      fill_in "product[rate_starts_attributes][1][min_duration]", with: "3"
+      fill_in "product[rate_starts_attributes][2][min_duration]", with: "4"
 
       fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "60"
       fill_in "price_policy_#{base_price_group.id}[minimum_cost]", with: "120"


### PR DESCRIPTION
# Release Notes
Instruments with Duration pricing mode have new fields in the Pricing rules table. There Stepped billing rates can be set.

Adjustment input now has a `-` before it, so we're explicit about it being a discount.

Pending:
- Validate that Stepped billing rate <= base rate
- Validate that Stepped billing adjustment <= base rate
- Improve error messages

# Screenshot
<img width="887" alt="image" src="https://github.com/tablexi/nucore-open/assets/28798610/14695ff3-6a99-4c75-bf51-9b5ab1de6503">



# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".
