### PR TITLE
[Shared dev] [#162254] Redirect to correct order after "Move Up"

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -222,15 +222,7 @@ class ReservationsController < ApplicationController
       flash[:error] = @reservation.errors.full_messages.join("<br/>").html_safe
     end
 
-    redirect_to_order_id = params[:redirect_to_order_id]
-
-    if redirect_to_order_id.present?
-      facility_order = Order.find(redirect_to_order_id)
-
-      redirect_to facility_order_path(current_facility, facility_order)
-    else
-      redirect_to reservations_status_path(status: "upcoming")
-    end
+    redirect_to redirect_to_path
   end
 
   # GET /orders/:order_id/order_details/:order_detail_id/reservations/:reservation_id/move
@@ -442,6 +434,18 @@ class ReservationsController < ApplicationController
     else
       facility_order = facility_orders.first
       @cross_core_cancel_path = facility_order_path(facility_order.facility, facility_order)
+    end
+  end
+
+  def redirect_to_path
+    redirect_to_order_id = params[:redirect_to_order_id]
+
+    if redirect_to_order_id.present?
+      facility_order = Order.find(redirect_to_order_id)
+
+      redirect_to facility_order_path(facility_order.facility, facility_order)
+    else
+      redirect_to reservations_status_path(status: "upcoming")
     end
   end
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -443,9 +443,9 @@ class ReservationsController < ApplicationController
     if redirect_to_order_id.present?
       facility_order = Order.find(redirect_to_order_id)
 
-      redirect_to facility_order_path(facility_order.facility, facility_order)
+      facility_order_path(facility_order.facility, facility_order)
     else
-      redirect_to reservations_status_path(status: "upcoming")
+      reservations_status_path(status: "upcoming")
     end
   end
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -222,7 +222,15 @@ class ReservationsController < ApplicationController
       flash[:error] = @reservation.errors.full_messages.join("<br/>").html_safe
     end
 
-    redirect_to reservations_status_path(status: "upcoming")
+    redirect_to_order_id = params[:redirect_to_order_id]
+
+    if redirect_to_order_id.present?
+      facility_order = Order.find(redirect_to_order_id)
+
+      redirect_to facility_order_path(current_facility, facility_order)
+    else
+      redirect_to reservations_status_path(status: "upcoming")
+    end
   end
 
   # GET /orders/:order_id/order_details/:order_detail_id/reservations/:reservation_id/move
@@ -238,6 +246,8 @@ class ReservationsController < ApplicationController
         end_time: human_time(@earliest_possible.reserve_end_at),
       }
     end
+
+    @redirect_to_order_id = params[:redirect_to_order_id]
 
     render layout: false
   end

--- a/app/presenters/reservation_user_action_presenter.rb
+++ b/app/presenters/reservation_user_action_presenter.rb
@@ -132,9 +132,13 @@ class ReservationUserActionPresenter
   end
 
   def move_link
-    link_to I18n.t("reservations.moving_up.link"), order_order_detail_reservation_move_reservation_path(order, order_detail, reservation),
-            class: "move-res",
-            data: { reservation_id: reservation.id }
+    path = if @redirect_to_order_id.present?
+             order_order_detail_reservation_move_reservation_path(order, order_detail, reservation, redirect_to_order_id: @redirect_to_order_id)
+           else
+             order_order_detail_reservation_move_reservation_path(order, order_detail, reservation)
+           end
+
+    link_to I18n.t("reservations.moving_up.link"), path, class: "move-res", data: { reservation_id: reservation.id }
   end
 
   def report_an_issue_link

--- a/app/views/reservations/earliest_move_possible.html.haml
+++ b/app/views/reservations/earliest_move_possible.html.haml
@@ -11,7 +11,8 @@
 
     %p= t('reservations.moving_up.confirm')
   .modal-footer
-    = form_for :reservation, :url => order_order_detail_reservation_move_reservation_path(@reservation.order, @reservation.order_detail, @reservation), :method => "post" do |f|
+    - url = order_order_detail_reservation_move_reservation_path(@reservation.order, @reservation.order_detail, @reservation, redirect_to_order_id: @redirect_to_order_id)
+    = form_for :reservation, url: url, method: "post" do |f|
       = f.submit t('reservations.moving_up.button'), :class => ['btn', 'btn-primary']
       = modal_cancel_button
 

--- a/spec/system/admin/reservation_actions_spec.rb
+++ b/spec/system/admin/reservation_actions_spec.rb
@@ -34,8 +34,17 @@ RSpec.describe "Reservation actions", :js, feature_setting: { cross_core_project
       accept_confirm do
         click_link("Cancel")
       end
-
       expect(page).to have_content("The reservation has been canceled successfully")
+    end
+  end
+
+  describe "Move up" do
+    it "redirects to original order show" do
+      find("h3", text: cross_core_reservation_order.facility.to_s, match: :first).click
+      find("a", text: "Move Up").click
+      click_button "Move"
+
+      expect(page).to have_content("The reservation was moved successfully.")
       expect(page).to have_content("Order ##{originating_order_facility1.id}")
     end
   end


### PR DESCRIPTION
# Release Notes
* Redirect to correct order after "Move Up"


# Accessibility
- [ ] Did you scan for accessibility issues?
- [ ] Did you check our accessibility goal checklist?
- [ ] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)?
