### PR TITLE
Tech task: reservation scheduling

### DIFF
--- a/app/controllers/quick_reservations_controller.rb
+++ b/app/controllers/quick_reservations_controller.rb
@@ -82,7 +82,7 @@ class QuickReservationsController < ApplicationController
 
   # POST /facilities/:facility_id/instruments/:instrument_id/quick_reservations/start
   def start
-    if @reservation&.startable_now? && @reservation&.move_to_earliest && @reservation&.start_reservation!
+    if @reservation&.movable_to_now? && @reservation&.move_to_earliest && @reservation&.start_reservation!
       flash[:notice] = "Reservation started"
       redirect_to facility_instrument_quick_reservation_path(@facility, @instrument, @reservation)
     else
@@ -134,7 +134,7 @@ class QuickReservationsController < ApplicationController
 
   def set_actionable_reservation
     reservations = current_user.reservations.where(product_id: @instrument.id).joins(:order_detail).merge(OrderDetail.new_or_inprocess)
-    startable = reservations.find(&:startable_now?)
+    startable = reservations.find(&:movable_to_now?)
     ongoing = reservations.ongoing.first
 
     @reservation = ongoing || startable

--- a/app/models/concerns/products/scheduling_support.rb
+++ b/app/models/concerns/products/scheduling_support.rb
@@ -42,7 +42,7 @@ module Products::SchedulingSupport
   end
 
   # The next available reservation that is valid must be in the future
-  # (see Reservations::Validations#n_the_future) so the `after` parameter is
+  # (see Reservations::Validations#in_the_future) so the `after` parameter is
   # set to 1 minute in the future so quick_reservation_data returns data that
   # can be used to create a valid reservation
   def quick_reservation_data(after: 1.minute.from_now)

--- a/app/models/concerns/products/scheduling_support.rb
+++ b/app/models/concerns/products/scheduling_support.rb
@@ -41,6 +41,10 @@ module Products::SchedulingSupport
     reservation_in_week(after, duration, rules, options)
   end
 
+  # The next available reservation that is valid must be in the future
+  # (see Reservations::Validations#n_the_future) so the `after` parameter is
+  # set to 1 minute in the future so quick_reservation_data returns data that
+  # can be used to create a valid reservation
   def quick_reservation_data(after: 1.minute.from_now)
     res = next_available_reservation(after:, duration: quick_reservation_intervals.first)
 

--- a/app/presenters/reservation_user_action_presenter.rb
+++ b/app/presenters/reservation_user_action_presenter.rb
@@ -5,7 +5,7 @@ class ReservationUserActionPresenter
   attr_accessor :reservation, :controller
   delegate :order_detail, :order, :facility, :product, :admin?,
            :can_switch_instrument?, :can_switch_instrument_on?, :can_switch_instrument_off?,
-           :can_cancel?, :startable_now?, :can_customer_edit?, :started?, :ongoing?, to: :reservation
+           :can_cancel?, :movable_to_now?, :can_customer_edit?, :started?, :ongoing?, to: :reservation
 
   delegate :current_facility, to: :controller
 
@@ -25,7 +25,7 @@ class ReservationUserActionPresenter
 
     if can_switch_instrument?
       actions << switch_actions
-    elsif startable_now?
+    elsif movable_to_now?
       actions << move_link
     end
 

--- a/app/support/reservations/moving_up.rb
+++ b/app/support/reservations/moving_up.rb
@@ -36,7 +36,8 @@ module Reservations::MovingUp
     false
   end
 
-  def startable_now?
+  # It is possible to move the reservation to the current time?
+  def movable_to_now?
     product.online? &&
       !(canceled? || order_detail.complete? || in_grace_period? || earliest_possible.nil?) # TODO: refactor?
   end

--- a/app/views/quick_reservations/show.html.haml
+++ b/app/views/quick_reservations/show.html.haml
@@ -1,5 +1,5 @@
 = render partial: "reservation_information", locals: { reservation: @reservation }
-- if @reservation.startable_now?
+- if @reservation.movable_to_now?
   = form_with url: facility_instrument_quick_reservations_start_path(@facility, @instrument) do |f|
     = f.submit t(".start")
 - elsif @reservation.ongoing?

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -671,13 +671,13 @@ RSpec.describe Reservation do
       before(:each) { @morning = Time.zone.parse("#{Date.today} 10:31:00") }
 
       context "when the reserved instrument is online" do
-        it { is_expected.to be_startable_now }
+        it { is_expected.to be_movable_to_now }
       end
 
       context "when the reserved instrument is offline" do
         let(:instrument) { FactoryBot.create(:setup_instrument, :offline, skip_schedule_rules: true) }
 
-        it { is_expected.not_to be_startable_now }
+        it { is_expected.not_to be_movable_to_now }
       end
 
       it "should return the earliest possible time slot" do
@@ -704,20 +704,20 @@ RSpec.describe Reservation do
         @instrument.update(reserve_interval: 1)
         @reservation1.duration_mins = 1
         travel_to_and_return(@reservation1.reserve_start_at - 4.minutes) do
-          expect(@reservation1).to_not be_startable_now
+          expect(@reservation1).to_not be_movable_to_now
         end
       end
 
       it "should not be moveable if the reservation is canceled" do
-        expect(@reservation1).to be_startable_now
+        expect(@reservation1).to be_movable_to_now
         @reservation1.order_detail.update(canceled_at: Time.zone.now)
-        expect(@reservation1).not_to be_startable_now
+        expect(@reservation1).not_to be_movable_to_now
       end
 
       it "should not be moveable if there is not a time slot earlier than this one" do
-        expect(@reservation1).to be_startable_now
+        expect(@reservation1).to be_movable_to_now
         expect(@reservation1.move_to_earliest).to be true
-        expect(@reservation1).not_to be_startable_now
+        expect(@reservation1).not_to be_movable_to_now
         expect(@reservation1.move_to_earliest).to be false
         expect(@reservation1.errors.messages).to eq(base: ["Sorry, but your reservation can no longer be moved."])
       end

--- a/spec/presenters/reservation_user_action_presenter_spec.rb
+++ b/spec/presenters/reservation_user_action_presenter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ReservationUserActionPresenter do
     allow(reservation).to receive(:can_switch_instrument?).and_return true
     allow(reservation).to receive(:can_switch_instrument_off?).and_return false
     allow(reservation).to receive(:can_switch_instrument_on?).and_return false
-    allow(reservation).to receive(:startable_now?).and_return false
+    allow(reservation).to receive(:movable_to_now?).and_return false
     allow(reservation).to receive(:can_cancel?).and_return false
     allow(reservation).to receive(:ongoing?).and_return false
   end
@@ -178,7 +178,7 @@ RSpec.describe ReservationUserActionPresenter do
 
       before do
         expect(reservation).to receive(:can_switch_instrument?).and_return false
-        expect(reservation).to receive(:startable_now?).and_return true
+        expect(reservation).to receive(:movable_to_now?).and_return true
       end
 
       it "includes the move 'Move Up' link" do


### PR DESCRIPTION
# Release Notes

This renames the `startable_now?` method to `movable_to_now?`, which is a name that more clearly communicates the question the method is answering.

It also adds a comment to the `quick_reservation_data` explaining why the time is set to 1 minute in the future