### PR TITLE
Fix failing spec for adding to order

### DIFF
--- a/spec/support/select_from_chosen.rb
+++ b/spec/support/select_from_chosen.rb
@@ -4,6 +4,8 @@ module SelectFromChosen
 
   # Allow running system specs with JS enabled and still access 'chosen' select inputs
   def select_from_chosen(item_text, options)
+    page.scroll_to(options[:scroll_to]) if options[:scroll_to]
+
     field = find_field(options[:from], visible: false)
     find("##{field[:id]}_chosen").click
     find("##{field[:id]}_chosen ul.chosen-results li", text: item_text).click

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -221,8 +221,7 @@ RSpec.describe "Adding to an existing order" do
           project = order.reload.cross_core_project
           second_facility_order = project.orders.last
 
-          puts page.body
-          select_from_chosen facility2.name, from: "add_to_order_form[facility_id]"
+          select_from_chosen facility2.name, from: "add_to_order_form[facility_id]", scroll_to: :center
           select_from_chosen instrument.name, from: "add_to_order_form[product_id]"
           fill_in "add_to_order_form[quantity]", with: "1"
           click_button "Add to Cross-Core Order"


### PR DESCRIPTION
# Release Notes
* Fix failing spec for adding to order

# Screenshot

Optional.

# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".

# Accessibility
- [ ] Did you scan for accessibility issues?
- [ ] Did you check our accessibility goal checklist?
- [ ] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)?
