### PR TITLE
[#161915] Make Search case insensitive and add spec

### DIFF
--- a/app/controllers/price_groups_controller.rb
+++ b/app/controllers/price_groups_controller.rb
@@ -117,7 +117,7 @@ class PriceGroupsController < ApplicationController
                                 .joins(:user)
 
     if search_term.present?
-      @user_members = @user_members.where("LOWER(users.last_name) LIKE :search OR LOWER(users.first_name) LIKE :search OR LOWER(users.username) LIKE :search", search: search_term)
+      @user_members = @user_members.where("LOWER(users.last_name) LIKE :search OR LOWER(users.first_name) LIKE :search OR LOWER(users.username) LIKE :search", search: search_term.downcase)
     end
 
     @user_members = @user_members.merge(User.sort_last_first)

--- a/spec/system/admin/price_group_management_spec.rb
+++ b/spec/system/admin/price_group_management_spec.rb
@@ -112,6 +112,15 @@ RSpec.describe "Managing Price Groups", :aggregate_failures do
           expect(page).to_not have_content(user_not_found.name)
           expect(page).to_not have_content(user2.name)
         end
+
+        it "searches for users by first name (case insensitive)" do
+          fill_in "price_group_user_search", with: "john"
+          click_button "Search"
+          wait_for_ajax
+          expect(page).to have_content(user_searchable.name)
+          expect(page).to_not have_content(user_not_found.name)
+          expect(page).to_not have_content(user2.name)
+        end
       end
 
     end


### PR DESCRIPTION
# Release Notes
* Make Price Groups Users tab Search case insensitive
# Screenshot

Optional.

# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".
