### PR TITLE
[#161995] Stepped billing calculations

### DIFF
--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -151,7 +151,7 @@ class PricePoliciesController < ApplicationController
   end
 
   # TO DO: consider moving the methods below to InstrumentPricePolicyController
-  ## Durate Rates methods start here
+  ## Duration Rates methods start here
   ## These only apply to instruments with duration pricing mode
 
   # Builds a collection of unique min duration hrs values

--- a/app/models/duration_rate.rb
+++ b/app/models/duration_rate.rb
@@ -2,6 +2,8 @@
 
 class DurationRate < ApplicationRecord
 
+  SIXTY_MIN = 60.0
+
   belongs_to :price_policy, required: true
 
   validate :rate_or_subsidy
@@ -15,20 +17,20 @@ class DurationRate < ApplicationRecord
 
   def rate=(hourly_rate)
     super
-    self[:rate] /= 60.0 if self[:rate].respond_to? :/
+    self[:rate] /= SIXTY_MIN if self[:rate].respond_to? :/
   end
 
   def subsidy=(hourly_subsidy)
     super
-    self[:subsidy] /= 60.0 if self[:subsidy].respond_to? :/
+    self[:subsidy] /= SIXTY_MIN if self[:subsidy].respond_to? :/
   end
 
   def hourly_rate
-    rate.try :*, 60
+    rate.try :*, SIXTY_MIN
   end
 
   def hourly_subsidy
-    subsidy.try :*, 60
+    subsidy.try :*, SIXTY_MIN
   end
 
   private

--- a/app/services/price_policies/time_based_price_calculator.rb
+++ b/app/services/price_policies/time_based_price_calculator.rb
@@ -66,7 +66,7 @@ module PricePolicies
     end
 
     def build_intervals
-      sorted_duration_rates = price_policy.duration_rates.sort_by { |dr| dr.min_duration_hours || 1_000 }
+      sorted_duration_rates = price_policy.duration_rates.sorted
 
       intervals = [{ interval_start: 0, interval_end: sorted_duration_rates[0]&.min_duration_hours || Float::INFINITY, rate: usage_rate * 60, subsidy: usage_subsidy * 60 }]
 

--- a/app/services/price_policies/time_based_price_calculator.rb
+++ b/app/services/price_policies/time_based_price_calculator.rb
@@ -67,15 +67,17 @@ module PricePolicies
 
     def build_intervals
       sorted_duration_rates = price_policy.duration_rates.sorted
+      default_rate = usage_rate * 60
+      default_subsidy = usage_subsidy * 60
 
-      intervals = [{ interval_start: 0, interval_end: sorted_duration_rates[0]&.min_duration_hours || Float::INFINITY, step_rate: usage_rate * 60, step_subsidy: usage_subsidy * 60 }]
+      intervals = [{ interval_start: 0, interval_end: sorted_duration_rates[0]&.min_duration_hours || Float::INFINITY, step_rate: default_rate, step_subsidy: default_subsidy }]
 
       sorted_duration_rates.each_with_index do |duration_rate, index|
         if duration_rate.rate.present?
           hourly_rate = duration_rate.rate
-          hourly_subsidy = 0
+          hourly_subsidy = default_subsidy
         else
-          hourly_rate = 0
+          hourly_rate = default_rate
           hourly_subsidy = duration_rate.subsidy
         end
 

--- a/app/services/price_policies/time_based_price_calculator.rb
+++ b/app/services/price_policies/time_based_price_calculator.rb
@@ -16,8 +16,13 @@ module PricePolicies
     def calculate(start_at, end_at)
       return if start_at > end_at
       duration_mins = TimeRange.new(start_at, end_at).duration_mins
-      discount_multiplier = calculate_discount(start_at, end_at)
-      cost_and_subsidy(duration_mins, discount_multiplier)
+
+      if product.is_a?(Instrument) && product.duration_pricing_mode? && price_policy.duration_rates.present?
+        duration_pricing_cost_and_subsidy(duration_mins)
+      else
+        discount_multiplier = calculate_discount(start_at, end_at)
+        cost_and_subsidy(duration_mins, discount_multiplier)
+      end
     end
 
     def calculate_discount(start_at, end_at)
@@ -37,6 +42,47 @@ module PricePolicies
         { cost: minimum_cost, subsidy: minimum_cost_subsidy }
       else
         costs.merge(subsidy: duration_mins * usage_subsidy * discount_multiplier)
+      end
+    end
+
+    def duration_pricing_cost_and_subsidy(duration_mins)
+      duration_in_hours = duration_mins / 60.0
+
+      result = build_intervals.reduce({ time_left: duration_in_hours, cost: 0, subsidy: 0 }) do |acc, interval_data|
+        time_left = acc[:time_left]
+
+        interval_length = interval_data[:interval_end] - interval_data[:interval_start]
+
+        time_to_charge = [time_left, interval_length].min
+
+        acc[:time_left] -= time_to_charge
+        acc[:cost] += interval_data[:rate] ? interval_data[:rate] * time_to_charge : 0
+        acc[:subsidy] += interval_data[:subsidy] ? interval_data[:subsidy] * time_to_charge : 0
+
+        acc
+      end
+
+      { cost: result[:cost], subsidy: result[:subsidy] }
+    end
+
+    def build_intervals
+      sorted_duration_rates = price_policy.duration_rates.sort_by { |dr| dr.min_duration_hours || 1_000 }
+      lower_intervals = sorted_duration_rates.dup
+      higher_intervals = sorted_duration_rates.dup
+
+      if sorted_duration_rates.first.min_duration_hours > 0
+        lower_intervals.prepend nil
+      else
+        higher_intervals.shift
+      end
+
+      lower_intervals.zip(higher_intervals).map do |lower, higher|
+        hourly_rate = lower ? lower.rate : usage_rate * 60
+        hourly_subsidy = lower ? lower.subsidy : usage_subsidy * 60
+        interval_start = lower&.min_duration_hours || 0
+        interval_end = higher&.min_duration_hours || Float::INFINITY
+
+        { interval_start: , interval_end:, rate: hourly_rate, subsidy: hourly_subsidy }
       end
     end
 

--- a/app/services/price_policies/time_based_price_calculator.rb
+++ b/app/services/price_policies/time_based_price_calculator.rb
@@ -82,7 +82,7 @@ module PricePolicies
       sorted_duration_rates.each_with_index do |duration_rate, index|
         if duration_rate.rate.present?
           hourly_rate = duration_rate.rate
-          hourly_subsidy = default_subsidy
+          hourly_subsidy = nil
         else
           hourly_rate = default_rate
           hourly_subsidy = duration_rate.subsidy

--- a/app/services/price_policies/time_based_price_calculator.rb
+++ b/app/services/price_policies/time_based_price_calculator.rb
@@ -56,8 +56,8 @@ module PricePolicies
         time_to_charge = [time_left, interval_length].min
 
         acc[:time_left] -= time_to_charge
-        acc[:cost] += interval_data[:step_rate] ? interval_data[:step_rate] * time_to_charge : 0
-        acc[:subsidy] += interval_data[:step_subsidy] ? interval_data[:step_subsidy] * time_to_charge : 0
+        acc[:cost] += (interval_data[:step_rate] || 0) * time_to_charge
+        acc[:subsidy] += (interval_data[:step_subsidy] || 0) * time_to_charge
 
         acc
       end

--- a/app/services/price_policies/time_based_price_calculator.rb
+++ b/app/services/price_policies/time_based_price_calculator.rb
@@ -46,12 +46,10 @@ module PricePolicies
     end
 
     def duration_pricing_cost_and_subsidy(duration_mins)
-      duration_in_hours = duration_mins / 60.0
-
-      result = build_intervals.reduce({ time_left: duration_in_hours, cost: 0, subsidy: 0 }) do |acc, interval_data|
+      result = build_intervals.reduce({ time_left: duration_mins, cost: 0, subsidy: 0 }) do |acc, interval_data|
         time_left = acc[:time_left]
 
-        interval_length = interval_data[:interval_end] - interval_data[:interval_start]
+        interval_length = (interval_data[:interval_end] - interval_data[:interval_start]) * 60
 
         time_to_charge = [time_left, interval_length].min
 
@@ -69,8 +67,8 @@ module PricePolicies
       sorted_duration_rates = price_policy.duration_rates.sorted
       sorted_subsidies = sorted_duration_rates.map { |dr| dr.subsidy || 0 }
 
-      default_rate = usage_rate * 60
-      default_subsidy = usage_subsidy * 60
+      default_rate = usage_rate
+      default_subsidy = usage_subsidy
 
       intervals = [
         {

--- a/app/services/price_policies/time_based_price_calculator.rb
+++ b/app/services/price_policies/time_based_price_calculator.rb
@@ -70,7 +70,14 @@ module PricePolicies
       default_rate = usage_rate * 60
       default_subsidy = usage_subsidy * 60
 
-      intervals = [{ interval_start: 0, interval_end: sorted_duration_rates[0]&.min_duration_hours || Float::INFINITY, step_rate: default_rate, step_subsidy: default_subsidy }]
+      intervals = [
+        {
+          interval_start: 0,
+          interval_end: sorted_duration_rates[0]&.min_duration_hours || Float::INFINITY,
+          step_rate: default_rate,
+          step_subsidy: default_subsidy
+        }
+      ]
 
       sorted_duration_rates.each_with_index do |duration_rate, index|
         if duration_rate.rate.present?

--- a/app/services/price_policies/time_based_price_calculator.rb
+++ b/app/services/price_policies/time_based_price_calculator.rb
@@ -64,15 +64,12 @@ module PricePolicies
     end
 
     def build_intervals
-      sorted_subsidies = sorted_duration_rates.map { |dr| dr.subsidy || 0 }
-      default_subsidy = usage_subsidy || 0
-
       intervals = [
         {
           interval_start: 0,
           interval_end: sorted_duration_rates[0]&.min_duration_hours || Float::INFINITY,
           step_rate: usage_rate,
-          step_subsidy: default_subsidy
+          step_subsidy: usage_subsidy || 0
         }
       ]
 
@@ -82,8 +79,7 @@ module PricePolicies
           step_subsidy = nil
         elsif duration_rate.subsidy.present?
           step_rate = usage_rate
-          # The subsidy for the current interval is the sum of the subsidies of all the previous intervals
-          step_subsidy = sorted_subsidies.slice(0, index+1).sum(default_subsidy)
+          step_subsidy = duration_rate.subsidy
         end
 
         interval_start = duration_rate.min_duration_hours

--- a/app/services/price_policies/time_based_price_calculator.rb
+++ b/app/services/price_policies/time_based_price_calculator.rb
@@ -67,6 +67,8 @@ module PricePolicies
 
     def build_intervals
       sorted_duration_rates = price_policy.duration_rates.sorted
+      sorted_subsidies = sorted_duration_rates.map { |dr| dr.subsidy || 0 }
+
       default_rate = usage_rate * 60
       default_subsidy = usage_subsidy * 60
 
@@ -85,7 +87,8 @@ module PricePolicies
           hourly_subsidy = nil
         else
           hourly_rate = default_rate
-          hourly_subsidy = duration_rate.subsidy
+          # The subsidy for the current interval is the sum of the subsidies of all the previous intervals
+          hourly_subsidy = sorted_subsidies.slice(0, index+1).sum(default_subsidy)
         end
 
         interval_start = duration_rate.min_duration_hours

--- a/app/services/price_policies/time_based_price_calculator.rb
+++ b/app/services/price_policies/time_based_price_calculator.rb
@@ -56,8 +56,8 @@ module PricePolicies
         time_to_charge = [time_left, interval_length].min
 
         acc[:time_left] -= time_to_charge
-        acc[:cost] += interval_data[:rate] ? interval_data[:rate] * time_to_charge : 0
-        acc[:subsidy] += interval_data[:subsidy] ? interval_data[:subsidy] * time_to_charge : 0
+        acc[:cost] += interval_data[:step_rate] ? interval_data[:step_rate] * time_to_charge : 0
+        acc[:subsidy] += interval_data[:step_subsidy] ? interval_data[:step_subsidy] * time_to_charge : 0
 
         acc
       end
@@ -68,7 +68,7 @@ module PricePolicies
     def build_intervals
       sorted_duration_rates = price_policy.duration_rates.sorted
 
-      intervals = [{ interval_start: 0, interval_end: sorted_duration_rates[0]&.min_duration_hours || Float::INFINITY, rate: usage_rate * 60, subsidy: usage_subsidy * 60 }]
+      intervals = [{ interval_start: 0, interval_end: sorted_duration_rates[0]&.min_duration_hours || Float::INFINITY, step_rate: usage_rate * 60, step_subsidy: usage_subsidy * 60 }]
 
       sorted_duration_rates.each_with_index do |duration_rate, index|
         if duration_rate.rate.present?
@@ -82,7 +82,7 @@ module PricePolicies
         interval_start = duration_rate.min_duration_hours
         interval_end = sorted_duration_rates[index + 1]&.min_duration_hours || Float::INFINITY
 
-        intervals << { interval_start: , interval_end:, rate: hourly_rate, subsidy: hourly_subsidy }
+        intervals << { interval_start: , interval_end:, step_rate: hourly_rate, step_subsidy: hourly_subsidy }
       end
 
       intervals

--- a/app/views/time_based_price_policies/_stepped_billing_price_policy_fields.html.haml
+++ b/app/views/time_based_price_policies/_stepped_billing_price_policy_fields.html.haml
@@ -35,9 +35,8 @@
       - if local_assigns[:cancellation]
         %td
       %th{ scope: "col" }
-        %p
-          = t(".rate_start")
-          = 0
+        = label :default_min_duration, t(".rate_start"), class: "normal-weight"
+        = number_field :default_min_duration, "default", value: 0, readonly: true, disabled:true, class: "half-width"
       - @min_durations.each_with_index do |min_duration, column_index|
         %th{ scope: "col" }
           .control-group

--- a/app/views/time_based_price_policies/_stepped_billing_price_policy_fields.html.haml
+++ b/app/views/time_based_price_policies/_stepped_billing_price_policy_fields.html.haml
@@ -62,11 +62,11 @@
             - if price_group.external? || price_group.master_internal?
               %td
                 = dr.label :rate, t(".rate_per_hr"), class: "normal-weight"
-                = dr.text_field :rate, value: number_to_currency(dr.object.rate, unit: "", delimiter: ""), size: 8
+                = dr.text_field :rate, value: number_to_currency(dr.object.hourly_rate, unit: "", delimiter: ""), size: 8
                 = dr.hidden_field :min_duration_hours
             - else
               %td
                 = dr.label :subsidy, t(".adjustment"), class: "normal-weight"
                 %span="-"
-                = dr.text_field :subsidy, value: number_to_currency(dr.object.subsidy, unit: "", delimiter: ""), size: 8
+                = dr.text_field :subsidy, value: number_to_currency(dr.object.hourly_subsidy, unit: "", delimiter: ""), size: 8
                 = dr.hidden_field :min_duration_hours

--- a/app/views/time_based_price_policies/_stepped_billing_table.html.haml
+++ b/app/views/time_based_price_policies/_stepped_billing_table.html.haml
@@ -73,9 +73,9 @@
           - price_policy.duration_rates.sorted.each do |duration_rate|
             %td.currency
               - if duration_rate.rate.present?
-                .rate= number_to_currency duration_rate.rate
+                .rate= number_to_currency duration_rate.hourly_rate
               - if duration_rate.subsidy.present?
-                .subsidy= "- #{number_to_currency duration_rate.subsidy}"
+                .subsidy= "- #{number_to_currency duration_rate.hourly_subsidy}"
           - (PricePolicy::MAX_RATE_STARTS - price_policy.duration_rates.length).times do
             %td.currency
 

--- a/db/migrate/20231116194445_update_duration_rate_rate_and_subsidy_to_per_minute_values.rb
+++ b/db/migrate/20231116194445_update_duration_rate_rate_and_subsidy_to_per_minute_values.rb
@@ -1,0 +1,7 @@
+class UpdateDurationRateRateAndSubsidyToPerMinuteValues < ActiveRecord::Migration[7.0]
+  class DurationRate < ApplicationRecord; end
+
+  def change
+    DurationRate.update_all("rate = rate / 60.0, subsidy = subsidy / 60.0")
+  end
+end

--- a/db/migrate/20231116194445_update_duration_rate_rate_and_subsidy_to_per_minute_values.rb
+++ b/db/migrate/20231116194445_update_duration_rate_rate_and_subsidy_to_per_minute_values.rb
@@ -3,7 +3,11 @@
 class UpdateDurationRateRateAndSubsidyToPerMinuteValues < ActiveRecord::Migration[7.0]
   class DurationRate < ApplicationRecord; end
 
-  def change
+  def up
     DurationRate.update_all("rate = rate / 60.0, subsidy = subsidy / 60.0")
+  end
+
+  def down
+    DurationRate.update_all("rate = rate * 60.0, subsidy = subsidy * 60.0")
   end
 end

--- a/db/migrate/20231116194445_update_duration_rate_rate_and_subsidy_to_per_minute_values.rb
+++ b/db/migrate/20231116194445_update_duration_rate_rate_and_subsidy_to_per_minute_values.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UpdateDurationRateRateAndSubsidyToPerMinuteValues < ActiveRecord::Migration[7.0]
   class DurationRate < ApplicationRecord; end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_15_142252) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_16_194445) do
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
     t.integer "account_id", null: false

--- a/spec/factories/duration_rates.rb
+++ b/spec/factories/duration_rates.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :duration_rate do
+    min_duration_hours { 1 }
+    rate { 60 }
+  end
+
+end

--- a/spec/services/price_policies/time_based_price_calculator_spec.rb
+++ b/spec/services/price_policies/time_based_price_calculator_spec.rb
@@ -293,7 +293,8 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
                   # 2 hours       @ $30 + $10               = $80       Duration rate - Minimum duration: 1 hour
                   # 2 hours       @ $30 + $10 + $15         = $110      Duration rate - Minimum duration: 3 hours
                   # 0.25 hours    @ $30 + $10 + $15 + $30   = $21.25    Duration rate - Minimum duration: 5 hours
-                  is_expected.to eq(cost: 630, subsidy: 241.25)
+                  expect(calculator.calculate(start_at, end_at)[:cost]).to eq(630)
+                  expect(calculator.calculate(start_at, end_at)[:subsidy].round(4)).to eq(241.25)
                 end
               end
 

--- a/spec/services/price_policies/time_based_price_calculator_spec.rb
+++ b/spec/services/price_policies/time_based_price_calculator_spec.rb
@@ -281,20 +281,20 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
                 let(:end_at) { start_at + 5.hour + 15.minute }
 
                 it "uses usage rate, usage subsidy and duration rates" do
-                  create(:duration_rate, price_policy: price_policy, min_duration_hours: 1, rate: nil, subsidy: 10)
-                  create(:duration_rate, price_policy: price_policy, min_duration_hours: 3, rate: nil, subsidy: 15)
-                  create(:duration_rate, price_policy: price_policy, min_duration_hours: 5, rate: nil, subsidy: 30)
+                  create(:duration_rate, price_policy: price_policy, min_duration_hours: 1, rate: nil, subsidy: 25)
+                  create(:duration_rate, price_policy: price_policy, min_duration_hours: 3, rate: nil, subsidy: 20)
+                  create(:duration_rate, price_policy: price_policy, min_duration_hours: 5, rate: nil, subsidy: 15)
 
                   # Cost
                   # 5.25 hours    @ $120   = $630   Usage rate
 
                   # Subsidy
-                  # 1 hours       @ $30                     = $30       Usage subsidy
-                  # 2 hours       @ $30 + $10               = $80       Duration rate - Minimum duration: 1 hour
-                  # 2 hours       @ $30 + $10 + $15         = $110      Duration rate - Minimum duration: 3 hours
-                  # 0.25 hours    @ $30 + $10 + $15 + $30   = $21.25    Duration rate - Minimum duration: 5 hours
+                  # 1 hours       @ $30   = $30      Usage subsidy
+                  # 2 hours       @ $25   = $50      Duration rate - Minimum duration: 1 hour
+                  # 2 hours       @ $20   = $40      Duration rate - Minimum duration: 3 hours
+                  # 0.25 hours    @ $15   = $3.75    Duration rate - Minimum duration: 5 hours
                   expect(calculator.calculate(start_at, end_at)[:cost]).to eq(630)
-                  expect(calculator.calculate(start_at, end_at)[:subsidy].round(4)).to eq(241.25)
+                  expect(calculator.calculate(start_at, end_at)[:subsidy].round(4)).to eq(123.75)
                 end
               end
 

--- a/spec/services/price_policies/time_based_price_calculator_spec.rb
+++ b/spec/services/price_policies/time_based_price_calculator_spec.rb
@@ -281,15 +281,19 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
                 let(:end_at) { start_at + 5.hour + 15.minute }
 
                 it "uses usage rate, usage subsidy and duration rates" do
-                  create(:duration_rate, price_policy: price_policy, min_duration_hours: 1, subsidy: 45)
+                  create(:duration_rate, price_policy: price_policy, min_duration_hours: 1, rate: nil, subsidy: 45)
                   create(:duration_rate, price_policy: price_policy, min_duration_hours: 3, rate: nil, subsidy: 60)
-                  create(:duration_rate, price_policy: price_policy, min_duration_hours: 5, subsidy: 90)
+                  create(:duration_rate, price_policy: price_policy, min_duration_hours: 5, rate: nil, subsidy: 90)
 
-                  # 1 hours       @ $120  - $30   = $90   Usage rate - Usage subsidy
-                  # 2 hours       @ $120  - $45   = $150  Duration rate - Minimum duration: 1 hour
-                  # 2 hours       @ $120  - $60   = $120  Duration rate - Minimum duration: 3 hours
-                  # 0.25 hours    @ $120  - $90   = $7.5  Duration rate - Minimum duration: 5 hours
-                  is_expected.to eq(cost: 630, subsidy: 367.5)
+                  # Cost
+                  # 5.25 hours    @ $120   = $630   Usage rate
+
+                  # Subsidy
+                  # 1 hours       @ $30   = $30     Usage subsidy
+                  # 2 hours       @ $45   = $90     Duration rate - Minimum duration: 1 hour
+                  # 2 hours       @ $60   = $120    Duration rate - Minimum duration: 3 hours
+                  # 0.25 hours    @ $90   = $22.5   Duration rate - Minimum duration: 5 hours
+                  is_expected.to eq(cost: 630, subsidy: 262.5)
                 end
               end
 

--- a/spec/services/price_policies/time_based_price_calculator_spec.rb
+++ b/spec/services/price_policies/time_based_price_calculator_spec.rb
@@ -4,195 +4,296 @@ require "rails_helper"
 
 RSpec.describe PricePolicies::TimeBasedPriceCalculator do
 
-  let(:product) { create(:setup_instrument, skip_schedule_rules: true) }
-  let!(:day_schedule) { create(:schedule_rule, :weekday, product: product) }
-  let!(:night_schedule) { create(:schedule_rule, :weekday, :evening, discount_percent: 10, product: product) }
-  let!(:weekend_schedule) { create(:schedule_rule, :weekend, :all_day, discount_percent: 25, product: product) }
   let(:calculator) { described_class.new(price_policy) }
   let(:price_policy) { build_stubbed(:instrument_price_policy, options.merge(product: product)) }
   let(:options) { {} }
 
-  describe "#calculate" do
-    subject(:costs) { calculator.calculate(start_at, end_at) }
+  context "when product has schedule rules pricing mode" do
+    let(:product) { create(:setup_instrument, skip_schedule_rules: true) }
+    let!(:day_schedule) { create(:schedule_rule, :weekday, product: product) }
+    let!(:night_schedule) { create(:schedule_rule, :weekday, :evening, discount_percent: 10, product: product) }
+    let!(:weekend_schedule) { create(:schedule_rule, :weekend, :all_day, discount_percent: 25, product: product) }
 
-    describe "with no subsidies" do
-      let(:options) { { usage_rate: 60 } }
+    describe "#calculate" do
+      subject(:costs) { calculator.calculate(start_at, end_at) }
 
-      describe "when it is all in one schedule rule" do
-        let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) }
-        let(:end_at) { start_at + 1.hour }
-        it { is_expected.to eq(cost: 60, subsidy: 0) }
-      end
+      describe "with no subsidies" do
+        let(:options) { { usage_rate: 60 } }
 
