### PR TITLE
[NUOPEN-366] Fix price adjustment users cannot reach transactions

### DIFF
--- a/app/lib/facility_user_permission_ability.rb
+++ b/app/lib/facility_user_permission_ability.rb
@@ -150,6 +150,8 @@ class FacilityUserPermissionAbility
 
   def grant_price_adjustment
     can :adjust_price, OrderDetail, { order: { facility_id: facility.id } }
+    can :transactions, Facility
+    can [:show, :orders], User
   end
 
   def grant_instrument_management

--- a/spec/controllers/facilities_controller_spec.rb
+++ b/spec/controllers/facilities_controller_spec.rb
@@ -365,6 +365,16 @@ RSpec.describe FacilitiesController do
         sign_in unpermitted_user
         expect { get :transactions, params: { facility_id: facility.url_name } }.to raise_error(CanCan::AccessDenied)
       end
+
+      it "allows a user with price_adjustment permission and renders the page" do
+        price_adjustment_user = create(:user)
+        create(:facility_user_permission, user: price_adjustment_user, facility:, price_adjustment: true)
+
+        sign_in price_adjustment_user
+        get :transactions, params: { facility_id: facility.url_name }
+        expect(response).to be_successful
+        expect(response.body).to include("menu_billing")
+      end
     end
 
     describe "GET #disputed_orders" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -117,6 +117,30 @@ RSpec.describe UsersController do
     end
   end
 
+  context "with price_adjustment permission", feature_setting: { granular_permissions: true } do
+    let(:target_user) { create(:user) }
+    let(:price_adjustment_user) { create(:user) }
+
+    before do
+      create(:facility_user_permission, user: price_adjustment_user, facility:, price_adjustment: true)
+      sign_in price_adjustment_user
+    end
+
+    describe "GET #show" do
+      it "renders the user details page" do
+        get :show, params: { facility_id: facility.url_name, id: target_user.id }
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET #orders" do
+      it "renders the user orders page" do
+        get :orders, params: { facility_id: facility.url_name, user_id: target_user.id }
+        expect(response).to be_successful
+      end
+    end
+  end
+
   context "creating users" do
     context "enabled", feature_setting: { "users_authentication.create_users" => true, reload_routes: true } do
       it "routes", :aggregate_failures do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -799,14 +799,17 @@ RSpec.describe Ability do
 
     context "with price_adjustment" do
       before do
-        FacilityUserPermission.find_by(user:, facility:).update!(price_adjustment: true)
+        FacilityUserPermission.find_by(user:, facility:).update!(price_adjustment: true, billing_send: false)
       end
 
       it { is_expected.to be_allowed_to(:adjust_price, OrderDetail) }
+      it { is_expected.to be_allowed_to(:transactions, facility) }
+      it_is_allowed_to([:show, :orders], User)
       it { is_expected.not_to be_allowed_to(:update, OrderDetail) }
       it { is_expected.not_to be_allowed_to(:edit, OrderDetail) }
       it { is_expected.not_to be_allowed_to(:mark_unrecoverable, OrderDetail) }
       it { is_expected.not_to be_allowed_to(:act_as, facility) }
+      it { is_expected.not_to be_allowed_to(:manage_billing, facility) }
       it_is_not_allowed_to([:create, :update, :batch_update], Order)
     end
 


### PR DESCRIPTION
# Notes

  Users with only the Price Adjustment permission can now reach the transactions they need to edit: the Billing tab shows up, and opening a user from the Users page no longer returns a permission denied.
  
  [NUOPEN-366 | Price Adjustment Permission](https://universe-of-universities.atlassian.net/browse/NUOPEN-366)
