### PR TITLE
[NU-444] Notify time slot available on reservation cancel

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,9 @@ Rails/ApplicationRecord:
     - "db/migrate/*.rb"
     - "vendor/engines/*/db/migrate/*.rb"
 
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - "spec/**/*.rb"

--- a/app/controllers/order_details_controller.rb
+++ b/app/controllers/order_details_controller.rb
@@ -37,12 +37,16 @@ class OrderDetailsController < ApplicationController
     if @order_detail.reservation && @order_detail.reservation.can_cancel?
       @order_detail.transaction do
         if @order_detail.cancel_reservation(session_user)
-          CancellationMailer.notify_facility(@order_detail).deliver_later
           flash[:notice] = text("cancel.success")
         else
           flash[:error] = text("cancel.error")
           raise ActiveRecord::Rollback
         end
+      end
+
+      if @order_detail.canceled? && @order_detail.status_recently_changed
+        CancellationMailer.notify_facility(@order_detail).deliver_later
+        ProductNotifications::SlotAvailableService.from_reservation(@order_detail.reservation).notify!
       end
 
       redirect_to redirect_to_path

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -22,6 +22,8 @@ class OrderManagement::OrderDetailsController < ApplicationController
   before_action :load_accounts, only: [:edit, :update]
   before_action :load_order_statuses, only: [:edit, :update]
 
+  after_action :handle_cancelation_notification, only: :update
+
   admin_tab :all
 
   # GET /facilities/:facility_id/orders/:order_id/order_details/:id/manage
@@ -200,4 +202,9 @@ class OrderManagement::OrderDetailsController < ApplicationController
     params.dig(:order_detail, :order_status_id)
   end
 
+  def handle_cancelation_notification
+    return unless @order_detail.canceled? && @order_detail.status_recently_changed && @order_detail.reservation.present?
+
+    ProductNotifications::SlotAvailableService.from_reservation(@order_detail.reservation).notify!
+  end
 end

--- a/app/mailers/product_notification_mailer.rb
+++ b/app/mailers/product_notification_mailer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class ProductNotificationMailer < ApplicationMailer
+  ##
+  # A future time slot has become available
+  def slot_available(product, user, start_time, end_time)
+    @product = product
+    @user = user
+    @time_range = TimeRange.new(start_time, end_time)
+
+    mail(
+      to: user.email,
+      subject: text(
+        "views.product_notification_mailer.slot_available.subject",
+        product_facility: "#{product} (#{product.facility.abbreviation})",
+        time_range: @time_range,
+      ),
+    )
+  end
+end

--- a/app/mailers/product_notification_mailer.rb
+++ b/app/mailers/product_notification_mailer.rb
@@ -3,14 +3,14 @@
 class ProductNotificationMailer < ApplicationMailer
   ##
   # A future time slot has become available
