### PR TITLE
[NU-455] Add rack attack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "bootsnap", require: false
 gem "puma"
 gem "jsbundling-rails", "~> 1.3"
 gem "rack-utf8_sanitizer"
+gem "rack-attack"
 gem "net-smtp"
 gem "net-imap"
 gem "net-pop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -515,6 +515,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-mini-profiler (4.0.1)
       rack (>= 1.2.0)
     rack-session (2.1.2)
@@ -823,6 +825,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma
+  rack-attack
   rack-mini-profiler (~> 4.0)
   rack-utf8_sanitizer
   rails (~> 8.0.4)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -24,5 +24,3 @@ class Rack::Attack
 end
 
 Rack::Attack.enabled = Settings.rack_attack&.enabled || false
-
-Rails.application.config.middleware.use Rack::Attack

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Rack::Attack
+
+  throttle("req/ip", limit: Settings.rack_attack.req_limit, period: Settings.rack_attack.req_period) do |req|
+    req.ip unless req.path.start_with?("/assets")
+  end
+
+  throttle("logins/ip", limit: Settings.rack_attack.login_limit, period: Settings.rack_attack.login_period) do |req|
+    req.ip if req.path == "/users/sign_in" && req.post?
+  end
+
+  self.throttled_responder = lambda do |request|
+    match_data = request.env["rack.attack.match_data"] || {}
+    retry_after = match_data[:period] || Settings.rack_attack.req_period
+
+    [
+      429,
+      { "Content-Type" => "text/html", "Retry-After" => retry_after.to_s },
+      [Rails.public_path.join("429.html").read],
+    ]
+  end
+
+end
+
+Rack::Attack.enabled = Settings.rack_attack&.enabled || false
+
+Rails.application.config.middleware.use Rack::Attack

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -70,6 +70,13 @@ email:
     sender: 'noreply@example.com'
     recipients: [ 'warn@example.com', 'error@example.com' ]
 
+rack_attack:
+  enabled: true
+  req_limit: 300
+  req_period: 60
+  login_limit: 10
+  login_period: 60
+
 # support_email_subject is only applied on the Support header link
 # this will be encoded by the mail_to helper, so use standard spaces (not %20)
 support_email: ~

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,6 +1,9 @@
 devise:
   secret_key: override-me-in-settings.local.yml
 
+rack_attack:
+  enabled: false
+
 # These credentials are set randomly in the standard settings, but need to be
 # more stable in a testing environment
 secure_rooms_api:

--- a/public/429.html
+++ b/public/429.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>429 - Too Many Requests</title>
+  <style type="text/css">
+    body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
+    div.dialog {
+      width: 25em;
+      padding: 0 4em;
+      margin: 4em auto 0 auto;
+      border: 1px solid #ccc;
+      border-right-color: #999;
+      border-bottom-color: #999;
+    }
+    h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
+  </style>
+</head>
+
+<body>
+  <div class="dialog">
+    <h1>Too many requests</h1>
+    <p>You have made too many requests in a short period. Please wait a moment and try again.</p>
+  </div>
+</body>
+</html>

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Rack::Attack", type: :request do
+  let(:login_limit) { Settings.rack_attack.login_limit }
+  let(:credentials) { { user: { email: "nobody@example.com", password: "wrong" } } }
+
+  around do |example|
+    original_store = Rack::Attack.cache.store
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    Rack::Attack.enabled = true
+
+    example.run
+
+    Rack::Attack.enabled = false
+    Rack::Attack.cache.store = original_store
+  end
+
+  describe "login throttling" do
+    it "allows requests up to the limit" do
+      login_limit.times { post "/users/sign_in", params: credentials }
+
+      expect(response).not_to have_http_status(:too_many_requests)
+    end
+
+    it "returns 429 once the limit is exceeded" do
+      (login_limit + 1).times { post "/users/sign_in", params: credentials }
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "renders the branded error page with a Retry-After header" do
+      (login_limit + 1).times { post "/users/sign_in", params: credentials }
+
+      expect(response.content_type).to include("text/html")
+      expect(response.headers["Retry-After"]).to eq(Settings.rack_attack.login_period.to_s)
+      expect(response.body).to include("Too many requests")
+    end
+  end
+
+  context "when disabled" do
+    around do |example|
+      Rack::Attack.enabled = false
+      example.run
+    end
+
+    it "never throttles" do
+      (login_limit + 5).times { post "/users/sign_in", params: credentials }
+
+      expect(response).not_to have_http_status(:too_many_requests)
+    end
+  end
+end


### PR DESCRIPTION
# Notes

  TECH TASK: Adds Rack::Attack as an HTTP rate-limiting layer to protect the application from abusive request volumes. Throttles requests per IP and login attempts per IP, returning HTTP 429 when limits are exceeded.
  
  [NU-455 | Receive a notification when an error happens more than X times in less than Y amount of time](https://universe-of-universities.atlassian.net/browse/NU-455)
  
