### PR TITLE
[#162190] QR walk up fixes

### DIFF
--- a/app/controllers/quick_reservations_controller.rb
+++ b/app/controllers/quick_reservations_controller.rb
@@ -133,6 +133,8 @@ class QuickReservationsController < ApplicationController
     ongoing = reservations.ongoing.first
 
     @reservation = ongoing || startable
+
+    @reservation&.order_detail&.problem? ? nil : @reservation
   end
 
   def build_order

--- a/app/controllers/quick_reservations_controller.rb
+++ b/app/controllers/quick_reservations_controller.rb
@@ -134,7 +134,7 @@ class QuickReservationsController < ApplicationController
 
     @reservation = ongoing || startable
 
-    @reservation&.order_detail&.problem? ? nil : @reservation
+    @reservation = nil if @reservation&.order_detail&.problem?
   end
 
   def build_order

--- a/app/models/concerns/products/scheduling_support.rb
+++ b/app/models/concerns/products/scheduling_support.rb
@@ -63,9 +63,13 @@ module Products::SchedulingSupport
     max_time = max_reserve_mins.presence || 181
     min_time = min_reserve_mins.to_i
 
-    intervals.select do |i|
-      min_time < i && i < max_time
+    intervals.select! do |i|
+      min_time <= i && i <= max_time
     end
+
+    intervals = [min_reserve_mins] if intervals.empty?
+
+    intervals
   end
 
   def offline?

--- a/app/views/quick_reservations/new.html.haml
+++ b/app/views/quick_reservations/new.html.haml
@@ -6,26 +6,28 @@
 - else
   %div.reservation_notice
     %h2= t(".reserved")
-    %p= t(".reserved_message")
+    - if @reservation_data
+      %p= t(".reserved_message")
 
-%dl
-  %dt= t(".reservation_date")
-  %dd= "#{@reservation_data[:reserve_start_at].strftime("%A")} #{human_date(@reservation_data[:reserve_start_at])}"
-
-  %dt= t(".reservation_time")
-  %dd= human_time(@reservation_data[:reserve_start_at])
-
-- if @can_add_to_cart
-  = form_with url: facility_instrument_quick_reservations_path(@facility, @instrument) do |f|
-    %fieldset
-      %legend= t(".reservation_length")
-      - @possible_reservation_data.each_with_index do |res_data, index|
-        - checked_value = index == 0 ? "checked" : ""
-        = f.radio_button "reservation[duration_mins]", res_data[:duration_mins], required: true, checked: checked_value
-        = f.label "reservation[duration_mins]_#{res_data[:duration_mins]}", "#{res_data[:duration_mins]} mins"
-    %fieldset
-      - accounts = @current_user.accounts_for_product(@instrument)
-      %legend= t(".payment_details")
-      = f.select :order_account, accounts.map { |a| [a, a.id] }, {}, {"aria-label": "account" }
-    %br
-    = f.submit t(".create_reservation")
+- if @reservation_data
+  %dl
+    %dt= t(".reservation_date")
+    %dd= "#{@reservation_data[:reserve_start_at].strftime("%A")} #{human_date(@reservation_data[:reserve_start_at])}"
+  
+    %dt= t(".reservation_time")
+    %dd= human_time(@reservation_data[:reserve_start_at])
+  
+  - if @can_add_to_cart
+    = form_with url: facility_instrument_quick_reservations_path(@facility, @instrument) do |f|
+      %fieldset
+        %legend= t(".reservation_length")
+        - @possible_reservation_data.each_with_index do |res_data, index|
+          - checked_value = index == 0 ? "checked" : ""
+          = f.radio_button "reservation[duration_mins]", res_data[:duration_mins], required: true, checked: checked_value
+          = f.label "reservation[duration_mins]_#{res_data[:duration_mins]}", "#{res_data[:duration_mins]} mins"
+      %fieldset
+        - accounts = @current_user.accounts_for_product(@instrument)
+        %legend= t(".payment_details")
+        = f.select :order_account, accounts.map { |a| [a, a.id] }, {}, {"aria-label": "account" }
+      %br
+      = f.submit t(".create_reservation")

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -7,7 +7,18 @@ RSpec.describe Instrument do
   it_should_behave_like "ReservationProduct", :instrument
 
   let(:facility) { FactoryBot.create(:setup_facility) }
-  subject(:instrument) { build :instrument, facility: facility }
+  let(:min_reserve_mins) { 60 }
+  let(:max_reserve_mins) { 120 }
+  let(:reserve_interval) { 1 }
+
+  subject(:instrument) do
+    build(:instrument,
+          facility:,
+          min_reserve_mins:,
+          max_reserve_mins:,
+          reserve_interval:,
+         )
+  end
 
   it "should create using factory" do
     expect(instrument).to be_valid
@@ -899,6 +910,31 @@ RSpec.describe Instrument do
       it "reserves 5 PM to midnight as unavailable" do
         expect(reservations.last.reserve_start_at).to eq(Time.zone.parse("2015-07-05T17:00:00"))
         expect(reservations.last.reserve_end_at).to eq(Time.zone.parse("2015-07-06T00:00:00"))
+      end
+    end
+  end
+
+  describe "#quick_reservation_intervals" do
+    before do
+      instrument.min_reserve_mins = min_reserve_mins
+      instrument.max_reserve_mins = max_reserve_mins
+      instrument.reserve_interval = reserve_interval
+    end
+
+    context "when min_reserve_mins is larger than all reserve intervals" do
+      let(:min_reserve_mins) { 100 }
+
+      it "returns the min_reserve_mins" do
+        expect(instrument.quick_reservation_intervals).to eq [min_reserve_mins]
+      end
+    end
+
+    context "when min_reserve_mins is smaller than all the reserve intervals" do
+      let(:min_reserve_mins) { 5 }
+
+      it "returns an array of 3 intervals" do
+        expect(instrument.quick_reservation_intervals).to eq [15, 30, 60]
+        expect(instrument.quick_reservation_intervals.count).to eq 3
       end
     end
   end

--- a/spec/system/quick_reservations_spec.rb
+++ b/spec/system/quick_reservations_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "Reserving an instrument using quick reservations", feature_setti
     end
   end
 
-  context "when the user has an ongoing problem reservation" do
+  context "when the user has an ongoing, complete reservation" do
     let!(:reservation) do
       r = create(
         :purchased_reservation,
@@ -114,14 +114,12 @@ RSpec.describe "Reserving an instrument using quick reservations", feature_setti
 
       od = r.order_detail
 
-      od.problem = true
       od.change_status!(OrderStatus.in_process)
       od.change_status!(OrderStatus.complete)
       od.save
     end
 
-    it "does not redirect to the problem reservation" do
-      expect(page).to have_content("Reservation Length")
+    it "does not redirect to the reservation" do
       expect(page).to have_current_path(new_facility_instrument_quick_reservation_path(facility, instrument))
     end
   end

--- a/spec/system/quick_reservations_spec.rb
+++ b/spec/system/quick_reservations_spec.rb
@@ -101,6 +101,31 @@ RSpec.describe "Reserving an instrument using quick reservations", feature_setti
     end
   end
 
+  context "when the user has an ongoing problem reservation" do
+    let!(:reservation) do
+      r = create(
+        :purchased_reservation,
+        product: instrument,
+        user:,
+        reserve_start_at: 30.minutes.ago,
+        actual_start_at: 30.minutes.ago,
+        reserve_end_at: 5.minutes.ago
+      )
+
+      od = r.order_detail
+
+      od.problem = true
+      od.change_status!(OrderStatus.in_process)
+      od.change_status!(OrderStatus.complete)
+      od.save
+    end
+
+    it "does not redirect to the problem reservation" do
+      expect(page).to have_content("Reservation Length")
+      expect(page).to have_current_path(new_facility_instrument_quick_reservation_path(facility, instrument))
+    end
+  end
+
   context "when another reservation exists in the future" do
     let(:start_at) {}
     let(:end_at) { start_at + 30.minutes }

--- a/spec/system/quick_reservations_spec.rb
+++ b/spec/system/quick_reservations_spec.rb
@@ -281,4 +281,14 @@ RSpec.describe "Reserving an instrument using quick reservations", feature_setti
       end
     end
   end
+
+  context "when the insturment has no schedule rules" do
+    let!(:instrument) do
+      create(:setup_instrument, :timer, min_reserve_mins: 5, skip_schedule_rules: true)
+    end
+
+    it "shows an error message" do
+      expect(page).to have_content(I18n.t("models.instrument_for_cart.schedule_not_available"))
+    end
+  end
 end


### PR DESCRIPTION
# Release Notes

This fixes a some  bugs in the QR walk up controller.

Handles that case
* when the minimum reserve time is larger than any of the reserve intervals
* when a non-actionable reservation is redirected to
* when the instrument has no schedule rules