### PR TITLE
[#162009] Improve access list import messages

### DIFF
--- a/app/controllers/product_user_imports_controller.rb
+++ b/app/controllers/product_user_imports_controller.rb
@@ -51,15 +51,25 @@ class ProductUserImportsController < ApplicationController
 
   def import_success_alert(import)
     if import.skipped.present?
-      html("controllers.product_user_imports.create.success", count: import.successes.count, added: import.successes.join) +
-      html("controllers.product_user_imports.create.skips", skipped: import.skipped.join)
+      html_text = html("controllers.product_user_imports.create.success", count: import.successes.count)
+
+      html_text += if import.skipped.count < 30
+                     html("controllers.product_user_imports.create.skips", skipped: import.skipped.join)
+                   else
+                     html("controllers.product_user_imports.create.skips_number", count: import.skipped.count)
+                   end
+      html_text
     else
-      html("controllers.product_user_imports.create.success", count: import.successes.count, added: import.successes.join)
+      html("controllers.product_user_imports.create.success", count: import.successes.count)
     end
   end
 
   def import_failed_alert(import)
-    html("controllers.product_user_imports.create.failure", count: import.failures.count, errors: import.failures.join)
+    if import.failures.count < 30
+      html("controllers.product_user_imports.create.failure", count: import.failures.count, errors: import.failures.join)
+    else
+      html("controllers.product_user_imports.create.failure_count", count: import.failures.count, support_email: Settings.support_email)
+    end
   end
 
   def file

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -175,20 +175,20 @@ en:
           %{count} error(s) occurred while importing:
 
           %{errors}
+        failure_count: |
+          %{count} failed. Contact %{support_email}
         success:
           zero: No new approved users were added.
           one: |
-            %{count} new approved user imported successfully:
-
-            %{added}
+            %{count} new approved user imported successfully
           other: |
-            %{count} new approved users imported successfully:
-
-            %{added}
+            %{count} new approved users imported successfully
         skips: |
           The following user(s) already had access:
 
           %{skipped}
+        skips_number: |
+          %{count} users already had access
 
     orders:
       purchase:

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -176,7 +176,7 @@ en:
 
           %{errors}
         failure_count: |
-          %{count} failed. Contact %{support_email}
+          %{count} errors occurred while importing. Contact %{support_email}
         success:
           zero: No new approved users were added.
           one: |

--- a/spec/system/admin/import_product_users_spec.rb
+++ b/spec/system/admin/import_product_users_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Importing Approved Users", :js do
 
       expect(page.current_path).to eq facility_instrument_users_path(facility, instrument)
       expect(page).to have_content("The following user(s) already had access:\n#{user_1.username}\n")
-      expect(page).to have_content("1 new approved user imported successfully:\n#{user_2.username}")
+      expect(page).to have_content("1 new approved user imported successfully")
     end
   end
 


### PR DESCRIPTION
# Release Notes

When importing an access list, the flash messages can get too large, which can cause a server side error in the Nginx proxy. This PR reduces the size of the flash messages.

# Screenshot

![Screen Shot 2023-11-10 at 5 23 28 PM](https://github.com/tablexi/nucore-open/assets/624487/38406faf-4387-4a65-94fb-3d6bf42d94f3)

More than 30 failures

![Screen Shot 2023-11-10 at 5 24 47 PM](https://github.com/tablexi/nucore-open/assets/624487/c1c40483-5792-44a0-a54d-66ab9e7e7d41)

Less than 30 failures

![Screen Shot 2023-11-10 at 5 26 18 PM](https://github.com/tablexi/nucore-open/assets/624487/b1e9b3ea-e46b-4a1e-9308-63c0d5703c71)
