### PR TITLE
[NUOPEN-339][Shared Dev] Schedule rule discount edit requires product pricing permission

### DIFF
--- a/app/controllers/schedule_rules_controller.rb
+++ b/app/controllers/schedule_rules_controller.rb
@@ -82,13 +82,17 @@ class ScheduleRulesController < ApplicationController
   private
 
   def schedule_rule_params
+    permitted_kwargs = { product_access_group_ids: [] }
+    if can?(:edit, PriceGroupDiscount)
+      permitted_kwargs[:price_group_discounts_attributes] = [:discount_percent, :price_group_id, :id]
+    end
+
     params
       .require(:schedule_rule)
       .permit(
         :start_hour, :start_min, :end_hour, :end_min,
         :on_sun, :on_mon, :on_tue, :on_wed, :on_thu, :on_fri, :on_sat,
-        price_group_discounts_attributes: [:discount_percent, :price_group_id, :id],
-        product_access_group_ids: []
+        **permitted_kwargs,
       ).tap do |schedule_rule_params|
         if @product.start_time_disabled?
           schedule_rule_params.merge! ScheduleRule.full_day_attributes

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -265,6 +265,7 @@ class Ability
         ProductAccessory,
         ProductUser,
         ScheduleRule,
+        PriceGroupDiscount,
         StoredFile,
         TrainingRequest,
         OfflineReservation,
@@ -384,6 +385,7 @@ class Ability
       can :manage, [PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ServicePricePolicy]
       can :manage, PriceGroup
       can :manage, PriceGroupProduct
+      can :manage, PriceGroupDiscount
     end
 
     if permission.order_management?

--- a/app/views/schedule_rules/_schedule_rule_fields.html.haml
+++ b/app/views/schedule_rules/_schedule_rule_fields.html.haml
@@ -18,7 +18,7 @@
         = f.label :end_time
         = time_select24(f, :end, hours: (0..24), minute_step: @product.reserve_interval)
 
-- if @product.can_apply_discounts?
+- if @product.can_apply_discounts? && can?(:edit, PriceGroupDiscount)
   %h3= t("views.schedule_rules.discount")
 
   %p= t("views.schedule_rules.discount_hint")

--- a/spec/support/shared_examples/schedule_rules_controller_shared_examples.rb
+++ b/spec/support/shared_examples/schedule_rules_controller_shared_examples.rb
@@ -3,8 +3,8 @@
 RSpec.shared_examples_for "A product supporting ScheduleRulesController" do |product_sym|
   render_views
 
-  let(:facility) { FactoryBot.create(:setup_facility) }
-  let(:product) { FactoryBot.create(product_sym, facility: facility) }
+  let(:facility) { create(:setup_facility) }
+  let(:product) { create(product_sym, facility: facility) }
   let(:senior_staff) { create(:user, :senior_staff, facility: facility) }
 
   let(:product_params) { { facility_id: facility.url_name, :"#{product_sym}_id" => product.url_name } }
@@ -68,7 +68,7 @@ RSpec.shared_examples_for "A product supporting ScheduleRulesController" do |pro
       post :create, params: product_params.merge(schedule_rule: rule_params)
     end
 
-    let(:rule_params) { FactoryBot.attributes_for(:schedule_rule, product_id: product.id) }
+    let(:rule_params) { attributes_for(:schedule_rule, product_id: product.id) }
 
     it "creates the schedule rule and redirects to index" do
       expect { do_request }.to change(ScheduleRule, :count).by(1)
@@ -76,7 +76,7 @@ RSpec.shared_examples_for "A product supporting ScheduleRulesController" do |pro
     end
 
     context "with product access groups" do
-      let!(:product_access_groups) { FactoryBot.create_list(:product_access_group, 3, product_id: product.id) }
+      let!(:product_access_groups) { create_list(:product_access_group, 3, product_id: product.id) }
 
       it "should come out with no restriction levels" do
         do_request
@@ -116,7 +116,7 @@ RSpec.shared_examples_for "A product supporting ScheduleRulesController" do |pro
   end
 
   describe "with an existing ScheduleRule" do
-    let(:rule) { product.schedule_rules.create(FactoryBot.attributes_for(:schedule_rule)) }
+    let(:rule) { product.schedule_rules.create(attributes_for(:schedule_rule)) }
 
     describe "edit" do
       before do
