### PR TITLE
[NUOPEN-331] Fix research safety certification authorization

### DIFF
--- a/app/controllers/user_research_safety_certifications_controller.rb
+++ b/app/controllers/user_research_safety_certifications_controller.rb
@@ -6,6 +6,8 @@ class UserResearchSafetyCertificationsController < ApplicationController
   before_action :check_acting_as
   before_action :init_current_facility
 
+  authorize_resource class: User
+
   layout "two_column"
 
   def initialize

--- a/spec/system/admin/user_research_safety_certifications_controller_spec.rb
+++ b/spec/system/admin/user_research_safety_certifications_controller_spec.rb
@@ -31,4 +31,14 @@ RSpec.describe "Viewing a user's safety certifications" do
       expect(page).not_to have_link "Certifications"
     end
   end
+
+  describe "as a user without access to the facility" do
+    let(:unauthorized_user) { create(:user) }
+
+    before { login_as unauthorized_user }
+
+    it_behaves_like "raises specified error",
+                    -> { visit facility_user_user_research_safety_certifications_path(facility, user) },
+                    CanCan::AccessDenied
+  end
 end


### PR DESCRIPTION
 # Notes
  
  Fixes a permissions gap where any logged-in user could view another user's research safety certifications. Access is now restricted to facility staff and users granted the appropriate permission, returning a 403 to everyone else.
  
  [NUOPEN-331 | Add User Management granular permission](https://universe-of-universities.atlassian.net/browse/NUOPEN-331)
