### PR TITLE
[#162402]Change cross-core orders header

### DIFF
--- a/app/views/facility_orders/show.html.haml
+++ b/app/views/facility_orders/show.html.haml
@@ -27,7 +27,7 @@
   = render "order_table", order_details: @order_details, cross_core: false, facility_id: current_facility.id
   = render "order_table_footer", order: @order, cross_core: false
 
-%h2= t("views.facility_orders.show.cross_core_orders_header")
+%h2= t("views.facility_orders.show.add_to_order_header")
 - if SettingsHelper.feature_on?(:cross_core_projects) && @cross_core_data_by_facility_id.present?
   #js--reportAnIssueModal.modal.hide.fade
 

--- a/app/views/facility_orders/show.html.haml
+++ b/app/views/facility_orders/show.html.haml
@@ -27,7 +27,9 @@
   = render "order_table", order_details: @order_details, cross_core: false, facility_id: current_facility.id
   = render "order_table_footer", order: @order, cross_core: false
 
-%h2= t("views.facility_orders.show.add_to_order_header")
+- subheader_key = (@cross_core_project.present? ? "views.facility_orders.show.add_to_cross_core_order_header" : "views.facility_orders.show.add_to_order_header")
+
+%h2= t(subheader_key)
 - if SettingsHelper.feature_on?(:cross_core_projects) && @cross_core_data_by_facility_id.present?
   #js--reportAnIssueModal.modal.hide.fade
 

--- a/config/locales/views/en.facility_orders.yml
+++ b/config/locales/views/en.facility_orders.yml
@@ -5,6 +5,7 @@ en:
         ordered_by: "Ordered By"
       show:
         add_to_order_header: "Add to Order"
+        add_to_cross_core_order_header: "Add to Cross-Core Order"
         cross_core_project_id: "Cross-Core Project ID"
         cross_core_project_total: "Cross-Core Project Total"
         table_caption: "Order detail information"

--- a/config/locales/views/en.facility_orders.yml
+++ b/config/locales/views/en.facility_orders.yml
@@ -4,7 +4,7 @@ en:
       index:
         ordered_by: "Ordered By"
       show:
-        cross_core_orders_header: "Cross-Core Orders"
+        add_to_order_header: "Add to Order"
         cross_core_project_id: "Cross-Core Project ID"
         cross_core_project_total: "Cross-Core Project Total"
         table_caption: "Order detail information"


### PR DESCRIPTION
# Release Notes

In the order's show view accessed through the "Manage Facility" menu, there's a section with a "Cross-core header". This header doesn't describe the menu's function correctly. The menu allows adding cross-core products to an order but it also allows to add products from the same facility as well and many users use it this way.

# Screenshot

Before:
<img width="1265" alt="Screenshot 2024-10-11 at 4 13 39 PM" src="https://github.com/user-attachments/assets/f356556b-783a-4f1c-87d8-abadb73d008d">

After:
<img width="1246" alt="Screenshot 2024-10-11 at 4 13 01 PM" src="https://github.com/user-attachments/assets/ccf08302-4248-4933-8f70-35094b783447">


# Additional Context

I suggest a less specific header: "Add Product to Selected Order"

Didn't opt for a dynamic header as the header is defined in the HTML view structure. I don't think moving the logic to the javascript code to change it dynamically when selecting a facility in the menu dropdown is worth the effort as it's just a header and the action button already provides this information dynamically to the user. Let me know what you guys think about this.

