### PR TITLE
[NU-28] Skip tests when ff is off

### DIFF
--- a/spec/models/order_detail_price_groups_spec.rb
+++ b/spec/models/order_detail_price_groups_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe OrderDetail do
-  describe "#price_groups with user_based_price_groups_exclude_purchaser feature" do
+  describe "#price_groups with user_based_price_groups_exclude_purchaser feature", if: SettingsHelper.feature_on?(:user_based_price_groups) do
     let(:product) { create(:setup_item) }
     let(:facility) { product.facility }
     let(:purchaser) { create(:user) }


### PR DESCRIPTION
# Release Notes

Since there are schools that don't use user-based price groups, the logic of this test doesn't make sense, so it shouldn't be run for those schools.
