### PR TITLE
[#162296] Add note field to quick reservation

### DIFF
--- a/app/views/quick_reservations/new.html.haml
+++ b/app/views/quick_reservations/new.html.haml
@@ -13,10 +13,10 @@
   %dl
     %dt= t(".reservation_date")
     %dd= "#{@reservation_data[:reserve_start_at].strftime("%A")} #{human_date(@reservation_data[:reserve_start_at])}"
-  
+
     %dt= t(".reservation_time")
     %dd= human_time(@reservation_data[:reserve_start_at])
-  
+
   - if @can_add_to_cart
     = form_with url: facility_instrument_quick_reservations_path(@facility, @instrument) do |f|
       %fieldset
@@ -29,5 +29,11 @@
         - accounts = @current_user.accounts_for_product(@instrument)
         %legend= t(".payment_details")
         = f.select :order_account, accounts.map { |a| [a, a.id] }, {}, {"aria-label": "account" }
+
+      - if show_note_input_to_user?(@order_detail)
+        %fieldset
+          %legend= @order_detail.product.user_notes_label.presence || OrderDetail.human_attribute_name(:note)
+          = f.text_field "reservation[note]", { required: @order_detail.product.user_notes_field_mode.required?, "aria-label": "note" }
+          %span= t(".note_hint")
       %br
       = f.submit t(".create_reservation")

--- a/config/locales/views/en.quick_reservations.yml
+++ b/config/locales/views/en.quick_reservations.yml
@@ -4,6 +4,7 @@ en:
       my_reservation: My Reservations
   quick_reservations:
     new:
+      note_hint: Visible to facility staff only
       reservation_details: Reservation Details
       reserved: Walkup Reservations Not Available
       reserved_message: "The next available start time is:"

--- a/spec/system/quick_reservations_spec.rb
+++ b/spec/system/quick_reservations_spec.rb
@@ -178,6 +178,21 @@ RSpec.describe "Reserving an instrument using quick reservations", feature_setti
         expect(page).to have_content("60 mins")
       end
     end
+
+    context "when the product requires a note" do
+      let(:start_at) { Time.current + intervals.first.minutes - 5.minutes }
+      let(:instrument) { create(:setup_instrument, :timer, min_reserve_mins: 5, user_notes_field_mode: "required") }
+
+      it "can create a reservation when note is provided" do
+        choose "60 mins"
+        click_button "Create Reservation"
+        expect(page).to have_content("Note may not be blank")
+        choose "60 mins"
+        fill_in "reservation[note]", with: "This is a note"
+        click_button "Create Reservation"
+        expect(page).to have_content("10:10 AM - 11:10 AM")
+      end
+    end
   end
 
   context "when another reservation is ongoing but abandoned" do

--- a/spec/system/quick_reservations_spec.rb
+++ b/spec/system/quick_reservations_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Reserving an instrument using quick reservations", feature_setti
   let(:user) { create(:user) }
   let!(:user_2) { create(:user) }
   let!(:admin_user) { create(:user, :administrator) }
-  let!(:instrument) { create(:setup_instrument, :timer, min_reserve_mins: 5) }
+  let!(:instrument) { create(:setup_instrument, :timer, min_reserve_mins: 5, user_notes_field_mode: "optional") }
   let!(:product_user) {}
   let(:intervals) { instrument.quick_reservation_intervals }
   let(:facility) { instrument.facility }
@@ -146,6 +146,7 @@ RSpec.describe "Reserving an instrument using quick reservations", feature_setti
         expect(page).to have_content("30 mins")
         expect(page).to have_content("60 mins")
         choose "60 mins"
+        fill_in "reservation[note]", with: "This is a note"
         click_button "Create Reservation"
         expect(page).to have_content("9:31 AM - 10:31 AM")
         expect(page).to have_content("End Reservation")


### PR DESCRIPTION
# Release Notes
* Add note field to quick reservation

# Screenshot
<img width="849" alt="image" src="https://github.com/user-attachments/assets/86704945-679f-450b-ab6d-1115c02114c4">

# Accessibility
- [x] Did you scan for accessibility issues?
- [x] Did you check our accessibility goal checklist?
- [x] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)?
