### PR TITLE
[#161850]Add ability to hide Price Groups

### DIFF
--- a/app/controllers/price_groups_controller.rb
+++ b/app/controllers/price_groups_controller.rb
@@ -131,7 +131,7 @@ class PriceGroupsController < ApplicationController
   end
 
   def price_group_params
-    params.require(:price_group).permit(:name, :display_order, :is_internal, :admin_editable, :facility_id)
+    params.require(:price_group).permit(:name, :display_order, :is_internal, :is_hidden, :admin_editable, :facility_id)
   end
 
   def paginate(relation)

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -21,6 +21,7 @@ class PriceGroup < ApplicationRecord
   before_destroy { throw :abort if global? }
   before_destroy { price_policies.destroy_all } # Cannot be a dependent: :destroy because of ordering of callbacks
   before_create  ->(o) { o.display_order = 999 unless o.facility_id.nil? }
+  before_update  :update_hidden_price_group_policies, if: :is_hidden_changed?
 
   scope :for_facility, ->(facility) { where(facility_id: [nil, facility.id]) }
   scope :globals, -> { where(facility_id: nil) }
@@ -116,6 +117,15 @@ class PriceGroup < ApplicationRecord
   end
 
   private
+
+  def is_hidden_changed?
+    self.will_save_change_to_attribute?(:is_hidden)
+  end
+
+  def update_hidden_price_group_policies
+    policies = self.price_policies.current
+    PricePolicyUpdater.update_can_purchase(policies)
+  end
 
   # Find a global price group by name, or create it if it does not exist
   def self.find_or_create_global(name:, display_order:, is_internal: false, admin_editable: true)

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -21,7 +21,7 @@ class PriceGroup < ApplicationRecord
   before_destroy { throw :abort if global? }
   before_destroy { price_policies.destroy_all } # Cannot be a dependent: :destroy because of ordering of callbacks
   before_create  ->(o) { o.display_order = 999 unless o.facility_id.nil? }
-  before_update  :update_hidden_price_group_policies, if: :will_save_change_to_is_hidden?
+  before_update  :update_hidden_price_group_policies, if: :will_save_change_to_is_hidden? && :is_hidden
 
   scope :for_facility, ->(facility) { where(facility_id: [nil, facility.id]) }
   scope :globals, -> { where(facility_id: nil) }

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -35,6 +35,7 @@ class PricePolicy < ApplicationRecord
   before_create :truncate_existing_policies
 
   scope :for_date, ->(start_date) { where("start_date >= ? AND start_date <= ?", start_date.beginning_of_day, start_date.end_of_day) if start_date }
+  scope :with_visible_price_group, -> { joins(:price_group).where(price_groups: { is_hidden: false }) }
 
   def self.current
     current_for_date(Time.zone.now)

--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -94,7 +94,7 @@ class PricePolicyBuilder
 
   def get_price_policies
     return [] unless editable?
-    facility.price_groups.map do |price_group|
+    facility.price_groups.where(is_hidden: false).map do |price_group|
       policy_for_price_group(price_group)
     end
   end

--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -94,7 +94,7 @@ class PricePolicyBuilder
 
   def get_price_policies
     return [] unless editable?
-    facility.price_groups.where(is_hidden: false).map do |price_group|
+    facility.price_groups.visible.map do |price_group|
       policy_for_price_group(price_group)
     end
   end

--- a/app/services/price_policy_updater.rb
+++ b/app/services/price_policy_updater.rb
@@ -12,6 +12,12 @@ class PricePolicyUpdater
     new(product, price_policies, start_date).destroy_all!
   end
 
+  def self.update_can_purchase(policies)
+    policies.each do |policy|
+      policy.update(can_purchase: false)
+    end
+  end
+
   def initialize(product, price_policies, start_date, expire_date = nil, params = nil)
     @product = product
     @price_policies = price_policies

--- a/app/services/price_policy_updater.rb
+++ b/app/services/price_policy_updater.rb
@@ -12,7 +12,7 @@ class PricePolicyUpdater
     new(product, price_policies, start_date).destroy_all!
   end
 
-  def self.update_can_purchase(policies)
+  def self.restrict_purchase(policies)
     policies.each do |policy|
       policy.update(can_purchase: false)
     end

--- a/app/views/price_groups/_price_group_fields.html.haml
+++ b/app/views/price_groups/_price_group_fields.html.haml
@@ -5,3 +5,8 @@
 
   = f.input :is_internal, as: :boolean, inline_label: true, label: false
 
+
+.well.well-small
+  %p.help-block= t(".hidden_instruction")
+
+  = f.input :is_hidden, as: :boolean, inline_label: true, label: false

--- a/app/views/price_groups/index.html.haml
+++ b/app/views/price_groups/index.html.haml
@@ -23,6 +23,7 @@
         %th= t(".th.global")
         %th= t(".th.users")
         %th= t(".th.accounts")
+        %th= t(".th.is_hidden")
     %tbody
       - @price_groups.each do |price_group|
         %tr
@@ -45,3 +46,5 @@
             %td= t("shared.not_applicable")
 
           %td= price_group.account_price_group_members.count
+          %td= t(".#{price_group.is_hidden?.to_s}")
+

--- a/app/views/price_groups/index.html.haml
+++ b/app/views/price_groups/index.html.haml
@@ -46,5 +46,5 @@
             %td= t("shared.not_applicable")
 
           %td= price_group.account_price_group_members.count
-          %td= t(".#{price_group.is_hidden?.to_s}")
+          %td= t(".#{price_group.is_hidden.to_s}")
 

--- a/app/views/price_policies/index.html.haml
+++ b/app/views/price_policies/index.html.haml
@@ -29,7 +29,7 @@
   %p
     %em= text("note", note: policy.note)
   = render "table",
-    price_policies: @current_price_policies,
+    price_policies: @current_price_policies.with_visible_price_group,
     url_date: @current_start_date.strftime("%Y-%m-%d"),
     product: @product
 

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -309,6 +309,7 @@ en:
         rate: Hourly rate
       price_group:
         is_internal: Is Internal?
+        is_hidden: Is Hidden?
       price_policy:
         type: Type
         can_purchase: Can Purchase?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -954,6 +954,7 @@ en:
   price_groups:
     price_group_fields:
       internal_instruction: "Check this box if this price group is internal:"
+      hidden_instruction: "Check this box if you want to hide this price group:"
     accounts:
       intro: "Pricing policies apply to orders paid for with the following payment sources."
       notice: "No payment sources have been added to this price group."
@@ -978,6 +979,7 @@ en:
         global: "Global"
         users: "Number of Users"
         accounts: "Number of Payment Sources"
+        is_hidden: "Is Hidden?"
     show:
       users:
         add_user: "Add User"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -954,7 +954,7 @@ en:
   price_groups:
     price_group_fields:
       internal_instruction: "Check this box if this price group is internal:"
-      hidden_instruction: "Check this box if you want to hide this price group:"
+      hidden_instruction: "Check this box if this price group is no longer used:"
     accounts:
       intro: "Pricing policies apply to orders paid for with the following payment sources."
       notice: "No payment sources have been added to this price group."

--- a/db/migrate/20241014161738_add_is_hidden_to_price_groups.rb
+++ b/db/migrate/20241014161738_add_is_hidden_to_price_groups.rb
@@ -2,8 +2,7 @@ class AddIsHiddenToPriceGroups < ActiveRecord::Migration[7.0]
   def up
     add_column :price_groups, :is_hidden, :boolean, default: false
 
-    PriceGroup.reset_column_information
-    PriceGroup.update_all(is_hidden: false)
+    execute("UPDATE price_groups SET is_hidden = false")
 
     change_column_null :price_groups, :is_hidden, false
   end

--- a/db/migrate/20241014161738_add_is_hidden_to_price_groups.rb
+++ b/db/migrate/20241014161738_add_is_hidden_to_price_groups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddIsHiddenToPriceGroups < ActiveRecord::Migration[7.0]
   def up
     add_column :price_groups, :is_hidden, :boolean, default: false

--- a/db/migrate/20241014161738_add_is_hidden_to_price_groups.rb
+++ b/db/migrate/20241014161738_add_is_hidden_to_price_groups.rb
@@ -1,0 +1,14 @@
+class AddIsHiddenToPriceGroups < ActiveRecord::Migration[7.0]
+  def up
+    add_column :price_groups, :is_hidden, :boolean, default: false
+
+    PriceGroup.reset_column_information
+    PriceGroup.update_all(is_hidden: false)
+
+    change_column_null :price_groups, :is_hidden, false
+  end
+
+  def down
+    remove_column :price_groups, :is_hidden
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -513,6 +513,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_15_214235) do
     t.datetime "deleted_at", precision: nil
     t.boolean "highlighted", default: false, null: false
     t.boolean "global", default: false, null: false
