### PR TITLE
[NUOPEN-326] Fix truncation overlap

### DIFF
--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -4,6 +4,8 @@ class PricePolicy < ApplicationRecord
 
   include Nucore::Database::DateHelper
 
+  has_paper_trail
+
   belongs_to :price_group
   belongs_to :product, optional: true
   belongs_to :created_by, class_name: "User", optional: true
@@ -22,6 +24,7 @@ class PricePolicy < ApplicationRecord
   validates :price_group_id, :type, presence: true
   validate :start_date_is_unique, if: :start_date?
   validate :expire_date_within_fiscal_year, if: :order_review_product?
+  validate :no_truncation_of_assigned_policies, on: :create, if: :start_date?
 
   validate :subsidy_less_than_rate, unless: :restrict_purchase?
 
@@ -238,16 +241,27 @@ class PricePolicy < ApplicationRecord
 
   def truncate_existing_policies
     logger.debug("Truncating existing policies")
-    existing_policies = PricePolicy.current.where(type: self.class.name,
-                                                  price_group_id: price_group_id,
-                                                  product_id: product_id)
 
-    existing_policies = existing_policies.where("id != ?", id) unless id.nil?
-
-    existing_policies.each do |policy|
+    policies_to_truncate.each do |policy|
       policy.expire_date = (start_date - 1.day).end_of_day
       policy.save
     end
+  end
+
+  def policies_to_truncate
+    existing_policies = PricePolicy.where(type: self.class.name,
+                                          price_group_id: price_group_id,
+                                          product_id: product_id)
+                                   .where("start_date <= :start_date AND expire_date >= :start_date", start_date: start_date)
+
+    existing_policies = existing_policies.where("id != ?", id) unless id.nil?
+    existing_policies
+  end
+
+  def no_truncation_of_assigned_policies
+    return unless OrderDetail.exists?(price_policy_id: policies_to_truncate.select(:id))
+
+    errors.add(:base, :overlapping_assigned_policy)
   end
 
 end

--- a/app/models/price_policy.rb
+++ b/app/models/price_policy.rb
@@ -36,6 +36,7 @@ class PricePolicy < ApplicationRecord
 
   before_save :set_default_subsidy
   before_create :truncate_existing_policies
+  before_create :extend_preceding_policy
 
   scope :for_date, ->(start_date) { where("start_date >= ? AND start_date <= ?", start_date.beginning_of_day, start_date.end_of_day) if start_date }
   scope :with_visible_price_group, -> { joins(:price_group).where(price_groups: { is_hidden: false }) }
@@ -241,11 +242,7 @@ class PricePolicy < ApplicationRecord
 
   def truncate_existing_policies
     logger.debug("Truncating existing policies")
-
-    policies_to_truncate.each do |policy|
-      policy.expire_date = (start_date - 1.day).end_of_day
-      policy.save
-    end
+    expire_before_new_policy(policies_to_truncate)
   end
 
   def policies_to_truncate
@@ -262,6 +259,26 @@ class PricePolicy < ApplicationRecord
     return unless OrderDetail.exists?(price_policy_id: policies_to_truncate.select(:id))
 
     errors.add(:base, :overlapping_assigned_policy)
+  end
+
+  # Extend the active policy to fill the gap until this one starts.
+  def extend_preceding_policy
+    preceding_policies = PricePolicy.current
+                                    .where(type: self.class.name,
+                                           price_group_id: price_group_id,
+                                           product_id: product_id)
+                                    .where("expire_date < :start_date", start_date: start_date)
+
+    preceding_policies = preceding_policies.where("id != ?", id) unless id.nil?
+
+    expire_before_new_policy(preceding_policies)
+  end
+
+  def expire_before_new_policy(policies)
+    policies.each do |policy|
+      policy.expire_date = (start_date - 1.day).end_of_day
+      policy.save
+    end
   end
 
 end

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -69,6 +69,7 @@ en:
         already_in_queue: Only one file may be in process at a time
         zero_duration: must be greater than zero
         start_after_end: must be after Ending Date
+        overlapping_assigned_policy: "cannot overlap an existing price policy that has orders assigned to it"
         # Append your own errors here or at the model/attributes scope.
       full_messages:
         format: "%{attribute} %{message}"

--- a/spec/models/price_policy_spec.rb
+++ b/spec/models/price_policy_spec.rb
@@ -180,6 +180,66 @@ RSpec.describe PricePolicy do
       end
     end
 
+    context "when an existing policy has orders assigned" do
+      def assign_order_to(price_policy)
+        order = @user.orders.create!(attributes_for(:order, created_by: @user.id, account: @account, facility: @facility))
+        order_detail = order.order_details.create!(attributes_for(:order_detail).update(product_id: @item.id, account_id: @account.id))
+        order_detail.update!(price_policy: price_policy)
+      end
+
+      it "blocks creating an overlapping policy and leaves the existing one untouched" do
+        @today = Time.zone.local(2011, 06, 06, 12, 0, 0)
+
+        travel_to_and_return(@today) do
+          @pp = create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today.beginning_of_day, expire_date: @today + 30.days)
+          assign_order_to(@pp)
+
+          overlapping = build(:item_price_policy, product: @item, price_group: @price_group, start_date: @today + 2.days, expire_date: @today + 30.days)
+
+          expect(overlapping.save).to be(false)
+          expect(overlapping.errors[:base]).to include("cannot overlap an existing price policy that has orders assigned to it")
+          expect(@pp.reload.expire_date).to eq(@today + 30.days)
+        end
+      end
+
+      it "allows creating a non-overlapping future policy" do
+        @today = Time.zone.local(2011, 06, 06, 12, 0, 0)
+
+        travel_to_and_return(@today) do
+          @pp = create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today.beginning_of_day, expire_date: @today + 30.days)
+          assign_order_to(@pp)
+
+          future = build(:item_price_policy, product: @item, price_group: @price_group, start_date: @today + 40.days, expire_date: @today + 70.days)
+
+          expect(future.save).to be(true)
+          expect(@pp.reload.expire_date).to eq(@today + 30.days)
+        end
+      end
+    end
+
+    context "auditing with PaperTrail" do
+      it "records a version when a policy is created" do
+        @today = Time.zone.local(2011, 06, 06, 12, 0, 0)
+
+        travel_to_and_return(@today) do
+          pp = create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today.beginning_of_day, expire_date: @today + 30.days)
+
+          expect(pp.versions.map(&:event)).to include("create")
+        end
+      end
+
+      it "records a version when a policy is truncated" do
+        @today = Time.zone.local(2011, 06, 06, 12, 0, 0)
+
+        travel_to_and_return(@today) do
+          @pp = create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today.beginning_of_day, expire_date: @today + 30.days)
+          create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today + 2.days, expire_date: @today + 30.days)
+
+          expect(@pp.reload.versions.map(&:event)).to include("update")
+        end
+      end
+    end
+
     context "should define abstract methods" do
 
       before :each do

