### PR TITLE
[NUOPEN-343] Cover sanger with granular permissions

### DIFF
--- a/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/sanger_products_controller.rb
+++ b/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/sanger_products_controller.rb
@@ -5,7 +5,7 @@ module SangerSequencing
   class SangerProductsController < BaseController
     before_action :set_resources
     before_action { @active_tab = "admin_products" }
-    before_action { authorize! :manage, current_facility }
+    before_action { authorize! :manage, @product }
 
     layout "two_column"
     admin_tab :all

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/ability.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/ability.rb
@@ -11,10 +11,19 @@ module SangerSequencing
 
       can [:show, :create, :update, :create_sample], Submission, user: user
 
-      if facility && user.operator_of?(facility)
+      if facility && (user.operator_of?(facility) || granted_product_management?(user, facility))
         can [:index, :show], Submission
         can :manage, [Batch, BatchForm, Primer]
       end
+    end
+
+    private
+
+    def granted_product_management?(user, facility)
+      return false unless SettingsHelper.feature_on?(:granular_permissions)
+
+      permission = user.facility_user_permissions.find_by(facility: facility)
+      permission&.read_access? && permission.product_management?
     end
 
   end

--- a/vendor/engines/sanger_sequencing/app/presenters/sanger_sequencing/link_collection_extension.rb
+++ b/vendor/engines/sanger_sequencing/app/presenters/sanger_sequencing/link_collection_extension.rb
@@ -12,13 +12,19 @@ module SangerSequencing
     end
 
     def admin_sanger_sequencing
-      if single_facility? && facility.sanger_sequencing_enabled? && ability.can?(:administer, Product)
+      if single_facility? && facility.sanger_sequencing_enabled? && sanger_ability.can?(:index, SangerSequencing::Submission)
         NavTab::Link.new(
           tab: :admin_sanger_sequencing,
           text: I18n.t("sanger_sequencing.name"),
           url: facility_sanger_sequencing_admin_submissions_path(facility),
         )
       end
+    end
+
+    private
+
+    def sanger_ability
+      SangerSequencing::Ability.new(user, facility)
     end
 
   end

--- a/vendor/engines/sanger_sequencing/app/presenters/sanger_sequencing/link_collection_extension.rb
+++ b/vendor/engines/sanger_sequencing/app/presenters/sanger_sequencing/link_collection_extension.rb
@@ -12,7 +12,7 @@ module SangerSequencing
     end
 
     def admin_sanger_sequencing
-      if single_facility? && facility.sanger_sequencing_enabled?
+      if single_facility? && facility.sanger_sequencing_enabled? && ability.can?(:administer, Product)
         NavTab::Link.new(
           tab: :admin_sanger_sequencing,
           text: I18n.t("sanger_sequencing.name"),

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/shared/tabnav_product/_sanger.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/shared/tabnav_product/_sanger.html.haml
@@ -1,4 +1,4 @@
-- if @product.sanger_sequencing_enabled? && can?(:manage, current_facility) && SettingsHelper.feature_on?(:sanger_enabled_service)
+- if @product.sanger_sequencing_enabled? && can?(:manage, @product) && SettingsHelper.feature_on?(:sanger_enabled_service)
   = tab t("sanger_sequencing.tabnav_product"),
     facility_service_sanger_sequencing_sanger_product_path(current_facility, @product),
     (secondary_tab == "sanger")

--- a/vendor/engines/sanger_sequencing/spec/controllers/sanger_sequencing/sanger_products_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/controllers/sanger_sequencing/sanger_products_spec.rb
@@ -70,4 +70,36 @@ RSpec.describe SangerSequencing::SangerProductsController do
       )
     end
   end
+
+  describe "authorization", feature_setting: { granular_permissions: true } do
+    before do
+      @method = :get
+      @action = :show
+    end
+
+    context "as a granular product_management user" do
+      let(:user) { create(:user) }
+
+      before do
+        create(:facility_user_permission, user:, facility:, product_management: true)
+      end
+
+      it "is allowed" do
+        do_request
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "as a granular user without product_management" do
+      let(:user) { create(:user) }
+
+      before do
+        create(:facility_user_permission, user:, facility:, read_access: true)
+      end
+
+      it "is forbidden" do
+        expect { do_request }.to raise_error(CanCan::AccessDenied)
+      end
+    end
+  end
 end

