### PR TITLE
FIX: [#161990] OrderRowImporter module loading issue

### DIFF
--- a/app/services/order_row_importer.rb
+++ b/app/services/order_row_importer.rb
@@ -4,6 +4,27 @@ require "date_helper" # parse_usa_import_date
 
 class OrderRowImporter
 
+  module Overridable
+
+    def validate_custom_attributes
+      if field(:project_name).present? && project.nil?
+        add_error(:project_not_found)
+      end
+    end
+
+    private
+
+    def project
+      facility.projects.active.find_by name: field(:project_name)
+    end
+
+    def custom_attributes
+      { project_id: project&.id }
+    end
+
+  end
+
+  prepend Overridable
   include DateHelper
 
   cattr_accessor(:importable_product_types) { [Item, Service, TimedService] }
@@ -18,6 +39,7 @@ class OrderRowImporter
       notes
       order_number
       reference_id
+      project_name
       errors
     ]
   end

--- a/vendor/engines/projects/lib/projects/engine.rb
+++ b/vendor/engines/projects/lib/projects/engine.rb
@@ -15,8 +15,6 @@ module Projects
       OrderDetailBatchUpdater.send :include, Projects::OrderDetailBatchUpdaterExtension
       OrdersController.send :include, Projects::OrdersControllerExtension
       Reservation.send :include, Projects::ReservationExtension
-      OrderRowImporter.send :prepend, Projects::OrderRowImporterExtension
-      OrderRowImporter.order_import_headers.insert(-2, :project_name)
 
       ViewHook.add_hook "reservations.account_field",
                         "after_account",

--- a/vendor/engines/projects/spec/models/projects/order_row_importer_extension_spec.rb
+++ b/vendor/engines/projects/spec/models/projects/order_row_importer_extension_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Projects::OrderRowImporterExtension do
 
   let(:row) do
     ref = {
-      "Netid / Email" => username,
+      I18n.t("order_row_importer.headers.user") => username,
       I18n.t("Chart_string") => chart_string,
       "Product Name" => product_name,
       "Quantity" => quantity,
@@ -72,7 +72,7 @@ RSpec.describe Projects::OrderRowImporterExtension do
   it "has all of the columns in the correct order" do
     expect(subject.row_with_errors.headers).to eq(
       [
-        "Netid / Email",
+        I18n.t("order_row_importer.headers.user"),
         I18n.t("Chart_string"),
         "Product Name",
         "Quantity",


### PR DESCRIPTION
# Release Notes

This removes the loading of `Projects::OrderRowImporterExtension` and instead puts that code in `OrderRowImporter::Overridable` to address an issue with `Projects::OrderRowImporterExtension` causing `OsuRelms::JournalRowExtension` not to load.

This also puts translations in `[order_row_importer_extension_spec.rb](https://github.com/tablexi/nucore-open/compare/161990-project-column-fix?expand=1#diff-ee151e6b0eb11f34bef758bcef1314bc065bab9303e53590e9d7bb6106b4a0f1)` 