-      describe "when it is all in one discounted rule" do
-        let(:start_at) { Time.zone.local(2017, 4, 29, 12, 0) } # Saturday
-        let(:end_at) { start_at + 1.hour }
-        it { is_expected.to eq(cost: 45, subsidy: 0) }
-      end
-
-      describe "when it overlaps into the evening" do
-        let(:start_at) { Time.zone.local(2017, 4, 27, 16, 0) }
-        let(:end_at) { start_at + 2.hours }
-        it { is_expected.to eq(cost: 60 + 54, subsidy: 0) }
-      end
-
-      describe "when it overlaps into the weekend" do
-        let(:start_at) { Time.zone.local(2017, 4, 28, 16, 0) }
-        let(:end_at) { Time.zone.local(2017, 4, 29, 2, 0) } # Saturday 2am
-        # 1 hour  @ $60 * 0%    = $60   Normal
-        # 7 hours @ $60 * 10%   = $378  Evening
-        # 2 hours @ $60 * 25%   = 90    Weekend
-        it { is_expected.to eq(cost: 60 + 378 + 90, subsidy: 0) }
-      end
-    end
-
-    describe "with subsidies" do
-      let(:options) { { usage_rate: 60, usage_subsidy: 15 } }
-      describe "when it is all in one schedule rule" do
-        let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) }
-        let(:end_at) { start_at + 1.hour }
-        it { is_expected.to eq(cost: 60, subsidy: 15) }
-      end
-
-      describe "when it is all in one discounted rule" do
-        let(:start_at) { Time.zone.local(2017, 4, 29, 12, 0) } # Saturday
-        let(:end_at) { start_at + 1.hour }
-        it { is_expected.to eq(cost: 45, subsidy: 11.25) }
-      end
-
-      describe "when it overlaps into the evening" do
-        let(:start_at) { Time.zone.local(2017, 4, 27, 16, 0) }
-        let(:end_at) { start_at + 2.hours }
-        it { is_expected.to eq(cost: 60 + 54, subsidy: 28.5) }
-      end
-
-      describe "when it overlaps into the weekend" do
-        let(:start_at) { Time.zone.local(2017, 4, 28, 16, 0) }
-        let(:end_at) { Time.zone.local(2017, 4, 29, 2, 0) } # Saturday 2am
-        # 1 hour  @ $60 * 0%    = $60   Normal
-        # 7 hours @ $60 * 10%   = $378  Evening
-        # 2 hours @ $60 * 25%   = 90    $Weekend
-        it { is_expected.to eq(cost: 60 + 378 + 90, subsidy: 132) }
-      end
-    end
-
-    describe "with higher precision" do
-      # $31/60 = .5167
-      # $17/60 = .2833
-      let(:options) { { usage_rate: 31, usage_subsidy: 17 } }
-
-      describe "with no discount" do
-        let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) } # Thursday
-        let(:end_at) { start_at + 13.minutes }
-        it { is_expected.to eq(cost: 6.71666671, subsidy: 3.68333329) }
-      end
-
-      describe "with the weekend discount of 25%" do
-        let(:start_at) { Time.zone.local(2017, 4, 29, 12, 0) } # Saturday
-        let(:end_at) { start_at + 13.minutes }
-        it { is_expected.to eq(cost: 5.0375000325, subsidy: 2.7624999675) }
-      end
-    end
-
-    describe "with a minimum cost" do
-      let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) } # Thursday
-
-      describe "with rate and subsidy" do
-        let(:options) { { usage_rate: 60, usage_subsidy: 10, minimum_cost: 30 } }
-
-        describe "when you are below the minimum" do
-          let(:end_at) { start_at + 29.minutes }
-          it { is_expected.to eq(cost: 30, subsidy: 5.0000001) }
-        end
-
-        describe "when you are above the minimum" do
-          let(:end_at) { start_at + 31.minutes }
-          it { is_expected.to eq(cost: 31, subsidy: 5.16666677) }
-        end
-      end
-
-      describe "with zero cost" do
-        let(:options) { { usage_rate: 0, minimum_cost: 30 } }
-        describe "when you use it for an hour" do
+        describe "when it is all in one schedule rule" do
+          let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) }
           let(:end_at) { start_at + 1.hour }
