### PR TITLE
[NUOPEN-318] Fix estimates duration issue

### DIFF
--- a/app/models/concerns/price_policies/quantity.rb
+++ b/app/models/concerns/price_policies/quantity.rb
@@ -40,7 +40,7 @@ module PricePolicies
     end
 
     def estimate_cost_from_estimate_detail(estimate_detail)
-      unit_cost * estimate_detail.quantity
+      unit_total * estimate_detail.quantity
     end
 
     private

--- a/app/models/instrument_price_policy_calculations.rb
+++ b/app/models/instrument_price_policy_calculations.rb
@@ -84,9 +84,12 @@ module InstrumentPricePolicyCalculations
   end
 
   def calculate_for_estimated_time(duration, quantity = 1)
-    cost_for_one = PricePolicies::TimeBasedPriceCalculator.new(self).calculate(nil, nil, duration)
+    costs = PricePolicies::TimeBasedPriceCalculator.new(self).calculate(nil, nil, duration)
+    return unless costs
 
-    cost_for_one * quantity
+    net_cost_for_one = costs[:cost] - costs[:subsidy]
+
+    net_cost_for_one * quantity
   end
 
 end

--- a/app/models/instrument_price_policy_calculations.rb
+++ b/app/models/instrument_price_policy_calculations.rb
@@ -85,8 +85,6 @@ module InstrumentPricePolicyCalculations
 
   def calculate_for_estimated_time(duration, quantity = 1)
     costs = PricePolicies::TimeBasedPriceCalculator.new(self).calculate(nil, nil, duration)
-    return unless costs
-
     net_cost_for_one = costs[:cost] - costs[:subsidy]
 
     net_cost_for_one * quantity

--- a/app/models/timed_service_price_policy.rb
+++ b/app/models/timed_service_price_policy.rb
@@ -23,9 +23,10 @@ class TimedServicePricePolicy < PricePolicy
   end
 
   def estimate_cost_from_estimate_detail(estimate_detail)
-    cost_for_one = calculate_for_time(estimate_detail.duration)[:cost]
+    costs = calculate_for_time(estimate_detail.duration)
+    net_cost_for_one = costs[:cost] - costs[:subsidy]
 
-    cost_for_one * estimate_detail.quantity
+    net_cost_for_one * estimate_detail.quantity
   end
 
   private

--- a/app/services/price_policies/strategy.rb
+++ b/app/services/price_policies/strategy.rb
@@ -61,7 +61,10 @@ module PricePolicies
       end
 
       def calculate_estimate
-        duration * usage_rate
+        {
+          cost: duration * usage_rate,
+          subsidy: duration * (usage_subsidy || 0),
+        }
       end
     end
 
@@ -90,7 +93,10 @@ module PricePolicies
       end
 
       def calculate_estimate
-        duration * usage_rate_daily
+        {
+          cost: duration * usage_rate_daily,
+          subsidy: duration * (usage_subsidy_daily || 0),
+        }
       end
 
     end
@@ -101,7 +107,15 @@ module PricePolicies
       delegate :duration_mins, to: :time_range
 
       def calculate
-        result = build_intervals.reduce({ time_left: duration_mins, cost: 0, subsidy: 0 }) do |acc, interval_data|
+        cost_and_subsidy_for(duration_mins)
+      end
+
+      def calculate_estimate
+        cost_and_subsidy_for(duration)
+      end
+
+      def cost_and_subsidy_for(total_mins)
+        result = build_intervals.reduce({ time_left: total_mins, cost: 0, subsidy: 0 }) do |acc, interval_data|
           time_left = acc[:time_left]
 
           interval_length = (interval_data[:interval_end] - interval_data[:interval_start]) * 60

--- a/app/services/price_policies/strategy.rb
+++ b/app/services/price_policies/strategy.rb
@@ -114,24 +114,6 @@ module PricePolicies
         cost_and_subsidy_for(duration)
       end
 
