### PR TITLE
[#162199] Cross Core transactions

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -982,6 +982,10 @@ class OrderDetail < ApplicationRecord
     estimated_price_policy&.price_group&.name
   end
 
+  def cross_core_activity_for_facility?(facility)
+    order.cross_core_project.present? && order.cross_core_project.facility_id != facility.id
+  end
+
   private
 
   # Is there enough information to move an associated order to complete/problem?

--- a/app/models/reports/account_transactions_report.rb
+++ b/app/models/reports/account_transactions_report.rb
@@ -121,10 +121,8 @@ class Reports::AccountTransactionsReport
   end
 
   def originating_cross_core_facility(order_detail)
-    cross_core_project = order_detail.order.cross_core_project
-
-    if cross_core_project.present? && cross_core_project.facility != order_detail.facility
-      cross_core_project.facility.abbreviation
+    if order_detail.cross_core_activity_for_facility?(order_detail.facility)
+      order_detail.order.cross_core_project.facility.abbreviation
     end
   end
 

--- a/app/models/reports/account_transactions_report.rb
+++ b/app/models/reports/account_transactions_report.rb
@@ -107,7 +107,9 @@ class Reports::AccountTransactionsReport
   private
 
   def notices_for(order_detail)
-    OrderDetailNoticePresenter.new(order_detail).badges_to_text
+    notices = OrderDetailNoticePresenter.new(order_detail).badges_to_text
+
+    "#{notices}#{cross_core_order(order_detail)}"
   end
 
   def order_detail_duration(order_detail)
@@ -115,6 +117,14 @@ class Reports::AccountTransactionsReport
       ""
     else
       order_detail.csv_quantity
+    end
+  end
+
+  def cross_core_order(order_detail)
+    cross_core_project = order_detail.order.cross_core_project
+
+    if cross_core_project.present? && cross_core_project.facility != order_detail.facility
+      "This order placed on your behalf by #{cross_core_project.facility.abbreviation}"
     end
   end
 

--- a/app/models/reports/account_transactions_report.rb
+++ b/app/models/reports/account_transactions_report.rb
@@ -109,7 +109,7 @@ class Reports::AccountTransactionsReport
   private
 
   def notices_for(order_detail)
-    notices = OrderDetailNoticePresenter.new(order_detail).badges_to_text
+    OrderDetailNoticePresenter.new(order_detail).badges_to_text
   end
 
   def order_detail_duration(order_detail)

--- a/app/models/reports/account_transactions_report.rb
+++ b/app/models/reports/account_transactions_report.rb
@@ -70,6 +70,7 @@ class Reports::AccountTransactionsReport
       Account.human_attribute_name(:expires_at),
       OrderDetail.human_attribute_name(:order_status),
       OrderDetail.human_attribute_name(:note),
+      text(".cross_core_project_facility"),
       text(".order_detail_notices"),
     ]
   end
@@ -100,6 +101,7 @@ class Reports::AccountTransactionsReport
       format_usa_date(order_detail.account.expires_at),
       order_detail.order_status,
       order_detail.note,
+      originating_cross_core_facility(order_detail),
       notices_for(order_detail),
     ]
   end
@@ -108,8 +110,6 @@ class Reports::AccountTransactionsReport
 
   def notices_for(order_detail)
     notices = OrderDetailNoticePresenter.new(order_detail).badges_to_text
-
-    "#{notices}#{cross_core_order(order_detail)}"
   end
 
   def order_detail_duration(order_detail)
@@ -120,11 +120,11 @@ class Reports::AccountTransactionsReport
     end
   end
 
-  def cross_core_order(order_detail)
+  def originating_cross_core_facility(order_detail)
     cross_core_project = order_detail.order.cross_core_project
 
     if cross_core_project.present? && cross_core_project.facility != order_detail.facility
-      "This order placed on your behalf by #{cross_core_project.facility.abbreviation}"
+      cross_core_project.facility.abbreviation
     end
   end
 

