### PR TITLE
[#162207] Add a message to all cross-core statements

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -130,7 +130,7 @@ class OrderDetail < ApplicationRecord
   scope :new_or_inprocess, -> { purchased.where(state: %w(new inprocess)) }
   scope :non_canceled, -> { where.not(state: "canceled") }
   scope :cross_core, lambda {
-    joins(order: :cross_core_project)
+    joins(order: [:facility, :cross_core_project])
     .where.not(orders: { cross_core_project_id: nil })
   }
 

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -129,7 +129,10 @@ class OrderDetail < ApplicationRecord
   scope :batch_updatable, -> { where(dispute_at: nil, state: %w(new inprocess)) }
   scope :new_or_inprocess, -> { purchased.where(state: %w(new inprocess)) }
   scope :non_canceled, -> { where.not(state: "canceled") }
-  scope :cross_core, -> { joins(order: :cross_core_project).where.not(orders: { cross_core_project_id: nil }) }
+  scope :cross_core, lambda {
+    joins(order: :cross_core_project)
+    .where.not(orders: { cross_core_project_id: nil })
+  }
 
   def self.for_facility(facility)
     for_facility_id(facility.id)

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -129,6 +129,7 @@ class OrderDetail < ApplicationRecord
   scope :batch_updatable, -> { where(dispute_at: nil, state: %w(new inprocess)) }
   scope :new_or_inprocess, -> { purchased.where(state: %w(new inprocess)) }
   scope :non_canceled, -> { where.not(state: "canceled") }
+  scope :cross_core, -> { joins(order: :facility).where.not(orders: { cross_core_project_id: nil }) }
 
   def self.for_facility(facility)
     for_facility_id(facility.id)

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -129,7 +129,7 @@ class OrderDetail < ApplicationRecord
   scope :batch_updatable, -> { where(dispute_at: nil, state: %w(new inprocess)) }
   scope :new_or_inprocess, -> { purchased.where(state: %w(new inprocess)) }
   scope :non_canceled, -> { where.not(state: "canceled") }
-  scope :cross_core, -> { joins(order: :facility).where.not(orders: { cross_core_project_id: nil }) }
+  scope :cross_core, -> { joins(order: :cross_core_project).where.not(orders: { cross_core_project_id: nil }) }
 
   def self.for_facility(facility)
     for_facility_id(facility.id)

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -117,4 +117,8 @@ class Statement < ApplicationRecord
     end
   end
 
+  def cross_core?
+    order_details.cross_core.any?
+  end
+
 end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -123,7 +123,6 @@ class Statement < ApplicationRecord
 
   def cross_core_order_details_from_other_facilities
     cross_core_order_details
-      .joins(order: :cross_core_project)
       .where.not(projects: { facility: facility})
   end
 

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -117,8 +117,18 @@ class Statement < ApplicationRecord
     end
   end
 
-  def cross_core?
-    order_details.cross_core.any?
+  def cross_core_order_details
+    order_details.cross_core
+  end
+
+  def cross_core_order_details_from_other_facilities
+    cross_core_order_details
+      .joins(order: :cross_core_project)
+      .where.not(projects: { facility: facility})
+  end
+
+  def display_cross_core_messsage?
+    cross_core_order_details_from_other_facilities.any?
   end
 
 end

--- a/app/support/example_statement_pdf.rb
+++ b/app/support/example_statement_pdf.rb
@@ -35,7 +35,7 @@ class ExampleStatementPdf < StatementPdf
     pdf.text "Account: #{@account}"
     pdf.text "Owner: #{@account.owner_user.full_name(suspended_label: false)}"
     pdf.move_down(10)
-    pdf.text "Items on this statement may have been placed on your behalf by another core facility.", style: :italic if @statement.cross_core?
+    pdf.text "Items on this statement may have been placed on your behalf by another core facility.", style: :italic if @statement.display_cross_core_messsage?
     pdf.move_down(10)
   end
 

--- a/app/support/example_statement_pdf.rb
+++ b/app/support/example_statement_pdf.rb
@@ -30,10 +30,12 @@ class ExampleStatementPdf < StatementPdf
   def generate_document_header(pdf)
     pdf.font_size = 10.5
 
-    pdf.text @facility.to_s, size: 20, font_style: :bold
+    pdf.text @facility.to_s, size: 20, style: :bold
     pdf.text "Invoice ##{@statement.invoice_number}"
     pdf.text "Account: #{@account}"
     pdf.text "Owner: #{@account.owner_user.full_name(suspended_label: false)}"
+    pdf.move_down(10)
+    pdf.text "Items on this statement may have been placed on your behalf by another core facility.", style: :italic if @statement.cross_core?
     pdf.move_down(10)
   end
 

--- a/app/support/example_statement_pdf.rb
+++ b/app/support/example_statement_pdf.rb
@@ -2,6 +2,8 @@
 
 class ExampleStatementPdf < StatementPdf
 
+  include TextHelpers::Translation
+
   def generate(pdf)
     generate_document_header(pdf)
     generate_contact_info(pdf) if @facility.has_contact_info?
@@ -35,7 +37,8 @@ class ExampleStatementPdf < StatementPdf
     pdf.text "Account: #{@account}"
     pdf.text "Owner: #{@account.owner_user.full_name(suspended_label: false)}"
     pdf.move_down(10)
-    pdf.text "Items on this statement may have been placed on your behalf by another core facility.", style: :italic if @statement.display_cross_core_messsage?
+    cross_core_message = text("cross_core_message")
+    pdf.text cross_core_message, style: :italic if @statement.display_cross_core_messsage?
     pdf.move_down(10)
   end
 
@@ -70,6 +73,10 @@ class ExampleStatementPdf < StatementPdf
         number_to_currency(order_detail.actual_total),
       ]
     end
