### PR TITLE
[NUOPEN-281] Fix order detail notices 

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -820,10 +820,6 @@ class OrderDetail < ApplicationRecord
     !valid_service_meta?
   end
 
-  def cached_missing_form?
-
-  end
-
   def ready_for_statement?
     reviewed? &&
       statement_id.blank? &&

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -820,12 +820,23 @@ class OrderDetail < ApplicationRecord
     !valid_service_meta?
   end
 
+  def cached_missing_form?
+
+  end
+
   def ready_for_statement?
-    reviewed? && statement_id.blank? && Account.config.using_statements?(account.type) && !missing_form?
+    reviewed? &&
+      statement_id.blank? &&
+      Account.config.using_statements?(account.type) &&
+      problem_keys.exclude?(:missing_form)
   end
 
   def ready_for_journal?
-    reviewed? && journal_id.blank? && Account.config.using_journal?(account.type) && !reconciled? && !missing_form?
+    reviewed? &&
+      journal_id.blank? &&
+      Account.config.using_journal?(account.type) &&
+      !reconciled? &&
+      problem_keys.exclude?(:missing_form)
   end
 
   def awaiting_payment?

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -577,8 +577,10 @@ class OrderDetail < ApplicationRecord
     return response if response
 
     # are survey requirements met
-    response = validate_service_meta
-    return response if response
+    unless being_purchased_by_admin && product.admin_skip_order_form
+      response = validate_service_meta
+      return response if response
+    end
 
     return nil if product.can_purchase_order_detail? self
 
@@ -602,7 +604,6 @@ class OrderDetail < ApplicationRecord
 
   def validate_service_meta
     return unless product.is_a?(Service)
-    return if being_purchased_by_admin && product.admin_skip_order_form
 
     requires_upload = !product.stored_files.template.empty?
     requires_survey = product.active_survey?

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -944,16 +944,6 @@ class OrderDetail < ApplicationRecord
     problem_keys.first
   end
 
-  def build_problem_keys
-    return [] unless complete?
-
-    time_data_problem_key = time_data.problem_description_key
-    price_policy_problem_key = :missing_price_policy if price_policy.blank?
-    missing_form_problem_key = :missing_form if missing_form?
-
-    [time_data_problem_key, price_policy_problem_key, missing_form_problem_key].compact
-  end
-
   def requires_but_missing_actuals?
     problem_description_keys.include?(:missing_actuals)
   end

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -9,21 +9,16 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
   end
 
   def statuses
-    values = if SettingsHelper.feature_on?(:stored_order_notices)
-               notice_keys
-             else
-               notices_service.notices
-             end
+    values = notice_keys
+    values += notices_service.dynamic_notices
+
     values.map { |s| Notice.new(s) }
   end
 
   def warnings
     if problem?
-      problem_key = if SettingsHelper.feature_on?(:stored_order_notices)
-                      problem_description_key
-                    else
-                      notices_service.problems.first
-                    end
+      problem_key = problem_description_key
+
       [Notice.new(problem_key || :problem_out_of_sync, :warning)]
     else
       []

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -9,8 +9,7 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
   end
 
   def statuses
-    values = notice_keys
-    values += notices_service.time_based_notices
+    values = notice_keys + notices_service.time_based_notices
 
     values.uniq.map { |s| Notice.new(s) }
   end

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -12,7 +12,7 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
     values = notice_keys
     values += notices_service.time_based_notices
 
-    values.map { |s| Notice.new(s) }
+    values.uniq.map { |s| Notice.new(s) }
   end
 
   def warnings

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -9,21 +9,16 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
   end
 
   def statuses
-    values = if SettingsHelper.feature_on?(:stored_order_notices)
-               notice_keys
-             else
-               notices_service.notices
-             end
+    values = notice_keys
+    values += notices_service.time_based_notices
+
     values.map { |s| Notice.new(s) }
   end
 
   def warnings
     if problem?
-      problem_key = if SettingsHelper.feature_on?(:stored_order_notices)
-                      problem_description_key
-                    else
-                      notices_service.problems.first
-                    end
+      problem_key = problem_description_key
+
       [Notice.new(problem_key || :problem_out_of_sync, :warning)]
     else
       []

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -17,9 +17,7 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
 
   def warnings
     if problem?
-      problem_key = problem_description_key
-
-      [Notice.new(problem_key || :problem_out_of_sync, :warning)]
+      [Notice.new(problem_description_key || :problem_out_of_sync, :warning)]
     else
       []
     end

--- a/app/services/journal_row_builder.rb
+++ b/app/services/journal_row_builder.rb
@@ -68,6 +68,7 @@ class JournalRowBuilder
     if valid? && journal_rows.present?
       journal_rows.each(&:save!)
       set_journal_for_order_details(journal, order_details.map(&:id))
+      enqueue_order_detail_notice_update
     end
     self
   end
@@ -183,6 +184,12 @@ class JournalRowBuilder
   # Updates the journal_id of each order_detail.
   def set_journal_for_order_details(journal, order_detail_ids)
     OrderDetail.where_ids_in(order_detail_ids).update_all(journal_id: journal.id)
