### PR TITLE
[NU-444] Product notifications add/edit

### DIFF
--- a/app/controllers/facility_product_notifications_controller.rb
+++ b/app/controllers/facility_product_notifications_controller.rb
@@ -67,13 +67,20 @@ class FacilityProductNotificationsController < ApplicationController
   private
 
   def load_instruments
-    @instruments = current_facility.products.active.not_archived.of_type("Instrument").alphabetized
+    @instruments =
+      current_facility
+      .products
+      .active
+      .not_archived
+      .of_type(Instrument)
+      .alphabetized
   end
 
   def facility_product_notification_params
     params.require(:product_notification).permit(
       :name,
       :reservation_days,
+      :email_subject,
       user_ids: [],
       product_ids: [],
     ).merge(facility_id: current_facility.id)

--- a/app/controllers/facility_product_notifications_controller.rb
+++ b/app/controllers/facility_product_notifications_controller.rb
@@ -12,6 +12,8 @@ class FacilityProductNotificationsController < ApplicationController
     class: ProductNotification,
   )
 
+  before_action :load_instruments, only: [:new, :edit]
+
   def show
   end
 
@@ -22,9 +24,9 @@ class FacilityProductNotificationsController < ApplicationController
   def create
     if @product_notification.save
       flash[:notice] = t(".success")
-      redirect_to :show
+      redirect_to action: :show, id: @product_notification
     else
-      flash[:error] = t(".error")
+      flash.now[:error] = t(".error")
       render :new
     end
   end
@@ -33,9 +35,9 @@ class FacilityProductNotificationsController < ApplicationController
   end
 
   def update
-    if @product_notification.update(product_notification_params)
+    if @product_notification.update(facility_product_notification_params)
       flash[:notice] = t(".success")
-      redirect_to :show
+      redirect_to action: :show
     else
       flash.now[:error] = t(".error")
       render :edit
@@ -53,16 +55,27 @@ class FacilityProductNotificationsController < ApplicationController
   def destroy
     @product_notification.destroy
     flash[:notice] = t(".success")
-    redirect_to :index
+    redirect_to action: :index
+  end
+
+  # TODO: Check permissions and Users that can be searched
+  def user_search
+    @users = UserFinder.search(params[:search_term], limit: 25)
+    render partial: "user_search_results", layout: false
   end
 
   private
 
-  def product_notification_params
+  def load_instruments
+    @instruments = current_facility.products.active.not_archived.of_type("Instrument").alphabetized
+  end
+
+  def facility_product_notification_params
     params.require(:product_notification).permit(
+      :name,
       :reservation_days,
-      :user_ids,
-      :product_ids,
+      user_ids: [],
+      product_ids: [],
     ).merge(facility_id: current_facility.id)
   end
 end

--- a/app/controllers/facility_product_notifications_controller.rb
+++ b/app/controllers/facility_product_notifications_controller.rb
@@ -60,9 +60,12 @@ class FacilityProductNotificationsController < ApplicationController
     redirect_to action: :index
   end
 
-  # TODO: Check permissions and Users that can be searched
   def user_search
-    @users = UserFinder.search(params[:search_term], limit: 25)
+    @users = UserFinder.search(
+      params[:search_term],
+      limit: 10,
+      actives_only: true,
+    )
     render partial: "user_search_results", layout: false
   end
 

--- a/app/controllers/facility_product_notifications_controller.rb
+++ b/app/controllers/facility_product_notifications_controller.rb
@@ -27,6 +27,7 @@ class FacilityProductNotificationsController < ApplicationController
       redirect_to action: :show, id: @product_notification
     else
       flash.now[:error] = t(".error")
+      load_instruments
       render :new
     end
   end
@@ -40,6 +41,7 @@ class FacilityProductNotificationsController < ApplicationController
       redirect_to action: :show
     else
       flash.now[:error] = t(".error")
+      load_instruments
       render :edit
     end
   end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,5 +1,6 @@
 import { Application } from "@hotwired/stimulus";
 import NewBulkImportController from "./new_bulk_import_controller";