+  end
+
+  def translation_scope
+    "statement_pdf"
   end
 
 end

--- a/config/locales/services/en.statement_pdf.yml
+++ b/config/locales/services/en.statement_pdf.yml
@@ -1,0 +1,3 @@
+en:
+  statement_pdf:
+    cross_core_message: "Items on this !statement_downcase! may have been placed on your behalf by another !facility_downcase!."

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -172,6 +172,49 @@ RSpec.describe Statement do
           expect(statement).to be_paid_in_full
         end
       end
+
+      describe "#display_cross_core_message" do
+        # Defined in spec/support/contexts/cross_core_context.rb
+        include_context "cross core orders"
+
+        context "with a cross core project that originates in the current facility" do
+          let(:order_detail) { cross_core_orders[0].order_details.first }
+
+          before :each do
+            statement.add_order_detail(order_detail)
+          end
+
+          it "does NOT display a message" do
+            expect(statement).not_to be_display_cross_core_messsage
+          end
+        end
+
+        context "with a cross core project that originates in a different facility, but includes an order in the current facility" do
+          let(:order_detail) { cross_core_orders[2].order_details.first }
+
+          before :each do
+            statement.add_order_detail(order_detail)
+          end
+
+          it "DOES display a message" do
+            expect(statement).to be_display_cross_core_messsage
+          end
+        end
+
+        context "with a cross core project that has no relation to the current facility" do
+          before :each do
+            order_detail_from_unrelated_facility = cross_core_orders[4].order_details.first
+            other_facility_statement = create(:statement, account: account, created_by: user.id, facility: facility3)
+            other_facility_statement.add_order_detail(order_detail_from_unrelated_facility)
+          end
+          
+          it "does NOT display a message" do
+            expect(statement).not_to be_display_cross_core_messsage
+          end
+        end
+
+      end
+
     end
   end
 end

--- a/spec/support/contexts/cross_core_context.rb
+++ b/spec/support/contexts/cross_core_context.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "cross core orders" do
+
+  # Facility 1 has cross core orders with Facility 2 but NOT Facility 3
+  # This is the "Current Facility"
+  let(:facility) { create(:setup_facility) }
+  let(:facility_administrator) { create(:user, :facility_administrator, facility:) }
+  let(:item) { create(:setup_item, facility:) }
+  let(:item2) { create(:setup_item, facility:) }
+  let(:accounts) { create_list(:setup_account, 2) }
+  let!(:originating_order_facility1) { create(:purchased_order, product: item, account: accounts.first, cross_core_project:) }
+  let!(:not_a_cross_core_order_facility1) { create(:purchased_order, product: item, account: accounts.first) }
+
+  # Facility 2 has cross core orders with both Facility 1 and Facility 3
+  let(:facility2) { create(:setup_facility) }
+  let(:facility2_item) { create(:setup_item, facility: facility2) }
+  let(:facility2_item2) { create(:setup_item, facility: facility2) }
+  let!(:originating_order_facility2) { create(:purchased_order, product: facility2_item, account: accounts.first, cross_core_project: cross_core_project2) }
+
+  # Facility 3 has cross core orders ONLY with Facility 2
+  let(:facility3) { create(:setup_facility) }
+  let(:facility3_item) { create(:setup_item, facility: facility3) }
+  let!(:originating_order_facility3) { create(:purchased_order, product: facility3_item, account: accounts.first, cross_core_project: cross_core_project3) }
+
+  # Create the cross core project records
+  let(:cross_core_project) { create(:project, facility:, name: "#{facility.abbreviation}-1") }
+  let(:cross_core_project2) { create(:project, facility: facility2, name: "#{facility2.abbreviation}-2") }
+  let(:cross_core_project3) { create(:project, facility: facility3, name: "#{facility3.abbreviation}-3") }
+
+  # Create the cross core orders and add them to the relevant projcects
+  let!(:cross_core_orders) do
+    [
+      create(:purchased_order, cross_core_project:, product: facility2_item, account: accounts.last),
+      create(:purchased_order, cross_core_project:, product: facility3_item, account: accounts.last),
+      create(:purchased_order, cross_core_project: cross_core_project2, product: item, account: accounts.last),
+      create(:purchased_order, cross_core_project: cross_core_project2, product: facility3_item, account: accounts.last),
+      # cross_core_project3 has no order details from facility 1
+      create(:purchased_order, cross_core_project: cross_core_project3, product: facility2_item2, account: accounts.last),
+    ]
+  end
+  
+end