--- a/app/views/shared/transactions/_cross_core_icon.html.haml
+++ b/app/views/shared/transactions/_cross_core_icon.html.haml
@@ -1,3 +1,3 @@
-- if order_detail.order.cross_core_project.present? && order_detail.order.cross_core_project.facility_id != current_facility.id
+- if order_detail.cross_core_activity_for_facility?(current_facility)
   %br
   %i.fa.fa-users{ data: { toggle: "tooltip" }, title: t(".tooltip", facility: order_detail.order.cross_core_project.facility.abbreviation)}

--- a/app/views/shared/transactions/_cross_core_icon.html.haml
+++ b/app/views/shared/transactions/_cross_core_icon.html.haml
@@ -1,0 +1,3 @@
+- if order_detail.order.cross_core_project.present? && order_detail.order.cross_core_project.facility_id != current_facility.id
+  %br
+  %i.fa.fa-users{ data: { toggle: "tooltip" }, title: t(".tooltip", facility: order_detail.order.cross_core_project.facility.abbreviation)}

--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -68,6 +68,7 @@
             = order_detail_presenter.price_group_name
         %td.nowrap
           = order_detail.order_status
+          %br
           = order_detail_status_badges(order_detail)
         - if local_assigns[:show_statements]
           %td= link_to "Download", account_statement_path(order_detail.account, order_detail.statement_id, format: :pdf) if order_detail.statement

--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -28,10 +28,14 @@
           %td.nowrap= order_detail.order.id
           %td.nowrap= order_detail.id
         - elsif backend?
-          %td.nowrap= link_to order_detail.order.id, facility_order_path(order_detail.order.facility, order_detail.order)
+          %td.nowrap
+            = link_to order_detail.order.id, facility_order_path(order_detail.order.facility, order_detail.order)
+            = render "shared/transactions/cross_core_icon", order_detail: order_detail
           %td.nowrap= link_to order_detail.id, manage_order_detail_path(order_detail), :class => 'manage-order-detail'
         - else
-          %td.nowrap= link_to order_detail.order.id, order_path(order_detail.order)
+          %td.nowrap
+            = link_to order_detail.order.id, order_path(order_detail.order)
+            = render "shared/transactions/cross_core_icon", order_detail: order_detail
           %td.nowrap= link_to order_detail.id, order_order_detail_path(order_detail.order, order_detail)
         %td.js--date-field= order_detail.send(:"#{@date_range_field}").try(:strftime, "%m/%d/%Y")
         - if @extra_date_column and order_detail.send(@extra_date_column)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,6 +166,8 @@ en:
       users: "Users"
       edit: "Edit"
     transactions:
+      cross_core_icon:
+        tooltip: "This order placed on your behalf by %{facility}"
       table_inside:
         total: Total
     update: Update

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1064,6 +1064,7 @@ en:
       fail_continue_on_error: "The import failed. %{successes} line item(s) created successfully, %{failures} failed. Please download the error report below, view each error message, correct the error, and try to import again."
       success: "The import completed successfully. %{successes} line items were created."
     account_transactions:
+      cross_core_project_facility: Cross Core Project Facility
       export: Export as CSV
       subject: "!app_name! Transaction Export"
       body: Your export is ready. Please see the attached file.

--- a/spec/models/reports/account_transaction_report_spec.rb
+++ b/spec/models/reports/account_transaction_report_spec.rb
@@ -3,6 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Reports::AccountTransactionsReport do
+  # Defined in spec/support/contexts/cross_core_context.rb
+  include_context "cross core orders"
+
   subject(:report) { Reports::AccountTransactionsReport.new(order_details, report_options) }
   let(:report_options) { {} }
 
@@ -20,7 +23,15 @@ RSpec.describe Reports::AccountTransactionsReport do
       let(:order_details) { OrderDetail }
 
       it "generates an order detail line" do
-        expect(report.to_csv.lines.count).to eq(2)
+        expect(report.to_csv.lines.count).to eq(11)
+      end
+
+      it "generates headers with Cross Core Project Facility" do
+        expect(report.to_csv.lines.first).to include("Cross Core Project Facility")
+      end
+
+      it "includes the order detail's cross core project facility" do
+        expect(report.to_csv.lines.second).to include(cross_core_project.facility.abbreviation)
       end
 
       describe "with estimated label_key_prefix" do

