### PR TITLE
[#162204] Fix typo and add spec

### DIFF
--- a/app/services/research_safety_adapters/scishield_api_client.rb
+++ b/app/services/research_safety_adapters/scishield_api_client.rb
@@ -29,14 +29,18 @@ module ResearchSafetyAdapters
 
       now = Time.current.to_i
       payload = {
-        # SciShield Support suggested setting this a couple of minutes in the past to make requests more reliable.
-        # There may be an issue with the API related to the time change for DST
-        iat: now - Settings.scishield.iat_offset.to_i.minutes.to_i,
+        iat: now - iat_offset,
         exp: now + 3600,
         drupal: { uid: KEY }
       }
       rsa_private = OpenSSL::PKey::RSA.new(unescape(PRIVATE_KEY))
       @token = JWT.encode(payload, rsa_private, "RS256", { kid: KEY_ID })
+    end
+
+    # SciShield Support suggested setting this a couple of minutes in the past to make requests more reliable.
+    # There may be an issue with the API related to the time change for DST
+    def iat_offset
+      Settings.research_safety_adapter.scishield.iat_offset.to_i.minutes.to_i
     end
 
     # need to make sure \n gets unescaped when reading this in from ENV

--- a/spec/services/scishield_api_client_spec.rb
+++ b/spec/services/scishield_api_client_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe ResearchSafetyAdapters::ScishieldApiClient do
     end
   end
 
+  describe "#iat_offset" do
+    it "returns 0 by default" do
+      expect(client.iat_offset).to eq(0)
+    end
+  end
+
   describe "#invalid_response?" do
     before do
       stub_request(:get, api_endpoint)


### PR DESCRIPTION
# Release Notes

The `scischield` settings are nested under the `research_safety_adapter` key in the `settings.yml` file