### PR TITLE
[NUOPEN-307][Fix] Allow tab_acounts with read access

### DIFF
--- a/app/lib/facility_user_permission_ability.rb
+++ b/app/lib/facility_user_permission_ability.rb
@@ -43,7 +43,7 @@ class FacilityUserPermissionAbility
     can [:administer, :index, :show, :tab_counts], Order
     can :show, OrderDetail
 
-    can [:administer, :index, :show, :timeline], Reservation
+    can [:administer, :index, :show, :timeline, :tab_counts], Reservation
 
     can [:administer, :index, :view_details, :schedule, :show], Product
     can :read, ProductDisplayGroup

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -963,7 +963,7 @@ RSpec.describe Ability do
       it_is_allowed_to([:list, :dashboard, :show], Facility)
       it_is_allowed_to([:administer, :index, :show, :tab_counts], Order)
       it_is_allowed_to([:show], OrderDetail)
-      it_is_allowed_to([:administer, :index, :show, :timeline], Reservation)
+      it_is_allowed_to([:administer, :index, :show, :timeline, :tab_counts], Reservation)
       it_is_allowed_to([:administer, :index, :view_details, :schedule, :show], Product)
       it_is_allowed_to([:index], Project)
       it_is_allowed_to(:read, PriceGroupProduct)


### PR DESCRIPTION
# Notes

Allow `FacilityReservationsController#tab_counts` action when Read Access granular permission is active. This endpoint is used to load the number of reservations in new/in progress and with problems on the facility reservations page.

The New/In progress tab is shown with Read Access permission so this prevents the count load to fail and leave the spinner indefinetly.

The Problem reservations tab requires additional permissions.

## Screenshot

<img width="1174" height="538" alt="Captura desde 2026-05-26 13-39-33" src="https://github.com/user-attachments/assets/32bdbc67-9935-4ddf-a49d-a03e8441b5c0" />
