### PR TITLE
[#162311] New reconciliation status for "abandoned" orders

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -435,7 +435,7 @@ GEM
       coffee-rails (>= 3.2.1)
       jquery-rails
       rails (>= 3.2.0)
-    net-imap (0.4.14)
+    net-imap (0.4.15)
       date
       net-protocol
     net-ldap (0.19.0)

--- a/app/assets/javascripts/app/hide_reconcile_fields.js
+++ b/app/assets/javascripts/app/hide_reconcile_fields.js
@@ -1,0 +1,33 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const orderStatusSelect = document.querySelector(".js--orderStatusSelect");
+
+  if (!orderStatusSelect) {
+    return;
+  }
+
+  orderStatusSelect.addEventListener("change", function (event) {
+    const selectedValue = event.target.value;
+
+    document
+      .querySelectorAll(".js--reconcileField")
+      .forEach((reconcileTableField) => {
+        if (selectedValue === "reconciled") {
+          reconcileTableField.classList.remove("hidden");
+        } else {
+          reconcileTableField.classList.add("hidden");
+        }
+      });
+
+    const reconcileOrdersActionRow = document.querySelector(".js--reconcileOrdersContainer");
+
+    if (!reconcileOrdersActionRow) {
+      return;
+    }
+
+    if (selectedValue === "reconciled") {
+      reconcileOrdersActionRow.classList.remove("hidden");
+    } else {
+      reconcileOrdersActionRow.classList.add("hidden");
+    }
+  });
+});

--- a/app/controllers/facility_accounts_reconciliation_controller.rb
+++ b/app/controllers/facility_accounts_reconciliation_controller.rb
@@ -36,10 +36,10 @@ class FacilityAccountsReconciliationController < ApplicationController
       unreconciled_details,
       params[:order_detail],
       reconciled_at,
+      params[:order_status],
       params[:bulk_reconcile_note],
       params[:bulk_deposit_number],
       params[:bulk_note_checkbox],
-      params[:order_status]
     )
 
     if reconciler.reconcile_all > 0

--- a/app/controllers/facility_accounts_reconciliation_controller.rb
+++ b/app/controllers/facility_accounts_reconciliation_controller.rb
@@ -51,7 +51,7 @@ class FacilityAccountsReconciliationController < ApplicationController
         LogEvent.log(statement, :closed, current_user)
       end
 
-      flash[:notice] = "#{count} payment#{count == 1 ? '' : 's'} successfully reconciled" if count > 0
+      flash[:notice] = "#{count} payment#{count == 1 ? '' : 's'} successfully updated" if count > 0
     else
       flash[:error] = reconciler.full_errors.join("<br />").html_safe
     end

--- a/app/controllers/facility_accounts_reconciliation_controller.rb
+++ b/app/controllers/facility_accounts_reconciliation_controller.rb
@@ -39,6 +39,7 @@ class FacilityAccountsReconciliationController < ApplicationController
       params[:bulk_reconcile_note],
       params[:bulk_deposit_number],
       params[:bulk_note_checkbox],
+      params[:order_status]
     )
 
     if reconciler.reconcile_all > 0

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -134,7 +134,7 @@ class FacilityJournalsController < ApplicationController
   end
 
   def reconcile
-    reconciler = OrderDetails::Reconciler.new(@journal.order_details, params[:order_detail], @journal.journal_date)
+    reconciler = OrderDetails::Reconciler.new(@journal.order_details, params[:order_detail], @journal.journal_date, "reconciled")
 
     if reconciler.reconcile_all > 0
       count = reconciler.count

--- a/app/forms/statement_search_form.rb
+++ b/app/forms/statement_search_form.rb
@@ -17,7 +17,7 @@ class StatementSearchForm
   end
 
   def available_statuses
-    ["Reconciled", "Unreconciled", "Canceled"]
+    ["Reconciled", "Unreconciled", "Unrecoverable", "Canceled"]
   end
 
   def facility_filter?
@@ -45,6 +45,8 @@ class StatementSearchForm
       results.reconciled
     when "Unreconciled"
       results.unreconciled
+    when "Unrecoverable"
+      results.unrecoverable
     when "Canceled"
       results.where.not(canceled_at: nil)
     else

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -497,8 +497,8 @@ class OrderDetail < ApplicationRecord
   end
 
   def can_be_marked_as_unrecoverable?
