### PR TITLE
[#162409] [Shared dev] Daily rate price policies updates

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -215,9 +215,14 @@ th.order-note {
 
 td.currency,
 th.currency,
-th.hourly_rate {
+th.hourly_rate,
+th.daily_rate {
   text-align: right;
 }
+td.daily_rate {
+  width: 120px;
+}
+
 .currency-input input {
   width: 7em;
 }
@@ -282,9 +287,17 @@ th.hourly_rate {
   }
 }
 
-.price-policy-table input[type=text],
 .half-width {
   width: 50%;
+}
+.adjustment-input::before {
+  content: '–';
+  width: 0;
+  display: inline-block;
+  overflow: visible;
+  position: relative;
+  left: -10px;
+  top: -4px;
 }
 
 .full-width {
@@ -303,6 +316,10 @@ p.per-minute {
 p.per-minute-show {
   @extend .per-minute;
   margin-top: 0;
+}
+
+.price-policy-table input[type=text] {
+  width: 80%;
 }
 
 /* Account Fields */

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -290,18 +290,18 @@ td.daily_rate {
 .half-width {
   width: 50%;
 }
-.adjustment-input::before {
+
+.full-width {
+  width: 100%;
+}
+
+.negative-number::before {
   content: '–';
   width: 0;
   display: inline-block;
   overflow: visible;
   position: relative;
   left: -10px;
-  top: -4px;
-}
-
-.full-width {
-  width: 100%;
 }
 
 /* Price policies */

--- a/app/helpers/price_policies_helper.rb
+++ b/app/helpers/price_policies_helper.rb
@@ -21,12 +21,16 @@ module PricePoliciesHelper
 
   def display_usage_rate(price_group, price_policy)
     param_for_price_group(price_group, :usage_rate) ||
-      number_to_currency(price_policy.hourly_usage_rate, unit: "", delimiter: "")
+      display_rate(price_policy.hourly_usage_rate)
   end
 
   def display_usage_subsidy(price_group, price_policy)
     param_for_price_group(price_group, :usage_subsidy) ||
-      number_to_currency(price_policy.hourly_usage_subsidy, unit: "", delimiter: "")
+      display_rate(price_policy.hourly_usage_subsidy)
+  end
+
+  def display_rate(value)
+    number_to_currency(value, unit: "", delimiter: "")
   end
 
   private

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -2,16 +2,21 @@
 
 class Instrument < Product
 
+  module Pricing
+    SCHEDULE_RULE = "Schedule Rule"
+    SCHEDULE_DAILY = "Schedule Rule (Daily Booking only)"
+    DURATION = "Duration"
+  end
+
   include Products::RelaySupport
   include Products::ScheduleRuleSupport
   include Products::SchedulingSupport
   include EmailListAttribute
 
   RESERVE_INTERVALS = [1, 5, 10, 15, 30, 60].freeze
-  SCHEDULE_RULE_DAILY_BOOKING = "Schedule Rule (Daily Booking only)"
-  PRICING_MODES = ["Schedule Rule", "Duration"].tap do |pricing_modes|
+  PRICING_MODES = [Pricing::SCHEDULE_RULE, Pricing::DURATION].tap do |pricing_modes|
     if SettingsHelper.feature_on?(:show_daily_rate_option)
-      pricing_modes.insert(1, SCHEDULE_RULE_DAILY_BOOKING)
+      pricing_modes.insert(1, Pricing::SCHEDULE_DAILY)
     end
   end.freeze
 
@@ -107,11 +112,11 @@ class Instrument < Product
   end
 
   def duration_pricing_mode?
-    pricing_mode == "Duration"
+    pricing_mode == Pricing::DURATION
   end
 
   def daily_booking?
-    pricing_mode == SCHEDULE_RULE_DAILY_BOOKING
+    pricing_mode == Pricing::SCHEDULE_DAILY
   end
 
   private

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -185,6 +185,12 @@ class PricePolicy < ApplicationRecord
     Settings.price_policy_note_options.include?(note) ? note : "Other"
   end
 
+  def daily_booking?
+    return false unless association(:product).loaded?
+
+    product&.daily_booking?
+  end
+
   private
 
   # TODO: Refactor

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -186,8 +186,6 @@ class PricePolicy < ApplicationRecord
   end
 
   def daily_booking?
-    return false unless association(:product).loaded?
-
     product&.daily_booking?
   end
 

--- a/app/services/price_policy_updater.rb
+++ b/app/services/price_policy_updater.rb
@@ -90,19 +90,23 @@ class PricePolicyUpdater
     [
       :can_purchase,
       :usage_rate,
+      :usage_rate_daily,
       :usage_subsidy,
+      :usage_subsidy_daily,
       :minimum_cost,
       :cancellation_cost,
       :unit_cost,
       :unit_subsidy,
-      duration_rates_attributes: [
-        :id,
-        :subsidy,
-        :rate,
-        :price_policy_id,
-        :min_duration_hours,
-        :_destroy
-      ]
+      {
+        duration_rates_attributes: [
+          :id,
+          :subsidy,
+          :rate,
+          :price_policy_id,
+          :min_duration_hours,
+          :_destroy,
+        ],
+      },
     ].tap do |attributes|
       attributes << :full_price_cancellation if SettingsHelper.feature_on?(:charge_full_price_on_cancellation)
     end

--- a/app/views/instrument_price_policies/_price_policy_fields.html.haml
+++ b/app/views/instrument_price_policies/_price_policy_fields.html.haml
@@ -1,1 +1,3 @@
-= render "time_based_price_policies/price_policy_fields", f: f, cancellation: true, minimum_cost: true, charge_for_collection: charge_for_options(@price_policies.first.product)
+= render("time_based_price_policies/price_policy_fields",
+  f: f, cancellation: !@product.daily_booking?, minimum_cost: !@product.daily_booking?,
+  charge_for_collection: charge_for_options(@price_policies.first.product))

--- a/app/views/instrument_price_policies/_table.html.haml
+++ b/app/views/instrument_price_policies/_table.html.haml
@@ -1,1 +1,5 @@
-= render "time_based_price_policies/table", price_policies: price_policies, url_date: url_date, cancellation: true, minimum_cost: true, product: product
+= render "time_based_price_policies/table",
+  price_policies: price_policies, url_date: url_date,
+  cancellation: !@product.daily_booking?,
+  minimum_cost: !@product.daily_booking?,
+  product: product

--- a/app/views/time_based_price_policies/_adjustment_row.html.haml
+++ b/app/views/time_based_price_policies/_adjustment_row.html.haml
@@ -23,12 +23,12 @@
     = pp.hidden_field :usage_rate_daily, value: price_policy.usage_rate_daily, class: "js--usageRate"
 
     = pp.label :usage_subsidy_daily, t("price_policies.adjustment"), class: "normal-weight"
-    %span.adjustment-input
+    %span.negative-number
       = pp.text_field :usage_subsidy_daily, value: display_rate(price_policy.usage_subsidy_daily)
 - else
   %td
     = pp.hidden_field :usage_rate, value: display_usage_rate(price_group, price_policy), class: "js--usageRate"
 
     = pp.label :usage_subsidy, t("price_policies.adjustment"), class: "normal-weight"
-    %span.adjustment-input
+    %span.negative-number
       = pp.text_field :usage_subsidy, value: display_usage_subsidy(price_group, price_policy), size: 8, class: "usage_adjustment"

--- a/app/views/time_based_price_policies/_adjustment_row.html.haml
+++ b/app/views/time_based_price_policies/_adjustment_row.html.haml
@@ -8,7 +8,7 @@
 
 
 - if local_assigns[:cancellation]
-  %td
+  %td.daily_rate
     = pp.label :cancellation_cost, t("price_policies.amount"), class: "normal-weight"
     %span.js--cancellationCost
     = pp.hidden_field :cancellation_cost, value: number_to_currency(price_policy.cancellation_cost, unit: "", delimiter: ""),
@@ -18,8 +18,17 @@
 
     = pp.hidden_field :full_price_cancellation, class: "js--fullCancellationCost", readonly: true
 
-%td
-  = pp.hidden_field :usage_rate, value: display_usage_rate(price_group, price_policy),
-    class: "js--usageRate"
-  = pp.label :usage_subsidy, t("price_policies.adjustment"), class: "normal-weight"
-  = "- #{pp.text_field :usage_subsidy, value: display_usage_subsidy(price_group, price_policy), size: 8, class: "usage_adjustment"}"
+- if @product.daily_booking?
+  %td
+    = pp.hidden_field :usage_rate_daily, value: price_policy.usage_rate_daily, class: "js--usageRate"
+
+    = pp.label :usage_subsidy_daily, t("price_policies.adjustment"), class: "normal-weight"
+    %span.adjustment-input
+      = pp.text_field :usage_subsidy_daily, value: display_rate(price_policy.usage_subsidy_daily)
+- else
+  %td
+    = pp.hidden_field :usage_rate, value: display_usage_rate(price_group, price_policy), class: "js--usageRate"
+
+    = pp.label :usage_subsidy, t("price_policies.adjustment"), class: "normal-weight"
+    %span.adjustment-input
+      = pp.text_field :usage_subsidy, value: display_usage_subsidy(price_group, price_policy), size: 8, class: "usage_adjustment"

--- a/app/views/time_based_price_policies/_adjustment_row.html.haml
+++ b/app/views/time_based_price_policies/_adjustment_row.html.haml
@@ -8,7 +8,7 @@
 
 
 - if local_assigns[:cancellation]
-  %td.daily_rate
+  %td
     = pp.label :cancellation_cost, t("price_policies.amount"), class: "normal-weight"
     %span.js--cancellationCost
     = pp.hidden_field :cancellation_cost, value: number_to_currency(price_policy.cancellation_cost, unit: "", delimiter: ""),
@@ -19,7 +19,7 @@
     = pp.hidden_field :full_price_cancellation, class: "js--fullCancellationCost", readonly: true
 
 - if @product.daily_booking?
-  %td
+  %td.daily_rate
     = pp.hidden_field :usage_rate_daily, value: price_policy.usage_rate_daily, class: "js--usageRate"
 
     = pp.label :usage_subsidy_daily, t("price_policies.adjustment"), class: "normal-weight"

--- a/app/views/time_based_price_policies/_amount_row.html.haml
+++ b/app/views/time_based_price_policies/_amount_row.html.haml
@@ -19,9 +19,15 @@
         = price_policy.class.human_attribute_name(:full_price_cancellation)
         = tooltip_icon "fa fa-question-circle-o", t("price_policies.charge_full_price_on_cancellation_hint")
 
-%td
-  = pp.label :usage_rate, t("price_policies.rate"), class: "normal-weight"
-  = pp.text_field :usage_rate, value: display_usage_rate(price_group, price_policy),
-    size: 8,
-    class: "#{price_group.master_internal? ? 'master_usage_cost' : ''} usage_rate",
-    data: { target: ".js--usageRate" }
+- if @product.daily_booking?
+  %td.daily_rate
+    = pp.label :usage_rate_daily, t("price_policies.rate"), class: "normal-weight"
+    = pp.text_field :usage_rate_daily, value: display_rate(price_policy.usage_rate_daily),
+      size: 8, data: { target: ".js--usageRate" }
+- else
+  %td
+    = pp.label :usage_rate, t("price_policies.rate"), class: "normal-weight"
+    = pp.text_field :usage_rate, value: display_usage_rate(price_group, price_policy),
+      size: 8,
+      class: "#{price_group.master_internal? ? 'master_usage_cost' : ''} usage_rate",
+      data: { target: ".js--usageRate" }

--- a/app/views/time_based_price_policies/_price_policy_fields.html.haml
+++ b/app/views/time_based_price_policies/_price_policy_fields.html.haml
@@ -11,7 +11,6 @@
 
 %div{ style: "display: flex; flex-direction: row-reverse" }
   - if @product.duration_pricing_mode?
-
     %h4.half-width= t("time_based_price_policies.table.stepped_rates_title")
   - else
     %h4.half-width= t("time_based_price_policies.table.rates_title")

--- a/app/views/time_based_price_policies/_price_policy_fields.html.haml
+++ b/app/views/time_based_price_policies/_price_policy_fields.html.haml
@@ -11,6 +11,7 @@
 
 %div{ style: "display: flex; flex-direction: row-reverse" }
   - if @product.duration_pricing_mode?
+
     %h4.half-width= t("time_based_price_policies.table.stepped_rates_title")
   - else
     %h4.half-width= t("time_based_price_policies.table.rates_title")
@@ -30,7 +31,9 @@
         %th{ scope: "col" }= t(".step_1")
         %th{ scope: "col" }= t(".step_2")
         %th{ scope: "col" }= t(".step_3")
-      - else 
+      - elsif @product.daily_booking?
+        %th.daily_rate{ scope: "col" }= t("activerecord.attributes.price_policy.daily_usage_rate")
+      - else
         %th.hourly_rate{ scope: "col" }= t("activerecord.attributes.price_policy.hourly_usage_rate")
 
   %tbody
@@ -43,7 +46,6 @@
           %td
         - if local_assigns[:cancellation]
           %td
-      - if @product.duration_pricing_mode?
         %th{ scope: "col" }
           = label :default_min_duration, t(".rate_start"), class: "normal-weight"
           = number_field :default_min_duration, "default", value: 0, readonly: true, disabled:true, class: "half-width"
@@ -81,7 +83,7 @@
             - else
               %td
                 = dr.label :subsidy, t(".adjustment"), class: "normal-weight"
-                %span="-"
-                = dr.text_field :subsidy, value: number_to_currency(dr.object.hourly_subsidy, unit: "", delimiter: ""), size: 8, class: "usage_adjustment"
+                %span.adjustment-input
+                  = dr.text_field :subsidy, value: number_to_currency(dr.object.hourly_subsidy, unit: "", delimiter: ""), size: 8, class: "usage_adjustment"
                 = dr.hidden_field :min_duration_hours
                 = dr.hidden_field :rate, class: "js--hiddenRate"

--- a/app/views/time_based_price_policies/_price_policy_fields.html.haml
+++ b/app/views/time_based_price_policies/_price_policy_fields.html.haml
@@ -82,7 +82,7 @@
             - else
               %td
                 = dr.label :subsidy, t(".adjustment"), class: "normal-weight"
-                %span.adjustment-input
+                %span.negative-number
                   = dr.text_field :subsidy, value: number_to_currency(dr.object.hourly_subsidy, unit: "", delimiter: ""), size: 8, class: "usage_adjustment"
                 = dr.hidden_field :min_duration_hours
                 = dr.hidden_field :rate, class: "js--hiddenRate"

--- a/app/views/time_based_price_policies/_price_policy_fields.html.haml
+++ b/app/views/time_based_price_policies/_price_policy_fields.html.haml
@@ -31,7 +31,7 @@
         %th{ scope: "col" }= t(".step_2")
         %th{ scope: "col" }= t(".step_3")
       - elsif @product.daily_booking?
-        %th.daily_rate{ scope: "col" }= t("activerecord.attributes.price_policy.daily_usage_rate")
+        %th.daily_rate{ scope: "col" }= PricePolicy.human_attribute_name(:usage_rate_daily)
       - else
         %th.hourly_rate{ scope: "col" }= t("activerecord.attributes.price_policy.hourly_usage_rate")
 

--- a/app/views/time_based_price_policies/_table.html.haml
+++ b/app/views/time_based_price_policies/_table.html.haml
@@ -30,7 +30,9 @@
         %th.currency{ scope: "col" }= t("time_based_price_policies.table.step_1")
         %th.currency{ scope: "col" }= t("time_based_price_policies.table.step_2")
         %th.currency{ scope: "col" }= t("time_based_price_policies.table.step_3")
-      - else 
+      - elsif @product.daily_booking?
+        %th.daily_rate{ scope: "col" }= t("activerecord.attributes.price_policy.daily_usage_rate")
+      - else
         %th.hourly_rate{ scope: "col" }= t("activerecord.attributes.price_policy.hourly_usage_rate")
 
   %tbody
@@ -78,6 +80,12 @@
                 - price_per_minute = (price_policy.subsidized_hourly_usage_cost / 60)
                 = number_to_currency price_per_minute, precision: 4
                 \/ minute
+            - elsif price_policy.usage_rate_daily.present?
+              .rate= number_to_currency price_policy.usage_rate_daily
+              - if price_policy.usage_subsidy_daily.present?
+                .subsidy= "- #{number_to_currency price_policy.usage_subsidy_daily}"
+                %strong= "= #{number_to_currency price_policy.subsidized_daily_usage_cost}"
+
           - price_policy.duration_rates.sorted.each do |duration_rate|
             %td.currency
               - per_minute = nil

--- a/app/views/time_based_price_policies/_table.html.haml
+++ b/app/views/time_based_price_policies/_table.html.haml
@@ -60,7 +60,7 @@
             %td.currency
               .rate= number_to_currency price_policy.minimum_cost
               - if price_policy.has_minimum_cost? && price_policy.has_subsidy?
-                .subsidy= "- #{number_to_currency price_policy.minimum_cost_subsidy}"
+                .subsidy.negative-number= number_to_currency price_policy.minimum_cost_subsidy
                 %strong= "= #{number_to_currency price_policy.subsidized_minimum_cost}"
 
           - if local_assigns[:cancellation]
@@ -73,7 +73,7 @@
             - if price_policy.has_rate?
               .rate= number_to_currency price_policy.hourly_usage_rate
               - if price_policy.has_subsidy?
-                .subsidy= "- #{number_to_currency price_policy.hourly_usage_subsidy}"
+                .subsidy.negative-number= number_to_currency price_policy.hourly_usage_subsidy
                 %strong= "= #{number_to_currency price_policy.subsidized_hourly_usage_cost}"
 
               %p.per-minute-show
@@ -83,7 +83,7 @@
             - elsif price_policy.usage_rate_daily.present?
               .rate= number_to_currency price_policy.usage_rate_daily
               - if price_policy.usage_subsidy_daily.present?
-                .subsidy= "- #{number_to_currency price_policy.usage_subsidy_daily}"
+                .subsidy.negative-number= number_to_currency price_policy.usage_subsidy_daily
                 %strong= "= #{number_to_currency price_policy.subsidized_daily_usage_cost}"
 
           - price_policy.duration_rates.sorted.each do |duration_rate|
@@ -93,7 +93,7 @@
                 .rate= number_to_currency duration_rate.hourly_rate
                 - per_minute = duration_rate.hourly_rate / 60
               - if duration_rate.subsidy.present?
-                .subsidy= "- #{number_to_currency duration_rate.hourly_subsidy}"
+                .subsidy.negative-number= number_to_currency duration_rate.hourly_subsidy
                 %strong= "= #{number_to_currency duration_rate.subsidized_hourly_cost}"
                 - per_minute = duration_rate.subsidized_hourly_cost / 60
 

--- a/app/views/time_based_price_policies/_table.html.haml
+++ b/app/views/time_based_price_policies/_table.html.haml
@@ -31,7 +31,7 @@
         %th.currency{ scope: "col" }= t("time_based_price_policies.table.step_2")
         %th.currency{ scope: "col" }= t("time_based_price_policies.table.step_3")
       - elsif @product.daily_booking?
-        %th.daily_rate{ scope: "col" }= t("activerecord.attributes.price_policy.daily_usage_rate")
+        %th.daily_rate{ scope: "col" }= PricePolicy.human_attribute_name(:usage_rate_daily)
       - else
         %th.hourly_rate{ scope: "col" }= t("activerecord.attributes.price_policy.hourly_usage_rate")
 

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -314,7 +314,7 @@ en:
         can_purchase: Can Purchase?
         minimum_cost: Minimum Cost
         hourly_usage_rate: Rate Per Hour
-        daily_usage_rate: Rate Per Day
+        usage_rate_daily: Rate Per Day
         cancellation_cost: Reservation Cost
         full_price_cancellation: Full reservation cost
         unit_cost: Unit Cost

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -314,6 +314,7 @@ en:
         can_purchase: Can Purchase?
         minimum_cost: Minimum Cost
         hourly_usage_rate: Rate Per Hour
+        daily_usage_rate: Rate Per Day
         cancellation_cost: Reservation Cost
         full_price_cancellation: Full reservation cost
         unit_cost: Unit Cost

--- a/config/locales/views/admin/en.price_policies.yml
+++ b/config/locales/views/admin/en.price_policies.yml
@@ -24,7 +24,7 @@ en:
       edit: "Edit Price Policies"
       remove: "Remove Price Policies"
   time_based_price_policies:
-    problem: 'There are errors in this policy:'
+    problem: "There are errors in this policy:"
     table:
       stepped_rates_title: Stepped Billing Rates
       rates_title: Billing Rates

--- a/config/locales/views/admin/en.price_policies.yml
+++ b/config/locales/views/admin/en.price_policies.yml
@@ -24,6 +24,7 @@ en:
       edit: "Edit Price Policies"
       remove: "Remove Price Policies"
   time_based_price_policies:
+    problem: 'There are errors in this policy:'
     table:
       stepped_rates_title: Stepped Billing Rates
       rates_title: Billing Rates

--- a/db/migrate/20241022135335_add_price_policy_usage_rate_daily.rb
+++ b/db/migrate/20241022135335_add_price_policy_usage_rate_daily.rb
@@ -1,0 +1,8 @@
+class AddPricePolicyUsageRateDaily < ActiveRecord::Migration[7.0]
+  def change
+    with_options(precision: 10, scale: 2) do
+      add_column :price_policies, :usage_rate_daily, :decimal
+      add_column :price_policies, :usage_subsidy_daily, :decimal
+    end
+  end
+end

--- a/db/migrate/20241022135335_add_price_policy_usage_rate_daily.rb
+++ b/db/migrate/20241022135335_add_price_policy_usage_rate_daily.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPricePolicyUsageRateDaily < ActiveRecord::Migration[7.0]
   def change
     with_options(precision: 10, scale: 2) do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_15_214235) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_22_135335) do
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
     t.integer "account_id", null: false
@@ -534,6 +534,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_15_214235) do
     t.boolean "full_price_cancellation", default: false, null: false
     t.string "note", limit: 256
     t.integer "created_by_id"
+    t.decimal "usage_rate_daily", precision: 10, scale: 2
+    t.decimal "usage_subsidy_daily", precision: 10, scale: 2
     t.index ["created_by_id"], name: "index_price_policies_on_created_by_id"
     t.index ["price_group_id"], name: "fk_rails_74aa223960"
     t.index ["product_id"], name: "index_price_policies_on_product_id"

--- a/spec/factories/price_policies.rb
+++ b/spec/factories/price_policies.rb
@@ -22,6 +22,13 @@ FactoryBot.define do
     charge_for { InstrumentPricePolicy::CHARGE_FOR[:overage] }
   end
 
+  factory :instrument_daily_booking_price_policy, parent: :instrument_price_policy do
+    usage_rate { nil }
+    usage_subsidy { nil }
+    usage_rate_daily { 100 }
+    usage_subsidy_daily { 0 }
+  end
+
   factory :item_price_policy do
     can_purchase { true }
     unit_cost { 1 }

--- a/spec/models/instrument_price_policy_spec.rb
+++ b/spec/models/instrument_price_policy_spec.rb
@@ -182,18 +182,17 @@ RSpec.describe InstrumentPricePolicy do
 
     let(:policy) { build :instrument_price_policy, product: instrument }
 
-    it "validates negative usage_rate_daily values" do
-      policy.usage_rate_daily = -1
-
-      expect(policy).to_not be_valid
-      expect(policy.errors).to include(:usage_rate_daily)
-    end
-
     shared_examples "validates policy field" do |field_name|
       before { policy.valid? }
 
       it { expect(policy).to_not be_valid }
       it { expect(policy.errors).to include(field_name) }
+    end
+
+    describe "with negative usage_rate_daily value" do
+      before { policy.usage_rate_daily = -1 }
+
+      it_behaves_like "validates policy field", :usage_rate_daily
     end
 
     describe "with negative usage_subsidy_daily value" do

--- a/spec/models/instrument_price_policy_spec.rb
+++ b/spec/models/instrument_price_policy_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe InstrumentPricePolicy do
       it_behaves_like "validates policy field", :usage_rate_daily
     end
 
-    describe "validates subsidy equals to rate" do
+    describe "when subsidy is greater than rate" do
       before do
         policy.usage_rate_daily = 9.9
         policy.usage_subsidy_daily = 10

--- a/spec/models/instrument_price_policy_spec.rb
+++ b/spec/models/instrument_price_policy_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe InstrumentPricePolicy do
 
   describe "daily rates" do
     let(:instrument) do
-      build :instrument, pricing_mode: Instrument::SCHEDULE_RULE_DAILY_BOOKING
+      build :instrument, pricing_mode: Instrument::Pricing::SCHEDULE_DAILY
     end
 
     let(:policy) { build :instrument_price_policy, product: instrument }
@@ -248,7 +248,7 @@ RSpec.describe InstrumentPricePolicy do
     end
 
     it "does not requires usage_rate_daily if instrumnet is not scheduled daily" do
-      instrument.pricing_mode = Instrument::PRICING_MODES.first
+      instrument.pricing_mode = Instrument::Pricing::DURATION
 
       expect(policy).to be_valid
     end

--- a/spec/models/instrument_price_policy_spec.rb
+++ b/spec/models/instrument_price_policy_spec.rb
@@ -233,7 +233,6 @@ RSpec.describe InstrumentPricePolicy do
       expect(policy.usage_subsidy).to be_nil
     end
 
-
     it "does not require usage_rate when instrument is scheduled daily" do
       policy.usage_rate_daily = 10
       policy.usage_rate = nil
@@ -241,13 +240,13 @@ RSpec.describe InstrumentPricePolicy do
       expect(policy).to be_valid
     end
 
-    it "does not requires usage_rate_daily if instrument is nil" do
+    it "does not require usage_rate_daily if instrument is nil" do
       policy.product = nil
 
       expect(policy).to be_valid
     end
 
-    it "does not requires usage_rate_daily if instrumnet is not scheduled daily" do
+    it "does not require usage_rate_daily if instrument is not scheduled daily" do
       instrument.pricing_mode = Instrument::Pricing::DURATION
 
       expect(policy).to be_valid

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -453,20 +453,15 @@ RSpec.describe InstrumentPricePoliciesController do
       let(:start_date) { Date.today }
       let(:expire_date) { PricePolicy.generate_expire_date(@start_date) }
       let(:base_price_policy) { instrument.price_policies.find_by(price_group: base_price_group) }
-      let!(:price_policies) do
-        PricePolicyBuilder.get_new_policies_based_on_most_recent(
-          instrument, start_date
-        ).each do |price_policy|
-          price_policy.assign_attributes(
-            note: "Some note about pricing",
-            usage_rate_daily: 100,
-            charge_for: InstrumentPricePolicy::CHARGE_FOR[:reservation]
+      let(:price_policies) { instrument.price_policies }
+
+      before do
+        PriceGroup.find_each do |price_group|
+          create(
+            :instrument_daily_booking_price_policy,
+            product: instrument,
+            price_group:
           )
-
-          price_group = price_policy.price_group
-          price_policy.usage_subsidy_daily = 10 if price_group.external? || price_group.master_internal?
-
-          price_policy.save!
         end
       end
 

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe InstrumentPricePoliciesController do
   let(:facility) { create(:setup_facility) }
   let(:billing_mode) { "Default" }
-  let(:pricing_mode) { "Schedule Rule" }
+  let(:pricing_mode) { Instrument::Pricing::SCHEDULE_RULE }
   let!(:instrument) { create(:instrument, facility:, billing_mode:, pricing_mode:) }
   let(:director) { create(:user, :facility_director, facility:) }
 
@@ -157,7 +157,7 @@ RSpec.describe InstrumentPricePoliciesController do
   end
 
   context "Duration pricing mode" do
-    let(:pricing_mode) { "Duration" }
+    let(:pricing_mode) { Instrument::Pricing::DURATION }
     let!(:cannot_purchase_group) { create(:price_group, facility:) }
 
     it "can set up the price policies", :js, feature_setting: { facility_directors_can_manage_price_groups: true } do
@@ -399,5 +399,9 @@ RSpec.describe InstrumentPricePoliciesController do
       # External
       expect(page).not_to have_content("$90.00") # Step 3 rate (removed)
     end
+  end
+
+  context "Schedule Rule Daily pricing mode" do
+    let(:pricing_mode) { Instrument::Pricing::SCHEDULE_DAILY }
   end
 end

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe InstrumentPricePoliciesController do
 
       click_button "Add Pricing Rules"
 
-      expect(page).to have_content("$60.00\n- $30.00\n= $30.00") # Cancer Center Usage Rate
-      expect(page).to have_content("$120.00\n- $60.00\n= $60.00") # Cancer Center Minimum Cost
+      expect(page).to have_content("$60.00\n$30.00\n= $30.00") # Cancer Center Usage Rate
+      expect(page).to have_content("$120.00\n$60.00\n= $60.00") # Cancer Center Minimum Cost
       expect(page).to have_content("$15.00", count: 2) # Internal and Cancer Center Reservation Costs
 
       # External price group
@@ -113,8 +113,8 @@ RSpec.describe InstrumentPricePoliciesController do
 
         click_button "Add Pricing Rules"
 
-        expect(page).to have_content("$60.00\n- $30.00\n= $30.00") # Cancer Center Usage Rate
-        expect(page).to have_content("$120.00\n- $60.00\n= $60.00") # Cancer Center Minimum Cost
+        expect(page).to have_content("$60.00\n$30.00\n= $30.00") # Cancer Center Usage Rate
+        expect(page).to have_content("$120.00\n$60.00\n= $60.00") # Cancer Center Minimum Cost
         expect(page).not_to have_content("$15.00")
         expect(page).to have_content(PricePolicy.human_attribute_name(:full_price_cancellation), count: 3)
       end
@@ -200,11 +200,11 @@ RSpec.describe InstrumentPricePoliciesController do
       expect(page).to have_content("$15.00", count: 2) # Internal and Cancer Center Reservation Costs
 
       # Cancer center
-      expect(page).to have_content("$60.00\n- $25.00\n= $35.00")    # Usage Rate
-      expect(page).to have_content("$120.00\n- $50.00\n= $70.00")   # Minimum Cost
-      expect(page).to have_content("$50.00\n- $20.00\n= $30.00")    # Step 2 rate
-      expect(page).to have_content("$40.00\n- $10.00\n= $30.00")    # Step 3 rate
-      expect(page).to have_content("$30.00\n- $5.00\n= $25.00")     # Step 4 rate
+      expect(page).to have_content("$60.00\n$25.00\n= $35.00")    # Usage Rate
+      expect(page).to have_content("$120.00\n$50.00\n= $70.00")   # Minimum Cost
+      expect(page).to have_content("$50.00\n$20.00\n= $30.00")    # Step 2 rate
+      expect(page).to have_content("$40.00\n$10.00\n= $30.00")    # Step 3 rate
+      expect(page).to have_content("$30.00\n$5.00\n= $25.00")     # Step 4 rate
 
       # External price group
       expect(page).to have_content("$120.11")

--- a/spec/system/admin/timed_service_price_policies_controller_spec.rb
+++ b/spec/system/admin/timed_service_price_policies_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe TimedServicePricePoliciesController, :js do
     click_button "Add Pricing Rules"
 
     expect(page).to have_content("$2.0000 / minute") # Base rate
-    expect(page).to have_content("$120.00\n- $25.25\n= $94.75") # Cancer center
+    expect(page).to have_content("$120.00\n$25.25\n= $94.75") # Cancer center
     expect(page).to have_content("$1.5792 / minute") # Cancer center
     expect(page).to have_content("$2.0858 / minute") # External
 


### PR DESCRIPTION
# Release Notes

Handle price policy for instruments with daily schedules.

## Feature changes

- Added two columns to `price_policies` table to track the usage rate per day and the usage subsidy per day.
- Hide minimum cost and cancellation cost inputs for instruments in this schedule, this applies for view and edit price policies tables. See screenshot.

## Other changes

- Improve format here and there
- Align minus sign for subsidy input
- Added constants for Instrument pricing modes

# Screenshot

Daily rate price policies view
![Captura desde 2024-10-23 16-12-35](https://github.com/user-attachments/assets/5b7219d4-13f5-4daf-bbb2-d531e571b023)

Daily rate price policies edit
![Captura desde 2024-10-23 16-23-43](https://github.com/user-attachments/assets/88650bd7-d0dd-4fb8-ba7b-ba0239964de7)