--- a/spec/support/contexts/cross_core_context.rb
+++ b/spec/support/contexts/cross_core_context.rb
@@ -28,7 +28,7 @@ RSpec.shared_context "cross core orders" do
   let(:cross_core_project2) { create(:project, facility: facility2, name: "#{facility2.abbreviation}-2") }
   let(:cross_core_project3) { create(:project, facility: facility3, name: "#{facility3.abbreviation}-3") }
 
-  # Create the cross core orders and add them to the relevant projcects
+  # Create the cross core orders and add them to the relevant projects
   let!(:cross_core_orders) do
     [
       create(:purchased_order, cross_core_project:, product: facility2_item, account: accounts.last),
@@ -39,5 +39,5 @@ RSpec.shared_context "cross core orders" do
       create(:purchased_order, cross_core_project: cross_core_project3, product: facility2_item2, account: accounts.last),
     ]
   end
-  
+
 end

--- a/vendor/engines/projects/app/controllers/projects/projects_controller.rb
+++ b/vendor/engines/projects/app/controllers/projects/projects_controller.rb
@@ -88,12 +88,8 @@ module Projects
     end
 
     def cross_core_order_details
-      project_ids = current_facility.order_details.joins(:order).pluck(:cross_core_project_id).compact.uniq
-
-      OrderDetail
-        .joins(:order)
-        .joins(order: :facility)
-        .where(orders: { cross_core_project_id: project_ids })
+      OrderDetail.cross_core
+        .where(projects: { facility: current_facility})
     end
 
     def sort_lookup_hash

--- a/vendor/engines/projects/app/controllers/projects/projects_controller.rb
+++ b/vendor/engines/projects/app/controllers/projects/projects_controller.rb
@@ -91,9 +91,9 @@ module Projects
     # Includes all order details from any cross core project that is associated with the current facility,
     # and also all order details from any cross core project that includes an order from the current facility.
     def cross_core_order_details
-      project_ids = current_facility.order_details.joins(:order).pluck(:cross_core_project_id).compact.uniq
+      projects = Projects::Project.for_facility(current_facility)
       OrderDetail.cross_core
-        .where(orders: { cross_core_project_id: project_ids })
+        .where(orders: { cross_core_project_id: projects })
     end
 
     def sort_lookup_hash

--- a/vendor/engines/projects/app/controllers/projects/projects_controller.rb
+++ b/vendor/engines/projects/app/controllers/projects/projects_controller.rb
@@ -87,9 +87,13 @@ module Projects
       TransactionSearch::OrderStatusSearcher.new(order_details).options - [OrderStatus.canceled, OrderStatus.reconciled].map(&:id)
     end
 
+    # Fetch ALL cross core order details related to the current facility
+    # Includes all order details from any cross core project that is associated with the current facility,
+    # and also all order details from any cross core project that includes an order from the current facility.
     def cross_core_order_details
+      project_ids = current_facility.order_details.joins(:order).pluck(:cross_core_project_id).compact.uniq
       OrderDetail.cross_core
-        .where(projects: { facility: current_facility})
+        .where(orders: { cross_core_project_id: project_ids })
     end
 
     def sort_lookup_hash

--- a/vendor/engines/projects/app/models/projects/project.rb
+++ b/vendor/engines/projects/app/models/projects/project.rb
@@ -17,6 +17,12 @@ module Projects
     scope :inactive, -> { where(active: false) }
     scope :display_order, -> { order(:name) }
 
