### PR TITLE
Tech task: Release describer script

### DIFF
--- a/bin/merge_describer
+++ b/bin/merge_describer
@@ -8,7 +8,7 @@
 target_branch=${1:-master}
 git log $target_branch.. | egrep '\(#\d+\)$' | while read LINE; do
   pr=$(echo $LINE | sed -E 's/^.+\(#//' | sed -E 's/\)$//')
-  desc=$(echo $LINE | sed -E 's/ *\(#[0-9]+\)$//')
+  desc=$(echo "$LINE" | sed -E 's/ *\(#[0-9]+\)$//' | sed -E 's/[*]//')
   echo "$pr\t$desc"
 done | sort -n |
 

--- a/bin/release_describer
+++ b/bin/release_describer
@@ -37,14 +37,15 @@ repos.each do |repo|
       line
     end
 
-    if line.include?("nucore-open")
-      if line.include?("Shared Dev")
+    downcased_line = line.downcase
+    if downcased_line.include?("nucore-open")
+      if downcased_line.include?("shared dev")
         data[repo][:shared_dev] << formatted_line
-      elsif line.start_with?("* Bump") || line.downcase.include?("tech task")
+      elsif downcased_line.start_with?("* bump") || downcased_line.include?("tech task")
         data[repo][:tech_tasks] << formatted_line
-      elsif line =~ /\bSecurity:/i
+      elsif downcased_line.include?("security:")
         data[repo][:security] << formatted_line
-      elsif line =~ /\bFix:/i
+      elsif downcased_line.include?("fix:")
         data[repo][:fixes] << formatted_line
       else
         data[repo][:open_highlights] << formatted_line

--- a/bin/release_describer
+++ b/bin/release_describer
@@ -40,7 +40,7 @@ repos.each do |repo|
     if line.include?("nucore-open")
       if line.include?("Shared Dev")
         data[repo][:shared_dev] << formatted_line
-      elsif line.start_with?("* Bump") || line.include?("Tech task")
+      elsif line.start_with?("* Bump") || line.downcase.include?("tech task")
         data[repo][:tech_tasks] << formatted_line
       elsif line =~ /\bSecurity:/i
         data[repo][:security] << formatted_line

