### PR TITLE
[#162423] Tech Task: bump rexml and fix saml authentication tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -558,8 +558,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.3.2)
-      strscan
+    rexml (3.3.8)
     rollbar (3.6.0)
     rspec-activejob (0.6.1)
       activejob (>= 4.2)
@@ -662,7 +661,6 @@ GEM
       net-ssh (>= 2.8.0)
       ostruct
     state_machines (0.6.0)
-    strscan (3.1.0)
     synaccess_connect (0.3.1)
       nokogiri (>= 1.6)
     sysexits (1.2.0)

--- a/vendor/engines/saml_authentication/spec/controllers/saml_authentication/sessions_controller_spec.rb
+++ b/vendor/engines/saml_authentication/spec/controllers/saml_authentication/sessions_controller_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe SamlAuthentication::SessionsController, type: :controller do
     end
 
     def self.encode(saml)
-      new.send(:encode_raw_saml, saml, OpenStruct.new(compress_request: true))
+      encoded = new.send(:encode_raw_saml, saml, OpenStruct.new(compress_request: false))
+      # encode_raw_saml url-encodes the encoded saml so it's correctly sent over http.
+      # Since this is a controller spec we don't have the automatic url-decoding step on params.
+      CGI.unescape(encoded)
     end
 
   end

--- a/vendor/engines/saml_authentication/spec/controllers/saml_authentication/sessions_controller_spec.rb
+++ b/vendor/engines/saml_authentication/spec/controllers/saml_authentication/sessions_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SamlAuthentication::SessionsController, type: :controller do
     end
 
     def self.encode(saml)
-      encoded = new.send(:encode_raw_saml, saml, OpenStruct.new(compress_request: false))
+      encoded = new.send(:encode_raw_saml, saml, OpenStruct.new(compress_request: true))
       # encode_raw_saml url-encodes the encoded saml so it's correctly sent over http.
       # Since this is a controller spec we don't have the automatic url-decoding step on params.
       CGI.unescape(encoded)


### PR DESCRIPTION
# Notes

- Bump rexml from 3.3.2 to 3.3.8
- Fix failing tests after upgrade on saml_authentication engine

# Context

SAML authentication tests were failing after the upgrade because the behaviour of `REXML::Document.new(value)` changed (from 3.3.2 to 3.3.3) when value is an invalid xml from returning an invalid document representation to raising an error.

SAML is a specification for exchanging authentication information between parties which uses xml with base64 for data exchange between servers.

The xml used in the failing tests was invalid because the ruby_saml library [url-encodes](https://github.com/SAML-Toolkits/ruby-saml/blob/148a4c2de713a98c58c28bbc7785c05698216a4d/lib/onelogin/ruby-saml/saml_message.rb#L112) the base64 encoded xml automtically but then does not url-decodes it when decoding the base64 back (because that would be done by a web server).

The reason why tests were passing before this fix with invalid xmls is unknown to me.