### PR TITLE
[#162250] Update default value for `cross_core_ordering_available` column

### DIFF
--- a/db/migrate/20240410203410_update_cross_core_ordering_available_in_products.rb
+++ b/db/migrate/20240410203410_update_cross_core_ordering_available_in_products.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+class Product < ApplicationRecord; end
+
 class UpdateCrossCoreOrderingAvailableInProducts < ActiveRecord::Migration[7.0]
   def up
     change_column :products, :cross_core_ordering_available, :boolean, default: false, null: false
+
+    Product.update_all(cross_core_ordering_available: false)
   end
 
   def down

--- a/db/migrate/20240410203410_update_cross_core_ordering_available_in_products.rb
+++ b/db/migrate/20240410203410_update_cross_core_ordering_available_in_products.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class UpdateCrossCoreOrderingAvailableInProducts < ActiveRecord::Migration[7.0]
+  def up
+    change_column :products, :cross_core_ordering_available, :boolean, default: false, null: false
+  end
+
+  def down
+    change_column :products, :cross_core_ordering_available, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_19_182716) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_10_203410) do
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
     t.integer "account_id", null: false
@@ -656,7 +656,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_19_182716) do
     t.text "tablet_location_description"
     t.string "billing_mode", default: "Default", null: false
     t.string "pricing_mode", default: "Schedule Rule", null: false
-    t.boolean "cross_core_ordering_available", default: true, null: false
+    t.boolean "cross_core_ordering_available", default: false, null: false
     t.index ["dashboard_token"], name: "index_products_on_dashboard_token"
     t.index ["facility_account_id"], name: "fk_facility_accounts"
     t.index ["facility_id"], name: "fk_rails_0c9fa1afbe"


### PR DESCRIPTION
# Release Notes
* Default Cross-Core ordering visibility to off.
