### PR TITLE
[#162433] Tech task: fix capybara warnings on selector types

### DIFF
--- a/spec/system/admin/all_transactions_search_spec.rb
+++ b/spec/system/admin/all_transactions_search_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe "All Transactions Search", :js do
     expect(page).to have_link(orders.second.order_details.first.id.to_s, href: manage_facility_order_order_detail_path(orders.second.facility, orders.second, orders.second.order_details.first))
 
     # Cross Core orders
-    expect(page).not_to have_link(originating_order_facility1.id, href: facility_order_path(originating_order_facility1.facility, originating_order_facility1))
-    expect(page).to have_link(cross_core_orders[2].id, href: facility_order_path(cross_core_orders[2].facility, cross_core_orders[2]))
+    expect(page).not_to have_link(originating_order_facility1.id.to_s, href: facility_order_path(originating_order_facility1.facility, originating_order_facility1))
+    expect(page).to have_link(cross_core_orders[2].id.to_s, href: facility_order_path(cross_core_orders[2].facility, cross_core_orders[2]))
     expect(page).to have_css(".fa-users", count: 1) # cross_core_orders[2] is a cross-core order that didn't originate in the current facility
   end
 

--- a/spec/system/admin/facility_orders_search_spec.rb
+++ b/spec/system/admin/facility_orders_search_spec.rb
@@ -105,12 +105,12 @@ RSpec.describe "Facility Orders Search" do
           expect(page).to have_css(".fa-users", count: 1) # cross_core_orders.last
           expect(page).to have_css(".fa-building", count: 1) # originating_cross_core_order
 
-          expect(page).to have_link(originating_cross_core_order.id, href: originating_cross_core_order_path)
-          expect(page).to have_link(cross_core_orders.last.id, href: cross_core_orders_last_path)
+          expect(page).to have_link(originating_cross_core_order.id.to_s, href: originating_cross_core_order_path)
+          expect(page).to have_link(cross_core_orders.last.id.to_s, href: cross_core_orders_last_path)
 
-          expect(page).not_to have_link(order_for_facility.id, href: order_for_facility_path)
-          expect(page).not_to have_link(cross_core_order_originating_facility2.id, href: cross_core_order_originating_facility2_path)
-          expect(page).not_to have_link(cross_core_orders.first.id, href: cross_core_orders_first_path)
+          expect(page).not_to have_link(order_for_facility.id.to_s, href: order_for_facility_path)
+          expect(page).not_to have_link(cross_core_order_originating_facility2.id.to_s, href: cross_core_order_originating_facility2_path)
+          expect(page).not_to have_link(cross_core_orders.first.id.to_s, href: cross_core_orders_first_path)
         end
       end
 
@@ -119,12 +119,12 @@ RSpec.describe "Facility Orders Search" do
           expect(page).to have_css(".fa-users", count: 1) # cross_core_orders.last
           expect(page).to have_css(".fa-building", count: 1) # originating_cross_core_order
 
-          expect(page).to have_link(order_for_facility.id, href: order_for_facility_path)
-          expect(page).to have_link(originating_cross_core_order.id, href: originating_cross_core_order_path)
-          expect(page).to have_link(cross_core_orders.last.id, href: cross_core_orders_last_path)
+          expect(page).to have_link(order_for_facility.id.to_s, href: order_for_facility_path)
+          expect(page).to have_link(originating_cross_core_order.id.to_s, href: originating_cross_core_order_path)
+          expect(page).to have_link(cross_core_orders.last.id.to_s, href: cross_core_orders_last_path)
 
-          expect(page).not_to have_link(cross_core_order_originating_facility2.id, href: cross_core_order_originating_facility2_path)
-          expect(page).not_to have_link(cross_core_orders.first.id, href: cross_core_orders_first_path)
+          expect(page).not_to have_link(cross_core_order_originating_facility2.id.to_s, href: cross_core_order_originating_facility2_path)
+          expect(page).not_to have_link(cross_core_orders.first.id.to_s, href: cross_core_orders_first_path)
         end
       end
     end
@@ -159,14 +159,14 @@ RSpec.describe "Facility Orders Search" do
           expect(page).to have_css(".fa-users", count: 1) # cross_core_orders.last
           expect(page).to have_css(".fa-building", count: 0)
 
-          expect(page).to have_link(cross_core_orders.last.id, href: cross_core_orders_last_path)
+          expect(page).to have_link(cross_core_orders.last.id.to_s, href: cross_core_orders_last_path)
 
-          expect(page).not_to have_link(originating_cross_core_order.id, href: originating_cross_core_order_path)
+          expect(page).not_to have_link(originating_cross_core_order.id.to_s, href: originating_cross_core_order_path)
 
-          expect(page).not_to have_link(order_for_facility.id, href: order_for_facility_path)
+          expect(page).not_to have_link(order_for_facility.id.to_s, href: order_for_facility_path)
 
-          expect(page).not_to have_link(cross_core_order_originating_facility2.id, href: cross_core_order_originating_facility2_path)
-          expect(page).not_to have_link(cross_core_orders.first.id, href: cross_core_orders_first_path)
+          expect(page).not_to have_link(cross_core_order_originating_facility2.id.to_s, href: cross_core_order_originating_facility2_path)
+          expect(page).not_to have_link(cross_core_orders.first.id.to_s, href: cross_core_orders_first_path)
         end
       end
 
@@ -175,12 +175,12 @@ RSpec.describe "Facility Orders Search" do
           expect(page).to have_css(".fa-users", count: 1) # cross_core_orders.last
           expect(page).to have_css(".fa-building", count: 0) # order_for_facility is not a cross-core order so it doesn't have an icon
 
-          expect(page).to have_link(order_for_facility.id, href: order_for_facility_path)
-          expect(page).to have_link(cross_core_orders.last.id, href: cross_core_orders_last_path)
+          expect(page).to have_link(order_for_facility.id.to_s, href: order_for_facility_path)
+          expect(page).to have_link(cross_core_orders.last.id.to_s, href: cross_core_orders_last_path)
 
-          expect(page).not_to have_link(originating_cross_core_order.id, href: originating_cross_core_order_path)
-          expect(page).not_to have_link(cross_core_order_originating_facility2.id, href: cross_core_order_originating_facility2_path)
-          expect(page).not_to have_link(cross_core_orders.first.id, href: cross_core_orders_first_path)
+          expect(page).not_to have_link(originating_cross_core_order.id.to_s, href: originating_cross_core_order_path)
+          expect(page).not_to have_link(cross_core_order_originating_facility2.id.to_s, href: cross_core_order_originating_facility2_path)
+          expect(page).not_to have_link(cross_core_orders.first.id.to_s, href: cross_core_orders_first_path)
         end
       end
     end

--- a/spec/system/admin/projects_show_spec.rb
+++ b/spec/system/admin/projects_show_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Projects show", feature_setting: { cross_core_order_view: true }
       end
 
       it "shows the order details" do
-        expect(page).to have_content(active_project_order.order_details.first.id)
+        expect(page).to have_content(active_project_order.order_details.first.id.to_s)
       end
 
       it "shows Edit button" do
@@ -41,9 +41,9 @@ RSpec.describe "Projects show", feature_setting: { cross_core_order_view: true }
       end
 
       it "navigates to order" do
-        click_link active_project_order.id
+        click_link active_project_order.id.to_s
 
-        expect(page).to have_content(active_project_order.id)
+        expect(page).to have_content(active_project_order.id.to_s)
       end
     end
 
@@ -73,17 +73,17 @@ RSpec.describe "Projects show", feature_setting: { cross_core_order_view: true }
         end
 
         it "shows the order details" do
-          expect(page).to have_content(originating_order_facility1.order_details.first.id)
-          expect(page).to have_content(cross_core_orders[0].order_details.first.id)
-          expect(page).to have_content(cross_core_orders[1].order_details.first.id)
+          expect(page).to have_content(originating_order_facility1.order_details.first.id.to_s)
+          expect(page).to have_content(cross_core_orders[0].order_details.first.id.to_s)
+          expect(page).to have_content(cross_core_orders[1].order_details.first.id.to_s)
         end
 
         it "shows other facility's orders as text" do
-          expect(page).not_to have_link(cross_core_orders[0].id)
-          expect(page).not_to have_link(cross_core_orders[1].id)
+          expect(page).not_to have_link(cross_core_orders[0].id.to_s)
+          expect(page).not_to have_link(cross_core_orders[1].id.to_s)
 
-          expect(page).to have_content(cross_core_orders[0].id)
-          expect(page).to have_content(cross_core_orders[1].id)
+          expect(page).to have_content(cross_core_orders[0].id.to_s)
+          expect(page).to have_content(cross_core_orders[1].id.to_s)
         end
 
         it "shows Edit button" do
@@ -95,9 +95,9 @@ RSpec.describe "Projects show", feature_setting: { cross_core_order_view: true }
         end
 
         it "navigates to original order" do
-          click_link originating_order_facility1.id
+          click_link originating_order_facility1.id.to_s
 
-          expect(page).to have_content(originating_order_facility1.id)
+          expect(page).to have_content(originating_order_facility1.id.to_s)
           expect(page).to have_content(facility2.name)
           expect(page).to have_content(facility3.name)
         end
@@ -113,9 +113,9 @@ RSpec.describe "Projects show", feature_setting: { cross_core_order_view: true }
         end
 
         it "shows the order details" do
-          expect(page).to have_content(originating_order_facility2.order_details.first.id)
-          expect(page).to have_content(cross_core_orders[2].order_details.first.id)
-          expect(page).to have_content(cross_core_orders[3].order_details.first.id)
+          expect(page).to have_content(originating_order_facility2.order_details.first.id.to_s)
+          expect(page).to have_content(cross_core_orders[2].order_details.first.id.to_s)
+          expect(page).to have_content(cross_core_orders[3].order_details.first.id.to_s)
         end
 
         it "shows Edit button" do
@@ -127,17 +127,17 @@ RSpec.describe "Projects show", feature_setting: { cross_core_order_view: true }
         end
 
         it "shows other facility's orders as text" do
-          expect(page).not_to have_link(originating_order_facility2.id)
-          expect(page).not_to have_link(cross_core_orders[3].id)
+          expect(page).not_to have_link(originating_order_facility2.id.to_s)
+          expect(page).not_to have_link(cross_core_orders[3].id.to_s)
 
-          expect(page).to have_content(originating_order_facility2.id)
-          expect(page).to have_content(cross_core_orders[3].id)
+          expect(page).to have_content(originating_order_facility2.id.to_s)
+          expect(page).to have_content(cross_core_orders[3].id.to_s)
         end
 
         it "navigates to facility order" do
-          click_link cross_core_orders[2].id
+          click_link cross_core_orders[2].id.to_s
 
-          expect(page).to have_content(cross_core_orders[2].id)
+          expect(page).to have_content(cross_core_orders[2].id.to_s)
           expect(page).to have_content(facility2.name)
           expect(page).to have_content(facility3.name)
         end


### PR DESCRIPTION
# Notes

Clean up capybara spec warnings by converting ids to strings when using them as selectors in matchers.
