### PR TITLE
Fix: Display reservation actions for all orders (not just cross core)

### DIFF
--- a/app/views/facility_orders/_order_table_actions.html.haml
+++ b/app/views/facility_orders/_order_table_actions.html.haml
@@ -7,6 +7,9 @@
   = link_to facility_order_order_detail_url(current_facility, @order, od, format: :ics) do
     = tooltip_icon "fa fa-calendar", t("ical.calendar_tooltip")
     %span= t("views.facility_orders.show.order_table.download")
-
+  - delimiter = "&nbsp;|&nbsp;".html_safe
+  = delimiter
   - if cross_core
     = reservation_actions(od.reservation, redirect_to_order_id: @order.id)
+  - else
+    = reservation_actions(od.reservation)


### PR DESCRIPTION
# Release Notes

In an earlier ticket (#162254) we made a change to the redirect for the Reservation Actions, and mistakenly removed those action links for non-cross-core reservations.