### PR TITLE
[NU-38] Disable nonbillable price changes

### DIFF
--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -172,6 +172,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
 
   def update_params
     raw_params = params[:order_detail] || empty_params
+    raw_params = raw_params.except(*PRICE_ADJUSTMENT_ATTRIBUTES) if @order_detail.product.skip_order_review?
 
     if cannot?(:update, @order_detail)
       raw_params.slice(*PRICE_ADJUSTMENT_ATTRIBUTES)

--- a/app/views/order_management/order_details/_costs.html.haml
+++ b/app/views/order_management/order_details/_costs.html.haml
@@ -1,5 +1,5 @@
 - f.object.send(:extend, PriceDisplayment)
-- price_edit_disabled = actual_cost_edit_disabled? || cannot?(:adjust_price, f.object)
+- price_edit_disabled = actual_cost_edit_disabled? || cannot?(:adjust_price, f.object) || f.object.product.skip_order_review?
 - if f.object.actual_cost?
   .cost-table
     .cost= f.input :actual_cost, as: :currency, disabled: price_edit_disabled

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -1109,6 +1109,38 @@ RSpec.describe OrderManagement::OrderDetailsController do
       end
     end
 
+    describe "for a Skip Review or Nonbillable item" do
+      ["Skip Review", "Nonbillable"].each do |billing_mode|
+        context "when the product is #{billing_mode}" do
+          let(:item) { FactoryBot.create(:setup_item, facility:, billing_mode:) }
+          let(:order) { FactoryBot.create(:purchased_order, product: item) }
+          let(:order_detail) { order.order_details.first }
+
+          before do
+            sign_in @admin
+            order_detail.change_status!(OrderStatus.complete)
+          end
+
+          it "ignores a manually submitted actual_cost" do
+            @params[:order_detail] = {
+              actual_cost: "10",
+              price_change_reason: "trying to override the price",
+            }
+
+            expect { do_request }.not_to change { order_detail.reload.actual_cost }
+          end
+
+          it "does not require a price change reason when a price is submitted" do
+            @params[:order_detail] = { actual_cost: "10" }
+            do_request
+
+            expect(assigns[:order_detail].errors).not_to include(:price_change_reason)
+            expect(response).to redirect_to([facility, order])
+          end
+        end
+      end
+    end
+
     describe "with granular permissions", feature_setting: { granular_permissions: true } do
       let(:order) { create(:purchased_order, product: item) }
       let(:order_detail) { order.order_details.first }

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -1112,8 +1112,8 @@ RSpec.describe OrderManagement::OrderDetailsController do
     describe "for a Skip Review or Nonbillable item" do
       ["Skip Review", "Nonbillable"].each do |billing_mode|
         context "when the product is #{billing_mode}" do
-          let(:item) { FactoryBot.create(:setup_item, facility:, billing_mode:) }
-          let(:order) { FactoryBot.create(:purchased_order, product: item) }
+          let(:item) { create(:setup_item, facility:, billing_mode:) }
+          let(:order) { create(:purchased_order, product: item) }
           let(:order_detail) { order.order_details.first }
 
           before do


### PR DESCRIPTION
# Notes

  Admins can no longer manually override the price of Nonbillable or Skip Review transactions on the order management screen — these products always carry $0 price policies, so manual overrides made no business sense and have been disabled in both the UI and the controller.
  
  [NU-38 | Disable price changes for Nonbillable and Skip Review transactions](https://universe-of-universities.atlassian.net/browse/NU-38)
