### PR TITLE
[#162031] Refactor global price groups

### DIFF
--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -132,10 +132,11 @@ class PriceGroup < ApplicationRecord
         is_internal:,
         admin_editable:,
         facility_id: nil,
+        global: true,
         display_order: display_order || (global_price_groups.count + 1)
       )
 
-      pg.save(validate: false)
+      pg.save
 
       puts("Created global price group '#{name}'") unless Rails.env.test?
 

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -12,7 +12,7 @@ class PriceGroup < ApplicationRecord
   has_many   :account_price_group_members, class_name: "AccountPriceGroupMember"
   has_many   :price_group_discounts, dependent: :destroy
 
-  validates_presence_of   :facility_id # enforce facility constraint here, though it's not always required
+  validates_presence_of   :facility_id, unless: :global?
   validates_presence_of   :name
   validates_uniqueness_of :name, scope: :facility_id, case_sensitive: false, unless: :deleted_at?
 
@@ -49,10 +49,6 @@ class PriceGroup < ApplicationRecord
 
   def is_not_global?
     !global?
-  end
-
-  def global?
-    facility.nil?
   end
 
   def can_manage_price_group_members?

--- a/db/migrate/20231102000551_add_global_boolean_column_to_price_groups.rb
+++ b/db/migrate/20231102000551_add_global_boolean_column_to_price_groups.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AddGlobalBooleanColumnToPriceGroups < ActiveRecord::Migration[7.0]
+
+  def up
+    change_table :price_groups do |t|
+      add_column :price_groups, :global, :boolean, null: false, default: false
+      execute <<-SQL
+        UPDATE price_groups SET price_groups.global = true
+        WHERE price_groups.deleted_at IS NULL
+        AND price_groups.facility_id IS NULL
+      SQL
+    end
+  end
+
+  def down
+    change_table :price_groups do |t|
+      remove_column :price_groups, :global
+    end
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_12_210150) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_02_000551) do
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
     t.integer "account_id", null: false
@@ -506,6 +506,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_12_210150) do
     t.datetime "updated_at", precision: nil
     t.datetime "deleted_at", precision: nil
     t.boolean "highlighted", default: false, null: false
+    t.boolean "global", default: false, null: false
     t.index ["facility_id", "name"], name: "index_price_groups_on_facility_id_and_name"
   end
 

--- a/spec/factories/price_groups.rb
+++ b/spec/factories/price_groups.rb
@@ -8,14 +8,9 @@ FactoryBot.define do
     is_internal { true }
     admin_editable { true }
 
-    trait :skip_validations do
-      to_create { |instance| instance.save(validate: false) }
-    end
-
     trait :global do
-      # Global PriceGroups are technically invalid because they have no facility
-      skip_validations
       facility { nil }
+      global { true }
       admin_editable { false }
     end
 

--- a/spec/models/price_group_spec.rb
+++ b/spec/models/price_group_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe PriceGroup do
 
   describe "can_delete?" do
     it "should not be deletable if global" do
-      @global_price_group = FactoryBot.build(:price_group, facility: nil)
-      @global_price_group.save(validate: false)
+      @global_price_group = FactoryBot.build(:price_group, facility: nil, global: true)
+      @global_price_group.save
       expect(@global_price_group).to be_persisted
       expect(@global_price_group).to be_global
       expect(@global_price_group).not_to be_can_delete
@@ -129,12 +129,5 @@ RSpec.describe PriceGroup do
       end
     end
   end
-
-  # global price groups are special cases; we don't test them here because price groups are required to have facilities
-  # it "should not be deletable if its a global price group" do
-  #   @global_price_group = FactoryBot.create(:price_group)
-  #   @global_price_group.should be_valid
-  #   @global_price_group.destroy.should == false
-  # end
 
 end


### PR DESCRIPTION
# Release Notes

This cleans up some long-standing technical cobwebs that were standing in the way of linking duration rates to price groups. 

Previously we required all price group records to have a facility ID, while also depending on a missing facility ID as a way of identifying global price groups.  This is clunky, and makes it impossible to update global price groups without skipping validations.  

With this change, price groups that are set up with `global: true` no longer require a facility ID.  This is a clearer, more standard approach, and it means the application no longer depends on invalid database records.  Plus, it paves the way for updating duration rates via price groups using `accepts_nested_attributes`.