-    # Can only be marked as unrecoverable if it has already been invoiced
-    state.to_sym == :complete && statement.present?
+    # Can only be marked as unrecoverable if it has already been completed
+    state.to_sym == :complete
   end
 
   def pending?

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -368,13 +368,14 @@ class OrderDetail < ApplicationRecord
 
   include AASM
 
-  CANCELABLE_STATES = [:new, :inprocess, :complete].freeze
+  CANCELABLE_STATES = [:new, :inprocess, :complete, :unrecoverable].freeze
   aasm column: :state do
     state :new, initial: true
     state :inprocess
     state :complete, enter: :make_complete
     state :reconciled, enter: :set_reconciled_at
     state :canceled, enter: :clear_costs
+    state :unrecoverable
 
     event :to_new do
       transitions to: :new, from: :inprocess
@@ -390,6 +391,10 @@ class OrderDetail < ApplicationRecord
 
     event :to_reconciled do
       transitions to: :reconciled, from: :complete, guard: :actual_total
+    end
+
+    event :to_unrecoverable do
+      transitions to: :unrecoverable, from: :complete, guard: :can_be_marked_as_unrecoverable?
     end
 
     event :to_canceled do
@@ -489,6 +494,11 @@ class OrderDetail < ApplicationRecord
   def cancelable?
     # can't cancel if the reservation isn't already canceled or if this OD has been added to a journal
     state_is_cancelable? && journal.nil? && !has_uncanceled_reservation?
+  end
+
+  def can_be_marked_as_unrecoverable?
+    # Can only be marked as unrecoverable if it has already been invoiced
+    state.to_sym == :complete && statement.present?
   end
 
   def pending?
@@ -752,7 +762,9 @@ class OrderDetail < ApplicationRecord
         change_status! order_status
       end
     else
+      return false if state.to_sym == :unreconciled
       return false unless reservation&.can_cancel?
+
       # must set canceled_at after calling #can_cancel?
       return false unless update(canceled_at: Time.current)
       clear_statement if cancellation_fee == 0

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -762,6 +762,7 @@ class OrderDetail < ApplicationRecord
         change_status! order_status
       end
     else
+      # If the order status is Unrecoverable, then it shouldn't be cancelable by the customer
       return false if state.to_sym == :unrecoverable
       return false unless reservation&.can_cancel?
 

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -497,8 +497,8 @@ class OrderDetail < ApplicationRecord
   end
 
   def can_be_marked_as_unrecoverable?
-    # Can only be marked as unrecoverable if it has already been completed
-    state.to_sym == :complete
+    # Can only be marked as unrecoverable if it has already been invoiced
+    state.to_sym == :complete && statement.present?
   end
 
   def pending?

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -762,7 +762,7 @@ class OrderDetail < ApplicationRecord
         change_status! order_status
       end
     else
-      return false if state.to_sym == :unreconciled
+      return false if state.to_sym == :unrecoverable
       return false unless reservation&.can_cancel?
 
       # must set canceled_at after calling #can_cancel?

--- a/app/models/order_status.rb
+++ b/app/models/order_status.rb
@@ -19,7 +19,7 @@ class OrderStatus < ApplicationRecord
 
   scope :for_facility, ->(facility) { where(facility_id: [nil, facility&.id]) }
 
-  ROOT_STATUS_ORDER = ["New", "In Process", "Canceled", "Complete", "Reconciled"].freeze
+  ROOT_STATUS_ORDER = ["New", "In Process", "Canceled", "Complete", "Reconciled", "Unrecoverable"].freeze
 
   # Needs to be overridable by engines
   cattr_accessor(:ordered_root_statuses) { ROOT_STATUS_ORDER.dup }
@@ -43,6 +43,10 @@ class OrderStatus < ApplicationRecord
 
   def self.reconciled
     find_by(name: "Reconciled")
+  end
+
+  def self.unrecoverable
+    find_by(name: "Unrecoverable")
   end
 
   def self.add_to_order_statuses(facility)

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -13,16 +13,16 @@ module OrderDetails
     validate :all_journals_and_statements_must_be_before_reconciliation_date
 
     def initialize(
-      order_detail_scope,
-      params,
-      reconciled_at,
-      bulk_reconcile_note = nil,
-      bulk_deposit_number = nil,
-      bulk_reconcile_checkbox = nil,
-      order_status = "reconciled"
-    )
+        order_detail_scope,
+        params,
+        reconciled_at,
+        bulk_reconcile_note = nil,
+        bulk_deposit_number = nil,
+        bulk_reconcile_checkbox = nil,
+        order_status
+      )
       @params = params || ActionController::Parameters.new
