### PR TITLE
[#162205] Scishield updates

### DIFF
--- a/app/controllers/user_research_safety_certifications_controller.rb
+++ b/app/controllers/user_research_safety_certifications_controller.rb
@@ -16,7 +16,11 @@ class UserResearchSafetyCertificationsController < ApplicationController
 
   def index
     @user = User.find(params[:user_id])
-    @certificates = ResearchSafetyCertificationLookup.certificates_with_status_for(@user)
+    begin
+      @certificates = ResearchSafetyCertificationLookup.certificates_with_status_for(@user)
+    rescue ResearchSafetyAdapters::ScishieldApiError => e
+      flash[:error] = e.message
+    end
   end
 
   # During rendering, we want to use the Ability as if we were using the UsersController

--- a/app/services/research_safety_adapters/scishield_api_client.rb
+++ b/app/services/research_safety_adapters/scishield_api_client.rb
@@ -2,6 +2,9 @@
 
 module ResearchSafetyAdapters
 
+  class ScishieldApiError < StandardError
+  end
+
   class ScishieldApiClient
 
     require "jwt"
@@ -19,7 +22,7 @@ module ResearchSafetyAdapters
 
       http_status_error || certification_data_error
     end
-    
+
     def token
       return @token if @token.present?
       return nil unless keys_present?
@@ -46,6 +49,8 @@ module ResearchSafetyAdapters
     def certifications_for(email)
       response = training_api_request(email)
       response.body
+    rescue Net::OpenTimeout
+      raise ScishieldApiError, "API request failed"
     end
 
     def training_api_request(email)

--- a/app/services/research_safety_adapters/scishield_api_client.rb
+++ b/app/services/research_safety_adapters/scishield_api_client.rb
@@ -50,7 +50,7 @@ module ResearchSafetyAdapters
       response = training_api_request(email)
       response.body
     rescue Net::OpenTimeout
-      raise ScishieldApiError, "API request failed"
+      raise ScishieldApiError, I18n.t("services.research_safety_adapters.scishield_api_client.request_failed")
     end
 
     def training_api_request(email)

--- a/app/services/reservation_creator.rb
+++ b/app/services/reservation_creator.rb
@@ -42,7 +42,7 @@ class ReservationCreator
         else
           @success = :default
         end
-      rescue OrderPurchaseValidatorError, ResearchSafetyAdapters::ScishieldApiError => e
+      rescue OrderPurchaseValidatorError => e
         @error = e.message
         raise ActiveRecord::Rollback
       rescue ActiveRecord::RecordInvalid => e

--- a/app/services/reservation_creator.rb
+++ b/app/services/reservation_creator.rb
@@ -42,7 +42,7 @@ class ReservationCreator
         else
           @success = :default
         end
-      rescue OrderPurchaseValidatorError => e
+      rescue OrderPurchaseValidatorError, ResearchSafetyAdapters::ScishieldApiError => e
         @error = e.message
         raise ActiveRecord::Rollback
       rescue ActiveRecord::RecordInvalid => e

--- a/app/views/user_research_safety_certifications/index.html.haml
+++ b/app/views/user_research_safety_certifications/index.html.haml
@@ -10,8 +10,9 @@
 %h1
   = text("title", name: @user.full_name)
 
-%ul.unstyled
-  - @certificates.each do |certificate, active|
-    %li{ class: active ? "" : "muted" }
-      = active ? fa_icon("check", class: "text-success") : fa_icon("ban")
-      = certificate.name
+- if @certificates
+  %ul.unstyled
+    - @certificates.each do |certificate, active|
+      %li{ class: active ? "" : "muted" }
+        = active ? fa_icon("check", class: "text-success") : fa_icon("ban")
+        = certificate.name

--- a/config/locales/en.services.yml
+++ b/config/locales/en.services.yml
@@ -1,0 +1,7 @@
+#
+# Messages that come from services
+en:
+  services:
+    research_safety_adapters:
+      scishield_api_client:
+        request_failed: API request failed

--- a/config/locales/en.services.yml
+++ b/config/locales/en.services.yml
@@ -4,4 +4,4 @@ en:
   services:
     research_safety_adapters:
       scishield_api_client:
-        request_failed: API request failed
+        request_failed: "Scishield API error: Unable to access training certificates."

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -116,6 +116,15 @@ RSpec.configure do |config|
     Settings.billing.review_period = original_review_period
   end
 
+  config.around(:each, :safety_adapter_class) do |example|
+    original_class = ResearchSafetyCertificationLookup.adapter_class
+    ResearchSafetyCertificationLookup.adapter_class = example.metadata[:safety_adapter_class]
+
+    example.call
+
+    ResearchSafetyCertificationLookup.adapter_class = original_class
+  end
+
   config.before(:all) do
     # users are not created within transactions, so delete them all here before running tests
     PriceGroupMember.delete_all

--- a/spec/services/scishield_api_adapter_spec.rb
+++ b/spec/services/scishield_api_adapter_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe ResearchSafetyAdapters::ScishieldApiAdapter do
       end
 
       it "raises an error" do
-        expect { adapter.certified?(anything) }.to raise_error(Timeout::Error)
+        expect { adapter.certified?(anything) }.to raise_error(ResearchSafetyAdapters::ScishieldApiError)
       end
     end
 

--- a/spec/system/research_safety/scishield/scishield_timeout_spec.rb
+++ b/spec/system/research_safety/scishield/scishield_timeout_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "scishield timeout" do
+  let!(:user) { create(:user) }
+  let(:admin) { create(:user, :administrator) }
+  let!(:instrument) { FactoryBot.create(:setup_instrument) }
+  let(:facility) { instrument.facility }
+  let!(:cert1) { create(:product_certification_requirement, product: instrument).research_safety_certificate }
+  let!(:cert2) { create(:product_certification_requirement, product: instrument).research_safety_certificate }
+  let!(:account) { create(:nufs_account, :with_account_owner, owner: user) }
+  let!(:account_price_group_member) do
+    create(
+      :account_price_group_member,
+      account:,
+      price_group: instrument.price_policies.first.price_group,
+    )
+  end
+
+  before do
+    Settings.research_safety_adapter.class_name = "ResearchSafetyAdapters::ScishieldApiAdapter"
+
+    # This will cause ResearchSafetyAdapters::ScishieldApiClient#certifications_for
+    # to raise ResearchSafetyAdapters::ScishieldApiError
+    allow_any_instance_of(ResearchSafetyAdapters::ScishieldApiClient).to(
+      receive(:training_api_request).and_raise(Net::OpenTimeout)
+    )
+  end
+
+  describe "viewing a user's certificates" do
+    before do
+      login_as admin
+      visit facility_user_user_research_safety_certifications_path Facility.cross_facility, user
+    end
+
+    it "displays an error on the page" do
+      expect(page).to have_content I18n.t("services.research_safety_adapters.scishield_api_client.request_failed")
+    end
+  end
+
+  describe "making a reservation" do
+    before do
+      login_as user
+      visit facility_path(facility)
+      click_link instrument.name
+    end
+
+    it "displays an error on the page" do
+      click_button "Create"
+      expect(page).to have_content I18n.t("services.research_safety_adapters.scishield_api_client.request_failed")
+    end
+  end
+end

--- a/spec/system/research_safety/scishield/scishield_timeout_spec.rb
+++ b/spec/system/research_safety/scishield/scishield_timeout_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "scishield timeout" do
+RSpec.describe "Scishield timeout", safety_adapter_class: ResearchSafetyAdapters::ScishieldApiAdapter do
   let!(:user) { create(:user) }
   let(:admin) { create(:user, :administrator) }
   let!(:instrument) { FactoryBot.create(:setup_instrument) }
@@ -19,8 +19,6 @@ RSpec.describe "scishield timeout" do
   end
 
   before do
-    Settings.research_safety_adapter.class_name = "ResearchSafetyAdapters::ScishieldApiAdapter"
-
     # This will cause ResearchSafetyAdapters::ScishieldApiClient#certifications_for
     # to raise ResearchSafetyAdapters::ScishieldApiError
     allow_any_instance_of(ResearchSafetyAdapters::ScishieldApiClient).to(


### PR DESCRIPTION
# Release Notes

This adds handling for timeout errors for requests to the Scishield API. An error message is displayed to users, instead of the previous behavior, which was throwing a 500 error.

# Screenshot

![Screenshot 2024-04-02 at 4 14 31 PM](https://github.com/tablexi/nucore-open/assets/624487/ac5df38c-fcce-41a6-88c7-0337306de64f)

![Screenshot 2024-04-02 at 4 17 39 PM](https://github.com/tablexi/nucore-open/assets/624487/35903a37-85ac-421d-85e6-926600356b58)

# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".

# Accessibility
- [ ] Did you scan for accessibility issues?
- [ ] Did you check our accessibility goal checklist?
- [ ] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)?