+    t.boolean "is_hidden", default: false, null: false
     t.index ["facility_id", "name"], name: "index_price_groups_on_facility_id_and_name"
   end
 

--- a/spec/factories/price_groups.rb
+++ b/spec/factories/price_groups.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
 
     trait :hidden do
       is_hidden { true }
+      sequence(:name, "AAAAAA") { |n| "Hidden Group #{n}" }
     end
   end
 

--- a/spec/factories/price_groups.rb
+++ b/spec/factories/price_groups.rb
@@ -19,6 +19,10 @@ FactoryBot.define do
       admin_editable { true }
       sequence(:name, "AAAAAA") { |n| "Cancer Center #{n}" }
     end
+
+    trait :hidden do
+      is_hidden { true }
+    end
   end
 
   factory :price_group_product do

--- a/spec/support/shared_examples/hidden_price_groups_shared_examples.rb
+++ b/spec/support/shared_examples/hidden_price_groups_shared_examples.rb
@@ -1,0 +1,56 @@
+RSpec.shared_examples "with hidden price groups" do |item_type|
+  let!(:price_group_to_hide) { create(:price_group, facility: facility) }
+
+  it "hides price policies related to that price group" do
+    visit send("facility_#{item_type}s_path", facility, item)
+    click_link item.name
+    click_link "Pricing"
+    click_link "Add Pricing Rules"
+
+    expect(page).to have_content(price_group_to_hide.name)
+
+    if item_type == "instrument"
+      fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "60"
+      fill_in "price_policy_#{base_price_group.id}[minimum_cost]", with: "120"
+      fill_in "price_policy_#{base_price_group.id}[cancellation_cost]", with: "15"
+
+      fill_in "price_policy_#{external_price_group.id}[usage_rate]", with: "120.11"
+      fill_in "price_policy_#{external_price_group.id}[minimum_cost]", with: "122"
+      fill_in "price_policy_#{external_price_group.id}[cancellation_cost]", with: "31"
+
+      check "price_policy_#{price_group_to_hide.id}[can_purchase]"
+      fill_in "price_policy_#{price_group_to_hide.id}[usage_subsidy]", with: "40"
+    else
+      fill_in "price_policy_#{base_price_group.id}[unit_cost]", with: "100.00"
+      fill_in "price_policy_#{cancer_center.id}[unit_subsidy]", with: "25.25"
+      fill_in "price_policy_#{external_price_group.id}[unit_cost]", with: "40"
+      fill_in "price_policy_#{price_group_to_hide.id}[unit_subsidy]", with: "40"
+    end
+
+    fill_in "note", with: "This is my note"
+
+    click_button "Add Pricing Rules"
+    
+    expect(page).to have_content(base_price_group.name)
+    expect(page).to have_content(price_group_to_hide.name)
+
+    visit edit_facility_price_group_path(facility, price_group_to_hide)
+
+    check "Is Hidden?"
+
+    click_button "Update"
+
+    visit send("facility_#{item_type}s_path", facility, item)
+
+    click_link item.name
+    click_link "Pricing"
+
+    expect(page).to have_content(base_price_group.name)
+    expect(page).not_to have_content(price_group_to_hide.name)
+
+    click_link "Add Pricing Rules"
+
+    expect(page).to have_content(base_price_group.name)
+    expect(page).not_to have_content(price_group_to_hide.name)
+  end
+end

