### PR TITLE
[#162194] Create a new order when adding cross-core products to an existing order

### DIFF
--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -15,6 +15,7 @@ class FacilityOrdersController < ApplicationController
   before_action :load_order, only: [:show, :update, :send_receipt]
   before_action :load_merge_orders, only: [:show, :update]
   before_action :load_add_to_order_form, only: [:show, :update]
+  before_action :load_cross_core_order_details, only: [:show]
 
   load_and_authorize_resource class: Order
 
@@ -32,7 +33,7 @@ class FacilityOrdersController < ApplicationController
     @order_details = @order.order_details.ordered_by_parents
     @order_details = @order_details.includes(:reservation, :order_status, :product, :order)
     if params[:refresh]
-      render partial: "order_table", locals: { order_details: @order_details }
+      render partial: "order_table", locals: { order_details: @order_details, cross_core: false }
     end
   end
 
@@ -112,6 +113,12 @@ class FacilityOrdersController < ApplicationController
 
   def problem_order_details
     current_facility.problem_plain_order_details
+  end
+
+  def load_cross_core_order_details
+    project = Projects::Project.find_by(name: "#{current_facility.abbreviation}-#{@order.id}")
+
+    @cross_core_order_details = project.present? ? project.order_details.where.not(order_id: @order.id) : []
   end
 
 end

--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -85,7 +85,7 @@ class FacilityOrdersController < ApplicationController
   private
 
   def add_to_order_params
-    params.require(:add_to_order_form).permit(:quantity, :product_id, :order_status_id, :note, :fulfilled_at, :duration, :account_id, :reference_id)
+    params.require(:add_to_order_form).permit(:quantity, :product_id, :order_status_id, :note, :fulfilled_at, :duration, :account_id, :reference_id, :facility_id)
   end
 
   def batch_updater

--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -71,6 +71,7 @@ class FacilityOrdersController < ApplicationController
       redirect_to facility_order_path(current_facility, @order)
     else
       flash.now[:error] = @add_to_order_form.error_message
+      load_cross_core_order_details
       show # set @order_details
       render :show
     end

--- a/app/forms/add_to_order_form.rb
+++ b/app/forms/add_to_order_form.rb
@@ -32,9 +32,9 @@ class AddToOrderForm
       facility_id: current_facility.id
     )
 
-    return add_to_order!(order_project) if @original_order.facility.id == @facility_id
-
-    if order_project.nil?
+    if @original_order.facility.id == @facility_id
+      add_to_order!(order_project)
+    elsif order_project.nil?
       create_cross_core_project_and_add_order!
     else
       facility_order_in_project = order_project.order_details.find { |od| od.order.facility_id == @facility_id }&.order

--- a/app/forms/add_to_order_form.rb
+++ b/app/forms/add_to_order_form.rb
@@ -123,7 +123,9 @@ class AddToOrderForm
 
   def add_to_order!(project = nil)
     OrderDetail.transaction do
-      merge_order.add(product, quantity, params).each do |order_detail|
+      item_adder_params = @original_order.facility_id == @facility_id ? params : params.merge(ordered_at: Time.zone.now)
+
+      merge_order.add(product, quantity, item_adder_params).each do |order_detail|
         backdate(order_detail)
 
         order_detail.set_default_status!
@@ -161,7 +163,7 @@ class AddToOrderForm
         created_by: created_by.id,
       )
 
-      product_order.add(product, quantity, params).each do |order_detail|
+      product_order.add(product, quantity, params.merge(ordered_at: Time.zone.now)).each do |order_detail|
         order_detail.set_default_status!
         order_detail.change_status!(order_status) if order_status.present?
 

--- a/app/forms/add_to_order_form.rb
+++ b/app/forms/add_to_order_form.rb
@@ -142,7 +142,7 @@ class AddToOrderForm
   end
 
   def create_cross_core_project_and_add_order!
-    Project.transaction do
+    Projects::Project.transaction do
       project = Projects::Project.find_or_initialize_by(
         name: "#{current_facility.abbreviation}-#{original_order.id}",
         facility_id: current_facility.id

--- a/app/support/orders/item_adder.rb
+++ b/app/support/orders/item_adder.rb
@@ -140,7 +140,6 @@ class Orders::ItemAdder
       quantity: 1,
       account: @order.account,
       created_by: @order.created_by,
-      ordered_at: Time.zone.now,
     )
     @order.order_details.create!(options)
   end

--- a/app/support/orders/item_adder.rb
+++ b/app/support/orders/item_adder.rb
@@ -140,6 +140,7 @@ class Orders::ItemAdder
       quantity: 1,
       account: @order.account,
       created_by: @order.created_by,
+      ordered_at: Time.zone.now,
     )
     @order.order_details.create!(options)
   end

