### PR TITLE
[NUOPEN-330] Add read only granular permission

### DIFF
--- a/app/controllers/facility_user_permissions_controller.rb
+++ b/app/controllers/facility_user_permissions_controller.rb
@@ -30,6 +30,11 @@ class FacilityUserPermissionsController < ApplicationController
     @user = User.find(params[:id])
     @permission = current_facility.facility_user_permissions.find_or_initialize_by(user: @user)
 
+    if @permission.new_record? && permission_params.values.all? { |v| ActiveModel::Type::Boolean.new.cast(v) == false }
+      flash[:notice] = text("update.success")
+      return redirect_to facility_facility_users_path(current_facility)
+    end
+
     if @permission.update(permission_params)
       if @permission.no_permissions?
         LogEvent.log(@permission, :delete, current_user, metadata: { loggable_to_s: @permission.to_log_s })

--- a/app/controllers/facility_user_permissions_controller.rb
+++ b/app/controllers/facility_user_permissions_controller.rb
@@ -57,7 +57,14 @@ class FacilityUserPermissionsController < ApplicationController
     allowed = FacilityUserPermission::PERMISSIONS
     allowed -= [:assign_permissions] unless current_user.administrator?
 
-    params.require(:facility_user_permission).permit(*allowed)
+    permitted = params.require(:facility_user_permission).permit(*allowed)
+
+    other_flags = (FacilityUserPermission::PERMISSIONS - [:read_access]).map(&:to_s)
+    if other_flags.any? { |flag| ActiveModel::Type::Boolean.new.cast(permitted[flag]) }
+      permitted[:read_access] = true
+    end
+
+    permitted
   end
 
   def permission_changes