--- a/spec/support/shared_examples/hidden_price_groups_shared_examples.rb
+++ b/spec/support/shared_examples/hidden_price_groups_shared_examples.rb
@@ -2,14 +2,12 @@ RSpec.shared_examples "with hidden price groups" do |item_type|
   let!(:price_group_to_hide) { create(:price_group, facility: facility) }
 
   it "hides price policies related to that price group" do
-    visit send("facility_#{item_type}s_path", facility, item)
-    click_link item.name
-    click_link "Pricing"
+    visit send("facility_#{item_type}_price_policies_path", facility, item)
     click_link "Add Pricing Rules"
 
     expect(page).to have_content(price_group_to_hide.name)
 
-    if item_type == "instrument"
+    if item.is_a?(Instrument)
       fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "60"
       fill_in "price_policy_#{base_price_group.id}[minimum_cost]", with: "120"
       fill_in "price_policy_#{base_price_group.id}[cancellation_cost]", with: "15"
@@ -40,11 +38,8 @@ RSpec.shared_examples "with hidden price groups" do |item_type|
 
     click_button "Update"
 
-    visit send("facility_#{item_type}s_path", facility, item)
-
-    click_link item.name
-    click_link "Pricing"
-
+    visit send("facility_#{item_type}_price_policies_path", facility, item)
+    
     expect(page).to have_content(base_price_group.name)
     expect(page).not_to have_content(price_group_to_hide.name)
 

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -155,54 +155,10 @@ RSpec.describe InstrumentPricePoliciesController do
       end
     end
 