--- a/app/views/facility_orders/_order_table.html.haml
+++ b/app/views/facility_orders/_order_table.html.haml
@@ -19,7 +19,7 @@
         %td.facility
           = od.facility
         %td.user
-          = od.user
+          = od.created_by_user
         %td.order_date
           = od.ordered_at&.strftime("%m/%d/%Y")
       %td.action

--- a/app/views/facility_orders/_order_table.html.haml
+++ b/app/views/facility_orders/_order_table.html.haml
@@ -1,10 +1,13 @@
 %tbody.js--orderTableRefresh
-  - OrderDetailPresenter.wrap(@order_details).each do |od|
+  - OrderDetailPresenter.wrap(order_details).each do |od|
     %tr{class: [od.parent_order_detail_id ? "child" : "parent", "status-#{od.order_status.root.name.underscore}", flash[:updated_order_details].try(:include?, od.id) ? "updated-order-detail" : ""] }
       %th.order-id{scope: "row"}
-        = link_to od,
-          manage_order_detail_path(od),
-          class: "manage-order-detail"
+        - if cross_core
+          = od
+        - else
+          = link_to od,
+            manage_order_detail_path(od),
+            class: "manage-order-detail"
       %td.badges
         = status_badge(od)
       %td.product
@@ -12,6 +15,13 @@
         - if od.time_data.present?
           %br
           = od.time_data
+      - if cross_core
+        %td.facility
+          = od.facility
+        %td.user
+          = od.user
+        %td.order_date
+          = od.ordered_at&.strftime("%m/%d/%Y")
       %td.action
         - if od.add_accessories?
           = link_to new_facility_order_order_detail_accessory_path(current_facility, @order, od), class: ["has_accessories", "persistent", "undecorated"] do

--- a/app/views/facility_orders/_order_table_headers.html.haml
+++ b/app/views/facility_orders/_order_table_headers.html.haml
@@ -1,0 +1,20 @@
+%thead
+  %tr
+    %td{colspan: 7}
+    %th{colspan: 2}= OrderDetail.human_attribute_name(:quantity)
+    %th{colspan: 3}= t("views.facility_orders.show.pricing")
+  %tr
+    %th.order-id{scope: "col"}= OrderDetail.human_attribute_name(:id)
+    %th.badges{scope: "col"}= t("views.facility_orders.show.status")
+    %th{scope: "col"}= Product.model_name.human
+    - if cross_core
+      %th{scope: "col"}= Facility.model_name.human
+      %th{scope: "col"}= t("views.facility_orders.show.order_by")
+      %th{scope: "col"}= t("views.facility_orders.show.order_date")
+    %th{scope: "col"}= t("views.facility_orders.show.actions")
+    %th.time{scope: "col"}= t("views.facility_orders.show.reserved")
+    %th.time{scope: "col"}= t("views.facility_orders.show.actual")
+    %th.currency{scope: "col"}= t("views.facility_orders.show.cost")
+    %th.currency{scope: "col"}= t("views.facility_orders.show.subsidy")
+    %th.currency{scope: "col"}= t("views.facility_orders.show.total")
+    %td.badges

--- a/app/views/facility_orders/show.html.haml
+++ b/app/views/facility_orders/show.html.haml
@@ -8,6 +8,12 @@
     = banner_date_label @order, :ordered_at
     = banner_label @order, :user
     = banner_label @order, :created_by_user
+    - project_id = @order_details.first&.project_id
+    - if project_id
+      %dl.span2
+        %dt= "Cross Core Project ID"
+        = link_to facility_project_path(current_facility, project_id) do
+          %dd= project_id
     - if @merge_orders.blank? && current_ability.can?(:send_receipt, @order)
       .pull-right= render "send_receipt"
 
@@ -32,7 +38,7 @@
       %th.currency{scope: "col"}= t("views.facility_orders.show.total")
       %td.badges
 
-  = render "order_table", order_details: @order_details
+  = render "order_table", order_details: @order_details, cross_core: false
 
   %tfoot
     %tr
@@ -55,5 +61,28 @@
 
 - if current_ability.can?(:update, Order)
   = render "merge_order_form"
