### PR TITLE
[Fix] Disable auto end prev reservation on reservation controller spec

### DIFF
--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "controller_spec_helper"
 
-RSpec.describe ReservationsController do
+RSpec.describe ReservationsController, feature_setting: { auto_end_reservations_on_next_start: false } do
   let(:facility) { @authable }
   let(:instrument) { @instrument }
   let(:order) { @order }


### PR DESCRIPTION
## Note

Set ff that makes spec to fail if on.