### PR TITLE
[#161345] Fix: Nonbillable account open parameter

### DIFF
--- a/app/models/nonbillable_account.rb
+++ b/app/models/nonbillable_account.rb
@@ -10,7 +10,7 @@ class NonbillableAccount < Account
     first || create
   end
 
-  def account_open?(_account_number)
+  def account_open?(_account_number, fulfillment_time: nil)
     true
   end
 

--- a/app/models/nonbillable_account.rb
+++ b/app/models/nonbillable_account.rb
@@ -10,7 +10,10 @@ class NonbillableAccount < Account
     first || create
   end
 
-  def account_open?(_account_number, fulfillment_time: nil)
+  # This account is always open, so the parameters don't matter.
+  # Though the method signature for other accounts is
+  # account_open?(account_number, fulfillment_time: fulfillment_time)
+  def account_open?(*)
     true
   end
 


### PR DESCRIPTION
# Release Notes

In https://github.com/tablexi/nucore-open/pull/3795, `Account#validate_against_product` adds a `fulfillment_time` parameter to what is passes into `account_open?`, making it necessary for each account subclass to add that parameter to its method signature.

This PR adds `fulfillment_time`  to `NonbillableAccount#account_open?`