### PR TITLE
[UMASS-232] Allow Purchase Order Accounts to be global

### DIFF
--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe Account do
       let!(:po_deleted) { create_po_for(user, facility, 1.day.ago) }
 
       it "filters by facility" do
-        expect(user.accounts.for_facility(facility)).to match_array([po_show])
+        expect(user.accounts.for_facility(facility)).to include(po_show)
       end
 
       it "filters deleted accounts" do

--- a/spec/support/accounts_test_helper.rb
+++ b/spec/support/accounts_test_helper.rb
@@ -16,6 +16,13 @@ module AccountsTestHelper
     skip("#{account_type} cannot be reconciled")
   end
 
+  def skip_if_account_global(account_type)
+    return unless Account.config.global_account_types.include?(
+      to_account_class(account_type))
+
+    skip("#{account_type} is global")
+  end
+
   def to_account_class(account_type)
     account_type = account_type.to_s.camelize
 

--- a/vendor/engines/c2po/lib/c2po.rb
+++ b/vendor/engines/c2po/lib/c2po.rb
@@ -6,7 +6,7 @@ module C2po
 
   C2PO_ACCOUNT_TYPES_APPENDER = proc do
     Account.config.account_types.concat C2po::C2PO_ACCOUNT_TYPES
-    Account.config.facility_account_types.concat C2po::C2PO_ACCOUNT_TYPES
+    Account.config.facility_account_types.concat C2po::C2PO_ACCOUNT_TYPES - ["PurchaseOrderAccount"]
     Account.config.statement_account_types.concat C2po::C2PO_ACCOUNT_TYPES
     Account.config.affiliate_account_types.concat C2po::C2PO_ACCOUNT_TYPES
   end.freeze

--- a/vendor/engines/c2po/lib/c2po.rb
+++ b/vendor/engines/c2po/lib/c2po.rb
@@ -6,7 +6,7 @@ module C2po
 
   C2PO_ACCOUNT_TYPES_APPENDER = proc do
     Account.config.account_types.concat C2po::C2PO_ACCOUNT_TYPES
-    Account.config.facility_account_types.concat C2po::C2PO_ACCOUNT_TYPES - ["PurchaseOrderAccount"]
+    Account.config.facility_account_types.concat C2po::C2PO_ACCOUNT_TYPES
     Account.config.statement_account_types.concat C2po::C2PO_ACCOUNT_TYPES
     Account.config.affiliate_account_types.concat C2po::C2PO_ACCOUNT_TYPES
   end.freeze

--- a/vendor/engines/c2po/spec/controllers/account_price_group_members_controller_spec.rb
+++ b/vendor/engines/c2po/spec/controllers/account_price_group_members_controller_spec.rb
@@ -11,11 +11,32 @@ RSpec.describe AccountPriceGroupMembersController do
 
     let(:partial_account_number) { build(:nufs_account).account_number[0..-4] }
     let(:price_group) { create(:price_group, facility: facility) }
-    let!(:global_account) { create(:nufs_account, :with_account_owner, account_number: "#{partial_account_number}234") }
-    let!(:facility_purchase_order) { create(:purchase_order_account, :with_account_owner, account_number: "#{partial_account_number}894", facility: facility) }
-    let!(:other_facility_purchase_order) { create(:purchase_order_account, :with_account_owner, account_number: "#{partial_account_number}542", facility: create(:facility)) }
-
-    let(:user) { create(:user, :facility_administrator, facility: facility) }
+    let(:global_account_type) { Account.config.global_account_types.first }
+    let(:facility_account_type) { Account.config.facility_account_types.first }
+    let!(:global_account) do
+      create(
+        global_account_type.underscore,
+        :with_account_owner,
+        account_number: "#{partial_account_number}234",
+      )
+    end
+    let!(:facility_purchase_order) do
+      create(
+        facility_account_type.underscore,
+        :with_account_owner,
+        account_number: "#{partial_account_number}894",
+        facility:,
+      )
+    end
+    let!(:other_facility_purchase_order) do
+      create(
+        facility_account_type.underscore,
+        :with_account_owner,
+        account_number: "#{partial_account_number}542",
+        facility: create(:facility),
+      )
+    end
+    let(:user) { create(:user, :facility_administrator, facility:) }
 
     it "limits the results to global and the facility" do
       sign_in user

--- a/vendor/engines/c2po/spec/controllers/account_price_group_members_controller_spec.rb
+++ b/vendor/engines/c2po/spec/controllers/account_price_group_members_controller_spec.rb
@@ -10,34 +10,42 @@ RSpec.describe AccountPriceGroupMembersController do
     before { allow(AccountValidator::ValidatorFactory).to receive(:instance).and_return(AccountValidator::ValidatorDefault.new) }
     before { skip if facility_account_type.blank? }
 
+    let(:user) { create(:user, :facility_administrator, facility:) }
     let(:partial_account_number) { build(:nufs_account).account_number[0..-4] }
     let(:price_group) { create(:price_group, facility: facility) }
     let(:global_account_type) { Account.config.global_account_types.first }
     let(:facility_account_type) { Account.config.facility_account_types.first }
