### PR TITLE
[NUOPEN-301] Fix 500 error page

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -9,7 +9,11 @@ class ErrorsController < ApplicationController
   end
 
   def internal_server_error
-    send_static_error_page
+    render(
+      file: Rails.public_path.join("500.html"),
+      status: :internal_server_error,
+      layout: false,
+    )
   end
 
   def forbidden
@@ -31,10 +35,4 @@ class ErrorsController < ApplicationController
   rescue ActionController::UnknownFormat
     head status
   end
-
-  def send_static_error_page
-    static_file_path = Rails.public_path.join("500.html")
-    send_file static_file_path, status: :internal_server_error, type: "text/html"
-  end
-
 end


### PR DESCRIPTION
# Notes

The error was caused by `send_file` using `disposition: :attachment` by default so the error page was not rendered by the browser. Changed action to use `render`.

[NUOPEN-301 | 500 error page problem](https://universe-of-universities.atlassian.net/browse/NUOPEN-301)
