### PR TITLE
[NUOPEN-281] Handle statement cancel order detail notices update

### DIFF
--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -9,7 +9,7 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
   end
 
   def statuses
-    values = notice_keys + notices_service.time_based_notices
+    values = notice_keys + notices_service.dynamic_notices
 
     values.uniq.map { |s| Notice.new(s) }
   end

--- a/app/services/order_details/notices_service.rb
+++ b/app/services/order_details/notices_service.rb
@@ -5,7 +5,7 @@ module OrderDetails
   # Used to retrieve OrderDetail notices and problems.
   #
   # notices and problems are stored in order detail
-  # where as time_based_notices are always computed.
+  # where as dynamic_notices are always computed.
   #
   class NoticesService
     attr_reader :order_detail
@@ -31,7 +31,7 @@ module OrderDetails
     ##
     # Notices that cannot be stored since depend on current time
     # or can be computed out of the order detail attributes
-    def time_based_notices
+    def dynamic_notices
       return [] if canceled?
 
       {

--- a/app/services/order_details/notices_service.rb
+++ b/app/services/order_details/notices_service.rb
@@ -25,12 +25,12 @@ module OrderDetails
         missing_form: missing_form? && !problem?,
         can_reconcile: can_reconcile_journaled?,
         in_open_journal: in_open_journal?,
-        awaiting_payment: awaiting_payment?,
       }.compact_blank.keys
     end
 
     ##
     # Notices that cannot be stored since depend on current time
+    # or can be computed out of the order detail attributes
     def time_based_notices
       return [] if canceled?
 
@@ -38,6 +38,7 @@ module OrderDetails
         in_review: in_review?,
         ready_for_statement: ready_for_statement?,
         ready_for_journal: ready_for_journal? && SettingsHelper.feature_on?(:ready_for_journal_notice),
+        awaiting_payment: awaiting_payment?,
       }.compact_blank.keys
     end
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -6,7 +6,7 @@ ssl = Rails.application.config.force_ssl
 
 Rails.application.config.session_store(
   :cookie_store,
-  key: "_nucore_session",
+  key: "_open_session",
   httponly: true,
   secure: ssl,
   same_site: (ssl ? :none : :lax)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -6,7 +6,7 @@ ssl = Rails.application.config.force_ssl
 
 Rails.application.config.session_store(
   :cookie_store,
-  key: "_open_session",
+  key: "_nucore_session",
   httponly: true,
   secure: ssl,
   same_site: (ssl ? :none : :lax)

--- a/spec/services/order_details/notices_service_spec.rb
+++ b/spec/services/order_details/notices_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe OrderDetails::NoticesService do
   let(:instance) { described_class.new(order_detail) }
 
   describe "statuses" do
-    subject { instance.notices + instance.time_based_notices }
+    subject { instance.notices + instance.dynamic_notices }
 
     it "shows nothing for a blank order detail" do
       is_expected.to be_blank


### PR DESCRIPTION
# Notes

Show `awaiting payment` notice order detail as a computed notice since it's order callbacks are skipped when a statement is cancelled and it can be computed out of order attributes.

[NUOPEN-281 | Order details badges](https://universe-of-universities.atlassian.net/browse/NUOPEN-281)

