### PR TITLE
[NUOPEN-351] Product access list buttons styles

### DIFF
--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -8,20 +8,6 @@ html {
   margin-bottom: 20px;
 }
 
-.well {
-  padding: 19px;
-  
-  // Use darker colors for better accessibility contrast
-  a {
-    color: darken($secondaryColor, 10%);
-    
-    &:hover,
-    &:focus {
-      color: darken($secondaryColor, 20%);
-    }
-  }
-}
-
 .nowrap {
   white-space: nowrap;
 }

--- a/app/views/order_imports/new.html.haml
+++ b/app/views/order_imports/new.html.haml
@@ -10,7 +10,7 @@
     - link = link_to text("download_link_here"), template_path
     = html("instructions", importable_products: OrderRowImporter.importable_products, optional_fields: OrderRowImporter.optional_fields, link: link)
     = simple_form_for [:facility, @order_import], html: { multipart: true } do |f|
-      .well.well-small#bulk-import-fields
+      .well.well-sm#bulk-import-fields
         .pull-right
           = link_to text("download_link"), template_path, id: "bulk-import-template"
         = f.file_field :upload_file

--- a/app/views/order_management/order_details/_dispute.html.haml
+++ b/app/views/order_management/order_details/_dispute.html.haml
@@ -7,7 +7,7 @@
     = banner_label      @order_detail, :dispute_resolved_reason
 - elsif !@order_detail.global_admin_must_resolve? || current_ability.can?(:manage, :all)
   .col-md-10
-    .well.well-small
+    .well.well-sm
       %h4= t('facility_order_details.edit.head.resolve_dispute')
       = f.input :resolve_dispute, as: :hidden
       .row

--- a/app/views/price_groups/_price_group_fields.html.haml
+++ b/app/views/price_groups/_price_group_fields.html.haml
@@ -3,13 +3,13 @@
 
 = f.input :name
 
-.well.well-small
+.well.well-sm
   %p.help-block= t(".internal_instruction")
 
   = f.input :is_internal, as: :boolean, inline_label: true, label: false, input_html: { class: "js--isInternal" }
 
 - if SettingsHelper.feature_on?(:external_price_group_subsidies) && @available_parent_groups.present?
-  .well.well-small.js--subsidySection{ style: f.object.is_internal? ? "display: none;" : "" }
+  .well.well-sm.js--subsidySection{ style: f.object.is_internal? ? "display: none;" : "" }
     %p.help-block= t(".subsidy_instruction")
 
     = f.input :parent_price_group_id,
@@ -20,7 +20,7 @@
       label: t(".subsidy_of"),
       input_html: { class: "form-control" }
 
-.well.well-small
+.well.well-sm
   %p.help-block= t(".hidden_instruction")
 
   = f.input :is_hidden, as: :boolean, inline_label: true, label: false

--- a/app/views/product_users/index.html.haml
+++ b/app/views/product_users/index.html.haml
@@ -11,12 +11,12 @@
 %h2= @product
 %h3= text("header")
 
-.well.well-small
+.well.well-sm
   = simple_form_for :product_user_import, url: facility_product_product_user_imports_path(current_facility, @product), html: { multipart: true } do |f|
     %p= text("import_hint", product_type: @product.model_name.human.downcase)
-    .row
-      %p.col-md-2= link_to text("add"), [:new, current_facility, @product, :user], class: "btn-add"
-      %label.col-md-2.btn.btn-primary
+    %div
+      %span= link_to text("add"), [:new, current_facility, @product, :user], class: "btn btn-add"
+      %label.btn.btn-primary
         = text("import_button")
         %span{ style:"display:none" }= f.file_field :file, onchange: "form.submit()"
 


### PR DESCRIPTION
# Notes

Fix product access list styles and invalid uses of css class `.well-small` that should be `.well-sm`.

Remove the custom style that break link buttons text color that should not be needed.

# Screenshot

Before:

<img width="1084" height="873" alt="Captura desde 2026-05-12 09-56-33" src="https://github.com/user-attachments/assets/1e54da99-43e7-4e95-b0de-9b4246ab0d13" />

After:

<img width="1103" height="891" alt="Captura desde 2026-05-12 09-47-13" src="https://github.com/user-attachments/assets/180fcb2f-2240-481a-9faf-0d1802483862" />
