### PR TITLE
[Fix] Account matching in price group tab spec

### DIFF
--- a/spec/system/admin/facility_account_price_groups_spec.rb
+++ b/spec/system/admin/facility_account_price_groups_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe(
 
       visit facility_account_path(facility, account)
 
-      expect(page).to have_content(account.to_s)
+      expect(page).to have_content(account.description)
       expect(page).not_to have_content("Price Groups")
     end
   end


### PR DESCRIPTION
## Notes

- Fix spec to match account description instead of the string representation which can vary on schools.