--- a/spec/models/price_policy_spec.rb
+++ b/spec/models/price_policy_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe PricePolicy do
         end
       end
 
-      it "allows creating a non-overlapping future policy" do
+      it "allows creating a non-overlapping future policy and extends the preceding one to fill the gap" do
         @today = Time.zone.local(2011, 06, 06, 12, 0, 0)
 
         travel_to_and_return(@today) do
@@ -212,30 +212,62 @@ RSpec.describe PricePolicy do
           future = build(:item_price_policy, product: @item, price_group: @price_group, start_date: @today + 40.days, expire_date: @today + 70.days)
 
           expect(future.save).to be(true)
-          expect(@pp.reload.expire_date).to eq(@today + 30.days)
+          expect(@pp.reload.expire_date).to be_within(1.second).of((@today + 40.days - 1.day).end_of_day)
         end
       end
     end
 
-    context "auditing with PaperTrail" do
-      it "records a version when a policy is created" do
+    context "extending the preceding policy to keep coverage continuous" do
+      it "extends the currently-active policy up to the day before the new one starts" do
         @today = Time.zone.local(2011, 06, 06, 12, 0, 0)
 
         travel_to_and_return(@today) do
-          pp = create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today.beginning_of_day, expire_date: @today + 30.days)
+          existing = create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today.beginning_of_day, expire_date: @today + 20.days)
 
-          expect(pp.versions.map(&:event)).to include("create")
+          create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today + 40.days, expire_date: @today + 70.days)
+
+          expect(existing.reload.expire_date).to be_within(1.second).of((@today + 40.days - 1.day).end_of_day)
         end
       end
 
-      it "records a version when a policy is truncated" do
+      it "does not extend a policy beyond the new one when they overlap" do
         @today = Time.zone.local(2011, 06, 06, 12, 0, 0)
 
         travel_to_and_return(@today) do
-          @pp = create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today.beginning_of_day, expire_date: @today + 30.days)
-          create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today + 2.days, expire_date: @today + 30.days)
+          existing = create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today.beginning_of_day, expire_date: @today + 30.days)
 
-          expect(@pp.reload.versions.map(&:event)).to include("update")
+          create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today + 10.days, expire_date: @today + 30.days)
+
+          expect(existing.reload.expire_date).to be_within(1.second).of((@today + 10.days - 1.day).end_of_day)
+        end
+      end
+
+      it "does not extend policies for other products or price groups" do
+        @today = Time.zone.local(2011, 06, 06, 12, 0, 0)
+
+        travel_to_and_return(@today) do
+          other_group = create(:price_group, facility: @facility)
+          other_product_policy = create(:item_price_policy, product: @item2, price_group: @price_group, start_date: @today.beginning_of_day, expire_date: @today + 20.days)
+          other_group_policy = create(:item_price_policy, product: @item, price_group: other_group, start_date: @today.beginning_of_day, expire_date: @today + 20.days)
+
+          create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today + 40.days, expire_date: @today + 70.days)
+
+          expect(other_product_policy.reload.expire_date).to eq(@today + 20.days)
+          expect(other_group_policy.reload.expire_date).to eq(@today + 20.days)
+        end
+      end
+
+      it "does not extend the preceding policy across a fiscal year boundary" do
+        @today = Time.zone.local(2011, 06, 06, 12, 0, 0)
+
+        travel_to_and_return(@today) do
+          existing = create(:item_price_policy, product: @item, price_group: @price_group, start_date: @today.beginning_of_day, expire_date: PricePolicy.generate_expire_date(@today))
+
+          next_fiscal_year = Time.zone.local(2012, 1, 15)
+          future = build(:item_price_policy, product: @item, price_group: @price_group, start_date: next_fiscal_year, expire_date: PricePolicy.generate_expire_date(next_fiscal_year))
+
+          expect(future.save).to be(true)
+          expect(existing.reload.expire_date).to be_within(1.second).of(PricePolicy.generate_expire_date(@today))
         end
       end
     end


### PR DESCRIPTION
# Notes

  Re-applies the guard that prevents a new price policy from silently truncating an existing, currently-active policy that already has orders assigned to it (showing an error instead). This version fixes a regression from the previously reverted PR (#6252): creation is now only blocked when the new policy's date range actually overlaps an existing policy with orders, so creating a non-overlapping policy (e.g. for a future fiscal year) works again even when older policies have orders. Price policies are also audited with PaperTrail.
  
  [NUOPEN-326 | Price Policy truncation result in wrong states](https://universe-of-universities.atlassian.net/browse/NUOPEN-326)
  