-      @order_status = order_status
+      @order_status = order_status || "reconciled"
       @order_details = order_detail_scope.readonly(false).find_ids(to_be_reconciled.keys)
       @reconciled_at = reconciled_at
       @bulk_reconcile_note = bulk_reconcile_note if bulk_reconcile_checkbox == "1"

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -16,10 +16,10 @@ module OrderDetails
         order_detail_scope,
         params,
         reconciled_at,
+        order_status,
         bulk_reconcile_note = nil,
         bulk_deposit_number = nil,
-        bulk_reconcile_checkbox = nil,
-        order_status
+        bulk_reconcile_checkbox = nil
       )
       @params = params || ActionController::Parameters.new
       @order_status = order_status || "reconciled"

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -54,14 +54,14 @@ module OrderDetails
     end
 
     def update_status(order_detail, params)
+      order_detail.assign_attributes(allowed(params))
+
       if @order_status == "reconciled"
         order_detail.reconciled_at = @reconciled_at
-        order_detail.assign_attributes(allowed(params))
         order_detail.reconciled_note = @bulk_reconcile_note if @bulk_reconcile_note.present?
         order_detail.deposit_number = @bulk_deposit_number if @bulk_deposit_number.present?
         order_detail.change_status!(OrderStatus.reconciled)
       else
-        order_detail.assign_attributes(allowed(params))
         order_detail.reconciled_at = nil
         order_detail.reconciled_note = nil
         order_detail.deposit_number = nil

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -12,8 +12,17 @@ module OrderDetails
     validate :reconciliation_must_be_in_past
     validate :all_journals_and_statements_must_be_before_reconciliation_date
 
-    def initialize(order_detail_scope, params, reconciled_at, bulk_reconcile_note = nil, bulk_deposit_number = nil, bulk_reconcile_checkbox = nil)
+    def initialize(
+      order_detail_scope,
+      params,
+      reconciled_at,
+      bulk_reconcile_note = nil,
+      bulk_deposit_number = nil,
+      bulk_reconcile_checkbox = nil,
+      order_status = "reconciled"
+    )
       @params = params || ActionController::Parameters.new
+      @order_status = order_status
       @order_details = order_detail_scope.readonly(false).find_ids(to_be_reconciled.keys)
       @reconciled_at = reconciled_at
       @bulk_reconcile_note = bulk_reconcile_note if bulk_reconcile_checkbox == "1"
@@ -26,7 +35,7 @@ module OrderDetails
       OrderDetail.transaction do
         order_details.each do |od|
           od_params = @params[od.id.to_s]
-          reconcile(od, od_params)
+          update_status(od, od_params)
         end
       end
       @count
@@ -44,12 +53,20 @@ module OrderDetails
       @params.select { |_order_detail_id, params| params[:reconciled] == "1" }
     end
 
-    def reconcile(order_detail, params)
-      order_detail.reconciled_at = @reconciled_at
-      order_detail.assign_attributes(allowed(params))
-      order_detail.reconciled_note = @bulk_reconcile_note if @bulk_reconcile_note.present?
-      order_detail.deposit_number = @bulk_deposit_number if @bulk_deposit_number.present?
-      order_detail.change_status!(OrderStatus.reconciled)
+    def update_status(order_detail, params)
+      if @order_status == "reconciled"
+        order_detail.reconciled_at = @reconciled_at
+        order_detail.assign_attributes(allowed(params))
+        order_detail.reconciled_note = @bulk_reconcile_note if @bulk_reconcile_note.present?
+        order_detail.deposit_number = @bulk_deposit_number if @bulk_deposit_number.present?
+        order_detail.change_status!(OrderStatus.reconciled)
+      else
+        order_detail.assign_attributes(allowed(params))
+        order_detail.reconciled_at = nil
+        order_detail.reconciled_note = nil
+        order_detail.deposit_number = nil
+        order_detail.change_status!(OrderStatus.unrecoverable)
+      end
       @count += 1
     rescue => e
       @error_fields = { order_detail.id => order_detail.errors.collect { |field, _error| field } }

