### PR TITLE
[#162336] Fix ampersand (&) in product names for Transactions report

### DIFF
--- a/app/models/reports/account_transactions_report.rb
+++ b/app/models/reports/account_transactions_report.rb
@@ -85,7 +85,7 @@ class Reports::AccountTransactionsReport
       order_detail.id,
       format_usa_date(order_detail.send(:"#{@date_range_field}")),
       order_detail.order.facility,
-      order_detail.description_as_html,
+      order_detail.description_as_html(skip_html_escape: true),
       format_usa_datetime(reservation.reserve_start_at),
       format_usa_datetime(reservation.reserve_end_at),
       format_usa_datetime(order_detail.time_data.try(:actual_start_at)),

--- a/app/presenters/order_detail_presenter.rb
+++ b/app/presenters/order_detail_presenter.rb
@@ -14,9 +14,9 @@ class OrderDetailPresenter < SimpleDelegator
     order_details.map { |order_detail| new(order_detail) }
   end
 
-  def description_as_html
+  def description_as_html(skip_html_escape: false)
     [bundle, product].compact.map do |description|
-      ERB::Util.html_escape(description)
+      skip_html_escape ? description : ERB::Util.html_escape(description)
     end.join(" &mdash; ").html_safe
   end
 

--- a/spec/models/reports/account_transaction_report_spec.rb
+++ b/spec/models/reports/account_transaction_report_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Reports::AccountTransactionsReport do
   # Defined in spec/support/contexts/cross_core_context.rb
   include_context "cross core orders"
 
+  let(:item) { create(:setup_item, facility:, name: "Item for testing & checking") }
   subject(:report) { Reports::AccountTransactionsReport.new(order_details, report_options) }
   let(:report_options) { {} }
 
@@ -32,6 +33,10 @@ RSpec.describe Reports::AccountTransactionsReport do
 
       it "includes the order detail's cross core project facility" do
         expect(report.to_csv.lines.second).to include(cross_core_project.facility.abbreviation)
+      end
+
+      it "includes the product's name" do
+        expect(report.to_csv.lines.second).to include(item.name)
       end
 
       describe "with estimated label_key_prefix" do


### PR DESCRIPTION
# Release Notes
* Fix ampersand (&) in product names for Transactions report