### PR TITLE
[OSU-226] Login disabled mode

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,6 +4,10 @@
     = render "/shared/head"
   %body{ class: SettingsHelper.feature_on?(:use_manage) && manage_mode? ? "manage-mode" : "" }
     %header
+      - if current_user.blank? && Settings.login.disabled
+        .global-alert-banner
+          .container= Settings.login.disabled_banner
+
       = render "/shared/acting_as"
       = yield(:banner)
       = render "/shared/header"

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Warden::Manager.after_set_user do |user, auth, _opts|
+  next unless Settings.login.disabled
+
+  unless user.administrator?
+    auth.logout
+    throw(:warden, message: Settings.login.disabled_error)
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -204,6 +204,11 @@ paperclip:
   url: ":rails_relative_url_root/system/:class/:attachment/:id_partition/:style/:safe_filename"
   path: ":rails_root/public/system/:class/:attachment/:id_partition/:style/:safe_filename"
 
+login:
+  disabled: <%= ENV.fetch("NUCORE_LOGIN_DSIABLED", false) %>
+  disabled_banner: NUcore login is disabled
+  disabled_error: Login is temporary disabled
+
 # saml:
 #   create_user: true
 #   # Use login_enabled: false if you want to allow access to metadata without yet

--- a/doc/HOWTO_feature_flags.md
+++ b/doc/HOWTO_feature_flags.md
@@ -20,6 +20,7 @@
 * `password_update` Allow users to update or reset password (forgot password button)
 * `saml: create_user` create/update saml users on login
 * `uses_ldap_authentication`: Enable if ldap authentication engine is used and configured.
+* `login.disabled`: Disable login for every user except from global administrators. This can be configured along `login.disabled_error` which is the error to show on login and `login.disabled_banner` which is the banner to show on top of every page.
 
 ## Roles
 

--- a/spec/requests/login_disabled_mode_spec.rb
+++ b/spec/requests/login_disabled_mode_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "login disabled" do
+  let(:password) { "Example1!" }
+  let(:normal_user) { create(:user, password:) }
+  let(:administrator_user) { create(:user, :administrator, password:) }
+
+  context "when login disabled" do
+    before do
+      allow(Settings.login).to receive(:disabled).and_return(true)
+    end
+
+    it "shows banner on the top" do
+      get root_path
+
+      expect(page).not_to have_content(Settings.login.disabled_banner)
+    end
+
+    it "cannot login as normal user" do
+      params = { user: { username: normal_user.username, password: } }
+      post(new_user_session_path, params:)
+
+      expect(response.location).to eq(new_user_session_url)
+      get response.location
+
+      expect(page).to have_content(Settings.login.disabled_error)
+    end
+
+    it "can login as global admin" do
+      params = { user: { username: administrator_user.username, password: } }
+      post(new_user_session_path, params:)
+
+      expect(response.location).to eq(root_url)
+      expect(page).not_to have_content(Settings.login.disabled_banner)
+    end
+  end
+end

--- a/spec/requests/login_disabled_mode_spec.rb
+++ b/spec/requests/login_disabled_mode_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe "login disabled" do
     end
 
     it "shows banner on the top" do
-      get root_path
+      get facilities_path
 
-      expect(page).not_to have_content(Settings.login.disabled_banner)
+      expect(page).to have_content(Settings.login.disabled_banner)
     end
 
     it "cannot login as normal user" do


### PR DESCRIPTION
# Notes

Allow to disable login for every user except from global admins.

This warden callback used applies to initial authentication and session user fetching.

Docs: https://github.com/wardencommunity/warden/wiki/Callbacks#example

[OSU-226 | Allow to disable login](https://universe-of-universities.atlassian.net/browse/OSU-226)
