### PR TITLE
[#162202] Fix Projects tab 

### DIFF
--- a/app/services/projects_search/cross_core_searcher.rb
+++ b/app/services/projects_search/cross_core_searcher.rb
@@ -30,7 +30,7 @@ module ProjectsSearch
     private
 
     def cross_core_projects
-      Projects::Project.cross_core.for_facility(@current_facility_id)
+      Projects::Project.cross_core.for_facility(@current_facility_id).distinct
     end
 
     def single_facility_projects

--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -56,7 +56,7 @@
         - if controller_name == "projects"
           %td= order_detail.created_by_user.full_name
           - colspan_for_total += 1
-        - if @account.nil?
+        - if @account.nil? && controller_name != "projects"
           %td= order_detail.account
           %td= order_detail.account.owner_user
           - colspan_for_total += 2

--- a/spec/system/admin/projects_show_spec.rb
+++ b/spec/system/admin/projects_show_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe "Projects show", feature_setting: { cross_core_order_view: true }
         expect(page).to have_link("Edit")
       end
 
+      it "doesn't show account info" do
+        expect(page).not_to have_content(active_project_order.account.to_s)
+      end
+
       it "navigates to order" do
         click_link active_project_order.id
 
@@ -86,6 +90,10 @@ RSpec.describe "Projects show", feature_setting: { cross_core_order_view: true }
           expect(page).to have_link("Edit")
         end
 
+        it "doesn't show account info" do
+          expect(page).not_to have_content(active_project_order.account.to_s)
+        end
+
         it "navigates to original order" do
           click_link originating_order_facility1.id
 
@@ -112,6 +120,10 @@ RSpec.describe "Projects show", feature_setting: { cross_core_order_view: true }
 
         it "shows Edit button" do
           expect(page).to have_link("Edit")
+        end
+
+        it "doesn't show account info" do
+          expect(page).not_to have_content(active_project_order.account.to_s)
         end
 
         it "shows other facility's orders as text" do


### PR DESCRIPTION
# Release Notes
* Prevent dup projects in index and hide account columns

# Screenshot
## Dup projects
### Before / After
<img width="230" alt="image" src="https://github.com/tablexi/nucore-open/assets/28798610/241cc7ae-dfce-4f17-a459-4c9ce93ab658">
<img width="230" alt="image" src="https://github.com/tablexi/nucore-open/assets/28798610/88a966c5-99d3-40bf-b9e4-68f6f03f5e90">


## Account columns
### Before
<img width="1217" alt="image" src="https://github.com/tablexi/nucore-open/assets/28798610/1eabcfeb-b126-4633-84d8-b82eecd40425">

### After
<img width="1218" alt="image" src="https://github.com/tablexi/nucore-open/assets/28798610/feee16ba-783a-49a1-8f6a-444ba93d9c50">
