### PR TITLE
[#162000] Tech task: Update Scishield sync batch sleep time default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,7 +35,7 @@ converters:
 research_safety_adapter:
   class_name: <%= ENV.fetch("RESEARCH_SAFETY_ADAPTER_CLASS", "ResearchSafetyAdapters::ResearchSafetyAlwaysCertifiedAdapter") %>
   scishield:
-    batch_sleep_time: <%= ENV.fetch("SCISHIELD_BATCH_SLEEP_TIME", 0) %>
+    batch_sleep_time: <%= ENV.fetch("SCISHIELD_BATCH_SLEEP_TIME", 20) %>
     batch_size: <%= ENV.fetch("SCISHIELD_BATCH_SIZE", 15) %>
 
 statement_pdf:


### PR DESCRIPTION
# Release Notes

This updates the default sleep time to 20 seconds.

Updating environment variables for OSU is a bit cumbersome, so this just sets the default to what OSU would use