### PR TITLE
[NUOPEN-342] Fix user tab 403

### DIFF
--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -484,7 +484,7 @@ class Ability
     can :index, Project
 
     can [:administer], User
-    can :index, User if controller.is_a?(FacilityUsersController)
+    can :index, User if controller.is_a?(FacilityUsersController) || controller.is_a?(UsersController)
   end
 
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -601,6 +601,18 @@ RSpec.describe Ability do
       it { is_expected.to be_allowed_to(:administer, User) }
       it { is_expected.to be_allowed_to(:read, Schedule) }
       it { is_expected.to be_allowed_to(:read, ProductDisplayGroup) }
+
+      context "when accessing UsersController" do
+        let(:stub_controller) { UsersController.new }
+
+        it { is_expected.to be_allowed_to(:index, User) }
+      end
+
+      context "when accessing FacilityUsersController" do
+        let(:stub_controller) { FacilityUsersController.new }
+
+        it { is_expected.to be_allowed_to(:index, User) }
+      end
     end
 
     context "write abilities are denied" do


### PR DESCRIPTION
  # Notes                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                               
  Fix a 403 error when users with granular permissions click the "Users" tab in the facility navbar. The tab was visible (because `can [:administer], User` is granted in read-only abilities) but `can :index, User` was only granted for `FacilityUsersController`, not  `UsersController` — which is the controller the tab actually links to. Users with `billing_journals` permission were unaffected because that block grants `:index` on `User` unconditionally.                                                                                
                                                                                                                                                                                                                                                                               
  [NUOPEN-342 | A 403 error happens when a user with "active" granular permissions try to access the User tab in the navbar](https://wyeworks.atlassian.net/browse/NUOPEN-342)                                                                                                 
                                                                                                                                                                                                                                                                               
  # Additional Context
                                                                                                                                                                                                                                                                               
  ## What changed                                                 
                 
  - `app/lib/ability.rb`: Extended the controller check in `granted_permission_read_only_abilities` to also allow `:index` on `User` when the controller is `UsersController` (in addition to `FacilityUsersController`).
  - `spec/lib/ability_spec.rb`: Added test coverage verifying that granular permission users can access `User#index` from both `UsersController` and `FacilityUsersController`.                                                                                                
                                                                                                                                                                               
  ## Root cause                                                                                                                                                                                                                                                                
                                                                  
  In `granted_permission_read_only_abilities`, line 487:                                                                                                                                                                                                                       
  ```ruby                                                                                                                                                                                                                                                                      
  # Before:
  can :index, User if controller.is_a?(FacilityUsersController)                                                                                                                                                                                                                
  # After:                                                        
  can :index, User if controller.is_a?(FacilityUsersController) || controller.is_a?(UsersController)
  ```                                                                                   
  The navbar tab links to facility_users_path(facility) → UsersController#index, but the ability only checked for FacilityUsersController. 
