### PR TITLE
[NUOPEN-349] Fix reservation cross origin

### DIFF
--- a/app/controllers/facility_accounts_controller.rb
+++ b/app/controllers/facility_accounts_controller.rb
@@ -149,7 +149,7 @@ class FacilityAccountsController < ApplicationController
 
   def accounts_available_for_order
     respond_to do |format|
-      format.js do
+      format.json do
         render json: @facility_accounts_for_user
       end
     end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -43,7 +43,7 @@ class OrdersController < ApplicationController
 
   def cart_order_details_count
     respond_to do |format|
-      format.js do
+      format.json do
         order_details_count = acting_user.cart(session_user).order_details.count
 
         render json: { data: { count: order_details_count } }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -31,7 +31,7 @@ class ProductsController < ApplicationController
 
   def available_for_cross_core_ordering
     respond_to do |format|
-      format.js do
+      format.json do
         render json: @facility_products
       end
     end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -32,7 +32,7 @@ class ReservationsController < ApplicationController
     @reservations_by_instrument = Reservation.for_timeline(@display_datetime, instrument_ids).group_by(&:product)
   end
 
-  # GET /facilities/1/instruments/1/reservations.js?_=1279579838269&start=1279429200&end=1280034000
+  # GET /facilities/1/instruments/1/reservations.json?_=1279579838269&start=1279429200&end=1280034000
   def index
     @facility = Facility.find_by!(url_name: params[:facility_id])
     @instrument = @facility.instruments.find_by!(url_name: params[:instrument_id])
@@ -64,7 +64,7 @@ class ReservationsController < ApplicationController
     discriminate = params[:discriminate] == "true" && can?(:administer, Reservation)
 
     respond_to do |format|
-      format.js do
+      format.json do
         render(
           json: CalendarEventsPresenter.new(
             @instrument,

--- a/app/controllers/schedule_rules_controller.rb
+++ b/app/controllers/schedule_rules_controller.rb
@@ -24,7 +24,7 @@ class ScheduleRulesController < ApplicationController
 
     respond_to do |format|
       format.html # index.html.haml
-      format.js do
+      format.json do
         render json: ScheduleRules::CalendarPresenter.events(@schedule_rules).to_json
       end
     end

--- a/app/forms/add_to_order_form.rb
+++ b/app/forms/add_to_order_form.rb
@@ -87,8 +87,8 @@ class AddToOrderForm
         f.name,
         f.id,
         {
-          "data-products-path": Rails.application.routes.url_helpers.available_for_cross_core_ordering_facility_products_path(f, format: :js),
-          "data-accounts-path": Rails.application.routes.url_helpers.accounts_available_for_order_facility_accounts_path(f, format: :js),
+          "data-products-path": Rails.application.routes.url_helpers.available_for_cross_core_ordering_facility_products_path(f, format: :json),
+          "data-accounts-path": Rails.application.routes.url_helpers.accounts_available_for_order_facility_accounts_path(f, format: :json),
           "data-original-order-facility": @original_order.facility_id,
           "data-original-order": @original_order.id,
         }

--- a/app/helpers/calendar_helper.rb
+++ b/app/helpers/calendar_helper.rb
@@ -12,7 +12,7 @@ module CalendarHelper
 
   def calendar_events_path(facility, product, **params)
     opts = {
-      format: "js",
+      format: "json",
       with_details: product.show_details?,
     }
     opts[:view] = product_calendar_view(product)

--- a/app/javascript/app/merge_orders.js
+++ b/app/javascript/app/merge_orders.js
@@ -76,7 +76,6 @@ window.MergeOrder = class MergeOrder {
             productField.append('<option value=""></option>');
           }
 
-          data = JSON.parse(data);
           data.forEach(function (product) {
             return productField.append(
               '<option value="' +
@@ -110,7 +109,6 @@ window.MergeOrder = class MergeOrder {
         success(data) {
           // Populate dropdown
           accountField.empty();
-          data = JSON.parse(data);
 
           const rawIncludeBlank = accountField.attr("include_blank");
           if (rawIncludeBlank && JSON.parse(rawIncludeBlank)) {

--- a/app/views/facility_estimates/_form.html.haml
+++ b/app/views/facility_estimates/_form.html.haml
@@ -47,7 +47,7 @@
       %div
         = label_tag :facility_id, Facility.model_name.human
         = select_tag :facility_id,
-          options_for_select(Facility.alphabetized.map { |f| [f.name, f.id, {"data-products-path": available_for_cross_core_ordering_facility_products_path(f, format: :js)}] }, current_facility.id),
+          options_for_select(Facility.alphabetized.map { |f| [f.name, f.id, {"data-products-path": available_for_cross_core_ordering_facility_products_path(f, format: :json)}] }, current_facility.id),
           class: "js--estimate-facility js--chosen",
           data: { original_facility: current_facility.id },
           include_blank: false

--- a/app/views/schedule_rules/index.html.haml
+++ b/app/views/schedule_rules/index.html.haml
@@ -1,7 +1,7 @@
 = content_for :head_content do
   = javascript_include_tag "schedule_rules.js"
   :javascript
-    var events_path = "#{url_for(:format => 'js')}";
+    var events_path = "#{url_for(:format => 'json')}";
 
 = content_for :h1 do
   = current_facility

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ReservationsController, feature_setting: { auto_end_reservations_
 
       @method = :xhr
       @action = :index
-      @params.merge!(instrument_id: instrument.url_name, facility_id: facility.url_name)
+      @params.merge!(instrument_id: instrument.url_name, facility_id: facility.url_name, format: :json)
     end
 
     it_should_allow_all facility_users do

--- a/spec/requests/reservations_spec.rb
+++ b/spec/requests/reservations_spec.rb
@@ -3,6 +3,35 @@
 require "rails_helper"
 
 RSpec.describe "reservations" do
+  describe "GET #index calendar events" do
+    let(:facility) { create(:setup_facility) }
+    let(:instrument) { create(:setup_instrument, facility:) }
+    let(:path) do
+      facility_instrument_reservations_path(facility, instrument, format: :json)
+    end
+
+    around do |example|
+      original = ActionController::Base.allow_forgery_protection
+      ActionController::Base.allow_forgery_protection = true
+      example.run
+      ActionController::Base.allow_forgery_protection = original
+    end
+
+    it "responds with JSON to a cross-origin GET without raising" do
+      expect do
+        get path, params: { start: Time.current.iso8601, end: (Time.current + 1.day).iso8601 }
+      end.not_to raise_error
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("application/json")
+    end
+
+    it "no longer responds to the .js format" do
+      get facility_instrument_reservations_path(facility, instrument, format: :js)
+      expect(response).to have_http_status(:not_acceptable)
+    end
+  end
+
   describe "switch_instrument" do
     let(:facility) { create(:setup_facility) }
     let(:user) { create(:user) }


### PR DESCRIPTION
  # Notes
  
  Fixes the `ActionController::InvalidCrossOriginRequest` exception from the public instrument schedule across every school. The calendar events endpoint now responds as JSON instead of JS — same body, but no longer subject to Rails' cross-origin protection.
  
  [NUOPEN-349 | [ERROR] reservations#index (ActionController::InvalidCrossOriginRequest)](https://universe-of-universities.atlassian.net/browse/NUOPEN-349)