-  def slot_available(product, user, start_time, end_time)
+  def slot_available(product, user, start_time, end_time, subject: nil)
     @product = product
     @user = user
     @time_range = TimeRange.new(start_time, end_time)
 
     mail(
       to: user.email,
-      subject: text(
+      subject: subject || text(
         "views.product_notification_mailer.slot_available.subject",
         product_facility: "#{product} (#{product.facility.abbreviation})",
         time_range: @time_range,

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -31,8 +31,9 @@ class Facility < ApplicationRecord
   has_many :facility_user_permissions, dependent: :destroy
   has_many :reservations, through: :instruments
   has_many :product_display_groups
-  has_many :projects, inverse_of: :facility, dependent: :destroy # Though Facilities cannot be destroyed
+  has_many :projects, inverse_of: :facility, dependent: :destroy
   has_many :estimates, inverse_of: :facility
+  has_many :product_notifications, dependent: :destroy
 
   validates_presence_of :name, :short_description, :abbreviation
   validate_url_name :url_name

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -81,6 +81,9 @@ class OrderDetail < ApplicationRecord
 
   alias_attribute :problem_description_keys, :problem_keys
 
+  # Used to track status changes side efects
+  attribute :status_recently_changed, :boolean, default: false
+
   def estimated_price_group
     estimated_price_policy.try(:price_group)
   end
@@ -424,6 +427,7 @@ class OrderDetail < ApplicationRecord
     # don't try to change status if it's the same as before
     unless new_status == order_status
       self.order_status = new_status
+      self.status_recently_changed = true
       yield(self) if block
       save!
     end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -20,6 +20,7 @@ class Product < ApplicationRecord
   has_many :training_requests, dependent: :destroy
   has_many :product_research_safety_certification_requirements
   has_many :research_safety_certificates, through: :product_research_safety_certification_requirements
+  has_and_belongs_to_many :product_notifications
   has_one :product_display_group_product
   has_one :product_display_group, through: :product_display_group_product
 

--- a/app/models/product_notification.rb
+++ b/app/models/product_notification.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ProductNotification < ApplicationRecord
+  enum :notification_type, { slot_available: "slot_available" }, default: "slot_available"
+
+  attribute :reservation_days, default: 15
+
+  belongs_to :facility
+  has_and_belongs_to_many :products
+  has_and_belongs_to_many :users
+
+  before_save :set_users_count
+
+  private
+
+  def set_users_count
+    return unless users.loaded?
+
+    self.users_count = users.length
+  end
+end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -111,16 +111,13 @@ class Reservation < ApplicationRecord
       .where("reserve_start_at < ?", end_time)
   end
 
-  def self.upcoming(t = Time.current)
-    # If this is a named scope differences emerge between Oracle & MySQL on #reserve_end_at querying.
-    # Eliminate by letting Rails filter by #reserve_end_at
+  def self.upcoming(time_from = Time.current)
     joins("LEFT JOIN order_details ON order_details.id = reservations.order_detail_id")
       .joins("LEFT JOIN orders ON orders.id = order_details.order_id")
       .not_canceled
       .where("orders.state" => [nil, "purchased"])
+      .where(reserve_end_at: time_from...)
       .order(reserve_end_at: :asc)
-      .to_a
-      .delete_if { |reservation| reservation.reserve_end_at < t }
   end
 
   def self.overlapping(start_at, end_at)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,7 @@ class User < ApplicationRecord
   has_many :file_uploads, class_name: "StoredFile" # accessed in the UI on the user's Docs tab
   has_many :log_events, as: :loggable
   has_many :user_preferences, dependent: :destroy
+  has_and_belongs_to_many :product_notifications
 
   validates_presence_of :username, :first_name, :last_name
 

--- a/app/services/product_notifications/slot_available_service.rb
+++ b/app/services/product_notifications/slot_available_service.rb
@@ -23,25 +23,18 @@ module ProductNotifications
     end
 
     def notify!
-      recipients.find_each do |user|
-        ProductNotificationMailer.slot_available(
-          product, user, start_time, end_time
-        ).deliver_later
+      product_notifications.find_each do |product_notification|
+        product_notification.users.where.not(id: exclude_user&.id).find_each do |user|
+          ProductNotificationMailer.slot_available(
+            product, user,
+            start_time, end_time,
+            subject: product_notification.email_subject,
+          ).deliver_later
+        end
       end
     end
 
     private
-
-    def recipients
-      return User.none if product_notifications.blank?
-
-      user_ids =
-        product_notifications
-        .joins("INNER JOIN product_notifications_users")
-        .select(:user_id)
-
-      User.where(id: user_ids).where.not(id: exclude_user&.id)
-    end
 
     def product_notifications
       product

--- a/app/services/product_notifications/slot_available_service.rb
+++ b/app/services/product_notifications/slot_available_service.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module ProductNotifications
+  ##
+  # Notify users that a time slot is available for an instrument.
+  class SlotAvailableService
+    attr_reader :product, :start_time, :end_time, :exclude_user
+
+    def self.from_reservation(reservation)
+      new(
+        reservation.order_detail.product,
+        reservation.reserve_start_at,
+        reservation.reserve_end_at,
+        exclude_user: reservation.order_detail.user,
+      )
+    end
+
+    def initialize(product, start_time, end_time, exclude_user: nil)
+      @product = product
+      @start_time = start_time
+      @end_time = end_time
+      @exclude_user = exclude_user
+    end
+
+    def notify!
+      recipients.find_each do |user|
+        ProductNotificationMailer.slot_available(
+          product, user, start_time, end_time
+        ).deliver_later
+      end
+    end
+
+    private
+
+    def recipients
+      return User.none if product_notifications.blank?
+
+      user_ids =
+        product_notifications
+        .joins("INNER JOIN product_notifications_users")
+        .select(:user_id)
+
+      User.where(id: user_ids).where.not(id: exclude_user&.id)
+    end
+
+    def product_notifications
+      product
+        .product_notifications
+        .slot_available
+        .where(reservation_days: slot_start_in_days..)
+    end
+
+    def slot_start_in_days
+      ((start_time - Time.current) / 1.day).floor
+    end
+  end
+end

--- a/app/views/product_notification_mailer/slot_available.html.haml
+++ b/app/views/product_notification_mailer/slot_available.html.haml
@@ -1,0 +1,7 @@
+= html("body",
+  user_name: @user.full_name,
+  new_reservation_url: new_facility_instrument_single_reservation_url(@product.facility, @product),
+  time_range: @time_range,
+  product: @product,
+  facility: @product.facility,
+)

--- a/app/views/product_notification_mailer/slot_available.txt.erb
+++ b/app/views/product_notification_mailer/slot_available.txt.erb
@@ -1,0 +1,7 @@
+<%= text("body",
+  user_name: @user.full_name,
+  new_reservation_url: new_facility_instrument_single_reservation_url(@product.facility, @product),
+  time_range: @time_range,
+  product: @product,
+  facility: @product.facility)
+%>

--- a/config/locales/views/en.product_notification_mailer.yml
+++ b/config/locales/views/en.product_notification_mailer.yml
@@ -2,7 +2,7 @@ en:
   views:
     product_notification_mailer:
       slot_available:
-        subject: "!app_name! - New availability %{product_facility} - %{time_range}"
+        subject: "!app_name! New availability for %{product_facility} - %{time_range}"
         body: |
           Hello %{user_name},
 

--- a/config/locales/views/en.product_notification_mailer.yml
+++ b/config/locales/views/en.product_notification_mailer.yml
@@ -1,0 +1,11 @@
+en:
+  views:
+    product_notification_mailer:
+      slot_available:
+        subject: "!app_name! - New availability %{product_facility} - %{time_range}"
+        body: |
+          Hello %{user_name},
+
+          Time slot %{time_range} became available for %{product} at %{facility}.
+
+          [Make a reservation](%{new_reservation_url})

--- a/db/migrate/20260529130915_create_product_notifications.rb
+++ b/db/migrate/20260529130915_create_product_notifications.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateProductNotifications < ActiveRecord::Migration[8.0]
+  def change
+    create_table :product_notifications do |t|
+      t.references :facility, null: false
+      t.string :name
+      t.string :notification_type, null: false
+      t.integer :users_count, null: false, default: 0
+      t.integer :reservation_days
+
+      t.timestamps
+    end
+
+    create_join_table :product_notifications, :products do |t|
+      t.index :product_notification_id
+      t.index :product_id
+    end
+    create_join_table :product_notifications, :users do |t|
+      t.index :product_notification_id
+      t.index :user_id
+    end
+  end
+end

--- a/db/migrate/20260529130915_create_product_notifications.rb
+++ b/db/migrate/20260529130915_create_product_notifications.rb
@@ -5,6 +5,7 @@ class CreateProductNotifications < ActiveRecord::Migration[8.0]
     create_table :product_notifications do |t|
       t.references :facility, null: false
       t.string :name
+      t.string :email_subject
       t.string :notification_type, null: false
       t.integer :users_count, null: false, default: 0
       t.integer :reservation_days

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -674,6 +674,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_08_125147) do
   create_table "product_notifications", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "facility_id", null: false
     t.string "name"
+    t.string "email_subject"
     t.string "notification_type", null: false
     t.integer "users_count", default: 0, null: false
     t.integer "reservation_days"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -671,6 +671,31 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_08_125147) do
     t.index ["facility_id"], name: "index_product_display_groups_on_facility_id"
   end
 
+  create_table "product_notifications", charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "facility_id", null: false
+    t.string "name"
+    t.string "notification_type", null: false
+    t.integer "users_count", default: 0, null: false
+    t.integer "reservation_days"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["facility_id"], name: "index_product_notifications_on_facility_id"
+  end
+
+  create_table "product_notifications_products", id: false, charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "product_notification_id", null: false
+    t.bigint "product_id", null: false
+    t.index ["product_id"], name: "index_product_notifications_products_on_product_id"
+    t.index ["product_notification_id"], name: "idx_on_product_notification_id_e060f366ad"
+  end
+
+  create_table "product_notifications_users", id: false, charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "product_notification_id", null: false
+    t.bigint "user_id", null: false
+    t.index ["product_notification_id"], name: "index_product_notifications_users_on_product_notification_id"
+    t.index ["user_id"], name: "index_product_notifications_users_on_user_id"
+  end
+
   create_table "product_user_imports", charset: "utf8mb3", force: :cascade do |t|
     t.string "file_file_name"
     t.string "file_content_type"

--- a/spec/mailers/product_notification_mailer_spec.rb
+++ b/spec/mailers/product_notification_mailer_spec.rb
@@ -9,15 +9,28 @@ RSpec.describe ProductNotificationMailer do
     let(:user) { create(:user) }
     let(:start_time) { 1.hour.from_now }
     let(:end_time) { start_time + 30.minutes }
-    let(:email) do
+    let(:subject) { nil }
+    let(:mail) do
       described_class.slot_available(
-        product, user, start_time, end_time,
+        product, user, start_time, end_time, subject:,
       )
     end
 
     it "includes new reservation link" do
-      expect(email.to).to eq [user.email]
-      expect(email.body).to include(new_facility_instrument_single_reservation_path(facility, product))
+      expect(mail.to).to eq [user.email]
+      expect(mail.body).to include(new_facility_instrument_single_reservation_path(facility, product))
+    end
+
+    describe "subject" do
+      it "handles subject by default" do
+        expect(mail.subject).to include("New availability for #{product.name}")
+      end
+
+      context "can override subject" do
+        let(:mail_subject) { "Some subject" }
+
+        it { expect(mail.subject).to eq(mail_subject) }
+      end
     end
   end
 end

--- a/spec/mailers/product_notification_mailer_spec.rb
+++ b/spec/mailers/product_notification_mailer_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProductNotificationMailer do
+  describe "slot_available" do
+    let(:product) { create(:setup_instrument) }
+    let(:facility) { product.facility }
+    let(:user) { create(:user) }
+    let(:start_time) { 1.hour.from_now }
+    let(:end_time) { start_time + 30.minutes }
+    let(:email) do
+      described_class.slot_available(
+        product, user, start_time, end_time,
+      )
+    end
+
+    it "includes new reservation link" do
+      expect(email.to).to eq [user.email]
+      expect(email.body).to include(new_facility_instrument_single_reservation_path(facility, product))
+    end
+  end
+end

--- a/spec/mailers/product_notification_mailer_spec.rb
+++ b/spec/mailers/product_notification_mailer_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe ProductNotificationMailer do
     let(:user) { create(:user) }
     let(:start_time) { 1.hour.from_now }
     let(:end_time) { start_time + 30.minutes }
-    let(:subject) { nil }
+    let(:mail_subject) { nil }
     let(:mail) do
       described_class.slot_available(
-        product, user, start_time, end_time, subject:,
+        product, user, start_time, end_time, subject: mail_subject,
       )
     end
 

--- a/spec/requests/order_details_spec.rb
+++ b/spec/requests/order_details_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "order_details" do
+  describe "cancel" do
+    let(:product) { create(:setup_instrument) }
+    let(:facility) { product.facility }
+    let(:user) { create(:user) }
+    let(:reservation) do
+      create(:purchased_reservation, product:, user:)
+    end
+    let(:order_detail) { reservation.order_detail }
+    let(:order) { order_detail.order }
+
+    let(:action) do
+      lambda do
+        put cancel_order_order_detail_path(order, order_detail)
+      end
+    end
+
+    before { login_as(user) }
+
+    it "calls slot available service" do
+      expect(ProductNotifications::SlotAvailableService).to(
+        receive(:new).and_call_original
+      )
+
+      action.call
+    end
+
+    context "when already canceled" do
+      before do
+        order_detail.cancel_reservation(user)
+      end
+
+      it "does not call slot available service" do
+        expect(ProductNotifications::SlotAvailableService).not_to(
+          receive(:new).and_call_original
+        )
+
+        action.call
+      end
+    end
+  end
+end

--- a/spec/requests/order_management/order_details_spec.rb
+++ b/spec/requests/order_management/order_details_spec.rb
@@ -2,11 +2,107 @@
 
 require "rails_helper"
 
-RSpec.describe "order_management/order_details", type: :request do
+RSpec.describe "order_management/order_details" do
   let(:facility) { create(:setup_facility) }
   let(:product) { create(:setup_service, facility:) }
   let(:order) { create(:purchased_order, product:) }
   let(:order_detail) { order.order_details.last }
+
+  describe "mark as canceled" do
+    let(:params) do
+      {
+        order_detail: {
+          id: order_detail.id,
+          order_status_id: OrderStatus.canceled.id,
+        }
+      }
+    end
+    let(:update_action) do
+      lambda do
+        put(
+          manage_facility_order_order_detail_path(facility, order, order_detail),
+          params:
+        )
+      end
+    end
+
+    before { login_as create(:user, :administrator) }
+
+    it "changes the order status" do
+      expect { update_action.call }.to(
+        change do
+          order_detail.reload.order_status
+        end.from(OrderStatus.new_status).to(OrderStatus.canceled)
+      )
+    end
+
+    it "does not call slot available service" do
+      expect(ProductNotifications::SlotAvailableService).not_to(
+        receive(:new)
+      )
+
+      update_action.call
+    end
+
+    context "when order detail has a reservation" do
+      let(:product) { create(:setup_instrument, facility:) }
+      let(:reservation) do
+        create(:purchased_reservation, product:, user: create(:user))
+      end
+      let(:order_detail) { reservation.order_detail }
+      let(:order) { order_detail.order }
+
+      it "calls slot available service when canceled" do
+        expect(ProductNotifications::SlotAvailableService).to(
+          receive(:new).and_call_original
+        )
+
+        update_action.call
+      end
+
+      context "when marked as in progress" do
+        let(:params) do
+          {
+            order_detail: {
+              id: order_detail.id,
+              order_status_id: OrderStatus.in_process.id,
+            }
+          }
+        end
+
+        it "does not call the slot available service" do
+          expect(ProductNotifications::SlotAvailableService).not_to(
+            receive(:new)
+          )
+
+          update_action.call
+        end
+      end
+
+      context "when already canceled" do
+        let(:params) do
+          {
+            order_detail: {
+              id: order_detail.id,
+              notes: "Some note",
+            }
+          }
+        end
+
+        before do
+          order_detail.update_order_status!(create(:user), OrderStatus.canceled)
+        end
+
+        it "does not call slot available service" do
+          expect(ProductNotifications::SlotAvailableService).not_to(
+            receive(:new)
+          )
+
+          update_action.call
+        end
+      end
+    end
+  end
 
   describe "mark as unrecoverable" do
     let(:params) do

--- a/spec/services/product_notifications/slot_available_service_spec.rb
+++ b/spec/services/product_notifications/slot_available_service_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProductNotifications::SlotAvailableService do
+  let(:product) { create(:setup_instrument) }
+  let(:facility) { product.facility }
+
+  let(:start_time) { 1.day.from_now }
+  let(:end_time) { start_time + 30.minutes }
+
+  subject { described_class.new(product, start_time, end_time) }
+
+  context "when product notification slot available no set" do
+    it "does not call the mailer" do
+      expect(ProductNotificationMailer).not_to receive(:slot_available)
+
+      subject.notify!
+    end
+  end
+
+  context "when product notification slot available set" do
+    let(:some_user) { create(:user) }
+    let(:reservation_user) { create(:user) }
+    let(:product_notification) do
+      ProductNotification.create!(
+        facility:,
+        notification_type: :slot_available,
+      )
+    end
+
+    before do
+      create(:purchased_reservation, product:, user: reservation_user)
+
+      product_notification.products << product
+      product_notification.users << [some_user, reservation_user]
+    end
+
+    it "notifies some user from upcoming reservations" do
+      expect { subject.notify! }.to(
+        have_enqueued_mail(
+          ProductNotificationMailer,
+          :slot_available,
+        ).with(product, some_user, start_time, end_time)
+      )
+    end
+
+    it "notifies reservation user from upcoming reservations" do
+      expect { subject.notify! }.to(
+        have_enqueued_mail(
+          ProductNotificationMailer,
+          :slot_available,
+        ).with(product, reservation_user, start_time, end_time)
+      )
+    end
+
+    it "enqueues exactly two emails" do
+      expect { subject.notify! }.to(
+        have_enqueued_mail(ProductNotificationMailer, :slot_available).exactly(2)
+      )
+    end
+
+    context "when upcoming reservation user excluded" do
+      subject do
+        described_class.new(
+          product, start_time, end_time,
+          exclude_user: reservation_user,
+        )
+      end
+
+      it "notifies some_user" do
+        expect { subject.notify! }.to(
+          have_enqueued_mail(
+            ProductNotificationMailer,
+            :slot_available,
+          ).with(product, some_user, start_time, end_time)
+        )
+      end
+
+      it "enqueue one email" do
+        expect { subject.notify! }.to(
+          have_enqueued_mail(ProductNotificationMailer, :slot_available).exactly(1)
+        )
+      end
+    end
+  end
+end

--- a/spec/services/product_notifications/slot_available_service_spec.rb
+++ b/spec/services/product_notifications/slot_available_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ProductNotifications::SlotAvailableService do
         have_enqueued_mail(
           ProductNotificationMailer,
           :slot_available,
-        ).with(product, some_user, start_time, end_time)
+        ).with(product, some_user, start_time, end_time, subject: nil)
       )
     end
 
