### PR TITLE
[NUOPEN-338] Split product management permission

### DIFF
--- a/app/controllers/instrument_relays_controller.rb
+++ b/app/controllers/instrument_relays_controller.rb
@@ -59,7 +59,7 @@ class InstrumentRelaysController < ApplicationController
 
   def manage
     if %w[new create edit update].include?(action_name)
-      authorize! :manage, @product
+      authorize! :update, @product
     else
       authorize! :view_details, @product
     end

--- a/app/helpers/facility_user_permissions_helper.rb
+++ b/app/helpers/facility_user_permissions_helper.rb
@@ -9,4 +9,11 @@ module FacilityUserPermissionsHelper
     end.join(", ")
   end
 
+  def permission_checkbox_classes(perm)
+    classes = [perm == :read_access ? "js--readAccessCheckbox" : "js--otherPermissionCheckbox"]
+    classes << "js--productCreationCheckbox" if perm == :product_creation
+    classes << "js--productEditionCheckbox" if perm == :product_edition
+    classes.join(" ")
+  end
+
 end

--- a/app/helpers/facility_user_permissions_helper.rb
+++ b/app/helpers/facility_user_permissions_helper.rb
@@ -10,9 +10,10 @@ module FacilityUserPermissionsHelper
   end
 
   def permission_checkbox_classes(perm)
-    classes = [perm == :read_access ? "js--readAccessCheckbox" : "js--otherPermissionCheckbox"]
-    classes << "js--productCreationCheckbox" if perm == :product_creation
-    classes << "js--productEditionCheckbox" if perm == :product_edition
+    return "js--readAccessCheckbox" if perm == :read_access
+
+    classes = ["js--otherPermissionCheckbox"]
+    classes << "js--#{perm.to_s.camelize(:lower)}Checkbox" if %i[product_creation product_edition].include?(perm)
     classes.join(" ")
   end
 

