### PR TITLE
[NUOPEN-346] Fix Services Order Form when read only access

### DIFF
--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -480,7 +480,7 @@ class Ability
     can :read, ProductDisplayGroup
     can :read, Schedule
     can :index, [BundleProduct, ScheduleRule, ProductAccessory, ProductAccessGroup]
-    can [:index], StoredFile
+    can [:index, :product_survey], StoredFile
     can [:instrument_status, :instrument_statuses], Instrument
 
     can [:show, :index], PriceGroup

--- a/app/views/file_uploads/product_survey.html.haml
+++ b/app/views/file_uploads/product_survey.html.haml
@@ -16,13 +16,15 @@
   %h3= t(".order_form.head")
   %p= html("file_uploads.product_survey.order_form.main", email: Settings.support_email)
 
-  = simple_form_for(@survey, url: create_product_survey_path(current_facility, @product.parameterize, @product), html: { multipart: true }) do |f|
-    = f.error_messages
-    = f.input :location, label: "Service URL", required: true, input_html: { size: 60 }
+  - if can?(:edit, StoredFile)
+    = simple_form_for(@survey, url: create_product_survey_path(current_facility, @product.parameterize, @product), html: { multipart: true }) do |f|
 
-    = f.submit "Add", data: { disable_with: "Adding..." }, class: "btn btn-default"
+      = f.error_messages
+      = f.input :location, label: "Service URL", required: true, input_html: { size: 60 }
 
-  %br
+      = f.submit "Add", data: { disable_with: "Adding..." }, class: "btn btn-default"
+
+    %br
 
   - surveys = @product.external_service_passers
 
@@ -33,7 +35,8 @@
     %table.table.table-striped.table-hover
       %thead
         %tr
-          %th
+          - if can?(:edit, StoredFile)
+            %th
           %th.centered Status
           %th Service URL
           %th Date Added
@@ -41,22 +44,19 @@
       %tbody
         - surveys.each do |esp|
           %tr
-            - if esp.active?
-              %td.centered
-                = link_to "Deactivate",
-                  deactivate_survey_path(current_facility, @product, esp),
-                  method: :put
+            - if can?(:edit, StoredFile)
+              - if esp.active?
+                %td.centered
+                  = link_to "Deactivate",
+                    deactivate_survey_path(current_facility, @product, esp),
+                    method: :put
+              - else
+                %td.centered
+                  = link_to "Activate",
+                    activate_survey_path(current_facility, @product, esp),
+                    method: :put
 
-              %td.centered Active
-
-            - else
-              %td.centered
-                = link_to "Activate",
-                  activate_survey_path(current_facility, @product, esp),
-                  method: :put
-
-              %td.centered Inactive
-
+            %td.centered= esp.active? ? "Active" : "Inactive"
             %td
               = link_to truncate(esp.external_service.location, length: 60),
                 esp.external_service.location,
@@ -68,15 +68,16 @@
   %h3= t(".download_form.head")
   %p= t(".download_form.main")
 
-  = form_for(@file, url: create_product_survey_path(current_facility, @product.parameterize, @product), html: { multipart: true, method: :post }) do |f|
-    = f.error_messages
-    = f.hidden_field :file_type
+  - if can?(:edit, StoredFile)
+    = form_for(@file, url: create_product_survey_path(current_facility, @product.parameterize, @product), html: { multipart: true, method: :post }) do |f|
+      = f.error_messages
+      = f.hidden_field :file_type
 
-    .form-group
-      = f.label :file, "File", class: "required"
-      = f.file_field :file
+      .form-group
+        = f.label :file, "File", class: "required"
+        = f.file_field :file
 
-    = f.submit text("shared.upload"), data: { disable_with: "Uploading..." }, class: "btn btn-default"
+      = f.submit text("shared.upload"), data: { disable_with: "Uploading..." }, class: "btn btn-default"
 
   %br
 

--- a/app/views/file_uploads/product_survey.html.haml
+++ b/app/views/file_uploads/product_survey.html.haml
@@ -37,7 +37,7 @@
         %tr
           - if can?(:edit, StoredFile)
             %th