+    # This includes all projects which include any order from the given facility,
+    # including projects that have orders from multiple facilities.
+    scope :for_facility, lambda { |facility|
+      joins(:orders).where(orders: { facility: })
+    }
+
     def to_s
       name
     end

--- a/vendor/engines/projects/spec/system/cross_core_orders_spec.rb
+++ b/vendor/engines/projects/spec/system/cross_core_orders_spec.rb
@@ -3,43 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Cross Core Orders", :js, feature_setting: { cross_core_order_view: true } do
-  # Facility 1 has cross core orders with Facility 2 but NOT Facility 3
-  # This is the "Current Facility"
-  let(:facility) { create(:setup_facility) }
-  let(:facility_administrator) { create(:user, :facility_administrator, facility:) }
-  let(:item) { create(:setup_item, facility:) }
-  let(:item2) { create(:setup_item, facility:) }
-  let(:accounts) { create_list(:setup_account, 2) }
-  let!(:originating_order_facility1) { create(:purchased_order, product: item, account: accounts.first, cross_core_project:) }
-  let!(:not_a_cross_core_order_facility1) { create(:purchased_order, product: item, account: accounts.first) }
-
-  # Facility 2 has cross core orders with both Facility 1 and Facility 3
-  let(:facility2) { create(:setup_facility) }
-  let(:facility2_item) { create(:setup_item, facility: facility2) }
-  let(:facility2_item2) { create(:setup_item, facility: facility2) }
-  let!(:originating_order_facility2) { create(:purchased_order, product: facility2_item, account: accounts.first, cross_core_project: cross_core_project2) }
-
-  # Facility 3 has cross core orders ONLY with Facility 2
-  let(:facility3) { create(:setup_facility) }
-  let(:facility3_item) { create(:setup_item, facility: facility3) }
-  let!(:originating_order_facility3) { create(:purchased_order, product: facility3_item, account: accounts.first, cross_core_project: cross_core_project3) }
-
-  # Create the cross core project records
-  let(:cross_core_project) { create(:project, facility:, name: "#{facility.abbreviation}-1") }
-  let(:cross_core_project2) { create(:project, facility: facility2, name: "#{facility2.abbreviation}-2") }
-  let(:cross_core_project3) { create(:project, facility: facility3, name: "#{facility3.abbreviation}-3") }
-
-  # Create the cross core orders and add them to the relevant projcects
-  let!(:cross_core_orders) do
-    [
-      create(:purchased_order, cross_core_project:, product: facility2_item, account: accounts.last),
-      create(:purchased_order, cross_core_project:, product: facility3_item, account: accounts.last),
-      create(:purchased_order, cross_core_project: cross_core_project2, product: item, account: accounts.last),
-      create(:purchased_order, cross_core_project: cross_core_project2, product: facility3_item, account: accounts.last),
-      # cross_core_project3 has no order details from facility 1
-      create(:purchased_order, cross_core_project: cross_core_project3, product: facility2_item2, account: accounts.last),
-    ]
-  end
+  # Defined in spec/support/contexts/cross_core_context.rb
+  include_context "cross core orders"
 
   before do
     login_as facility_administrator