--- a/app/views/facility_accounts_reconciliation/_action_row.html.haml
+++ b/app/views/facility_accounts_reconciliation/_action_row.html.haml
@@ -1,7 +1,7 @@
 .row.table-actions.form-horizontal
   .span2.select_all_none= select_all_link
   - if local_assigns[:show_order_status]
-    = select_tag :order_status, options_for_select([['Reconciled', 'reconciled'], ['Unrecoverable', 'unrecoverable']]), class: "js--orderStatusSelect"
+    = select_tag :order_status, options_for_select([["Reconciled", "reconciled"], ["Unrecoverable", "unrecoverable"]]), class: "js--orderStatusSelect"
   .span1.pull-right= submit_tag t("facility_accounts_reconciliation.index.submit"), class: ["btn", "btn-primary", "js--requireValueForSubmit"], data: { disable_with: t("facility_accounts_reconciliation.index.submit") }
 
 - if local_assigns[:date]

--- a/app/views/facility_accounts_reconciliation/_action_row.html.haml
+++ b/app/views/facility_accounts_reconciliation/_action_row.html.haml
@@ -1,5 +1,7 @@
 .row.table-actions.form-horizontal
   .span2.select_all_none= select_all_link
+  - if show_order_status
+    = select_tag :order_status, options_for_select([['Reconciled', 'reconciled'], ['Unrecoverable', 'unrecoverable']])
   .span1.pull-right= submit_tag t("facility_accounts_reconciliation.index.submit"), class: ["btn", "btn-primary", "js--requireValueForSubmit"], data: { disable_with: t("facility_accounts_reconciliation.index.submit") }
 
 - if local_assigns[:date]

--- a/app/views/facility_accounts_reconciliation/_action_row.html.haml
+++ b/app/views/facility_accounts_reconciliation/_action_row.html.haml
@@ -1,29 +1,30 @@
 .row.table-actions.form-horizontal
   .span2.select_all_none= select_all_link
   - if show_order_status
-    = select_tag :order_status, options_for_select([['Reconciled', 'reconciled'], ['Unrecoverable', 'unrecoverable']])
+    = select_tag :order_status, options_for_select([['Reconciled', 'reconciled'], ['Unrecoverable', 'unrecoverable']]), class: "js--orderStatusSelect"
   .span1.pull-right= submit_tag t("facility_accounts_reconciliation.index.submit"), class: ["btn", "btn-primary", "js--requireValueForSubmit"], data: { disable_with: t("facility_accounts_reconciliation.index.submit") }
 
 - if local_assigns[:date]
-  .row.table-actions.form-horizontal
-    .span5.pull-left.control-group.fields
-      %label.control-label{ for: :reconciled_at }= OrderDetail.human_attribute_name(:reconciled_at)
-      .controls
-        = text_field_tag :reconciled_at, format_usa_date(Time.current), class: :datepicker__data, data: { min_date: unreconciled_order_details.map(&:journal_or_statement_date).min.iso8601, max_date: Time.current.iso8601 }
-  .row.table-actions.form-horizontal
-    .span3.control-group.fields
-      %label.control-label{ for: "bulk_note_checkbox" }= t("facility_accounts_reconciliation.index.bulk_note_checkbox")
-      .controls
-        = check_box_tag :bulk_note_checkbox
-    #bulk-note-input.span5.control-group.fields
-      %label.control-label{ for: :bulk_reconcile_note }= t("facility_accounts_reconciliation.index.bulk_note")
-      .controls
-        = text_field_tag :bulk_reconcile_note
+  .js--reconcileOrdersContainer
+    .row.table-actions.form-horizontal
+      .span5.pull-left.control-group.fields
+        %label.control-label{ for: :reconciled_at }= OrderDetail.human_attribute_name(:reconciled_at)
+        .controls
+          = text_field_tag :reconciled_at, format_usa_date(Time.current), class: :datepicker__data, data: { min_date: unreconciled_order_details.map(&:journal_or_statement_date).min.iso8601, max_date: Time.current.iso8601 }
+    .row.table-actions.form-horizontal
+      .span3.control-group.fields
+        %label.control-label{ for: "bulk_note_checkbox" }= t("facility_accounts_reconciliation.index.bulk_note_checkbox")
+        .controls
+          = check_box_tag :bulk_note_checkbox
+      #bulk-note-input.span5.control-group.fields
+        %label.control-label{ for: :bulk_reconcile_note }= t("facility_accounts_reconciliation.index.bulk_note")
+        .controls
+          = text_field_tag :bulk_reconcile_note
 
