### PR TITLE
Fix health check engine migrations

### DIFF
--- a/config/initializers/health_check.rb
+++ b/config/initializers/health_check.rb
@@ -4,3 +4,13 @@
 HealthCheck.setup do |config|
   config.uri = "healthz"
 end
+
+# The gem's migration check scans a single directory via
+# `Dir[File.join(db_migrate_path, "[0-9]*_*.rb")]` and misses migrations
+# contributed by engines via `initializer :append_migrations`. Without this
+# override the gem only sees host migrations under db/migrate/, producing a
+# false positive whenever an engine ships the newest migration timestamp.
+Rails.application.config.after_initialize do
+  HealthCheck::Utils.db_migrate_path =
+    "{#{Rails.application.paths['db/migrate'].to_a.join(',')}}"
+end


### PR DESCRIPTION
# Notes

Fix `/healthz`returning a false failure when the newest applied migration was contributed by an engine, which silently broke ECS / containerized deployments (new tasks failed health check and the deploy circuit-breaker rolled back to the  previous image).
 