-          it { is_expected.to eq(cost: 30, subsidy: 0) }
+          it { is_expected.to eq(cost: 60, subsidy: 0) }
         end
 
-        describe "when you use for a day" do
-          let(:end_at) { start_at + 1.day }
-          it { is_expected.to eq(cost: 30, subsidy: 0) }
+        describe "when it is all in one discounted rule" do
+          let(:start_at) { Time.zone.local(2017, 4, 29, 12, 0) } # Saturday
+          let(:end_at) { start_at + 1.hour }
+          it { is_expected.to eq(cost: 45, subsidy: 0) }
         end
+
+        describe "when it overlaps into the evening" do
+          let(:start_at) { Time.zone.local(2017, 4, 27, 16, 0) }
+          let(:end_at) { start_at + 2.hours }
+          it { is_expected.to eq(cost: 60 + 54, subsidy: 0) }
+        end
+
+        describe "when it overlaps into the weekend" do
+          let(:start_at) { Time.zone.local(2017, 4, 28, 16, 0) }
+          let(:end_at) { Time.zone.local(2017, 4, 29, 2, 0) } # Saturday 2am
+          # 1 hour  @ $60 * 0%    = $60   Normal
+          # 7 hours @ $60 * 10%   = $378  Evening
+          # 2 hours @ $60 * 25%   = 90    Weekend
+          it { is_expected.to eq(cost: 60 + 378 + 90, subsidy: 0) }
+        end
+      end
+
+      describe "with subsidies" do
+        let(:options) { { usage_rate: 60, usage_subsidy: 15 } }
+        describe "when it is all in one schedule rule" do
+          let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) }
+          let(:end_at) { start_at + 1.hour }
+          it { is_expected.to eq(cost: 60, subsidy: 15) }
+        end
+
+        describe "when it is all in one discounted rule" do
+          let(:start_at) { Time.zone.local(2017, 4, 29, 12, 0) } # Saturday
+          let(:end_at) { start_at + 1.hour }
+          it { is_expected.to eq(cost: 45, subsidy: 11.25) }
+        end
+
+        describe "when it overlaps into the evening" do
+          let(:start_at) { Time.zone.local(2017, 4, 27, 16, 0) }
+          let(:end_at) { start_at + 2.hours }
+          it { is_expected.to eq(cost: 60 + 54, subsidy: 28.5) }
+        end
+
+        describe "when it overlaps into the weekend" do
+          let(:start_at) { Time.zone.local(2017, 4, 28, 16, 0) }
+          let(:end_at) { Time.zone.local(2017, 4, 29, 2, 0) } # Saturday 2am
+          # 1 hour  @ $60 * 0%    = $60   Normal
+          # 7 hours @ $60 * 10%   = $378  Evening
+          # 2 hours @ $60 * 25%   = 90    $Weekend
+          it { is_expected.to eq(cost: 60 + 378 + 90, subsidy: 132) }
+        end
+      end
+
+      describe "with higher precision" do
+        # $31/60 = .5167
+        # $17/60 = .2833
+        let(:options) { { usage_rate: 31, usage_subsidy: 17 } }
+
+        describe "with no discount" do
+          let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) } # Thursday
+          let(:end_at) { start_at + 13.minutes }
+          it { is_expected.to eq(cost: 6.71666671, subsidy: 3.68333329) }
+        end
+
+        describe "with the weekend discount of 25%" do
+          let(:start_at) { Time.zone.local(2017, 4, 29, 12, 0) } # Saturday
+          let(:end_at) { start_at + 13.minutes }
+          it { is_expected.to eq(cost: 5.0375000325, subsidy: 2.7624999675) }
+        end
+      end
+
+      describe "with a minimum cost" do
+        let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) } # Thursday
+
+        describe "with rate and subsidy" do
+          let(:options) { { usage_rate: 60, usage_subsidy: 10, minimum_cost: 30 } }
+
+          describe "when you are below the minimum" do
+            let(:end_at) { start_at + 29.minutes }
+            it { is_expected.to eq(cost: 30, subsidy: 5.0000001) }
+          end
+
+          describe "when you are above the minimum" do
+            let(:end_at) { start_at + 31.minutes }
+            it { is_expected.to eq(cost: 31, subsidy: 5.16666677) }
+          end
+        end
+
+        describe "with zero cost" do
+          let(:options) { { usage_rate: 0, minimum_cost: 30 } }
+          describe "when you use it for an hour" do
+            let(:end_at) { start_at + 1.hour }
+            it { is_expected.to eq(cost: 30, subsidy: 0) }
+          end
+
+          describe "when you use for a day" do
+            let(:end_at) { start_at + 1.day }
+            it { is_expected.to eq(cost: 30, subsidy: 0) }
+          end
+        end
+      end
+
+      describe "with seconds" do
+        let(:options) { { usage_rate: 60 } }
+
+        describe "when within the same minute" do
+          let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0, 10) } # Thursday
+          let(:end_at) { Time.zone.local(2017, 4, 27, 12, 0, 20) } # Thursday
+          it "charges for one minute" do
+            expect(costs).to eq(cost: 1, subsidy: 0)
+          end
+        end
+
+        describe "when spans two minutes, but less than a minute" do
+          let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0, 50) } # Thursday
+          let(:end_at) { Time.zone.local(2017, 4, 27, 12, 1, 10) } # Thursday
+          it "charges for one minute because the seconds are stripped off" do
+            expect(costs).to eq(cost: 1, subsidy: 0)
+          end
+        end
+
+        describe "when going across 3 minutes" do
+          let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0, 0) } # Thursday
+          let(:end_at) { Time.zone.local(2017, 4, 27, 12, 2, 50) } # Thursday
+          it "charges for two minutes because the seconds are stripped off" do
+            expect(costs).to eq(cost: 2, subsidy: 0)
+          end
+        end
+      end
+
+      describe "invalid times" do
+        let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) } # Thursday
+        let(:end_at) { start_at - 1.hour }
+
+        it { is_expected.to be_nil }
       end
     end
 
