### PR TITLE
[#162094] Display price group discounts properly when editing

### DIFF
--- a/app/controllers/schedule_rules_controller.rb
+++ b/app/controllers/schedule_rules_controller.rb
@@ -42,10 +42,7 @@ class ScheduleRulesController < ApplicationController
     PriceGroup.by_display_order.globals.each do |price_group|
       @schedule_rule.price_group_discounts.build(price_group:, discount_percent: 0)
     end
-
-    @highlighted_price_group_discounts, @non_highlighted_price_group_discounts = @schedule_rule.price_group_discounts.partition do |pgd|
-      pgd.price_group.highlighted
-    end
+    partition_price_group_discounts
   end
 
   # POST /schedule_rules
@@ -62,6 +59,7 @@ class ScheduleRulesController < ApplicationController
 
   # GET /schedule_rules/1/edit
   def edit
+    partition_price_group_discounts
   end
 
   # PUT /schedule_rules/1
@@ -97,6 +95,12 @@ class ScheduleRulesController < ApplicationController
 
   def init_schedule_rule
     @schedule_rule = @product.schedule_rules.find(params[:id])
+  end
+
+  def partition_price_group_discounts
+    @highlighted_price_group_discounts, @non_highlighted_price_group_discounts = @schedule_rule.price_group_discounts.partition do |pgd|
+      pgd.price_group.highlighted
+    end
   end
 
 end

--- a/app/views/schedule_rules/_schedule_rule_fields.html.haml
+++ b/app/views/schedule_rules/_schedule_rule_fields.html.haml
@@ -20,19 +20,19 @@
 
   %p= t("views.schedule_rules.discount_hint")
 
-  - if @highlighted_price_group_discounts&.present?
+  - if @highlighted_price_group_discounts.present?
     .well
       %h4= t("views.schedule_rules.highlighted_heading")
-      = f.association :price_group_discounts, collection: @highlighted_price_group_discounts do |pgd|
+      = f.association :price_group_discounts, collection: @highlighted_price_group_discounts.by_display_order do |pgd|
         = render partial: "price_group_discount", locals: { pgd: pgd }
 
-  - unless @non_highlighted_price_group_discounts&.empty?
+  - if @non_highlighted_price_group_discounts.present?
     .well
       - if @highlighted_price_group_discounts.blank?
         %h4= t("views.schedule_rules.price_groups_heading")
       - else
         %h4= t("views.schedule_rules.non_highlighted_heading")
-      = f.association :price_group_discounts, collection: @non_highlighted_price_group_discounts do |pgd|
+      = f.association :price_group_discounts, collection: @non_highlighted_price_group_discounts.by_display_order do |pgd|
         = render partial: "price_group_discount", locals: { pgd: pgd }
 
 - if @product.has_product_access_groups?

--- a/app/views/schedule_rules/_schedule_rule_fields.html.haml
+++ b/app/views/schedule_rules/_schedule_rule_fields.html.haml
@@ -23,7 +23,7 @@
   - if @highlighted_price_group_discounts.present?
     .well
       %h4= t("views.schedule_rules.highlighted_heading")
-      = f.association :price_group_discounts, collection: @highlighted_price_group_discounts.by_display_order do |pgd|
+      = f.association :price_group_discounts, collection: @highlighted_price_group_discounts do |pgd|
         = render partial: "price_group_discount", locals: { pgd: pgd }
 
   - if @non_highlighted_price_group_discounts.present?
@@ -32,7 +32,7 @@
         %h4= t("views.schedule_rules.price_groups_heading")
       - else
         %h4= t("views.schedule_rules.non_highlighted_heading")
-      = f.association :price_group_discounts, collection: @non_highlighted_price_group_discounts.by_display_order do |pgd|
+      = f.association :price_group_discounts, collection: @non_highlighted_price_group_discounts do |pgd|
         = render partial: "price_group_discount", locals: { pgd: pgd }
 
 - if @product.has_product_access_groups?


### PR DESCRIPTION
# Release Notes

Update the styling and ordering on the edit page to match the form when adding new discounts