### PR TITLE
[OSU-223] Handle job retries with active job

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationJob < ActiveJob::Base
-
+  retry_on StandardError, attempts: 5
 end

--- a/app/jobs/bulk_import_job.rb
+++ b/app/jobs/bulk_import_job.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class BulkImportJob < ApplicationJob
+  # Do not retry this job
+  retry_on StandardError, attempts: 1
+
   def perform(bulk_import)
     bulk_import.load!
   end

--- a/app/jobs/bulk_import_job.rb
+++ b/app/jobs/bulk_import_job.rb
@@ -4,8 +4,4 @@ class BulkImportJob < ApplicationJob
   def perform(bulk_import)
     bulk_import.load!
   end
-
-  def max_attempts
-    1
-  end
 end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Handle retries with ActiveJob
+Delayed::Worker.max_attempts = 0


### PR DESCRIPTION
# Notes

[OSU-223 | Handle Job retries](https://universe-of-universities.atlassian.net/browse/OSU-223)

Handle job retries purely with with active job. The `max_attempts` attribute previously defined in jobs did not work. This change allow us to define the retry mechanism on a per job basis. 

Delayed job retry mechanism conflicts active job's. If we use both, AJ retries will catch exceptions and reschedule the job until the maximum attempts is reached, in which case the exception bubbles up and the DJ retry mechanism kicks in.

So, in order to further decouple from delayed job I've disabled retries there.

Also, disabled `BulkImportJob` retries.

## Job failure debugging

AJ retry mechanism reschedule a new job, so from the point of view of `Delayed::Job` the attempts fields will always be 0. The information about job executions is stored in the handler field which contains active job object serialized.

