### PR TITLE
[NUOPEN-300] Refactor github action pipelines

### DIFF
--- a/.github/actions/setup-bundler/action.yml
+++ b/.github/actions/setup-bundler/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: cache gems
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-bundle-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -6,6 +6,12 @@ runs:
   steps:
     - uses: ./.github/actions/setup-node
     - uses: ./.github/actions/setup-bundler
+    - name: cache bootsnap
+      uses: actions/cache@v4
+      with:
+        path: tmp/cache/bootsnap
+        key: ${{ runner.os }}-bootsnap-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: ${{ runner.os }}-bootsnap-
     - run: cp config/database.yml.mysql.template config/database.yml
       shell: bash
     - run: cp config/secrets.yml.template config/secrets.yml

--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -1,5 +1,5 @@
-name: Setup Rails
-description: Install dependencies and create the database
+name: Setup dependencies
+description: Install Ruby/JS dependencies and write test configuration
 
 runs:
   using: composite
@@ -10,8 +10,3 @@ runs:
       shell: bash
     - run: cp config/secrets.yml.template config/secrets.yml
       shell: bash
-    - run: bundle exec rake db:create db:schema:load
-      shell: bash
-    - run: yarn build
-      shell: bash
-

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: node-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock') }}

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -8,7 +8,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: node_modules
-        key: ${{ runner.os }}-bundle-${{ hashFiles('yarn.lock') }}
-        restore-keys: ${{ runner.os }}-yarn-
+        key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock') }}
+        restore-keys: ${{ runner.os }}-node-
     - run: yarn install
       shell: bash

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -73,6 +73,10 @@ jobs:
     needs: build-assets
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_node: [0, 1, 2, 3]
     services:
       mysql:
         image: mysql:8.0.28
@@ -102,7 +106,12 @@ jobs:
       # - uses: mxschmitt/action-tmate@v3
       - run: bundle exec rails parallel:create
       - run: bundle exec rails parallel:load_schema
-      - run: bundle exec rails parallel:spec
+      - name: Run rspec shard ${{ matrix.ci_node }} of 4
+        run: |
+          start=$(( ${{ matrix.ci_node }} * 4 + 1 ))
+          groups=$(seq -s, "$start" "$(( start + 3 ))")
+          echo "Shard ${{ matrix.ci_node }}: running groups $groups of 16"
+          bundle exec parallel_test spec --type rspec -n 16 --only-group "$groups" --group-by filesize
 
   run-teaspoon:
     needs: build-assets

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -8,7 +8,30 @@ on:
   pull_request:
 
 jobs:
+  build-assets:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: wyeworkshub/ruby-node-chrome-pack:ruby3.4.4-node22
+    env:
+      RAILS_ENV: test
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-deps
+      - run: yarn build
+      - run: bundle exec rails assets:precompile
+      - name: Upload compiled assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: compiled-assets
+          path: |
+            public/assets
+            app/assets/builds
+          retention-days: 1
+          include-hidden-files: true
+
   run-rspec-engines:
+    needs: build-assets
     runs-on: ubuntu-latest
     timeout-minutes: 60
     services:
@@ -30,7 +53,12 @@ jobs:
       MYSQL_PASSWORD: root
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-rails
+      - uses: ./.github/actions/setup-deps
+      - name: Download compiled assets
+        uses: actions/download-artifact@v4
+        with:
+          name: compiled-assets
+      - run: bundle exec rake db:create db:schema:load
 
       - name: Glob match
         uses: tj-actions/glob@v22
@@ -39,10 +67,10 @@ jobs:
           files: |
             vendor/engines/*/spec/**/*_spec.rb
 
-      - run: bundle exec rails assets:precompile
       - run: bundle exec rspec ${{ steps.glob.outputs.paths }}
 
   run-rspec:
+    needs: build-assets
     runs-on: ubuntu-latest
     timeout-minutes: 60
     services:
@@ -65,15 +93,19 @@ jobs:
       PARALLEL_TEST_PROCESSORS: 4
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-rails
+      - uses: ./.github/actions/setup-deps
+      - name: Download compiled assets
+        uses: actions/download-artifact@v4
+        with:
+          name: compiled-assets
       # Uncomment below to open ssh tunnel for debugging
       # - uses: mxschmitt/action-tmate@v3
       - run: bundle exec rails parallel:create
       - run: bundle exec rails parallel:load_schema
-      - run: bundle exec rails assets:precompile
       - run: bundle exec rails parallel:spec
 
   run-teaspoon:
+    needs: build-assets
     runs-on: ubuntu-latest
     timeout-minutes: 60
     services:
@@ -103,8 +135,12 @@ jobs:
       TEST_APP_PORT: 3000
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-rails
-      - run: yarn build
+      - uses: ./.github/actions/setup-deps
+      - name: Download compiled assets
+        uses: actions/download-artifact@v4
+        with:
+          name: compiled-assets
+      - run: bundle exec rake db:create db:schema:load
       - run: bundle exec rake teaspoon
 
   run-rubocop:


### PR DESCRIPTION
# Notes

TECH TASK: Refactors the GitHub Actions test suite so assets are built once and shared across jobs, and the main rspec suite runs as a 4-way sharded matrix. This cuts CI wall-clock from ~11 min to ~7.5 min and makes re-running a failed (e.g. flaky) job skip the rebuild.
  
  [NUOPEN-300 | Refactor Github actions pipelines](https://universe-of-universities.atlassian.net/browse/NUOPEN-300)
  
  # Additional Context
  
  Previously each test job re-ran the full setup independently (`yarn build` ×3, `assets:precompile` ×2) and the main rspec suite ran as a single 4-process job.
  
  ### What changed
  
  **Shared build step**
  - New `build-assets` job runs `yarn build` + `assets:precompile` once and uploads a `compiled-assets` artifact (`public/assets` + `app/assets/builds`, `include-hidden-files: true` for the sprockets manifest).
  - `run-rspec`, `run-rspec-engines`, and `run-teaspoon` now `needs: build-assets` and download the artifact instead of rebuilding. Removed `run-rspec`'s redundant `db:create db:schema:load` and `run-teaspoon`'s duplicate `yarn build`.
  - New `setup-deps` composite action (deps + config only) replaces `setup-rails`, which conflated dependency install, DB creation, and asset building.
  
  **Sharded rspec**
  - `run-rspec` is now a `strategy.matrix` of 4 nodes (`ci_node: 0..3`, `fail-fast: false`). Each node runs `parallel_test spec --type rspec -n 16 --only-group <4 groups> --group-by filesize`, giving 16-way parallelism across machines. `run-rspec` critical path drops from ~9m39 to ~6m (slowest shard). Verified the 4 shards run the full suite (sum of examples unchanged, 0 failures).
  
  **Caching cleanup**
  - Bumped `actions/cache@v3 → @v4` (v3 is deprecated) in `setup-bundler` and `setup-node`.
  - Added a bootsnap cache (`tmp/cache/bootsnap`, keyed on `Gemfile.lock`) in `setup-deps`.
  - Fixed the mislabeled `setup-node` cache key (`-bundle-` → `-node-`, a copy-paste from the bundler action).
  
  