+  end
+
+  def enqueue_order_detail_notice_update
+    journal.order_details.map do |order_detail|
+      OrderDetailNoticesUpdateJob.perform_later(order_detail)
+    end
   end
 
 end

--- a/app/services/order_details/notices_service.rb
+++ b/app/services/order_details/notices_service.rb
@@ -15,15 +15,22 @@ module OrderDetails
 
       statuses = []
 
-      statuses << :in_review if in_review?
       statuses << :in_dispute if in_dispute? && !global_admin_must_resolve?
       statuses << :global_admin_must_resolve if in_dispute? && global_admin_must_resolve?
       statuses << :missing_form if missing_form? && !problem?
       statuses << :can_reconcile if can_reconcile_journaled?
       statuses << :in_open_journal if in_open_journal?
+      statuses << :awaiting_payment if awaiting_payment?
+
+      statuses
+    end
+
+    def dynamic_notices
+      statuses = []
+
+      statuses << :in_review if in_review?
       statuses << :ready_for_statement if ready_for_statement?
       statuses << :ready_for_journal if ready_for_journal? && SettingsHelper.feature_on?(:ready_for_journal_notice)
-      statuses << :awaiting_payment if awaiting_payment?
 
       statuses
     end

--- a/app/services/order_details/notices_service.rb
+++ b/app/services/order_details/notices_service.rb
@@ -15,15 +15,22 @@ module OrderDetails
 
       statuses = []
 
-      statuses << :in_review if in_review?
       statuses << :in_dispute if in_dispute? && !global_admin_must_resolve?
       statuses << :global_admin_must_resolve if in_dispute? && global_admin_must_resolve?
       statuses << :missing_form if missing_form? && !problem?
       statuses << :can_reconcile if can_reconcile_journaled?
       statuses << :in_open_journal if in_open_journal?
+      statuses << :awaiting_payment if awaiting_payment?
+
+      statuses
+    end
+
+    def time_based_notices
+      statuses = []
+
+      statuses << :in_review if in_review?
       statuses << :ready_for_statement if ready_for_statement?
       statuses << :ready_for_journal if ready_for_journal? && SettingsHelper.feature_on?(:ready_for_journal_notice)
-      statuses << :awaiting_payment if awaiting_payment?
 
       statuses
     end

--- a/app/services/order_details/notices_service.rb
+++ b/app/services/order_details/notices_service.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module OrderDetails
+  ##
+  # Used to retrieve OrderDetail notices and problems.
+  #
+  # notices and problems are stored in order detail
+  # where as time_based_notices are always computed.
+  #
   class NoticesService
     attr_reader :order_detail
 
@@ -36,7 +42,13 @@ module OrderDetails
     end
 
     def problems
-      build_problem_keys
+      return [] unless complete?
+
+      [
+        time_data.problem_description_key,
+        (:missing_price_policy if price_policy.blank?),
+        (:missing_form if missing_form?),
+      ].compact
     end
   end
 end

--- a/app/services/order_details/notices_service.rb
+++ b/app/services/order_details/notices_service.rb
@@ -13,26 +13,26 @@ module OrderDetails
     def notices
       return [] if canceled?
 
-      statuses = []
-
-      statuses << :in_dispute if in_dispute? && !global_admin_must_resolve?
-      statuses << :global_admin_must_resolve if in_dispute? && global_admin_must_resolve?
-      statuses << :missing_form if missing_form? && !problem?
-      statuses << :can_reconcile if can_reconcile_journaled?
-      statuses << :in_open_journal if in_open_journal?
-      statuses << :awaiting_payment if awaiting_payment?
-
-      statuses
+      {
+        in_dispute: in_dispute? && !global_admin_must_resolve?,
+        global_admin_must_resolve: in_dispute? && global_admin_must_resolve?,
+        missing_form: missing_form? && !problem?,
+        can_reconcile: can_reconcile_journaled?,
+        in_open_journal: in_open_journal?,
+        awaiting_payment: awaiting_payment?,
+      }.compact_blank.keys
     end
 
+    ##
+    # Notices that cannot be stored since depend on current time
     def time_based_notices
-      statuses = []
+      return [] if canceled?
 
-      statuses << :in_review if in_review?
-      statuses << :ready_for_statement if ready_for_statement?
-      statuses << :ready_for_journal if ready_for_journal? && SettingsHelper.feature_on?(:ready_for_journal_notice)
-
-      statuses
+      {
+        in_review: in_review?,
+        ready_for_statement: ready_for_statement?,
+        ready_for_journal: ready_for_journal? && SettingsHelper.feature_on?(:ready_for_journal_notice),
+      }.compact_blank.keys
     end
 
     def problems

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -178,7 +178,6 @@ feature:
   add_accessories_before_reservation_starts: false
   billing_table_price_groups: false
   reference_statement_invoice_number: false
-  stored_order_notices: false
   account_tabs: false
   user_based_price_groups_exclude_purchaser: false
   item_initial_order_status_complete: false