-    describe "with hidden price groups", :js do
-      let!(:price_group_to_hide) { create(:price_group, facility: facility) }
-
-      it "hides price policies related to that price group" do
-        visit facility_instruments_path(facility, instrument)
-        click_link instrument.name
-        click_link "Pricing"
-        click_link "Add Pricing Rules"
-
-        expect(page).to have_content(price_group_to_hide.name)
-
-        fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "60"
-        fill_in "price_policy_#{base_price_group.id}[minimum_cost]", with: "120"
-        fill_in "price_policy_#{base_price_group.id}[cancellation_cost]", with: "15"
-
-        fill_in "price_policy_#{external_price_group.id}[usage_rate]", with: "120.11"
-        fill_in "price_policy_#{external_price_group.id}[minimum_cost]", with: "122"
-        fill_in "price_policy_#{external_price_group.id}[cancellation_cost]", with: "31"
-
-        check "price_policy_#{price_group_to_hide.id}[can_purchase]"
-        fill_in "price_policy_#{price_group_to_hide.id}[usage_subsidy]", with: "40"
-
-        fill_in "note", with: "This is my note"
-
-        click_button "Add Pricing Rules"
-        
-        expect(page).to have_content(base_price_group.name)
-        expect(page).to have_content(price_group_to_hide.name)
-
-        visit edit_facility_price_group_path(facility, price_group_to_hide)
-
-        check "Is Hidden?"
-
-        click_button "Update"
-
-        visit facility_instruments_path(facility, instrument)
-
-        click_link instrument.name
-        click_link "Pricing"
-
-        expect(page).to have_content(base_price_group.name)
-        expect(page).not_to have_content(price_group_to_hide.name)
-
-        click_link "Add Pricing Rules"
-
-        expect(page).to have_content(base_price_group.name)
-        expect(page).not_to have_content(price_group_to_hide.name)
-      end
+    describe "with hidden price policies", :js do
+      let(:item) { instrument }
+      
+      include_examples "with hidden price groups", "instrument"
     end
   end
 
@@ -448,6 +404,12 @@ RSpec.describe InstrumentPricePoliciesController do
 
       # External
       expect(page).not_to have_content("$90.00") # Step 3 rate (removed)
+    end
+
+    describe "with hidden price policies", :js do
+      let(:item) { instrument }
+
+      include_examples "with hidden price groups", "instrument"
     end
   end
 end

--- a/spec/system/admin/item_price_policies_controller_spec.rb
+++ b/spec/system/admin/item_price_policies_controller_spec.rb
@@ -68,6 +68,10 @@ RSpec.describe ItemPricePoliciesController, :js do
     end
   end
 
+  describe "with hidden price policies", :js do
+    include_examples "with hidden price groups", "item"
+  end
+
   def table_row(*columns)
     columns.join(" ")
   end

--- a/spec/system/admin/item_price_policies_controller_spec.rb
+++ b/spec/system/admin/item_price_policies_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe ItemPricePoliciesController, :js do
     end
   end
 
-  describe "with hidden price policies", :js do
+  describe "with hidden price policies" do
     include_examples "with hidden price groups", "item"
   end
 


### PR DESCRIPTION
# Release Notes

Added the ability to hide price groups in the admin menu. This option is only available for non-global price groups.
Once a price group is hidden, current price policies related to that group aren't visible or editable anymore. Old price policies remain visible. It also updates their can_parchase value to false

# Screenshot

<img width="1209" alt="Screenshot 2024-10-25 at 10 27 08 AM" src="https://github.com/user-attachments/assets/63da9880-2af9-4da4-9ce9-60e71536f293">

<img width="903" alt="Screenshot 2024-10-25 at 10 34 55 AM" src="https://github.com/user-attachments/assets/d81ca837-c483-49bf-af15-983b8be5abfe">


# Additional Context

This is a draft PR, tests are on their way
