### PR TITLE
[NUOPEN-360] Fix order management permission

### DIFF
--- a/app/models/concerns/users/roles.rb
+++ b/app/models/concerns/users/roles.rb
@@ -70,12 +70,22 @@ module Users
       user_roles.staff?(facility) || administrator?
     end
 
+    def can_act_as?(facility)
+      return false if facility.blank?
+      return true if operator_of?(facility)
+
+      @can_act_as ||= {}
+      @can_act_as.fetch(facility.id) do
+        @can_act_as[facility.id] = Ability.new(self, facility).can?(:act_as, facility)
+      end
+    end
+
     def can_override_restrictions?(product)
-      operator_of? product.facility
+      can_act_as?(product.facility)
     end
 
     def cannot_override_restrictions?(product)
-      !operator_of?(product.facility)
+      !can_override_restrictions?(product)
     end
 
     # Creates methods #purchaser_of?, #owner_of?, etc.

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -473,12 +473,12 @@ class OrderDetail < ApplicationRecord
   end
 
   def valid_as_user?(user)
-    @being_purchased_by_admin = user.operator_of?(product.facility)
+    @being_purchased_by_admin = user.can_act_as?(product.facility)
     valid?
   end
 
   def save_as_user(user)
-    @being_purchased_by_admin = user.operator_of?(product.facility)
+    @being_purchased_by_admin = user.can_act_as?(product.facility)
     save
   end
 

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -209,7 +209,7 @@ class Reservation < ApplicationRecord
   end
 
   def valid_as_user?(user)
-    if user.operator_of?(product.facility)
+    if user.can_act_as?(product.facility)
       self.reserved_by_admin = true
       valid?
     else
@@ -219,7 +219,7 @@ class Reservation < ApplicationRecord
   end
 
   def save_as_user(user)
-    if user.operator_of?(product.facility)
+    if user.can_act_as?(product.facility)
       self.reserved_by_admin = true
       save
     else

--- a/app/services/reservation_window.rb
+++ b/app/services/reservation_window.rb
@@ -30,7 +30,7 @@ class ReservationWindow
   private
 
   def operator?
-    @user.operator_of?(@reservation.facility)
+    @user.can_act_as?(@reservation.facility)
   end
 
   ##

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -924,6 +924,18 @@ RSpec.describe Reservation do
         expect(new_user_reservation.save_as_user(user)).to be_falsy
         expect(new_user_reservation.errors[:base]).to include("The reservation conflicts with another reservation.")
       end
+
+      context "with granular permissions", feature_setting: { granular_permissions: true } do
+        let(:order_management_user) { create(:user) }
+
+        before do
+          create(:facility_user_permission, user: order_management_user, facility:, order_management: true)
+        end
+
+        it "can schedule over an admin reservation if order is placed by a user with order management" do
+          expect(new_user_reservation.save_as_user(order_management_user)).to be_truthy
+        end
+      end
     end
 
     it "should be invalid" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -270,4 +270,71 @@ RSpec.describe User do
       end
     end
   end
+
+  describe "#can_act_as?" do
+    let(:user) { create(:user) }
+    let(:facility) { create(:facility) }
+
+    it "returns false without roles or permissions" do
+      expect(user.can_act_as?(facility)).to be(false)
+    end
+
+    it "returns false for a blank facility" do
+      expect(user.can_act_as?(nil)).to be(false)
+    end
+
+    context "when user is facility staff" do
+      before do
+        UserRole.grant(user, UserRole::FACILITY_STAFF, facility)
+      end
+
+      it "returns true" do
+        expect(user.can_act_as?(facility)).to be(true)
+      end
+    end
+
+    context "when user is an administrator" do
+      let(:user) { create(:user, :administrator) }
+
+      it "returns true" do
+        expect(user.can_act_as?(facility)).to be(true)
+      end
+    end
+
+    context "with granular permissions on", feature_setting: { granular_permissions: true } do
+      context "when user has order_management" do
+        before do
+          create(:facility_user_permission, user:, facility:, order_management: true)
+        end
+
+        it "returns true" do
+          expect(user.can_act_as?(facility)).to be(true)
+        end
+
+        it "returns false for another facility" do
+          expect(user.can_act_as?(create(:facility))).to be(false)
+        end
+      end
+
+      context "when user has other permissions but not order_management" do
+        before do
+          create(:facility_user_permission, user:, facility:, billing_send: true)
+        end
+
+        it "returns false" do
+          expect(user.can_act_as?(facility)).to be(false)
+        end
+      end
+    end
+
+    context "with granular permissions off", feature_setting: { granular_permissions: false } do
+      before do
+        create(:facility_user_permission, user:, facility:, order_management: true)
+      end
+
+      it "returns false" do
+        expect(user.can_act_as?(facility)).to be(false)
+      end
+    end
+  end
 end

--- a/spec/services/reservation_window_spec.rb
+++ b/spec/services/reservation_window_spec.rb
@@ -17,4 +17,40 @@ RSpec.describe ReservationWindow do
       instance.max_window
     end
   end
+
+  describe "operator window" do
+    let(:instrument) { create(:setup_instrument) }
+    let(:reservation) { create(:reservation, product: instrument) }
+    let(:instance) { described_class.new(reservation, user) }
+
+    context "when user is facility staff" do
+      let(:user) { create(:user, :staff, facility: instrument.facility) }
+
+      it "gets the operator window" do
+        expect(instance.max_window).to eq(365)
+        expect(instance.max_days_ago).to eq(-365)
+      end
+    end
+
+    context "when user has order management granular permission", feature_setting: { granular_permissions: true } do
+      let(:user) { create(:user) }
+
+      before do
+        create(:facility_user_permission, user:, facility: instrument.facility, order_management: true)
+      end
+
+      it "gets the operator window" do
+        expect(instance.max_window).to eq(365)
+        expect(instance.max_days_ago).to eq(-365)
+      end
+    end
+
+    context "when user has no roles or permissions" do
+      let(:user) { create(:user) }
+
+      it "gets the end user window" do
+        expect(instance.max_days_ago).to eq(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
  # Notes

  Users whose only access is the Order Management granular permission can now fully manage orders: editing completed orders with past reservations, ordering restricted products on behalf of users, and booking with the extended operator reservation window.
  
  [NUOPEN-360 | Order Management Permission](https://universe-of-universities.atlassian.net/browse/NUOPEN-360)

