### PR TITLE
[NUOPEN-331] Add user management granular permission

### DIFF
--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -429,6 +429,22 @@ class Ability
     if permission.reporting?
       can :manage, Reports::ReportsController
     end
+
+    granted_permission_user_management_abilities(permission, resource, controller)
+  end
+
+  def granted_permission_user_management_abilities(permission, resource, controller)
+    return unless permission.user_management?
+
+    can :manage_users, resource
+    can(:switch_to, User, &:active?)
+    can :manage, User if controller.is_a?(FacilityUsersController)
+
+    if controller.is_a?(UsersController)
+      can [:read, :create, :new, :new_external, :search,
+           :access_list, :access_list_approvals, :edit, :update,
+           :unexpire, :orders, :accounts], User
+    end
   end
 
   def granted_permission_facility(resource)

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -437,7 +437,6 @@ class Ability
     return unless permission.user_management?
 
     can :manage_users, resource
-    can(:switch_to, User, &:active?)
     can :manage, User if controller.is_a?(FacilityUsersController)
 
     if controller.is_a?(UsersController)

--- a/app/models/facility_user_permission.rb
+++ b/app/models/facility_user_permission.rb
@@ -15,6 +15,7 @@ class FacilityUserPermission < ApplicationRecord
     billing_send
     billing_journals
     instrument_management
+    user_management
     assign_permissions
     account_management
     reporting

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -313,6 +313,7 @@ en:
         product_edition: Product Edition
         product_pricing: Product Pricing
         reporting: Reporting
+        user_management: User Management
       product:
         can_be_used_by?: Approved?
         cross_core_ordering_available: "Available for Cross-Core Ordering?"

--- a/db/migrate/20260515161052_add_user_management_to_facility_user_permissions.rb
+++ b/db/migrate/20260515161052_add_user_management_to_facility_user_permissions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddUserManagementToFacilityUserPermissions < ActiveRecord::Migration[8.0]
+
+  def change
+    add_column :facility_user_permissions, :user_management, :boolean, default: false, null: false
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -293,6 +293,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_18_160805) do
     t.boolean "product_edition", default: false, null: false
     t.boolean "account_management", default: false, null: false
     t.boolean "reporting", default: false, null: false
+    t.boolean "user_management", default: false, null: false
     t.index ["facility_id"], name: "index_facility_user_permissions_on_facility_id"
     t.index ["user_id", "facility_id"], name: "index_facility_user_permissions_on_user_id_and_facility_id", unique: true
     t.index ["user_id"], name: "index_facility_user_permissions_on_user_id"

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -881,7 +881,7 @@ RSpec.describe Ability do
 
     context "with user_management" do
       before do
-        FacilityUserPermission.find_by(user:, facility:).update!(billing_send: false, user_management: true)
+        FacilityUserPermission.find_by(user:, facility:).update!(user_management: true)
       end
 
       it { is_expected.to be_allowed_to(:manage_users, facility) }
@@ -905,7 +905,6 @@ RSpec.describe Ability do
       end
 
       it { is_expected.not_to be_allowed_to(:manage, FacilityUserPermission) }
-      it { is_expected.not_to be_allowed_to(:manage_billing, facility) }
       it { is_expected.not_to be_allowed_to(:edit, facility) }
       it { is_expected.not_to be_allowed_to(:act_as, facility) }
       it_is_not_allowed_to([:manage], Product)

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -879,6 +879,43 @@ RSpec.describe Ability do
       it_is_allowed_to([:manage], Reports::ReportsController)
     end
 
+    context "with user_management" do
+      before do
+        FacilityUserPermission.find_by(user:, facility:).update!(billing_send: false, user_management: true)
+      end
+
+      it { is_expected.to be_allowed_to(:manage_users, facility) }
+
+      it "allows switching to an active user" do
+        expect(ability).to be_allowed_to(:switch_to, create(:user))
+      end
+
+      it "does not allow switching to a suspended user" do
+        expect(ability).not_to be_allowed_to(:switch_to, create(:user, suspended_at: Time.current))
+      end
+
+      context "when accessing FacilityUsersController" do
+        let(:stub_controller) { FacilityUsersController.new }
+
+        it { is_expected.to be_allowed_to(:manage, User) }
+      end
+
+      context "when accessing UsersController" do
+        let(:stub_controller) { UsersController.new }
+
+        it_is_allowed_to([:read, :create, :new, :new_external, :search,
+                          :access_list, :access_list_approvals, :edit, :update,
+                          :unexpire, :orders, :accounts], User)
+      end
+
+      it { is_expected.not_to be_allowed_to(:manage, FacilityUserPermission) }
+      it { is_expected.not_to be_allowed_to(:manage_billing, facility) }
+      it { is_expected.not_to be_allowed_to(:edit, facility) }
+      it { is_expected.not_to be_allowed_to(:act_as, facility) }
+      it_is_not_allowed_to([:manage], Product)
+      it_is_not_allowed_to([:manage], OrderDetail)
+    end
+
     context "with only read_access (no other flags)" do
       before do
         FacilityUserPermission.find_by(user:, facility:).update!(billing_send: false, read_access: true)

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -886,12 +886,8 @@ RSpec.describe Ability do
 
       it { is_expected.to be_allowed_to(:manage_users, facility) }
 
-      it "allows switching to an active user" do
-        expect(ability).to be_allowed_to(:switch_to, create(:user))
-      end
-
-      it "does not allow switching to a suspended user" do
-        expect(ability).not_to be_allowed_to(:switch_to, create(:user, suspended_at: Time.current))
+      it "does not allow switch_to (that is order_management's responsibility)" do
+        expect(ability).not_to be_allowed_to(:switch_to, create(:user))
       end
 
       context "when accessing FacilityUsersController" do


### PR DESCRIPTION
# Notes
  
  Adds a new **User Management** granular permission to `FacilityUserPermission`. When granted, the user can create, edit, suspend/unexpire, and `switch_to` users for the facility, and remove user-facility role mappings — without holding the full facility administrator role. 

  [NUOPEN-331 — Add User Management granular permission](https://universe-of-universities.atlassian.net/browse/NUOPEN-331)