### PR TITLE
[#162193] Add clearer secondary outlet message

### DIFF
--- a/app/controllers/instrument_relays_controller.rb
+++ b/app/controllers/instrument_relays_controller.rb
@@ -36,10 +36,9 @@ class InstrumentRelaysController < ApplicationController
   private
 
   def handle_relay(action_string)
-    previous_secondary_outlet = @product.relay.secondary_outlet
     @relay = @product.replace_relay(relay_params, params[:relay][:control_mechanism])
     if @relay.valid?
-      @relay.try(:activate_secondary_outlet) if @relay.secondary_outlet != previous_secondary_outlet
+      @relay.try(:activate_secondary_outlet)
       flash[:notice] = "Relay was successfully updated."
       redirect_to facility_instrument_relays_path(current_facility, @product)
     else

--- a/app/controllers/instrument_relays_controller.rb
+++ b/app/controllers/instrument_relays_controller.rb
@@ -36,8 +36,10 @@ class InstrumentRelaysController < ApplicationController
   private
 
   def handle_relay(action_string)
+    previous_secondary_outlet = @product.relay.secondary_outlet
     @relay = @product.replace_relay(relay_params, params[:relay][:control_mechanism])
     if @relay.valid?
+      @relay.try(:activate_secondary_outlet) if @relay.secondary_outlet != previous_secondary_outlet
       flash[:notice] = "Relay was successfully updated."
       redirect_to facility_instrument_relays_path(current_facility, @product)
     else

--- a/app/models/power_relay.rb
+++ b/app/models/power_relay.rb
@@ -36,7 +36,6 @@ module PowerRelay
       toggled_status = relay_connection.toggle(outlet, status)
       if secondary_outlet
         secondary_toggled_status = relay_connection.toggle(secondary_outlet, status)
-        handle_mismatch_status(status, toggled_status) if toggled_status != secondary_toggled_status
       end
       toggled_status
     end
@@ -49,22 +48,9 @@ module PowerRelay
       relay_status = relay_connection.status(outlet)
       if secondary_outlet
         secondary_outlet_status = relay_connection.status(secondary_outlet)
-        handle_mismatch_status if relay_status != secondary_outlet_status
       end
       relay_status
     end
-  end
-
-  # Returns:
-  # string - an error
-  def handle_mismatch_status(requested_status=nil, primary_status=nil)
-    event = if requested_status.present?
-      "toggling relays (#{requested_status ? "on" : "off"})"
-    else
-      "querying status"
-    end
-    msg = "Outlet statuses don't match after #{event} for relay #{id} - outlet #{outlet} is (#{primary_status ? "on" : "off"}), outlet #{secondary_outlet} is (#{primary_status ? "off" : "on"})"
-    Rollbar.error(msg, relay: id)
   end
 
   def relay_connection

--- a/app/models/power_relay.rb
+++ b/app/models/power_relay.rb
@@ -41,6 +41,13 @@ module PowerRelay
     end
   end
 
+  # This method will toggle the secondary outlet to match the primary outlet.
+  # Useful to sync up the outlets whenever the secondary outlet changes.
+  def activate_secondary_outlet
+    primary_outlet_status = relay_connection.status(outlet)
+    relay_connection.toggle(secondary_outlet, primary_outlet_status)
+  end
+
   # Returns:
   # boolean - The current on/off status of the outlet (and secondary outlet, if configured).
   def query_status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1194,7 +1194,9 @@ en:
         instruct:
           ip_port: "Leave blank unless your device is on a non-standard port"
           outlet: "e.g. 1 or 2"
-          secondary_outlet: "turned on/off in sync with the outlet above (Synaccess only)"
+          secondary_outlet: |
+            This outlet will be turned on/off in sync with the outlet above (Synaccess only). <br>
+            If you enter a value in this field, you must toggle the relay to activate.
       reservation:
         instruct:
           reserve_interval: "The minutes of an hour on which a reservation is allowed to begin (e.g. if 5 reservations can be scheduled every 5 minutes)"

--- a/spec/system/admin/instrument_relay_tab_spec.rb
+++ b/spec/system/admin/instrument_relay_tab_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Instrument Relay Tab" do
   let(:user) { FactoryBot.create(:user, :administrator) }
 
   before do
+    allow_any_instance_of(RelaySynaccessRevA).to receive(:activate_secondary_outlet).and_return(true)
     login_as user
     visit facility_instrument_relays_path(facility, instrument)
   end
@@ -104,7 +105,7 @@ RSpec.describe "Instrument Relay Tab" do
           fill_in "relay_building_room_number", with: "1a"
           fill_in "relay_circuit_number", with: "1"
           fill_in "relay_ethernet_port_number", with: "2000"
-  
+
           click_button "Save"
           instrument.reload
           expect(instrument.relay).to be_present
@@ -136,7 +137,7 @@ RSpec.describe "Instrument Relay Tab" do
           click_button "Save"
           expect(page).to have_content("Outlet has already been taken")
         end
-        
+
         context "both instruments have the same schedule" do
           let!(:instrument2) { create(:instrument, facility: facility, no_relay: true, schedule: instrument.schedule) }
           let!(:existing_relay) { create(:relay_syna, instrument: instrument2) }
@@ -199,7 +200,7 @@ RSpec.describe "Instrument Relay Tab" do
 
   context "switching relay types" do
     let(:instrument) { FactoryBot.create(:setup_instrument, facility: facility, relay: build(:relay)) }
-    
+
     before do
       click_link "Edit"
     end
@@ -213,7 +214,7 @@ RSpec.describe "Instrument Relay Tab" do
 
         expect(instrument.relay).to be_a(RelayDummy)
       end
-      
+
     end
 
     context "from relay to reservation only" do
@@ -226,7 +227,7 @@ RSpec.describe "Instrument Relay Tab" do
 
         expect(instrument.relay).not_to be_present
       end
-      
+
     end
 
     context "from reservation only to timer" do


### PR DESCRIPTION
# Release Notes

- Improve hint message
- Remove noisy rollbar logging
- I went ahead and added logic to automatically sync up the outlets as well since it seemed pretty straightforward

# Screenshot

![Screenshot 2024-05-02 at 9 53 41 PM](https://github.com/tablexi/nucore-open/assets/30355046/39efd640-f53a-4945-972e-5119192e4667)


# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".

# Accessibility
- [ ] Did you scan for accessibility issues?
- [ ] Did you check our accessibility goal checklist?
- [ ] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)?
