### PR TITLE
[#162094] FIX: rake task to add missing global price groups to schedule rules

### DIFF
--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -100,7 +100,7 @@ class PriceGroup < ApplicationRecord
 
       schedule_rule.price_group_discounts.create(
         price_group: self,
-        discount_percent: discount_percent || schedule_rule.discount_percent
+        discount_percent: discount_percent || schedule_rule.discount_percent # this column defaults to 0
       )
 
       puts("Created price_group_discount for #{self} and schedule rule #{schedule_rule.id}") unless Rails.env.test?

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -89,7 +89,7 @@ class PriceGroup < ApplicationRecord
   end
 
   # Creates price group discounts for this price group, if they do not exist
-  def setup_schedule_rules(discount_percent: 0)
+  def setup_schedule_rules(discount_percent: nil)
     ScheduleRule.all.each do |schedule_rule|
       schedule_price_groups = schedule_rule.price_group_discounts.map(&:price_group)
 
@@ -100,7 +100,7 @@ class PriceGroup < ApplicationRecord
 
       schedule_rule.price_group_discounts.create(
         price_group: self,
-        discount_percent:
+        discount_percent: discount_percent || schedule_rule.discount_percent
       )
 
       puts("Created price_group_discount for #{self} and schedule rule #{schedule_rule.id}") unless Rails.env.test?

--- a/lib/tasks/schedule_rules.rake
+++ b/lib/tasks/schedule_rules.rake
@@ -24,8 +24,38 @@ namespace :schedule_rule do
     end
   end
 
+  # Usage:
+  # Dry run: rake "schedule_rule:add_missing_price_group_discounts[0]"
+  # Commit: rake "schedule_rule:add_missing_price_group_discounts[0,true]"
+  #
+  # You can skip the discount_percent argument to use existing legacy discounts if they exist
+  # Dry run: rake "schedule_rule:add_missing_price_group_discounts[,]"
+  # Commit: rake "schedule_rule:add_missing_price_group_discounts[,true]"
   desc "Adds missing global price groups to existing schedule rules"
-  task add_missing_price_group_discounts: :environment do |_t, _args|
-    PriceGroup.globals.each(&:setup_schedule_rules)
+  task :add_missing_price_group_discounts, [:discount_percent, :commit] => :environment do |_t, args|
+    discount_percent = args[:discount_percent]
+    puts "Discount percent: #{discount_percent}"
+    puts "Discount percent set to nil - this will attempt to use existing legacy discounts" if discount_percent.nil?
+    commit = args[:commit] == "true"
+    # if the schedule rule is missing, add it to the hash empty array values
+    missing = Hash.new { |hash, key| hash[key] = { price_groups: [], previous: [] } }
+    if commit
+      PriceGroup.globals.each { |pg| pg.setup_schedule_rules(discount_percent:) }
+    else
+      ScheduleRule.all.find_each do |schedule_rule|
+        PriceGroup.globals.each do |price_group|
+          next if schedule_rule.price_group_discounts.find_by(price_group_id: price_group.id)
+
+          missing[schedule_rule.id][:price_groups] << price_group.name
+          missing[schedule_rule.id][:previous] << schedule_rule.discount_percent
+        end
+      end
+      puts "Missing Price Groups:"
+      puts missing.values.map { |data| data[:price_groups] }.flatten.uniq
+      puts "Missing price_group_discount for #{missing.count} schedule rules."
+      puts "Existing legacy discount values:"
+      missing.map { |key, data| puts "#{key}: #{data[:previous].join(", ")}" }
+    end
+
   end
 end

--- a/lib/tasks/schedule_rules.rake
+++ b/lib/tasks/schedule_rules.rake
@@ -26,17 +26,6 @@ namespace :schedule_rule do
 
   desc "Adds missing global price groups to existing schedule rules"
   task add_missing_price_group_discounts: :environment do |_t, _args|
-    ScheduleRule.all.find_each do |schedule_rule|
-      PriceGroup.globals.each do |price_group|
-        next if schedule_rule.price_group_discounts.find_by(price_group_id: price_group.id)
-
-        schedule_rule.price_group_discounts.create(
-          price_group:,
-          discount_percent: schedule_rule.discount_percent
-        )
-
-        puts "Created price_group_discount for price group #{price_group.name} and schedule rule #{schedule_rule.id}"
-      end
-    end
+    PriceGroup.globals.each(&:setup_schedule_rules)
   end
 end

--- a/lib/tasks/schedule_rules.rake
+++ b/lib/tasks/schedule_rules.rake
@@ -25,7 +25,7 @@ namespace :schedule_rule do
   end
 
   desc "Adds missing global price groups to existing schedule rules"
-  taks add_missing_price_group_discounts: :environment do |_t, _args|
+  task add_missing_price_group_discounts: :environment do |_t, _args|
     ScheduleRule.all.find_each do |schedule_rule|
       PriceGroup.globals.each do |price_group|
         next if schedule_rule.price_group_discounts.find_by(price_group_id: price_group.id)

--- a/lib/tasks/schedule_rules.rake
+++ b/lib/tasks/schedule_rules.rake
@@ -8,18 +8,34 @@ namespace :schedule_rule do
   task add_price_group_discounts: :environment do |_t, _args|
     price_groups = PriceGroup.globals
 
-    ScheduleRule.all.each do |schedule_rule|
+    ScheduleRule.all.find_each do |schedule_rule|
       if schedule_rule.price_group_discounts.present?
         puts "Skipping schedule rule #{schedule_rule.id}, already has price_group_discounts"
       else
         price_groups.each_with_index do |price_group, _i|
           schedule_rule.price_group_discounts.create(
-            price_group: price_group,
+            price_group:,
             discount_percent: schedule_rule.discount_percent
           )
         end
 
         puts "Created price_group_discounts for #{schedule_rule.id}"
+      end
+    end
+  end
+
+  desc "Adds missing global price groups to existing schedule rules"
+  taks add_missing_price_group_discounts: :environment do |_t, _args|
+    ScheduleRule.all.find_each do |schedule_rule|
+      PriceGroup.globals.each do |price_group|
+        next if schedule_rule.price_group_discounts.find_by(price_group_id: price_group.id)
+
+        schedule_rule.price_group_discounts.create(
+          price_group:,
+          discount_percent: schedule_rule.discount_percent
+        )
+
+        puts "Created price_group_discount for price group #{price_group.name} and schedule rule #{schedule_rule.id}"
       end
     end
   end


### PR DESCRIPTION
# Release Notes

At least some existing schedule rules are missing price group discounts for some global price groups.

This rake task will check all schedule rules and add missing global price group discounts to them.