### PR TITLE
[NUOPEN-359] Allow product_pricing permission to manage price groups

### DIFF
--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -139,6 +139,8 @@ class NavTab::LinkCollection
       NavTab::Link.new(tab: :admin_facility, url: manage_facility_path(facility))
     elsif single_facility? && ability.can?(:manage, FacilityUserPermission)
       NavTab::Link.new(tab: :admin_facility, url: facility_facility_users_path(facility))
+    elsif single_facility? && ability.can?(:manage, PriceGroupDiscount)
+      NavTab::Link.new(tab: :admin_facility, url: facility_price_groups_path(facility))
     end
   end
 

--- a/app/views/admin/shared/_sidenav_admin.html.haml
+++ b/app/views/admin/shared/_sidenav_admin.html.haml
@@ -3,7 +3,8 @@
     = tab t("shared.sidenav_admin.overview"), manage_facility_path(current_facility), sidenav_tab == "overview"
     = tab FacilityAccount.model_name.human(count: 2), facility_facility_accounts_path(current_facility), sidenav_tab == "recharge_accounts"
   = tab text("facility_users.title"), facility_facility_users_path(current_facility), sidenav_tab == "staff"
-  - if can?(:edit, current_facility)
+  - if can?(:edit, current_facility) || can?(:manage, PriceGroupDiscount)
     = tab PriceGroup.model_name.human(count: 2), facility_price_groups_path(current_facility), sidenav_tab == "price_groups"
+  - if can?(:edit, current_facility)
     = tab OrderStatus.model_name.human(count: 2), facility_order_statuses_path(current_facility), sidenav_tab == "statuses"
   = render_view_hook "last", sidenav_tab: sidenav_tab

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -691,6 +691,20 @@ RSpec.describe Ability do
       it { is_expected.not_to be_allowed_to(:create_daily_booking, Product) }
     end
 
+    context "with product_pricing" do
+      before do
+        FacilityUserPermission.find_by(user:, facility:).update!(product_pricing: true)
+      end
+
+      it { is_expected.to be_allowed_to(:manage, PriceGroup) }
+      it { is_expected.to be_allowed_to(:manage, PriceGroupProduct) }
+      it { is_expected.to be_allowed_to(:manage, PriceGroupDiscount) }
+      it_is_allowed_to([:create, :update, :destroy], PricePolicy)
+      it_is_allowed_to([:create, :update, :destroy], InstrumentPricePolicy)
+      it_is_allowed_to([:create, :update, :destroy], ItemPricePolicy)
+      it_is_allowed_to([:create, :update, :destroy], ServicePricePolicy)
+    end
+
     context "with order_management" do
       before do
         FacilityUserPermission.find_by(user:, facility:).update!(order_management: true)


### PR DESCRIPTION
# Notes
* Allow product_pricing permission to manage price groups
[NUOPEN-359 | Product Pricing Permissions ](https://universe-of-universities.atlassian.net/browse/NUOPEN-359)

# Screenshot
## Before
<img width="1173" height="103" alt="image" src="https://github.com/user-attachments/assets/c5f910f9-ab30-439e-b595-2bee7b31e942" />

## After
<img width="1189" height="694" alt="image" src="https://github.com/user-attachments/assets/229d5efd-4d83-46ad-821f-33cca5106068" />