--- a/app/javascript/facility_user_permission_form.js
+++ b/app/javascript/facility_user_permission_form.js
@@ -1,17 +1,30 @@
 /*
  * Facility User Permission form
- * When any non-read-access permission is checked, auto-check Read Access.
- * Read Access is only unchecked when the admin does it manually.
+ * Read Access is required whenever any other permission is active.
+ * Checking another permission auto-checks Read Access and locks it
+ * (visually disabled and unclickable). When all other permissions
+ * are unchecked, Read Access becomes editable again.
  */
 $(document).ready(function() {
   const readAccessCheckbox = $(".js--readAccessCheckbox");
   const otherCheckboxes = $(".js--otherPermissionCheckbox");
 
-  if (!readAccessCheckbox.length) return;
-
-  otherCheckboxes.on("change", function() {
-    if ($(this).is(":checked")) {
+  function syncReadAccess() {
+    const anyOtherChecked = otherCheckboxes.is(":checked");
+    if (anyOtherChecked) {
       readAccessCheckbox.prop("checked", true);
+      readAccessCheckbox.attr("data-locked", "true").css("opacity", "0.5");
+    } else {
+      readAccessCheckbox.removeAttr("data-locked").css("opacity", "");
+    }
+  }
+
+  readAccessCheckbox.on("click", function(event) {
+    if ($(this).attr("data-locked") === "true") {
+      event.preventDefault();
     }
   });
+
+  otherCheckboxes.on("change", syncReadAccess);
+  syncReadAccess();
 });

--- a/app/javascript/facility_user_permission_form.js
+++ b/app/javascript/facility_user_permission_form.js
@@ -1,0 +1,17 @@
+/*
+ * Facility User Permission form
+ * When any non-read-access permission is checked, auto-check Read Access.
+ * Read Access is only unchecked when the admin does it manually.
+ */
+$(document).ready(function() {
+  const readAccessCheckbox = $(".js--readAccessCheckbox");
+  const otherCheckboxes = $(".js--otherPermissionCheckbox");
+
+  if (!readAccessCheckbox.length) return;
+
+  otherCheckboxes.on("change", function() {
+    if ($(this).is(":checked")) {
+      readAccessCheckbox.prop("checked", true);
+    }
+  });
+});

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -330,7 +330,7 @@ class Ability
     return unless facility
 
     permission = user.facility_user_permissions.find_by(facility:)
-    return unless permission
+    return unless permission&.read_access?
 
     if resource.is_a?(OrderDetail)
       can :show, OrderDetail, order: { facility_id: resource.order.facility_id }
@@ -479,7 +479,6 @@ class Ability
     can :index, [BundleProduct, ScheduleRule, ProductAccessory, ProductAccessGroup]
     can [:index], StoredFile
     can [:instrument_status, :instrument_statuses], Instrument
-    can [:index, :dashboard, :tab_counts, :show], SecureRooms::Occupancy
 
     can [:show, :index], PriceGroup
     can [:show, :index], [PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ServicePricePolicy]

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -479,6 +479,7 @@ class Ability
     can :index, [BundleProduct, ScheduleRule, ProductAccessory, ProductAccessGroup]
     can [:index], StoredFile
     can [:instrument_status, :instrument_statuses], Instrument
+    can [:index, :dashboard, :tab_counts, :show], SecureRooms::Occupancy
 
     can [:show, :index], PriceGroup
     can [:show, :index], [PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ServicePricePolicy]

--- a/app/models/facility_user_permission.rb
+++ b/app/models/facility_user_permission.rb
@@ -14,6 +14,7 @@ class FacilityUserPermission < ApplicationRecord
     billing_journals
     instrument_management
     assign_permissions
+    read_only
   ].freeze
 
   validates :user_id, uniqueness: { scope: :facility_id }

--- a/app/models/facility_user_permission.rb
+++ b/app/models/facility_user_permission.rb
@@ -6,6 +6,7 @@ class FacilityUserPermission < ApplicationRecord
   belongs_to :facility
 
   PERMISSIONS = %i[
+    read_access
     product_management
     product_pricing
     order_management
@@ -14,7 +15,6 @@ class FacilityUserPermission < ApplicationRecord
     billing_journals
     instrument_management
     assign_permissions
-    read_only
   ].freeze
 
   validates :user_id, uniqueness: { scope: :facility_id }

--- a/app/models/facility_user_permission.rb
+++ b/app/models/facility_user_permission.rb
@@ -18,6 +18,7 @@ class FacilityUserPermission < ApplicationRecord
   ].freeze
 
   validates :user_id, uniqueness: { scope: :facility_id }
+  validate :read_access_required_with_other_permissions
 
   def no_permissions?
     PERMISSIONS.none? { |perm| send(perm) }
@@ -25,6 +26,15 @@ class FacilityUserPermission < ApplicationRecord
 
   def to_log_s
     "#{user} - #{facility.abbreviation}"
+  end
+
+  private
+
+  def read_access_required_with_other_permissions
+    return if read_access?
+    return if (PERMISSIONS - [:read_access]).none? { |perm| send(perm) }
+
+    errors.add(:read_access, "must be granted when other permissions are active")
   end
 
 end

--- a/app/views/facility_user_permissions/edit.html.haml
+++ b/app/views/facility_user_permissions/edit.html.haml
@@ -1,3 +1,5 @@
+= content_for :head_content do
+  = javascript_include_tag "facility_user_permission_form"
 = content_for :h1 do
   = current_facility
 = content_for :sidebar do
@@ -19,13 +21,13 @@
         = label_tag :email
         = text_field_tag :email, @user.email, disabled: true, class: "form-control"
 
-    %fieldset
+    %fieldset.js--permissionsFieldset
       %legend= text(".permissions")
       - FacilityUserPermission::PERMISSIONS.each do |perm|
         - next if perm == :assign_permissions && !current_user.administrator?
         .checkbox
           %label
-            = f.check_box perm
+            = f.check_box perm, class: (perm == :read_access ? "js--readAccessCheckbox" : "js--otherPermissionCheckbox")
             = text(".permission_labels.#{perm}")
 
   %ul.list-inline

--- a/config/locales/views/admin/en.facility_user_permissions.yml
+++ b/config/locales/views/admin/en.facility_user_permissions.yml
@@ -17,3 +17,4 @@ en:
           billing_journals: Billing Journals
           instrument_management: Instrument Management
           assign_permissions: Assign Permissions
+          read_only: Read Only

--- a/config/locales/views/admin/en.facility_user_permissions.yml
+++ b/config/locales/views/admin/en.facility_user_permissions.yml
@@ -9,6 +9,7 @@ en:
         user_info: User Info
         permissions: Permissions
         permission_labels:
+          read_access: Read Access
           product_management: Product Management
           product_pricing: Product Pricing
           order_management: Order Management
@@ -17,4 +18,3 @@ en:
           billing_journals: Billing Journals
           instrument_management: Instrument Management
           assign_permissions: Assign Permissions
-          read_only: Read Only

--- a/db/migrate/20260422115005_add_read_access_to_facility_user_permissions.rb
+++ b/db/migrate/20260422115005_add_read_access_to_facility_user_permissions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddReadAccessToFacilityUserPermissions < ActiveRecord::Migration[8.0]
+  def up
+    add_column :facility_user_permissions, :read_access, :boolean, default: false, null: false
+    execute "UPDATE facility_user_permissions SET read_access = true"
+  end
+
+  def down
+    remove_column :facility_user_permissions, :read_access
+  end
+end

--- a/db/migrate/20260422115005_add_read_only_to_facility_user_permissions.rb
+++ b/db/migrate/20260422115005_add_read_only_to_facility_user_permissions.rb
@@ -1,0 +1,5 @@
+class AddReadOnlyToFacilityUserPermissions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :facility_user_permissions, :read_only, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260422115005_add_read_only_to_facility_user_permissions.rb
+++ b/db/migrate/20260422115005_add_read_only_to_facility_user_permissions.rb
@@ -1,5 +1,0 @@
-class AddReadOnlyToFacilityUserPermissions < ActiveRecord::Migration[8.0]
-  def change
-    add_column :facility_user_permissions, :read_only, :boolean, default: false, null: false
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_28_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_22_115005) do
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
     t.integer "account_id", null: false