-      - if show_reconciliation_deposit_number
-        .deposit-number-row
-          %label.inline{ for: :bulk_deposit_number, data: { toggle: "tooltip" }, title: text("facility_accounts_reconciliation.index.bulk_deposit_number_hint") }
-            = text("facility_accounts_reconciliation.index.bulk_deposit_number")
-          %span
-            = text("facility_accounts_reconciliation.index.bulk_deposit_number_prefix")
-          = text_field_tag :bulk_deposit_number
+        - if show_reconciliation_deposit_number
+          .deposit-number-row
+            %label.inline{ for: :bulk_deposit_number, data: { toggle: "tooltip" }, title: text("facility_accounts_reconciliation.index.bulk_deposit_number_hint") }
+              = text("facility_accounts_reconciliation.index.bulk_deposit_number")
+            %span
+              = text("facility_accounts_reconciliation.index.bulk_deposit_number_prefix")
+            = text_field_tag :bulk_deposit_number

--- a/app/views/facility_accounts_reconciliation/_action_row.html.haml
+++ b/app/views/facility_accounts_reconciliation/_action_row.html.haml
@@ -1,6 +1,6 @@
 .row.table-actions.form-horizontal
   .span2.select_all_none= select_all_link
-  - if show_order_status
+  - if local_assigns[:show_order_status]
     = select_tag :order_status, options_for_select([['Reconciled', 'reconciled'], ['Unrecoverable', 'unrecoverable']]), class: "js--orderStatusSelect"
   .span1.pull-right= submit_tag t("facility_accounts_reconciliation.index.submit"), class: ["btn", "btn-primary", "js--requireValueForSubmit"], data: { disable_with: t("facility_accounts_reconciliation.index.submit") }
 

--- a/app/views/facility_accounts_reconciliation/_table.html.haml
+++ b/app/views/facility_accounts_reconciliation/_table.html.haml
@@ -7,9 +7,9 @@
       %th{scope: "col"}= Account.model_name.human
       %th{scope: "col"}= Order.model_name.human
       %th{scope: "col"}= Statement.human_attribute_name(:total_cost)
-      %th#reconcile-note.row-note-input{scope: "col"}= Statement.human_attribute_name(:reconcile_note)
+      %th#reconcile-note.row-note-input.js--reconcileField{scope: "col"}= Statement.human_attribute_name(:reconcile_note)
       - if show_reconciliation_deposit_number
-        %th#reconcile-deposit-number.row-note-input{ scope: "col", data: { toggle: "tooltip" }, title: text("facility_accounts_reconciliation.index.bulk_deposit_number_hint") }
+        %th#reconcile-deposit-number.row-note-input.js--reconcileField{ scope: "col", data: { toggle: "tooltip" }, title: text("facility_accounts_reconciliation.index.bulk_deposit_number_hint") }
           = OrderDetail.human_attribute_name(:deposit_number)
   %tbody
     - @unreconciled_details.each do |order_detail|
@@ -30,6 +30,6 @@
               .order-detail-extra.order-detail-note= order_detail.note
 
         %td= show_actual_total(order_detail)
-        %td.row-note-input= text_field_tag "order_detail[#{order_detail.id}][reconciled_note]", nil, aria: {labelledby: "reconcile-note"}
+        %td.row-note-input.js--reconcileField= text_field_tag "order_detail[#{order_detail.id}][reconciled_note]", nil, aria: {labelledby: "reconcile-note"}
         - if show_reconciliation_deposit_number
-          %td.row-note-input= text_field_tag "order_detail[#{order_detail.id}][deposit_number]", nil, aria: {labelledby: "reconcile-deposit-number"}
+          %td.row-note-input.js--reconcileField= text_field_tag "order_detail[#{order_detail.id}][deposit_number]", nil, aria: {labelledby: "reconcile-deposit-number"}