--- a/bin/release_describer
+++ b/bin/release_describer
@@ -1,0 +1,62 @@
+#!/usr/bin/env ruby
+# Usage:
+# The first argument is the path to the directory containing the repos
+# The second argument is the previous release tag
+# bin/release_describer ~/Workspace v2023-11-08
+
+require "set"
+
+repos = ["nucore-nu", "nucore-osu", "nucore-umass", "nucore-dartmouth"]
+repo_dir = ARGV[0]
+previous_release_tag = ARGV[1]
+
+school_specific = Hash.new { |h, k| h[k] = [] }
+data = {
+  shared_dev: Set.new,
+  open_highlights: Set.new,
+  fixes: Set.new,
+  tech_tasks: Set.new,
+  security: Set.new,
+}
+
+repos.each do |repo|
+  puts "Processing changes from #{repo} ..."
+  git_log = `cd #{repo_dir}/#{repo} && bin/merge_describer #{previous_release_tag}`
+  git_log.split("\n").each do |line|
+    ticket_number_match = line.match(/\[#(\d*)/)
+    formatted_line = if ticket_number_match
+      line.gsub(/\[#(\d*)\]/, "[##{ticket_number_match[1]}](https://pm.tablexi.com/issues/#{ticket_number_match[1]})")
+    else
+      line
+    end
+
+    if line.include?("nucore-open")
+      if line.include?("Shared Dev")
+        data[:shared_dev] << formatted_line
+      elsif line.start_with?("* Bump") || line.include?("Tech task")
+        data[:tech_tasks] << formatted_line
+      elsif line =~ /\bSecurity:/i
+        data[:security] << formatted_line
+      elsif line =~ /\bFix:/i
+        data[:fixes] << formatted_line
+      else
+        data[:open_highlights] << formatted_line
+      end
+    else
+      school_specific[repo] << formatted_line
+    end
+  end
+end
+
+puts "\nSchool Specific"
+school_specific.each do |repo, lines|
+  puts "\n#{repo}"
+  puts lines.sort.join("\n")
+end
+
+data.each do |key, value|
+  title = key.to_s.split("_").map(&:capitalize).join(" ")
+  puts "\n#{title} (#{value.size})"
+  puts value.sort.join("\n")
+end
+

--- a/bin/release_describer
+++ b/bin/release_describer
@@ -6,19 +6,22 @@
 
 require "set"
 
-repos = ["nucore-nu", "nucore-osu", "nucore-umass", "nucore-dartmouth"]
+repos = ["nucore-open", "nucore-nu", "nucore-osu", "nucore-umass", "nucore-dartmouth"]
 repo_dir = ARGV[0]
 previous_release_tag = ARGV[1]
 
-school_specific = Hash.new { |h, k| h[k] = [] }
-data = {
-  shared_dev: Set.new,
-  open_highlights: Set.new,
-  fixes: Set.new,
-  tech_tasks: Set.new,
-  security: Set.new,
-}
-
+data = Hash.new do |h, k|
+  h[k] = {
+    shared_dev: Set.new,
+    open_highlights: Set.new,
+    fixes: Set.new,
+    tech_tasks: Set.new,
+    security: Set.new,
+    school_specific: Set.new,
+    behind: Set.new,
+    ahead: Set.new,
+  }
+end
 repos.each do |repo|
   puts "Processing changes from #{repo} ..."
   git_log = `cd #{repo_dir}/#{repo} && bin/merge_describer #{previous_release_tag}`
@@ -32,31 +35,40 @@ repos.each do |repo|
 
     if line.include?("nucore-open")
       if line.include?("Shared Dev")
-        data[:shared_dev] << formatted_line
+        data[repo][:shared_dev] << formatted_line
       elsif line.start_with?("* Bump") || line.include?("Tech task")
-        data[:tech_tasks] << formatted_line
+        data[repo][:tech_tasks] << formatted_line
       elsif line =~ /\bSecurity:/i
-        data[:security] << formatted_line
+        data[repo][:security] << formatted_line
       elsif line =~ /\bFix:/i
-        data[:fixes] << formatted_line
+        data[repo][:fixes] << formatted_line
       else
-        data[:open_highlights] << formatted_line
+        data[repo][:open_highlights] << formatted_line
       end
     else
-      school_specific[repo] << formatted_line
+      data[repo][:school_specific] << formatted_line
     end
+  end
+  data[repo].each do |key, value|
+    next if key == :ahead || key == :behind || key == :school_specific
+
+    data[repo][:behind].merge(data["nucore-open"][key] - data[repo][key])
+    data[repo][:ahead].merge(data[repo][key] - data["nucore-open"][key])
   end
 end
 
-puts "\nSchool Specific"
-school_specific.each do |repo, lines|
+data.each do |repo, value_hash|
+  keys = if repo == "nucore-open"
+    [:shared_dev, :open_highlights, :fixes, :tech_tasks, :security]
+  else
+    [:school_specific, :behind, :ahead]
+  end
   puts "\n#{repo}"
-  puts lines.sort.join("\n")
-end
-
-data.each do |key, value|
-  title = key.to_s.split("_").map(&:capitalize).join(" ")
-  puts "\n#{title} (#{value.size})"
-  puts value.sort.join("\n")
+  value_hash.slice(*keys).each do |key, value|
+    title = key.to_s.split("_").map(&:capitalize).join(" ")
+    puts "\n#{title} (#{value.size})"
+    puts value.sort.join("\n")
+  end
+  puts "~~~~~~~~~~~~~~~~~~~~~"
 end
 

--- a/bin/release_describer
+++ b/bin/release_describer
@@ -1,14 +1,18 @@
 #!/usr/bin/env ruby
 # Usage:
-# The first argument is the path to the directory containing the repos
-# The second argument is the previous release tag
-# bin/release_describer ~/Workspace v2023-11-08
+# The script will output a summary of changes since the previous release tag.
+# Run this from the root of the nucore-open repo (or any repo in the nucore-* family).
+# All repos should be checked out to the same parent directory,
+# with the default branch checked out, up to date, and clean (stash any changes).
+#
+# The first argument is the previous release tag
+# bin/release_describer v2023-11-08
 
 require "set"
 
 repos = ["nucore-open", "nucore-nu", "nucore-osu", "nucore-umass", "nucore-dartmouth"]
-repo_dir = ARGV[0]
-previous_release_tag = ARGV[1]
+repo_dir = `dirname $PWD`.chomp
+previous_release_tag = ARGV.first
 
 data = Hash.new do |h, k|
   h[k] = {

--- a/doc/HOWTO_related_repos.md
+++ b/doc/HOWTO_related_repos.md
@@ -17,7 +17,7 @@ or just a few commits with a cherry-picked branch.
 1. Open a new branch (for more details see the sections on creating a [latest_from_open](#creating-a-latest_from_open_mmddyyyy-branch) or [cherry-picked](#creating-a-branch-with-cherry-picked-commits) branch below)
 1. Merge the PR (not squash) once it has been approved and CI is green [(see below)](#squash-vs-merge)
 1. For a production release, create a Github release [(see below)](#creating-a-github-release)
-1. Deploy the new code using capistrano or helm/CircleCI [(see below)](#deploy)
+1. Deploy the new code using capistrano or Github Actions [(see below)](#deploy)
 1. Perform any release/deployment related tasks (e.g. add new env variables, run one-off rake task, etc.)
 1. Check the site in a browser and confirm new functionality is there
 
@@ -58,12 +58,14 @@ Before merging “latest from open” PRs, make sure that the related PR against
 
 On github, squash commits include a parenthesized branch number like `(#45)` in the commit title by default, except when the PR only includes 1 commit. Merge commits do not include the parenthesized branch number in the title. So...
 
-* Use **Squash** for feature PRs, and copy the PR description into the squash merge message.  Make sure the parenthesized branch number is in the commit title so the squash commit will get described later on in the GitHub release and release ticket.
+* Use **Squash** for feature PRs, and copy the PR description into the squash merge message.  Make sure the parenthesized branch number is in the commit title so the squash commit will get described later on in the GitHub release and release notes.
 * Use **Merge** commits for `latest_from_open_MMDDYYYY` branch PRs.  Make sure that the related PR against nucore-open has deployed successfully before merging.
 
 ## PR Titles
 
-For feature PRs, the PR title will become the squash commit message. These appear later in the `bin/merge_describer` output, which is used in the`latest_from_open_MMDDYYYY` PR description, github release, and release redmine ticket. Try to write feature PR titles that focus on user outcomes rather than technical details - "Fix ability to download CSV" is preferred over "Resolve issues with JSON parsing".
+For feature PRs, the PR title will become the squash commit message. These appear later in the `bin/merge_describer` and `bin/release_describer` output, which is used in the`latest_from_open_MMDDYYYY` PR description, github release, and release notes. Try to write feature PR titles that focus on user outcomes rather than technical details - "Fix ability to download CSV" is preferred over "Resolve issues with JSON parsing".
+
+PR Titles that include “Shared Dev” or “Tech Task”, or start with “Security:” or “Fix:” will be automatically sorted by `bin/release_describer`.
 
 ## Creating a GitHub release
 
@@ -91,9 +93,10 @@ git cherry-pick XXXXX
 # Deploy
 
 Deploy process will vary depending on the hosting setup.
-Helm is used for apps hosted in kubernetes, and capistrano is used for legacy-hosting setups.
+Github Actions is used to trigger deploys for cloud-hosting setups (ECS and Azure).
+Capistrano is used for legacy-hosting setups.
 
-## Helm deploy steps
+## Github Actions deploy steps
 
 ### To staging:
 
@@ -101,7 +104,7 @@ Merging to `master` will trigger a stage deployment.
 
 ### To production:
 
-Approve the CircleCI job to trigger a production deployment.
+Create a Github Release with a tag starting with `v` to trigger a production deployment.
 
 ## Capistrano deploy steps
 


### PR DESCRIPTION
# Release Notes

Adds ruby script for collecting, merging, sorting and organizing merge describer output from a list of repos.
This is very useful for us at TXI, since we are supporting 4 instances of the application.

Also:
Dartmouth had a few git log entries with `*`s. This removes them so `echo` doesn't try to list every file in the working directory

Example:
```
bin/release_describer ~/Workspace v2023-11-08
Processing changes from nucore-open ...
Processing changes from nucore-nu ...
Processing changes from nucore-osu ...
Processing changes from nucore-umass ...
Processing changes from nucore-dartmouth ...

nucore-open

Shared Dev (0)


Open Highlights (12)
* Adds .png to email attachement (https://github.com/tablexi/nucore-open/pull/3800)
* [#161345](https://pm.tablexi.com/issues/161345) Handle expired accounts in order imports (https://github.com/tablexi/nucore-open/pull/3833)
* [#161345](https://pm.tablexi.com/issues/161345) Order import account validation (https://github.com/tablexi/nucore-open/pull/3795)
* [#161995](https://pm.tablexi.com/issues/161995) Oracle doesn't handle update all on joins (https://github.com/tablexi/nucore-open/pull/3822)
* [#161995](https://pm.tablexi.com/issues/161995) Stepped billing calculations (https://github.com/tablexi/nucore-open/pull/3819)
* [#162000](https://pm.tablexi.com/issues/162000) SciShield local storage (https://github.com/tablexi/nucore-open/pull/3821)
* [#162009](https://pm.tablexi.com/issues/162009) Improve access list import messages (https://github.com/tablexi/nucore-open/pull/3805)
* [#162029](https://pm.tablexi.com/issues/162029) Allow using a logo for new user emails (https://github.com/tablexi/nucore-open/pull/3799)
* [#162084](https://pm.tablexi.com/issues/162084) Change model association for DurationRate (https://github.com/tablexi/nucore-open/pull/3804)
* [#162084](https://pm.tablexi.com/issues/162084) Improvements for stepped billing form inputs (https://github.com/tablexi/nucore-open/pull/3808)
* [#162084](https://pm.tablexi.com/issues/162084) Show Scheduling groups for duration instruments (https://github.com/tablexi/nucore-open/pull/3806)
* [#162094](https://pm.tablexi.com/issues/162094) Display price group discounts properly when editing (https://github.com/tablexi/nucore-open/pull/3810)

Fixes (3)
* [#161345](https://pm.tablexi.com/issues/161345) FIX: Order imports for expried accounts (https://github.com/tablexi/nucore-open/pull/3834)
* [#161345](https://pm.tablexi.com/issues/161345) Fix: Nonbillable account open parameter (https://github.com/tablexi/nucore-open/pull/3811)
* [#162094](https://pm.tablexi.com/issues/162094) FIX: rake task to add missing global price groups to schedule rules (https://github.com/tablexi/nucore-open/pull/3826)

Tech Tasks (20)
* Bump aws-partitions from 1.841.0 to 1.848.0 (https://github.com/tablexi/nucore-open/pull/3809)
* Bump aws-partitions from 1.848.0 to 1.849.0 (https://github.com/tablexi/nucore-open/pull/3814)
* Bump aws-sdk-core from 3.185.1 to 3.186.0 (https://github.com/tablexi/nucore-open/pull/3803)
* Bump aws-sigv4 from 1.6.1 to 1.7.0 (https://github.com/tablexi/nucore-open/pull/3853)
* Bump bootsnap from 1.16.0 to 1.17.0 (https://github.com/tablexi/nucore-open/pull/3779)
* Bump bullet from 7.1.1 to 7.1.3 (https://github.com/tablexi/nucore-open/pull/3801)
* Bump date from 3.3.3 to 3.3.4 (https://github.com/tablexi/nucore-open/pull/3796)
* Bump net-imap from 0.4.2 to 0.4.4 (https://github.com/tablexi/nucore-open/pull/3790)
* Bump net-imap from 0.4.4 to 0.4.6 (https://github.com/tablexi/nucore-open/pull/3843)
* Bump net-protocol from 0.2.1 to 0.2.2 (https://github.com/tablexi/nucore-open/pull/3798)
* Bump nokogiri from 1.15.4 to 1.15.5 (https://github.com/tablexi/nucore-open/pull/3839)
* Bump racc from 1.7.1 to 1.7.3 (https://github.com/tablexi/nucore-open/pull/3791)
* Bump rake from 13.0.6 to 13.1.0 (https://github.com/tablexi/nucore-open/pull/3776)
* Bump rspec-rails from 6.0.3 to 6.1.0 (https://github.com/tablexi/nucore-open/pull/3844)
* Bump rubocop from 1.56.4 to 1.57.2 (https://github.com/tablexi/nucore-open/pull/3771)
* Bump rubocop-rspec from 2.24.1 to 2.25.0 (https://github.com/tablexi/nucore-open/pull/3777)
* Bump selenium-webdriver from 4.12.0 to 4.15.0 (https://github.com/tablexi/nucore-open/pull/3786)
* Bump timeout from 0.4.0 to 0.4.1 (https://github.com/tablexi/nucore-open/pull/3802)
* Bump unf_ext from 0.0.8.2 to 0.0.9 (https://github.com/tablexi/nucore-open/pull/3812)
* Tech task: Properly handle oracle in db migration (https://github.com/tablexi/nucore-open/pull/3793)

Security (0)

~~~~~~~~~~~~~~~~~~~~~

nucore-nu

School Specific (0)


Behind (5)
* Bump aws-sigv4 from 1.6.1 to 1.7.0 (https://github.com/tablexi/nucore-open/pull/3853)
* Bump net-imap from 0.4.4 to 0.4.6 (https://github.com/tablexi/nucore-open/pull/3843)
* Bump nokogiri from 1.15.4 to 1.15.5 (https://github.com/tablexi/nucore-open/pull/3839)
* Bump rspec-rails from 6.0.3 to 6.1.0 (https://github.com/tablexi/nucore-open/pull/3844)
* [#162000](https://pm.tablexi.com/issues/162000) SciShield local storage (https://github.com/tablexi/nucore-open/pull/3821)

Ahead (0)

~~~~~~~~~~~~~~~~~~~~~

nucore-osu

School Specific (1)
* [#162019](https://pm.tablexi.com/issues/162019) Statement row quantity fix (#319)

Behind (1)
* [#162029](https://pm.tablexi.com/issues/162029) Allow using a logo for new user emails (https://github.com/tablexi/nucore-open/pull/3799)

Ahead (0)

~~~~~~~~~~~~~~~~~~~~~

nucore-umass

School Specific (2)
* [#161345](https://pm.tablexi.com/issues/161345) Order import account validation (#574)
* [#162019](https://pm.tablexi.com/issues/162019) Statement row quantity fix (#579)

Behind (0)


Ahead (0)

~~~~~~~~~~~~~~~~~~~~~

nucore-dartmouth

School Specific (0)


Behind (5)
* Bump aws-sigv4 from 1.6.1 to 1.7.0 (https://github.com/tablexi/nucore-open/pull/3853)
* Bump net-imap from 0.4.4 to 0.4.6 (https://github.com/tablexi/nucore-open/pull/3843)
* Bump nokogiri from 1.15.4 to 1.15.5 (https://github.com/tablexi/nucore-open/pull/3839)
* Bump rspec-rails from 6.0.3 to 6.1.0 (https://github.com/tablexi/nucore-open/pull/3844)
* [#162000](https://pm.tablexi.com/issues/162000) SciShield local storage (https://github.com/tablexi/nucore-open/pull/3821)

Ahead (0)

~~~~~~~~~~~~~~~~~~~~~
```