### PR TITLE
TECH TASK: fix flaky  billing mode specs

### DIFF
--- a/spec/system/admin/billing_mode_workflow_spec.rb
+++ b/spec/system/admin/billing_mode_workflow_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe "Billing mode workflows" do
         click_button "Save"
         visit facility_transactions_path(facility)
 
+        wait_for_ajax
+
         expect(page).to have_selector("tr td.nowrap", text: "Reconciled")
       end
     end
@@ -61,6 +63,8 @@ RSpec.describe "Billing mode workflows" do
 
       click_button "Save"
       visit facility_transactions_path(facility)
+
+      wait_for_ajax
 
       expect(page).to have_selector("tr td.nowrap", text: "Reconciled")
     end


### PR DESCRIPTION
# Release Notes

A couple of billing mode workflow specs fail in CI but not locally. Adding `wait_for_ajax` seems to make them more reliable.