### PR TITLE
[#160449] Add feature flag for quick reservation spec

### DIFF
--- a/spec/system/quick_reservations_spec.rb
+++ b/spec/system/quick_reservations_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+
 RSpec.describe "Reserving an instrument using quick reservations", feature_setting: { walkup_reservations: true, reload_routes: true, user_based_price_groups: true } do
   include ResearchSafetyTestHelpers
 

--- a/spec/system/quick_reservations_spec.rb
+++ b/spec/system/quick_reservations_spec.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-
-RSpec.describe "Reserving an instrument using quick reservations", feature_setting: { walkup_reservations: true, reload_routes: true } do
+RSpec.describe "Reserving an instrument using quick reservations", feature_setting: { walkup_reservations: true, reload_routes: true, user_based_price_groups: true } do
   include ResearchSafetyTestHelpers
 
   let(:user) { create(:user) }


### PR DESCRIPTION
# Release Notes

This adds the `user_based_price_groups` feature flag to `spec/system/quick_reservations_spec.rb`. Dartmouth doesn't have this flag enabled, but it's required for one of the specs to work correctly