--- a/app/views/facility_accounts_reconciliation/index.html.haml
+++ b/app/views/facility_accounts_reconciliation/index.html.haml
@@ -14,9 +14,9 @@
 - if @unreconciled_details.any?
   - show_reconciliation_deposit_number = SettingsHelper.feature_on?(:show_reconciliation_deposit_number)
   = form_tag([:update, account_route.to_sym, FacilityAccount], method: :post) do
-    = render "action_row", date: true, unreconciled_order_details: @unreconciled_details, show_reconciliation_deposit_number: show_reconciliation_deposit_number
+    = render "action_row", date: true, unreconciled_order_details: @unreconciled_details, show_reconciliation_deposit_number: show_reconciliation_deposit_number, show_order_status: true
     = render "table", show_reconciliation_deposit_number: show_reconciliation_deposit_number
-    = render "action_row", show_reconciliation_deposit_number: show_reconciliation_deposit_number
+    = render "action_row", show_reconciliation_deposit_number: show_reconciliation_deposit_number, show_order_status: false
 
   %p= will_paginate(@unreconciled_details)
 - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -249,7 +249,7 @@ en:
     index:
       head: Reconcile %{model}
       none: There are no %{model} with completed orders to be reconciled at this time
-      submit: "Reconcile Orders"
+      submit: "Update Orders"
       instructions: "Please review the following orders. Check those that are paid, record any notes, and click 'Reconcile Orders'."
       caption: Reconcilable Orders for %{model} payment sources
       checkbox_label: select order %{order_number} to be reconciled

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -250,7 +250,7 @@ en:
       head: Reconcile %{model}
       none: There are no %{model} with completed orders to be reconciled at this time
       submit: "Update Orders"
-      instructions: "Please review the following orders. Check those that are paid, record any notes, and click 'Reconcile Orders'."
+      instructions: "Please review the following orders. Check those that are paid, record any notes, and click 'Update Orders'."
       caption: Reconcilable Orders for %{model} payment sources
       checkbox_label: select order %{order_number} to be reconciled
       bulk_note_checkbox: Use Bulk Note

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,6 +13,7 @@ OrderStatus.find_or_create_by(name: "In Process")
 OrderStatus.find_or_create_by(name: "Canceled")
 OrderStatus.find_or_create_by(name: "Complete")
 OrderStatus.find_or_create_by(name: "Reconciled")
+OrderStatus.find_or_create_by(name: "Unrecoverable")
 
 Affiliate.OTHER
 

--- a/lib/tasks/demo_seed.rake
+++ b/lib/tasks/demo_seed.rake
@@ -15,6 +15,7 @@ namespace :demo do
     canceled   = OrderStatus.find_or_create_by!(name: "Canceled")
     complete   = OrderStatus.find_or_create_by!(name: "Complete")
     reconciled = OrderStatus.find_or_create_by!(name: "Reconciled")
+    abandoned  = OrderStatus.find_or_create_by!(name: "Unrecoverable")
 
     facility = Facility.find_or_create_by!(url_name: "example") do |example_facility|
       example_facility.name = "Example Facility"

--- a/lib/tasks/order_status.rake
+++ b/lib/tasks/order_status.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+namespace :order_status do
+  # This creates a new "Unrecoverable" order status, if it does not exist.
+  #
+  # rake order_status:add_unrecoverable_order_status
+  desc "Create a Unrecoverable order status"
+  task :add_unrecoverable_order_status, [] => :environment do
+    OrderStatus.find_or_create_by(name: "Unrecoverable")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -140,7 +140,7 @@ RSpec.configure do |config|
     OrderStatus.find_or_create_by(name: "Canceled")
     OrderStatus.find_or_create_by(name: "Complete")
     OrderStatus.find_or_create_by(name: "Reconciled")
-    OrderStatus.find_or_create_by(name: "Abandoned")
+    OrderStatus.find_or_create_by(name: "Unrecoverable")
 
     # initialize affiliates
     Affiliate.OTHER

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -140,6 +140,7 @@ RSpec.configure do |config|
     OrderStatus.find_or_create_by(name: "Canceled")
     OrderStatus.find_or_create_by(name: "Complete")
     OrderStatus.find_or_create_by(name: "Reconciled")
+    OrderStatus.find_or_create_by(name: "Abandoned")
 
     # initialize affiliates
     Affiliate.OTHER

