### PR TITLE
[NUOPEN-335] Project management granular permission

### DIFF
--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -341,6 +341,10 @@ class Ability
       granted_permission_reservation_abilities(permission)
     end
 
+    if resource.is_a?(Project) && permission.project_management?
+      can [:show, :edit, :update], Project
+    end
+
     return unless resource.is_a?(Facility)
 
     granted_permission_read_access_abilities(controller)
@@ -430,6 +434,10 @@ class Ability
       can :manage, Reports::ReportsController
     end
 
+    if permission.project_management?
+      can [:create, :new, :cross_core_orders], Project
+    end
+
     granted_permission_user_management_abilities(permission, resource, controller)
   end
 
@@ -449,7 +457,7 @@ class Ability
   def granted_permission_facility(resource)
     case resource
     when Facility then resource
-    when OrderDetail then resource.facility
+    when OrderDetail, Project then resource.facility
     when Reservation then resource.product.facility
     end
   end

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -342,7 +342,7 @@ class Ability
     end
 
     if resource.is_a?(Project) && permission.project_management?
-      can [:show, :edit, :update], Project
+      can [:show, :edit, :update], Project, facility_id: facility.id
     end
 
     return unless resource.is_a?(Facility)

--- a/app/models/facility_user_permission.rb
+++ b/app/models/facility_user_permission.rb
@@ -19,6 +19,7 @@ class FacilityUserPermission < ApplicationRecord
     assign_permissions
     account_management
     reporting
+    project_management
   ].freeze
 
   validates :user_id, uniqueness: { scope: :facility_id }

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -312,6 +312,7 @@ en:
         product_creation: Product Creation
         product_edition: Product Edition
         product_pricing: Product Pricing
+        project_management: Project Management
         reporting: Reporting
         user_management: User Management
       product:

--- a/db/migrate/20260522122529_add_project_management_to_facility_user_permissions.rb
+++ b/db/migrate/20260522122529_add_project_management_to_facility_user_permissions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddProjectManagementToFacilityUserPermissions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :facility_user_permissions, :project_management, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_18_160805) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_22_122529) do
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
     t.integer "account_id", null: false
@@ -294,6 +294,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_18_160805) do
     t.boolean "account_management", default: false, null: false
     t.boolean "reporting", default: false, null: false
     t.boolean "user_management", default: false, null: false
+    t.boolean "project_management", default: false, null: false
     t.index ["facility_id"], name: "index_facility_user_permissions_on_facility_id"
     t.index ["user_id", "facility_id"], name: "index_facility_user_permissions_on_user_id_and_facility_id", unique: true
     t.index ["user_id"], name: "index_facility_user_permissions_on_user_id"

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -911,6 +911,36 @@ RSpec.describe Ability do
       it_is_not_allowed_to([:manage], OrderDetail)
     end
 
+    context "with project_management" do
+      before do
+        user.facility_user_permissions.where(facility:).update!(project_management: true)
+      end
+
+      it_is_allowed_to([:create, :new, :cross_core_orders], Project)
+
+      context "when authorizing against a Project instance" do
+        let(:project) { create(:project, facility:) }
+        let(:subject_resource) { project }
+
+        it_is_allowed_to([:show, :edit, :update], Project)
+      end
+    end
+
+    context "without project_management" do
+      it { is_expected.not_to be_allowed_to(:create, Project) }
+      it { is_expected.not_to be_allowed_to(:update, Project) }
+      it { is_expected.not_to be_allowed_to(:cross_core_orders, Project) }
+
+      context "when authorizing against a Project instance" do
+        let(:project) { create(:project, facility:) }
+        let(:subject_resource) { project }
+
+        it { is_expected.not_to be_allowed_to(:show, project) }
+        it { is_expected.not_to be_allowed_to(:edit, project) }
+        it { is_expected.not_to be_allowed_to(:update, project) }
+      end
+    end
+
     context "with only read_access (no other flags)" do
       before do
         FacilityUserPermission.find_by(user:, facility:).update!(billing_send: false, read_access: true)


### PR DESCRIPTION
  # Notes
  
  Adds a new "Project Management" granular permission that lets facility staff grant non-admin users access to create, view, edit, and update projects (including the cross-core orders view) within a facility.
  
  [NUOPEN-335 — Add Managing Projects granular permission](https://universe-of-universities.atlassian.net/browse/NUOPEN-335)
