### PR TITLE
[#162375] Allow adding multiple services to order

### DIFF
--- a/app/support/orders/item_adder.rb
+++ b/app/support/orders/item_adder.rb
@@ -21,14 +21,12 @@ class Orders::ItemAdder
     ods = case product
           when Bundle
             add_bundles(product, quantity, attributes)
-          when Service
-            add_services(product, quantity, attributes)
           when TimedService
             add_timed_services(product, quantity, duration, attributes)
           when Instrument
             add_instruments(product, quantity, attributes)
           else
-            [create_order_detail({ product: product, quantity: quantity }.merge(attributes))]
+            [create_order_detail({ product:, quantity: }.merge(attributes))]
           end
     ods || []
   end
@@ -89,21 +87,6 @@ class Orders::ItemAdder
       }.merge(attributes)
 
       create_order_detail(**order_detail_parameters)
-    end
-  end
-
-  # If the service has a survey or order form, we create one row for each quantity since
-  # each one will require a separate upload form.
-  def add_services(product, quantity, attributes)
-    separate = (product.active_template? || product.active_survey?)
-    # can't add single order_detail for service when it requires a template or a survey.
-    # number of order details to add
-    repeat = separate ? quantity : 1
-    # quantity to add them with
-    individual_quantity = separate ? 1 : quantity
-
-    Array.new(repeat) do
-      create_order_detail({ product: product, quantity: individual_quantity }.merge(attributes))
     end
   end
 

--- a/app/support/orders/item_adder.rb
+++ b/app/support/orders/item_adder.rb
@@ -34,14 +34,7 @@ class Orders::ItemAdder
   # Returns true if adding the product creates multiple line items if you add a
   # quantity greater than 1.
   def self.multiline?(product)
-    case product
-    when Service
-      product.active_template? || product.active_survey?
-    when Bundle, TimedService, Instrument
-      true
-    else
-      false
-    end
+    [Bundle, TimedService, Instrument].any? { |klass| product.is_a?(klass) }
   end
 
   private

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe Order do
       end
 
       context "service" do
-        it "should add two order_details when has an active survey and a quantity of 2" do
+        it "should add one order_detail when has an active survey and a quantity of 2" do
           # setup
           @service_w_active_survey = FactoryBot.create(:service, facility: @facility, initial_order_status: @order_status)
           allow(@service_w_active_survey).to receive(:active_survey?).and_return(true)
@@ -297,10 +297,11 @@ RSpec.describe Order do
 
           # asserts
           expect(@ods).to respond_to :each
-          expect(@ods.size).to eq(2)
+          expect(@ods.size).to eq(1)
+          expect(@ods.first.quantity).to eq(2)
         end
 
-        it "should add two order_details when has an active template and a quantity of 2" do
+        it "should add one order_detail when has an active template and a quantity of 2" do
           # setup
           @service_w_active_template = FactoryBot.create(:service, facility: @facility, initial_order_status: @order_status)
           @service_w_active_template.stored_files.create! FactoryBot.attributes_for(:stored_file, file_type: "template", created_by: @user.id)
@@ -310,7 +311,8 @@ RSpec.describe Order do
 
           # asserts
           expect(@ods).to respond_to :each
-          expect(@ods.size).to eq(2)
+          expect(@ods.size).to eq(1)
+          expect(@ods.first.quantity).to eq(2)
         end
 
         it "should add one order_detail when has a quantity of 2 and service doesn't have a template or survey" do


### PR DESCRIPTION
# Release Notes
* Allow adding multiple services to order without requiring multiple forms

# Screenshot
<img width="1239" alt="image" src="https://github.com/user-attachments/assets/cf6eecf9-f2d8-4635-8508-ada228925577">
