### PR TITLE
[#162263] Fix Payment Sources list in Reservation form

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -406,7 +406,7 @@ class ReservationsController < ApplicationController
 
     return if @order.cross_core_project_id.nil?
 
-    @accounts_for_cross_core_project = AvailableAccountsFinder.new(original_project_order.user, original_project_order.facility)
+    @accounts_for_cross_core_project = AvailableAccountsFinder.new(original_project_order.user, @order.facility)
   end
 
   def original_project_order

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -212,6 +212,7 @@ RSpec.describe "Adding to an existing order" do
       let(:product) { create(:setup_item, :with_facility_account) }
       let!(:instrument) { create(:setup_instrument, facility: facility2, cross_core_ordering_available: true) }
       let(:user) { create(:user, :facility_administrator, facility:) }
+      let!(:facility2_account) { create(:account, :with_account_owner, type: "CreditCardAccount", owner: order.user, description: "Other Account", facility: facility2) }
 
       describe "with one reservation" do
         before do
@@ -219,6 +220,7 @@ RSpec.describe "Adding to an existing order" do
           select_from_chosen facility2.name, from: "add_to_order_form[facility_id]"
           select_from_chosen instrument.name, from: "add_to_order_form[product_id]"
           fill_in "add_to_order_form[quantity]", with: "1"
+          select_from_chosen facility2_account.to_s, from: "Payment Source", scroll_to: :center
           click_button "Add to Cross-Core Order"
         end
 
@@ -227,12 +229,14 @@ RSpec.describe "Adding to an existing order" do
 
           click_button "OK"
           click_link "Make a Reservation"
+          select facility2_account.to_s, from: "Payment Source"
           click_button "Create"
 
           expect(order.reload.order_details.count).to be(1)
           project = order.cross_core_project
           expect(project).to be_present
           expect(project.orders.last.order_details.last.product).to eq(instrument)
+          expect(project.orders.last.account_id).to eq(facility2_account.id)
         end
 
         it "brings you back to the facility order path on 'Cancel'" do


### PR DESCRIPTION
# Release Notes
* Payment Sources list in Reservation form for Cross-Core orders to only include the ones available for the instrument's facility.

# Screenshot

Optional.

# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".

# Accessibility
- [ ] Did you scan for accessibility issues?
- [ ] Did you check our accessibility goal checklist?
- [ ] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)?