+
+%table.order-list.table.table-striped.table-hover#order-management
+  %thead
+    %tr
+      %td{colspan: 7}
+      %th{colspan: 2}= OrderDetail.human_attribute_name(:quantity)
+      %th{colspan: 3}= t("views.facility_orders.show.pricing")
+    %tr
+      %th.order-id{scope: "col"}= OrderDetail.human_attribute_name(:id)
+      %th.badges{scope: "col"}= t("views.facility_orders.show.status")
+      %th{scope: "col"}= Product.model_name.human
+      %th{scope: "col"}= Facility.model_name.human
+      %th{scope: "col"}= "Order By"
+      %th{scope: "col"}= "Order Date"
+      %th{scope: "col"}= t("views.facility_orders.show.actions")
+      %th.time{scope: "col"}= t("views.facility_orders.show.reserved")
+      %th.time{scope: "col"}= t("views.facility_orders.show.actual")
+      %th.currency{scope: "col"}= t("views.facility_orders.show.cost")
+      %th.currency{scope: "col"}= t("views.facility_orders.show.subsidy")
+      %th.currency{scope: "col"}= t("views.facility_orders.show.total")
+      %td.badges
+
+  = render "order_table", order_details: @cross_core_order_details, cross_core: true
 
 #order-detail-modal.modal.hide.fade{ data: { backdrop: "static" } }

--- a/app/views/facility_orders/show.html.haml
+++ b/app/views/facility_orders/show.html.haml
@@ -11,7 +11,7 @@
     - project_id = @order_details.first&.project_id
     - if project_id
       %dl.span2
-        %dt= "Cross Core Project ID"
+        %dt= t("views.facility_orders.show.cross_core_project_id")
         = link_to facility_project_path(current_facility, project_id) do
           %dd= project_id
     - if @merge_orders.blank? && current_ability.can?(:send_receipt, @order)
@@ -20,24 +20,7 @@
 = render "merge_order"
 
 %table.order-list.table.table-striped.table-hover#order-management
-  %caption.text-left= t("views.facility_orders.show.table_caption")
-  %thead
-    %tr
-      %td{colspan: 4}
-      %th{colspan: 2}= OrderDetail.human_attribute_name(:quantity)
-      %th{colspan: 3}= t("views.facility_orders.show.pricing")
-    %tr
-      %th.order-id{scope: "col"}= OrderDetail.human_attribute_name(:id)
-      %th.badges{scope: "col"}= t("views.facility_orders.show.status")
-      %th{scope: "col"}= Product.model_name.human
-      %th{scope: "col"}= t("views.facility_orders.show.actions")
-      %th.time{scope: "col"}= t("views.facility_orders.show.reserved")
-      %th.time{scope: "col"}= t("views.facility_orders.show.actual")
-      %th.currency{scope: "col"}= t("views.facility_orders.show.cost")
-      %th.currency{scope: "col"}= t("views.facility_orders.show.subsidy")
-      %th.currency{scope: "col"}= t("views.facility_orders.show.total")
-      %td.badges
-
+  = render "order_table_headers", cross_core: false
   = render "order_table", order_details: @order_details, cross_core: false
 
   %tfoot
@@ -62,27 +45,8 @@
 - if current_ability.can?(:update, Order)
   = render "merge_order_form"
 
-%table.order-list.table.table-striped.table-hover#order-management
-  %thead
-    %tr
-      %td{colspan: 7}
-      %th{colspan: 2}= OrderDetail.human_attribute_name(:quantity)
-      %th{colspan: 3}= t("views.facility_orders.show.pricing")
-    %tr
-      %th.order-id{scope: "col"}= OrderDetail.human_attribute_name(:id)
-      %th.badges{scope: "col"}= t("views.facility_orders.show.status")
-      %th{scope: "col"}= Product.model_name.human
-      %th{scope: "col"}= Facility.model_name.human
-      %th{scope: "col"}= "Order By"
-      %th{scope: "col"}= "Order Date"
-      %th{scope: "col"}= t("views.facility_orders.show.actions")
-      %th.time{scope: "col"}= t("views.facility_orders.show.reserved")
-      %th.time{scope: "col"}= t("views.facility_orders.show.actual")
-      %th.currency{scope: "col"}= t("views.facility_orders.show.cost")
-      %th.currency{scope: "col"}= t("views.facility_orders.show.subsidy")
-      %th.currency{scope: "col"}= t("views.facility_orders.show.total")
-      %td.badges
-
+%table.order-list.table.table-striped.table-hover
+  = render "order_table_headers", cross_core: true
   = render "order_table", order_details: @cross_core_order_details, cross_core: true
 
 #order-detail-modal.modal.hide.fade{ data: { backdrop: "static" } }

--- a/config/locales/views/en.facility_orders.yml
+++ b/config/locales/views/en.facility_orders.yml
@@ -2,6 +2,7 @@ en:
   views:
     facility_orders:
       show:
+        cross_core_project_id: "Cross Core Project ID"
         table_caption: "Order detail information"
         pricing: "Pricing"
         status: "Status"
@@ -11,6 +12,8 @@ en:
         cost: "Cost"
         subsidy: "Subsidy"
         total: "Total"
+        order_by: "Order By"
+        order_date: "Order Date"
         order_table:
           accessories: "Add Accessories"
           download: "Download Event"

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -209,6 +209,18 @@ RSpec.describe "Adding to an existing order" do
         select_from_chosen product2.name, from: "add_to_order_form[product_id]"
         expect(page).to have_button("Add to Cross-Core Order")
       end