@@ -50,7 +50,7 @@ RSpec.describe ProductNotifications::SlotAvailableService do
         have_enqueued_mail(
           ProductNotificationMailer,
           :slot_available,
-        ).with(product, reservation_user, start_time, end_time)
+        ).with(product, reservation_user, start_time, end_time, subject: nil)
       )
     end
 
@@ -58,6 +58,23 @@ RSpec.describe ProductNotifications::SlotAvailableService do
       expect { subject.notify! }.to(
         have_enqueued_mail(ProductNotificationMailer, :slot_available).exactly(2)
       )
+    end
+
+    context "when email subject is specified" do
+      let(:email_subject) { "Some subject" }
+
+      before do
+        product_notification.update(email_subject:)
+      end
+
+      it "pass the subject to the mailer" do
+        expect { subject.notify! }.to(
+          have_enqueued_mail(
+            ProductNotificationMailer,
+            :slot_available,
+          ).with(product, some_user, start_time, end_time, subject: email_subject)
+        )
+      end
     end
 
     context "when upcoming reservation user excluded" do
@@ -73,7 +90,7 @@ RSpec.describe ProductNotifications::SlotAvailableService do
           have_enqueued_mail(
             ProductNotificationMailer,
             :slot_available,
-          ).with(product, some_user, start_time, end_time)
+          ).with(product, some_user, start_time, end_time, subject: nil)
         )
       end
 


### PR DESCRIPTION
# Notes

Add `ProductNotification` model and use it to trigger notifications on reservation cancel.

Part of [NU-444 | An automatic email that would notify user of canceled reservations.](https://universe-of-universities.atlassian.net/browse/NU-444).

