### PR TITLE
[NUOPEN-367] Add missing permission for Facility Admins

### DIFF
--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -200,6 +200,7 @@ class Ability
     if resource.is_a?(Facility) && user.facility_administrator_of?(resource)
       manager_abilities_for_facility(user, resource, controller)
       can :manage, PriceGroup
+      can :manage, PriceGroupDiscount
       can :manage, [PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ServicePricePolicy]
     end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -276,6 +276,7 @@ RSpec.describe Ability do
     it_is_allowed_to([:batch_update, :cancel, :index], Reservation)
     it { is_expected.to be_allowed_to(:administer, User) }
     it { is_expected.to be_allowed_to(:manage, PriceGroup) }
+    it { is_expected.to be_allowed_to(:manage, PriceGroupDiscount) }
     it { is_expected.to be_allowed_to(:manage, ScheduleRule) }
     it { is_expected.to be_allowed_to(:manage, ProductAccessGroup) }
     it_is_not_allowed_to([:edit, :update]) { FactoryBot.create(:user) }


### PR DESCRIPTION
# Notes
* Add missing permission for Facility Admins

[NUOPEN-367 | Scheduling Discounts does not work for Facility Administrators ](https://universe-of-universities.atlassian.net/browse/NUOPEN-367)