--- a/spec/services/order_details/reconciler_spec.rb
+++ b/spec/services/order_details/reconciler_spec.rb
@@ -8,12 +8,13 @@ RSpec.describe OrderDetails::Reconciler do
   let!(:order) { create(:order, user: user, created_by_user: user) }
   let(:order_details) do
     Array.new(number_of_order_details).map do
-      OrderDetail.create!(product: product, quantity: 1, actual_cost: 1, actual_subsidy: 0, state: "complete", journal: journal, order_id: order.id, created_by_user: user)
+      OrderDetail.create!(product: product, quantity: 1, actual_cost: 1, actual_subsidy: 0, state: "complete", statement:, order_id: order.id, created_by_user: user)
     end
   end
   let(:params) { order_details.each_with_object({}) { |od, h| h[od.id.to_s] = ActionController::Parameters.new(reconciled: "1") } }
   let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "reconciled") }
-  let(:journal) { create(:journal, facility: product.facility) }
+  let(:account) { create(:account, :with_account_owner, type: Account.config.statement_account_types.first) }
+  let(:statement) { create(:statement, facility: product.facility, account:, created_by_user: user) }
 
   describe "reconciling" do
     let(:number_of_order_details) { 5 }

--- a/spec/services/order_details/reconciler_spec.rb
+++ b/spec/services/order_details/reconciler_spec.rb
@@ -92,6 +92,22 @@ RSpec.describe OrderDetails::Reconciler do
     end
   end
 
+  describe "marking as 'Unrecoverable'" do
+    let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "unrecoverable") }
+    let(:number_of_order_details) { 5 }
+
+    it "marks all the orders as 'Unrecoverable'" do
+      previous_reconciled_count = OrderDetail.reconciled.count
+      previous_unrecoverable_count = OrderDetail.unrecoverable.count
+      reconciler.reconcile_all
+      updated_reconciled_count = OrderDetail.reconciled.count
+      updated_unrecoverable_count = OrderDetail.unrecoverable.count
+
+      expect(updated_reconciled_count).to eq(previous_reconciled_count)
+      expect(updated_unrecoverable_count).to eq(previous_unrecoverable_count + 5)
+    end
+  end
+
   # describe "reconciling more than 1000 order details (because of oracle)" do
   #   let(:number_of_order_details) { 1001 }
 

--- a/spec/services/order_details/reconciler_spec.rb
+++ b/spec/services/order_details/reconciler_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe OrderDetails::Reconciler do
     end
   end
   let(:params) { order_details.each_with_object({}) { |od, h| h[od.id.to_s] = ActionController::Parameters.new(reconciled: "1") } }
-  let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current) }
+  let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "reconciled") }
   let(:journal) { create(:journal, facility: product.facility) }
 
   describe "reconciling" do
@@ -24,7 +24,7 @@ RSpec.describe OrderDetails::Reconciler do
 
     context "with a bulk note" do
       context "bulk note checkbox checked" do
-        let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "this is a bulk note", "CRT1234567", "1") }
+        let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "reconciled", "this is a bulk note", "CRT1234567", "1") }
 
         it "adds the note to all order details" do
           reconciler.reconcile_all
@@ -36,7 +36,7 @@ RSpec.describe OrderDetails::Reconciler do
       end
 
       context "bulk note checkbox UNchecked" do
-        let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "this is a bulk note", "CRT1234567") }
+        let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "reconciled", "this is a bulk note", "CRT1234567") }
 
         it "does NOT add the note to the order details" do
           reconciler.reconcile_all
@@ -50,7 +50,7 @@ RSpec.describe OrderDetails::Reconciler do
 
     context "with NO bulk note" do
       context "with reconciled note set" do
-        let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "" ) }
+        let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "reconciled", "" ) }
         let(:params) { order_details.each_with_object({}) { |od, h| h[od.id.to_s] = ActionController::Parameters.new(reconciled: "1", reconciled_note: "note #{od.id}") } }
 
         it "adds the note to the appropriate order details" do
@@ -62,7 +62,7 @@ RSpec.describe OrderDetails::Reconciler do
       end
 
       context "with NO reconciled note set" do
-        let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "", "" ) }
+        let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "reconciled", "", "" ) }
 
         it "does not set a value" do
           reconciler.reconcile_all
@@ -74,7 +74,7 @@ RSpec.describe OrderDetails::Reconciler do
       end
 
       context "with previous reconciled note value, no new value set" do
