### PR TITLE
Change single quotes to double

### DIFF
--- a/vendor/engines/bulk_email/spec/services/bulk_email/content_generator_spec.rb
+++ b/vendor/engines/bulk_email/spec/services/bulk_email/content_generator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe BulkEmail::ContentGenerator do
 
   describe "#greeting" do
     it "generates a greeting" do
-      expect(subject.greeting).to include(I18n.t('bulk_email.body.greeting'))
+      expect(subject.greeting).to include(I18n.t("bulk_email.body.greeting"))
     end
 
     context "with an offline instrument as a subject_product" do


### PR DESCRIPTION
# Release Notes
* Recently we introduced a change that had single quotes instead of double ones. Updating it before I forget about it