+
+    # Reload account built with type attribute
+    # so it's the correct STI class
+    to_typed_account = proc { |account| Account.find(account.id) }
+
     let!(:global_account) do
       create(
-        global_account_type.underscore,
+        :account,
         :with_account_owner,
+        type: global_account_type,
         account_number: "#{partial_account_number}234",
-      )
+      ).then(&to_typed_account)
     end
     let!(:facility_purchase_order) do
       create(
-        facility_account_type.underscore,
+        :account,
         :with_account_owner,
+        type: facility_account_type,
         account_number: "#{partial_account_number}894",
         facility:,
-      )
+      ).then(&to_typed_account)
     end
     let!(:other_facility_purchase_order) do
       create(
-        facility_account_type.underscore,
+        :account,
         :with_account_owner,
+        type: facility_account_type,
         account_number: "#{partial_account_number}542",
         facility: create(:facility),
-      )
+      ).then(&to_typed_account)
     end
-    let(:user) { create(:user, :facility_administrator, facility:) }
 
     it "limits the results to global and the facility" do
       sign_in user

--- a/vendor/engines/c2po/spec/controllers/account_price_group_members_controller_spec.rb
+++ b/vendor/engines/c2po/spec/controllers/account_price_group_members_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe AccountPriceGroupMembersController do
   describe "search_results" do
     # Ignore validation errors, e.g. number format
     before { allow(AccountValidator::ValidatorFactory).to receive(:instance).and_return(AccountValidator::ValidatorDefault.new) }
+    before { skip if facility_account_type.blank? }
 
     let(:partial_account_number) { build(:nufs_account).account_number[0..-4] }
     let(:price_group) { create(:price_group, facility: facility) }

--- a/vendor/engines/c2po/spec/controllers/facility_accounts_controller_spec.rb
+++ b/vendor/engines/c2po/spec/controllers/facility_accounts_controller_spec.rb
@@ -63,6 +63,10 @@ RSpec.describe FacilityAccountsController do
     end
 
     context "but it belongs to another facility" do
+      before do
+        skip_if_account_global(:purchase_order)
+      end
+
       let(:other_facility) { FactoryBot.create(:facility, name: "other") }
       let(:account) { FactoryBot.create(:purchase_order_account, :with_account_owner, facility: other_facility) }
 
@@ -171,6 +175,10 @@ RSpec.describe FacilityAccountsController do
 
       context "PurchaseOrderAccount" do
         let(:account_type) { "PurchaseOrderAccount" }
+
+        before do
+          skip_if_account_global(:purchase_order)
+        end
 
         it "falls back to using a chartstring" do
           expect(response).to be_successful

--- a/vendor/engines/c2po/spec/models/chart_string_reassignment_form_spec.rb
+++ b/vendor/engines/c2po/spec/models/chart_string_reassignment_form_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe ChartStringReassignmentForm do
     subject(:form) { ChartStringReassignmentForm.new(order_details) }
 
     context "User has accounts in multiple facilities" do
-      let(:current_facility_account) { setup_account(:purchase_order_account, current_facility, user) }
+      let(:facility_account_type) { Account.config.facility_account_types.first&.underscore }
+      let(:current_facility_account) do
+        setup_account(facility_account_type, current_facility, user)
+      end
       let(:current_facility) { create(:facility) }
       let(:order) { create(:purchased_order, product: product) }
       let(:order_details) { [create(:order_detail, order: order, product: product)] }
@@ -15,8 +18,10 @@ RSpec.describe ChartStringReassignmentForm do
       let(:product) { create(:setup_item) }
       let(:user) { create(:user) }
 
+      before { skip if facility_account_type.blank? }
+
       before :each do
-        setup_account(:purchase_order_account, other_facility, user)
+        setup_account(facility_account_type, other_facility, user)
 
         order.update(facility_id: current_facility.id, user_id: user.id)
 

--- a/vendor/engines/c2po/spec/models/purchase_order_account_spec.rb
+++ b/vendor/engines/c2po/spec/models/purchase_order_account_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe PurchaseOrderAccount do
   include TextHelpers
+  include AccountsTestHelper
 
   let(:facility) { FactoryBot.create(:facility) }
   subject(:account) { FactoryBot.create(:purchase_order_account, :with_account_owner, facility: facility) }
@@ -11,12 +12,18 @@ RSpec.describe PurchaseOrderAccount do
   include_examples "AffiliateAccount"
   include_examples "an Account"
 
-  it "is a per-facility account" do
-    expect(described_class).to be_per_facility
-  end
+  context "when it's not global" do
+    before do
+      skip_if_account_global(:purchase_order)
+    end
 
-  it "is not a global account" do
-    expect(described_class).not_to be_global
+    it "is a per-facility account" do
+      expect(described_class).to be_per_facility
+    end
+
+    it "is not a global account" do
+      expect(described_class).not_to be_global
+    end
   end
 
   it "includes the facility in the description" do


### PR DESCRIPTION
# Notes

Allow purchase orders to be global: adjust or skip tests that break if purchase orders are global accounts.

[UMASS-232 | Global Purchase Orders](https://universe-of-universities.atlassian.net/browse/UMASS-232)
