### PR TITLE
Fix orde detail file blank validation spec

### DIFF
--- a/spec/controllers/order_detail_stored_files_controller_spec.rb
+++ b/spec/controllers/order_detail_stored_files_controller_spec.rb
@@ -51,7 +51,10 @@ RSpec.describe OrderDetailStoredFilesController do
 
     it "gets an error if there is no file" do
       post :upload_order_file, params: params
-      expect(assigns(:file).errors).to be_added(:file, :blank, validator_type: :attached)
+
+      error_options = SettingsHelper.feature_on?(:active_storage) ? { validator_type: :attached } : {}
+
+      expect(assigns(:file).errors).to be_added(:file, :blank, error_options)
     end
   end
 end


### PR DESCRIPTION
## Notes

- Add conditional expectation option on validation errors for StoredFile when active_storage is used
- I manually tested it with active_storage option on and off