-      def cost_and_subsidy_for(total_mins)
-        result = build_intervals.reduce({ time_left: total_mins, cost: 0, subsidy: 0 }) do |acc, interval_data|
-          time_left = acc[:time_left]
-
-          interval_length = (interval_data[:interval_end] - interval_data[:interval_start]) * 60
-
-          time_to_charge = [time_left, interval_length].min
-
-          acc[:time_left] -= time_to_charge
-          acc[:cost] += (interval_data[:step_rate] || 0) * time_to_charge
-          acc[:subsidy] += (interval_data[:step_subsidy] || 0) * time_to_charge
-
-          acc
-        end
-
-        { cost: result[:cost], subsidy: result[:subsidy] }
-      end
-
       def build_intervals
         intervals = [
           {
@@ -157,6 +139,26 @@ module PricePolicies
 
       def sorted_duration_rates
         @sorted_duration_rates ||= price_policy.duration_rates.sorted
+      end
+
+      private
+
+      def cost_and_subsidy_for(total_mins)
+        result = build_intervals.reduce({ time_left: total_mins, cost: 0, subsidy: 0 }) do |acc, interval_data|
+          time_left = acc[:time_left]
+
+          interval_length = (interval_data[:interval_end] - interval_data[:interval_start]) * 60
+
+          time_to_charge = [time_left, interval_length].min
+
+          acc[:time_left] -= time_to_charge
+          acc[:cost] += (interval_data[:step_rate] || 0) * time_to_charge
+          acc[:subsidy] += (interval_data[:step_subsidy] || 0) * time_to_charge
+
+          acc
+        end
+
+        { cost: result[:cost], subsidy: result[:subsidy] }
       end
     end
 

--- a/app/services/price_policies/time_based_price_calculator.rb
+++ b/app/services/price_policies/time_based_price_calculator.rb
@@ -16,7 +16,7 @@ module PricePolicies
       return if start_at.blank? && end_at.blank? && duration.blank?
 
       if duration.present?
-        strategy_class(avoid_stepped: true).new(price_policy, start_at, end_at, duration:).calculate_estimate
+        strategy_class.new(price_policy, start_at, end_at, duration:).calculate_estimate
       else
         return if start_at > end_at
 
@@ -26,10 +26,10 @@ module PricePolicies
 
     private
 
-    def strategy_class(avoid_stepped: false)
+    def strategy_class
       if product.daily_booking?
         Strategy::PerDay
-      elsif !avoid_stepped && product.is_a?(Instrument) && product.duration_pricing_mode? && price_policy.duration_rates.present?
+      elsif product.is_a?(Instrument) && product.duration_pricing_mode? && price_policy.duration_rates.present?
         Strategy::SteppedRate
       else
         Strategy::PerMinute

--- a/spec/models/instrument_price_policy_calculations_spec.rb
+++ b/spec/models/instrument_price_policy_calculations_spec.rb
@@ -84,16 +84,6 @@ RSpec.describe InstrumentPricePolicyCalculations do
     it "stores the net cost (cost minus subsidy) per unit, times quantity" do
       expect(policy.estimate_cost_from_estimate_detail(estimate_detail)).to be_within(0.001).of((852 - 85.2) * 2)
     end
-
-    context "when the calculator returns nil" do
-      before do
-        allow(calculator).to receive(:calculate).with(nil, nil, 480).and_return(nil)
-      end
-
-      it "returns nil" do
-        expect(policy.estimate_cost_from_estimate_detail(estimate_detail)).to be_nil
-      end
-    end
   end
 
   describe "calculating with two effective schedule rules, one discounting one not" do

--- a/spec/models/instrument_price_policy_calculations_spec.rb
+++ b/spec/models/instrument_price_policy_calculations_spec.rb
@@ -72,6 +72,30 @@ RSpec.describe InstrumentPricePolicyCalculations do
     end
   end
 
+  describe "#estimate_cost_from_estimate_detail" do
+    let(:estimate_detail) { double("EstimateDetail", duration: 480, quantity: 2) }
+    let(:calculator) { instance_double(PricePolicies::TimeBasedPriceCalculator) }
+
+    before do
+      allow(PricePolicies::TimeBasedPriceCalculator).to receive(:new).with(policy).and_return(calculator)
+      allow(calculator).to receive(:calculate).with(nil, nil, 480).and_return(cost: 852, subsidy: 85.2)
+    end
+
+    it "stores the net cost (cost minus subsidy) per unit, times quantity" do
+      expect(policy.estimate_cost_from_estimate_detail(estimate_detail)).to be_within(0.001).of((852 - 85.2) * 2)
+    end
+
+    context "when the calculator returns nil" do
+      before do
+        allow(calculator).to receive(:calculate).with(nil, nil, 480).and_return(nil)
+      end
+
+      it "returns nil" do
+        expect(policy.estimate_cost_from_estimate_detail(estimate_detail)).to be_nil
+      end
+    end
+  end
+
   describe "calculating with two effective schedule rules, one discounting one not" do
     describe "no minimum cost" do
       let(:friday_evening) { Time.zone.parse("2017-04-21 23:00:15") }

--- a/spec/models/item_price_policy_spec.rb
+++ b/spec/models/item_price_policy_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe ItemPricePolicy do
     expect(ipp.unit_total.to_f).to eq(10)
   end
 
+  describe "#estimate_cost_from_estimate_detail" do
+    it "returns the net cost (unit_cost minus unit_subsidy) times quantity" do
+      ipp = ItemPricePolicy.new(unit_cost: 10.75, unit_subsidy: 0.75)
+      estimate_detail = double("EstimateDetail", quantity: 3)
+      expect(ipp.estimate_cost_from_estimate_detail(estimate_detail).to_f).to eq(30)
+    end
+  end
+
   context "validations" do
     it { is_expected.to validate_presence_of(:unit_cost) }
     it { is_expected.to validate_numericality_of(:unit_cost).is_greater_than_or_equal_to(0) }

--- a/spec/models/timed_service_price_policy_spec.rb
+++ b/spec/models/timed_service_price_policy_spec.rb
@@ -23,4 +23,14 @@ RSpec.describe TimedServicePricePolicy do
       it { is_expected.to eq(cost: 0, subsidy: 0) }
     end
   end
+
+  describe "#estimate_cost_from_estimate_detail" do
+    let(:product) { build_stubbed(:timed_service) }
+    let(:price_policy) { build_stubbed(:timed_service_price_policy, product: product, usage_rate: 60, usage_subsidy: 15) }
+    let(:estimate_detail) { double("EstimateDetail", duration: 60, quantity: 2) }
+
+    it "returns the net cost (cost minus subsidy) times quantity" do
+      expect(price_policy.estimate_cost_from_estimate_detail(estimate_detail)).to eq((60 - 15) * 2)
+    end
+  end
 end

--- a/spec/services/price_policies/time_based_price_calculator_spec.rb
+++ b/spec/services/price_policies/time_based_price_calculator_spec.rb
@@ -206,6 +206,19 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
         it { is_expected.to eq(0.88) }
       end
     end
+
+    describe "#calculate with a duration (estimate path)" do
+      let(:options) { { usage_rate: 60, usage_subsidy: 15 } }
+      subject(:costs) { calculator.calculate(nil, nil, 60) }
+
+      it "uses the per-minute strategy" do
+        expect(calculator_strategy).to be PricePolicies::Strategy::PerMinute
+      end
+
+      it "returns cost and subsidy without applying schedule-rule discounts" do
+        is_expected.to eq(cost: 60, subsidy: 15)
+      end
+    end
   end
 
   context "when product has duration pricing mode" do
@@ -350,6 +363,46 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
         end
       end
     end
+
+    describe "#calculate with a duration (estimate path)" do
+      subject(:costs) { calculator.calculate(nil, nil, duration_mins) }
+
+      describe "for external price group" do
+        let(:price_group) { create(:price_group, is_internal: false) }
+        let(:options) { { usage_rate: 130 } }
+        let(:duration_mins) { 8 * 60 }
+
+        before do
+          create(:duration_rate, price_policy:, min_duration_hours: 6, rate: 36)
+        end
+
+        it "uses the stepped strategy" do
+          expect(calculator_strategy).to be PricePolicies::Strategy::SteppedRate
+        end
+
+        it "charges each tier across the duration" do
+          expect(costs[:cost].round(4)).to eq(852)
+          expect(costs[:subsidy]).to eq(0)
+        end
+      end
+
+      describe "for a subsidized (cancer center) price group" do
+        let(:price_group) { create(:price_group, :cancer_center) }
+        let(:options) { { usage_rate: 120, usage_subsidy: 30 } }
+        let(:duration_mins) { (5 * 60) + 15 }
+
+        before do
+          create(:duration_rate, price_policy:, min_duration_hours: 1, rate: 110, subsidy: 25)
+          create(:duration_rate, price_policy:, min_duration_hours: 3, rate: 100, subsidy: 20)
+          create(:duration_rate, price_policy:, min_duration_hours: 5, rate: 90, subsidy: 15)
+        end
+
+        it "returns both cost and subsidy across the tiers" do
+          expect(costs[:cost]).to eq(562.5)
+          expect(costs[:subsidy].round(4)).to eq(123.75)
+        end
+      end
+    end
   end
 
   context "when instrument has daily rate pricing" do
@@ -402,6 +455,17 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
       let(:start_at) { Time.current.beginning_of_day }
 
       it { is_expected.to eq(cost: expected_cost, subsidy: expected_subsidy) }
+    end
+
+    describe "#calculate with a duration (estimate path)" do
+      subject { calculator.calculate(nil, nil, duration_days) }
+
+      it "returns cost and subsidy for the daily rate" do
+        is_expected.to eq(
+          cost: duration_days * usage_rate_daily,
+          subsidy: duration_days * usage_subsidy_daily,
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
 # Notes
  
  Fixes the Estimates feature so duration-based instruments are priced across each rate step instead of charging the whole reservation at the first step, and so price-group subsidies (e.g. Cancer Center) are applied. 
  
  [NUOPEN-318 | Estimates Duration Issue](https://universe-of-universities.atlassian.net/browse/NUOPEN-318)
  
  # Screenshots
  before:
  <img width="1326" height="752" alt="Screenshot 2026-05-25 at 10 56 55 AM" src="https://github.com/user-attachments/assets/31af53b0-575d-449e-b35c-ba215d3d5a8c" />
  
  After:
<img width="1265" height="712" alt="Screenshot 2026-05-25 at 10 56 39 AM" src="https://github.com/user-attachments/assets/49d5cbf7-489e-4ef1-9795-5f702044f063" />

