### PR TITLE
[Shared dev] [#162175] Show price group in orders table

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -966,6 +966,14 @@ class OrderDetail < ApplicationRecord
     end
   end
 
+  def estimated_price_group_name
+    return if account && !product.facility.can_pay_with_account?(account)
+
+    estimated_price_policy = product.cheapest_price_policy(self, fulfilled_at || Time.current)
+
+    estimated_price_policy&.price_group&.name
+  end
+
   private
 
   # Is there enough information to move an associated order to complete/problem?

--- a/app/presenters/order_detail_presenter.rb
+++ b/app/presenters/order_detail_presenter.rb
@@ -45,6 +45,10 @@ class OrderDetailPresenter < SimpleDelegator
     facility_order_path(facility, order)
   end
 
+  def price_group_name
+    price_group&.name || estimated_price_group_name
+  end
+
   private
 
   # Is a fulfilled order detail nearing the end of the 90 day reconcile period?

--- a/app/views/facility_orders/index.html.haml
+++ b/app/views/facility_orders/index.html.haml
@@ -38,6 +38,7 @@
         %tbody
           - @order_details.each do |od|
             %tr
+              - order_detail = OrderDetailPresenter.new(od)
               %td.centered= check_box_tag("order_detail_ids[]", od.id, false, {class: "toggle", id: nil })
               %td.centered= link_to od.order_id, facility_order_path(current_facility, od.order)
               %td.centered= link_to od.id, manage_order_detail_path(od), class: "manage-order-detail"
@@ -45,16 +46,16 @@
                 %td= od.order.created_by_user.full_name
               %td= od.order.user.full_name
               %td= format_usa_datetime(od.ordered_at)
-              %td.centered= OrderDetailPresenter.new(od).wrapped_quantity
+              %td.centered= order_detail.wrapped_quantity
               = render partial: "shared/order_detail_cell", locals: { od: od }
               - if cross_core_order_view_enabled
                 %td= render "shared/cross_core_facility_abbreviation_order_details", order_detail: od, current_facility: current_facility
               %td= od.assigned_user
               %td= od.order_status
               %td.currency
-                =  OrderDetailPresenter.new(od).wrapped_total
+                =  order_detail.wrapped_total
               - if cross_core_order_view_enabled
-                %td= od.price_group&.name || od.estimated_price_group_name
+                %td= order_detail.price_group_name
         = render partial: "table_controls"
 
     = will_paginate(@order_details)

--- a/app/views/facility_orders/index.html.haml
+++ b/app/views/facility_orders/index.html.haml
@@ -33,6 +33,8 @@
             %th.nowrap= sortable "status"
             - # OrderDetail.human_attribute_name(:actual_cost) returns "Price".  Despite the :actual_ prefix, these order details are new/in process, so most will have estimated costs, but could be actual or unassigned.
             %th.nowrap.currency= OrderDetail.human_attribute_name(:actual_cost)
+            - if cross_core_order_view_enabled
+              %th.nowrap= PriceGroup.model_name.human
         %tbody
           - @order_details.each do |od|
             %tr
@@ -51,6 +53,8 @@
               %td= od.order_status
               %td.currency
                 =  OrderDetailPresenter.new(od).wrapped_total
+              - if cross_core_order_view_enabled
+                %td= od.price_group&.name || od.estimated_price_group_name
         = render partial: "table_controls"
 
     = will_paginate(@order_details)

--- a/vendor/engines/projects/app/services/projects/cross_core_facility_searcher.rb
+++ b/vendor/engines/projects/app/services/projects/cross_core_facility_searcher.rb
@@ -39,6 +39,8 @@ module Projects
       :select
     end
 
+    # Translation scope cannot be inferred, so we need to specify it.
+    # Returns empty string because label includes the complete path.
     def translation_scope
       ""
     end

--- a/vendor/engines/projects/app/services/projects/cross_core_facility_searcher.rb
+++ b/vendor/engines/projects/app/services/projects/cross_core_facility_searcher.rb
@@ -3,6 +3,7 @@
 module Projects
 
   class CrossCoreFacilitySearcher < TransactionSearch::BaseSearcher
+    include TextHelpers::Translation
 
     def self.key
       :cross_core_facilties
@@ -31,11 +32,16 @@ module Projects
     end
 
     def label
-      I18n.t("projects.projects.cross_core_orders.filter_label")
+      text("projects.projects.cross_core_orders.filter_label")
     end
 
     def input_type
       :select
     end
+
+    def translation_scope
+      ""
+    end
   end
+
 end

--- a/vendor/engines/projects/app/views/projects/projects/cross_core_orders.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/cross_core_orders.html.haml
@@ -29,19 +29,20 @@
         %tbody
           - @order_details.each do |od|
             %tr
+              - order_detail = OrderDetailPresenter.new(od)
               %td= od
               %td= od.order.created_by_user.full_name
               %td= od.order.user.full_name
               %td= format_usa_datetime(od.ordered_at)
-              %td.centered= OrderDetailPresenter.new(od).wrapped_quantity
+              %td.centered= order_detail.wrapped_quantity
               = render partial: "shared/order_detail_cell", locals: { od: od }
               %td= od.order.facility.abbreviation.truncate(6)
               -# TODO: This should be a link when we have the project page
               %td= od.order.cross_core_project&.name
               %td= od.order_status
               %td.currency
-                =  OrderDetailPresenter.new(od).wrapped_total
-              %td= od.price_group&.name || od.estimated_price_group_name
+                =  order_detail.wrapped_total
+              %td= order_detail.price_group_name
 
       = will_paginate(@order_details)
       = render partial: "/price_display_footnote", locals: { admin: true }

--- a/vendor/engines/projects/app/views/projects/projects/cross_core_orders.html.haml
+++ b/vendor/engines/projects/app/views/projects/projects/cross_core_orders.html.haml
@@ -25,6 +25,7 @@
             %th.nowrap= Projects::Project.model_name.human
             %th.nowrap= sortable "status"
             %th.nowrap.currency= OrderDetail.human_attribute_name(:actual_cost)
+            %th.nowrap= PriceGroup.model_name.human
         %tbody
           - @order_details.each do |od|
             %tr
@@ -40,6 +41,7 @@
               %td= od.order_status
               %td.currency
                 =  OrderDetailPresenter.new(od).wrapped_total
+              %td= od.price_group&.name || od.estimated_price_group_name
 
       = will_paginate(@order_details)
       = render partial: "/price_display_footnote", locals: { admin: true }

--- a/vendor/engines/projects/config/locales/en.yml
+++ b/vendor/engines/projects/config/locales/en.yml
@@ -27,8 +27,7 @@ en:
   projects:
     projects:
       cross_core_orders:
-        # TODO: This should use the preferred term for "facility" (e.g. "facility" or "core")
-        filter_label: "Participating Facilities"
+        filter_label: "Participating !facilities_downcase!"
         head: "Cross Core Orders"
         no_orders: There are no orders for your Cross Core projects.
       edit:

--- a/vendor/engines/projects/spec/system/cross_core_orders_spec.rb
+++ b/vendor/engines/projects/spec/system/cross_core_orders_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Cross Core Orders", :js, feature_setting: { cross_core_order_vie
 
   context "when selecting All" do
     before do
-      select "All", from: "Participating Facilities"
+      select "All", from: "Participating facilities"
       click_button "Filter"
     end
 
@@ -91,7 +91,7 @@ RSpec.describe "Cross Core Orders", :js, feature_setting: { cross_core_order_vie
 
   context "when selecting Current" do
     before do
-      select "Current", from: "Participating Facilities"
+      select "Current", from: "Participating facilities"
       click_button "Filter"
     end
 

--- a/vendor/engines/projects/spec/system/cross_core_orders_spec.rb
+++ b/vendor/engines/projects/spec/system/cross_core_orders_spec.rb
@@ -78,6 +78,14 @@ RSpec.describe "Cross Core Orders", :js, feature_setting: { cross_core_order_vie
 
       expect(page).to have_content(cross_core_order_originating_facility2.order_details.first)
       expect(page).to have_content(cross_core_order_originating_facility.order_details.first)
+
+      item_price_group = item.price_policies.first.price_group.name
+      facility2_item_price_group = facility2_item.price_policies.first.price_group.name
+      facility3_item_price_group = facility3_item.price_policies.first.price_group.name
+
+      expect(page).to have_content(item_price_group, count: 2)
+      expect(page).to have_content(facility2_item_price_group, count: 2)
+      expect(page).to have_content(facility3_item_price_group, count: 2)
     end
   end
 

--- a/vendor/engines/projects/spec/system/cross_core_orders_spec.rb
+++ b/vendor/engines/projects/spec/system/cross_core_orders_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Cross Core Orders", :js, feature_setting: { cross_core_order_vie
 
   context "when selecting All" do
     before do
-      select "All", from: "Participating facilities"
+      select "All", from: "Participating #{I18n.t("facilities_downcase")}"
       click_button "Filter"
     end
 
@@ -91,7 +91,7 @@ RSpec.describe "Cross Core Orders", :js, feature_setting: { cross_core_order_vie
 
   context "when selecting Current" do
     before do
-      select "Current", from: "Participating facilities"
+      select "Current", from: "Participating #{I18n.t("facilities_downcase")}"
       click_button "Filter"
     end
 


### PR DESCRIPTION
# Release Notes
* Show price group (estimated or final) in orders table.

# Screenshot
## Orders tab
<img width="1206" alt="image" src="https://github.com/tablexi/nucore-open/assets/28798610/1139f40f-eaa7-42d8-85a4-ef86c7739315">

## Cross core orders tab
<img width="1204" alt="image" src="https://github.com/tablexi/nucore-open/assets/28798610/165d3092-e88d-42d2-9526-603a8f70cf9f">

# Accessibility
- [x] Did you scan for accessibility issues?
- [x] Did you check our accessibility goal checklist?
- [ ] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)?