--- a/vendor/engines/projects/spec/system/cross_core_orders_spec.rb
+++ b/vendor/engines/projects/spec/system/cross_core_orders_spec.rb
@@ -9,21 +9,21 @@ RSpec.describe "Cross Core Orders", :js, feature_setting: { cross_core_order_vie
   let(:item2) { create(:setup_item, facility:) }
   let(:accounts) { create_list(:setup_account, 2) }
 
-  let!(:cross_core_order_originating_facility) { create(:purchased_order, product: item, account: accounts.first) }
+  let!(:originating_order_facility1) { create(:purchased_order, product: item, account: accounts.first) }
   let!(:order_for_facility) { create(:purchased_order, product: item, account: accounts.first) }
 
   let(:facility2) { create(:setup_facility) }
   let(:facility2_item) { create(:setup_item, facility: facility2) }
   let(:facility2_item2) { create(:setup_item, facility: facility2) }
-  let!(:cross_core_order_originating_facility2) { create(:purchased_order, product: facility2_item, account: accounts.first) }
+  let!(:originating_order_facility2) { create(:purchased_order, product: facility2_item, account: accounts.first) }
 
-  let(:cross_core_project) { create(:project, facility:, name: "#{facility.abbreviation}-#{cross_core_order_originating_facility.id}") }
-  let(:cross_core_project2) { create(:project, facility: facility2, name: "#{facility2.abbreviation}-#{cross_core_order_originating_facility2.id}") }
-  let(:cross_core_project3) { create(:project, facility: facility3, name: "#{facility3.abbreviation}-#{cross_core_order_originating_facility3.id}") }
+  let(:cross_core_project) { create(:project, facility:, name: "#{facility.abbreviation}-#{originating_order_facility1.id}") }
+  let(:cross_core_project2) { create(:project, facility: facility2, name: "#{facility2.abbreviation}-#{originating_order_facility2.id}") }
+  let(:cross_core_project3) { create(:project, facility: facility3, name: "#{facility3.abbreviation}-#{originating_order_facility3.id}") }
 
   let(:facility3) { create(:setup_facility) }
   let(:facility3_item) { create(:setup_item, facility: facility3) }
-  let!(:cross_core_order_originating_facility3) { create(:purchased_order, product: facility3_item, account: accounts.first) }
+  let!(:originating_order_facility3) { create(:purchased_order, product: facility3_item, account: accounts.first) }
 
   let!(:cross_core_orders) do
     [
@@ -39,11 +39,11 @@ RSpec.describe "Cross Core Orders", :js, feature_setting: { cross_core_order_vie
   before do
     login_as facility_administrator
 
-    cross_core_order_originating_facility.update!(cross_core_project:)
-    cross_core_order_originating_facility.reload
+    originating_order_facility1.update!(cross_core_project:)
+    originating_order_facility1.reload
 
-    cross_core_order_originating_facility2.update!(cross_core_project: cross_core_project2)
-    cross_core_order_originating_facility2.reload
+    originating_order_facility2.update!(cross_core_project: cross_core_project2)
+    originating_order_facility2.reload
 
     visit cross_core_orders_facility_projects_path(facility)
   end
@@ -58,10 +58,10 @@ RSpec.describe "Cross Core Orders", :js, feature_setting: { cross_core_order_vie
       expect(page).to have_content(cross_core_orders[0].order_details.first)
       expect(page).to have_content(cross_core_orders[1].order_details.first)
       expect(page).to have_content(cross_core_orders[3].order_details.first)
-      expect(page).to have_content(cross_core_order_originating_facility2.order_details.first)
+      expect(page).to have_content(originating_order_facility2.order_details.first)
 
       expect(page).not_to have_content(cross_core_orders[2].order_details.first)
-      expect(page).not_to have_content(cross_core_order_originating_facility.order_details.first)
+      expect(page).not_to have_content(originating_order_facility1.order_details.first)
     end
   end
 
@@ -79,8 +79,8 @@ RSpec.describe "Cross Core Orders", :js, feature_setting: { cross_core_order_vie
       # This is from a cross core order that is not related to facility 1
       expect(page).not_to have_content(cross_core_orders[4].order_details.first)
 
-      expect(page).to have_content(cross_core_order_originating_facility2.order_details.first)
-      expect(page).to have_content(cross_core_order_originating_facility.order_details.first)
+      expect(page).to have_content(originating_order_facility2.order_details.first)
+      expect(page).to have_content(originating_order_facility1.order_details.first)
 
       item_price_group = item.price_policies.first.price_group.name
       facility2_item_price_group = facility2_item.price_policies.first.price_group.name
@@ -100,12 +100,12 @@ RSpec.describe "Cross Core Orders", :js, feature_setting: { cross_core_order_vie
 
     it "shows only cross core orders placed for current facility" do
       expect(page).to have_content(cross_core_orders[2].order_details.first)
-      expect(page).to have_content(cross_core_order_originating_facility.order_details.first)
+      expect(page).to have_content(originating_order_facility1.order_details.first)
 
       expect(page).not_to have_content(cross_core_orders[0].order_details.first)
       expect(page).not_to have_content(cross_core_orders[1].order_details.first)
       expect(page).not_to have_content(cross_core_orders[3].order_details.first)
-      expect(page).not_to have_content(cross_core_order_originating_facility2.order_details.first)
+      expect(page).not_to have_content(originating_order_facility2.order_details.first)
     end
   end
 end


### PR DESCRIPTION
# Release Notes

Adds a message to cross-core statements which include cross-core transactions from other facilities.
If the user placed the order, then this message would just cause confusion:
Items on this statement may have been placed on your behalf by another core facility.

This will need to be applied to each school's statement format individually

# Screenshot

![Screenshot 2024-06-07 at 2 37 52 PM](https://github.com/tablexi/nucore-open/assets/30355046/ea549c42-8a58-4487-860f-85d3266cef39)

# Tasks

- [x] Should this be applied to all cross core statements? NO - just the ones that were ordered on behalf
- [x] Consider using the new `cross_core` scope in other places, if appropriate
- [x] Add specs
