### PR TITLE
[#162293] Only update secondary outlet when we have a secondary outlet to set

### DIFF
--- a/app/controllers/instrument_relays_controller.rb
+++ b/app/controllers/instrument_relays_controller.rb
@@ -38,7 +38,7 @@ class InstrumentRelaysController < ApplicationController
   def handle_relay(action_string)
     @relay = @product.replace_relay(relay_params, params[:relay][:control_mechanism])
     if @relay.valid?
-      @relay.try(:activate_secondary_outlet)
+      @relay.try(:activate_secondary_outlet) if @relay.secondary_outlet.present?
       flash[:notice] = "Relay was successfully updated."
       redirect_to facility_instrument_relays_path(current_facility, @product)
     else

--- a/spec/system/admin/instrument_relay_tab_spec.rb
+++ b/spec/system/admin/instrument_relay_tab_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe "Instrument Relay Tab" do
   let(:user) { FactoryBot.create(:user, :administrator) }
 
   before do
-    allow_any_instance_of(RelaySynaccessRevA).to receive(:activate_secondary_outlet).and_return(true)
     login_as user
     visit facility_instrument_relays_path(facility, instrument)
   end
@@ -29,6 +28,7 @@ RSpec.describe "Instrument Relay Tab" do
       end
 
       it "saves a new relay" do
+        expect_any_instance_of(RelaySynaccessRevA).to receive(:activate_secondary_outlet).and_return(true)
         select "Timer with relay", from: "Control mechanism"
         fill_in "relay_ip", with: "123.456.789"
         fill_in "relay_ip_port", with: "1234"
@@ -94,6 +94,7 @@ RSpec.describe "Instrument Relay Tab" do
         let(:user) { FactoryBot.create(:user, :facility_director, facility: facility) }
 
         it "saves a new relay" do
+          expect_any_instance_of(RelaySynaccessRevA).to receive(:activate_secondary_outlet).and_return(true)
           select "Timer with relay", from: "Control mechanism"
           fill_in "relay_ip", with: "123.456.789"
           fill_in "relay_ip_port", with: "1234"
@@ -143,6 +144,8 @@ RSpec.describe "Instrument Relay Tab" do
           let!(:existing_relay) { create(:relay_syna, instrument: instrument2) }
 
           it "saves the relay" do
+            # existing relay has no secondary outlet, so this should not be called
+            expect_any_instance_of(RelaySynaccessRevA).not_to receive(:activate_secondary_outlet)
             select "Timer with relay", from: "Control mechanism"
             select "Synaccess Revision A", from: "Relay Type"
             fill_in "relay_ip", with: existing_relay.ip
@@ -171,6 +174,7 @@ RSpec.describe "Instrument Relay Tab" do
     end
 
     it "can be saved" do
+      expect_any_instance_of(RelaySynaccessRevA).to receive(:activate_secondary_outlet).and_return(true)
       select "Timer with relay", from: "Control mechanism"
       fill_in "relay_ip", with: "123.456.789"
       fill_in "relay_ip_port", with: "1234"


### PR DESCRIPTION
# Release Notes

Addresses:
```
A TypeError occurred in instrument_relays#update:

  no implicit conversion of nil into Integer
  app/models/power_relay.rb:48:in `activate_secondary_outlet'
```