### PR TITLE
Revert "Bump akhileshns/heroku-deploy from 3.13.15 to 4"

### DIFF
--- a/.github/workflows/nucore-heroku-auto-deploy-staging.yml
+++ b/.github/workflows/nucore-heroku-auto-deploy-staging.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: akhileshns/heroku-deploy@v4
+      - uses: akhileshns/heroku-deploy@v3.13.15
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: "nucore-open"


### PR DESCRIPTION
Reverts tablexi/nucore-open#4182

Since this got in master, deploys to Heroku are failing. Also, I couldn't find this version in the repo (tag or release) or marketplace.