### PR TITLE
[#162253] Fix redirect path after SSO login

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,4 +2,12 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: "_nucore_session"
+ssl = Rails.application.config.force_ssl
+
+Rails.application.config.session_store(
+  :cookie_store,
+  key: "_nucore_session",
+  httponly: true,
+  secure: ssl,
+  same_site: (ssl ? :none : :lax)
+)


### PR DESCRIPTION
Set same_site to :none so that we pass along the originating url when making the SAML request

The return_to path was already being included in the cookie, but this was not being sent to the IdP because the default is SameSite=Lax

For more info:
https://support.okta.com/help/s/article/FAQ-How-Chrome-80-Update-for-SameSite-by-default-Potentially-Impacts-Your-Okta-Environment?language=en_US "...the new default will be SameSite=Lax, and cookies that need to work cross-site must be explicitly labeled with a new SameSite=None attribute value. Additionally this will require HTTPS (not plaintext HTTP) because browsers will ignore the SameSite=None attribute unless it is accompanied by the Secure attribute."
