### PR TITLE
[#162262] Put each cross-core order into a toggle/accordion element

### DIFF
--- a/app/assets/javascripts/app/facility_order_show.js
+++ b/app/assets/javascripts/app/facility_order_show.js
@@ -1,0 +1,22 @@
+window.FacilityOrderShow = class FacilityOrderShow {
+  constructor($accordion) {
+    this.$accordion = $accordion;
+  }
+
+  initAccordion() {
+    if (!this.$accordion.length) {
+      return;
+    }
+
+    this.$accordion.accordion({
+      active: false,
+      heightStyle: "content",
+      collapsible: true,
+    });
+  }
+};
+
+$(function () {
+  const facilityOrderShow = new FacilityOrderShow($("#accordion"));
+  return facilityOrderShow.initAccordion();
+});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,6 +3,7 @@
 
 //= require jquery
 //= require jquery_ujs
+//= require jquery-ui/widgets/accordion
 //= require jquery-ui/widgets/datepicker
 //= require jquery-ui/widgets/tabs
 //= require jquery-ui/effect

--- a/app/assets/stylesheets/app/accordion.scss
+++ b/app/assets/stylesheets/app/accordion.scss
@@ -10,4 +10,9 @@
   .ui-widget-content {
     border: none;
   }
+
+  .ui-accordion-header {
+    font-size: 20px;
+    padding: 0;
+  }
 }

--- a/app/assets/stylesheets/app/accordion.scss
+++ b/app/assets/stylesheets/app/accordion.scss
@@ -1,0 +1,13 @@
+#accordion {
+  margin-bottom: 2em;
+
+  .ui-state-default, .ui-state-hover, .ui-state-active {
+    background: none;
+    border: none;
+    color: black;
+  }
+
+  .ui-widget-content {
+    border: none;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,6 +13,7 @@ $secondaryColor: #005B8A;
 @import "nucore-overrides";
 @import "nucore";
 
+@import "app/accordion";
 @import "app/typography";
 @import "app/reservation_edit";
 @import "app/header";

--- a/app/views/facility_orders/show.html.haml
+++ b/app/views/facility_orders/show.html.haml
@@ -29,6 +29,7 @@
   = render "order_table", order_details: @order_details, cross_core: false
   = render "order_table_footer", order: @order, cross_core: false
 
+%h2= t("views.facility_orders.show.cross_core_orders_header")
 - if SettingsHelper.feature_on?(:cross_core_projects) && @cross_core_order_details_by_facility.present?
   #accordion
     - @cross_core_order_details_by_facility.each do |facility, order_details|

--- a/app/views/facility_orders/show.html.haml
+++ b/app/views/facility_orders/show.html.haml
@@ -30,12 +30,13 @@
   = render "order_table_footer", order: @order, cross_core: false
 
 - if SettingsHelper.feature_on?(:cross_core_projects) && @cross_core_order_details_by_facility.present?
-  - @cross_core_order_details_by_facility.each do |facility, order_details|
-    %h3= facility
-    %table.order-list.table.table-striped.table-hover
-      = render "order_table_headers", cross_core: true
-      = render "order_table", order_details: order_details, cross_core: true
-      = render "order_table_footer", order: @cross_core_orders_by_facility[facility], cross_core: true
+  #accordion
+    - @cross_core_order_details_by_facility.each do |facility, order_details|
+      %h3= facility
+      %table.order-list.table.table-striped.table-hover
+        = render "order_table_headers", cross_core: true
+        = render "order_table", order_details: order_details, cross_core: true
+        = render "order_table_footer", order: @cross_core_orders_by_facility[facility], cross_core: true
 
 - if current_ability.can?(:update, Order)
   = render "merge_order_form"

--- a/config/locales/views/en.facility_orders.yml
+++ b/config/locales/views/en.facility_orders.yml
@@ -2,6 +2,7 @@ en:
   views:
     facility_orders:
       show:
+        cross_core_orders_header: "Cross-Core Orders"
         cross_core_project_id: "Cross-Core Project ID"
         cross_core_project_total: "Cross-Core Project Total"
         table_caption: "Order detail information"


### PR DESCRIPTION
# Release Notes
- Put each cross-core order into a toggle/accordion element, which will be closed when the user first visits the page
- Add a Header that says “Cross Core Orders” to separate them from the “original” order

# Screenshot
## Initial
![localhost_3000_facilities_example_orders_279 (7)](https://github.com/tablexi/nucore-open/assets/28798610/26c1eab0-3c0a-4ede-8188-931bf6313e77)

## One open
![localhost_3000_facilities_example_orders_279 (8)](https://github.com/tablexi/nucore-open/assets/28798610/77d24bb3-c6b4-48e3-bde7-ca37dffcf66c)


# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".

# Accessibility
- [ ] Did you scan for accessibility issues?
- [ ] Did you check our accessibility goal checklist?
- [ ] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)?