--- a/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/ability_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/ability_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SangerSequencing::Ability do
+  subject(:ability) { described_class.new(user, facility) }
+
+  let(:facility) { create(:facility, sanger_sequencing_enabled: true) }
+
+  describe "no user" do
+    let(:user) { nil }
+
+    it_is_not_allowed_to([:index, :show, :create, :update], SangerSequencing::Submission)
+    it_is_not_allowed_to(:manage, SangerSequencing::Batch)
+  end
+
+  describe "submission owner" do
+    let(:user) { create(:user) }
+    let(:submission) { SangerSequencing::Submission.new }
+
+    before { allow(submission).to receive(:user).and_return(user) }
+
+    it { is_expected.to be_allowed_to(:show, submission) }
+    it { is_expected.to be_allowed_to(:update, submission) }
+    it { is_expected.to be_allowed_to(:create_sample, submission) }
+  end
+
+  describe "another user's submission" do
+    let(:user) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:submission) { SangerSequencing::Submission.new }
+
+    before { allow(submission).to receive(:user).and_return(other_user) }
+
+    it { is_expected.not_to be_allowed_to(:show, submission) }
+    it { is_expected.not_to be_allowed_to(:update, submission) }
+  end
+
+  describe "facility staff" do
+    let(:user) { create(:user, :staff, facility: facility) }
+
+    it_is_allowed_to([:index, :show], SangerSequencing::Submission)
+    it_is_allowed_to(:manage, SangerSequencing::Batch)
+    it_is_allowed_to(:manage, SangerSequencing::BatchForm)
+    it_is_allowed_to(:manage, SangerSequencing::Primer)
+  end
+
+  describe "facility administrator" do
+    let(:user) { create(:user, :facility_administrator, facility: facility) }
+
+    it_is_allowed_to([:index, :show], SangerSequencing::Submission)
+    it_is_allowed_to(:manage, SangerSequencing::Batch)
+  end
+
+  describe "global administrator" do
+    let(:user) { create(:user, :administrator) }
+
+    it_is_allowed_to([:index, :show], SangerSequencing::Submission)
+    it_is_allowed_to(:manage, SangerSequencing::Batch)
+  end
+
+  describe "unprivileged user" do
+    let(:user) { create(:user) }
+
+    it_is_not_allowed_to([:index], SangerSequencing::Submission)
+    it_is_not_allowed_to(:manage, SangerSequencing::Batch)
+  end
+
+  describe "user with granular permissions", feature_setting: { granular_permissions: true } do
+    let(:user) { create(:user) }
+
+    context "with product_management" do
+      before do
+        create(:facility_user_permission, user:, facility:, product_management: true)
+      end
+
+      it_is_allowed_to([:index, :show], SangerSequencing::Submission)
+      it_is_allowed_to(:manage, SangerSequencing::Batch)
+      it_is_allowed_to(:manage, SangerSequencing::BatchForm)
+      it_is_allowed_to(:manage, SangerSequencing::Primer)
+    end
+
+    context "with read_access only (no product_management)" do
+      before do
+        create(:facility_user_permission, user:, facility:, read_access: true)
+      end
+
+      it_is_not_allowed_to([:index], SangerSequencing::Submission)
+      it_is_not_allowed_to(:manage, SangerSequencing::Batch)
+    end
+
+    context "with product_management but read_access disabled" do
+      before do
+        permission = build(:facility_user_permission, user:, facility:, product_management: true, read_access: false)
+        permission.save(validate: false)
+      end
+
+      it_is_not_allowed_to([:index], SangerSequencing::Submission)
+      it_is_not_allowed_to(:manage, SangerSequencing::Batch)
+    end
+
+    context "with other granular permissions but not product_management" do
+      before do
+        create(:facility_user_permission, user:, facility:, order_management: true)
+      end
+
+      it_is_not_allowed_to([:index], SangerSequencing::Submission)
+      it_is_not_allowed_to(:manage, SangerSequencing::Batch)
+    end
+
+    context "with permission for a different facility" do
+      let(:other_facility) { create(:facility, sanger_sequencing_enabled: true) }
+
+      before do
+        create(:facility_user_permission, user:, facility: other_facility, product_management: true)
+      end
+
+      it_is_not_allowed_to([:index], SangerSequencing::Submission)
+      it_is_not_allowed_to(:manage, SangerSequencing::Batch)
+    end
+  end
+
+  describe "user with product_management granular permission, feature flag off",
+           feature_setting: { granular_permissions: false } do
+    let(:user) { create(:user) }
+
+    before do
+      create(:facility_user_permission, user:, facility:, product_management: true)
+    end
+
+    it_is_not_allowed_to([:index], SangerSequencing::Submission)
+    it_is_not_allowed_to(:manage, SangerSequencing::Batch)
+  end
+end

