### PR TITLE
[#162382] Load images lazily

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -81,6 +81,9 @@ module Nucore
     config.middleware.insert 0, Rack::UTF8Sanitizer
 
     config.active_storage.variant_processor = :vips
+
+    # Indicate to the browser that an image should be lazily loaded
+    config.action_view.image_loading = "lazy"
   end
 
 end


### PR DESCRIPTION
# Release Notes
* Load images as user scrolls, to help avoid high loading times.