--- a/app/javascript/facility_user_permission_form.js
+++ b/app/javascript/facility_user_permission_form.js
@@ -1,30 +1,58 @@
 /*
  * Facility User Permission form
- * Read Access is required whenever any other permission is active.
- * Checking another permission auto-checks Read Access and locks it
- * (visually disabled and unclickable). When all other permissions
- * are unchecked, Read Access becomes editable again.
+ *
+ * Two invariants are enforced visually here (and server-side in the model):
+ * - Read Access is required whenever any other permission is active.
+ *   Checking another permission auto-checks Read Access and locks it
+ *   (visually disabled and unclickable).
+ * - Granting Product Creation implies Product Edition. Checking Product
+ *   Creation auto-checks Product Edition and locks it. Unchecking Product
+ *   Creation releases the lock (Product Edition keeps its current state).
  */
 $(document).ready(function() {
   const readAccessCheckbox = $(".js--readAccessCheckbox");
   const otherCheckboxes = $(".js--otherPermissionCheckbox");
+  const creationCheckbox = $(".js--productCreationCheckbox");
+  const editionCheckbox = $(".js--productEditionCheckbox");
+
+  function lock($checkbox) {
+    $checkbox.attr("data-locked", "true").css("opacity", "0.5");
+  }
+
+  function unlock($checkbox) {
+    $checkbox.removeAttr("data-locked").css("opacity", "");
+  }
 
   function syncReadAccess() {
-    const anyOtherChecked = otherCheckboxes.is(":checked");
-    if (anyOtherChecked) {
+    if (otherCheckboxes.is(":checked")) {
       readAccessCheckbox.prop("checked", true);
-      readAccessCheckbox.attr("data-locked", "true").css("opacity", "0.5");
+      lock(readAccessCheckbox);
     } else {
-      readAccessCheckbox.removeAttr("data-locked").css("opacity", "");
+      unlock(readAccessCheckbox);
     }
   }
 
-  readAccessCheckbox.on("click", function(event) {
+  function syncProductEdition() {
+    if (creationCheckbox.is(":checked")) {
+      editionCheckbox.prop("checked", true);
+      lock(editionCheckbox);
+    } else {
+      unlock(editionCheckbox);
+    }
+  }
+
+  function preventClickWhenLocked(event) {
     if ($(this).attr("data-locked") === "true") {
       event.preventDefault();
     }
-  });
+  }
+
+  readAccessCheckbox.on("click", preventClickWhenLocked);
+  editionCheckbox.on("click", preventClickWhenLocked);
 
   otherCheckboxes.on("change", syncReadAccess);
+  creationCheckbox.on("change", syncProductEdition);
+
   syncReadAccess();
+  syncProductEdition();
 });

--- a/app/javascript/facility_user_permission_form.js
+++ b/app/javascript/facility_user_permission_form.js
@@ -4,7 +4,8 @@
  * Two invariants are enforced visually here (and server-side in the model):
  * - Read Access is required whenever any other permission is active.
  *   Checking another permission auto-checks Read Access and locks it
- *   (visually disabled and unclickable).
+ *   (visually disabled and unclickable). When all other permissions
+ *   are unchecked, Read Access becomes editable again.
  * - Granting Product Creation implies Product Edition. Checking Product
  *   Creation auto-checks Product Edition and locks it. Unchecking Product
  *   Creation releases the lock (Product Edition keeps its current state).

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -360,7 +360,7 @@ class Ability
       can [:disputed_orders, :transactions, :reassign_chart_strings, :confirm_transactions], Facility
     end
 
-    if permission.product_creation? || permission.product_edition?
+    if permission.product_edition?
       can :manage, [
         BundleProduct,
         Product,
@@ -375,12 +375,15 @@ class Ability
         OfflineReservation,
       ]
       cannot :create_daily_booking, Product
+      cannot :create, Product
       can [:show, :index], PriceGroup
       can [:show, :index], [PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ServicePricePolicy]
       can [:read, :edit], PriceGroupProduct
       can [:index, :create, :destroy], ProductResearchSafetyCertificationRequirement
+    end
 
-      cannot :create, Product unless permission.product_creation?
+    if permission.product_creation?
+      can :create, Product
     end
 
     if permission.product_pricing?

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -363,7 +363,6 @@ class Ability
     if permission.product_edition?
       can :manage, [
         BundleProduct,
-        Product,
         ProductAccessGroup,
         ProductAccessory,
         ProductDisplayGroup,
@@ -374,8 +373,8 @@ class Ability
         TrainingRequest,
         OfflineReservation,
       ]
+      can [:update, :destroy], Product
       cannot :create_daily_booking, Product
-      cannot :create, Product
       can [:show, :index], PriceGroup
       can [:show, :index], [PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ServicePricePolicy]
       can [:read, :edit], PriceGroupProduct

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -360,7 +360,7 @@ class Ability
       can [:disputed_orders, :transactions, :reassign_chart_strings, :confirm_transactions], Facility
     end
 
-    if permission.product_management?
+    if permission.product_creation? || permission.product_edition?
       can :manage, [
         BundleProduct,
         Product,
@@ -379,6 +379,8 @@ class Ability
       can [:show, :index], [PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ServicePricePolicy]
       can [:read, :edit], PriceGroupProduct
       can [:index, :create, :destroy], ProductResearchSafetyCertificationRequirement
+
+      cannot :create, Product unless permission.product_creation?
     end
 
     if permission.product_pricing?

--- a/app/models/facility_user_permission.rb
+++ b/app/models/facility_user_permission.rb
@@ -7,7 +7,8 @@ class FacilityUserPermission < ApplicationRecord
 
   PERMISSIONS = %i[
     read_access
-    product_management
+    product_creation
+    product_edition
     product_pricing
     order_management
     price_adjustment

--- a/app/models/facility_user_permission.rb
+++ b/app/models/facility_user_permission.rb
@@ -22,6 +22,8 @@ class FacilityUserPermission < ApplicationRecord
   validates :user_id, uniqueness: { scope: :facility_id }
   validate :read_access_required_with_other_permissions
 
+  before_validation :grant_product_edition_when_product_creation_granted
+
   def no_permissions?
     PERMISSIONS.none? { |perm| send(perm) }
   end
@@ -37,6 +39,10 @@ class FacilityUserPermission < ApplicationRecord
     return if (PERMISSIONS - [:read_access]).none? { |perm| send(perm) }
 
     errors.add(:read_access, "must be granted when other permissions are active")
+  end
+
+  def grant_product_edition_when_product_creation_granted
+    self.product_edition = true if product_creation?
   end
 
 end

--- a/app/views/facility_user_permissions/edit.html.haml
+++ b/app/views/facility_user_permissions/edit.html.haml
@@ -27,7 +27,7 @@
         - next if perm == :assign_permissions && !current_user.administrator?
         .checkbox
           %label
-            = f.check_box perm, class: (perm == :read_access ? "js--readAccessCheckbox" : "js--otherPermissionCheckbox")
+            = f.check_box perm, class: permission_checkbox_classes(perm)
             = FacilityUserPermission.human_attribute_name(perm)
 
   %ul.list-inline

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -309,7 +309,8 @@ en:
         instrument_management: Instrument Management
         order_management: Order Management
         price_adjustment: Price Adjustment
-        product_management: Product Management
+        product_creation: Product Creation
+        product_edition: Product Edition
         product_pricing: Product Pricing
       product:
         can_be_used_by?: Approved?

--- a/db/migrate/20260513141023_split_product_management_in_facility_user_permissions.rb
+++ b/db/migrate/20260513141023_split_product_management_in_facility_user_permissions.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class SplitProductManagementInFacilityUserPermissions < ActiveRecord::Migration[8.0]
+
+  class FacilityUserPermission < ActiveRecord::Base
+  end
+
+  def up
+    add_column :facility_user_permissions, :product_creation, :boolean, default: false, null: false
+    add_column :facility_user_permissions, :product_edition, :boolean, default: false, null: false
+
+    FacilityUserPermission.where(product_management: true)
+                          .update_all(product_creation: true, product_edition: true)
+
+    remove_column :facility_user_permissions, :product_management
+  end
+
+  def down
+    add_column :facility_user_permissions, :product_management, :boolean, default: false, null: false
+
+    FacilityUserPermission.where("product_creation = ? OR product_edition = ?", true, true)
+                          .update_all(product_management: true)
+
+    remove_column :facility_user_permissions, :product_creation
+    remove_column :facility_user_permissions, :product_edition
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -279,7 +279,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_14_174415) do
   create_table "facility_user_permissions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "facility_id", null: false
-    t.boolean "product_management", default: false, null: false
     t.boolean "product_pricing", default: false, null: false
     t.boolean "order_management", default: false, null: false
     t.boolean "price_adjustment", default: false, null: false
@@ -291,6 +290,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_14_174415) do
     t.datetime "updated_at", null: false
     t.boolean "read_access", default: false, null: false
     t.boolean "account_management", default: false, null: false
+    t.boolean "product_creation", default: false, null: false
+    t.boolean "product_edition", default: false, null: false
     t.index ["facility_id"], name: "index_facility_user_permissions_on_facility_id"
     t.index ["user_id", "facility_id"], name: "index_facility_user_permissions_on_user_id_and_facility_id", unique: true
     t.index ["user_id"], name: "index_facility_user_permissions_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -289,9 +289,9 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_14_174415) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "read_access", default: false, null: false
-    t.boolean "account_management", default: false, null: false
     t.boolean "product_creation", default: false, null: false
     t.boolean "product_edition", default: false, null: false
+    t.boolean "account_management", default: false, null: false
     t.index ["facility_id"], name: "index_facility_user_permissions_on_facility_id"
     t.index ["user_id", "facility_id"], name: "index_facility_user_permissions_on_user_id_and_facility_id", unique: true
     t.index ["user_id"], name: "index_facility_user_permissions_on_user_id"

--- a/spec/controllers/facility_user_permissions_controller_spec.rb
+++ b/spec/controllers/facility_user_permissions_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe FacilityUserPermissionsController, feature_setting: { granular_pe
       let(:other_permission_user) { create(:user) }
 
       before do
-        create(:facility_user_permission, user: other_permission_user, facility:, product_management: true)
+        create(:facility_user_permission, user: other_permission_user, facility:, product_edition: true)
         sign_in other_permission_user
       end
 
@@ -76,12 +76,12 @@ RSpec.describe FacilityUserPermissionsController, feature_setting: { granular_pe
     before :each do
       @method = :patch
       @action = :update
-      @params[:facility_user_permission] = { product_management: true, billing_journals: true }
+      @params[:facility_user_permission] = { product_edition: true, billing_journals: true }
     end
 
     it_should_allow_admin_only :redirect do
       expect(assigns(:permission)).to be_persisted
-      expect(assigns(:permission).product_management).to be true
+      expect(assigns(:permission).product_edition).to be true
       expect(assigns(:permission).billing_journals).to be true
       expect(assigns(:permission).order_management).to be false
     end
@@ -115,14 +115,14 @@ RSpec.describe FacilityUserPermissionsController, feature_setting: { granular_pe
       end
 
       it "destroys the record when all permissions are unchecked" do
-        create(:facility_user_permission, user: target_user, facility:, product_management: true)
+        create(:facility_user_permission, user: target_user, facility:, product_edition: true)
         @params[:facility_user_permission] = FacilityUserPermission::PERMISSIONS.index_with { false }
         expect { patch :update, params: @params }.to change { FacilityUserPermission.count }.by(-1)
         expect(FacilityUserPermission.find_by(user: target_user, facility:)).to be_nil
       end
 
       it "logs a delete event when the record is destroyed" do
-        permission = create(:facility_user_permission, user: target_user, facility:, product_management: true)
+        permission = create(:facility_user_permission, user: target_user, facility:, product_edition: true)
         @params[:facility_user_permission] = FacilityUserPermission::PERMISSIONS.index_with { false }
         patch :update, params: @params
         expect(LogEvent).to be_exists(loggable: permission, event_type: :delete, user: @admin)
@@ -147,16 +147,16 @@ RSpec.describe FacilityUserPermissionsController, feature_setting: { granular_pe
         patch :update, params: @params
         expect(response).to redirect_to(facility_facility_users_path(facility))
         permission = FacilityUserPermission.find_by(user: target_user, facility:)
-        expect(permission.product_management).to be true
+        expect(permission.product_edition).to be true
         expect(permission.billing_journals).to be true
       end
 
       it "cannot assign the assign_permissions permission" do
-        @params[:facility_user_permission] = { assign_permissions: true, product_management: true }
+        @params[:facility_user_permission] = { assign_permissions: true, product_edition: true }
         patch :update, params: @params
         permission = FacilityUserPermission.find_by(user: target_user, facility:)
         expect(permission.assign_permissions).to be false
-        expect(permission.product_management).to be true
+        expect(permission.product_edition).to be true
       end
     end
 
@@ -185,7 +185,7 @@ RSpec.describe FacilityUserPermissionsController, feature_setting: { granular_pe
     end
 
     it "allows access to update" do
-      patch :update, params: { facility_id: facility.url_name, id: target_user.id, facility_user_permission: { product_management: true } }
+      patch :update, params: { facility_id: facility.url_name, id: target_user.id, facility_user_permission: { product_edition: true } }
       expect(response).to redirect_to(facility_facility_users_path(facility))
     end
 
@@ -199,7 +199,7 @@ RSpec.describe FacilityUserPermissionsController, feature_setting: { granular_pe
     let(:user_without_assign) { create(:user) }
 
     before do
-      create(:facility_user_permission, user: user_without_assign, facility:, product_management: true)
+      create(:facility_user_permission, user: user_without_assign, facility:, product_edition: true)
       sign_in user_without_assign
     end
 
@@ -219,7 +219,7 @@ RSpec.describe FacilityUserPermissionsController, feature_setting: { granular_pe
 
     it "raises a routing error on update" do
       expect do
-        patch :update, params: { facility_id: facility.url_name, id: target_user.id, facility_user_permission: { product_management: true } }
+        patch :update, params: { facility_id: facility.url_name, id: target_user.id, facility_user_permission: { product_edition: true } }
       end.to raise_error(ActionController::RoutingError)
     end
   end

--- a/spec/controllers/instrument_price_policies_controller_spec.rb
+++ b/spec/controllers/instrument_price_policies_controller_spec.rb
@@ -57,11 +57,11 @@ RSpec.describe InstrumentPricePoliciesController do
       end
     end
 
-    context "with only product_management permission" do
+    context "with only product_edition permission" do
       let(:management_user) { create(:user) }
 
       before do
-        create(:facility_user_permission, user: management_user, facility:, product_management: true)
+        create(:facility_user_permission, user: management_user, facility:, product_edition: true)
       end
 
       it "allows viewing price policies index" do

--- a/spec/controllers/instrument_relays_controller_spec.rb
+++ b/spec/controllers/instrument_relays_controller_spec.rb
@@ -8,19 +8,19 @@ RSpec.describe InstrumentRelaysController do
 
   context "with granular permissions", feature_setting: { granular_permissions: true } do
     describe "authorization for write actions" do
-      let(:product_management_user) { create(:user) }
+      let(:product_edition_user) { create(:user) }
       let(:product_pricing_user) { create(:user) }
       let(:billing_send_user) { create(:user) }
 
       before do
-        create(:facility_user_permission, user: product_management_user, facility:, product_management: true)
+        create(:facility_user_permission, user: product_edition_user, facility:, product_edition: true)
         create(:facility_user_permission, user: product_pricing_user, facility:, product_pricing: true)
         create(:facility_user_permission, user: billing_send_user, facility:, billing_send: true)
       end
 
       describe "GET #new" do
-        it "allows a user with product_management permission" do
-          sign_in product_management_user
+        it "allows a user with product_edition permission" do
+          sign_in product_edition_user
           get :new, params: { facility_id: facility.url_name, instrument_id: instrument.url_name }
           expect(response).to be_successful
         end

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -569,60 +569,85 @@ RSpec.describe InstrumentsController, type: :controller do
   end
 
   context "with granular permissions", feature_setting: { granular_permissions: true } do
-    let(:permitted_user) { create(:user) }
+    let(:creation_user) { create(:user) }
+    let(:edition_user) { create(:user) }
     let(:unpermitted_user) { create(:user) }
 
     before do
-      create(:facility_user_permission, user: permitted_user, facility:, product_management: true)
+      create(:facility_user_permission, user: creation_user, facility:, product_creation: true)
+      create(:facility_user_permission, user: edition_user, facility:, product_edition: true)
     end
 
     describe "GET #index" do
-      it "allows a user with product_management permission" do
-        sign_in permitted_user
+      it "allows a user with product_creation permission" do
+        sign_in creation_user
         get :index, params: { facility_id: facility.url_name }
         expect(response).to be_successful
       end
 
-      it "denies a user without product_management permission" do
+      it "allows a user with product_edition permission" do
+        sign_in edition_user
+        get :index, params: { facility_id: facility.url_name }
+        expect(response).to be_successful
+      end
+
+      it "denies a user without product creation or edition permission" do
         sign_in unpermitted_user
         expect { get :index, params: { facility_id: facility.url_name } }.to raise_error(CanCan::AccessDenied)
       end
     end
 
     describe "GET #new" do
-      it "allows a user with product_management permission" do
-        sign_in permitted_user
+      it "allows a user with product_creation permission" do
+        sign_in creation_user
         get :new, params: { facility_id: facility.url_name }
         expect(response).to be_successful
       end
 
-      it "denies a user without product_management permission" do
+      it "denies a user with only product_edition permission" do
+        sign_in edition_user
+        expect { get :new, params: { facility_id: facility.url_name } }.to raise_error(CanCan::AccessDenied)
+      end
+
+      it "denies a user without product creation or edition permission" do
         sign_in unpermitted_user
         expect { get :new, params: { facility_id: facility.url_name } }.to raise_error(CanCan::AccessDenied)
       end
     end
 
     describe "GET #edit" do
-      it "allows a user with product_management permission" do
-        sign_in permitted_user
+      it "allows a user with product_creation permission" do
+        sign_in creation_user
         get :edit, params: { facility_id: facility.url_name, id: instrument.url_name }
         expect(response).to be_successful
       end
 
-      it "denies a user without product_management permission" do
+      it "allows a user with product_edition permission" do
+        sign_in edition_user
+        get :edit, params: { facility_id: facility.url_name, id: instrument.url_name }
+        expect(response).to be_successful
+      end
+
+      it "denies a user without product creation or edition permission" do
         sign_in unpermitted_user
         expect { get :edit, params: { facility_id: facility.url_name, id: instrument.url_name } }.to raise_error(CanCan::AccessDenied)
       end
     end
 
     describe "GET #manage" do
-      it "allows a user with product_management permission" do
-        sign_in permitted_user
+      it "allows a user with product_creation permission" do
+        sign_in creation_user
         get :manage, params: { facility_id: facility.url_name, id: instrument.url_name }
         expect(response).to be_successful
       end
 
-      it "denies a user without product_management permission" do
+      it "allows a user with product_edition permission" do
+        sign_in edition_user
+        get :manage, params: { facility_id: facility.url_name, id: instrument.url_name }
+        expect(response).to be_successful
+      end
+
+      it "denies a user without product creation or edition permission" do
         sign_in unpermitted_user
         expect { get :manage, params: { facility_id: facility.url_name, id: instrument.url_name } }.to raise_error(CanCan::AccessDenied)
       end
@@ -638,13 +663,18 @@ RSpec.describe InstrumentsController, type: :controller do
         }
       end
 
-      it "allows a user with product_management permission" do
-        sign_in permitted_user
+      it "allows a user with product_creation permission" do
+        sign_in creation_user
         post :create, params: create_params
         expect(response).to be_redirect
       end
 
-      it "denies a user without product_management permission" do
+      it "denies a user with only product_edition permission" do
+        sign_in edition_user
+        expect { post :create, params: create_params }.to raise_error(CanCan::AccessDenied)
+      end
+
+      it "denies a user without product creation or edition permission" do
         sign_in unpermitted_user
         expect { post :create, params: create_params }.to raise_error(CanCan::AccessDenied)
       end

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe OrderManagement::OrderDetailsController do
 
     context "with a permission that does not grant order detail management" do
       before do
-        create(:facility_user_permission, user:, facility:, product_management: true)
+        create(:facility_user_permission, user:, facility:, product_edition: true)
         sign_in user
         do_request
       end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -661,7 +661,7 @@ RSpec.describe Ability do
       it { is_expected.not_to be_allowed_to(:manage, OrderDetail) }
     end
 
-    context "with product_creation" do
+    context "with product_creation (implies product_edition)" do
       before do
         FacilityUserPermission.find_by(user:, facility:).update!(product_creation: true)
       end
@@ -689,14 +689,6 @@ RSpec.describe Ability do
       it { is_expected.to be_allowed_to(:manage, StoredFile) }
       it { is_expected.to be_allowed_to(:manage, OfflineReservation) }
       it { is_expected.not_to be_allowed_to(:create_daily_booking, Product) }
-    end
-
-    context "with both product_creation and product_edition" do
-      before do
-        FacilityUserPermission.find_by(user:, facility:).update!(product_creation: true, product_edition: true)
-      end
-
-      it_is_allowed_to([:new, :create, :update, :edit, :destroy], Product)
     end
 
     context "with order_management" do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -661,6 +661,44 @@ RSpec.describe Ability do
       it { is_expected.not_to be_allowed_to(:manage, OrderDetail) }
     end
 
+    context "with product_creation" do
+      before do
+        FacilityUserPermission.find_by(user:, facility:).update!(product_creation: true)
+      end
+
+      it_is_allowed_to([:new, :create, :update, :edit, :destroy], Product)
+      it_is_allowed_to([:new, :create, :update, :edit, :destroy], BundleProduct)
+      it { is_expected.to be_allowed_to(:manage, Schedule) }
+      it { is_expected.to be_allowed_to(:manage, ScheduleRule) }
+      it { is_expected.to be_allowed_to(:manage, StoredFile) }
+      it { is_expected.to be_allowed_to(:manage, OfflineReservation) }
+      it { is_expected.not_to be_allowed_to(:create_daily_booking, Product) }
+    end
+
+    context "with product_edition" do
+      before do
+        FacilityUserPermission.find_by(user:, facility:).update!(product_edition: true)
+      end
+
+      it_is_allowed_to([:update, :edit, :destroy], Product)
+      it { is_expected.not_to be_allowed_to(:new, Product) }
+      it { is_expected.not_to be_allowed_to(:create, Product) }
+      it_is_allowed_to([:new, :create, :update, :edit, :destroy], BundleProduct)
+      it { is_expected.to be_allowed_to(:manage, Schedule) }
+      it { is_expected.to be_allowed_to(:manage, ScheduleRule) }
+      it { is_expected.to be_allowed_to(:manage, StoredFile) }
+      it { is_expected.to be_allowed_to(:manage, OfflineReservation) }
+      it { is_expected.not_to be_allowed_to(:create_daily_booking, Product) }
+    end
+
+    context "with both product_creation and product_edition" do
+      before do
+        FacilityUserPermission.find_by(user:, facility:).update!(product_creation: true, product_edition: true)
+      end
+
+      it_is_allowed_to([:new, :create, :update, :edit, :destroy], Product)
+    end
+
     context "with order_management" do
       before do
         FacilityUserPermission.find_by(user:, facility:).update!(order_management: true)

--- a/spec/models/facility_user_permission_spec.rb
+++ b/spec/models/facility_user_permission_spec.rb
@@ -53,4 +53,30 @@ RSpec.describe FacilityUserPermission do
       expect(permission).to be_valid
     end
   end
+
+  describe "product_creation implies product_edition" do
+    it "auto-grants product_edition when product_creation is true" do
+      permission.read_access = true
+      permission.product_creation = true
+      permission.product_edition = false
+      permission.save!
+      expect(permission.reload.product_edition).to be true
+    end
+
+    it "does not auto-grant product_edition when product_creation is false" do
+      permission.read_access = true
+      permission.product_creation = false
+      permission.product_edition = false
+      permission.save!
+      expect(permission.reload.product_edition).to be false
+    end
+
+    it "leaves product_edition true when both flags are explicitly set" do
+      permission.read_access = true
+      permission.product_creation = true
+      permission.product_edition = true
+      permission.save!
+      expect(permission.reload).to have_attributes(product_creation: true, product_edition: true)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe User do
     context "when user has both role and permission on the same facility" do
       before do
         UserRole.grant(user, UserRole::FACILITY_STAFF, facility1)
-        create(:facility_user_permission, user:, facility: facility1, product_management: true)
+        create(:facility_user_permission, user:, facility: facility1, product_edition: true)
       end
 
       it "returns the facility once" do

--- a/spec/support/shared_examples/schedule_rules_controller_shared_examples.rb
+++ b/spec/support/shared_examples/schedule_rules_controller_shared_examples.rb
@@ -212,7 +212,7 @@ RSpec.shared_examples_for "A product supporting ScheduleRulesController" do |pro
     describe "price group discounts permissions" do
       let(:user) { create(:user) }
       let!(:facility_user_permission) do
-        FacilityUserPermission.create(user:, facility:, product_management: true, read_access: true)
+        FacilityUserPermission.create(user:, facility:, product_edition: true, read_access: true)
       end
       let(:schedule_rule) { create(:schedule_rule, product:) }
       let(:price_group_discount) do

--- a/spec/system/schedule_rules_spec.rb
+++ b/spec/system/schedule_rules_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Schedule Rules" do
     let(:user) { create(:user) }
     let!(:facility_user_permission) do
       FacilityUserPermission.create(
-        user:, facility:, product_management: true, read_access: true,
+        user:, facility:, product_edition: true, read_access: true,
       )
     end
     let(:schedule_rule) { create(:schedule_rule, product: instrument) }

--- a/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/sanger_products_controller.rb
+++ b/vendor/engines/sanger_sequencing/app/controllers/sanger_sequencing/sanger_products_controller.rb
@@ -5,7 +5,7 @@ module SangerSequencing
   class SangerProductsController < BaseController
     before_action :set_resources
     before_action { @active_tab = "admin_products" }
-    before_action { authorize! :manage, @product }
+    before_action { authorize! :update, @product }
 
     layout "two_column"
     admin_tab :all

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/ability.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/ability.rb
@@ -11,7 +11,7 @@ module SangerSequencing
 
       can [:show, :create, :update, :create_sample], Submission, user: user
 
-      if facility && (user.operator_of?(facility) || granted_product_management?(user, facility))
+      if facility && (user.operator_of?(facility) || granted_product_edition?(user, facility))
         can [:index, :show], Submission
         can :manage, [Batch, BatchForm, Primer]
       end
@@ -19,11 +19,11 @@ module SangerSequencing
 
     private
 
-    def granted_product_management?(user, facility)
+    def granted_product_edition?(user, facility)
       return false unless SettingsHelper.feature_on?(:granular_permissions)
 
       permission = user.facility_user_permissions.find_by(facility: facility)
-      permission&.read_access? && permission.product_management?
+      permission&.read_access? && permission.product_edition?
     end
 
   end

--- a/vendor/engines/sanger_sequencing/spec/controllers/sanger_sequencing/sanger_products_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/controllers/sanger_sequencing/sanger_products_spec.rb
@@ -77,11 +77,11 @@ RSpec.describe SangerSequencing::SangerProductsController do
       @action = :show
     end
 
-    context "as a granular product_management user" do
+    context "as a granular product_edition user" do
       let(:user) { create(:user) }
 
       before do
-        create(:facility_user_permission, user:, facility:, product_management: true)
+        create(:facility_user_permission, user:, facility:, product_edition: true)
       end
 
       it "is allowed" do
@@ -90,7 +90,7 @@ RSpec.describe SangerSequencing::SangerProductsController do
       end
     end
 
-    context "as a granular user without product_management" do
+    context "as a granular user without product_edition" do
       let(:user) { create(:user) }
 
       before do

--- a/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/ability_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/ability_spec.rb
@@ -80,6 +80,15 @@ RSpec.describe SangerSequencing::Ability do
       it_is_allowed_to(:manage, SangerSequencing::Primer)
     end
 
+    context "with product_creation (implies product_edition)" do
+      before do
+        create(:facility_user_permission, user:, facility:, product_creation: true)
+      end
+
+      it_is_allowed_to([:index, :show], SangerSequencing::Submission)
+      it_is_allowed_to(:manage, SangerSequencing::Batch)
+    end
+
     context "with read_access only (no product_edition)" do
       before do
         create(:facility_user_permission, user:, facility:, read_access: true)

--- a/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/ability_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/ability_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe SangerSequencing::Ability do
   describe "user with granular permissions", feature_setting: { granular_permissions: true } do
     let(:user) { create(:user) }
 
-    context "with product_management" do
+    context "with product_edition" do
       before do
-        create(:facility_user_permission, user:, facility:, product_management: true)
+        create(:facility_user_permission, user:, facility:, product_edition: true)
       end
 
       it_is_allowed_to([:index, :show], SangerSequencing::Submission)
@@ -80,7 +80,7 @@ RSpec.describe SangerSequencing::Ability do
       it_is_allowed_to(:manage, SangerSequencing::Primer)
     end
 
-    context "with read_access only (no product_management)" do
+    context "with read_access only (no product_edition)" do
       before do
         create(:facility_user_permission, user:, facility:, read_access: true)
       end
@@ -89,9 +89,9 @@ RSpec.describe SangerSequencing::Ability do
       it_is_not_allowed_to(:manage, SangerSequencing::Batch)
     end
 
-    context "with product_management but read_access disabled" do
+    context "with product_edition but read_access disabled" do
       before do
-        permission = build(:facility_user_permission, user:, facility:, product_management: true, read_access: false)
+        permission = build(:facility_user_permission, user:, facility:, product_edition: true, read_access: false)
         permission.save(validate: false)
       end
 
@@ -99,7 +99,7 @@ RSpec.describe SangerSequencing::Ability do
       it_is_not_allowed_to(:manage, SangerSequencing::Batch)
     end
 
-    context "with other granular permissions but not product_management" do
+    context "with other granular permissions but not product_edition" do
       before do
         create(:facility_user_permission, user:, facility:, order_management: true)
       end
@@ -112,7 +112,7 @@ RSpec.describe SangerSequencing::Ability do
       let(:other_facility) { create(:facility, sanger_sequencing_enabled: true) }
 
       before do
-        create(:facility_user_permission, user:, facility: other_facility, product_management: true)
+        create(:facility_user_permission, user:, facility: other_facility, product_edition: true)
       end
 
       it_is_not_allowed_to([:index], SangerSequencing::Submission)
@@ -120,12 +120,12 @@ RSpec.describe SangerSequencing::Ability do
     end
   end
 
-  describe "user with product_management granular permission, feature flag off",
+  describe "user with product_edition granular permission, feature flag off",
            feature_setting: { granular_permissions: false } do
     let(:user) { create(:user) }
 
     before do
-      create(:facility_user_permission, user:, facility:, product_management: true)
+      create(:facility_user_permission, user:, facility:, product_edition: true)
     end
 
     it_is_not_allowed_to([:index], SangerSequencing::Submission)

--- a/vendor/engines/sanger_sequencing/spec/presenters/sanger_sequencing/link_collection_extension_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/presenters/sanger_sequencing/link_collection_extension_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe SangerSequencing::LinkCollectionExtension do
   describe "user with granular permissions", feature_setting: { granular_permissions: true } do
     let(:user) { create(:user) }
 
-    context "with product_management" do
-      before { create(:facility_user_permission, user:, facility:, product_management: true) }
+    context "with product_edition" do
+      before { create(:facility_user_permission, user:, facility:, product_edition: true) }
 
       it { is_expected.to be_a(NavTab::Link) }
     end
@@ -47,7 +47,7 @@ RSpec.describe SangerSequencing::LinkCollectionExtension do
       it { is_expected.to be_nil }
     end
 
-    context "with order_management but no product_management" do
+    context "with order_management but no product_edition" do
       before { create(:facility_user_permission, user:, facility:, order_management: true) }
 
       it { is_expected.to be_nil }

--- a/vendor/engines/sanger_sequencing/spec/requests/sanger_sequencing/admin/submissions_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/requests/sanger_sequencing/admin/submissions_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe "sanger_sequencing/admin/submissions" do
       proc { get facility_sanger_sequencing_admin_submissions_path(facility) }
     end
 
-    describe "as a granular product_management user", feature_setting: { granular_permissions: true } do
+    describe "as a granular product_edition user", feature_setting: { granular_permissions: true } do
       let(:user) { create(:user) }
 
       before do
-        create(:facility_user_permission, user:, facility:, product_management: true)
+        create(:facility_user_permission, user:, facility:, product_edition: true)
         login_as user
       end
 
@@ -25,7 +25,7 @@ RSpec.describe "sanger_sequencing/admin/submissions" do
       end
     end
 
-    describe "as a granular user without product_management", feature_setting: { granular_permissions: true } do
+    describe "as a granular user without product_edition", feature_setting: { granular_permissions: true } do
       let(:user) { create(:user) }
 
       before do


### PR DESCRIPTION
  # Notes
  
  Splits the Product Management granular permission into two separate permissions — Product Creation and Product Edition — so facility admins can grant the right to edit products without granting the right to create them. Users who can create products can also edit them.
  
  [NUOPEN-338 | Split Product Management granular permission](https://universe-of-universities.atlassian.net/browse/NUOPEN-338)
  