-    describe "with seconds" do
-      let(:options) { { usage_rate: 60 } }
+    describe "#calculate_discount" do
+      subject(:discount) { calculator.calculate_discount(start_at, end_at) }
 
-      describe "when within the same minute" do
-        let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0, 10) } # Thursday
-        let(:end_at) { Time.zone.local(2017, 4, 27, 12, 0, 20) } # Thursday
-        it "charges for one minute" do
-          expect(costs).to eq(cost: 1, subsidy: 0)
+      describe "when the entire time is within a zero discount" do
+        let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) }
+        let(:end_at) { Time.zone.local(2017, 4, 27, 14, 0) }
+        it { is_expected.to eq(1) }
+      end
+
+      describe "when it overlaps into evening" do
+        let(:start_at) { Time.zone.local(2017, 4, 27, 16, 0) }
+
+        describe "one hour in zero percent, one hour in 10%" do
+          let(:end_at) { Time.zone.local(2017, 4, 27, 18, 0) }
+          it { is_expected.to eq(0.95) }
+        end
+
+        describe "one hour in zero percent, and three hours in 10%" do
+          let(:end_at) { Time.zone.local(2017, 4, 27, 20, 0) }
+          it { is_expected.to eq(0.925) }
         end
       end
 
-      describe "when spans two minutes, but less than a minute" do
-        let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0, 50) } # Thursday
-        let(:end_at) { Time.zone.local(2017, 4, 27, 12, 1, 10) } # Thursday
-        it "charges for one minute because the seconds are stripped off" do
-          expect(costs).to eq(cost: 1, subsidy: 0)
-        end
+      describe "when it overlaps multiple schedule rules" do
+        # Friday at 4pm
+        let(:start_at) { Time.zone.local(2017, 4, 28, 16, 0) }
+        # Saturday at 2am
+        let(:end_at) { Time.zone.local(2017, 4, 29, 2, 0) }
+        # 1 hour in 0%, 7 hours in 10%, 2 hours in 25%
+        it { is_expected.to eq(0.88) }
       end
 
