### PR TITLE
[#162406] Fix: bug when choosing an account

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -198,7 +198,7 @@ class OrdersController < ApplicationController
               elsif request.post?
                 Account.find(params[:account_id])
               end
-    add_account_result = add_account_to_order(account) if acount.present?
+    add_account_result = add_account_to_order(account) if account.present?
 
     if @product.blank?
       redirect_to(cart_path)

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -185,12 +185,15 @@ class OrdersController < ApplicationController
   # GET  /orders/:id/choose_account
   # POST /orders/:id/choose_account
   def choose_account
+    # For nonbillable products, we don't ask the user to choose an account
     # POST requests are sent from the form on the choose_account page,
     # so we need to assign the account selected by the user to the order
-    if request.post?
-      account = Account.find(params[:account_id])
-      add_account_result = add_account_to_order(account)
-    end
+    account = if @product.nonbillable_mode?
+                NonbillableAccount.singleton_instance
+              elsif request.post?
+                Account.find(params[:account_id])
+              end
+    add_account_result = add_account_to_order(account) if acount.present?
 
     @product = if session[:add_to_cart].blank?
                  @order.order_details[0].try(:product)
@@ -200,18 +203,10 @@ class OrdersController < ApplicationController
 
     if @product.blank?
       redirect_to(cart_path)
-    elsif @product.nonbillable_mode?
-      # For nonbillable products, we don't ask the user to choose an account
-      add_account_result = add_account_to_order(NonbillableAccount.singleton_instance)
-      if add_account_result[:success]
-        redirect_to add_account_result[:redirect_path]
-      else
-        flash.now[:error] = add_account_result[:error_message]
-      end
-    elsif request.post? && add_account_result[:success]
+    elsif add_account_result && add_account_result[:success]
       redirect_to add_account_result[:redirect_path]
     else
-      flash.now[:error] = add_account_result[:error_message] if request.post?
+      flash.now[:error] = add_account_result[:error_message] if add_account_result[:error_message]
       @accounts = AvailableAccountsFinder.new(acting_user, @product.facility).accounts
       @errors   = {}
       details   = @order.order_details

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -185,6 +185,11 @@ class OrdersController < ApplicationController
   # GET  /orders/:id/choose_account
   # POST /orders/:id/choose_account
   def choose_account
+    @product = if session[:add_to_cart].blank?
+              @order.order_details[0].try(:product)
+            else
+              Product.find(session[:add_to_cart].first[:product_id])
+            end
     # For nonbillable products, we don't ask the user to choose an account
     # POST requests are sent from the form on the choose_account page,
     # so we need to assign the account selected by the user to the order
@@ -194,12 +199,6 @@ class OrdersController < ApplicationController
                 Account.find(params[:account_id])
               end
     add_account_result = add_account_to_order(account) if acount.present?
-
-    @product = if session[:add_to_cart].blank?
-                 @order.order_details[0].try(:product)
-               else
-                 Product.find(session[:add_to_cart].first[:product_id])
-               end
 
     if @product.blank?
       redirect_to(cart_path)

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -198,7 +198,7 @@ class OrdersController < ApplicationController
               elsif @product.nonbillable_mode?
                 NonbillableAccount.singleton_instance
               elsif request.post?
-                Account.find(params[:account_id])
+                Account.where(id: params[:account_id]).first
               end
     add_account_result = add_account_to_order(account) if account.present?
 
@@ -208,6 +208,7 @@ class OrdersController < ApplicationController
       redirect_to add_account_result[:redirect_path]
     else
       flash.now[:error] = add_account_result[:error_message] if add_account_result && add_account_result[:error_message]
+      flash.now[:error] = I18n.t("orders.choose_account.missing_account") if account.blank?
       @accounts = AvailableAccountsFinder.new(acting_user, @product.facility).accounts
       @errors   = {}
       details   = @order.order_details

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -205,7 +205,7 @@ class OrdersController < ApplicationController
     elsif add_account_result && add_account_result[:success]
       redirect_to add_account_result[:redirect_path]
     else
-      flash.now[:error] = add_account_result[:error_message] if add_account_result[:error_message]
+      flash.now[:error] = add_account_result[:error_message] if add_account_result && add_account_result[:error_message]
       @accounts = AvailableAccountsFinder.new(acting_user, @product.facility).accounts
       @errors   = {}
       details   = @order.order_details

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -185,16 +185,6 @@ class OrdersController < ApplicationController
   # GET  /orders/:id/choose_account
   # POST /orders/:id/choose_account
   def choose_account
-    if request.post?
-      account = Account.find(params[:account_id])
-      add_account_result = add_account_to_order(account)
-      if add_account_result[:success]
-        redirect_to add_account_result[:redirect_path] && return
-      else
-        flash.now[:error] = add_account_result[:error_message]
-      end
-    end
-
     @product = if session[:add_to_cart].blank?
                  @order.order_details[0].try(:product)
                else
@@ -203,6 +193,14 @@ class OrdersController < ApplicationController
 
     if @product.blank?
       redirect_to(cart_path)
+    elsif request.post?
+      account = Account.find(params[:account_id])
+      add_account_result = add_account_to_order(account)
+      if add_account_result[:success]
+        redirect_to add_account_result[:redirect_path]
+      else
+        flash.now[:error] = add_account_result[:error_message]
+      end
     elsif @product.nonbillable_mode?
       add_account_result = add_account_to_order(NonbillableAccount.singleton_instance)
       if add_account_result[:success]

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -193,7 +193,9 @@ class OrdersController < ApplicationController
     # For nonbillable products, we don't ask the user to choose an account
     # POST requests are sent from the form on the choose_account page,
     # so we need to assign the account selected by the user to the order
-    account = if @product.nonbillable_mode?
+    account = if @product.blank?
+                nil
+              elsif @product.nonbillable_mode?
                 NonbillableAccount.singleton_instance
               elsif request.post?
                 Account.find(params[:account_id])

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -208,7 +208,7 @@ class OrdersController < ApplicationController
       redirect_to add_account_result[:redirect_path]
     else
       flash.now[:error] = add_account_result[:error_message] if add_account_result && add_account_result[:error_message]
-      flash.now[:error] = I18n.t("orders.choose_account.missing_account") if account.blank?
+      flash.now[:error] = I18n.t("controllers.orders.choose_account.missing_account") if account.blank? && request.post?
       @accounts = AvailableAccountsFinder.new(acting_user, @product.facility).accounts
       @errors   = {}
       details   = @order.order_details

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -135,6 +135,8 @@ en:
         failure: The reservation cannot be updated.
       switch_instrument:
         prior_is_still_running: Cannot "Begin Reservation" when a previously scheduled reservation is ongoing.
+      choose_account:
+        missing_account: "Payment source not found.  Please select a payment source and try again."
 
     general_reports:
       headers:

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -135,8 +135,6 @@ en:
         failure: The reservation cannot be updated.
       switch_instrument:
         prior_is_still_running: Cannot "Begin Reservation" when a previously scheduled reservation is ongoing.
-      choose_account:
-        missing_account: "Payment source not found.  Please select a payment source and try again."
 
     general_reports:
       headers:
@@ -198,6 +196,8 @@ en:
         quantities_changed: Quantities have changed. Please review updated prices then click "Purchase"
         reservation:
           success: Reservation created successfully
+      choose_account:
+        missing_account: "Payment source not found.  Please select a payment source and try again."
 
     order_imports:
       create:


### PR DESCRIPTION
Refactor add_account_to_order to return redirect path or error message

The nested `return` was intended to stop processing after the redirect,
but instead was returning control to the caller, causing:
 orders#choose_account (AbstractController::DoubleRenderError)
 "Render and/or redirect were called multiple times..."
Introduced in https://github.com/tablexi/nucore-open/pull/3637

To recreate:

1. Add something to the cart
2. Click “Change Payment Source”
3. Open a new tab
4. Remove item from the cart
5. In the original tab, select a payment source and click “Continue”

Also, when you click “Change Payment Source”, you can click “Continue” without selecting a payment source.  Then you get a 404.