### PR TITLE
[NUOPEN-326] Fix price policy trunaction

### DIFF
--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -4,6 +4,8 @@ class PricePolicy < ApplicationRecord
 
   include Nucore::Database::DateHelper
 
+  has_paper_trail
+
   belongs_to :price_group
   belongs_to :product, optional: true
   belongs_to :created_by, class_name: "User", optional: true
@@ -22,6 +24,7 @@ class PricePolicy < ApplicationRecord
   validates :price_group_id, :type, presence: true
   validate :start_date_is_unique, if: :start_date?
   validate :expire_date_within_fiscal_year, if: :order_review_product?
+  validate :no_truncation_of_assigned_policies, on: :create, if: :start_date?
 
   validate :subsidy_less_than_rate, unless: :restrict_purchase?
 
@@ -238,16 +241,26 @@ class PricePolicy < ApplicationRecord
 
   def truncate_existing_policies
     logger.debug("Truncating existing policies")
+
+    policies_to_truncate.each do |policy|
+      policy.expire_date = (start_date - 1.day).end_of_day
+      policy.save
+    end
+  end
+
+  def policies_to_truncate
     existing_policies = PricePolicy.current.where(type: self.class.name,
                                                   price_group_id: price_group_id,
                                                   product_id: product_id)
 
     existing_policies = existing_policies.where("id != ?", id) unless id.nil?
+    existing_policies
+  end
 
-    existing_policies.each do |policy|
-      policy.expire_date = (start_date - 1.day).end_of_day
-      policy.save
-    end
+  def no_truncation_of_assigned_policies
+    return unless OrderDetail.exists?(price_policy_id: policies_to_truncate.select(:id))
+
+    errors.add(:base, "cannot overlap an existing price policy that has orders assigned to it")
   end
 
 end

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -260,7 +260,7 @@ class PricePolicy < ApplicationRecord
   def no_truncation_of_assigned_policies
     return unless OrderDetail.exists?(price_policy_id: policies_to_truncate.select(:id))
 
-    errors.add(:base, "cannot overlap an existing price policy that has orders assigned to it")
+    errors.add(:base, :overlapping_assigned_policy)
   end
 
 end

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -69,6 +69,7 @@ en:
         already_in_queue: Only one file may be in process at a time
         zero_duration: must be greater than zero
         start_after_end: must be after Ending Date
+        overlapping_assigned_policy: "cannot overlap an existing price policy that has orders assigned to it"
         # Append your own errors here or at the model/attributes scope.
       full_messages:
         format: "%{attribute} %{message}"

--- a/spec/models/price_policy_spec.rb
+++ b/spec/models/price_policy_spec.rb
@@ -180,6 +180,49 @@ RSpec.describe PricePolicy do
       end
     end
 
+    context "when the existing policy has orders assigned" do
+      it "does not truncate it and adds a base error" do
+        @today = Time.zone.local(2011, 06, 06, 12, 0, 0)
+
+        travel_to_and_return(@today) do
+          @pp = create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today.beginning_of_day, expire_date: @today + 30.days)
+
+          order = @user.orders.create(attributes_for(:order, created_by: @user.id, account: @account, facility: @facility))
+          order_detail = order.order_details.create(attributes_for(:order_detail).update(product_id: @item.id, account_id: @account.id))
+          order_detail.update!(price_policy: @pp)
+
+          overlapping = build(:item_price_policy, product: @item, price_group: @price_group, start_date: @today + 2.days, expire_date: @today + 30.days)
+
+          expect(overlapping.save).to be(false)
+          expect(overlapping.errors[:base]).to be_present
+          expect(@pp.reload.expire_date).to eq(@today + 30.days)
+        end
+      end
+    end
+
+    context "auditing with PaperTrail" do
+      it "records a version when a policy is created" do
+        @today = Time.zone.local(2011, 06, 06, 12, 0, 0)
+
+        travel_to_and_return(@today) do
+          pp = create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today.beginning_of_day, expire_date: @today + 30.days)
+
+          expect(pp.versions.map(&:event)).to include("create")
+        end
+      end
+
+      it "records a version when a policy is truncated" do
+        @today = Time.zone.local(2011, 06, 06, 12, 0, 0)
+
+        travel_to_and_return(@today) do
+          @pp = create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today.beginning_of_day, expire_date: @today + 30.days)
+          create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today + 2.days, expire_date: @today + 30.days)
+
+          expect(@pp.reload.versions.map(&:event)).to include("update")
+        end
+      end
+    end
+
     context "should define abstract methods" do
 
       before :each do


### PR DESCRIPTION
  # Notes
  
  Adds a guard so that creating a new price policy can no longer silently truncate an existing, currently-active policy that already has orders assigned to it. Instead of leaving those orders pointing at a policy whose date range was shifted out from under them, the system now blocks the create and shows an error. Price policies are also now audited with PaperTrail.
  
  [NUOPEN-326 | Price Policy truncation result in wrong states](https://universe-of-universities.atlassian.net/browse/NUOPEN-326)
