### PR TITLE
[#162176] Make it harder to ignore missing forms

### DIFF
--- a/app/assets/stylesheets/app/order_management.scss
+++ b/app/assets/stylesheets/app/order_management.scss
@@ -187,6 +187,8 @@ table.order-list {
 }
 
 .label {
+  font-size: 1.4em;
+  font-weight: 300;
   &.status-complete,
   &.status-reconciled {
     @extend .label-success;

--- a/app/views/facility_orders/_merge_order.html.haml
+++ b/app/views/facility_orders/_merge_order.html.haml
@@ -1,6 +1,8 @@
 - if @merge_orders.present?
+  = render "merge_order_missing_form_reminder"
   .well
-    %p.alert.alert-info= t("facility_orders.edit.attention")
+    %p.alert.alert-error
+      = t("facility_orders.edit.attention_html")
     %table.table.table-striped.table-hover
       %thead
         %tr

--- a/app/views/facility_orders/_merge_order.html.haml
+++ b/app/views/facility_orders/_merge_order.html.haml
@@ -6,7 +6,7 @@
     %table.table.table-striped.table-hover
       %thead
         %tr
-          %th
+          %th= t("facility_orders.edit.actions")
           %th= OrderDetail.human_attribute_name(:product)
           %th.centered= OrderDetail.human_attribute_name(:quantity)
           %th.currency= OrderDetail.human_attribute_name(:estimated_cost)

--- a/app/views/facility_orders/_merge_order_missing_form_reminder.html.haml
+++ b/app/views/facility_orders/_merge_order_missing_form_reminder.html.haml
@@ -1,0 +1,11 @@
+#merge-order-missing-form-reminder.modal.hide.fade{ data: { backdrop: "static" } }
+  .modal-header
+    = modal_close_button
+    %h3= text("facility_orders.edit.missing_form_modal.header")
+  .modal-body
+    %p.alert.alert-error
+      = t("facility_orders.edit.missing_form_modal.body_html")
+  .modal-footer
+    %button.btn{ type: "button", data: { dismiss: "modal" } }= text("facility_orders.edit.missing_form_modal.ok")
+
+= javascript_tag "$('#merge-order-missing-form-reminder').modal('show');"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -400,7 +400,17 @@ en:
     index:
       no_new_or_inprocess_orders: There are no "New" or "In Process" orders.
     edit:
-      attention: "The following order details need your attention. Before you can add to this order you need to address them."
+      missing_form_modal:
+        header: Action Required - Missing Form
+        body_html: |
+          Your order includes order details that have not been added successfully. <br>
+          Before you can add anything else to this order you need to address them. <br>
+          Please click the "Complete Online Order Form" button below to complete the form (required).
+        ok: OK
+      attention_html: |
+        Your order includes order details that have not been added successfully. <br>
+        Before you can add anything else to this order you need to address them. <br>
+        Please click the button below to complete the form (required).
       head:
         h1: "Summary Of Order #%{order_number}"
         h2: "Order Detail #%{order_number}"
@@ -1330,5 +1340,5 @@ en:
     calendar_tooltip: Calendar file download
     summary: "%{facility}: %{product}"
     description: "%{facility} reservation for %{product}. Order number %{order_number}."
-  
+
   timed_service_hint: The number of timed services, not time per service. Time can be adjusted in cart.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -403,12 +403,12 @@ en:
       missing_form_modal:
         header: Action Required - Missing Form
         body_html: |
-          Your order includes order details that have not been added successfully. <br>
+          Your order includes order details that need your attention. <br>
           Before you can add anything else to this order you need to address them. <br>
           Please click the "Complete Online Order Form" button below to complete the form (required).
         ok: OK
       attention_html: |
-        Your order includes order details that have not been added successfully. <br>
+        Your order includes order details that need your attention. <br>
         Before you can add anything else to this order you need to address them. <br>
         Please click the button below to complete the form (required).
       head:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -400,6 +400,7 @@ en:
     index:
       no_new_or_inprocess_orders: There are no "New" or "In Process" orders.
     edit:
+      actions: Actions
       missing_form_modal:
         header: Action Required - Missing Form
         body_html: |

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -331,7 +331,7 @@ RSpec.describe "Adding to an existing order" do
         expect(page.has_selector?("option", text: product.name, visible: false)).to be(true)
         expect(page.has_selector?("option", text: facility2_account.to_s, visible: false)).to be(false)
 
-        select_from_chosen facility2.name, from: "add_to_order_form[facility_id]"
+        select_from_chosen facility2.name, from: "add_to_order_form[facility_id]", scroll_to: :center
         select_from_chosen cross_core_product_facility2.name, from: "add_to_order_form[product_id]"
         select_from_chosen facility2_account.to_s, from: "Payment Source"
 

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -181,6 +181,11 @@ RSpec.describe "Adding to an existing order" do
         click_button "Add To Order"
       end
 
+      it "is accessible" do
+        click_button "OK"
+        expect(page).to be_axe_clean
+      end
+
       it "requires a reservation to be set up before adding to the order" do
         expect(page).to have_content("Your order includes order details that need your attention.")
 

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "Adding to an existing order" do
     end
 
     it "requires a file to be uploaded before adding to the order" do
-      expect(page).to have_content("The following order details need your attention.")
+      expect(page).to have_content("Your order includes order details that need your attention.")
     end
 
     describe "after uploading the file" do
@@ -151,7 +151,7 @@ RSpec.describe "Adding to an existing order" do
       end
 
       it "requires a reservation to be set up before adding to the order" do
-        expect(page).to have_content("The following order details need your attention.")
+        expect(page).to have_content("Your order includes order details that need your attention.")
 
         click_link "Make a Reservation"
         click_button "Create"
@@ -182,8 +182,9 @@ RSpec.describe "Adding to an existing order" do
       end
 
       it "requires a reservation to be set up before adding to the order" do
-        expect(page).to have_content("The following order details need your attention.")
+        expect(page).to have_content("Your order includes order details that need your attention.")
 
+        click_button "OK"
         click_link "Make a Reservation"
         click_button "Create"
 
@@ -192,6 +193,7 @@ RSpec.describe "Adding to an existing order" do
       end
 
       it "brings you back to the facility order path on 'Cancel'" do
+        click_button "OK"
         click_link "Make a Reservation"
         click_link "Cancel"
 
@@ -216,8 +218,9 @@ RSpec.describe "Adding to an existing order" do
         end
 
         it "requires a reservation to be set up before adding to the order" do
-          expect(page).to have_content("The following order details need your attention.")
+          expect(page).to have_content("Your order includes order details that need your attention.")
 
+          click_button "OK"
           click_link "Make a Reservation"
           click_button "Create"
 
@@ -228,6 +231,7 @@ RSpec.describe "Adding to an existing order" do
         end
 
         it "brings you back to the facility order path on 'Cancel'" do
+          click_button "OK"
           click_link "Make a Reservation"
           click_link "Cancel"
 
@@ -260,6 +264,7 @@ RSpec.describe "Adding to an existing order" do
           # This is the second order for this facility so it has a merge_order set
           expect(project.reload.orders.last.merge_with_order_id).to eq(second_facility_order.id)
 
+          click_button "OK"
           click_link "Make a Reservation"
           click_button "Create"
 


### PR DESCRIPTION
# Release Notes

- Make the warning message red
- Make the warning message clearer
- Add the warning message to a modal that appears when page is loaded

# Screenshot

## Before
![Screenshot 2024-05-01 at 3 25 02 PM](https://github.com/tablexi/nucore-open/assets/30355046/4ef38a95-fbbf-4c35-94ef-5def48adb99c)

## After
<img width="1542" alt="Screenshot 2024-05-02 at 8 05 54 AM" src="https://github.com/tablexi/nucore-open/assets/30355046/c4504708-58fc-48ac-8917-18cf8c8d67b5">
<img width="1527" alt="Screenshot 2024-05-02 at 8 09 02 AM" src="https://github.com/tablexi/nucore-open/assets/30355046/eac9dc1e-9b29-4dc9-9d5c-f2987a78a07b">

# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".

# Accessibility
- [x] Did you scan for accessibility issues?
- [x] Did you check our accessibility goal checklist?
- [x] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)?
