### PR TITLE
[#162448] Tech task: Group rails gems on dependabot prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,10 @@ updates:
   - dependency-type: all
   groups:
     rails-gems:
-      update-types: [patch]
+      update-types:
+        - patch
+        - minor
+
       patterns:
         - rails
         - railties

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,22 @@ updates:
   open-pull-requests-limit: 99
   allow:
   - dependency-type: all
+  groups:
+    rails-gems:
+      update-types: [patch]
+      patterns:
+        - rails
+        - railties
+        - actioncable
+        - actionmailbox
+        - actionmailer
+        - actionpack
+        - actiontext
+        - actionview
+        - activejob
+        - activemodel
+        - activerecord
+        - activestorage
 
 # Check for updates to GitHub Actions every week
 - package-ecosystem: "github-actions"


### PR DESCRIPTION
# Create Dependabot group for rails gems

This should cause all rails gems to be updated together in the same pr.
Allow only patch updates since larger updates should be done with manually.