### PR TITLE
[NUOPEN-307][Fix] Hide add to order header if form not shown

### DIFF
--- a/app/views/facility_orders/show.html.haml
+++ b/app/views/facility_orders/show.html.haml
@@ -28,8 +28,8 @@
 
 - subheader_key = (@cross_core_project.present? ? "views.facility_orders.show.add_to_cross_core_order_header" : "views.facility_orders.show.add_to_order_header")
 
-%h2= t(subheader_key)
 - if @cross_core_data_by_facility_id.present?
+  %h2= t(subheader_key)
   #js--reportAnIssueModal.modal.fade
 
   #accordion
@@ -41,4 +41,5 @@
         = render "order_table_footer", order: @cross_core_data_by_facility_id[facility_id][:order], cross_core: true
 
 - if current_ability.can?(:update, Order)
+  %h2= t(subheader_key)
   = render "merge_order_form"

--- a/app/views/facility_orders/show.html.haml
+++ b/app/views/facility_orders/show.html.haml
@@ -26,10 +26,11 @@
   = render "order_table", order_details: @order_details, cross_core: false, facility_id: current_facility.id
   = render "order_table_footer", order: @order, cross_core: false
 
-- subheader_key = (@cross_core_project.present? ? "views.facility_orders.show.add_to_cross_core_order_header" : "views.facility_orders.show.add_to_order_header")
+- if @cross_core_data_by_facility_id.present? || current_ability.can?(:update, Order)
+  - subheader_key = (@cross_core_project.present? ? "views.facility_orders.show.add_to_cross_core_order_header" : "views.facility_orders.show.add_to_order_header")
+  %h2= t(subheader_key)
 
 - if @cross_core_data_by_facility_id.present?
-  %h2= t(subheader_key)
   #js--reportAnIssueModal.modal.fade
 
   #accordion
@@ -41,5 +42,4 @@
         = render "order_table_footer", order: @cross_core_data_by_facility_id[facility_id][:order], cross_core: true
 
 - if current_ability.can?(:update, Order)
-  %h2= t(subheader_key)
   = render "merge_order_form"


### PR DESCRIPTION
# Notes

Fix Order show page showing the "Add to Order" heading when that action is not allowed to the user.

# Screenshot

<img width="1315" height="696" alt="Captura desde 2026-05-27 09-42-55" src="https://github.com/user-attachments/assets/dc2f0f11-6aee-4b51-9aaf-340efa10f7ab" />
