### PR TITLE
[#162263] Multi-Facility - 5c When an admin places a cross-core order, update valid payment source list

### DIFF
--- a/app/assets/javascripts/app/merge_orders.js
+++ b/app/assets/javascripts/app/merge_orders.js
@@ -118,9 +118,7 @@ window.MergeOrder = class MergeOrder {
               '<option value="' +
                 account.id +
                 '">' +
-                account.description +
-                " / " +
-                account.account_number +
+                account.label +
                 "</option>"
             );
           });

--- a/app/assets/javascripts/app/merge_orders.js
+++ b/app/assets/javascripts/app/merge_orders.js
@@ -62,6 +62,9 @@ window.MergeOrder = class MergeOrder {
       const originalOrderFacility = selectedElement.data("original-order-facility");
       const originalOrder = selectedElement.data("original-order");
       const facility_id = $(event.target).val();
+      const includeBlank = JSON.parse(
+        account_field.data("include-blank")
+      );
 
       $.ajax({
         type: "get",
@@ -105,6 +108,11 @@ window.MergeOrder = class MergeOrder {
           // Populate dropdown
           account_field.empty();
           data = JSON.parse(data);
+
+          if (includeBlank) {
+            account_field.append('<option value=""></option>');
+          }
+
           data.forEach(function (account) {
             return account_field.append(
               '<option value="' +

--- a/app/assets/javascripts/app/merge_orders.js
+++ b/app/assets/javascripts/app/merge_orders.js
@@ -46,6 +46,7 @@ window.MergeOrder = class MergeOrder {
 
     const product_field = this.$form.find(".js--edit-order__product");
     const facility_field = this.$form.find(".js--edit-order__facility");
+    const account_field = this.$form.find(".js--edit-order__account");
     const button = this.$form.find(".js--edit-order__button");
 
     if (!facility_field || !button) return;
@@ -56,14 +57,16 @@ window.MergeOrder = class MergeOrder {
 
     return facility_field.on("change", (event) => {
       const selectedElement = $(event.target).find(":selected");
-      const url = selectedElement.data("products-path");
+      const productsUrl = selectedElement.data("products-path");
+      const accountsUrl = selectedElement.data("accounts-path");
       const originalOrderFacility = selectedElement.data("original-order-facility");
+      const originalOrder = selectedElement.data("original-order");
       const facility_id = $(event.target).val();
 
-      return $.ajax({
+      $.ajax({
         type: "get",
         data: { facility_id, original_order_facility: originalOrderFacility },
-        url,
+        url: productsUrl,
         success(data) {
           // Populate dropdown
           product_field.empty();
@@ -91,6 +94,32 @@ window.MergeOrder = class MergeOrder {
           button.val(buttonText);
 
           return product_field.trigger("change");
+        },
+      });
+
+      return $.ajax({
+        type: "get",
+        data: { order_id: originalOrder },
+        url: accountsUrl,
+        success(data) {
+          // Populate dropdown
+          account_field.empty();
+          data = JSON.parse(data);
+          data.forEach(function (account) {
+            return account_field.append(
+              '<option value="' +
+                account.id +
+                '">' +
+                account.description +
+                " / " +
+                account.account_number +
+                "</option>"
+            );
+          });
+
+          account_field.trigger("chosen:updated");
+
+          return account_field.trigger("change");
         },
       });
     });

--- a/app/assets/javascripts/app/merge_orders.js
+++ b/app/assets/javascripts/app/merge_orders.js
@@ -44,18 +44,18 @@ window.MergeOrder = class MergeOrder {
   initCrossCoreOrdering() {
     if (!this.$form.length) { return; }
 
-    const product_field = this.$form.find(".js--edit-order__product");
-    const facility_field = this.$form.find(".js--edit-order__facility");
-    const account_field = this.$form.find(".js--edit-order__account");
+    const productField = this.$form.find(".js--edit-order__product");
+    const facilityField = this.$form.find(".js--edit-order__facility");
+    const accountField = this.$form.find(".js--edit-order__account");
     const button = this.$form.find(".js--edit-order__button");
 
-    if (!facility_field || !button) return;
+    if (!facilityField || !button) return;
 
     const originalFacilityId = button.data("original-facility");
     const defaultButtonText = button.data("default-button-text");
     const crossCoreButtonText = button.data("cross-core-button-text");
 
-    return facility_field.on("change", (event) => {
+    return facilityField.on("change", (event) => {
       const selectedElement = $(event.target).find(":selected");
       const productsUrl = selectedElement.data("products-path");
       const accountsUrl = selectedElement.data("accounts-path");
@@ -63,7 +63,7 @@ window.MergeOrder = class MergeOrder {
       const originalOrder = selectedElement.data("original-order");
       const facility_id = $(event.target).val();
       const includeBlank = JSON.parse(
-        account_field.data("include-blank")
+        accountField.data("include-blank")
       );
 
       $.ajax({
@@ -72,10 +72,10 @@ window.MergeOrder = class MergeOrder {
         url: productsUrl,
         success(data) {
           // Populate dropdown
-          product_field.empty();
+          productField.empty();
           data = JSON.parse(data);
           data.forEach(function (product) {
-            return product_field.append(
+            return productField.append(
               '<option value="' +
                 product.id +
                 '" data-timed-product="' +
@@ -86,7 +86,7 @@ window.MergeOrder = class MergeOrder {
             );
           });
 
-          product_field.trigger("chosen:updated");
+          productField.trigger("chosen:updated");
 
           // Update button text
           const buttonText =
@@ -96,7 +96,7 @@ window.MergeOrder = class MergeOrder {
 
           button.val(buttonText);
 
-          return product_field.trigger("change");
+          return productField.trigger("change");
         },
       });
 
@@ -106,15 +106,15 @@ window.MergeOrder = class MergeOrder {
         url: accountsUrl,
         success(data) {
           // Populate dropdown
-          account_field.empty();
+          accountField.empty();
           data = JSON.parse(data);
 
           if (includeBlank) {
-            account_field.append('<option value=""></option>');
+            accountField.append('<option value=""></option>');
           }
 
           data.forEach(function (account) {
-            return account_field.append(
+            return accountField.append(
               '<option value="' +
                 account.id +
                 '">' +
@@ -125,9 +125,9 @@ window.MergeOrder = class MergeOrder {
             );
           });
 
-          account_field.trigger("chosen:updated");
+          accountField.trigger("chosen:updated");
 
-          return account_field.trigger("change");
+          return accountField.trigger("change");
         },
       });
     });

--- a/app/controllers/facility_accounts_controller.rb
+++ b/app/controllers/facility_accounts_controller.rb
@@ -12,6 +12,7 @@ class FacilityAccountsController < ApplicationController
   before_action :init_current_facility
   before_action :init_account, except: :search_results
   before_action :build_account, only: [:new, :create]
+  before_action :set_facility_accounts_for_user, only: [:accounts_available_for_order]
 
   authorize_resource :account
 
@@ -119,6 +120,14 @@ class FacilityAccountsController < ApplicationController
     end
   end
 
+  def accounts_available_for_order
+    respond_to do |format|
+      format.js do
+        render json: @facility_accounts_for_user
+      end
+    end
+  end
+
   private
 
   def available_account_types
@@ -156,6 +165,19 @@ class FacilityAccountsController < ApplicationController
       owner_user: @owner_user,
       params: params,
     ).build
+  end
+
+  def set_facility_accounts_for_user
+    order_id = params[:order_id]&.to_i
+
+    return unless order_id
+
+    order = Order.find(order_id)
+
+    return unless order
+
+    order_user = order.user
+    @facility_accounts_for_user = AvailableAccountsFinder.new(order_user, current_facility).accounts
   end
 
 end

--- a/app/controllers/facility_accounts_controller.rb
+++ b/app/controllers/facility_accounts_controller.rb
@@ -168,13 +168,13 @@ class FacilityAccountsController < ApplicationController
   end
 
   def set_facility_accounts_for_user
-    order_id = params[:order_id]&.to_i
+    order_id = params[:order_id]
     order = Order.find(order_id) if order_id
 
     return unless order
 
     order_user = order.user
-    @facility_accounts_for_user = AvailableAccountsFinder.new(order_user, current_facility).accounts
+    @facility_accounts_for_user = AvailableAccountsFinder.new(order_user, current_facility).accounts.map { |a| { id: a.id, label: a.to_s } }
   end
 
 end

--- a/app/controllers/facility_accounts_controller.rb
+++ b/app/controllers/facility_accounts_controller.rb
@@ -169,10 +169,7 @@ class FacilityAccountsController < ApplicationController
 
   def set_facility_accounts_for_user
     order_id = params[:order_id]&.to_i
-
-    return unless order_id
-
-    order = Order.find(order_id)
+    order = Order.find(order_id) if order_id
 
     return unless order
 

--- a/app/controllers/facility_accounts_controller.rb
+++ b/app/controllers/facility_accounts_controller.rb
@@ -171,10 +171,12 @@ class FacilityAccountsController < ApplicationController
     order_id = params[:order_id]
     order = Order.find(order_id) if order_id
 
-    return unless order
-
-    order_user = order.user
-    @facility_accounts_for_user = AvailableAccountsFinder.new(order_user, current_facility).accounts.map { |a| { id: a.id, label: a.to_s } }
+    if order
+      order_user = order.user
+      @facility_accounts_for_user = AvailableAccountsFinder.new(order_user, current_facility).accounts.map { |a| { id: a.id, label: a.to_s } }
+    else
+      @facility_accounts_for_user = []
+    end
   end
 
 end

--- a/app/forms/add_to_order_form.rb
+++ b/app/forms/add_to_order_form.rb
@@ -92,7 +92,9 @@ class AddToOrderForm
         f.id,
         {
           "data-products-path": Rails.application.routes.url_helpers.available_for_cross_core_ordering_facility_products_path(f, format: :js),
+          "data-accounts-path": Rails.application.routes.url_helpers.accounts_available_for_order_facility_accounts_path(f, format: :js),
           "data-original-order-facility": @original_order.facility_id,
+          "data-original-order": @original_order.id,
         }
       ]
     end

--- a/app/forms/add_to_order_form.rb
+++ b/app/forms/add_to_order_form.rb
@@ -82,7 +82,7 @@ class AddToOrderForm
   end
 
   def available_accounts
-    AvailableAccountsFinder.new(original_order.user, current_facility)
+    AvailableAccountsFinder.new(original_order.user, product_facility)
   end
 
   def facilities_options

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -168,7 +168,9 @@ class Ability
   def facility_administrator_abilities(user, resource, controller)
     can :available_for_cross_core_ordering, Product if controller.is_a?(ProductsController)
 
-    can [:accounts_available_for_order, :show], Account if controller.is_a?(FacilityAccountsController)
+    if controller.is_a?(FacilityAccountsController) && user.facility_administrator_of_any_facility?
+      can [:accounts_available_for_order, :show], Account
+    end
 
     if resource.is_a?(PriceGroup) && user.facility_administrator_of?(resource.facility)
       if !resource.global?

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -168,6 +168,8 @@ class Ability
   def facility_administrator_abilities(user, resource, controller)
     can :available_for_cross_core_ordering, Product if controller.is_a?(ProductsController)
 
+    can [:accounts_available_for_order, :show], Account if controller.is_a?(FacilityAccountsController)
+
     if resource.is_a?(PriceGroup) && user.facility_administrator_of?(resource.facility)
       if !resource.global?
         can :manage, [AccountPriceGroupMember, UserPriceGroupMember]

--- a/app/models/concerns/users/roles.rb
+++ b/app/models/concerns/users/roles.rb
@@ -33,6 +33,10 @@ module Users
       end
     end
 
+    def facility_administrator_of_any_facility?
+      user_roles.find { |r| r.role == UserRole::FACILITY_ADMINISTRATOR }.present?
+    end
+
     # Returns relation of facilities for which this user is a director or admin
     def manageable_facilities
       if administrator? || global_billing_administrator?

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -32,20 +32,12 @@
           input_html: { class: "js--chosen" },
           include_blank: false,
           label: OrderDetail.human_attribute_name(:order_status)
-        - if enable_cross_core_changes
-          = f.input :account_id,
-            collection: @add_to_order_form.available_accounts,
-            hint: @order.account.active? ? "" : t(".original_account_inactive", account: @order.account),
-            include_blank: !@order.account.active?,
-            input_html: { class: "js--edit-order__account js--chosen",
-              data: { "include-blank" => !@order.account.active? } }
-        - else
-          = f.input :account_id,
-            collection: @add_to_order_form.available_accounts,
-            include_blank: !@order.account.active?,
-            hint: @order.account.active? ? "" : t(".original_account_inactive", account: @order.account),
-            input_html: { class: "js--chosen" }
-
+        - input_html = enable_cross_core_changes ? { class: "js--edit-order__account js--chosen", data: { "include-blank" => !@order.account.active? } } : { class: "js--chosen" }
+        = f.input :account_id,
+          collection: @add_to_order_form.available_accounts,
+          include_blank: !@order.account.active?,
+          hint: @order.account.active? ? "" : t(".original_account_inactive", account: @order.account),
+          input_html: input_html
 
       = f.input_field :fulfilled_at,
         placeholder: OrderDetail.human_attribute_name(:fulfilled_at),

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -33,12 +33,12 @@
           include_blank: false,
           label: OrderDetail.human_attribute_name(:order_status)
         - if enable_cross_core_changes
-          -# TODO: include_blank and hint should work when data comes from server
           = f.input :account_id,
             collection: @add_to_order_form.available_accounts,
-            include_blank: !@order.account.active?,
             hint: @order.account.active? ? "" : t(".original_account_inactive", account: @order.account),
-            input_html: { class: "js--edit-order__account js--chosen" }
+            include_blank: !@order.account.active?,
+            input_html: { class: "js--edit-order__account js--chosen",
+              data: { "include-blank" => !@order.account.active? } }
         - else
           = f.input :account_id,
             collection: @add_to_order_form.available_accounts,

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -33,6 +33,7 @@
           include_blank: false,
           label: OrderDetail.human_attribute_name(:order_status)
         - if enable_cross_core_changes
+          -# TODO: include_blank and hint should work when data comes from server
           = f.input :account_id,
             collection: @add_to_order_form.available_accounts,
             include_blank: !@order.account.active?,

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -1,7 +1,8 @@
 - if @merge_orders.blank?
   .well
     = simple_form_for [current_facility, @add_to_order_form], url: facility_order_path(current_facility, @order), method: :put, html: { class: "js--edit-order" } do |f|
-      - if SettingsHelper.feature_on?(:cross_core_projects) && can?(:available_for_cross_core_ordering, Product)
+      - enable_cross_core_changes = SettingsHelper.feature_on?(:cross_core_projects) && can?(:available_for_cross_core_ordering, Product)
+      - if enable_cross_core_changes
         = f.label :facility_id, Facility.model_name.human
         = f.input_field :facility_id,
           collection: @add_to_order_form.facilities_options,
@@ -31,11 +32,18 @@
           input_html: { class: "js--chosen" },
           include_blank: false,
           label: OrderDetail.human_attribute_name(:order_status)
-        = f.input :account_id,
-          collection: @add_to_order_form.available_accounts,
-          include_blank: !@order.account.active?,
-          hint: @order.account.active? ? "" : t(".original_account_inactive", account: @order.account),
-          input_html: { class: "js--chosen" }
+        - if enable_cross_core_changes
+          = f.input :account_id,
+            collection: @add_to_order_form.available_accounts,
+            include_blank: !@order.account.active?,
+            hint: @order.account.active? ? "" : t(".original_account_inactive", account: @order.account),
+            input_html: { class: "js--edit-order__account js--chosen" }
+        - else
+          = f.input :account_id,
+            collection: @add_to_order_form.available_accounts,
+            include_blank: !@order.account.active?,
+            hint: @order.account.active? ? "" : t(".original_account_inactive", account: @order.account),
+            input_html: { class: "js--chosen" }
 
 
       = f.input_field :fulfilled_at,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -288,6 +288,10 @@ Rails.application.routes.draw do
       end
 
       resources :orders, controller: "facility_account_orders", only: [:index]
+
+      collection do
+        get :accounts_available_for_order
+      end
     end
 
     ######

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe "Adding to an existing order" do
 
     context "with admin role" do
       let(:user) { create(:user, :facility_administrator, facility:) }
-      let!(:other_account) { create(:account, :with_account_owner, owner: order.user, description: "Other Account", facility: facility2) }
+      let!(:other_account) { create(:account, :with_account_owner, type: "CreditCardAccount", owner: order.user, description: "Other Account", facility: facility2) }
 
       it "changes the button text" do
         expect(page).to have_button("Add To Order")
@@ -292,8 +292,7 @@ RSpec.describe "Adding to an existing order" do
 
         select_from_chosen facility2.name, from: "add_to_order_form[facility_id]"
         select_from_chosen cross_core_product_facility2.name, from: "add_to_order_form[product_id]"
-        # This fails because the account is not valid for the facility
-        # select_from_chosen other_account.to_s, from: "Payment Source"
+        select_from_chosen other_account.to_s, from: "Payment Source"
 
         expect(page.has_selector?("option", text: product2.name, visible: false)).to be(false)
 

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -275,6 +275,7 @@ RSpec.describe "Adding to an existing order" do
 
     context "with admin role" do
       let(:user) { create(:user, :facility_administrator, facility:) }
+      let!(:other_account) { create(:account, :with_account_owner, owner: order.user, description: "Other Account", facility: facility2) }
 
       it "changes the button text" do
         expect(page).to have_button("Add To Order")
@@ -287,10 +288,12 @@ RSpec.describe "Adding to an existing order" do
         expect(page).not_to have_content("Cross Core Project ID")
         expect(page.has_selector?("option", text: cross_core_product_facility.name, visible: false)).to be(true)
         expect(page.has_selector?("option", text: product.name, visible: false)).to be(true)
+        expect(page.has_selector?("option", text: other_account.to_s, visible: false)).to be(false)
 
         select_from_chosen facility2.name, from: "add_to_order_form[facility_id]"
         select_from_chosen cross_core_product_facility2.name, from: "add_to_order_form[product_id]"
-        select_from_chosen other_account.to_s, from: "Payment Source"
+        # This fails because the account is not valid for the facility
+        # select_from_chosen other_account.to_s, from: "Payment Source"
 
         expect(page.has_selector?("option", text: product2.name, visible: false)).to be(false)
 

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -290,6 +290,7 @@ RSpec.describe "Adding to an existing order" do
 
         select_from_chosen facility2.name, from: "add_to_order_form[facility_id]"
         select_from_chosen cross_core_product_facility2.name, from: "add_to_order_form[product_id]"
+        select_from_chosen other_account.to_s, from: "Payment Source"
 
         expect(page.has_selector?("option", text: product2.name, visible: false)).to be(false)
 

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe "Adding to an existing order" do
 
     context "with admin role" do
       let(:user) { create(:user, :facility_administrator, facility:) }
-      let!(:other_account) { create(:account, :with_account_owner, type: "CreditCardAccount", owner: order.user, description: "Other Account", facility: facility2) }
+      let!(:facility2_account) { create(:account, :with_account_owner, type: "CreditCardAccount", owner: order.user, description: "Other Account", facility: facility2) }
 
       it "changes the button text" do
         expect(page).to have_button("Add To Order")
@@ -288,11 +288,11 @@ RSpec.describe "Adding to an existing order" do
         expect(page).not_to have_content("Cross Core Project ID")
         expect(page.has_selector?("option", text: cross_core_product_facility.name, visible: false)).to be(true)
         expect(page.has_selector?("option", text: product.name, visible: false)).to be(true)
-        expect(page.has_selector?("option", text: other_account.to_s, visible: false)).to be(false)
+        expect(page.has_selector?("option", text: facility2_account.to_s, visible: false)).to be(false)
 
         select_from_chosen facility2.name, from: "add_to_order_form[facility_id]"
         select_from_chosen cross_core_product_facility2.name, from: "add_to_order_form[product_id]"
-        select_from_chosen other_account.to_s, from: "Payment Source"
+        select_from_chosen facility2_account.to_s, from: "Payment Source"
 
         expect(page.has_selector?("option", text: product2.name, visible: false)).to be(false)
 


### PR DESCRIPTION
# Release Notes
* When an admin places a cross-core order, update valid payment source list.

# Screenshot
<img width="1185" alt="image" src="https://github.com/tablexi/nucore-open/assets/28798610/3bc964eb-6f83-4b5f-b9f6-c87feeca309e">

<img width="1182" alt="image" src="https://github.com/tablexi/nucore-open/assets/28798610/51b3bd78-2303-4e14-8fb1-61fae645dd45">


# Additional Context

# Accessibility
- [x] Did you scan for accessibility issues?
- [x] Did you check our accessibility goal checklist?
- [ ] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)?