-      describe "when going across 3 minutes" do
-        let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0, 0) } # Thursday
-        let(:end_at) { Time.zone.local(2017, 4, 27, 12, 2, 50) } # Thursday
-        it "charges for two minutes because the seconds are stripped off" do
-          expect(costs).to eq(cost: 2, subsidy: 0)
-        end
-      end
     end
 
-    describe "invalid times" do
-      let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) } # Thursday
-      let(:end_at) { start_at - 1.hour }
-
-      it { is_expected.to be_nil }
-    end
   end
 
-  describe "#calculate_discount" do
-    subject(:discount) { calculator.calculate_discount(start_at, end_at) }
+  context "when product has duration pricing mode" do
+    let(:product) { create(:setup_instrument, pricing_mode: "Duration") }
 
-    describe "when the entire time is within a zero discount" do
-      let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) }
-      let(:end_at) { Time.zone.local(2017, 4, 27, 14, 0) }
-      it { is_expected.to eq(1) }
-    end
+    describe "#calculate" do
+      subject(:costs) { calculator.calculate(start_at, end_at) }
 
-    describe "when it overlaps into evening" do
-      let(:start_at) { Time.zone.local(2017, 4, 27, 16, 0) }
+      describe "with no duration rates set" do
+        let(:options) { { usage_rate: 120 } }
+        let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) }
+        let(:end_at) { start_at + 1.hour }
 
