### PR TITLE
[NUOPEN-353] Fix product purchase checks with granular permissions

### DIFF
--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -23,9 +23,9 @@ class InstrumentsController < ProductsCommonController
 
   # GET /facilities/:facility_id/instruments/:instrument_id
   def show
-    instrument_for_cart = InstrumentForCart.new(@product)
+    instrument_for_cart = InstrumentForCart.new(@product, session_user, current_ability)
     # TODO: Remove this instance variable-not used anywhere but tests
-    @add_to_cart = instrument_for_cart.purchasable_by?(acting_user, session_user)
+    @add_to_cart = instrument_for_cart.purchasable_by?(acting_user)
     if @add_to_cart
       redirect_to new_facility_instrument_single_reservation_path(current_facility, @product)
     elsif instrument_for_cart.error_path

--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -38,8 +38,8 @@ class ProductsCommonController < ApplicationController
   # GET /facilities/:facility_id/(services|items|bundles)/:(service|item|bundle)_id
   def show
     @active_tab = "home"
-    product_for_cart = ProductForCart.new(@product)
-    @add_to_cart = product_for_cart.purchasable_by?(acting_user, session_user)
+    product_for_cart = ProductForCart.new(@product, session_user, current_ability)
+    @add_to_cart = product_for_cart.purchasable_by?(acting_user)
 
     if product_for_cart.error_path
       redirect_to product_for_cart.error_path, notice: product_for_cart.error_message

--- a/app/controllers/quick_reservations_controller.rb
+++ b/app/controllers/quick_reservations_controller.rb
@@ -119,7 +119,14 @@ class QuickReservationsController < ApplicationController
 
     # Check if the user can create a reservation, among other things, this will
     # catch instruments with no schedule rules
-    instrument_for_cart = InstrumentForCart.new(@instrument, current_user, current_ability, quick_reservation: true)
+    instrument_for_cart = InstrumentForCart.new(
+      @instrument,
+      current_user,
+      # Use ability basedd on facility since
+      # ability_resource is not present yet
+      Ability.new(current_user, current_facility, self),
+      quick_reservation: true,
+    )
     @can_add_to_cart = instrument_for_cart.purchasable_by?(current_user)
 
     if instrument_for_cart.error_message

--- a/app/controllers/quick_reservations_controller.rb
+++ b/app/controllers/quick_reservations_controller.rb
@@ -119,8 +119,8 @@ class QuickReservationsController < ApplicationController
 
     # Check if the user can create a reservation, among other things, this will
     # catch instruments with no schedule rules
-    instrument_for_cart = InstrumentForCart.new(@instrument, quick_reservation: true)
-    @can_add_to_cart = instrument_for_cart.purchasable_by?(current_user, current_user)
+    instrument_for_cart = InstrumentForCart.new(@instrument, current_user, current_ability, quick_reservation: true)
+    @can_add_to_cart = instrument_for_cart.purchasable_by?(current_user)
 
     if instrument_for_cart.error_message
       flash.now[:notice] = instrument_for_cart.error_message

