### PR TITLE
Fix: [#162313] Purchase cross core order when it only has one instrument

### DIFF
--- a/spec/system/admin/adding_to_a_cross_core_order_spec.rb
+++ b/spec/system/admin/adding_to_a_cross_core_order_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe "Adding to an existing order for cross core", :js, feature_settin
           expect(project).to be_present
           expect(project.orders.last.order_details.last.product).to eq(instrument)
           expect(project.orders.last.account_id).to eq(facility2_account.id)
+          expect(project.orders.last.state).to eq("purchased")
         end
 
         it "brings you back to the facility order path on 'Cancel'" do


### PR DESCRIPTION
# Release Notes
* Purchase cross core order when it only has one instrument