--- a/doc/HOWTO_feature_flags.md
+++ b/doc/HOWTO_feature_flags.md
@@ -113,5 +113,4 @@
 * `active_storage_for_images_only` enables `ActiveStorage` for the `DownloadableFiles::Image` module. This flag needs to be enabled even if `active_storage` is
 * `show_estimates_option`: Enable estimates menu entry on facility management.
 * `billing_log_events`: Enable billing logs on global menu.
-* `stored_order_notices`: Show order details notices and problems from order detail table instead of computing them on the fly.
 * `admin_skip_order_forms`: Allow admins to skip order forms when ordering for a User. This should be enabled for each Service.

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -169,7 +169,10 @@ RSpec.describe OrderManagement::OrderDetailsController do
         before :each do
           item_order_detail.change_status!(OrderStatus.complete)
           item_order_detail.update(reviewed_at: 1.day.ago)
-          journal.create_journal_rows! [item_order_detail]
+          # Needs job that sets order detail notices
+          perform_enqueued_jobs do
+            journal.create_journal_rows! [item_order_detail]
+          end
           item_order_detail.reload
           expect(item_order_detail.journal).to be_present
 

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -406,12 +406,23 @@ RSpec.describe OrderDetail do
       end
 
       it "is not valid as user" do
-        expect(@order_detail.valid_service_meta?).to be false
+        expect(@order_detail.valid_for_purchase?).to be false
       end
 
-      it "is valid as admin" do
-        @order_detail.being_purchased_by_admin = true
-        expect(@order_detail.valid_service_meta?).to be true
+      context "as admin" do
+        before do
+          @order_detail.being_purchased_by_admin = true
+        end
+
+        it "is valid" do
+          expect(@order_detail.valid_for_purchase?).to be true
+        end
+
+        it "assigns missing_form notice on save" do
+          @order_detail.save
+
+          expect(@order_detail.notice_keys).to include(:missing_form)
+        end
       end
     end
   end

--- a/spec/presenters/order_detail_notice_presenter_spec.rb
+++ b/spec/presenters/order_detail_notice_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OrderDetailNoticePresenter do
   let(:order_detail) { OrderDetail.new(note: "Treat me like a double") }
   let(:presenter) { described_class.new(order_detail) }
 
-  describe "badges_to_html", feature_setting: { stored_order_notices: true } do
+  describe "badges_to_html" do
     matcher :have_html_badge do |expected_text|
       match do |string|
         level_class = case @level

--- a/spec/services/journals/closer_spec.rb
+++ b/spec/services/journals/closer_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Journals::Closer do
   let(:facility) { create(:facility) }
-  let(:journal) do
+  let!(:journal) do
     create(
       :journal,
       :with_completed_order,
@@ -59,7 +59,7 @@ RSpec.describe Journals::Closer do
     let(:params) { ActionController::Parameters.new }
 
     it "does not schedule update order notices on error" do
-      expect { subject.perform("succeeded") }.not_to have_enqueued_job
+      expect { subject.perform("succeeded") }.not_to have_enqueued_job(OrderDetailNoticesUpdateJob)
     end
   end
 end

--- a/spec/services/order_details/notices_service_spec.rb
+++ b/spec/services/order_details/notices_service_spec.rb
@@ -115,7 +115,8 @@ RSpec.describe OrderDetails::NoticesService do
     subject { instance.problems }
 
     it "shows a problem notice" do
-      allow(order_detail).to receive_messages(problem?: true, build_problem_keys: [:missing_price_policy])
+      order_detail.price_policy = nil
+      order_detail.state = :complete
 
       is_expected.to eq([:missing_price_policy])
     end

--- a/spec/services/order_details/notices_service_spec.rb
+++ b/spec/services/order_details/notices_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe OrderDetails::NoticesService do
   let(:instance) { described_class.new(order_detail) }
 
   describe "statuses" do
-    subject { instance.notices }
+    subject { instance.notices + instance.time_based_notices }
 
     it "shows nothing for a blank order detail" do
       is_expected.to be_blank
@@ -76,6 +76,38 @@ RSpec.describe OrderDetails::NoticesService do
       )
 
       is_expected.to include(:in_review, :in_dispute)
+    end
+
+    describe "in review" do
+      it "includes in review" do
+        order_detail.reviewed_at = 2.hours.from_now
+        is_expected.to include(:in_review)
+      end
+
+      context "in 3 hours" do
+        around do |example|
+          order_detail.reviewed_at = 2.hours.from_now
+          order_detail.account = build(:account)
+
+          travel_to_and_return(3.hours.from_now) do
+            example.run
+          end
+        end
+
+        it "does not include in review in three hours" do
+          is_expected.not_to include(:in_review)
+        end
+
+        context "when ready_for_journal notice enabled", feature_setting: { ready_for_journal_notice: true } do
+          before do
+            allow(Account.config).to receive(:using_journal?) { true }
+          end
+
+          it "includes ready for journal" do
+            is_expected.to include(:ready_for_journal)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
# Notes

Fix order details notices by splitting stored and time based order detail notices.

[NUOPEN-281 | Fix order detail notices](https://universe-of-universities.atlassian.net/browse/NUOPEN-281)
