### PR TITLE
[NUOPEN-348] Patch to retry on chromdriver unknown error

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,6 +21,8 @@ FactoryBot.use_parent_strategy = false
 # don't overlap with db instances
 FactoryBot::Strategy::Stub.next_id = 100_000
 
+Capybara::Node::Base.prepend(CapybaraStaleNodeRetry)
+
 RSpec.configure do |config|
   include ActiveJob::TestHelper
 

--- a/spec/support/capybara_stale_node_retry.rb
+++ b/spec/support/capybara_stale_node_retry.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+##
+# Patch to retry on chromdriver issue that causes:
+#
+#  Selenium::WebDriver::Error::UnknownError:
+#    unknown error: unhandled inspector error: {
+#      "code":-32000,
+#      "message":"Node with given id does not belong to the document"
+#    }
+#
+# See https://issues.chromium.org/issues/375343406
+#
+module CapybaraStaleNodeRetry
+  STALE_NODE_MESSAGE = "does not belong to the document"
+
+  def catch_error?(error, errors = nil)
+    return true if stale_node_error?(error)
+
+    super
+  end
+
+  private
+
+  def stale_node_error?(error)
+    error.is_a?(Selenium::WebDriver::Error::UnknownError) &&
+      error.message.to_s.include?(STALE_NODE_MESSAGE)
+  end
+end


### PR DESCRIPTION
# Notes

Workaround to make Capybara retry on chromedriver issue.

> Credits to @diebas 

[NUOPEN-348 | NUOPEN-348](https://universe-of-universities.atlassian.net/browse/NUOPEN-348)
