### PR TITLE
[SHARED DEV] [#162194] Return products depending on original order facility

### DIFF
--- a/app/assets/javascripts/app/merge_orders.js
+++ b/app/assets/javascripts/app/merge_orders.js
@@ -50,12 +50,14 @@ window.MergeOrder = class MergeOrder {
     const crossCoreButtonText = button.data("cross-core-button-text");
 
     return facility_field.on("change", (event) => {
-      const url = $(event.target).find(":selected").data("products-path");
+      const selectedElement = $(event.target).find(":selected");
+      const url = selectedElement.data("products-path");
+      const originalOrderFacility = selectedElement.data("original-order-facility");
       const facility_id = $(event.target).val();
 
       return $.ajax({
         type: "get",
-        data: { facility_id },
+        data: { facility_id, original_order_facility: originalOrderFacility },
         url,
         success(data) {
           // Populate dropdown

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -32,7 +32,14 @@ class ProductsController < ApplicationController
   def available_for_cross_core_ordering
     respond_to do |format|
       format.js do
-        @facility_products = current_facility.products.mergeable_into_order.cross_core_available.alphabetized.map { |p| { id: p.id, name: p.name, time_based: p.order_quantity_as_time? } }
+        query = current_facility.products.mergeable_into_order
+
+        original_order_facility = params[:original_order_facility]&.to_i
+        unless original_order_facility.present? && (current_facility.id == original_order_facility)
+          query = query.cross_core_available
+        end
+
+        @facility_products = query.alphabetized.map { |p| { id: p.id, name: p.name, time_based: p.order_quantity_as_time? } }
 
         render json: @facility_products
       end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -6,6 +6,7 @@ class ProductsController < ApplicationController
   before_action :authenticate_user!
   before_action :check_acting_as, except: [:index]
   before_action :init_current_facility
+  before_action :set_facility_products, only: [:available_for_cross_core_ordering]
 
   load_and_authorize_resource
 
@@ -32,17 +33,20 @@ class ProductsController < ApplicationController
   def available_for_cross_core_ordering
     respond_to do |format|
       format.js do
-        query = current_facility.products.mergeable_into_order
-
-        original_order_facility = params[:original_order_facility]&.to_i
-        unless original_order_facility.present? && (current_facility.id == original_order_facility)
-          query = query.cross_core_available
-        end
-
-        @facility_products = query.alphabetized.map { |p| { id: p.id, name: p.name, time_based: p.order_quantity_as_time? } }
-
         render json: @facility_products
       end
     end
+  end
+
+  def set_facility_products
+    original_order_facility = params[:original_order_facility]&.to_i
+
+    query = current_facility.products.mergeable_into_order
+
+    unless original_order_facility.present? && (current_facility.id == original_order_facility)
+      query = query.cross_core_available
+    end
+
+    @facility_products = query.alphabetized.map { |p| { id: p.id, name: p.name, time_based: p.order_quantity_as_time? } }
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -42,10 +42,8 @@ class ProductsController < ApplicationController
     original_order_facility = params[:original_order_facility]&.to_i
 
     query = current_facility.products.mergeable_into_order
-
-    unless original_order_facility.present? && (current_facility.id == original_order_facility)
-      query = query.cross_core_available
-    end
+    adding_to_original_order = current_facility.id == original_order_facility
+    query = query.cross_core_available unless adding_to_original_order
 
     @facility_products = query.alphabetized.map { |p| { id: p.id, name: p.name, time_based: p.order_quantity_as_time? } }
   end

--- a/app/forms/add_to_order_form.rb
+++ b/app/forms/add_to_order_form.rb
@@ -92,8 +92,17 @@ class AddToOrderForm
     AvailableAccountsFinder.new(original_order.user, current_facility)
   end
 
-  def facilities
-    @facilities ||= Facility.alphabetized
+  def facilities_options
+    @facilities_options ||= Facility.alphabetized.map do |f|
+      [
+        f.name,
+        f.id,
+        {
+          "data-products-path": Rails.application.routes.url_helpers.available_for_cross_core_ordering_facility_products_path(f, format: :js),
+          "data-original-order-facility": @original_order.facility_id,
+        }
+      ]
+    end
   end
 
   # We're using the ordered_at of the order details to determine if additional OrderDetails

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -2,7 +2,7 @@
   .well
     = simple_form_for [current_facility, @add_to_order_form], url: facility_order_path(current_facility, @order), method: :put, html: { class: "js--edit-order" } do |f|
       - if SettingsHelper.feature_on?(:cross_core_projects) && can?(:available_for_cross_core_ordering, Product)
-        - facilities = @add_to_order_form.facilities.map { |f| [f.name, f.id, {"data-products-path" => available_for_cross_core_ordering_facility_products_path(f, format: :js)}] }
+        - facilities = @add_to_order_form.facilities.map { |f| [f.name, f.id, {"data-products-path" => available_for_cross_core_ordering_facility_products_path(f, format: :js), "data-original-order-facility" => @order.facility_id}] }
         = f.input_field :facility_id,
           collection: facilities,
           class: "js--edit-order__facility js--chosen",

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -2,9 +2,8 @@
   .well
     = simple_form_for [current_facility, @add_to_order_form], url: facility_order_path(current_facility, @order), method: :put, html: { class: "js--edit-order" } do |f|
       - if SettingsHelper.feature_on?(:cross_core_projects) && can?(:available_for_cross_core_ordering, Product)
-        - facilities = @add_to_order_form.facilities.map { |f| [f.name, f.id, {"data-products-path" => available_for_cross_core_ordering_facility_products_path(f, format: :js), "data-original-order-facility" => @order.facility_id}] }
         = f.input_field :facility_id,
-          collection: facilities,
+          collection: @add_to_order_form.facilities_options,
           class: "js--edit-order__facility js--chosen",
           label: Facility.model_name.human,
           include_blank: false

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -187,10 +187,10 @@ RSpec.describe "Adding to an existing order" do
 
   describe "adding a product from another facility", :js, feature_setting: { cross_core_projects: true } do
     let(:facility2) { create(:setup_facility) }
-    let(:product) { create(:setup_item, :with_facility_account, cross_core_ordering_available: true) }
-    let!(:product2) { create(:setup_item, :with_facility_account, facility: facility2, cross_core_ordering_available: true) }
-    let!(:product3) { create(:setup_item, :with_facility_account, facility:, cross_core_ordering_available: false) }
-    let!(:product4) { create(:setup_item, :with_facility_account, facility: facility2, cross_core_ordering_available: false) }
+    let(:product) { create(:setup_item, :with_facility_account, cross_core_ordering_available: false) }
+    let!(:product2) { create(:setup_item, :with_facility_account, facility: facility2, cross_core_ordering_available: false) }
+    let!(:cross_core_product_facility) { create(:setup_item, :with_facility_account, facility:, cross_core_ordering_available: true) }
+    let!(:cross_core_product_facility2) { create(:setup_item, :with_facility_account, facility: facility2, cross_core_ordering_available: true) }
 
     before do
       visit facility_order_path(facility, order)
@@ -208,23 +208,23 @@ RSpec.describe "Adding to an existing order" do
       it "changes the button text" do
         expect(page).to have_button("Add To Order")
         select_from_chosen facility2.name, from: "add_to_order_form[facility_id]"
-        select_from_chosen product2.name, from: "add_to_order_form[product_id]"
+        select_from_chosen cross_core_product_facility2.name, from: "add_to_order_form[product_id]"
         expect(page).to have_button("Add to Cross-Core Order")
       end
 
       it "creates a new order for the selected facility" do
         expect(page).not_to have_content("Cross Core Project ID")
+        expect(page.has_selector?("option", text: cross_core_product_facility.name, visible: false)).to be(true)
         expect(page.has_selector?("option", text: product.name, visible: false)).to be(true)
-        expect(page.has_selector?("option", text: product3.name, visible: false)).to be(true)
 
         select_from_chosen facility2.name, from: "add_to_order_form[facility_id]"
-        select_from_chosen product2.name, from: "add_to_order_form[product_id]"
+        select_from_chosen cross_core_product_facility2.name, from: "add_to_order_form[product_id]"
 
-        expect(page.has_selector?("option", text: product4.name, visible: false)).to be(false)
+        expect(page.has_selector?("option", text: product2.name, visible: false)).to be(false)
 
         click_button "Add to Cross-Core Order"
 
-        expect(page).to have_content("#{product2.name} was successfully added to this order.")
+        expect(page).to have_content("#{cross_core_product_facility2.name} was successfully added to this order.")
         expect(page).to have_content(facility2.to_s), count: 2
         expect(page).to have_content(user.full_name), count: 2
 

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -187,8 +187,10 @@ RSpec.describe "Adding to an existing order" do
 
   describe "adding a product from another facility", :js, feature_setting: { cross_core_projects: true } do
     let(:facility2) { create(:setup_facility) }
-    let(:product) { create(:setup_item, :with_facility_account) }
-    let!(:product2) { create(:setup_item, :with_facility_account, facility: facility2) }
+    let(:product) { create(:setup_item, :with_facility_account, cross_core_ordering_available: true) }
+    let!(:product2) { create(:setup_item, :with_facility_account, facility: facility2, cross_core_ordering_available: true) }
+    let!(:product3) { create(:setup_item, :with_facility_account, facility:, cross_core_ordering_available: false) }
+    let!(:product4) { create(:setup_item, :with_facility_account, facility: facility2, cross_core_ordering_available: false) }
 
     before do
       visit facility_order_path(facility, order)
@@ -212,8 +214,14 @@ RSpec.describe "Adding to an existing order" do
 
       it "creates a new order for the selected facility" do
         expect(page).not_to have_content("Cross Core Project ID")
+        expect(page.has_selector?("option", text: product.name, visible: false)).to be(true)
+        expect(page.has_selector?("option", text: product3.name, visible: false)).to be(true)
+
         select_from_chosen facility2.name, from: "add_to_order_form[facility_id]"
         select_from_chosen product2.name, from: "add_to_order_form[product_id]"
+
+        expect(page.has_selector?("option", text: product4.name, visible: false)).to be(false)
+
         click_button "Add to Cross-Core Order"
 
         expect(page).to have_content("#{product2.name} was successfully added to this order.")


### PR DESCRIPTION
# Release Notes
* Only the products that are available for cross core ordering are in the list.

# Screenshot

Optional.

# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".

# Accessibility
- [ ] Did you scan for accessibility issues?
- [ ] Did you check our accessibility goal checklist?
- [ ] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)?
