### PR TITLE
[Fix] Some facility billing pages styles

### DIFF
--- a/app/javascript/utils/activate_chosen.js
+++ b/app/javascript/utils/activate_chosen.js
@@ -4,9 +4,22 @@
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/main/docs/suggestions.md
  */
 window.ChosenActivator = class ChosenActivator {
+  static activateChosen(elem, options = null) {
+    elem = $(elem);
+
+    options = {...options }
+    if (elem.hasClass("chosen-full-width")) {
+      options.width = "100%";
+    }
+    elem.chosen(options);
+  }
+
   static activate() {
-    $(".js--chosen").not(".optional").chosen();
-    return $(".js--chosen.optional").chosen({allow_single_deselect: true});
+    $(".js--chosen").not(".optional").each(function() { ChosenActivator.activateChosen(this) })
+
+    return $(".js--chosen.optional").each(function() {
+      ChosenActivator.activateChosen(this, {allow_single_deselect: true})
+    });
   }
 };
 

--- a/app/views/facility_accounts_reconciliation/index.html.haml
+++ b/app/views/facility_accounts_reconciliation/index.html.haml
@@ -12,7 +12,8 @@
 - else
   %h2= t(".head", model: account_class.model_name.human(count: 2))
 
-= render "shared/transactions/search"
+.col-md-12
+  = render "shared/transactions/search"
 
 - if @unreconciled_details.any?
   - show_reconciliation_deposit_number = SettingsHelper.feature_on?(:show_reconciliation_deposit_number)
@@ -36,7 +37,8 @@
 
   %p= will_paginate(@unreconciled_details)
 - else
-  %p.notice= t(".none", model: account_class.model_name.human(count: 2).downcase)
+  .col-md-12
+    %p.notice= t(".none", model: account_class.model_name.human(count: 2).downcase)
 
 - if view_hook_exists?("reconciliation_modal") && use_custom_reconciliation_features?(account_class)
   = render_view_hook("reconciliation_modal", account_class: account_class)

--- a/app/views/facility_statements/index.html.haml
+++ b/app/views/facility_statements/index.html.haml
@@ -5,14 +5,21 @@
 = content_for :sidebar do
   = render "admin/shared/sidenav_billing", sidenav_tab: "statement_history"
 
-= simple_form_for @search_form, url: url_for, method: :get, html: { class: "search_form" }, defaults: { required: false } do |f|
+= simple_form_for @search_form, url: url_for, method: :get,
+  html: { class: "search_form" }, defaults: { required: false } do |f|
   .row
-    %fieldset.col-md-6#search
+    %fieldset.col-md-8#search
       - if @search_form.facility_filter?
-        = f.input :facilities, collection: @search_form.available_facilities, as: :transaction_chosen, input_html: { class: "js--chosen" }
-      = f.input :accounts, collection: @search_form.available_accounts, as: :transaction_chosen, input_html: { class: "js--chosen" }, label_method: :account_list_item
-      = f.input :account_admins, collection: @search_form.available_account_admins, as: :transaction_chosen, input_html: { class: "js--chosen" }, label: Statement.human_attribute_name(:account_admins), hint: text(".account_admins_hint")
-    %fieldset.col-md-2
+        = f.input :facilities, collection: @search_form.available_facilities,
+          as: :transaction_chosen, input_html: { class: "js--chosen chosen-full-width" }
+      = f.input :accounts, collection: @search_form.available_accounts,
+        as: :transaction_chosen, input_html: { class: "js--chosen chosen-full-width" },
+        label_method: :account_list_item
+      = f.input :account_admins, collection: @search_form.available_account_admins,
+        as: :transaction_chosen, input_html: { class: "js--chosen chosen-full-width" },
+        label: Statement.human_attribute_name(:account_admins),
+        hint: text(".account_admins_hint")
+    %fieldset.col-md-4
       = f.input :status, collection: @search_form.available_statuses
       = f.input :date_range_start, input_html: { class: "datepicker__data" }
       = f.input :date_range_end, input_html: { class: "datepicker__data" }

--- a/app/views/layouts/two_column.html.haml
+++ b/app/views/layouts/two_column.html.haml
@@ -16,12 +16,12 @@
             - if content_for?(:h2)
               %h2= yield(:h2)
         .row
-          .col-md-9.pull-right
+          .col-xs-12.col-md-3.pull-left
+            #sidebar
+              = yield :sidebar
+          .col-xs-12.col-md-9.pull-right
             = render partial: "shared/flashes"
             = yield :tabnav
             = yield
-          .col-md-3.pull-left
-            #sidebar
-              = yield :sidebar
     %footer
       = render partial: "/shared/footer"


### PR DESCRIPTION
# Notes

There were some UI glitches to fix:

1. Reconcile Account Type page: notice overlapping filter button when there're no orders to reconcile
Before:
<img width="1066" height="727" alt="Captura desde 2026-04-17 09-35-37" src="https://github.com/user-attachments/assets/df9023ee-1179-4766-a4c1-7ff8414fc3bd" />

2. Two columns layout: page content and side menu looked weird on sm and xs view ports. Make it look the same as two columns head layout: menu on top and content below, both with full width.
Before:
<img width="710" height="858" alt="Captura desde 2026-04-17 10-53-54" src="https://github.com/user-attachments/assets/d72b12fb-00ca-40ff-a5bf-17dab82983b8" />

After:
<img width="710" height="858" alt="Captura desde 2026-04-17 10-54-22" src="https://github.com/user-attachments/assets/539b073c-ddca-48a7-a635-e076679fe5c6" />

3. Statement/invoice history page: filter form was narrower than others. Make it look the same as the rest. Also use chosen dynamic width, otherwise chosen inputs will have a fixed size.

Before:
<img width="1083" height="612" alt="Captura desde 2026-04-17 11-00-23" src="https://github.com/user-attachments/assets/a0232aba-3a41-4105-ad7b-cc82630b1bf5" />

After:
<img width="1083" height="612" alt="Captura desde 2026-04-17 11-00-37" src="https://github.com/user-attachments/assets/2b74e3d7-c816-4977-874b-44b827948390" />
