### PR TITLE
[Tech task] Fix flaky reservation actions spec

### DIFF
--- a/spec/system/admin/reservation_actions_spec.rb
+++ b/spec/system/admin/reservation_actions_spec.rb
@@ -42,6 +42,9 @@ RSpec.describe "Reservation actions", :js, feature_setting: { cross_core_project
     it "redirects to original order show" do
       find("h3", text: cross_core_reservation_order.facility.to_s, match: :first).click
       find("a", text: "Move Up").click
+
+      wait_for_ajax
+
       click_button "Move"
 
       expect(page).to have_content("The reservation was moved successfully.")


### PR DESCRIPTION
# Release Notes
* Tech task: fix flaky test

# Additional context
Spec failed multiple times and always the "Move" button seemed to not get clicked. Now we wait until AJAX request (the one that loads the modal) finishes before clicking the button