### PR TITLE
TECH TASK: Fix flaky test

### DIFF
--- a/spec/system/admin/billing_mode_workflow_spec.rb
+++ b/spec/system/admin/billing_mode_workflow_spec.rb
@@ -31,9 +31,10 @@ RSpec.describe "Billing mode workflows" do
         select "Complete", from: "Order Status"
 
         click_button "Save"
-        visit facility_transactions_path(facility)
 
-        wait_for_ajax
+        expect(page).to have_content("The order was successfully updated")
+
+        visit facility_transactions_path(facility)
 
         expect(page).to have_selector("tr td.nowrap", text: "Reconciled")
       end
@@ -62,9 +63,10 @@ RSpec.describe "Billing mode workflows" do
       select "Complete", from: "Order Status"
 
       click_button "Save"
-      visit facility_transactions_path(facility)
 
-      wait_for_ajax
+      expect(page).to have_content("The order was successfully updated")
+
+      visit facility_transactions_path(facility)
 
       expect(page).to have_selector("tr td.nowrap", text: "Reconciled")
     end


### PR DESCRIPTION
# Release Notes
* Fix flaky test

# Screenshot

Optional.

# Additional Context
Removed the `wait_for_ajax` and added an expectation before navigating to the Transactions page. My idea is that we want to be sure change got saved before visiting the other page.