+import UserSearchController from "./user_search_controller";
 
 const application = Application.start();
 
@@ -7,5 +8,6 @@ application.debug = false;
 window.Stimulus = application;
 
 application.register("new-bulk-import", NewBulkImportController);
+application.register("user-search", UserSearchController);
 
 export { application };

--- a/app/javascript/controllers/user_search_controller.js
+++ b/app/javascript/controllers/user_search_controller.js
@@ -4,16 +4,23 @@ export default class extends Controller {
   static targets = ["searchInput", "searchResults", "selectedUsers"]
   static values = { searchUrl: String }
 
+  connect() {
+    this.searchInputTarget.addEventListener(
+      "keydown",
+      this.maybeSubmitSearch.bind(this),
+    )
+  }
+
   search() {
     const term = this.searchInputTarget.value.trim()
     if (term.length === 0) return
 
-    const resultsUrl = `${this.searchUrlValue}?search_term=${encodeURIComponent(term)}`;
-    this.searchResultsTarget.src = resultsUrl;
+    const resultsUrl = `${this.searchUrlValue}?search_term=${encodeURIComponent(term)}`
+    this.searchResultsTarget.src = resultsUrl
   }
 
   addUser({ target } = event) {
-    if (this.selectedIds.includes(target.dataset.userId)) { return; }
+    if (this.selectedIds.includes(target.dataset.userId)) { return }
 
     const li = event.currentTarget.closest("li")
     const input = li.querySelector("input")
@@ -36,5 +43,12 @@ export default class extends Controller {
     return [...this.selectedUsersTarget.querySelectorAll("li")].map(
       li => li.dataset.userId
     )
+  }
+
+  maybeSubmitSearch(event) {
+    if (event.key === "Enter") {
+      event.preventDefault()
+      this.search()
+    }
   }
 }

--- a/app/javascript/controllers/user_search_controller.js
+++ b/app/javascript/controllers/user_search_controller.js
@@ -1,0 +1,40 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["searchInput", "searchResults", "selectedUsers"]
+  static values = { searchUrl: String }
+
+  search() {
+    const term = this.searchInputTarget.value.trim()
+    if (term.length === 0) return
+
+    const resultsUrl = `${this.searchUrlValue}?search_term=${encodeURIComponent(term)}`;
+    this.searchResultsTarget.src = resultsUrl;
+  }
+
+  addUser({ target } = event) {
+    if (this.selectedIds.includes(target.dataset.userId)) { return; }
+
+    const li = event.currentTarget.closest("li")
+    const input = li.querySelector("input")
+    const addBtn = li.querySelector("button")
+
+    input.disabled = false
+    addBtn.classList.remove("btn-primary")
+    addBtn.classList.add("btn-danger")
+    addBtn.textContent = addBtn.dataset.removeLabel || "Remove"
+    addBtn.dataset.action = "click->user-search#removeUser"
+
+    this.selectedUsersTarget.appendChild(li)
+  }
+
+  removeUser(event) {
+    event.currentTarget.closest("li").remove()
+  }
+
+  get selectedIds() {
+    return [...this.selectedUsersTarget.querySelectorAll("li")].map(
+      li => li.dataset.userId
+    )
+  }
+}

--- a/app/javascript/controllers/user_search_controller.js
+++ b/app/javascript/controllers/user_search_controller.js
@@ -19,12 +19,12 @@ export default class extends Controller {
     this.searchResultsTarget.src = resultsUrl
   }
 
