### PR TITLE
[NU-436] Update specs for recharge chartstring creation

### DIFF
--- a/spec/controllers/facility_facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_facility_accounts_controller_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe FacilityFacilityAccountsController do
 
   let(:facility) { create(:facility) }
   let(:director) { create(:user, :facility_director, facility: facility) }
+  let(:admin) { create(:user, :administrator) }
   let(:senior_staff) { create(:user, :senior_staff, facility: facility) }
 
   let(:params) { { facility_id: facility.url_name } }
@@ -38,8 +39,8 @@ RSpec.describe FacilityFacilityAccountsController do
   end
 
   describe "GET #new" do
-    it "allows a director" do
-      sign_in director
+    it "allows an authorized user" do
+      sign_in admin
       get :new, params: params
 
       is_expected.to render_template "new"
@@ -56,10 +57,10 @@ RSpec.describe FacilityFacilityAccountsController do
   describe "POST #create" do
     let(:params) { super().merge(facility_account: attributes_for(:facility_account).except(:created_by)) }
 
-    describe "as a director" do
-      before { sign_in director }
+    describe "as an authorized user" do
+      before { sign_in admin }
 
-      it "allows a director to create an account if it is open" do
+      it "creates the account if it is open" do
         expect_any_instance_of(AccountValidator::ValidatorFactory.validator_class).to receive(:account_is_open!).and_return(true)
 
         expect { put :create, params: params }.to change(FacilityAccount, :count).by(1)

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -267,6 +267,7 @@ RSpec.describe Ability do
 
     it_is_allowed_to([:bring_online, :create, :edit, :new, :update], OfflineReservation)
     it { is_expected.to be_allowed_to(:manage, Account) }
+    it { is_expected.to be_allowed_to(:manage, FacilityAccount) }
     it { is_expected.to be_allowed_to(:read, Notification) }
     it { is_expected.to be_allowed_to(:manage, Schedule) }
     it { is_expected.to be_allowed_to(:manage, TrainingRequest) }
@@ -316,6 +317,7 @@ RSpec.describe Ability do
 
     it_is_allowed_to([:bring_online, :create, :edit, :new, :update], OfflineReservation)
     it { is_expected.to be_allowed_to(:manage, Account) }
+    it { is_expected.to be_allowed_to(:manage, FacilityAccount) }
     it { is_expected.to be_allowed_to(:manage, TrainingRequest) }
     it { is_expected.to be_allowed_to(:read, Notification) }
     it { is_expected.to be_allowed_to(:manage, Schedule) }


### PR DESCRIPTION
# Notes                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                               
Update `FacilityFacilityAccountsController` and `Ability` specs so that the controller flow tests authorize via Global Admin instead of being coupled to the Facility Director role, and add explicit `:manage, FacilityAccount` assertions for facility administrator and facility director in the ability spec. No production code changes; this prepares the parent test suite to remain green for forks (e.g. Northwestern) that restrict recharge chartstring creation to global admins only.                                    
                                                                                                                                                                                                                                           
  [NU-436 | Recharge chartstring creation adjustment](https://universe-of-universities.atlassian.net/browse/NU-436)                                                                                                                                                            
                                                                                                                      