### PR TITLE
[NU-444] Timeslot available notification

### DIFF
--- a/app/controllers/order_details_controller.rb
+++ b/app/controllers/order_details_controller.rb
@@ -37,12 +37,16 @@ class OrderDetailsController < ApplicationController
     if @order_detail.reservation && @order_detail.reservation.can_cancel?
       @order_detail.transaction do
         if @order_detail.cancel_reservation(session_user)
-          CancellationMailer.notify_facility(@order_detail).deliver_later
           flash[:notice] = text("cancel.success")
         else
           flash[:error] = text("cancel.error")
           raise ActiveRecord::Rollback
         end
+      end
+
+      if @order_detail.canceled? && @order_detail.status_recently_changed
+        CancellationMailer.notify_facility(@order_detail).deliver_later
+        ProductNotifications::SlotAvailableService.from_reservation(@order_detail.reservation).notify!
       end
 
       redirect_to redirect_to_path

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -19,6 +19,8 @@ class OrderManagement::OrderDetailsController < ApplicationController
   before_action :load_accounts, only: [:edit, :update]
   before_action :load_order_statuses, only: [:edit, :update]
 
+  after_action :handle_cancelation_notification, only: :update
+
   admin_tab :all
 
   # GET /facilities/:facility_id/orders/:order_id/order_details/:id/manage
@@ -169,4 +171,9 @@ class OrderManagement::OrderDetailsController < ApplicationController
     authorize!(:mark_unrecoverable, OrderDetail)
   end
 
+  def handle_cancelation_notification
+    return unless @order_detail.canceled? && @order_detail.status_recently_changed && @order_detail.reservation.present?
+
+    ProductNotifications::SlotAvailableService.from_reservation(@order_detail.reservation).notify!
+  end
 end

--- a/app/mailers/product_notification_mailer.rb
+++ b/app/mailers/product_notification_mailer.rb
@@ -2,7 +2,7 @@
 
 class ProductNotificationMailer < ApplicationMailer
   ##
-  # An future time slot has become available
+  # A future time slot has become available
   def slot_available(product, user, start_time, end_time)
     @product = product
     @user = user

--- a/app/mailers/product_notification_mailer.rb
+++ b/app/mailers/product_notification_mailer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class ProductNotificationMailer < ApplicationMailer
+  ##
+  # An future time slot has become available
+  def slot_available(product, user, start_time, end_time)
+    @product = product
+    @user = user
+    @time_range = TimeRange.new(start_time, end_time)
+
+    mail(
+      to: user.email,
+      subject: text(
+        "product_notification_mailer.slot_available.subject",
+        product_facility: "#{product} (#{product.facility.abbreviation})",
+        time_range: @time_range,
+      ),
+    )
+  end
+end

