### PR TITLE
[Chore] Run yarn build on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,5 @@ FROM base AS deploy
 ENV RAILS_ENV=production
 RUN bundle install --without=development test
 # asset compile
+RUN yarn build
 RUN SECRET_KEY_BASE=fake bundle exec rake assets:precompile


### PR DESCRIPTION
## Notes

Yarn build was missing in Dockerfile.
This has not caused an issue because we generally build images with assets already built.