-  addUser({ target } = event) {
+  addUser({ target } = _event) {
     if (this.selectedIds.includes(target.dataset.userId)) { return }
 
-    const li = event.currentTarget.closest("li")
+    const li = target.closest("li")
     const input = li.querySelector("input")
-    const addBtn = li.querySelector("button")
+    const addBtn = target
 
     input.disabled = false
     addBtn.classList.remove("btn-primary")
@@ -35,8 +35,8 @@ export default class extends Controller {
     this.selectedUsersTarget.appendChild(li)
   }
 
-  removeUser(event) {
-    event.currentTarget.closest("li").remove()
+  removeUser({ target } = _event) {
+    target.closest("li").remove()
   }
 
   get selectedIds() {

--- a/app/presenters/product_notification_presenter.rb
+++ b/app/presenters/product_notification_presenter.rb
@@ -10,7 +10,7 @@ class ProductNotificationPresenter < SimpleDelegator
       name,
       notification_type_human,
       "#{users_count} Users"
-    ].compact.join(" • ")
+    ].compact_blank.join(" • ")
   end
 
   def product_names

--- a/app/views/facility_product_notifications/_form.html.haml
+++ b/app/views/facility_product_notifications/_form.html.haml
@@ -1,4 +1,8 @@
 = form.input :name
+= form.input :notification_type,
+  disabled: true,
+  hint: t(".hints.#{form.object.notification_type}"),
+  input_html: { value: ProductNotification.human_attribute_name("notification_type.#{form.object.notification_type}") }
 = form.input :reservation_days
 
 %h4= ProductNotification.human_attribute_name(:products)

--- a/app/views/facility_product_notifications/_form.html.haml
+++ b/app/views/facility_product_notifications/_form.html.haml
@@ -4,6 +4,7 @@
   hint: t(".hints.#{form.object.notification_type}"),
   input_html: { value: ProductNotification.human_attribute_name("notification_type.#{form.object.notification_type}") }
 = form.input :reservation_days, hint: t(".hints.reservation_days")
+= form.input :email_subject, hint: t(".hints.email_subject")
 
 %h4= ProductNotification.human_attribute_name(:products)
 

--- a/app/views/facility_product_notifications/_form.html.haml
+++ b/app/views/facility_product_notifications/_form.html.haml
@@ -3,7 +3,7 @@
   disabled: true,
   hint: t(".hints.#{form.object.notification_type}"),
   input_html: { value: ProductNotification.human_attribute_name("notification_type.#{form.object.notification_type}") }
-= form.input :reservation_days
+= form.input :reservation_days, hint: t(".hints.reservation_days")
 
 %h4= ProductNotification.human_attribute_name(:products)
 

--- a/app/views/facility_product_notifications/_form.html.haml
+++ b/app/views/facility_product_notifications/_form.html.haml
@@ -1,0 +1,43 @@
+= form.input :name
+= form.input :reservation_days
+
+%h4= ProductNotification.human_attribute_name(:products)
+
+= form.input :product_ids,
+  collection: @instruments,
+  label: false,
+  input_html: { class: "js--chosen", multiple: true, data: { placeholder: t(".select_products_hint") } }
+
+%h4= ProductNotification.human_attribute_name(:users)
+
+%p.text-muted= t(".select_users_hint")
+
+.well{ data: { controller: "user-search",
+               user_search_search_url_value: user_search_facility_product_notifications_path(current_facility) } }
+  .input-group
+    = text_field_tag :search_term, nil,
+      class: "form-control",
+      placeholder: t(".search_users_placeholder"),
+      data: { user_search_target: "searchInput" }
+    .input-group-btn
+      %button.btn.btn-default{ type: "button", data: { action: "click->user-search#search" } }
+        = t(".search_users")
+
+  %div
+    = render "user_search_results"
+
+  %div
+    %strong= t(".selected_users")
+
+  %ul.list-unstyled{ data: { user_search_target: "selectedUsers" } }
+    = hidden_field_tag "product_notification[user_ids][]"
+    - form.object.users.each do |user|
+      %li.list-group-item{ data: { user_id: user.id } }
+        %span= "#{user.name} (#{user.username})"
+        = hidden_field_tag "product_notification[user_ids][]", user.id
+        %button.btn.btn-xs.btn-danger.pull-right{ type: "button", data: { action: "click->user-search#removeUser" } }
+          = t(".remove")
+
+.actions
+  = form.button :submit, class: "btn-primary"
+  = link_to t("shared.cancel"), :back, class: "btn btn-default"

--- a/app/views/facility_product_notifications/_form.html.haml
+++ b/app/views/facility_product_notifications/_form.html.haml
@@ -18,14 +18,13 @@
 
 .well{ data: { controller: "user-search",
                user_search_search_url_value: user_search_facility_product_notifications_path(current_facility) } }
-  .input-group
+  %p
     = text_field_tag :search_term, nil,
       class: "form-control",
       placeholder: t(".search_users_placeholder"),
       data: { user_search_target: "searchInput" }
-    .input-group-btn
-      %button.btn.btn-default{ type: "button", data: { action: "click->user-search#search" } }
-        = t(".search_users")
+    %button.btn.btn-default{ type: "button", data: { action: "click->user-search#search" } }
+      = t("shared.search")
 
   %div
     = render "user_search_results"

--- a/app/views/facility_product_notifications/_user_search_results.html.haml
+++ b/app/views/facility_product_notifications/_user_search_results.html.haml
@@ -1,0 +1,14 @@
+= turbo_frame_tag("user-search-result", data: { user_search_target: "searchResults" }) do
+  - if @users.blank?
+    %p.text-muted= t(".no_results")
+  - else
+    %ul.list-unstyled
+      - @users.each do |user|
+        %li.list-group-item{ data: { user_id: user.id } }
+          %span= "#{user.name} (#{user.username})"
+          = hidden_field_tag "product_notification[user_ids][]", user.id, disabled: true
+          %button.btn.btn-xs.btn-primary.pull-right{ type: "button",
+            data: { user_id: user.id,
+                    action: "click->user-search#addUser",
+                    remove_label: t("facility_product_notifications.form.remove") } }
+            = t(".add_user")

--- a/app/views/facility_product_notifications/edit.html.haml
+++ b/app/views/facility_product_notifications/edit.html.haml
@@ -1,0 +1,10 @@
+= content_for :h1 do
+  = current_facility
+= content_for :sidebar do
+  = render "admin/shared/sidenav_product", sidenav_tab: ProductNotification.model_name.plural
+
+%h2= t(".title")
+
+= simple_form_for @product_notification,
+  url: [current_facility, @product_notification] do |f|
+  = render "form", form: f

--- a/app/views/facility_product_notifications/new.html.haml
+++ b/app/views/facility_product_notifications/new.html.haml
@@ -1,0 +1,10 @@
+= content_for :h1 do
+  = current_facility
+= content_for :sidebar do
+  = render "admin/shared/sidenav_product", sidenav_tab: ProductNotification.model_name.plural
+
+%h2= t(".title")
+
+= simple_form_for @product_notification,
+  url: [:create, current_facility, @product_notification] do |f|
+  = render "form", form: f

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -346,6 +346,11 @@ en:
       product_display_group:
         product_ids: Products
         ungrouped_product_ids: Ungrouped
+      product_notification:
+        name: Name
+        reservation_days: Reservation Days
+        products: Products
+        users: Users
       product_notification/notification_type:
         slot_available: Time Slot Available
       instrument:

--- a/config/locales/views/en.facility_product_notifications.yml
+++ b/config/locales/views/en.facility_product_notifications.yml
@@ -13,7 +13,6 @@ en:
       success: Product Notification updated successfully
       error: An error occurred updating the record
     form:
-      search_users: Search
       search_users_placeholder: Type name or username
       add_user: Add
       remove: Remove

--- a/config/locales/views/en.facility_product_notifications.yml
+++ b/config/locales/views/en.facility_product_notifications.yml
@@ -1,7 +1,29 @@
 en:
   facility_product_notifications:
     index:
-      empty: No product notifications have been created
+      empty: No Product Notifications have been created
+    new:
+      title: New Product Notification
+    create:
+      success: Product Notification created successfully
+      error: An error occurred creating the record
+    edit:
+      title: Edit Product Notification
+    update:
+      success: Product Notification updated successfully
+      error: An error occurred updating the record
+    form:
+      search_users: Search
+      search_users_placeholder: Type name or username
+      add_user: Add
+      remove: Remove
+      no_results: No users found
+      selected_users: Selected Users
+      select_products_hint: Select instruments
+      select_users_hint: Search and select users one by one
+    user_search_results:
+      add_user: Add
+      no_results: No users found
     show:
       empty_users: No users added
       empty_products: No products added

--- a/config/locales/views/en.facility_product_notifications.yml
+++ b/config/locales/views/en.facility_product_notifications.yml
@@ -22,7 +22,7 @@ en:
       select_users_hint: Search and select users one by one
       hints:
         email_subject: Override default email subject
-        reservation_days: Reservations canceled within the amount of days will trigger the notification
+        reservation_days: Reservations canceled within this amount of days will trigger the notification
         slot_available: Notify users when a Reservation or Admin Hold is canceled for any of the selected instruments
     user_search_results:
       add_user: Add

--- a/config/locales/views/en.facility_product_notifications.yml
+++ b/config/locales/views/en.facility_product_notifications.yml
@@ -14,7 +14,6 @@ en:
       error: An error occurred updating the record
     form:
       search_users_placeholder: Type name or username
-      add_user: Add
       remove: Remove
       no_results: No users found
       selected_users: Selected Users

--- a/config/locales/views/en.facility_product_notifications.yml
+++ b/config/locales/views/en.facility_product_notifications.yml
@@ -21,6 +21,7 @@ en:
       select_products_hint: Select instruments
       select_users_hint: Search and select users one by one
       hints:
+        email_subject: Override default email subject
         reservation_days: Reservations canceled within the amount of days will trigger the notification
         slot_available: Notify users when a Reservation or Admin Hold is canceled for any of the selected instruments
     user_search_results:

--- a/config/locales/views/en.facility_product_notifications.yml
+++ b/config/locales/views/en.facility_product_notifications.yml
@@ -21,6 +21,7 @@ en:
       select_products_hint: Select instruments
       select_users_hint: Search and select users one by one
       hints:
+        reservation_days: Reservations canceled within the amount of days will trigger the notification
         slot_available: Notify users when a Reservation or Admin Hold is canceled for any of the selected instruments
     user_search_results:
       add_user: Add

--- a/config/locales/views/en.facility_product_notifications.yml
+++ b/config/locales/views/en.facility_product_notifications.yml
@@ -21,6 +21,8 @@ en:
       selected_users: Selected Users
       select_products_hint: Select instruments
       select_users_hint: Search and select users one by one
+      hints:
+        slot_available: Notify users when a Reservation or Admin Hold is canceled for any of the selected instruments
     user_search_results:
       add_user: Add
       no_results: No users found

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,9 +89,11 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :product_notifications, controller: "facility_product_notifications", except: :index do
+    resources :product_notifications, controller: "facility_product_notifications", except: [:index, :create] do
       collection do
+        post :create, action: :create, as: :create
         get :list, action: :index
+        get :user_search
       end
 
     end

--- a/spec/requests/facility_product_notifications_spec.rb
+++ b/spec/requests/facility_product_notifications_spec.rb
@@ -127,21 +127,31 @@ RSpec.describe "FacilityProductNotifications" do
 
     context "as an administrator" do
       before { login_as create(:user, :administrator) }
+      let(:product_notification_attributes) do
+        {
+          name: "New Notification",
+          reservation_days: 10,
+          email_subject: "Some subject",
+        }
+      end
 
       context "with valid params" do
         let(:params) do
           {
             product_notification: {
-              name: "New Notification",
-              reservation_days: 10,
               product_ids: [],
               user_ids: [],
+              **product_notification_attributes,
             },
           }
         end
 
-        it "creates a product notification" do
-          expect { action.call }.to change(ProductNotification, :count).by(1)
+        it "creates a product notification with correct attributes" do
+          expect { action.call }.to(
+            change do
+              ProductNotification.where(product_notification_attributes).count
+            end.by(1)
+          )
         end
 
         it "redirects to show" do

--- a/spec/requests/facility_product_notifications_spec.rb
+++ b/spec/requests/facility_product_notifications_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "FacilityProductNotifications" do
       it "displays empty message when no notifications" do
         action.call
 
-        expect(page).to have_content("No product notifications have been created")
+        expect(page).to have_content("No Product Notifications have been created")
         expect(page).to have_link(
           "Add Product Notification",
           href: new_facility_product_notification_path(facility),
@@ -49,7 +49,9 @@ RSpec.describe "FacilityProductNotifications" do
       end
 
       context "with product notifications" do
-        let!(:product_notification) { create(:product_notification, facility:, name: "Some Notification") }
+        let!(:product_notification) do
+          create(:product_notification, facility:, name: "Some Notification")
+        end
 
         it "lists product notifications" do
           action.call
@@ -66,15 +68,258 @@ RSpec.describe "FacilityProductNotifications" do
 
           action.call
 
-          expect(page).to have_content("Some Notification • Time Slot Available • 10 Users")
+          expect(page).to have_content(
+            "Some Notification • Time Slot Available • 10 Users",
+          )
+        end
+      end
+    end
+  end
+
+  describe "new" do
+    let(:action) { -> { get new_facility_product_notification_path(facility) } }
+
+    it_behaves_like "requires authentication"
+    it_behaves_like "forbids non-admin user"
+
+    context "as an administrator" do
+      before { login_as create(:user, :administrator) }
+
+      it "renders the new page" do
+        action.call
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "displays the form" do
+        action.call
+
+        expect(page).to have_content("New Product Notification")
+        expect(page).to have_field("product_notification[name]")
+        expect(page).to have_field("product_notification[reservation_days]")
+      end
+
+      it "loads instruments for selection" do
+        instrument = create(:instrument, facility:)
+        item = create(:item, facility:)
+
+        action.call
+
+        expect(page).to have_select(
+          "product_notification[product_ids][]",
+          with_options: [instrument.name],
+        )
+        expect(page).not_to have_select(
+          "product_notification[product_ids][]",
+          with_options: [item.name],
+        )
+      end
+    end
+  end
+
+  describe "create" do
+    let(:params) { {} }
+    let(:action) do
+      -> { post create_facility_product_notifications_path(facility), params: }
+    end
+
+    it_behaves_like "requires authentication"
+
+    context "as an administrator" do
+      before { login_as create(:user, :administrator) }
+
+      context "with valid params" do
+        let(:params) do
+          {
+            product_notification: {
+              name: "New Notification",
+              reservation_days: 10,
+              product_ids: [],
+              user_ids: [],
+            },
+          }
+        end
+
+        it "creates a product notification" do
+          expect { action.call }.to change(ProductNotification, :count).by(1)
+        end
+
+        it "redirects to show" do
+          action.call
+
+          expect(response).to redirect_to(
+            facility_product_notification_path(facility, ProductNotification.last),
+          )
+        end
+
+        it "sets a success flash" do
+          action.call
+
+          expect(flash[:notice]).to eq("Product Notification created successfully")
+        end
+
+        it "creates with the given name and reservation days" do
+          action.call
+
+          notification = ProductNotification.last
+          expect(notification.name).to eq("New Notification")
+          expect(notification.reservation_days).to eq(10)
+        end
+
+        it "associates products" do
+          instrument = create(:instrument, facility:)
+          params[:product_notification][:product_ids] = [instrument.id]
+
+          action.call
+
+          expect(ProductNotification.last.products).to(
+            contain_exactly(instrument)
+          )
+        end
+
+        it "associates users" do
+          user = create(:user)
+          params[:product_notification][:user_ids] = [user.id]
+
+          action.call
+
+          expect(ProductNotification.last.users).to contain_exactly(user)
+        end
+      end
+    end
+  end
+
+  describe "edit" do
+    let(:notification) { create(:product_notification, facility:) }
+    let(:action) do
+      -> { get edit_facility_product_notification_path(facility, notification) }
+    end
+
+    it_behaves_like "requires authentication"
+    it_behaves_like "forbids non-admin user"
+
+    context "as an administrator" do
+      before { login_as create(:user, :administrator) }
+
+      it "renders the edit page" do
+        action.call
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "displays the form with existing name" do
+        action.call
+
+        expect(page).to have_content("Edit Product Notification")
+        expect(page).to have_field(
+          "product_notification[name]",
+          with: notification.name,
+        )
+      end
+
+      it "loads instruments for selection" do
+        instrument = create(:instrument, facility:)
+
+        action.call
+
+        expect(page).to have_select(
+          "product_notification[product_ids][]",
+          with_options: [instrument.name],
+        )
+      end
+    end
+  end
+
+  describe "update" do
+    let(:notification) { create(:product_notification, facility:) }
+    let(:params) { {} }
+    let(:action) do
+      lambda do
+        put facility_product_notification_path(facility, notification), params:
+      end
+    end
+
+    it_behaves_like "requires authentication"
+
+    context "as an administrator" do
+      before { login_as create(:user, :administrator) }
+
+      context "with valid params" do
+        let(:params) do
+          {
+            product_notification: {
+              name: "Updated Name",
+              reservation_days: 20,
+            }
+          }
+        end
+
+        it "updates the notification" do
+          action.call
+
+          notification.reload
+          expect(notification.name).to eq("Updated Name")
+          expect(notification.reservation_days).to eq(20)
+        end
+
+        it "redirects to show" do
+          action.call
+
+          expect(response).to redirect_to(
+            facility_product_notification_path(facility, notification),
+          )
+        end
+
+        it "sets a success flash" do
+          action.call
+
+          expect(flash[:notice]).to eq("Product Notification updated successfully")
+        end
+
+        it "updates associated products" do
+          instrument = create(:instrument, facility:)
+          params[:product_notification][:product_ids] = [instrument.id]
+
+          action.call
+
+          notification.reload
+          expect(notification.products).to contain_exactly(instrument)
+        end
+      end
+
+      context "when removing all users" do
+        let(:user) { create(:user) }
+        let(:params) do
+          {
+            product_notification: {
+              name: notification.name,
+              reservation_days: notification.reservation_days,
+              user_ids: [],
+            }
+          }
+        end
+
+        before do
+          notification.users << user
+        end
+
+        it "removes all users" do
+          action.call
+
+          notification.reload
+          expect(notification.users).to be_empty
         end
       end
     end
   end
 
   describe "show" do
-    let(:notification) { create(:product_notification, facility:, name: "Some Notification") }
-    let(:action) { -> { get facility_product_notification_path(facility, notification) } }
+    let(:notification) do
+      create(:product_notification, facility:, name: "Some Notification")
+    end
+    let(:action) do
+      -> { get facility_product_notification_path(facility, notification) }
+    end
 
     it_behaves_like "requires authentication"
     it_behaves_like "forbids non-admin user"
@@ -93,7 +338,8 @@ RSpec.describe "FacilityProductNotifications" do
 
         expect(page).to have_content("Some Notification")
         expect(page).to have_link(
-          "Edit", href: edit_facility_product_notification_path(facility, notification),
+          "Edit",
+          href: edit_facility_product_notification_path(facility, notification),
         )
       end
 


### PR DESCRIPTION
# Notes

Add/Edit `ProductNotification`.

Part of [NU-444 | An automatic email that would notify user of canceled reservations](https://universe-of-universities.atlassian.net/browse/NU-444)

# Additional Context

Optional. Feel free to add/modify additional headers as appropriate, e.g. "Refactorings", "Concerns".

# Screenshot

<img width="1310" height="1033" alt="Captura desde 2026-06-15 15-55-37" src="https://github.com/user-attachments/assets/4dbac861-ea2e-4780-b756-b17c12197ea8" />