--- a/app/controllers/quick_reservations_controller.rb
+++ b/app/controllers/quick_reservations_controller.rb
@@ -122,7 +122,7 @@ class QuickReservationsController < ApplicationController
     instrument_for_cart = InstrumentForCart.new(
       @instrument,
       current_user,
-      # Use ability basedd on facility since
+      # Use ability based on facility since
       # ability_resource is not present yet
       Ability.new(current_user, current_facility, self),
       quick_reservation: true,

--- a/app/lib/facility_user_permission_ability.rb
+++ b/app/lib/facility_user_permission_ability.rb
@@ -128,6 +128,8 @@ class FacilityUserPermissionAbility
     can [:administer, :assign_price_policies_to_problem_orders, :batch_update,
          :create, :index, :order_in_past, :send_receipt, :show, :tab_counts, :update], Order
 
+    can :manage, Reservation if resource.is_a?(Reservation)
+
     can [:administer, :assign_price_policies_to_problem_orders, :batch_update,
          :cancel, :edit, :index, :show, :tab_counts,
          :timeline, :update], Reservation

--- a/app/models/instrument_for_cart.rb
+++ b/app/models/instrument_for_cart.rb
@@ -4,7 +4,7 @@ class InstrumentForCart < ProductForCart
 
   private
 
-  def checks(acting_user, _session_user)
+  def checks(acting_user)
     [check_that_user_is_present(acting_user), check_that_product_has_schedule_rules] + super
   end
 

--- a/app/models/instrument_for_cart.rb
+++ b/app/models/instrument_for_cart.rb
@@ -4,7 +4,7 @@ class InstrumentForCart < ProductForCart
 
   private
 
-  def checks(acting_user, session_user)
+  def checks(acting_user, _session_user)
     [check_that_user_is_present(acting_user), check_that_product_has_schedule_rules] + super
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -319,7 +319,7 @@ class Product < ApplicationRecord
     self[:user_notes_field_mode] = Products::UserNoteMode[str_value]
   end
 
-  def is_accessible_to_user?(is_operator = false)
+  def is_accessible_to_user?(is_operator)
     !(is_archived? || (is_hidden? && !is_operator))
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -319,8 +319,7 @@ class Product < ApplicationRecord
     self[:user_notes_field_mode] = Products::UserNoteMode[str_value]
   end
 
-  def is_accessible_to_user?(user)
-    is_operator = user&.operator_of?(facility)
+  def is_accessible_to_user?(is_operator = false)
     !(is_archived? || (is_hidden? && !is_operator))
   end
 

--- a/app/models/product_for_cart.rb
+++ b/app/models/product_for_cart.rb
@@ -16,7 +16,7 @@ class ProductForCart
   def purchasable_by?(acting_user)
     raise NUCore::PermissionDenied unless product.is_accessible_to_user?(operator?)
 
-    checks(acting_user, session_user).all? do |check|
+    checks(acting_user).all? do |check|
       result = check.call
       [error_path, error_message].all?(&:blank?) && result != false
     end
@@ -38,7 +38,7 @@ class ProductForCart
 
   private
 
-  def checks(acting_user, session_user)
+  def checks(acting_user)
     [
       check_that_user_is_present(acting_user),
       check_that_product_is_available_for_purchase,

--- a/app/models/product_for_cart.rb
+++ b/app/models/product_for_cart.rb
@@ -4,16 +4,17 @@ class ProductForCart
 
   include TextHelpers::Translation
 
-  attr_accessor :error_message
-  attr_accessor :error_path
+  attr_accessor :error_message, :error_path
 
-  def initialize(product, quick_reservation: false)
+  def initialize(product, session_user, ability, quick_reservation: false)
     @product = product
+    @ability = ability
+    @session_user = session_user
     @quick_reservation = quick_reservation
   end
 
-  def purchasable_by?(acting_user, session_user)
-    raise NUCore::PermissionDenied unless product.is_accessible_to_user?(session_user)
+  def purchasable_by?(acting_user)
+    raise NUCore::PermissionDenied unless product.is_accessible_to_user?(operator?)
 
     checks(acting_user, session_user).all? do |check|
       result = check.call
@@ -23,13 +24,19 @@ class ProductForCart
 
   protected
 
+  attr_reader :product, :quick_reservation, :ability, :session_user
+
+  delegate :facility, to: :product
+
+  def operator?
+    ability.can?(:act_as, facility)
+  end
+
   def translation_scope
     "models.#{self.class.name.underscore}"
   end
 
   private
-
-  attr_accessor :product
 
   def checks(acting_user, session_user)
     [
@@ -60,7 +67,7 @@ class ProductForCart
 
   def check_that_product_can_be_used(acting_user, session_user)
     proc do
-      if !product.can_be_used_by?(acting_user) && !(session_user.present? && session_user.can_override_restrictions?(product))
+      if !product.can_be_used_by?(acting_user) && !operator?
         if SettingsHelper.feature_on?(:training_requests) && product.allows_training_requests?
           if TrainingRequest.submitted?(session_user, product)
             @error_message = text("models.product_for_cart.already_requested_access", i18n_params)
@@ -94,7 +101,7 @@ class ProductForCart
 
   def check_that_session_user_can_order_on_behalf_of_assumed_user(acting_user, session_user)
     proc do
-      if acting_as?(acting_user, session_user) && !session_user.operator_of?(product.facility)
+      if acting_as?(acting_user, session_user) && !operator?
         @error_message = text(".not_authorized_to_order_on_behalf", i18n_params)
       end
     end

--- a/app/models/product_for_cart.rb
+++ b/app/models/product_for_cart.rb
@@ -14,7 +14,7 @@ class ProductForCart
   end
 
   def purchasable_by?(acting_user)
-    raise NUCore::PermissionDenied unless product.is_accessible_to_user?(operator?)
+    raise NUCore::PermissionDenied unless product.is_accessible_to_user?(facility_operator?)
 
     checks(acting_user).all? do |check|
       result = check.call
@@ -28,7 +28,7 @@ class ProductForCart
 
   delegate :facility, to: :product
 
-  def operator?
+  def facility_operator?
     ability.can?(:act_as, facility)
   end
 
@@ -67,7 +67,7 @@ class ProductForCart
 
   def check_that_product_can_be_used(acting_user, session_user)
     proc do
-      if !product.can_be_used_by?(acting_user) && !operator?
+      if !product.can_be_used_by?(acting_user) && !facility_operator?
         if SettingsHelper.feature_on?(:training_requests) && product.allows_training_requests?
           if TrainingRequest.submitted?(session_user, product)
             @error_message = text("models.product_for_cart.already_requested_access", i18n_params)
@@ -101,7 +101,7 @@ class ProductForCart
 
   def check_that_session_user_can_order_on_behalf_of_assumed_user(acting_user, session_user)
     proc do
-      if acting_as?(acting_user, session_user) && !operator?
+      if acting_as?(acting_user, session_user) && !facility_operator?
         @error_message = text(".not_authorized_to_order_on_behalf", i18n_params)
       end
     end

--- a/spec/models/instrument_for_cart_spec.rb
+++ b/spec/models/instrument_for_cart_spec.rb
@@ -7,29 +7,30 @@ RSpec.describe InstrumentForCart do
   let(:facility) { FactoryBot.create(:setup_facility) }
   let(:instrument) { FactoryBot.create(:instrument, facility: facility, no_relay: true) }
   let(:user) { FactoryBot.create(:user) }
-  let(:instrument_for_cart) { InstrumentForCart.new(instrument) }
+  let(:ability) { Ability.new(user, facility, ApplicationController.new) }
+  let(:instrument_for_cart) { InstrumentForCart.new(instrument, user, ability) }
 
   context "#purchasable_by?" do
 
     context "when the acting user is not present" do
       it "sets error_path to the sign-in page" do
-        instrument_for_cart.purchasable_by?(nil, user)
+        instrument_for_cart.purchasable_by?(nil)
         expect(instrument_for_cart.error_path).to eq Rails.application.routes.url_helpers.new_user_session_path
       end
     end
 
     context "when the instrument does not have any schedule rules" do
       it "returns false" do
-        expect(instrument_for_cart.purchasable_by?(user, user)).to be false
+        expect(instrument_for_cart.purchasable_by?(user)).to be false
       end
 
       it "sets error_message explaining that a schedule is unavailable" do
-        instrument_for_cart.purchasable_by?(user, user)
+        instrument_for_cart.purchasable_by?(user)
         expect(instrument_for_cart.error_message).to match(/A schedule for this instrument is currently unavailable/)
       end
 
       it "does not set an error_path" do
-        instrument_for_cart.purchasable_by?(user, user)
+        instrument_for_cart.purchasable_by?(user)
         expect(instrument_for_cart.error_path).to be_blank
       end
     end

--- a/spec/models/product_for_cart_spec.rb
+++ b/spec/models/product_for_cart_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe ProductForCart do
   let(:facility) { create(:setup_facility) }
-  let(:item) { create(:setup_item, facility: facility) }
+  let(:item) { create(:setup_item, facility:) }
   let(:user) { create(:user) }
   let(:ability) { Ability.new(user, facility, ApplicationController.new) }
   let(:product_for_cart) { described_class.new(item, user, ability) }
@@ -124,6 +124,48 @@ RSpec.describe ProductForCart do
       it "sets error_message explaining that we could not find a valid payment source" do
         product_for_cart.purchasable_by?(user)
         expect(product_for_cart.error_message).to match(/could not find a valid payment source/)
+      end
+    end
+  end
+
+  describe "ordering for", :use_test_account do
+    let(:other_user) { create(:user) }
+    let(:account) { create(:test_account, :with_account_owner, created_by: user.id) }
+
+    before do
+      allow(item).to receive(:can_purchase?).and_return(true)
+      create(
+        :account_user, :purchaser,
+        account:, user: other_user,
+        created_by_user: user,
+      )
+      account.price_groups << PriceGroup.base
+    end
+
+    context "when user has a user_role" do
+      before do
+        UserRole.create!(
+          user:, facility:,
+          role: UserRole::FACILITY_STAFF,
+        )
+      end
+
+      it "can purchase on behalf" do
+        expect(product_for_cart.purchasable_by?(other_user)).to be true
+      end
+    end
+
+    context "when user has granular permission with order mngm" do
+      before do
+        user.facility_user_permissions.create!(
+          facility:,
+          read_access: true,
+          order_management: true,
+        )
+      end
+
+      it "can purchase on behalf" do
+        expect(product_for_cart.purchasable_by?(other_user)).to be true
       end
     end
   end

--- a/spec/models/product_for_cart_spec.rb
+++ b/spec/models/product_for_cart_spec.rb
@@ -150,12 +150,20 @@ RSpec.describe ProductForCart do
         )
       end
 
-      it "can purchase on behalf" do
-        expect(product_for_cart.purchasable_by?(other_user)).to be true
+      context "when granular permissions is off", feature_setting: { granular_permissions: false } do
+        it "can purchase on behalf" do
+          expect(product_for_cart.purchasable_by?(other_user)).to be true
+        end
+      end
+
+      context "when granular permission is on", feature_setting: { granular_permissions: true } do
+        it "can purchase on behalf" do
+          expect(product_for_cart.purchasable_by?(other_user)).to be true
+        end
       end
     end
 
-    context "when user has granular permission with order mngm" do
+    context "when user has granular permission with order mngm", feature_setting: { granular_permissions: true } do
       before do
         user.facility_user_permissions.create!(
           facility:,

--- a/spec/models/product_for_cart_spec.rb
+++ b/spec/models/product_for_cart_spec.rb
@@ -3,22 +3,20 @@
 require "rails_helper"
 
 RSpec.describe ProductForCart do
-
-  let(:facility) { FactoryBot.create(:setup_facility) }
-  let(:item) { FactoryBot.create(:setup_item, facility: facility) }
-  let(:user) { FactoryBot.create(:user) }
-
-  let(:product_for_cart) { ProductForCart.new(item) }
+  let(:facility) { create(:setup_facility) }
+  let(:item) { create(:setup_item, facility: facility) }
+  let(:user) { create(:user) }
+  let(:ability) { Ability.new(user, facility, ApplicationController.new) }
+  let(:product_for_cart) { described_class.new(item, user, ability) }
 
   describe "#purchasable_by?" do
-
     context "when a product is not available for purchase" do
       before(:each) { allow(item).to receive(:available_for_purchase?).and_return(false) }
 
-      it("returns false") { expect(product_for_cart.purchasable_by?(user, user)).to be false }
+      it("returns false") { expect(product_for_cart.purchasable_by?(user)).to be false }
 
       it "sets error_message explaining that the product can't be purchased online" do
-        product_for_cart.purchasable_by?(user, user)
+        product_for_cart.purchasable_by?(user)
         expect(product_for_cart.error_message).to match(/unavailable for purchase online/)
       end
     end
@@ -27,18 +25,18 @@ RSpec.describe ProductForCart do
       before(:each) { item.price_policies.delete_all }
 
       context "and it is not a bundle" do
-        it("returns false") { expect(product_for_cart.purchasable_by?(user, user)).to be false }
+        it("returns false") { expect(product_for_cart.purchasable_by?(user)).to be false }
 
         it "sets error_message explaining that pricing is unavailable" do
-          product_for_cart.purchasable_by?(user, user)
+          product_for_cart.purchasable_by?(user)
           expect(product_for_cart.error_message).to match(/Pricing for this item is currently unavailable/)
         end
       end
 
       context "and it is a bundle" do
-        let(:bundle) { FactoryBot.create(:bundle, facility: facility) }
+        let(:bundle) { create(:bundle, facility: facility) }
         let(:bundle_product) { BundleProduct.new(bundle: @bundle, product: item, quantity: 1) }
-        let(:product_for_cart) { ProductForCart.new(bundle) }
+        let(:product_for_cart) { described_class.new(bundle, user, ability) }
 
         before(:each) { BundleProduct.create(bundle: bundle, product: item, quantity: 1) }
 
@@ -46,18 +44,18 @@ RSpec.describe ProductForCart do
           before(:each) { item.price_policies.delete_all }
 
           it "sets error_message explaining that pricing is unavailable" do
-            product_for_cart.purchasable_by?(user, user)
+            product_for_cart.purchasable_by?(user)
             expect(product_for_cart.error_message).to match(/Pricing for this bundle is currently unavailable/)
           end
         end
 
         context "and at least one of its products has pricing policies" do
           before(:each) do
-            item.item_price_policies.create(FactoryBot.attributes_for(:item_price_policy, price_group: @nupg))
+            item.item_price_policies.create(attributes_for(:item_price_policy, price_group: @nupg))
           end
 
           it "does not set error_message about unavailable pricing" do
-            product_for_cart.purchasable_by?(user, user)
+            product_for_cart.purchasable_by?(user)
             expect(product_for_cart.error_message).not_to match(/Pricing for this bundle is currently unavailable/)
           end
         end
@@ -75,12 +73,12 @@ RSpec.describe ProductForCart do
           before(:each) { allow(TrainingRequest).to receive(:submitted?).and_return(true) }
 
           it "sets error_message explaining that the user has already requested access" do
-            product_for_cart.purchasable_by?(user, user)
+            product_for_cart.purchasable_by?(user)
             expect(product_for_cart.error_message).to match(/You have requested/)
           end
 
           it "sets error_path to the facility page" do
-            product_for_cart.purchasable_by?(user, user)
+            product_for_cart.purchasable_by?(user)
             expect(product_for_cart.error_path).to eq Rails.application.routes.url_helpers.facility_path(item.facility)
           end
         end
@@ -89,7 +87,7 @@ RSpec.describe ProductForCart do
           before(:each) { allow(TrainingRequest).to receive(:submitted?).and_return(false) }
 
           it "sets error_path to the page for making a training request" do
-            product_for_cart.purchasable_by?(user, user)
+            product_for_cart.purchasable_by?(user)
             expect(product_for_cart.error_path).to eq Rails.application.routes.url_helpers.new_facility_product_training_request_path(item.facility, item)
           end
         end
@@ -97,7 +95,7 @@ RSpec.describe ProductForCart do
 
       context "and training requests are turned off", feature_setting: { training_requests: false, reload_routes: true } do
         it "sets error_message explaining that the product requires approval" do
-          product_for_cart.purchasable_by?(user, user)
+          product_for_cart.purchasable_by?(user)
           expect(product_for_cart.error_message).to match(/requires approval to purchase/)
         end
       end
@@ -107,7 +105,7 @@ RSpec.describe ProductForCart do
       before(:each) { allow(item).to receive(:can_purchase?).and_return(false) }
 
       it "sets error_message explaining why they can't purchase the product" do
-        product_for_cart.purchasable_by?(user, user)
+        product_for_cart.purchasable_by?(user)
         expect(product_for_cart.error_message).to match(/No price groups found for this purchase/)
       end
     end
@@ -124,11 +122,9 @@ RSpec.describe ProductForCart do
       end
 
       it "sets error_message explaining that we could not find a valid payment source" do
-        product_for_cart.purchasable_by?(user, user)
+        product_for_cart.purchasable_by?(user)
         expect(product_for_cart.error_message).to match(/could not find a valid payment source/)
       end
     end
-
   end
-
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -713,6 +713,7 @@ RSpec.describe Product do
 
   describe "#is_accessible_to_user?" do
     let(:user) { User.new }
+    let(:is_operator) { user.operator_of?(subject.facility) }
 
     context "when the product is not archived" do
       before(:each) { subject.is_archived = false }
@@ -720,7 +721,7 @@ RSpec.describe Product do
       context "and it is not hidden" do
         before(:each) { subject.is_hidden = false }
 
-        it("returns true") { expect(subject.is_accessible_to_user?(user)).to be true }
+        it("returns true") { expect(subject.is_accessible_to_user?(is_operator)).to be true }
       end
 
       context "and it is hidden" do
@@ -729,13 +730,13 @@ RSpec.describe Product do
         context "and the user is an operator of the product’s facility" do
           before(:each) { allow(user).to receive(:operator_of?).and_return(true) }
 
-          it("returns true") { expect(subject.is_accessible_to_user?(user)).to be true }
+          it("returns true") { expect(subject.is_accessible_to_user?(is_operator)).to be true }
         end
 
         context "and the user is not an operator of the product’s facility" do
           before(:each) { allow(user).to receive(:operator_of?).and_return(false) }
 
-          it("returns false") { expect(subject.is_accessible_to_user?(user)).to be false }
+          it("returns false") { expect(subject.is_accessible_to_user?(is_operator)).to be false }
         end
       end
     end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -744,7 +744,7 @@ RSpec.describe Product do
     context "when the product is archived" do
       before(:each) { subject.is_archived = true }
 
-      it("returns false") { expect(subject.is_accessible_to_user?(user)).to be false }
+      it("returns false") { expect(subject.is_accessible_to_user?(is_operator)).to be false }
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -215,6 +215,11 @@ RSpec.configure do |config|
         end
       end
     )
+    Account.config.account_types << TestAccount.name
+  end
+
+  config.after :each, :use_test_account do
+    Account.config.account_types.delete TestAccount.name
   end
 
   config.around :each, :use_test_account do |example|


### PR DESCRIPTION
# Notes

Update `ProductForCart` class which perform some checks before purchasing to use the ability instead of relying on fixed user roles. The permission verified to tell if someone is an operator of a facility is :act_as, Facility, which is added for all operators of fixed user roles and some granular permissions.

Also:
- Added permission over `Reservation` missed in the Granular permission refactor which added a required permission to order for (reservation creation) (https://github.com/wyeworks/nucore-open/pull/6207)
- Update `:use_test_account` spec filter to add `TestAccount` to `Account.config`


[NUOPEN-353 | Order for another user not fully working](https://universe-of-universities.atlassian.net/browse/NUOPEN-353)