@@ -275,6 +275,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_28_120000) do
     t.boolean "assign_permissions", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "read_only", default: false, null: false
     t.index ["facility_id"], name: "index_facility_user_permissions_on_facility_id"
     t.index ["user_id", "facility_id"], name: "index_facility_user_permissions_on_user_id_and_facility_id", unique: true
     t.index ["user_id"], name: "index_facility_user_permissions_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -275,7 +275,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_22_115005) do
     t.boolean "assign_permissions", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "read_only", default: false, null: false
+    t.boolean "read_access", default: false, null: false
     t.index ["facility_id"], name: "index_facility_user_permissions_on_facility_id"
     t.index ["user_id", "facility_id"], name: "index_facility_user_permissions_on_user_id_and_facility_id", unique: true
     t.index ["user_id"], name: "index_facility_user_permissions_on_user_id"

--- a/spec/controllers/facility_user_permissions_controller_spec.rb
+++ b/spec/controllers/facility_user_permissions_controller_spec.rb
@@ -116,9 +116,22 @@ RSpec.describe FacilityUserPermissionsController, feature_setting: { granular_pe
 
       it "destroys the record when all permissions are unchecked" do
         create(:facility_user_permission, user: target_user, facility:, product_management: true)
-        @params[:facility_user_permission] = { product_management: false }
+        @params[:facility_user_permission] = FacilityUserPermission::PERMISSIONS.index_with { false }
         expect { patch :update, params: @params }.to change { FacilityUserPermission.count }.by(-1)
         expect(FacilityUserPermission.find_by(user: target_user, facility:)).to be_nil
+      end
+
+      it "logs a delete event when the record is destroyed" do
+        permission = create(:facility_user_permission, user: target_user, facility:, product_management: true)
+        @params[:facility_user_permission] = FacilityUserPermission::PERMISSIONS.index_with { false }
+        patch :update, params: @params
+        expect(LogEvent).to be_exists(loggable: permission, event_type: :delete, user: @admin)
+      end
+
+      it "does not create a record when all permissions are unchecked on a new permission" do
+        @params[:facility_user_permission] = FacilityUserPermission::PERMISSIONS.index_with { false }
+        expect { patch :update, params: @params }.not_to change { FacilityUserPermission.count }
+        expect(response).to redirect_to(facility_facility_users_path(facility))
       end
     end
 

--- a/spec/factories/facility_user_permissions.rb
+++ b/spec/factories/facility_user_permissions.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :facility_user_permission do
     user
     facility
+    read_access { true }
   end
 end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -595,7 +595,6 @@ RSpec.describe Ability do
       it { is_expected.to be_allowed_to(:show, OrderDetail) }
       it_is_allowed_to([:administer, :index, :show, :timeline], Reservation)
       it_is_allowed_to([:administer, :index, :view_details, :schedule, :show], Product)
-      it_is_allowed_to([:index, :dashboard, :tab_counts, :show], SecureRooms::Occupancy)
       it_is_allowed_to([:show, :index], PriceGroup)
       it_is_allowed_to([:index], StoredFile)
       it { is_expected.to be_allowed_to(:index, Project) }
@@ -819,29 +818,42 @@ RSpec.describe Ability do
       it { is_expected.to be_allowed_to(:switch, Instrument) }
     end
 
-    context "with only read_only (no other flags)" do
+    context "with only read_access (no other flags)" do
       before do
-        FacilityUserPermission.find_by(user:, facility:).update!(billing_send: false, read_only: true)
+        FacilityUserPermission.find_by(user:, facility:).update!(billing_send: false, read_access: true)
       end
 
       it_is_allowed_to([:list, :dashboard, :show], Facility)
       it_is_allowed_to([:administer, :index, :show, :tab_counts], Order)
-      it { is_expected.to be_allowed_to(:show, OrderDetail) }
+      it_is_allowed_to([:show], OrderDetail)
       it_is_allowed_to([:administer, :index, :show, :timeline], Reservation)
       it_is_allowed_to([:administer, :index, :view_details, :schedule, :show], Product)
-      it_is_allowed_to([:index, :dashboard, :tab_counts, :show], SecureRooms::Occupancy)
-      it { is_expected.to be_allowed_to(:index, Project) }
+      it_is_allowed_to([:index], Project)
 
+      it_is_not_allowed_to([:manage], Journal)
+      it_is_not_allowed_to([:manage], Statement)
+      it_is_not_allowed_to([:manage], FacilityUserPermission)
+      it_is_not_allowed_to([:manage, :adjust_price], OrderDetail)
+      it_is_not_allowed_to([:manage], Product)
+      it_is_not_allowed_to([:manage], OfflineReservation)
       it { is_expected.not_to be_allowed_to(:manage_billing, facility) }
-      it { is_expected.not_to be_allowed_to(:manage, Journal) }
-      it { is_expected.not_to be_allowed_to(:manage, Statement) }
-      it { is_expected.not_to be_allowed_to(:manage, FacilityUserPermission) }
       it { is_expected.not_to be_allowed_to(:edit, facility) }
       it { is_expected.not_to be_allowed_to(:act_as, facility) }
-      it { is_expected.not_to be_allowed_to(:manage, OrderDetail) }
-      it { is_expected.not_to be_allowed_to(:adjust_price, OrderDetail) }
-      it { is_expected.not_to be_allowed_to(:manage, Product) }
-      it { is_expected.not_to be_allowed_to(:manage, OfflineReservation) }
+    end
+
+    context "with read_access: false but other flags true (master switch off)" do
+      before do
+        FacilityUserPermission.find_by(user:, facility:).update!(
+          read_access: false,
+          billing_send: true,
+          order_management: true,
+        )
+      end
+
+      it_is_not_allowed_to([:list, :dashboard, :show], Facility)
+      it_is_not_allowed_to([:manage], OrderDetail)
+      it_is_not_allowed_to([:administer, :index, :show], Order)
+      it { is_expected.not_to be_allowed_to(:manage_billing, facility) }
     end
   end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -595,6 +595,7 @@ RSpec.describe Ability do
       it { is_expected.to be_allowed_to(:show, OrderDetail) }
       it_is_allowed_to([:administer, :index, :show, :timeline], Reservation)
       it_is_allowed_to([:administer, :index, :view_details, :schedule, :show], Product)
+      it_is_allowed_to([:index, :dashboard, :tab_counts, :show], SecureRooms::Occupancy)
       it_is_allowed_to([:show, :index], PriceGroup)
       it_is_allowed_to([:index], StoredFile)
       it { is_expected.to be_allowed_to(:index, Project) }
@@ -816,6 +817,31 @@ RSpec.describe Ability do
       it { is_expected.to be_allowed_to(:manage, OrderDetail) }
       it { is_expected.to be_allowed_to(:act_as, facility) }
       it { is_expected.to be_allowed_to(:switch, Instrument) }
+    end
+
+    context "with only read_only (no other flags)" do
+      before do
+        FacilityUserPermission.find_by(user:, facility:).update!(billing_send: false, read_only: true)
+      end
+
+      it_is_allowed_to([:list, :dashboard, :show], Facility)
+      it_is_allowed_to([:administer, :index, :show, :tab_counts], Order)
+      it { is_expected.to be_allowed_to(:show, OrderDetail) }
+      it_is_allowed_to([:administer, :index, :show, :timeline], Reservation)
+      it_is_allowed_to([:administer, :index, :view_details, :schedule, :show], Product)
+      it_is_allowed_to([:index, :dashboard, :tab_counts, :show], SecureRooms::Occupancy)
+      it { is_expected.to be_allowed_to(:index, Project) }
+
+      it { is_expected.not_to be_allowed_to(:manage_billing, facility) }
+      it { is_expected.not_to be_allowed_to(:manage, Journal) }
+      it { is_expected.not_to be_allowed_to(:manage, Statement) }
+      it { is_expected.not_to be_allowed_to(:manage, FacilityUserPermission) }
+      it { is_expected.not_to be_allowed_to(:edit, facility) }
+      it { is_expected.not_to be_allowed_to(:act_as, facility) }
+      it { is_expected.not_to be_allowed_to(:manage, OrderDetail) }
+      it { is_expected.not_to be_allowed_to(:adjust_price, OrderDetail) }
+      it { is_expected.not_to be_allowed_to(:manage, Product) }
+      it { is_expected.not_to be_allowed_to(:manage, OfflineReservation) }
     end
   end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -841,20 +841,6 @@ RSpec.describe Ability do
       it { is_expected.not_to be_allowed_to(:act_as, facility) }
     end
 
-    context "with read_access: false but other flags true (master switch off)" do
-      before do
-        FacilityUserPermission.find_by(user:, facility:).update!(
-          read_access: false,
-          billing_send: true,
-          order_management: true,
-        )
-      end
-
-      it_is_not_allowed_to([:list, :dashboard, :show], Facility)
-      it_is_not_allowed_to([:manage], OrderDetail)
-      it_is_not_allowed_to([:administer, :index, :show], Order)
-      it { is_expected.not_to be_allowed_to(:manage_billing, facility) }
-    end
   end
 
   describe "account administrator" do

--- a/spec/models/facility_user_permission_spec.rb
+++ b/spec/models/facility_user_permission_spec.rb
@@ -28,4 +28,29 @@ RSpec.describe FacilityUserPermission do
       expect(permission.send(perm)).to be false
     end
   end
+
+  describe "read_access validation" do
+    it "is invalid when another permission is set without read_access" do
+      permission.read_access = false
+      permission.billing_send = true
+      expect(permission).not_to be_valid
+      expect(permission.errors[:read_access]).to be_present
+    end
+
+    it "is valid with read_access plus another permission" do
+      permission.read_access = true
+      permission.billing_send = true
+      expect(permission).to be_valid
+    end
+
+    it "is valid with only read_access" do
+      permission.read_access = true
+      expect(permission).to be_valid
+    end
+
+    it "is valid with no permissions at all" do
+      permission.read_access = false
+      expect(permission).to be_valid
+    end
+  end
 end

--- a/spec/models/facility_user_permission_spec.rb
+++ b/spec/models/facility_user_permission_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe FacilityUserPermission do
     expect(permission).to be_valid
   end
 
-  it "defaults all permissions to false" do
-    permission.save!
+  it "defaults all permission columns to false at the DB level" do
+    permission = FacilityUserPermission.create!(user: create(:user), facility: create(:facility))
     FacilityUserPermission::PERMISSIONS.each do |perm|
       expect(permission.send(perm)).to be false
     end

--- a/spec/support/shared_examples/schedule_rules_controller_shared_examples.rb
+++ b/spec/support/shared_examples/schedule_rules_controller_shared_examples.rb
@@ -212,7 +212,7 @@ RSpec.shared_examples_for "A product supporting ScheduleRulesController" do |pro
     describe "price group discounts permissions" do
       let(:user) { create(:user) }
       let!(:facility_user_permission) do
-        FacilityUserPermission.create(user:, facility:, product_management: true)
+        FacilityUserPermission.create(user:, facility:, product_management: true, read_access: true)
       end
       let(:schedule_rule) { create(:schedule_rule, product:) }
       let(:price_group_discount) do

--- a/spec/system/schedule_rules_spec.rb
+++ b/spec/system/schedule_rules_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Schedule Rules" do
     let(:user) { create(:user) }
     let!(:facility_user_permission) do
       FacilityUserPermission.create(
-        user:, facility:, product_management: true,
+        user:, facility:, product_management: true, read_access: true,
       )
     end
     let(:schedule_rule) { create(:schedule_rule, product: instrument) }

--- a/vendor/engines/secure_rooms/app/models/secure_rooms/ability_extension.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/ability_extension.rb
@@ -29,6 +29,19 @@ module SecureRooms
         ability.can :manage, CardReader
         ability.can :show_problems, Occupancy
       end
+
+      if granted_read_access?(user, resource)
+        ability.can [:index, :dashboard, :tab_counts, :show], Occupancy
+      end
+    end
+
+    private
+
+    def granted_read_access?(user, resource)
+      return false unless SettingsHelper.feature_on?(:granular_permissions)
+      return false unless resource.is_a?(Facility)
+
+      user.facility_user_permissions.find_by(facility: resource)&.read_access?
     end
 
   end

--- a/vendor/engines/secure_rooms/spec/models/ability_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/ability_spec.rb
@@ -69,22 +69,12 @@ RSpec.describe Ability do
   end
 
   describe "granular permission user with read_access", feature_setting: { granular_permissions: true } do
-    let(:user) { FactoryBot.create(:user) }
+    let(:user) { create(:user) }
 
     before do
-      FactoryBot.create(:facility_user_permission, user:, facility:, read_access: true)
+      create(:facility_user_permission, user:, facility:, read_access: true)
     end
 
     it_is_allowed_to([:index, :dashboard, :tab_counts, :show], SecureRooms::Occupancy)
-  end
-
-  describe "granular permission user without read_access", feature_setting: { granular_permissions: true } do
-    let(:user) { FactoryBot.create(:user) }
-
-    before do
-      FactoryBot.create(:facility_user_permission, user:, facility:, read_access: false, billing_send: true)
-    end
-
-    it_is_not_allowed_to([:index, :dashboard, :tab_counts, :show], SecureRooms::Occupancy)
   end
 end

--- a/vendor/engines/secure_rooms/spec/models/ability_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/ability_spec.rb
@@ -67,4 +67,24 @@ RSpec.describe Ability do
     it_is_allowed_to([:index, :dashboard, :tab_counts, :show_problems,
                       :assign_price_policies_to_problem_orders], SecureRooms::Occupancy)
   end
+
+  describe "granular permission user with read_access", feature_setting: { granular_permissions: true } do
+    let(:user) { FactoryBot.create(:user) }
+
+    before do
+      FactoryBot.create(:facility_user_permission, user:, facility:, read_access: true)
+    end
+
+    it_is_allowed_to([:index, :dashboard, :tab_counts, :show], SecureRooms::Occupancy)
+  end
+
+  describe "granular permission user without read_access", feature_setting: { granular_permissions: true } do
+    let(:user) { FactoryBot.create(:user) }
+
+    before do
+      FactoryBot.create(:facility_user_permission, user:, facility:, read_access: false, billing_send: true)
+    end
+
+    it_is_not_allowed_to([:index, :dashboard, :tab_counts, :show], SecureRooms::Occupancy)
+  end
 end


### PR DESCRIPTION
# Notes                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                               
  Adds a new "Read Only" granular permission that allows a user to view a facility's Orders, Reservations, Occupancies, Products, and Projects without granting access to Billing, Admin, or Reporting areas.
                                                                                                                                                                                                                                                                               
  [NUOPEN-330 | Add Read only granular permission](https://universe-of-universities.atlassian.net/browse/NUOPEN-330)


# Screenshot

<img width="778" height="718" alt="Screenshot 2026-04-22 at 4 42 24 PM" src="https://github.com/user-attachments/assets/db665e45-69a7-4cca-8949-0dc10f038688" />