-      describe "one hour in zero percent, one hour in 10%" do
-        let(:end_at) { Time.zone.local(2017, 4, 27, 18, 0) }
-        it { is_expected.to eq(0.95) }
+        it "uses usage_rate as rate" do
+          is_expected.to eq(cost: 120, subsidy: 0)
+        end
       end
 
-      describe "one hour in zero percent, and three hours in 10%" do
-        let(:end_at) { Time.zone.local(2017, 4, 27, 20, 0) }
-        it { is_expected.to eq(0.925) }
+      context "with duration rates" do
+        context "rounded to hour time range" do
+          context "which is below lowest duration rate minimum duration" do
+            let(:options) { { usage_rate: 120 } }
+            let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) }
+            let(:end_at) { start_at + 1.hour }
+
+            it "uses usage rate" do
+              create(:duration_rate, price_policy: price_policy, min_duration_hours: 3)
+
+              is_expected.to eq(cost: 120, subsidy: 0)
+            end
+          end
+
+          context "which is above lowest duration rate minimum duration" do
+            let(:options) { { usage_rate: 120 } }
+            let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) }
+            let(:end_at) { start_at + 4.hour }
+
+            it "uses both usage rate and duration rates" do
+              create(:duration_rate, price_policy: price_policy, min_duration_hours: 3)
+
+              # 3 hours @ $120 = $360 Usage rate
+              # 1 hour  @ $60  = $60  Duration rate
+              is_expected.to eq(cost: 420, subsidy: 0)
+            end
+          end
+        end
+
+        context "not rounded to hour time range" do
+          context "which is below lowest duration rate minimum duration" do
+            let(:options) { { usage_rate: 120 } }
+            let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) }
+            let(:end_at) { start_at + 1.hour + 15.minute }
+
+            it "uses usage rate" do
+              create(:duration_rate, price_policy: price_policy, min_duration_hours: 3)
+
+              is_expected.to eq(cost: 120 + 30, subsidy: 0)
+            end
+          end
+
+          context "which is above lowest duration rate minimum duration" do
+            let(:options) { { usage_rate: 120 } }
+            let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) }
+            let(:end_at) { start_at + 4.hour + 15.minute }
+
+            it "uses both usage rate and duration rates" do
+              create(:duration_rate, price_policy: price_policy, min_duration_hours: 3)
+
+              # 3 hours    @ $120 = $360 Usage rate
+              # 1.25 hour  @ $60  = $75  Duration rate
+              is_expected.to eq(cost: 435, subsidy: 0)
+            end
+          end
+        end
+
+        context "multiple of them" do
+          context "and not rounded to hour time range" do
+            context "which is above highest duration rate minimum duration" do
+              let(:options) { { usage_rate: 120 } }
+              let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) }
+              let(:end_at) { start_at + 5.hour + 15.minute }
+
+              it "uses both usage rate and duration rates" do
+                create(:duration_rate, price_policy: price_policy, min_duration_hours: 1, rate: 90)
+                create(:duration_rate, price_policy: price_policy, min_duration_hours: 3)
+                create(:duration_rate, price_policy: price_policy, min_duration_hours: 5, rate: 30)
+
+                # 1 hours       @ $120 = $120 Usage rate
+                # 2 hours       @ $90  = $180 Duration rate - Minimum duration: 1 hour
+                # 2 hours       @ $60  = $120 Duration rate - Minimum duration: 3 hours
+                # 0.25 hours    @ $30  = $7.5 Duration rate - Minimum duration: 5 hours
+                is_expected.to eq(cost: 427.5, subsidy: 0)
+              end
+            end
+          end
+        end
       end
     end
