### PR TITLE
[#162383] Use order_detail instead of order

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -245,7 +245,7 @@ class Reservation < ApplicationRecord
   end
 
   def admin?
-    order.nil? && !blackout?
+    order_detail_id.nil? && !blackout?
   end
 
   def admin_removable?


### PR DESCRIPTION
# Release Notes
* Decrease Facility reservations page load time

# Additional Context
We could just check the `order_detail_id` and that should be faster than checking the `order` (which goes through the `order_detail`).