--- a/app/mailers/product_notification_mailer.rb
+++ b/app/mailers/product_notification_mailer.rb
@@ -11,7 +11,7 @@ class ProductNotificationMailer < ApplicationMailer
     mail(
       to: user.email,
       subject: text(
-        "product_notification_mailer.slot_available.subject",
+        "views.product_notification_mailer.slot_available.subject",
         product_facility: "#{product} (#{product.facility.abbreviation})",
         time_range: @time_range,
       ),

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -81,7 +81,7 @@ class OrderDetail < ApplicationRecord
 
   alias_attribute :problem_description_keys, :problem_keys
 
-  # Used to track status change of an object
+  # Used to track status changes side efects
   attribute :status_recently_changed, :boolean, default: false
 
   def estimated_price_group

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -81,6 +81,9 @@ class OrderDetail < ApplicationRecord
 
   alias_attribute :problem_description_keys, :problem_keys
 
+  # Used to track status change of an object
+  attribute :status_recently_changed, :boolean, default: false
+
   def estimated_price_group
     estimated_price_policy.try(:price_group)
   end
@@ -424,6 +427,7 @@ class OrderDetail < ApplicationRecord
     # don't try to change status if it's the same as before
     unless new_status == order_status
       self.order_status = new_status
+      self.status_recently_changed = true
       yield(self) if block
       save!
     end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -22,6 +22,9 @@ class Product < ApplicationRecord
   has_many :research_safety_certificates, through: :product_research_safety_certification_requirements
   has_one :product_display_group_product
   has_one :product_display_group, through: :product_display_group_product
+  # TODO: move notifications recipient fields to the product
+  # notification model (and then change to has_many)
+  has_one :product_notification, dependent: :destroy
 
   # Instrument specifc
   has_one(

--- a/app/models/product_notification.rb
+++ b/app/models/product_notification.rb
@@ -3,10 +3,13 @@
 class ProductNotification < ApplicationRecord
   belongs_to :product
 
-  enum :notification_type, { slot_available: :slot_available }
-  enum :recipient_source, { access_list: :access_list, reservations: :reservations }
+  DEFAULT_RESERVATION_DAYS = 15
+
+  enum :notification_type, { slot_available: "slot_available" }
+  enum :recipient_source, { access_list: "access_list", reservations: "reservations" }, prefix: :recipients
 
   store :data, accessors: %i[recipients reservation_days], coder: JSON
 
   validates_uniqueness_of :notification_type, scope: :product_id
+  validates_presence_of :notification_type, :recipient_source
 end

--- a/app/models/product_notification.rb
+++ b/app/models/product_notification.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ProductNotification < ApplicationRecord
+  belongs_to :product
+
+  enum :notification_type, { slot_available: :slot_available }
+  enum :recipient_source, { access_list: :access_list, reservations: :reservations }
+
+  store :data, accessors: %i[recipients reservation_days], coder: JSON
+
+  validates_uniqueness_of :notification_type, scope: :product_id
+end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -111,16 +111,13 @@ class Reservation < ApplicationRecord
       .where("reserve_start_at < ?", end_time)
   end
 
-  def self.upcoming(t = Time.current)
-    # If this is a named scope differences emerge between Oracle & MySQL on #reserve_end_at querying.
-    # Eliminate by letting Rails filter by #reserve_end_at
+  def self.upcoming(time_from = Time.current)
     joins("LEFT JOIN order_details ON order_details.id = reservations.order_detail_id")
       .joins("LEFT JOIN orders ON orders.id = order_details.order_id")
       .not_canceled
       .where("orders.state" => [nil, "purchased"])
+      .where(reserve_end_at: time_from...)
       .order(reserve_end_at: :asc)
-      .to_a
-      .delete_if { |reservation| reservation.reserve_end_at < t }
   end
 
   def self.overlapping(start_at, end_at)

--- a/app/services/product_notifications/slot_available_service.rb
+++ b/app/services/product_notifications/slot_available_service.rb
@@ -9,6 +9,15 @@ module ProductNotifications
 
     delegate :product_notification, to: :product
 
+    def self.from_reservation(reservation)
+      new(
+        reservation.order_detail.product,
+        reservation.reserve_start_at,
+        reservation.reserve_end_at,
+        exclude_user: reservation.order_detail.user,
+      )
+    end
+
     def initialize(product, start_time, end_time, exclude_user: nil)
       @product = product
       @start_time = start_time

--- a/app/services/product_notifications/slot_available_service.rb
+++ b/app/services/product_notifications/slot_available_service.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module ProductNotifications
+  ##
+  # Notify users that a time slot is available for an
+  # instrument.
+  class SlotAvailableService
+    attr_reader :product, :start_time, :end_time, :exclude_user
+
+    delegate :product_notification, to: :product
+
+    def initialize(product, start_time, end_time, exclude_user: nil)
+      @product = product
+      @start_time = start_time
+      @end_time = end_time
+      @exclude_user = exclude_user
+    end
+
+    def notify!
+      recipients.find_each do |user|
+        ProductNotificationMailer.slot_available(
+          product, user, start_time, end_time
+        ).deliver_later
+      end
+    end
+
+    private
+
+    def recipients
+      all_recipient_users.where.not(id: exclude_user&.id)
+    end
+
+    def all_recipient_users
+      return User.none unless product_notification.try(:slot_available?)
+
+      if product_notification.recipients_reservations?
+        upcoming_reservation_users
+      elsif product_notification.recipients_access_list?
+        User.where(id: product.product_users.select(:user_id))
+      end
+    end
+
+    def upcoming_reservation_users
+      window_days =
+        product_notification.reservation_days ||
+        ProductNotification::DEFAULT_RESERVATION_DAYS
+
+      # upcoming reservations after empty time slot
+      reservations =
+        product
+        .reservations
+        .upcoming(end_time)
+        .where(reserve_start_at: ...window_days.days.from_now)
+
+      User.where(id: reservations.select(:user_id))
+    end
+  end
+end

--- a/app/views/product_notification_mailer/slot_available.html.haml
+++ b/app/views/product_notification_mailer/slot_available.html.haml
@@ -1,4 +1,4 @@
-= html("product_notification_mailer.slot_available.body_html",
+= html("body",
   user_name: @user.full_name,
   new_reservation_url: new_facility_instrument_single_reservation_url(@product.facility, @product),
   time_range: @time_range,

--- a/app/views/product_notification_mailer/slot_available.html.haml
+++ b/app/views/product_notification_mailer/slot_available.html.haml
@@ -1,0 +1,7 @@
+= html("product_notification_mailer.slot_available.body_html",
+  user_name: @user.full_name,
+  new_reservation_url: new_facility_instrument_single_reservation_url(@product.facility, @product),
+  time_range: @time_range,
+  product: @product,
+  facility: @product.facility,
+)

--- a/app/views/product_notification_mailer/slot_available.txt.erb
+++ b/app/views/product_notification_mailer/slot_available.txt.erb
@@ -1,4 +1,4 @@
-<%= t(".body",
+<%= text("body",
   user_name: @user.full_name,
   new_reservation_url: new_facility_instrument_single_reservation_url(@product.facility, @product),
   time_range: @time_range,

--- a/app/views/product_notification_mailer/slot_available.txt.erb
+++ b/app/views/product_notification_mailer/slot_available.txt.erb
@@ -1,0 +1,7 @@
+<%= t(".body",
+  user_name: @user.full_name,
+  new_reservation_url: new_facility_instrument_single_reservation_url(@product.facility, @product),
+  time_range: @time_range,
+  product: @product,
+  facility: @product.facility)
+%>

--- a/config/locales/views/en.product_notification_mailer.yml
+++ b/config/locales/views/en.product_notification_mailer.yml
@@ -1,16 +1,11 @@
 en:
-  product_notification_mailer:
-    slot_available:
-      subject: "!app_name! - New availability %{product_facility} - %{time_range}"
-      body_html: |
-        Hello %{user_name},
+  views:
+    product_notification_mailer:
+      slot_available:
+        subject: "!app_name! - New availability %{product_facility} - %{time_range}"
+        body: |
+          Hello %{user_name},
 
-        Time slot %{time_range} became available for %{product} at %{facility}.
+          Time slot %{time_range} became available for %{product} at %{facility}.
 
-        [Make a reservation](%{new_reservation_url}Make a reservation)
-      body: |
-        Hello %{user_name},
-
-        Time slot %{time_range} became available for %{product} at %{facility}.
-
-        Make a reservation: %{new_reservation_url}
+          [Make a reservation](%{new_reservation_url})

--- a/config/locales/views/en.product_notification_mailer.yml
+++ b/config/locales/views/en.product_notification_mailer.yml
@@ -1,0 +1,16 @@
+en:
+  product_notification_mailer:
+    slot_available:
+      subject: "!app_name! - New availability %{product_facility} - %{time_range}"
+      body_html: |
+        Hello %{user_name},
+
+        Time slot %{time_range} became available for %{product} at %{facility}.
+
+        [Make a reservation](%{new_reservation_url}Make a reservation)
+      body: |
+        Hello %{user_name},
+
+        Time slot %{time_range} became available for %{product} at %{facility}.
+
+        Make a reservation: %{new_reservation_url}

--- a/db/migrate/20260429170631_create_product_notifications.rb
+++ b/db/migrate/20260429170631_create_product_notifications.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateProductNotifications < ActiveRecord::Migration[8.0]
+  def change
+    create_table :product_notifications do |t|
+      t.belongs_to :product, null: false
+      t.string :notification_type, null: false
+      t.string :recipient_source
+      t.text :data
+
+      t.timestamps
+    end
+
+    add_index :product_notifications, [:product_id, :notification_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_29_140724) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_29_170631) do
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
     t.integer "account_id", null: false
@@ -662,6 +662,17 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_29_140724) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["facility_id"], name: "index_product_display_groups_on_facility_id"
+  end
+
+  create_table "product_notifications", charset: "utf8", force: :cascade do |t|
+    t.bigint "product_id", null: false
+    t.string "notification_type", null: false
+    t.string "recipient_source"
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id", "notification_type"], name: "idx_on_product_id_notification_type_a94d780b74"
+    t.index ["product_id"], name: "index_product_notifications_on_product_id"
   end
 
   create_table "product_user_imports", charset: "utf8mb3", force: :cascade do |t|

--- a/spec/mailers/product_notification_mailer_spec.rb
+++ b/spec/mailers/product_notification_mailer_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProductNotificationMailer do
+  describe "slot_available" do
+    let(:product) { create(:setup_instrument) }
+    let(:facility) { product.facility }
+    let(:user) { create(:user) }
+    let(:start_time) { 1.hour.from_now }
+    let(:end_time) { start_time + 30.minutes }
+    let(:email) do
+      described_class.slot_available(
+        product, user, start_time, end_time,
+      )
+    end
+
+    it "includes new reservation link" do
+      expect(email.to).to eq [user.email]
+      expect(email.body).to include(new_facility_instrument_single_reservation_path(facility, product))
+    end
+  end
+end

--- a/spec/requests/order_details_spec.rb
+++ b/spec/requests/order_details_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "order_details" do
+  describe "cancel" do
+    let(:product) { create(:setup_instrument) }
+    let(:facility) { product.facility }
+    let(:user) { create(:user) }
+    let(:reservation) do
+      create(:purchased_reservation, product:, user:)
+    end
+    let(:order_detail) { reservation.order_detail }
+    let(:order) { order_detail.order }
+
+    let(:action) do
+      lambda do
+        put cancel_order_order_detail_path(order, order_detail)
+      end
+    end
+
+    before { login_as(user) }
+
+    it "calls slot available service" do
+      expect(ProductNotifications::SlotAvailableService).to(
+        receive(:new).and_call_original
+      )
+
+      action.call
+    end
+
+    context "when already canceled" do
+      before do
+        order_detail.cancel_reservation(user)
+      end
+
+      it "does not call slot available service" do
+        expect(ProductNotifications::SlotAvailableService).not_to(
+          receive(:new).and_call_original
+        )
+
+        action.call
+      end
+    end
+  end
+end

--- a/spec/requests/order_management/order_details_spec.rb
+++ b/spec/requests/order_management/order_details_spec.rb
@@ -2,11 +2,107 @@
 
 require "rails_helper"
 
-RSpec.describe "order_management/order_details", type: :request do
+RSpec.describe "order_management/order_details" do
   let(:facility) { create(:setup_facility) }
   let(:product) { create(:setup_service, facility:) }
   let(:order) { create(:purchased_order, product:) }
   let(:order_detail) { order.order_details.last }
+
+  describe "mark as canceled" do
+    let(:params) do
+      {
+        order_detail: {
+          id: order_detail.id,
+          order_status_id: OrderStatus.canceled.id,
+        }
+      }
+    end
+    let(:update_action) do
+      lambda do
+        put(
+          manage_facility_order_order_detail_path(facility, order, order_detail),
+          params:
+        )
+      end
+    end
+
+    before { login_as create(:user, :administrator) }
+
+    it "changes the order status" do
+      expect { update_action.call }.to(
+        change do
+          order_detail.reload.order_status
+        end.from(OrderStatus.new_status).to(OrderStatus.canceled)
+      )
+    end
+
+    it "does not call slot available service" do
+      expect(ProductNotifications::SlotAvailableService).not_to(
+        receive(:new)
+      )
+
+      update_action.call
+    end
+
+    context "when order detail has a reservation" do
+      let(:product) { create(:setup_instrument, facility:) }
+      let(:reservation) do
+        create(:purchased_reservation, product:, user: create(:user))
+      end
+      let(:order_detail) { reservation.order_detail }
+      let(:order) { order_detail.order }
+
+      it "calls slot available service when canceled" do
+        expect(ProductNotifications::SlotAvailableService).to(
+          receive(:new).and_call_original
+        )
+
+        update_action.call
+      end
+
+      context "when marked as in progress" do
+        let(:params) do
+          {
+            order_detail: {
+              id: order_detail.id,
+              order_status_id: OrderStatus.in_process.id,
+            }
+          }
+        end
+
+        it "does not call the slot available service" do
+          expect(ProductNotifications::SlotAvailableService).not_to(
+            receive(:new)
+          )
+
+          update_action.call
+        end
+      end
+
+      context "when already canceled" do
+        let(:params) do
+          {
+            order_detail: {
+              id: order_detail.id,
+              notes: "Some note",
+            }
+          }
+        end
+
+        before do
+          order_detail.update_order_status!(create(:user), OrderStatus.canceled)
+        end
+
+        it "does not call slot available service" do
+          expect(ProductNotifications::SlotAvailableService).not_to(
+            receive(:new)
+          )
+
+          update_action.call
+        end
+      end
+    end
+  end
 
   describe "mark as unrecoverable" do
     let(:params) do

--- a/spec/services/product_notifications/slot_available_service_spec.rb
+++ b/spec/services/product_notifications/slot_available_service_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProductNotifications::SlotAvailableService do
+  let(:product) { create(:setup_instrument) }
+  let(:facility) { product.facility }
+
+  let(:start_time) { 1.day.from_now }
+  let(:end_time) { start_time + 30.minutes }
+
+  subject { described_class.new(product, start_time, end_time) }
+
+  context "when product notification slot available no set" do
+    it "does not call the mailer" do
+      expect(ProductNotificationMailer).not_to receive(:slot_available)
+
+      subject.notify!
+    end
+  end
+
+  context "when product notification slot available set" do
+    let(:access_list_user) { create(:user) }
+    let(:reservation_user) { create(:user) }
+
+    before do
+      create(:product_user, product:, user: access_list_user)
+      create(:purchased_reservation, product:, user: reservation_user)
+
+      product.create_product_notification!(
+        product:,
+        notification_type: :slot_available,
+        recipient_source:,
+      )
+    end
+
+    context "when recipients taken from access list" do
+      let(:recipient_source) { :access_list }
+
+      it "notifies users from access list" do
+        expect { subject.notify! }.to(
+          have_enqueued_mail(
+            ProductNotificationMailer,
+            :slot_available,
+          ).with(product, access_list_user, start_time, end_time)
+        )
+      end
+
+      it "enqueues exactly one email" do
+        expect { subject.notify! }.to(
+          have_enqueued_mail(ProductNotificationMailer, :slot_available).exactly(1)
+        )
+      end
+    end
+
+    context "when recipients taken from reservations" do
+      let(:recipient_source) { :reservations }
+
+      it "notifies users from upcoming reservations" do
+        expect { subject.notify! }.to(
+          have_enqueued_mail(
+            ProductNotificationMailer,
+            :slot_available,
+          ).with(product, reservation_user, start_time, end_time)
+        )
+      end
+
+      it "enqueues exactly one email" do
+        expect { subject.notify! }.to(
+          have_enqueued_mail(ProductNotificationMailer, :slot_available).exactly(1)
+        )
+      end
+
+      context "when upcoming reservation user excluded" do
+        subject do
+          described_class.new(
+            product, start_time, end_time,
+            exclude_user: reservation_user,
+          )
+        end
+
+        it "notifies no one" do
+          expect { subject.notify! }.not_to enqueue_mail
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Notes

Allow instrument to be configured for notify users on reservation cancellation.

- Add `ProductNotifiation` model to store notifications for products
- Notify users accordingly if a reservation is canceled and the product notification is configured

> Note: Changes in views will be done in an upcomming PR.

[NU-444 | Notify users on canceled reservation](https://universe-of-universities.atlassian.net/browse/NU-444)

## Other changes

- Change `Reservation.upcoming` to return an active record relation instead of an array. It used an array filter because of an oracle issue but it seems to be from long ago (2013).