+
+      it "creates a new order for the selected facility" do
+        expect(page).not_to have_content("Cross Core Project ID")
+        select_from_chosen facility2.name, from: "add_to_order_form[facility_id]"
+        select_from_chosen product2.name, from: "add_to_order_form[product_id]"
+        click_button "Add to Cross-Core Order"
+
+        expect(page).to have_content("#{product2.name} was successfully added to this order.")
+        expect(page).to have_content("Cross Core Project ID")
+        expect(page).to have_content(facility2.to_s)
+        expect(page).to have_content(user.full_name), count: 2
+      end
     end
 
   end

--- a/vendor/engines/projects/app/models/projects/order_detail_extension.rb
+++ b/vendor/engines/projects/app/models/projects/order_detail_extension.rb
@@ -12,7 +12,6 @@ module Projects
                  foreign_key: :project_id,
                  inverse_of: :order_details
 
-      validate :project_facility_must_match
       validate :project_must_be_active, if: :project_id_changed?
 
       delegate :projects, to: :facility, prefix: true
@@ -23,12 +22,6 @@ module Projects
     end
 
     private
-
-    def project_facility_must_match
-      if project_id.present? && project.facility != facility
-        errors.add(:project_id, :project_facility_mismatch)
-      end
-    end
 
     def project_must_be_active
       if project.present? && !project.active?

--- a/vendor/engines/projects/config/locales/en.yml
+++ b/vendor/engines/projects/config/locales/en.yml
@@ -5,7 +5,6 @@ en:
         order_detail:
           attributes:
             project_id:
-              project_facility_mismatch: The project belongs to another facility
               project_is_inactive: The project is inactive
 
     models:

--- a/vendor/engines/projects/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/vendor/engines/projects/spec/controllers/order_management/order_details_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe OrderManagement::OrderDetailsController do
 
         context "that is associated with a different facility" do
           let(:project_id) { FactoryBot.create(:project).id }
-          it { expect(order_detail.project_id).to be_blank }
+          it { expect(order_detail.project_id).not_to be_blank }
         end
       end
 

--- a/vendor/engines/projects/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/vendor/engines/projects/spec/controllers/order_management/order_details_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe OrderManagement::OrderDetailsController do
 
         context "that is associated with a different facility" do
           let(:project_id) { FactoryBot.create(:project).id }
-          it { expect(order_detail.project_id).not_to be_blank }
+          it { expect(order_detail.project_id).to eq(project_id) }
         end
       end
 

--- a/vendor/engines/projects/spec/models/projects/order_detail_extension_spec.rb
+++ b/vendor/engines/projects/spec/models/projects/order_detail_extension_spec.rb
@@ -29,11 +29,7 @@ RSpec.describe Projects::OrderDetailExtension do
       context "when the Project belongs to a different facility than the Order" do
         let(:facility) { FactoryBot.create(:facility) }
 
-        it "is invalid" do
-          is_expected.not_to be_valid
-          expect(order_detail.errors[:project_id])
-            .to include("The project belongs to another facility")
-        end
+        it { is_expected.to be_valid }
       end
     end
 


### PR DESCRIPTION
⚠️ **This PR relies on Projects module being enabled. We should check this won't fail in Production and cause errors for any school that doesn't have it enabled.**

# Release Notes
* Create a new order when a product from a new facility is added to an existing order. If the order already exists, add to it.

# Screenshot
![localhost_3000_facilities_example_orders_31](https://github.com/tablexi/nucore-open/assets/28798610/d5b7be8a-1a12-4904-9277-f5bb1f43d047)

# Additional Context
## TODO

- [x] Confirm UI
- [x] Add system specs
  - Fix failing spec - it's reasonable that it's failing but it's worth it to improve the spec instead of just making it pass
- [x] Use I18n
- [x] Create partial for order table
- [x] Use `attributes` and remove `ordered_at` from `ItemAdder`

### Other PRs
- [ ] Accessibility
- [ ] Check time based input and quantity
- [ ] Consider using `merge_order` method and set `original_order` instead of setting `@merge_order`

#### #4112
- [x] Fix condition to show "CC Project ID", as it currently will cause issues if the first order detail has a project that isn't CC
- [x] Add separate table for each facility
- [x] Add total footer for new table
- [x] Add total for all the orders (top, next to CC Project ID)
- [x] Add headers

- [x] Prevent errors for schools that don't have Projects engine enabled
- [x] Change Order By to be the user that added the order detail


# Accessibility
- [ ] Did you scan for accessibility issues?
- [ ] Did you check our accessibility goal checklist?
- [ ] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)?