-
-    describe "when it overlaps multiple schedule rules" do
-      # Friday at 4pm
-      let(:start_at) { Time.zone.local(2017, 4, 28, 16, 0) }
-      # Saturday at 2am
-      let(:end_at) { Time.zone.local(2017, 4, 29, 2, 0) }
-      # 1 hour in 0%, 7 hours in 10%, 2 hours in 25%
-      it { is_expected.to eq(0.88) }
-    end
-
   end
-
 end

--- a/spec/services/price_policies/time_based_price_calculator_spec.rb
+++ b/spec/services/price_policies/time_based_price_calculator_spec.rb
@@ -281,19 +281,19 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
                 let(:end_at) { start_at + 5.hour + 15.minute }
 
                 it "uses usage rate, usage subsidy and duration rates" do
-                  create(:duration_rate, price_policy: price_policy, min_duration_hours: 1, rate: nil, subsidy: 45)
-                  create(:duration_rate, price_policy: price_policy, min_duration_hours: 3, rate: nil, subsidy: 60)
-                  create(:duration_rate, price_policy: price_policy, min_duration_hours: 5, rate: nil, subsidy: 90)
+                  create(:duration_rate, price_policy: price_policy, min_duration_hours: 1, rate: nil, subsidy: 10)
+                  create(:duration_rate, price_policy: price_policy, min_duration_hours: 3, rate: nil, subsidy: 15)
+                  create(:duration_rate, price_policy: price_policy, min_duration_hours: 5, rate: nil, subsidy: 30)
 
                   # Cost
                   # 5.25 hours    @ $120   = $630   Usage rate
 
                   # Subsidy
-                  # 1 hours       @ $30   = $30     Usage subsidy
-                  # 2 hours       @ $45   = $90     Duration rate - Minimum duration: 1 hour
-                  # 2 hours       @ $60   = $120    Duration rate - Minimum duration: 3 hours
-                  # 0.25 hours    @ $90   = $22.5   Duration rate - Minimum duration: 5 hours
-                  is_expected.to eq(cost: 630, subsidy: 262.5)
+                  # 1 hours       @ $30                     = $30       Usage subsidy
+                  # 2 hours       @ $30 + $10               = $80       Duration rate - Minimum duration: 1 hour
+                  # 2 hours       @ $30 + $10 + $15         = $110      Duration rate - Minimum duration: 3 hours
+                  # 0.25 hours    @ $30 + $10 + $15 + $30   = $21.25    Duration rate - Minimum duration: 5 hours
+                  is_expected.to eq(cost: 630, subsidy: 241.25)
                 end
               end
 


### PR DESCRIPTION
# Release Notes

Implements the calculation logic to apply the stepped billing rates set by admin users.

Includes a couple small changes as well:
- Store rate and subsidy as per-minute values for consistency with price policies
- A small visual fix for displaying the Initial Rate start as 0hrs in a read only input