### PR TITLE
[NUOPEN-357] Allow Read-only to see price groups and Cross-core projects

### DIFF
--- a/app/lib/facility_user_permission_ability.rb
+++ b/app/lib/facility_user_permission_ability.rb
@@ -56,7 +56,7 @@ class FacilityUserPermissionAbility
     can :read, PriceGroupProduct
     can [:show, :index], [PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ServicePricePolicy]
 
-    can :index, Project
+    can [:index, :cross_core_orders], Project
 
     can [:administer], User
     can :index, User if controller.is_a?(FacilityUsersController) || controller.is_a?(UsersController)

--- a/app/presenters/nav_tab/link_collection.rb
+++ b/app/presenters/nav_tab/link_collection.rb
@@ -139,7 +139,7 @@ class NavTab::LinkCollection
       NavTab::Link.new(tab: :admin_facility, url: manage_facility_path(facility))
     elsif single_facility? && ability.can?(:manage, FacilityUserPermission)
       NavTab::Link.new(tab: :admin_facility, url: facility_facility_users_path(facility))
-    elsif single_facility? && ability.can?(:manage, PriceGroupDiscount)
+    elsif single_facility? && ability.can?(:index, PriceGroup)
       NavTab::Link.new(tab: :admin_facility, url: facility_price_groups_path(facility))
     end
   end

--- a/app/views/admin/shared/_sidenav_admin.html.haml
+++ b/app/views/admin/shared/_sidenav_admin.html.haml
@@ -2,7 +2,8 @@
   - if can?(:edit, current_facility)
     = tab t("shared.sidenav_admin.overview"), manage_facility_path(current_facility), sidenav_tab == "overview"
     = tab FacilityAccount.model_name.human(count: 2), facility_facility_accounts_path(current_facility), sidenav_tab == "recharge_accounts"
-  = tab text("facility_users.title"), facility_facility_users_path(current_facility), sidenav_tab == "staff"
+  - if can?(:edit, current_facility) || can?(:manage_users, current_facility) || can?(:manage, FacilityUserPermission)
+    = tab text("facility_users.title"), facility_facility_users_path(current_facility), sidenav_tab == "staff"
   - if can?(:edit, current_facility) || can?(:index, PriceGroup)
     = tab PriceGroup.model_name.human(count: 2), facility_price_groups_path(current_facility), sidenav_tab == "price_groups"
   - if can?(:edit, current_facility)

--- a/app/views/admin/shared/_sidenav_admin.html.haml
+++ b/app/views/admin/shared/_sidenav_admin.html.haml
@@ -3,7 +3,7 @@
     = tab t("shared.sidenav_admin.overview"), manage_facility_path(current_facility), sidenav_tab == "overview"
     = tab FacilityAccount.model_name.human(count: 2), facility_facility_accounts_path(current_facility), sidenav_tab == "recharge_accounts"
   = tab text("facility_users.title"), facility_facility_users_path(current_facility), sidenav_tab == "staff"
-  - if can?(:edit, current_facility) || can?(:manage, PriceGroupDiscount)
+  - if can?(:edit, current_facility) || can?(:index, PriceGroup)
     = tab PriceGroup.model_name.human(count: 2), facility_price_groups_path(current_facility), sidenav_tab == "price_groups"
   - if can?(:edit, current_facility)
     = tab OrderStatus.model_name.human(count: 2), facility_order_statuses_path(current_facility), sidenav_tab == "statuses"

--- a/app/views/price_groups/index.html.haml
+++ b/app/views/price_groups/index.html.haml
@@ -37,8 +37,11 @@
           %td
             - if price_group.external_subsidy?
               %span.text-muted ↳
