### PR TITLE
[#162271] Remove references to the IMSERC app (no longer in use)

### DIFF
--- a/app/models/external_services/survey_response.rb
+++ b/app/models/external_services/survey_response.rb
@@ -32,7 +32,7 @@ class SurveyResponse
 
   def response_data
     show_url = params[:survey_url]
-    # new survey services (i.e. IMSERC) provide the edit URL
+    # new survey services (i.e. form.io) provide the edit URL
     # old survey services (i.e. Surveyor) have the edit URL inferred
     edit_url = params[:survey_edit_url] || "#{show_url}/take"
     { show_url: show_url, edit_url: edit_url }.to_json

--- a/doc/HOWTO_external_services.md
+++ b/doc/HOWTO_external_services.md
@@ -9,7 +9,7 @@ Currently, you can only use one external service class at a time.
 You can change the default external service by creating a new class that extends from [`ExternalService`](../app/models/external_service.rb). The current implementation, [`UrlService`](../app/models/url_service.rb), provides the majority of functionality.
 
 There may be other gems or companion applications that utilize `UrlService`.
-For example, NU is using `acgt`, `sanger_sequencing`, and the IMSERC application (https://github.com/tablexi/nucore-imserc).
+For example, NU is using `acgt` and `sanger_sequencing`.
 
 ## Process
 


### PR DESCRIPTION
# Release Notes

The IMSERC app (used by NU) is no longer in use