### PR TITLE
[#162138] Improvements stepped billing

### DIFF
--- a/app/assets/javascripts/price_policy.js
+++ b/app/assets/javascripts/price_policy.js
@@ -21,6 +21,7 @@ $(document).ready(function() {
     const isDisabled = !$checkbox.prop("checked");
     $cells.toggleClass("disabled", isDisabled);
     $cells.find("input[type=text], input[type=hidden], input[type=checkbox]").not($checkbox).each((_i, elem) => hardToggleField($(elem), isDisabled));
+    $cells.find(".per-minute").toggleClass("hidden", isDisabled);
     // If we are enabling the row, make sure the cancellation cost field gets the correct state
     if (!isDisabled) { return $cells.find(".js--fullCancellationCost").trigger("change"); }
   };

--- a/app/models/duration_rate.rb
+++ b/app/models/duration_rate.rb
@@ -10,7 +10,10 @@ class DurationRate < ApplicationRecord
   validates :rate, numericality: { greater_than_or_equal_to: 0 }
   validates :subsidy, presence: { message: ->(object, _data) { "^Missing subsidy for #{object.price_group.name}" } }, if: -> { requires_subsidy? }
   validates :subsidy, numericality: { greater_than: 0, allow_blank: true }
-  validates :min_duration_hours, presence: true, numericality: { greater_than: 0, allow_blank: true }, uniqueness: { scope: :price_policy_id }
+  validates :min_duration_hours,
+    presence: { message: ->(object, _data) { "^Missing value for 'Rate start (hr)'" } },
+    numericality: { greater_than: 0, allow_blank: true },
+    uniqueness: { scope: :price_policy_id }
   validate :rate_lesser_than_or_equal_to_base_rate
   validate :subsidy_lesser_than_or_equal_to_rate
 

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -25,13 +25,6 @@ class PricePolicy < ApplicationRecord
 
   validate :subsidy_less_than_rate, unless: :restrict_purchase?
 
-  validates :duration_rates, length: {
-    is: MAX_RATE_STARTS,
-    message: ->(object, _data) do
-      "^Missing rate or subsidy for #{object.price_group.name}"
-    end
-  }, allow_blank: true
-
   with_options if: -> { SettingsHelper.feature_on?(:price_policy_requires_note) } do
     # Length of 10 is defined by Dartmouth.
     validates :note, presence: true, length: { minimum: 10, allow_blank: true }, on: :create

--- a/app/views/time_based_price_policies/_stepped_billing_price_policy_fields.html.haml
+++ b/app/views/time_based_price_policies/_stepped_billing_price_policy_fields.html.haml
@@ -59,13 +59,13 @@
           - duration_rates = pp.object.duration_rates.sort_by { |d| d.min_duration_hours || 1_000 }
           = pp.fields_for :duration_rates, duration_rates do |dr|
             - if price_group.external? || price_group.master_internal?
-              - rate_input_class = price_group.master_internal? ? "js--baseRate" : ""
+              - rate_input_class = price_group.master_internal? ? "js--baseRate usage_rate" : "usage_rate"
               %td
                 = dr.label :rate, t(".rate_per_hr"), class: "normal-weight"
                 = dr.text_field :rate,
                   value: number_to_currency(dr.object.hourly_rate, unit: "", delimiter: ""),
                   size: 8,
-                  class: "usage_rate #{rate_input_class}",
+                  class: rate_input_class,
                   data: { index: duration_rates.find_index(dr.object) }
                 = dr.hidden_field :min_duration_hours
             - else

--- a/app/views/time_based_price_policies/_stepped_billing_price_policy_fields.html.haml
+++ b/app/views/time_based_price_policies/_stepped_billing_price_policy_fields.html.haml
@@ -65,13 +65,13 @@
                 = dr.text_field :rate,
                   value: number_to_currency(dr.object.hourly_rate, unit: "", delimiter: ""),
                   size: 8,
-                  class: rate_input_class,
+                  class: "usage_rate #{rate_input_class}",
                   data: { index: duration_rates.find_index(dr.object) }
                 = dr.hidden_field :min_duration_hours
             - else
               %td
                 = dr.label :subsidy, t(".adjustment"), class: "normal-weight"
                 %span="-"
-                = dr.text_field :subsidy, value: number_to_currency(dr.object.hourly_subsidy, unit: "", delimiter: ""), size: 8
+                = dr.text_field :subsidy, value: number_to_currency(dr.object.hourly_subsidy, unit: "", delimiter: ""), size: 8, class: "usage_adjustment"
                 = dr.hidden_field :min_duration_hours
                 = dr.hidden_field :rate, class: "js--hiddenRate"

--- a/app/views/time_based_price_policies/_stepped_billing_table.html.haml
+++ b/app/views/time_based_price_policies/_stepped_billing_table.html.haml
@@ -72,11 +72,19 @@
                 \/ minute
           - price_policy.duration_rates.sorted.each do |duration_rate|
             %td.currency
+              - per_minute = nil
               - if duration_rate.rate.present?
                 .rate= number_to_currency duration_rate.hourly_rate
+                - per_minute = duration_rate.hourly_rate / 60
               - if duration_rate.subsidy.present?
                 .subsidy= "- #{number_to_currency duration_rate.hourly_subsidy}"
                 %strong= "= #{number_to_currency duration_rate.subsidized_hourly_cost}"
+                - per_minute = duration_rate.subsidized_hourly_cost / 60
+
+              - if per_minute.present?
+                %p.per-minute-show
+                  = number_to_currency per_minute, precision: 4
+                  \/ minute
 
           - (PricePolicy::MAX_RATE_STARTS - price_policy.duration_rates.length).times do
             %td.currency

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe InstrumentPricePoliciesController do
 
         click_button "Add Pricing Rules"
 
-        expect(page).to have_content("Duration rates min duration hours may not be blank")
+        expect(page).to have_content("Missing value for 'Rate start (hr)'")
       end
     end
 
@@ -329,7 +329,7 @@ RSpec.describe InstrumentPricePoliciesController do
       fill_in "price_policy_#{cancer_center.id}[usage_subsidy]", with: "25"
       fill_in "price_policy_#{cancer_center.id}[duration_rates_attributes][0][subsidy]", with: "15"
       fill_in "price_policy_#{cancer_center.id}[duration_rates_attributes][1][subsidy]", with: "15"
-      fill_in "price_policy_#{cancer_center.id}[duration_rates_attributes][2][subsidy]", with: "5"
+      fill_in "price_policy_#{cancer_center.id}[duration_rates_attributes][2][subsidy]", with: "4"
 
       fill_in "price_policy_#{external_price_group.id}[usage_rate]", with: "120.11"
       fill_in "price_policy_#{external_price_group.id}[minimum_cost]", with: "122"
@@ -393,7 +393,7 @@ RSpec.describe InstrumentPricePoliciesController do
 
       # Cancer Center subsidy
       expect(page).to have_content("$25.00")
-      expect(page).not_to have_content("$5.00") # Step 3 subsidy (removed)
+      expect(page).not_to have_content("$4.00") # Step 3 subsidy (removed)
 
       # External
       expect(page).not_to have_content("$90.00") # Step 3 rate (removed)

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -357,9 +357,11 @@ RSpec.describe InstrumentPricePoliciesController do
       expect(page).to have_field("price_policy_#{base_price_group.id}[duration_rates_attributes][1][rate]", with: "40.00")
       expect(page).to have_field("price_policy_#{base_price_group.id}[duration_rates_attributes][2][rate]", with: "30.00")
 
+      # Update values for Step 2
       fill_in "min_duration_1", with: "5"
       fill_in "price_policy_#{base_price_group.id}[duration_rates_attributes][1][rate]", with: "20"
 
+      # Remove all values for Step 3
       fill_in "min_duration_2", with: ""
       fill_in "price_policy_#{base_price_group.id}[duration_rates_attributes][2][rate]", with: ""
       fill_in "price_policy_#{cancer_center.id}[duration_rates_attributes][2][subsidy]", with: ""
@@ -374,20 +376,27 @@ RSpec.describe InstrumentPricePoliciesController do
 
       expect(page).to have_content("Price Rules were successfully updated.")
 
+      # Base rate start for Step 2 is updated
       expect(page).to have_content("Over 5 hrs")
       expect(page).not_to have_content("Over 3 hrs")
 
+      # Rate start for Step 3 is removed
       expect(page).not_to have_content("Over 4 hrs")
-      expect(page).not_to have_content("$40.00")
 
       # Base price group - Duration rates
       expect(page).to have_content("$50.00")
+      expect(page).not_to have_content("$30.00") # Step 3 rate (removed)
 
+      # Duration rate for Step 2 is updated
+      expect(page).not_to have_content("$40.00")
       expect(page).to have_content("$20.00")
-      expect(page).not_to have_content("$30.00")
 
       # Cancer Center subsidy
       expect(page).to have_content("$25.00")
+      expect(page).not_to have_content("$5.00") # Step 3 subsidy (removed)
+
+      # External
+      expect(page).not_to have_content("$90.00") # Step 3 rate (removed)
     end
   end
 end

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -361,6 +361,7 @@ RSpec.describe InstrumentPricePoliciesController do
       fill_in "min_duration_1", with: "5"
       fill_in "price_policy_#{base_price_group.id}[duration_rates_attributes][1][rate]", with: "20"
 
+      ## START When values for Step 3 are removed, you can still save Step 1 and 2
       # Remove all values for Step 3
       fill_in "min_duration_2", with: ""
       fill_in "price_policy_#{base_price_group.id}[duration_rates_attributes][2][rate]", with: ""

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe InstrumentPricePoliciesController do
         expect(page).to have_content("Subsidy must be lesser than or equal to step rate")
       end
 
-       it "fails to save if not all steps are filled", :js, feature_setting: { facility_directors_can_manage_price_groups: true } do
+      it "fails to save if not all steps are filled", :js, feature_setting: { facility_directors_can_manage_price_groups: true } do
         visit new_facility_instrument_price_policy_path(facility, instrument)
 
         fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "60"

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -275,6 +275,22 @@ RSpec.describe InstrumentPricePoliciesController do
         expect(page).to have_content("Subsidy must be lesser than or equal to step rate")
       end
 
+       it "fails to save if not all steps are filled", :js, feature_setting: { facility_directors_can_manage_price_groups: true } do
+        visit new_facility_instrument_price_policy_path(facility, instrument)
+
+        fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "60"
+        fill_in "price_policy_#{base_price_group.id}[duration_rates_attributes][0][rate]", with: "50"
+
+        uncheck "price_policy_#{cancer_center.id}[can_purchase]"
+        uncheck "price_policy_#{external_price_group.id}[can_purchase]"
+        uncheck "price_policy_#{cannot_purchase_group.id}[can_purchase]"
+
+        fill_in "note", with: "This is my note"
+
+        click_button "Add Pricing Rules"
+        expect(page).to have_content("Missing value for 'Rate start (hr)'")
+      end
+
       it "fails to save duration rates do not have a rate start provided", :js, feature_setting: { facility_directors_can_manage_price_groups: true } do
         visit new_facility_instrument_price_policy_path(facility, instrument)
 


### PR DESCRIPTION
# Release Notes
* Allow users to fill up to 4 steps for Stepped billing.
* Display per minute rate/subsidy for steps.

# Screenshot
<img width="885" alt="image" src="https://github.com/tablexi/nucore-open/assets/28798610/03c7ebb7-1ce7-44bc-b653-faf383181e63">

# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".