-            = link_to price_group.name,
-              facility_price_group_path(current_facility, price_group)
+            - if current_ability.can?(:accounts, price_group)
+              = link_to price_group.name,
+                facility_price_group_path(current_facility, price_group)
+            - else
+              = price_group.name
             - if price_group.external_subsidy?
               %small.text-muted
                 = "(#{t('.subsidy_of', parent: price_group.parent_price_group&.name)})"

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -943,7 +943,6 @@ RSpec.describe Ability do
     context "without project_management" do
       it { is_expected.not_to be_allowed_to(:create, Project) }
       it { is_expected.not_to be_allowed_to(:update, Project) }
-      it { is_expected.not_to be_allowed_to(:cross_core_orders, Project) }
 
       context "when authorizing against a Project instance" do
         let(:project) { create(:project, facility:) }

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -599,7 +599,7 @@ RSpec.describe Ability do
       it_is_allowed_to([:administer, :index, :view_details, :schedule, :show], Product)
       it_is_allowed_to([:show, :index], PriceGroup)
       it_is_allowed_to([:index], StoredFile)
-      it { is_expected.to be_allowed_to(:index, Project) }
+      it_is_allowed_to([:index, :cross_core_orders], Project)
       it { is_expected.to be_allowed_to(:administer, User) }
       it { is_expected.to be_allowed_to(:read, Schedule) }
       it { is_expected.to be_allowed_to(:read, ProductDisplayGroup) }

--- a/spec/system/admin/price_group_management_spec.rb
+++ b/spec/system/admin/price_group_management_spec.rb
@@ -139,6 +139,10 @@ RSpec.describe "Managing Price Groups", :aggregate_failures do
       expect(page).not_to have_link("Remove")
     end
 
+    it "does not show the Facility Staff sidenav link" do
+      expect(page).not_to have_link("Facility Staff")
+    end
+
     it "is not authorized to view a price group's accounts" do
       visit accounts_facility_price_group_path(facility, price_group)
       expect(page).to have_content("not authorized")

--- a/spec/system/admin/price_group_management_spec.rb
+++ b/spec/system/admin/price_group_management_spec.rb
@@ -122,6 +122,29 @@ RSpec.describe "Managing Price Groups", :aggregate_failures do
     end
   end
 
+  describe "read-only access", feature_setting: { granular_permissions: true } do
+    let(:user) { create(:user) }
+    let!(:price_group) { create(:price_group, facility:) }
+
+    before do
+      create(:facility_user_permission, user:, facility:, read_access: true)
+      login_as user
+      visit facility_price_groups_path(facility)
+    end
+
+    it "lists the price group but does not link into it" do
+      expect(page).to have_content(price_group.name)
+      expect(page).not_to have_link(price_group.name)
+      expect(page).not_to have_link("Add Price Group")
+      expect(page).not_to have_link("Remove")
+    end
+
+    it "is not authorized to view a price group's accounts" do
+      visit accounts_facility_price_group_path(facility, price_group)
+      expect(page).to have_content("not authorized")
+    end
+  end
+
   describe "destroy" do
     describe "as a facility admin", feature_setting: { facility_directors_can_manage_price_groups: true } do
       let(:user) { create(:user, :facility_director, facility:) }


### PR DESCRIPTION
# Notes
* Allow Read-only to see price groups and Cross-core projects

[NUOPEN-357 | Read-Only Permission ](https://universe-of-universities.atlassian.net/browse/NUOPEN-357)

# Additional Context
Also fixes the bug when users without access to seeing the Accounts still got a link to them.

# Screenshot
## Price groups
<img width="1182" height="650" alt="image" src="https://github.com/user-attachments/assets/64fd2208-0618-4cc9-8f2c-06c843af6cb4" />

## Projects
<img width="1230" height="706" alt="image" src="https://github.com/user-attachments/assets/0f79520d-df52-4063-9c14-cce892c1d827" />

## Facility Staff hiden
<img width="1157" height="635" alt="image" src="https://github.com/user-attachments/assets/83dcc7b9-b44d-4d21-ac63-638ea38ea4c1" />


