### PR TITLE
[NUOPEN-344] Only allow order status update for order management permission

### DIFF
--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -15,6 +15,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
 
   before_action :authorize_order_detail, except: %i(sample_results update remove_from_journal)
   before_action :authorize_order_detail_update, only: %i(update remove_from_journal)
+  before_action :authorize_change_status, only: :update
   before_action :authorize_mark_unrecoverable, only: :update
   before_action :load_accounts, only: [:edit, :update]
   before_action :load_order_statuses, only: [:edit, :update]
@@ -111,6 +112,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
 
   def load_order_statuses
     return if @order_detail.reconciled?
+    return if cannot?(:change_status, @order_detail)
 
     if @order_detail.complete?
       @order_statuses = OrderStatus.by_names([
@@ -167,6 +169,17 @@ class OrderManagement::OrderDetailsController < ApplicationController
     return if @order_detail.unrecoverable? || update_params[:order_status_id].to_s != OrderStatus.unrecoverable.id.to_s
 
     authorize!(:mark_unrecoverable, OrderDetail)
+  end
+
+  def authorize_change_status
+    return unless changing_order_status?
+
+    authorize!(:change_status, @order_detail)
+  end
+
+  def changing_order_status?
+    new_status = update_params[:order_status_id]
+    new_status.present? && new_status.to_s != @order_detail.order_status_id.to_s
   end
 
 end

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -4,6 +4,8 @@ class OrderManagement::OrderDetailsController < ApplicationController
 
   include OrderDetailFileDownload
 
+  PRICE_ADJUSTMENT_ATTRIBUTES = %i[actual_cost actual_subsidy price_change_reason].freeze
+
   load_resource :facility, find_by: :url_name
 
   load_resource :order, through: :facility, except: [:files, :template_results]
@@ -11,7 +13,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
   # We can't load through the facility because of cross-core orders
   before_action :init_order_detail, only: [:files, :template_results]
 
-  helper_method :edit_disabled?, :actual_cost_edit_disabled?, :read_only?
+  helper_method :edit_disabled?, :actual_cost_edit_disabled?, :read_only?, :metadata_edit_disabled?
 
   before_action :authorize_order_detail, except: %i(sample_results update remove_from_journal)
   before_action :authorize_order_detail_update, only: %i(update remove_from_journal)
@@ -105,6 +107,10 @@ class OrderManagement::OrderDetailsController < ApplicationController
     cannot?(:update, @order_detail)
   end
 
+  def metadata_edit_disabled?
+    read_only? || cannot?(:manage_order_details, @order_detail)
+  end
+
   def load_accounts
     @available_accounts = @order_detail.available_accounts.to_a
     @available_accounts << @order.account unless @available_accounts.include?(@order.account)
@@ -160,13 +166,14 @@ class OrderManagement::OrderDetailsController < ApplicationController
 
   def update_params
     raw_params = params[:order_detail] || empty_params
-    return raw_params if can?(:adjust_price, @order_detail)
+    return raw_params.slice(*PRICE_ADJUSTMENT_ATTRIBUTES) unless can?(:manage_order_details, @order_detail)
 
-    raw_params.except(:actual_cost, :actual_subsidy)
+    raw_params = raw_params.except(:actual_cost, :actual_subsidy) unless can?(:adjust_price, @order_detail)
+    raw_params
   end
 
   def authorize_mark_unrecoverable
-    return if @order_detail.unrecoverable? || update_params[:order_status_id].to_s != OrderStatus.unrecoverable.id.to_s
+    return if @order_detail.unrecoverable? || submitted_order_status_id.to_s != OrderStatus.unrecoverable.id.to_s
 
     authorize!(:mark_unrecoverable, OrderDetail)
   end
@@ -178,8 +185,12 @@ class OrderManagement::OrderDetailsController < ApplicationController
   end
 
   def changing_order_status?
-    new_status = update_params[:order_status_id]
-    new_status.present? && new_status.to_s != @order_detail.order_status_id.to_s
+    submitted_order_status_id.present? &&
+      submitted_order_status_id.to_s != @order_detail.order_status_id.to_s
+  end
+
+  def submitted_order_status_id
+    params.dig(:order_detail, :order_status_id)
   end
 
 end

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -16,8 +16,8 @@ class OrderManagement::OrderDetailsController < ApplicationController
   helper_method :edit_disabled?, :actual_cost_edit_disabled?, :read_only?, :metadata_edit_disabled?
 
   before_action :authorize_order_detail, except: %i(sample_results update remove_from_journal)
-  before_action :authorize_order_detail_update, only: %i(update remove_from_journal)
-  before_action :authorize_change_status, only: :update
+  before_action :authorize_order_detail_update, only: :update
+  before_action :authorize_remove_from_journal, only: :remove_from_journal
   before_action :authorize_mark_unrecoverable, only: :update
   before_action :load_accounts, only: [:edit, :update]
   before_action :load_order_statuses, only: [:edit, :update]
@@ -100,15 +100,21 @@ class OrderManagement::OrderDetailsController < ApplicationController
   end
 
   def authorize_order_detail_update
-    authorize! :update, @order_detail
+    return if can?(:adjust_price, @order_detail)
+
+    authorize!(:update, @order_detail)
+  end
+
+  def authorize_remove_from_journal
+    authorize!(:update, @order_detail)
   end
 
   def read_only?
-    cannot?(:manage_order_details, @order_detail) && cannot?(:adjust_price, @order_detail)
+    cannot?(:update, @order_detail) && cannot?(:adjust_price, @order_detail)
   end
 
   def metadata_edit_disabled?
-    cannot?(:manage_order_details, @order_detail)
+    cannot?(:update, @order_detail)
   end
 
   def load_accounts
@@ -118,7 +124,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
 
   def load_order_statuses
     return if @order_detail.reconciled?
-    return if cannot?(:change_status, @order_detail)
+    return if cannot?(:update, @order_detail)
 
     if @order_detail.complete?
       @order_statuses = OrderStatus.by_names([
@@ -167,7 +173,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
   def update_params
     raw_params = params[:order_detail] || empty_params
 
-    if cannot?(:manage_order_details, @order_detail)
+    if cannot?(:update, @order_detail)
       raw_params.slice(*PRICE_ADJUSTMENT_ATTRIBUTES)
     elsif cannot?(:adjust_price, @order_detail)
       raw_params.except(*PRICE_ADJUSTMENT_ATTRIBUTES).merge(persisted_actual_price_params)
@@ -187,17 +193,6 @@ class OrderManagement::OrderDetailsController < ApplicationController
     return if @order_detail.unrecoverable? || submitted_order_status_id.to_s != OrderStatus.unrecoverable.id.to_s
 
     authorize!(:mark_unrecoverable, OrderDetail)
-  end
-
-  def authorize_change_status
-    return unless changing_order_status?
-
-    authorize!(:change_status, @order_detail)
-  end
-
-  def changing_order_status?
-    submitted_order_status_id.present? &&
-      submitted_order_status_id.to_s != @order_detail.order_status_id.to_s
   end
 
   def submitted_order_status_id

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -104,11 +104,11 @@ class OrderManagement::OrderDetailsController < ApplicationController
   end
 
   def read_only?
-    cannot?(:update, @order_detail)
+    cannot?(:manage_order_details, @order_detail) && cannot?(:adjust_price, @order_detail)
   end
 
   def metadata_edit_disabled?
-    read_only? || cannot?(:manage_order_details, @order_detail)
+    cannot?(:manage_order_details, @order_detail)
   end
 
   def load_accounts

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -166,10 +166,14 @@ class OrderManagement::OrderDetailsController < ApplicationController
 
   def update_params
     raw_params = params[:order_detail] || empty_params
-    return raw_params.slice(*PRICE_ADJUSTMENT_ATTRIBUTES) unless can?(:manage_order_details, @order_detail)
 
-    raw_params = raw_params.except(:actual_cost, :actual_subsidy) unless can?(:adjust_price, @order_detail)
-    raw_params
+    if cannot?(:manage_order_details, @order_detail)
+      raw_params.slice(*PRICE_ADJUSTMENT_ATTRIBUTES)
+    elsif cannot?(:adjust_price, @order_detail)
+      raw_params.except(*PRICE_ADJUSTMENT_ATTRIBUTES)
+    else
+      raw_params
+    end
   end
 
   def authorize_mark_unrecoverable

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -170,10 +170,17 @@ class OrderManagement::OrderDetailsController < ApplicationController
     if cannot?(:manage_order_details, @order_detail)
       raw_params.slice(*PRICE_ADJUSTMENT_ATTRIBUTES)
     elsif cannot?(:adjust_price, @order_detail)
-      raw_params.except(*PRICE_ADJUSTMENT_ATTRIBUTES)
+      raw_params.except(*PRICE_ADJUSTMENT_ATTRIBUTES).merge(persisted_actual_price_params)
     else
       raw_params
     end
+  end
+
+  def persisted_actual_price_params
+    return {} if @order_detail.actual_cost.blank?
+
+    { actual_cost: @order_detail.actual_cost.to_s,
+      actual_subsidy: @order_detail.actual_subsidy.to_s }
   end
 
   def authorize_mark_unrecoverable

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -2,14 +2,14 @@
 
 module AccountsHelper
 
-  def account_input(form)
+  def account_input(form, disabled: false)
     form.input :account_id,
       as: :select,
       label: OrderDetail.human_attribute_name(:account),
       collection: available_accounts_array,
       selected: @order_detail.account_id,
       include_blank: false,
-      disabled: edit_disabled?
+      disabled: edit_disabled? || disabled
   end
 
   def payment_source_link_or_text(account)

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -414,7 +414,10 @@ class Ability
     if permission.price_adjustment?
       can :adjust_price, OrderDetail
       can :manage, OrderDetail
-      cannot :change_status, OrderDetail unless permission.order_management?
+      unless permission.order_management?
+        cannot :change_status, OrderDetail
+        cannot :manage_order_details, OrderDetail
+      end
     end
 
     if permission.billing_journals?
@@ -457,6 +460,7 @@ class Ability
       end
       if permission.price_adjustment? && !permission.order_management?
         cannot :change_status, OrderDetail
+        cannot :manage_order_details, OrderDetail
       end
     end
   end

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -414,6 +414,7 @@ class Ability
     if permission.price_adjustment?
       can :adjust_price, OrderDetail
       can :manage, OrderDetail
+      cannot :change_status, OrderDetail unless permission.order_management?
     end
 
     if permission.billing_journals?
@@ -453,6 +454,9 @@ class Ability
       can :manage, OrderDetail, order: { facility_id: resource.order.facility_id }
       unless permission.price_adjustment?
         cannot :adjust_price, OrderDetail
+      end
+      if permission.price_adjustment? && !permission.order_management?
+        cannot :change_status, OrderDetail
       end
     end
   end

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -389,8 +389,8 @@ class Ability
     end
 
     if permission.order_management?
-      can :manage, OrderDetail
-      cannot :adjust_price, OrderDetail
+      can :update, OrderDetail
+      can :mark_unrecoverable, OrderDetail
 
       can [:administer, :assign_price_policies_to_problem_orders, :batch_update,
            :create, :index, :order_in_past, :send_receipt, :show, :tab_counts, :update], Order
@@ -413,11 +413,6 @@ class Ability
 
     if permission.price_adjustment?
       can :adjust_price, OrderDetail
-      can :manage, OrderDetail
-      unless permission.order_management?
-        cannot :change_status, OrderDetail
-        cannot :manage_order_details, OrderDetail
-      end
     end
 
     if permission.billing_journals?
@@ -453,15 +448,15 @@ class Ability
   end
 
   def granted_permission_order_detail_abilities(permission, resource)
-    if permission.order_management? || permission.price_adjustment?
-      can :manage, OrderDetail, order: { facility_id: resource.order.facility_id }
-      unless permission.price_adjustment?
-        cannot :adjust_price, OrderDetail
-      end
-      if permission.price_adjustment? && !permission.order_management?
-        cannot :change_status, OrderDetail
-        cannot :manage_order_details, OrderDetail
-      end
+    facility_scope = { order: { facility_id: resource.order.facility_id } }
+
+    if permission.order_management?
+      can :update, OrderDetail, facility_scope
+      can :mark_unrecoverable, OrderDetail, facility_scope
+    end
+
+    if permission.price_adjustment?
+      can :adjust_price, OrderDetail, facility_scope
     end
   end
 

--- a/app/views/order_management/order_details/_assigned_user.html.haml
+++ b/app/views/order_management/order_details/_assigned_user.html.haml
@@ -2,4 +2,4 @@
   - if f.object.complete?
     = f.object.assigned_user ? f.object.assigned_user.full_name : "Unassigned"
   - else
-    = f.association :assigned_user, collection: User.find_users_by_facility(current_facility), label_method: :full_name, label: false, prompt: "Unassigned"
+    = f.association :assigned_user, collection: User.find_users_by_facility(current_facility), label_method: :full_name, label: false, prompt: "Unassigned", input_html: { disabled: metadata_edit_disabled? }

--- a/app/views/order_management/order_details/_dispute.html.haml
+++ b/app/views/order_management/order_details/_dispute.html.haml
@@ -18,6 +18,6 @@
         .col-md-3
           = f.input :dispute_reason, as: :readonly
         .col-md-4
-          = f.input :dispute_resolved_reason, input_html: { class: 'note' }
+          = f.input :dispute_resolved_reason, input_html: { class: 'note', disabled: metadata_edit_disabled? }
 - else
   = t("order_details.notices.global_admin_must_resolve.alert")

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -12,7 +12,7 @@
     %div{class: modal? ? "modal-body" : ""}
       .row
         .col-md-5.js--pricingUpdate
-          = account_input(f)
+          = account_input(f, disabled: metadata_edit_disabled?)
         .col-md-2
           %strong= t("facility_order_details.edit.label.account_owner")
           .account-owner= @order_detail.account.owner_user
@@ -49,7 +49,8 @@
 
       .row
         .col-md-3
-          = render "projects/shared/select_project", f: f, order_detail: @order_detail
+          %fieldset{disabled: metadata_edit_disabled? || nil}
+            = render "projects/shared/select_project", f: f, order_detail: @order_detail
           - # TODO: Check if un-used and remove.  This was used by the old projects engine before it was brought into the application.
           = render_view_hook "after_order_status", f: f, order_detail: @order_detail
         .col-md-7
@@ -62,11 +63,13 @@
           .col-md-7= render "costs", f: f
         .row
           .col-md-3
-          .col-md-7= render "order_management/order_details/#{@order_detail.time_data.class.name.underscore}", f: f
+          .col-md-7
+            %fieldset{disabled: metadata_edit_disabled? || nil}
+              = render "order_management/order_details/#{@order_detail.time_data.class.name.underscore}", f: f
       - else
         .row
           .col-md-3.js--pricingUpdate
-            = f.input :quantity, as: :order_detail_quantity, hint_html: { class: "help-block" }
+            = f.input :quantity, as: :order_detail_quantity, hint_html: { class: "help-block" }, input_html: { disabled: metadata_edit_disabled? }
           .col-md-7= render "costs", f: f
 
       - unless read_only?
@@ -81,7 +84,7 @@
           = render "assigned_user", f: f
 
         .col-md-3
-          = f.input :reference_id
+          = f.input :reference_id, input_html: { disabled: metadata_edit_disabled? }
 
         .col-md-3
           - if @order_detail.actual_cost?
@@ -95,11 +98,11 @@
       .row
         .col-md-3
         .col-md-7
-          = f.input :note, input_html: { class: "note", rows: 3 }
+          = f.input :note, input_html: { class: "note", rows: 3, disabled: metadata_edit_disabled? }
           - if @order_detail.can_reconcile? || @order_detail.reconciled?
-            = f.input :reconciled_note, input_html: { class: "note" }
+            = f.input :reconciled_note, input_html: { class: "note", disabled: metadata_edit_disabled? }
           - if @order_detail.unrecoverable?
-            = f.input :unrecoverable_note, input_html: { class: "note" }
+            = f.input :unrecoverable_note, input_html: { class: "note", disabled: metadata_edit_disabled? }
 
       - if @order_detail.dispute_at
         .row= render "dispute", f: f

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -72,7 +72,7 @@
             = f.input :quantity, as: :order_detail_quantity, hint_html: { class: "help-block" }, input_html: { disabled: metadata_edit_disabled? }
           .col-md-7= render "costs", f: f
 
-      - unless read_only?
+      - unless metadata_edit_disabled?
         .row
           .col-md-7
           .col-md-3

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -202,6 +202,7 @@ RSpec.describe OrderManagement::OrderDetailsController do
     let(:item_order) { create(:purchased_order, product: item) }
     let(:item_order_detail) { item_order.order_details.first }
     let(:user) { create(:user) }
+    let(:dom) { Nokogiri::HTML(response.body) }
 
     before do
       @action = :edit
@@ -262,9 +263,6 @@ RSpec.describe OrderManagement::OrderDetailsController do
       end
 
       it "disables management inputs (account, quantity, reference_id, note)" do
-        dom = Nokogiri::HTML(response.body)
-        # assigned_user is rendered as static text once the order is Complete,
-        # so it is not present as an input — covered indirectly.
         %w[order_detail_account_id order_detail_quantity order_detail_reference_id
            order_detail_note].each do |id|
           input = dom.css("##{id}").first
@@ -274,7 +272,6 @@ RSpec.describe OrderManagement::OrderDetailsController do
       end
 
       it "leaves price-related inputs enabled" do
-        dom = Nokogiri::HTML(response.body)
         cost = dom.css("#order_detail_actual_cost").first
         expect(cost).to be_present
         expect(cost).not_to be_has_attribute("disabled")
@@ -289,7 +286,6 @@ RSpec.describe OrderManagement::OrderDetailsController do
       end
 
       it "leaves management inputs enabled" do
-        dom = Nokogiri::HTML(response.body)
         %w[order_detail_account_id order_detail_quantity order_detail_reference_id
            order_detail_note].each do |id|
           input = dom.css("##{id}").first

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -248,6 +248,56 @@ RSpec.describe OrderManagement::OrderDetailsController do
         expect(response.body).to include('value="Save"')
       end
     end
+
+    context "with price_adjustment only" do
+      before do
+        create(:facility_user_permission, user:, facility:, price_adjustment: true)
+        item_order_detail.change_status!(OrderStatus.complete)
+        sign_in user
+        do_request
+      end
+
+      it "renders the Save button" do
+        expect(response.body).to include('value="Save"')
+      end
+
+      it "disables management inputs (account, quantity, reference_id, note)" do
+        dom = Nokogiri::HTML(response.body)
+        # assigned_user is rendered as static text once the order is Complete,
+        # so it is not present as an input — covered indirectly.
+        %w[order_detail_account_id order_detail_quantity order_detail_reference_id
+           order_detail_note].each do |id|
+          input = dom.css("##{id}").first
+          expect(input).to be_present, "expected #{id} to be rendered"
+          expect(input).to be_has_attribute("disabled"), "expected #{id} to be disabled"
+        end
+      end
+
+      it "leaves price-related inputs enabled" do
+        dom = Nokogiri::HTML(response.body)
+        cost = dom.css("#order_detail_actual_cost").first
+        expect(cost).to be_present
+        expect(cost).not_to be_has_attribute("disabled")
+      end
+    end
+
+    context "with order_management only" do
+      before do
+        create(:facility_user_permission, user:, facility:, order_management: true)
+        sign_in user
+        do_request
+      end
+
+      it "leaves management inputs enabled" do
+        dom = Nokogiri::HTML(response.body)
+        %w[order_detail_account_id order_detail_quantity order_detail_reference_id
+           order_detail_note].each do |id|
+          input = dom.css("##{id}").first
+          expect(input).to be_present, "expected #{id} to be rendered"
+          expect(input).not_to be_has_attribute("disabled"), "expected #{id} to be enabled"
+        end
+      end
+    end
   end
 
   describe "PUT #update" do
@@ -1099,6 +1149,43 @@ RSpec.describe OrderManagement::OrderDetailsController do
           expect { do_request }.not_to raise_error
           expect(response).to have_http_status(:redirect)
         end
+
+        it "silently strips order management attributes (note, reference_id)" do
+          @params[:order_detail] = {
+            note: "tampered note",
+            reference_id: "tampered ref",
+            actual_cost: "10",
+            actual_subsidy: "0",
+            price_change_reason: "adjusting the price",
+          }
+          do_request
+
+          expect(response).to have_http_status(:redirect)
+          order_detail.reload
+          expect(order_detail.note).not_to eq("tampered note")
+          expect(order_detail.reference_id).not_to eq("tampered ref")
+          expect(order_detail.actual_cost).to eq(10)
+        end
+
+        it "silently strips account_id and quantity changes" do
+          alternate_account = create(:setup_account, owner: order_detail.user)
+          original_account_id = order_detail.account_id
+          original_quantity = order_detail.quantity
+
+          @params[:order_detail] = {
+            account_id: alternate_account.id,
+            quantity: original_quantity + 5,
+            actual_cost: "10",
+            actual_subsidy: "0",
+            price_change_reason: "adjusting the price",
+          }
+          do_request
+
+          expect(response).to have_http_status(:redirect)
+          order_detail.reload
+          expect(order_detail.account_id).to eq(original_account_id)
+          expect(order_detail.quantity).to eq(original_quantity)
+        end
       end
 
       context "with order_management" do
@@ -1112,6 +1199,19 @@ RSpec.describe OrderManagement::OrderDetailsController do
 
           expect(response).to have_http_status(:redirect)
           expect(order_detail.reload.order_status).to eq(OrderStatus.complete)
+        end
+
+        it "allows updating order management attributes (note, reference_id)" do
+          @params[:order_detail] = {
+            note: "updated note",
+            reference_id: "REF-123",
+          }
+          do_request
+
+          expect(response).to have_http_status(:redirect)
+          order_detail.reload
+          expect(order_detail.note).to eq("updated note")
+          expect(order_detail.reference_id).to eq("REF-123")
         end
       end
 

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -1051,6 +1051,84 @@ RSpec.describe OrderManagement::OrderDetailsController do
         end
       end
     end
+
+    describe "with granular permissions", feature_setting: { granular_permissions: true } do
+      let(:order) { create(:purchased_order, product: item) }
+      let(:order_detail) { order.order_details.first }
+      let(:user) { create(:user) }
+      let(:complete_status_id) { OrderStatus.complete.id.to_s }
+      let(:canceled_status_id) { OrderStatus.canceled.id.to_s }
+
+      before do
+        sign_in user
+      end
+
+      context "with price_adjustment only" do
+        before do
+          create(:facility_user_permission, user:, facility:, price_adjustment: true)
+          order_detail.change_status!(OrderStatus.complete)
+        end
+
+        it "allows updating actual_cost without changing status" do
+          @params[:order_detail] = {
+            actual_cost: "10",
+            actual_subsidy: "0",
+            price_change_reason: "adjusting the price",
+          }
+          do_request
+
+          expect(response).to have_http_status(:redirect)
+          expect(order_detail.reload.actual_cost).to eq(10)
+        end
+
+        it "denies changing the order status" do
+          @params[:order_detail] = { order_status_id: canceled_status_id }
+
+          expect { do_request }.to raise_error(CanCan::AccessDenied)
+          expect(order_detail.reload.order_status).to eq(OrderStatus.complete)
+        end
+
+        it "allows submitting the current status (idempotent)" do
+          @params[:order_detail] = {
+            order_status_id: complete_status_id,
+            actual_cost: "5",
+            actual_subsidy: "0",
+            price_change_reason: "adjusting the price",
+          }
+
+          expect { do_request }.not_to raise_error
+          expect(response).to have_http_status(:redirect)
+        end
+      end
+
+      context "with order_management" do
+        before do
+          create(:facility_user_permission, user:, facility:, order_management: true)
+        end
+
+        it "allows marking the order complete" do
+          @params[:order_detail] = { order_status_id: complete_status_id }
+          do_request
+
+          expect(response).to have_http_status(:redirect)
+          expect(order_detail.reload.order_status).to eq(OrderStatus.complete)
+        end
+      end
+
+      context "with both order_management and price_adjustment" do
+        before do
+          create(:facility_user_permission, user:, facility:, order_management: true, price_adjustment: true)
+        end
+
+        it "allows marking the order complete" do
+          @params[:order_detail] = { order_status_id: complete_status_id }
+          do_request
+
+          expect(response).to have_http_status(:redirect)
+          expect(order_detail.reload.order_status).to eq(OrderStatus.complete)
+        end
+      end
+    end
   end
 
   describe "pricing" do

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -1135,10 +1135,11 @@ RSpec.describe OrderManagement::OrderDetailsController do
           expect(order_detail.reload.actual_cost).to eq(10)
         end
 
-        it "denies changing the order status" do
+        it "silently strips the order_status_id" do
           @params[:order_detail] = { order_status_id: canceled_status_id }
+          do_request
 
-          expect { do_request }.to raise_error(CanCan::AccessDenied)
+          expect(response).to have_http_status(:redirect)
           expect(order_detail.reload.order_status).to eq(OrderStatus.complete)
         end
 

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -1217,6 +1217,23 @@ RSpec.describe OrderManagement::OrderDetailsController do
           expect(order_detail.note).to eq("updated note")
           expect(order_detail.reference_id).to eq("REF-123")
         end
+
+        it "preserves a manually-set actual_cost when editing other fields" do
+          order_detail.change_status!(OrderStatus.complete)
+          order_detail.update_columns(actual_cost: 50.0, actual_subsidy: 0.0,
+                                       estimated_cost: 60.0, estimated_subsidy: 0.0,
+                                       price_change_reason: "manual override",
+                                       price_changed_by_user_id: create(:user).id)
+          @params[:order_detail] = { note: "OM user editing note" }
+
+          do_request
+
+          expect(response).to have_http_status(:redirect)
+          order_detail.reload
+          expect(order_detail.actual_cost).to eq(50)
+          expect(order_detail.actual_subsidy).to eq(0)
+          expect(order_detail.note).to eq("OM user editing note")
+        end
       end
 
       context "with both order_management and price_adjustment" do

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -276,6 +276,10 @@ RSpec.describe OrderManagement::OrderDetailsController do
         expect(cost).to be_present
         expect(cost).not_to be_has_attribute("disabled")
       end
+
+      it "hides the Recalculate pricing button" do
+        expect(dom.css(".js--recalculate-pricing")).to be_empty
+      end
     end
 
     context "with order_management only" do
@@ -292,6 +296,10 @@ RSpec.describe OrderManagement::OrderDetailsController do
           expect(input).to be_present, "expected #{id} to be rendered"
           expect(input).not_to be_has_attribute("disabled"), "expected #{id} to be enabled"
         end
+      end
+
+      it "shows the Recalculate pricing button" do
+        expect(dom.css(".js--recalculate-pricing")).not_to be_empty
       end
     end
   end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -666,6 +666,7 @@ RSpec.describe Ability do
 
       it { is_expected.to be_allowed_to(:manage, OrderDetail) }
       it { is_expected.to be_allowed_to(:change_status, OrderDetail) }
+      it { is_expected.to be_allowed_to(:manage_order_details, OrderDetail) }
       it_is_allowed_to([:administer, :assign_price_policies_to_problem_orders, :batch_update, :create, :index, :order_in_past, :send_receipt, :show, :tab_counts, :update], Order)
       it_is_allowed_to([:administer, :assign_price_policies_to_problem_orders, :batch_update, :cancel, :edit, :index, :show, :tab_counts, :timeline, :update], Reservation)
       it { is_expected.to be_allowed_to(:act_as, facility) }
@@ -748,6 +749,7 @@ RSpec.describe Ability do
       it { is_expected.to be_allowed_to(:adjust_price, OrderDetail) }
       it { is_expected.to be_allowed_to(:manage, OrderDetail) }
       it { is_expected.not_to be_allowed_to(:change_status, OrderDetail) }
+      it { is_expected.not_to be_allowed_to(:manage_order_details, OrderDetail) }
       it { is_expected.not_to be_allowed_to(:act_as, facility) }
       it_is_not_allowed_to([:create, :update, :batch_update], Order)
     end
@@ -760,6 +762,7 @@ RSpec.describe Ability do
       it { is_expected.to be_allowed_to(:manage, OrderDetail) }
       it { is_expected.to be_allowed_to(:adjust_price, OrderDetail) }
       it { is_expected.to be_allowed_to(:change_status, OrderDetail) }
+      it { is_expected.to be_allowed_to(:manage_order_details, OrderDetail) }
       it { is_expected.to be_allowed_to(:act_as, facility) }
     end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -665,6 +665,7 @@ RSpec.describe Ability do
       end
 
       it { is_expected.to be_allowed_to(:manage, OrderDetail) }
+      it { is_expected.to be_allowed_to(:change_status, OrderDetail) }
       it_is_allowed_to([:administer, :assign_price_policies_to_problem_orders, :batch_update, :create, :index, :order_in_past, :send_receipt, :show, :tab_counts, :update], Order)
       it_is_allowed_to([:administer, :assign_price_policies_to_problem_orders, :batch_update, :cancel, :edit, :index, :show, :tab_counts, :timeline, :update], Reservation)
       it { is_expected.to be_allowed_to(:act_as, facility) }
@@ -746,6 +747,7 @@ RSpec.describe Ability do
 
       it { is_expected.to be_allowed_to(:adjust_price, OrderDetail) }
       it { is_expected.to be_allowed_to(:manage, OrderDetail) }
+      it { is_expected.not_to be_allowed_to(:change_status, OrderDetail) }
       it { is_expected.not_to be_allowed_to(:act_as, facility) }
       it_is_not_allowed_to([:create, :update, :batch_update], Order)
     end
@@ -757,6 +759,7 @@ RSpec.describe Ability do
 
       it { is_expected.to be_allowed_to(:manage, OrderDetail) }
       it { is_expected.to be_allowed_to(:adjust_price, OrderDetail) }
+      it { is_expected.to be_allowed_to(:change_status, OrderDetail) }
       it { is_expected.to be_allowed_to(:act_as, facility) }
     end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -664,9 +664,7 @@ RSpec.describe Ability do
         FacilityUserPermission.find_by(user:, facility:).update!(order_management: true)
       end
 
-      it { is_expected.to be_allowed_to(:manage, OrderDetail) }
-      it { is_expected.to be_allowed_to(:change_status, OrderDetail) }
-      it { is_expected.to be_allowed_to(:manage_order_details, OrderDetail) }
+      it_is_allowed_to([:update, :edit, :mark_unrecoverable], OrderDetail)
       it_is_allowed_to([:administer, :assign_price_policies_to_problem_orders, :batch_update, :create, :index, :order_in_past, :send_receipt, :show, :tab_counts, :update], Order)
       it_is_allowed_to([:administer, :assign_price_policies_to_problem_orders, :batch_update, :cancel, :edit, :index, :show, :tab_counts, :timeline, :update], Reservation)
       it { is_expected.to be_allowed_to(:act_as, facility) }
@@ -747,9 +745,9 @@ RSpec.describe Ability do
       end
 
       it { is_expected.to be_allowed_to(:adjust_price, OrderDetail) }
-      it { is_expected.to be_allowed_to(:manage, OrderDetail) }
-      it { is_expected.not_to be_allowed_to(:change_status, OrderDetail) }
-      it { is_expected.not_to be_allowed_to(:manage_order_details, OrderDetail) }
+      it { is_expected.not_to be_allowed_to(:update, OrderDetail) }
+      it { is_expected.not_to be_allowed_to(:edit, OrderDetail) }
+      it { is_expected.not_to be_allowed_to(:mark_unrecoverable, OrderDetail) }
       it { is_expected.not_to be_allowed_to(:act_as, facility) }
       it_is_not_allowed_to([:create, :update, :batch_update], Order)
     end
@@ -759,10 +757,7 @@ RSpec.describe Ability do
         FacilityUserPermission.find_by(user:, facility:).update!(order_management: true, price_adjustment: true)
       end
 
-      it { is_expected.to be_allowed_to(:manage, OrderDetail) }
-      it { is_expected.to be_allowed_to(:adjust_price, OrderDetail) }
-      it { is_expected.to be_allowed_to(:change_status, OrderDetail) }
-      it { is_expected.to be_allowed_to(:manage_order_details, OrderDetail) }
+      it_is_allowed_to([:update, :edit, :mark_unrecoverable, :adjust_price], OrderDetail)
       it { is_expected.to be_allowed_to(:act_as, facility) }
     end
 
@@ -819,7 +814,7 @@ RSpec.describe Ability do
       end
 
       it_is_allowed_to([:bring_online, :create, :edit, :new, :update], OfflineReservation)
-      it { is_expected.to be_allowed_to(:manage, OrderDetail) }
+      it_is_allowed_to([:update, :edit, :mark_unrecoverable], OrderDetail)
       it { is_expected.to be_allowed_to(:act_as, facility) }
       it { is_expected.to be_allowed_to(:switch, Instrument) }
     end


### PR DESCRIPTION
  # Notes                                                                                                                                                                                                                                                                    
         
  Fixes a granular-permissions bug where users with only the "Price adjustment" permission could change an order's status (e.g. mark Complete). Status changes now require the "Order management" permission.              
                                                                                                                                                                                                                                                                             
  [NUOPEN-344 — I should be able to change the status of an order only with the "Order management" permission](https://universe-of-universities.atlassian.net/browse/NUOPEN-344)
