### PR TITLE
[#162204] Add sleep time to SciShield availability check

### DIFF
--- a/app/services/research_safety_adapters/scishield_api_client.rb
+++ b/app/services/research_safety_adapters/scishield_api_client.rb
@@ -19,14 +19,14 @@ module ResearchSafetyAdapters
 
       http_status_error || certification_data_error
     end
-    
+
     def token
       return @token if @token.present?
       return nil unless keys_present?
 
       now = Time.current.to_i
       payload = {
-        iat: now,
+        iat: now - 2.minutes.to_i, # SciShield Support suggested setting this a couple of minutes into that past to make requests more reliable. There may be an issue with the API related to the time change
         exp: now + 3600,
         drupal: { uid: KEY }
       }

--- a/app/services/research_safety_adapters/scishield_api_client.rb
+++ b/app/services/research_safety_adapters/scishield_api_client.rb
@@ -26,7 +26,9 @@ module ResearchSafetyAdapters
 
       now = Time.current.to_i
       payload = {
-        iat: now - 2.minutes.to_i, # SciShield Support suggested setting this a couple of minutes into that past to make requests more reliable. There may be an issue with the API related to the time change
+        # SciShield Support suggested setting this a couple of minutes in the past to make requests more reliable.
+        # There may be an issue with the API related to the time change for DST
+        iat: now - Settings.scishield.iat_offset.to_i.minutes.to_i,
         exp: now + 3600,
         drupal: { uid: KEY }
       }

--- a/app/services/research_safety_adapters/scishield_training_synchronizer.rb
+++ b/app/services/research_safety_adapters/scishield_training_synchronizer.rb
@@ -80,7 +80,7 @@ module ResearchSafetyAdapters
     def api_unavailable?
       # Test API responses for 10 random users
       users.sample(10).map do |user|
-        sleep(batch_sleep_time)
+        sleep(batch_sleep_time / 2)
         api_client.invalid_response?(user.email)
       end.all?
     end

--- a/app/services/research_safety_adapters/scishield_training_synchronizer.rb
+++ b/app/services/research_safety_adapters/scishield_training_synchronizer.rb
@@ -79,7 +79,7 @@ module ResearchSafetyAdapters
 
     def api_unavailable?
       # Test API responses for 10 random users
-      users.sample(10).map do |user|
+      users.sample(batch_size).map do |user|
         sleep(batch_sleep_time / 2)
         api_client.invalid_response?(user.email)
       end.all?

--- a/app/services/research_safety_adapters/scishield_training_synchronizer.rb
+++ b/app/services/research_safety_adapters/scishield_training_synchronizer.rb
@@ -80,6 +80,7 @@ module ResearchSafetyAdapters
     def api_unavailable?
       # Test API responses for 10 random users
       users.sample(10).map do |user|
+        sleep(batch_sleep_time)
         api_client.invalid_response?(user.email)
       end.all?
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,6 +38,7 @@ research_safety_adapter:
     batch_sleep_time: <%= ENV.fetch("SCISHIELD_BATCH_SLEEP_TIME", 20) %>
     batch_size: <%= ENV.fetch("SCISHIELD_BATCH_SIZE", 15) %>
     retry_max: <%= ENV.fetch("SCISHIELD_SYNC_RETRY_MAX", 5) %>
+    iat_offset: <%= ENV.fetch("SCISHIELD_IAT_OFFSET", 0) %>
 
 statement_pdf:
   class_name: ExampleStatementPdf

--- a/spec/services/research_safety_adapters/scishield_training_synchronizer_spec.rb
+++ b/spec/services/research_safety_adapters/scishield_training_synchronizer_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe ResearchSafetyAdapters::ScishieldTrainingSynchronizer do
   let(:satus_code) { nil }
   let(:api_endpoint) { ResearchSafetyAdapters::ScishieldApiClient.new.api_endpoint(user.email) }
 
+  before do
+    # In settings.yml, `synchronizer.batch_sleep_time` defaults to 20 seconds
+    # so this is to speed up spec runs
+    allow(synchronizer).to receive(:batch_sleep_time).and_return(0)
+  end
+
   describe "#retry_max" do
     it "returns an integer" do
       expect(synchronizer.retry_max).to be_a(Integer)
@@ -38,11 +44,6 @@ RSpec.describe ResearchSafetyAdapters::ScishieldTrainingSynchronizer do
 
     context "when the API responds without error" do
       let(:status_code) { "200" }
-      before do
-        # In settings.yml, `synchronizer.batch_sleep_time` defaults to 20 seconds
-        # so this is to speed up spec runs
-        allow(synchronizer).to receive(:batch_sleep_time).and_return(0)
-      end
 
       it "adds courses to database" do
         expect(ScishieldTraining.count).to eq 0


### PR DESCRIPTION
# Release Notes

This adds a sleep of `batch_sleep_time` to each API request in `api_unavailable?`.

The sync for OSU is failing due to `api_unavailable?` returning `false` when API requests are generally possible. Adding the sleep time in `api_unavailable?` makes it more reliable.