### PR TITLE
[Shared dev] [#162151] Allow subsidy to be zero in price rules

### DIFF
--- a/app/models/duration_rate.rb
+++ b/app/models/duration_rate.rb
@@ -9,7 +9,7 @@ class DurationRate < ApplicationRecord
   validates :rate, presence: true
   validates :rate, numericality: { greater_than_or_equal_to: 0 }
   validates :subsidy, presence: { message: ->(object, _data) { "^Missing subsidy for #{object.price_group.name}" } }, if: -> { requires_subsidy? }
-  validates :subsidy, numericality: { greater_than: 0, allow_blank: true }
+  validates :subsidy, numericality: { greater_than_or_equal_to: 0, allow_blank: true }
   validates :min_duration_hours,
     presence: { message: ->(object, _data) { "^Missing value for 'Rate start (hr)'" } },
     numericality: { greater_than: 0, allow_blank: true },

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe InstrumentPricePoliciesController do
 
         fill_in "price_policy_#{cancer_center.id}[duration_rates_attributes][0][subsidy]", with: "60"
         fill_in "price_policy_#{cancer_center.id}[duration_rates_attributes][1][subsidy]", with: "20"
-        fill_in "price_policy_#{cancer_center.id}[duration_rates_attributes][2][subsidy]", with: "20"
+        fill_in "price_policy_#{cancer_center.id}[duration_rates_attributes][2][subsidy]", with: "0"
 
         uncheck "price_policy_#{external_price_group.id}[can_purchase]"
         uncheck "price_policy_#{cannot_purchase_group.id}[can_purchase]"


### PR DESCRIPTION
# Release Notes
* Update validation for Duration based pricing rules so subsidy can be zero.

# Screenshot

Optional.

# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".

# Accessibility
- [ ] Did you scan for accessibility issues?
- [ ] Did you check our accessibility goal checklist?
- [ ] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)?