--- a/vendor/engines/sanger_sequencing/spec/presenters/sanger_sequencing/link_collection_extension_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/presenters/sanger_sequencing/link_collection_extension_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SangerSequencing::LinkCollectionExtension do
+  subject(:link) { NavTab::LinkCollection.new(facility, ability, user).admin_sanger_sequencing }
+
+  let(:facility) { create(:facility, sanger_sequencing_enabled: true) }
+  let(:ability) { Ability.new(user, facility) }
+
+  describe "facility staff" do
+    let(:user) { create(:user, :staff, facility: facility) }
+
+    it { is_expected.to be_a(NavTab::Link) }
+  end
+
+  describe "facility administrator" do
+    let(:user) { create(:user, :facility_administrator, facility: facility) }
+
+    it { is_expected.to be_a(NavTab::Link) }
+  end
+
+  describe "global administrator" do
+    let(:user) { create(:user, :administrator) }
+
+    it { is_expected.to be_a(NavTab::Link) }
+  end
+
+  describe "unprivileged user" do
+    let(:user) { create(:user) }
+
+    it { is_expected.to be_nil }
+  end
+
+  describe "user with granular permissions", feature_setting: { granular_permissions: true } do
+    let(:user) { create(:user) }
+
+    context "with product_management" do
+      before { create(:facility_user_permission, user:, facility:, product_management: true) }
+
+      it { is_expected.to be_a(NavTab::Link) }
+    end
+
+    context "with read_access only" do
+      before { create(:facility_user_permission, user:, facility:, read_access: true) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "with order_management but no product_management" do
+      before { create(:facility_user_permission, user:, facility:, order_management: true) }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "facility without sanger_sequencing_enabled" do
+    let(:facility) { create(:facility, sanger_sequencing_enabled: false) }
+    let(:user) { create(:user, :administrator) }
+
+    it { is_expected.to be_nil }
+  end
+end

--- a/vendor/engines/sanger_sequencing/spec/requests/sanger_sequencing/admin/submissions_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/requests/sanger_sequencing/admin/submissions_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "sanger_sequencing/admin/submissions" do
+  let(:facility) { create(:setup_facility, sanger_sequencing_enabled: true) }
+
+  describe "GET index" do
+    let(:action) do
+      proc { get facility_sanger_sequencing_admin_submissions_path(facility) }
+    end
+
+    describe "as a granular product_management user", feature_setting: { granular_permissions: true } do
+      let(:user) { create(:user) }
+
+      before do
+        create(:facility_user_permission, user:, facility:, product_management: true)
+        login_as user
+      end
+
+      it "is allowed to view the Sanger admin submissions index" do
+        action.call
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "as a granular user without product_management", feature_setting: { granular_permissions: true } do
+      let(:user) { create(:user) }
+
+      before do
+        create(:facility_user_permission, user:, facility:, read_access: true)
+        login_as user
+      end
+
+      it "is forbidden" do
+        action.call
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    describe "as a normal user" do
+      let(:user) { create(:user) }
+
+      before { login_as user }
+
+      it "is forbidden" do
+        action.call
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    describe "as an admin" do
+      let(:admin) { create(:user, :administrator) }
+
+      before { login_as admin }
+
+      it "is allowed" do
+        action.call
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
  # Notes
                                                                                                                                                                                                                                                                               
  Users with the `product_management` granular permission can now access the Sanger module — both the facility-level navbar tab and the product-level Sanger tab. Previously they hit a 403 because Sanger's authorization did not account for granular permissions.
                                                                                                                                                                                                                                                                               
  [NUOPEN-343 | A 403 error happens when a user with "active" granular permissions try to access the Sanger tab in the navbar](https://universe-of-universities.atlassian.net/browse/NUOPEN-343)
