### PR TITLE
[NU-444] Product notification delete

### DIFF
--- a/app/controllers/facility_product_notifications_controller.rb
+++ b/app/controllers/facility_product_notifications_controller.rb
@@ -56,6 +56,7 @@ class FacilityProductNotificationsController < ApplicationController
 
   def destroy
     @product_notification.destroy
+
     flash[:notice] = t(".success")
     redirect_to action: :index
   end

--- a/app/views/facility_product_notifications/show.html.haml
+++ b/app/views/facility_product_notifications/show.html.haml
@@ -8,7 +8,12 @@
 %p
   = link_to t("shared.edit"),
     edit_facility_product_notification_path(current_facility, @product_notification),
-    class: "btn btn-default right"
+    class: "btn btn-default"
+  = link_to t("shared.delete"),
+    facility_product_notification_path(current_facility, @product_notification),
+    method: :delete,
+    class: "btn btn-danger",
+    data: { confirm: t(".confirm_delete") }
 
 = readonly_form_for(:product_notification) do |f|
   = f.input :notification_type,

--- a/config/locales/views/en.facility_product_notifications.yml
+++ b/config/locales/views/en.facility_product_notifications.yml
@@ -2,6 +2,10 @@ en:
   facility_product_notifications:
     index:
       empty: No Product Notifications have been created
+    show:
+      empty_users: No users added
+      empty_products: No products added
+      confirm_delete: Are you sure you want to delete this record?
     new:
       title: New Product Notification
     create:
@@ -12,6 +16,8 @@ en:
     update:
       success: Product Notification updated successfully
       error: An error occurred updating the record
+    destroy:
+      success: Product Notification deleted successfully
     form:
       search_users_placeholder: Type name or username
       remove: Remove
@@ -26,6 +32,3 @@ en:
     user_search_results:
       add_user: Add
       no_results: No users found
-    show:
-      empty_users: No users added
-      empty_products: No products added

--- a/spec/requests/facility_product_notifications_spec.rb
+++ b/spec/requests/facility_product_notifications_spec.rb
@@ -385,4 +385,44 @@ RSpec.describe "FacilityProductNotifications" do
       end
     end
   end
+
+  describe "destroy" do
+    let(:notification) do
+      create(:product_notification, facility:, name: "Some Notification")
+    end
+    let(:action) do
+      -> { delete facility_product_notification_path(facility, notification) }
+    end
+
+    it_behaves_like "forbids non-admin user"
+
+    context "with admin user" do
+      before { login_as create(:user, :administrator) }
+
+      it "deletes the product notification" do
+        expect { action.call }.to(
+          change do
+            ProductNotification.find_by(id: notification.id)
+          end.to(nil)
+        )
+      end
+
+      it "redirects to index action" do
+        action.call
+
+        expect(response).to have_http_status(:found)
+        expect(response.location).to eq(
+          list_facility_product_notifications_url(facility)
+        )
+      end
+
+      it "shows a success message" do
+        action.call
+
+        get response.location
+
+        expect(page).to have_content("deleted successfully")
+      end
+    end
+  end
 end

--- a/spec/requests/facility_product_notifications_spec.rb
+++ b/spec/requests/facility_product_notifications_spec.rb
@@ -421,7 +421,7 @@ RSpec.describe "FacilityProductNotifications" do
 
         get response.location
 
-        expect(page).to have_content("deleted successfully")
+        expect(flash[:notice]).to include("deleted successfully")
       end
     end
   end


### PR DESCRIPTION
# Notes

- Allow to remove product notifications.

Part of [NU-444 | An automatic email that would notify user of canceled reservations](https://universe-of-universities.atlassian.net/browse/NU-444)

# Screenshot

<img width="1249" height="797" alt="Captura desde 2026-06-22 11-48-15" src="https://github.com/user-attachments/assets/0c43fa76-a73e-44b1-acb3-a368b51f0804" />


