### PR TITLE
[NUOPEN-355] Secure rooms card reader access

### DIFF
--- a/vendor/engines/secure_rooms/app/models/secure_rooms/ability_extension.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_rooms/ability_extension.rb
@@ -32,6 +32,11 @@ module SecureRooms
 
       if granted_read_access?(user, resource)
         ability.can [:index, :dashboard, :tab_counts, :show], Occupancy
+        ability.can [:index, :show], CardReader
+      end
+
+      if granted_product_edition?(user, resource)
+        ability.can :manage, CardReader
       end
     end
 
@@ -42,6 +47,13 @@ module SecureRooms
       return false unless resource.is_a?(Facility)
 
       user.facility_user_permissions.find_by(facility: resource)&.read_access?
+    end
+
+    def granted_product_edition?(user, resource)
+      return false unless SettingsHelper.feature_on?(:granular_permissions)
+      return false unless resource.is_a?(Facility)
+
+      user.facility_user_permissions.find_by(facility: resource)&.product_edition?
     end
 
   end

--- a/vendor/engines/secure_rooms/app/views/secure_rooms/card_readers/index.html.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_rooms/card_readers/index.html.haml
@@ -9,7 +9,8 @@
 
 %p= text("views.admin.secure_rooms.card_readers.index.description")
 
-%p= link_to text("admin.shared.add", model: SecureRooms::CardReader.model_name.human), new_facility_secure_room_card_reader_path(current_facility, @product), class: "btn-add"
+- if can? :create, SecureRooms::CardReader
+  %p= link_to text("admin.shared.add", model: SecureRooms::CardReader.model_name.human), new_facility_secure_room_card_reader_path(current_facility, @product), class: "btn-add"
 
 - if @card_readers.empty?
   %p.notice= text("views.admin.secure_rooms.card_readers.index.none")
@@ -32,8 +33,12 @@
           %td= card_reader.card_reader_number
           %td= card_reader.direction
           %td= card_reader.tablet_token if card_reader.ingress?
-          %td= link_to text("shared.edit"), edit_facility_secure_room_card_reader_path(current_facility, @product, card_reader)
-          %td= link_to text("shared.remove"), facility_secure_room_card_reader_path(current_facility, @product, card_reader), data: { confirm: text("shared.confirm_message") }, method: :delete
+          %td
+            - if can? :manage, SecureRooms::CardReader
+              = link_to text("shared.edit"), edit_facility_secure_room_card_reader_path(current_facility, @product, card_reader)
+          %td
+            - if can? :manage, SecureRooms::CardReader
+              = link_to text("shared.remove"), facility_secure_room_card_reader_path(current_facility, @product, card_reader), data: { confirm: text("shared.confirm_message") }, method: :delete
 
 = readonly_form_for :product do |f|
   = f.simple_fields_for @product, :defaults => { :default_value => 'N/A'} do |r|

--- a/vendor/engines/secure_rooms/spec/models/ability_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/ability_spec.rb
@@ -76,5 +76,17 @@ RSpec.describe Ability do
     end
 
     it_is_allowed_to([:index, :dashboard, :tab_counts, :show], SecureRooms::Occupancy)
+    it_is_allowed_to([:index, :show], SecureRooms::CardReader)
+    it_is_not_allowed_to([:create, :update, :destroy], SecureRooms::CardReader)
+  end
+
+  describe "granular permission user with product_edition", feature_setting: { granular_permissions: true } do
+    let(:user) { create(:user) }
+
+    before do
+      create(:facility_user_permission, user:, facility:, read_access: true, product_edition: true)
+    end
+
+    it_is_allowed_to([:index, :show, :create, :update, :destroy], SecureRooms::CardReader)
   end
 end

--- a/vendor/engines/secure_rooms/spec/system/manage_card_reader_spec.rb
+++ b/vendor/engines/secure_rooms/spec/system/manage_card_reader_spec.rb
@@ -54,4 +54,40 @@ RSpec.describe "Managing CardReaders" do
       expect { SecureRooms::CardReader.find(card_reader.id) }.to raise_error ActiveRecord::RecordNotFound
     end
   end
+
+  context "with granular permissions", feature_setting: { granular_permissions: true } do
+    let!(:card_reader) { create(:card_reader, secure_room: secure_room) }
+    let(:user) { create(:user) }
+
+    before { login_as user }
+
+    context "with read access only" do
+      before { create(:facility_user_permission, user:, facility:, read_access: true) }
+
+      it "views card readers without management links" do
+        visit facility_secure_room_card_readers_path(facility, secure_room)
+
+        within(".product_list") { expect(page).to have_content(card_reader.card_reader_number) }
+        expect(page).not_to have_link("Add Card Reader")
+        within(".product_list") do
+          expect(page).not_to have_link("Edit")
+          expect(page).not_to have_link("Remove")
+        end
+      end
+    end
+
+    context "with product management" do
+      before { create(:facility_user_permission, user:, facility:, read_access: true, product_edition: true) }
+
+      it "shows the management links" do
+        visit facility_secure_room_card_readers_path(facility, secure_room)
+
+        expect(page).to have_link("Add Card Reader")
+        within(".product_list") do
+          expect(page).to have_link("Edit")
+          expect(page).to have_link("Remove")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
 # Notes
  
  Facility users can now be granted access to Secure Rooms Card Readers through granular permissions: **Read Access** allows viewing card readers, and **Product Management** allows creating, editing, and deleting them.
  
  [NUOPEN-355 | Secure Rooms Card Reader Access](https://universe-of-universities.atlassian.net/browse/NUOPEN-355)