### PR TITLE
[#162314] Fix bug where order results files were not visible

### DIFF
--- a/app/views/facility_orders/_order_table.html.haml
+++ b/app/views/facility_orders/_order_table.html.haml
@@ -18,14 +18,16 @@
         - if od.add_accessories? || od.reservation.present?
           %br
           = render "order_table_actions", od: od, cross_core: cross_core
+
+        %br
+        = render "order_file_icon", od: od
+        = render "result_file_icon", od: od
+
       - if cross_core
         %td.user
           = od.created_by_user
         %td.order_date
           = od.ordered_at&.strftime("%m/%d/%Y")
-
-        = render "order_file_icon", od: od
-        = render "result_file_icon", od: od
 
       %td.currency.timeinput= od.reservation.try(:duration_mins)
       - if od.time_data.present?

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -136,6 +136,8 @@ RSpec.describe "Adding to an existing order" do
         expect(new_order_detail).to be_complete
         expect(I18n.l(new_order_detail.fulfilled_at.to_date, format: :usa)).to eq(fulfilled_at_string)
         expect(I18n.l(new_order_detail.ordered_at.to_date, format: :usa)).to eq(fulfilled_at_string)
+
+        expect(page).to have_content("0 Uploaded"), count: 2
       end
     end
   end


### PR DESCRIPTION
# Release Notes
* Fix bug where order results files were not visible

# Screenshot

<img width="1208" alt="image" src="https://github.com/tablexi/nucore-open/assets/28798610/754e41d2-ad9c-4f9d-9811-a477f97c4fb2">

# Additional Context
Bug was introduced as part of https://github.com/tablexi/nucore-open/pull/4344