-          %th.centered Status
+          %th Status
           %th Service URL
           %th Date Added
 
@@ -56,7 +56,7 @@
                     activate_survey_path(current_facility, @product, esp),
                     method: :put
 
-            %td.centered= esp.active? ? "Active" : "Inactive"
+            %td= esp.active? ? "Active" : "Inactive"
             %td
               = link_to truncate(esp.external_service.location, length: 60),
                 esp.external_service.location,
@@ -90,7 +90,8 @@
     %table.table.table-striped.table-hover
       %thead
         %tr
-          %th
+          - if can?(:edit, StoredFile)
+            %th
           %th File
           %th Date Uploaded
           %th Uploaded By
@@ -98,11 +99,12 @@
       %tbody
         - files.each do |stored_file|
           %tr
-            %td
-              = link_to text("shared.delete"),
-                [current_facility, @product, :file_upload, id: stored_file],
-                method: :delete,
-                data: { confirm: t(".download_form.confirm") }
+            - if can?(:edit, StoredFile)
+              %td.centered
+                = link_to text("shared.delete"),
+                  [current_facility, @product, :file_upload, id: stored_file],
+                  method: :delete,
+                  data: { confirm: t(".download_form.confirm") }
 
             %td= link_to stored_file.name, product_file_path(stored_file)
             %td= format_usa_datetime(stored_file.created_at)

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -833,6 +833,8 @@ RSpec.describe Ability do
       it_is_allowed_to([:administer, :index, :view_details, :schedule, :show], Product)
       it_is_allowed_to([:index], Project)
       it_is_allowed_to(:read, PriceGroupProduct)
+      it_is_allowed_to(:index, StoredFile)
+      it_is_allowed_to(:product_survey, StoredFile)
 
       it_is_not_allowed_to([:manage], Journal)
       it_is_not_allowed_to([:manage], Statement)

--- a/spec/system/admin/service_order_form_spec.rb
+++ b/spec/system/admin/service_order_form_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "product survey page" do
         .update_all(product_management: true)
     end
 
-    it "does not see survey or template forms" do
+    it "sees survey and template forms" do
       visit product_survey_url(facility, service.model_name.plural, service)
 
       expect(page).to have_css("form#new_url_service")

--- a/spec/system/admin/service_order_form_spec.rb
+++ b/spec/system/admin/service_order_form_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "product survey page" do
+  let(:service) { create(:setup_service) }
+  let(:facility) { service.facility }
+  let(:user) { create(:user) }
+
+  before do
+    user.facility_user_permissions.create(
+      facility:, read_access: true,
+    )
+
+    login_as user
+  end
+
+  context "when user does not have product management permission" do
+    it "does not see survey or template forms" do
+      visit product_survey_url(facility, service.model_name.plural, service)
+
+      expect(page).not_to have_css("form#new_url_service")
+      expect(page).not_to have_css("form#new_stored_file")
+    end
+  end
+
+  context "when user has product management permission" do
+    before do
+      FacilityUserPermission
+        .where(user:, facility:)
+        .update_all(product_management: true)
+    end
+
+    it "does not see survey or template forms" do
+      visit product_survey_url(facility, service.model_name.plural, service)
+
+      expect(page).to have_css("form#new_url_service")
+      expect(page).to have_css("form#new_stored_file")
+    end
+  end
+end


### PR DESCRIPTION
# Notes

- Allow `read_access` granular permission to access services Order Forms page
- Update order form page to handle read only case

[NUOPEN-346 | Product management: service order form error 403](https://universe-of-universities.atlassian.net/browse/NUOPEN-346)

## Screenshot

No product management access:

<img width="1263" height="816" alt="Captura desde 2026-05-13 17-30-35" src="https://github.com/user-attachments/assets/be484196-5ec7-42ce-b764-befa3f88f3fe" />

Product management access page:

<img width="1263" height="816" alt="Captura desde 2026-05-13 17-30-39" src="https://github.com/user-attachments/assets/145a802b-a575-49bb-9c1e-74195727549a" />

