### PR TITLE
[#161345] Order import account validation

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -41,7 +41,7 @@ class Account < ApplicationRecord
   accepts_nested_attributes_for :account_users
   has_many :log_events, as: :loggable
 
-  scope :active, -> { where("expires_at > ?", Time.current).where(suspended_at: nil) }
+  scope :active, -> { active_at (Time.current) }
   scope :active_at, ->(time) { where("expires_at > ?", time).where(suspended_at: nil) }
 
   scope :administered_by, lambda { |user|

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -42,6 +42,7 @@ class Account < ApplicationRecord
   has_many :log_events, as: :loggable
 
   scope :active, -> { where("expires_at > ?", Time.current).where(suspended_at: nil) }
+  scope :active_at, ->(time) { where("expires_at > ?", time).where(suspended_at: nil) }
 
   scope :administered_by, lambda { |user|
     for_user(user).where("account_users.user_role" => AccountUser.admin_user_roles)
@@ -196,7 +197,7 @@ class Account < ApplicationRecord
     "#{account_number} #{description}"
   end
 
-  def validate_against_product(product, user)
+  def validate_against_product(product, user, fulfillment_time = Time.current)
     # does the facility accept payment method?
     return "#{product.facility.name} does not accept #{type_string} payment" unless product.facility.can_pay_with_account?(self)
 
@@ -207,7 +208,7 @@ class Account < ApplicationRecord
     if respond_to?(:account_open?)
       accts = product.is_a?(Bundle) ? product.products.collect(&:account) : [product.account]
       accts.uniq.each do |acct|
-        return I18n.t("not_open", model: type_string, scope: "activerecord.errors.models.account") unless account_open?(acct)
+        return I18n.t("not_open", model: type_string, scope: "activerecord.errors.models.account") unless account_open?(acct, fulfillment_time: fulfillment_time)
       end
     end
 

--- a/app/models/nufs_account.rb
+++ b/app/models/nufs_account.rb
@@ -19,9 +19,9 @@ class NufsAccount < Account
     self.expires_at ||= Time.current
   end
 
-  def account_open?(account_num)
+  def account_open?(account_num, fulfillment_time: Time.current)
     begin
-      AccountValidator::ValidatorFactory.instance(account_number, account_num).account_is_open!
+      AccountValidator::ValidatorFactory.instance(account_number, account_num).account_is_open!(fulfillment_time)
     rescue AccountValidator::ValidatorError
       return false
     end

--- a/app/services/order_row_importer.rb
+++ b/app/services/order_row_importer.rb
@@ -69,7 +69,7 @@ class OrderRowImporter
       user
       .accounts
       .for_facility(facility)
-      .active.find_by(account_number: field(:chart_string))
+      .active_at(fulfillment_date).find_by(account_number: field(:chart_string))
   end
 
   def errors?
@@ -263,7 +263,7 @@ class OrderRowImporter
   def validate_account
     return if user.blank? || product.blank?
     if account.present?
-      add_error(account.validate_against_product(product, user))
+      add_error(account.validate_against_product(product, user, fulfillment_date))
     else
       add_error(:account_not_found)
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -45,6 +45,7 @@ validator:
     helper: 'spec/validator_helper' # relative to Rails.root
 
 testing:
+  account_class_name: NufsAccount
   account_factory: "nufs_account"
   api_account_factory: ~
 

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -17,14 +17,6 @@ FactoryBot.define do
     end
   end
 
-  trait :expired do
-    transient do
-      expired_date { 1.month.ago }
-    end
-
-    expires_at { expired_date }
-  end
-
   trait :with_account_owner do
     transient do
       owner { FactoryBot.create(:user) }

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -17,6 +17,14 @@ FactoryBot.define do
     end
   end
 
+  trait :expired do
+    transient do
+      expired_date { 1.month.ago }
+    end
+
+    expires_at { expired_date }
+  end
+
   trait :with_account_owner do
     transient do
       owner { FactoryBot.create(:user) }

--- a/spec/services/order_row_importer_spec.rb
+++ b/spec/services/order_row_importer_spec.rb
@@ -5,7 +5,8 @@ require "csv"
 
 RSpec.describe OrderRowImporter do
   subject { OrderRowImporter.new(row, order_import) }
-  let(:account) { create(:nufs_account, :with_account_owner, owner: user) }
+  let(:account) { create(Settings.testing.account_factory.to_sym, :with_account_owner, owner: user) }
+  let!(:account_api_record) { create(Settings.testing.api_account_factory.to_sym, account_number: account.account_number) } if Settings.testing.api_account_factory
   let(:facility) { create(:setup_facility) }
   let(:order_import) { build(:order_import, creator: user, facility: facility) }
   let(:service) { create(:setup_service, facility: facility) }
@@ -97,12 +98,14 @@ RSpec.describe OrderRowImporter do
       include_context "valid row values"
 
       let!(:account) do
-        a = build(:nufs_account, :with_account_owner, :expired, owner: user)
-        a.save(validate: false)
-        a
+        create(Settings.testing.account_factory.to_sym,
+          :with_account_owner,
+          owner: user,
+          expires_at: 1.month.ago
+        )
       end
 
-      context "when the order occured before the account expires" do
+      context "when the order occurred before the account expires" do
         let(:order_date) { I18n.l(50.days.ago.to_date, format: :usa) }
         let(:fulfillment_date) { I18n.l(45.days.ago.to_date, format: :usa) }
 
@@ -111,7 +114,7 @@ RSpec.describe OrderRowImporter do
         end
       end
 
-      context "when the order occred after the account expires" do
+      context "when the order occurred after the account expires" do
         let(:order_date) { I18n.l(1.day.ago.to_date, format: :usa) }
         let(:fulfillment_date) { I18n.l(Time.current.to_date, format: :usa) }
 
@@ -441,7 +444,7 @@ RSpec.describe OrderRowImporter do
           end
 
           it_behaves_like "an order was not created"
-          it_behaves_like "it has an error message", "does not accept #{NufsAccount.model_name.human} payment"
+          it_behaves_like "it has an error message", "does not accept #{Settings.testing.account_class_name.constantize.model_name.human} payment"
         end
 
         context "and the account is valid for the product" do
@@ -523,6 +526,8 @@ RSpec.describe OrderRowImporter do
       let(:chart_string) { account.account_number }
       let(:product_name) { service.name }
       let(:quantity) { 1 }
+      let(:order_date) { I18n.l(Time.current.to_date, format: :usa) }
+      let(:fulfillment_date) { I18n.l(Time.current.to_date, format: :usa) }
 
       before(:each) do
         allow_any_instance_of(Product).to receive(:can_purchase?).and_return(true)


### PR DESCRIPTION
# Release Notes

Currently when orders are imported, the account validation is checked against the current time, rather than the time the order was actually fulfilled.

This PR changes the validation to check against the time the order was fulfilled, rather than the current time.

These changes are ported in from https://github.com/UMass-CORUM/nucore-umass/pull/574