@@ -131,7 +131,7 @@ RSpec.shared_examples_for "A product supporting ScheduleRulesController" do |pro
     end
 
     describe "update" do
-      let(:rule_params) { FactoryBot.attributes_for(:schedule_rule, :weekend) }
+      let(:rule_params) { attributes_for(:schedule_rule, :weekend) }
       def do_request
         sign_in senior_staff
         put :update, params: product_params.merge(
@@ -150,7 +150,7 @@ RSpec.shared_examples_for "A product supporting ScheduleRulesController" do |pro
       end
 
       context "with product access groups" do
-        let!(:product_access_groups) { FactoryBot.create_list(:product_access_group, 3, product_id: product.id) }
+        let!(:product_access_groups) { create_list(:product_access_group, 3, product_id: product.id) }
 
         it "should come out with no restriction levels" do
           do_request
@@ -205,6 +205,61 @@ RSpec.shared_examples_for "A product supporting ScheduleRulesController" do |pro
             expect(rule.end_hour).to eq(0)
             expect(rule.end_min).to eq(1)
           end
+        end
+      end
+    end
+
+    describe "price group discounts permissions" do
+      let(:user) { create(:user) }
+      let!(:facility_user_permission) do
+        FacilityUserPermission.create(user:, facility:, product_management: true)
+      end
+      let(:schedule_rule) { create(:schedule_rule, product:) }
+      let(:price_group_discount) do
+        PriceGroupDiscount.create(
+          price_group: PriceGroup.base,
+          discount_percent: 10,
+          schedule_rule:,
+        )
+      end
+      let(:params) do
+        product_params.merge(
+          id: schedule_rule.id,
+          schedule_rule: {
+            price_group_discounts_attributes: {
+              id: price_group_discount.id,
+              discount_percent: price_group_discount.discount_percent + 1,
+            }
+          }
+        )
+      end
+      let(:action) do
+        lambda do
+          put(:update, params:)
+        end
+      end
+
+      before do
+        sign_in user
+      end
+
+      context "when product pricing disabled" do
+        it "cannot update price group discount" do
+          expect { action.call }.not_to(
+            change { price_group_discount.reload.discount_percent }
+          )
+        end
+      end
+
+      context "when product pricing enabled" do
+        before do
+          facility_user_permission.update(product_pricing: true)
+        end
+
+        it "can update price group discount" do
+          expect { action.call }.to(
+            change { price_group_discount.reload.discount_percent }.by(1)
+          )
         end
       end
     end

--- a/spec/system/schedule_rules_spec.rb
+++ b/spec/system/schedule_rules_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
-RSpec.describe "Schedule Rules", type: :system, js: true do
+RSpec.describe "Schedule Rules" do
   let(:facility) { create(:setup_facility) }
   let(:instrument) { create(:setup_instrument, facility:, skip_schedule_rules: true) }
   let(:admin) { create(:user, :administrator) }
@@ -21,5 +23,37 @@ RSpec.describe "Schedule Rules", type: :system, js: true do
     expect(page).to have_content("5:00 PM")
 
     expect(page.text).not_to include("undefined")
+  end
+
+  describe "product pricing permission" do
+    let(:user) { create(:user) }
+    let!(:facility_user_permission) do
+      FacilityUserPermission.create(
+        user:, facility:, product_management: true,
+      )
+    end
+    let(:schedule_rule) { create(:schedule_rule, product: instrument) }
+
+    before { login_as user }
+
+    context "when product pricing disabled" do
+      it "does not show price group discounts section" do
+        visit edit_facility_instrument_schedule_rule_path(facility, instrument, schedule_rule)
+
+        expect(page).not_to have_content("Price Group Discounts")
+      end
+    end
+
+    context "when product pricing enabled" do
+      before do
+        facility_user_permission.update(product_pricing: true)
+      end
+
+      it "shows price group discounts section" do
+        visit edit_facility_instrument_schedule_rule_path(facility, instrument, schedule_rule)
+
+        expect(page).to have_content("Price Group Discounts")
+      end
+    end
   end
 end


### PR DESCRIPTION
# Notes

Require "Product Pricing" permission to set schedule rules discounts. If a user can manage products but cannot edit pricing then schedule rules are editable but the discount section is not shown.

[NUOPEN-339 | Schedule rules discount permission require product_pricing](https://universe-of-universities.atlassian.net/browse/NUOPEN-339)