-        let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "", "" ) }
+        let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "reconciled", "", "" ) }
         before(:each) do
           order_details.each do |od|
             od.update!(reconciled_note: "rec note #{od.id}", deposit_number: "CRT0000123")

--- a/spec/system/admin/facility_statements_spec.rb
+++ b/spec/system/admin/facility_statements_spec.rb
@@ -17,8 +17,6 @@ RSpec.describe "Facility Statement Admin" do
     order_details.each do |detail|
       detail.update(reviewed_at: 1.day.ago)
     end
-
-    order_details.last.change_status!(OrderStatus.unrecoverable)
   end
 
   describe "filtering on Create Statement" do
@@ -39,6 +37,7 @@ RSpec.describe "Facility Statement Admin" do
     let!(:statement3) { create(:statement, created_at: 10.days.ago, order_details: [order_details.last], account: order_details.last.account, facility:) }
 
     before do
+      order_details.last.change_status!(OrderStatus.unrecoverable)
       login_as director
       visit facility_statements_path(facility)
     end

--- a/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
+++ b/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Account Reconciliation", js: true do
 
       fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
       fill_in "order_detail_#{order_detail.id}_reconciled_note", with: "this is a note!"
-      click_button "Reconcile Orders", match: :first
+      click_button "Update Orders", match: :first
 
       expect(order_detail.reload).to be_reconciled
       expect(order_detail.reconciled_note).to eq("this is a note!")
@@ -82,7 +82,7 @@ RSpec.describe "Account Reconciliation", js: true do
         check "order_detail_#{order_detail.id}_reconciled"
         check "order_detail_#{orders.last.order_details.first.id}_reconciled"
         fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
-        click_button "Reconcile Orders", match: :first
+        click_button "Update Orders", match: :first
 
         expect(order_detail.reload.reconciled_note).to eq("this is the bulk note")
         expect(orders.last.order_details.first.reload.reconciled_note).to eq("this is the bulk note")
@@ -98,7 +98,7 @@ RSpec.describe "Account Reconciliation", js: true do
         check "order_detail_#{order_detail.id}_reconciled"
         check "order_detail_#{orders.last.order_details.first.id}_reconciled"
         fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
-        click_button "Reconcile Orders", match: :first
+        click_button "Update Orders", match: :first
 
         expect(order_detail.reload.reconciled_note).to eq("")
         expect(orders.last.order_details.first.reload.reconciled_note).to eq("")
@@ -128,7 +128,7 @@ RSpec.describe "Account Reconciliation", js: true do
       check "order_detail_#{order_detail.id}_reconciled"
       fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
       fill_in "order_detail_#{order_detail.id}_reconciled_note", with: "this is a note!"
-      click_button "Reconcile Orders", match: :first
+      click_button "Update Orders", match: :first
 
       expect(order_detail.reload).to be_reconciled
       expect(order_detail.reconciled_note).to eq("this is a note!")
@@ -148,7 +148,7 @@ RSpec.describe "Account Reconciliation", js: true do
       check "order_detail_#{order_detail.id}_reconciled"
       check "order_detail_#{orders.last.order_details.first.id}_reconciled"
       fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
-      click_button "Reconcile Orders", match: :first
+      click_button "Update Orders", match: :first
       expect(order_detail.reload.reconciled_note).to eq("this is the bulk note")
       expect(orders.last.order_details.first.reload.reconciled_note).to eq("this is the bulk note")
     end


### PR DESCRIPTION
# Release Notes
NOTE: run the rake task on heroku after deploying

* Admins can now mark as "Unrecoverable" statements that are unreconciled.

# Screenshot
## Reconcile
<img width="945" alt="image" src="https://github.com/user-attachments/assets/b26ff186-d417-4a3e-be0a-75a6aca24a54">

## Mark as "Unrecoverable"
<img width="950" alt="image" src="https://github.com/user-attachments/assets/51972d22-c498-477d-ac7d-6da602386182">

## Statement history
<img width="1217" alt="image" src="https://github.com/user-attachments/assets/2cc9deae-0c3b-4851-843b-213d8ba3b1b5">

# Additional Context
## Pending work
- [ ] Specs

# Accessibility
- [ ] Did you scan for accessibility issues?
- [ ] Did you check our accessibility goal checklist?
- [ ] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)?
