### PR TITLE
[#162289] Update label styling

### DIFF
--- a/app/assets/stylesheets/app/order_management.scss
+++ b/app/assets/stylesheets/app/order_management.scss
@@ -187,8 +187,9 @@ table.order-list {
 }
 
 .label {
-  font-size: 1.4em;
+  font-size: 1.0em;
   font-weight: 300;
+  background-color: $grayDark;
   &.status-complete,
   &.status-reconciled {
     @extend .label-success;
@@ -197,6 +198,11 @@ table.order-list {
   &.status-canceled {
     @extend .label-important;
   }
+
+}
+
+.label-warning {
+  background-color: $errorText;
 }
 
 .updating-message {

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -246,7 +246,7 @@ th.hourly_rate {
   }
 
   .reconcile-note {
-    color:#dbbfc6;
+    color:#d8305d;
   }
 
   tr.reconcile-warning td {


### PR DESCRIPTION
# Release Notes

Makes font size consistent with other text on the page
Makes background colors darker to maintain color contrast ratio

# Screenshot
Before:
<img width="1322" alt="Previous styling with larger font" src="https://github.com/tablexi/nucore-open/assets/30355046/a2941ed7-7674-44cb-9a99-1da5b2385521">

Now:
![Screenshot 2024-05-15 at 8 39 14 PM](https://github.com/tablexi/nucore-open/assets/30355046/6517beb4-4b03-4c76-9a1b-38279f5ebb19)

Also made the word "red" more red to bring the contrast ratio into compliance =:

![Screenshot 2024-05-15 at 8 57 19 PM](https://github.com/tablexi/nucore-open/assets/30355046/99b850c9-9534-4949-baa8-760b22e767da)

# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".

# Accessibility
- [x] Did you scan for accessibility issues?
- [x] Did you check our accessibility goal checklist?
- [x] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)?
