### PR TITLE
[NUOPEN-345] Allow read Price Group Product (Product Restrictions) wit read access

### DIFF
--- a/app/controllers/price_group_products_controller.rb
+++ b/app/controllers/price_group_products_controller.rb
@@ -7,7 +7,8 @@ class PriceGroupProductsController < ApplicationController
   before_action :init_current_facility
   before_action :init_price_group_products
 
-  load_and_authorize_resource
+  load_resource
+  authorize_resource except: :edit
 
   layout "two_column"
 
@@ -17,6 +18,7 @@ class PriceGroupProductsController < ApplicationController
   end
 
   def edit
+    authorize! :show, PriceGroupProduct
   end
 
   def update

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -224,7 +224,7 @@ class Ability
       can :manage, AccountUser
 
       can :index, [BundleProduct, ScheduleRule, ServicePricePolicy, ProductAccessory, ProductAccessGroup]
-      can :edit, [PriceGroupProduct]
+      can [:read, :edit], PriceGroupProduct
       can [:index], StoredFile
 
       can :manage, [Journal, Statement, OrderDetail]
@@ -343,7 +343,7 @@ class Ability
 
     return unless resource.is_a?(Facility)
 
-    granted_permission_read_only_abilities(controller)
+    granted_permission_read_access_abilities(controller)
 
     if permission.assign_permissions?
       can :manage, FacilityUserPermission
@@ -377,7 +377,7 @@ class Ability
       cannot :create_daily_booking, Product
       can [:show, :index], PriceGroup
       can [:show, :index], [PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ServicePricePolicy]
-      can :edit, [PriceGroupProduct]
+      can [:read, :edit], PriceGroupProduct
       can [:index, :create, :destroy], ProductResearchSafetyCertificationRequirement
     end
 
@@ -465,7 +465,7 @@ class Ability
   end
 
   # Read-only access for users with any granular permission.
-  def granted_permission_read_only_abilities(controller)
+  def granted_permission_read_access_abilities(controller)
     can [:list, :dashboard, :show], Facility
 
     can [:administer, :index, :show, :tab_counts], Order
@@ -481,6 +481,7 @@ class Ability
     can [:instrument_status, :instrument_statuses], Instrument
 
     can [:show, :index], PriceGroup
+    can :read, PriceGroupProduct
     can [:show, :index], [PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ServicePricePolicy]
 
     can :index, Project
@@ -558,7 +559,7 @@ class Ability
     can :act_as, Facility
     can :index, [BundleProduct, PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ScheduleRule, ServicePricePolicy, ProductAccessory, ProductAccessGroup]
     can [:instrument_status, :instrument_statuses, :switch], Instrument
-    can :edit, [PriceGroupProduct]
+    can [:read, :edit], PriceGroupProduct
 
     can [:index, :create, :destroy], ProductResearchSafetyCertificationRequirement
   end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -831,6 +831,7 @@ RSpec.describe Ability do
       it_is_allowed_to([:administer, :index, :show, :timeline], Reservation)
       it_is_allowed_to([:administer, :index, :view_details, :schedule, :show], Product)
       it_is_allowed_to([:index], Project)
+      it_is_allowed_to(:read, PriceGroupProduct)
 
       it_is_not_allowed_to([:manage], Journal)
       it_is_not_allowed_to([:manage], Statement)

--- a/spec/support/matchers/ability_matchers.rb
+++ b/spec/support/matchers/ability_matchers.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-RSpec::Matchers.define :be_allowed_to do |actions, object|
+RSpec::Matchers.define :be_allowed_to do |action, object|
   description do
-    "be allowed to #{actions} " +
+    "be allowed to #{action} " +
       if object.respond_to?(:model_name)
         object.model_name.human.pluralize
       elsif object.class.respond_to?(:model_name)
@@ -13,15 +13,13 @@ RSpec::Matchers.define :be_allowed_to do |actions, object|
   end
 
   match do |ability|
-    [actions].flatten.all? do |action|
-      ability.can?(action, object)
-    end
+    ability.can?(action, object)
   end
 end
 
 def it_is_allowed_to(actions, object = nil)
   Array(actions).each do |action|
-    it "is allowed to #{action} #{object}" do
+    it "is allowed to #{action}" do
       target = object || yield
       expect(subject).to be_allowed_to(action, target)
     end

--- a/spec/support/matchers/ability_matchers.rb
+++ b/spec/support/matchers/ability_matchers.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-RSpec::Matchers.define :be_allowed_to do |action, object|
+RSpec::Matchers.define :be_allowed_to do |actions, object|
   description do
-    "be allowed to #{action} " +
+    "be allowed to #{actions} " +
       if object.respond_to?(:model_name)
         object.model_name.human.pluralize
       elsif object.class.respond_to?(:model_name)
@@ -13,13 +13,15 @@ RSpec::Matchers.define :be_allowed_to do |action, object|
   end
 
   match do |ability|
-    ability.can?(action, object)
+    [actions].flatten.each do |action|
+      ability.can?(action, object)
+    end
   end
 end
 
 def it_is_allowed_to(actions, object = nil)
   Array(actions).each do |action|
-    it "is allowed to #{action}" do
+    it "is allowed to #{action} #{object}" do
       target = object || yield
       expect(subject).to be_allowed_to(action, target)
     end

--- a/spec/support/matchers/ability_matchers.rb
+++ b/spec/support/matchers/ability_matchers.rb
@@ -13,7 +13,7 @@ RSpec::Matchers.define :be_allowed_to do |actions, object|
   end
 
   match do |ability|
-    [actions].flatten.each do |action|
+    [actions].flatten.all? do |action|
       ability.can?(action, object)
     end
   end


### PR DESCRIPTION
# Notes

Instrument restriction tab returning 403.

Since there's no show action for that resource, change edit to authorize show. The form is rendered with fields disabled already so there's no confusion for users.

[NUOPEN-345 | Product Restriccion read access error](https://universe-of-universities.atlassian.net/browse/nuopen-345)

