### PR TITLE
[#161851] Make name an email link

### DIFF
--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -42,7 +42,9 @@
                     class: "btn btn-danger",
                     data: { confirm: "Are you sure you want to cancel?" })
           %td= format_usa_datetime(s.created_at)
-          %td= s.account.notify_users.map(&:full_name).join(', ')
+          %td
+            - s.account.notify_users.each do |user|
+              = mail_to user.email, user.full_name
           - unless @account
             %td= link_to s.account, facility_account_path(current_facility, s.account)
           - if current_facility&.cross_facility?


### PR DESCRIPTION
# Release Notes
* On the Statement History page, convert the Account Admins names to an emailto: link.