### PR TITLE
[NUOPEN-358] Rename prodcut edition label

### DIFF
--- a/app/javascript/facility_user_permission_form.js
+++ b/app/javascript/facility_user_permission_form.js
@@ -6,9 +6,9 @@
  *   Checking another permission auto-checks Read Access and locks it
  *   (visually disabled and unclickable). When all other permissions
  *   are unchecked, Read Access becomes editable again.
- * - Granting Product Creation implies Product Edition. Checking Product
- *   Creation auto-checks Product Edition and locks it. Unchecking Product
- *   Creation releases the lock (Product Edition keeps its current state).
+ * - Granting Product Creation implies Product Editing. Checking Product
+ *   Creation auto-checks Product Editing and locks it. Unchecking Product
+ *   Creation releases the lock (Product Editing keeps its current state).
  */
 $(document).ready(function() {
   const readAccessCheckbox = $(".js--readAccessCheckbox");

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -311,7 +311,7 @@ en:
         order_management: Order Management
         price_adjustment: Price Adjustment
         product_creation: Product Creation
-        product_edition: Product Edition
+        product_edition: Product Editing
         product_pricing: Product Pricing
         project_management: Project Management
         quoting: Quoting


### PR DESCRIPTION
# Notes

  Renames the "Product Edition" facility user permission label to "Product Editing" in the permissions UI, so it reads as the action of editing products rather than a version/release of something.
  
  [NUOPEN-358 | Product Creation Permission](https://universe-of-universities.atlassian.net/browse/NUOPEN-358)
