### PR TITLE
[#162275 Make the SciShield backup layer more resilient

### DIFF
--- a/app/services/research_safety_adapters/scishield_training_synchronizer.rb
+++ b/app/services/research_safety_adapters/scishield_training_synchronizer.rb
@@ -41,7 +41,10 @@ module ResearchSafetyAdapters
       # Test API responses for 10 random users
       users.sample(batch_size).map do |user|
         sleep(batch_sleep_time / 2)
-        api_client.invalid_response?(user.email)
+        puts "Testing user: #{user.email}"
+        response_is_invalid = api_client.invalid_response?(user.email)
+        puts "Invalid response: #{response_is_invalid}"
+        response_is_invalid
       end.all?
     end
 

--- a/app/services/research_safety_adapters/scishield_training_synchronizer.rb
+++ b/app/services/research_safety_adapters/scishield_training_synchronizer.rb
@@ -40,7 +40,7 @@ module ResearchSafetyAdapters
     def api_unavailable?
       retries = 0
       begin
-        # Test API responses for 10 random users
+        # Test API responses for `batch_size` random users
         users.sample(batch_size).map do |user|
           puts "Testing user: #{user.email}"
           response_is_invalid = api_client.invalid_response?(user.email)
@@ -74,8 +74,9 @@ module ResearchSafetyAdapters
       puts batch_size
       total_batches = users.size / batch_size
       puts "#{total_batches} batches to be processed"
-      batch_number = 1
+      batch_number = 0
       users.in_batches(of: batch_size) do |user_batch|
+        batch_number += 1
         puts "starting batch #{batch_number} of #{total_batches}"
         sleep(batch_sleep_time)
 

--- a/app/services/research_safety_adapters/scishield_training_synchronizer.rb
+++ b/app/services/research_safety_adapters/scishield_training_synchronizer.rb
@@ -65,7 +65,7 @@ module ResearchSafetyAdapters
         sleep(batch_sleep_time)
 
         user_batch.each do |user|
-          adapter = ScishieldApiAdapter.new(user, api_client)
+          adapter = ScishieldApiAdapter.new(user)
           retries = 0
           retry_sleep_time = batch_sleep_time
 

--- a/app/services/research_safety_adapters/scishield_training_synchronizer.rb
+++ b/app/services/research_safety_adapters/scishield_training_synchronizer.rb
@@ -53,7 +53,13 @@ module ResearchSafetyAdapters
       # to make the API work in most cases where this is a problem. `sleep`
       # is put first here because `api_unavailable?` will have already made
       # 10 API requests.
+      puts users.size
+      puts batch_size
+      total_batches = users.size / batch_size
+      puts "#{total_batches} batches to be processed"
+      batch_number = 1
       users.in_batches(of: batch_size) do |user_batch|
+        puts "starting batch #{batch_number} of #{total_batches}"
         sleep(batch_sleep_time)
 
         user_batch.each do |user|

--- a/app/services/research_safety_adapters/scishield_training_synchronizer.rb
+++ b/app/services/research_safety_adapters/scishield_training_synchronizer.rb
@@ -40,7 +40,6 @@ module ResearchSafetyAdapters
     def api_unavailable?
       # Test API responses for 10 random users
       users.sample(batch_size).map do |user|
-        sleep(batch_sleep_time / 2)
         puts "Testing user: #{user.email}"
         response_is_invalid = api_client.invalid_response?(user.email)
         puts "Invalid response: #{response_is_invalid}"

--- a/spec/system/research_safety/scishield/scishield_timeout_spec.rb
+++ b/spec/system/research_safety/scishield/scishield_timeout_spec.rb
@@ -18,6 +18,23 @@ RSpec.describe "Scishield timeout", safety_adapter_class: ResearchSafetyAdapters
     )
   end
 
+  describe "api_unavailable?" do
+    before do
+      # Raise a Net::OpenTimeout error when calling ScishieldApiClient#invalid_response?
+      allow_any_instance_of(ResearchSafetyAdapters::ScishieldApiClient).to(
+        receive(:invalid_response?).and_raise(Net::OpenTimeout)
+      )
+      # We just want to test the retry logic, so we'll set the retry_max to 2
+      allow_any_instance_of(ResearchSafetyAdapters::ScishieldTrainingSynchronizer).to(
+        receive(:retry_max).and_return(2)
+      )
+    end
+
+    it "returns true instead of failing with a Net::OpenTimeout error" do
+      expect(ResearchSafetyAdapters::ScishieldTrainingSynchronizer.new.api_unavailable?).to be true
+    end
+  end
+
   describe "Net::OpenTimeout errors when the user does not have a ScishieldTraining record" do
     before do
       # This will cause ResearchSafetyAdapters::ScishieldApiClient#certifications_for

--- a/spec/system/research_safety/scishield/scishield_timeout_spec.rb
+++ b/spec/system/research_safety/scishield/scishield_timeout_spec.rb
@@ -18,35 +18,37 @@ RSpec.describe "Scishield timeout", safety_adapter_class: ResearchSafetyAdapters
     )
   end
 
-  before do
-    # This will cause ResearchSafetyAdapters::ScishieldApiClient#certifications_for
-    # to raise ResearchSafetyAdapters::ScishieldApiError
-    allow_any_instance_of(ResearchSafetyAdapters::ScishieldApiClient).to(
-      receive(:training_api_request).and_raise(Net::OpenTimeout)
-    )
-  end
-
-  describe "viewing a user's certificates" do
+  describe "Net::OpenTimeout errors when the user does not have a ScishieldTraining record" do
     before do
-      login_as admin
-      visit facility_user_user_research_safety_certifications_path Facility.cross_facility, user
+      # This will cause ResearchSafetyAdapters::ScishieldApiClient#certifications_for
+      # to raise ResearchSafetyAdapters::ScishieldApiError
+      allow_any_instance_of(ResearchSafetyAdapters::ScishieldApiClient).to(
+        receive(:training_api_request).and_raise(Net::OpenTimeout)
+      )
     end
 
-    it "displays an error on the page" do
-      expect(page).to have_content I18n.t("services.research_safety_adapters.scishield_api_client.request_failed")
-    end
-  end
+    describe "viewing a user's certificates" do
+      before do
+        login_as admin
+        visit facility_user_user_research_safety_certifications_path Facility.cross_facility, user
+      end
 
-  describe "making a reservation" do
-    before do
-      login_as user
-      visit facility_path(facility)
-      click_link instrument.name
+      it "displays an error on the page" do
+        expect(page).to have_content I18n.t("services.research_safety_adapters.scishield_api_client.request_failed")
+      end
     end
 
-    it "displays an error on the page" do
-      click_button "Create"
-      expect(page).to have_content I18n.t("services.research_safety_adapters.scishield_api_client.request_failed")
+    describe "making a reservation" do
+      before do
+        login_as user
+        visit facility_path(facility)
+        click_link instrument.name
+      end
+
+      it "displays an error on the page" do
+        click_button "Create"
+        expect(page).to have_content I18n.t("services.research_safety_adapters.scishield_api_client.request_failed")
+      end
     end
   end
 end


### PR DESCRIPTION
# Release Notes

We're seeing frequent and inconsistent Net::OpenTimeout errors that are causing `api_unavailable?` to fail, preventing the sync task from running.
By making `api_unavailable?` more resilient, we have a better chance of keeping the backup layer more up to date.
We are in communication with SciShield customer service as well to see if they can help identify the root cause.