--- a/spec/support/contexts/cross_core_context.rb
+++ b/spec/support/contexts/cross_core_context.rb
@@ -40,12 +40,9 @@ RSpec.shared_context "cross core orders" do
     ]
   end
 
-  before do
-    all_cross_core_orders = cross_core_orders
-    all_cross_core_orders << originating_order_facility1
-    all_cross_core_orders << originating_order_facility2
-    all_cross_core_orders << originating_order_facility3
+  let(:all_cross_core_orders) { cross_core_orders + [originating_order_facility1, originating_order_facility2, originating_order_facility3] }
 
+  before do
     all_cross_core_orders.each do |order|
       order.order_details.each do |order_detail|
         order_detail.update(project: order.cross_core_project)

--- a/spec/system/admin/all_transactions_search_spec.rb
+++ b/spec/system/admin/all_transactions_search_spec.rb
@@ -2,17 +2,27 @@
 
 require "rails_helper"
 
-RSpec.describe "All Transactions Search" do
+RSpec.describe "All Transactions Search", :js do
+  # Defined in spec/support/contexts/cross_core_context.rb
+  include_context "cross core orders"
 
-  let(:facility) { create(:setup_facility) }
   let(:director) { create(:user, :facility_director, facility: facility) }
-  let(:item) { create(:setup_item, facility: facility) }
-  let(:accounts) { create_list(:setup_account, 2) }
   let!(:orders) do
     accounts.map { |account| create(:complete_order, product: item, account: account) }
   end
 
   let(:order_detail) { orders.first.order_details.first }
+
+  before do
+    all_cross_core_orders = cross_core_orders
+    all_cross_core_orders << originating_order_facility1
+    all_cross_core_orders << originating_order_facility2
+    all_cross_core_orders << originating_order_facility3
+
+    all_cross_core_orders.each do |order|
+      order.order_details.each(&:complete!)
+    end
+  end
 
   it "can do a basic search" do
     login_as director
@@ -20,9 +30,15 @@ RSpec.describe "All Transactions Search" do
     expected_default_date = 1.month.ago.beginning_of_month
     expect(page).to have_field("Start Date", with: I18n.l(expected_default_date.to_date, format: :usa))
 
-    select accounts.first.account_list_item, from: "Payment Sources"
+    select_from_chosen accounts.second.account_list_item, from: "Payment Sources"
     click_button "Filter"
-    expect(page).to have_link(order_detail.id.to_s, href: manage_facility_order_order_detail_path(facility, orders.first, orders.first.order_details.first))
-    expect(page).not_to have_link(orders.second.order_details.first.id.to_s)
+
+    expect(page).not_to have_link(order_detail.id.to_s)
+    expect(page).to have_link(orders.second.order_details.first.id.to_s)
+
+    # Cross Core orders
+    expect(page).not_to have_link(originating_order_facility1.id)
+    expect(page).to have_link(cross_core_orders[2].id)
+    expect(page).to have_css(".fa-users", count: 1) # cross_core_orders[2] is a cross-core order that didn't originate in the current facility
   end
 end

--- a/spec/system/admin/all_transactions_search_spec.rb
+++ b/spec/system/admin/all_transactions_search_spec.rb
@@ -14,11 +14,6 @@ RSpec.describe "All Transactions Search", :js do
   let(:order_detail) { orders.first.order_details.first }
 
   before do
-    all_cross_core_orders = cross_core_orders
-    all_cross_core_orders << originating_order_facility1
-    all_cross_core_orders << originating_order_facility2
-    all_cross_core_orders << originating_order_facility3
-
     all_cross_core_orders.each do |order|
       order.order_details.each(&:complete!)
     end


### PR DESCRIPTION
# Release Notes
* Show an icon for Cross Core transactions under the order id.

# Screenshot
<img width="1333" alt="image" src="https://github.com/tablexi/nucore-open/assets/28798610/5ff01118-8aee-4ec6-8a2c-2720fd336bbe">


# Additional Context
## Pending work
### CSV export
* Should it be part of the "badges" in the last column?
