### PR TITLE
[NU-444] Notify on admin hold removal and wrap up

### DIFF
--- a/app/controllers/facility_reservations_controller.rb
+++ b/app/controllers/facility_reservations_controller.rb
@@ -154,6 +154,8 @@ class FacilityReservationsController < ApplicationController
 
     @reservation.destroy
     flash[:notice] = "The reservation has been removed successfully"
+    ProductNotifications::SlotAvailableService.from_reservation(@reservation).notify!
+
     redirect_to facility_instrument_schedule_url
   end
 

--- a/app/controllers/facility_reservations_controller.rb
+++ b/app/controllers/facility_reservations_controller.rb
@@ -154,7 +154,7 @@ class FacilityReservationsController < ApplicationController
 
     @reservation.destroy
     flash[:notice] = "The reservation has been removed successfully"
-    ProductNotifications::SlotAvailableService.from_reservation(@reservation).notify!
+    ProductNotifications::SlotAvailableService.from_reservation(@reservation).notify_later
 
     redirect_to facility_instrument_schedule_url
   end

--- a/app/controllers/order_details_controller.rb
+++ b/app/controllers/order_details_controller.rb
@@ -46,7 +46,7 @@ class OrderDetailsController < ApplicationController
 
       if @order_detail.canceled? && @order_detail.status_recently_changed
         CancellationMailer.notify_facility(@order_detail).deliver_later
-        ProductNotifications::SlotAvailableService.from_reservation(@order_detail.reservation).notify!
+        ProductNotifications::SlotAvailableService.from_reservation(@order_detail.reservation).notify_later
       end
 
       redirect_to redirect_to_path

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -205,6 +205,6 @@ class OrderManagement::OrderDetailsController < ApplicationController
   def handle_cancelation_notification
     return unless @order_detail.canceled? && @order_detail.status_recently_changed && @order_detail.reservation.present?
 
-    ProductNotifications::SlotAvailableService.from_reservation(@order_detail.reservation).notify!
+    ProductNotifications::SlotAvailableService.from_reservation(@order_detail.reservation).notify_later
   end
 end

--- a/app/jobs/slot_available_job.rb
+++ b/app/jobs/slot_available_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+##
+# Job to run SlotAvailableService.notfy! async
+#
+class SlotAvailableJob < ApplicationJob
+  def perform(product, start_time, end_time, exclude_user: nil)
+    ProductNotifications::SlotAvailableService.new(
+      product, start_time, end_time, exclude_user:
+    ).notify!
+  end
+end

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -202,6 +202,7 @@ class Ability
       can :manage, PriceGroup
       can :manage, PriceGroupDiscount
       can :manage, [PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ServicePricePolicy]
+      can :manage, ProductNotification, facility_id: resource.id
     end
 
     if SettingsHelper.feature_on?(:show_estimates_option) && resource.is_a?(Facility) && user.facility_administrator_of?(resource)

--- a/app/lib/facility_user_permission_ability.rb
+++ b/app/lib/facility_user_permission_ability.rb
@@ -163,6 +163,7 @@ class FacilityUserPermissionAbility
          :timeline, :update, :update_admin], Reservation
     can(:destroy, Reservation, &:admin?)
     can :read, ProductAccessory
+    can :manage, ProductNotification, facility_id: facility.id
   end
 
   def grant_account_management

--- a/app/services/order_detail_batch_updater.rb
+++ b/app/services/order_detail_batch_updater.rb
@@ -146,7 +146,7 @@ class OrderDetailBatchUpdater
         if order_detail.cancel_reservation(user, order_status: order_status, admin: true)
           ProductNotifications::SlotAvailableService
             .from_reservation(order_detail.reservation)
-            .notify!
+            .notify_later
         else
           raise "#{msg_type} ##{order_detail} failed cancellation."
         end

--- a/app/services/order_detail_batch_updater.rb
+++ b/app/services/order_detail_batch_updater.rb
@@ -143,7 +143,11 @@ class OrderDetailBatchUpdater
     order_details.each do |order_detail|
       # cancel reservation order details
       if order_status.id == OrderStatus.canceled.id && order_detail.reservation
-        unless order_detail.cancel_reservation(user, order_status: order_status, admin: true)
+        if order_detail.cancel_reservation(user, order_status: order_status, admin: true)
+          ProductNotifications::SlotAvailableService
+            .from_reservation(order_detail.reservation)
+            .notify!
+        else
           raise "#{msg_type} ##{order_detail} failed cancellation."
         end
       # cancel other orders

--- a/app/services/product_notifications/slot_available_service.rb
+++ b/app/services/product_notifications/slot_available_service.rb
@@ -27,7 +27,7 @@ module ProductNotifications
     end
 
     def notify!
-      return unless should_notfy?
+      return unless should_notify?
 
       product_notifications.find_each do |product_notification|
         users =
@@ -48,7 +48,7 @@ module ProductNotifications
 
     private
 
-    def should_notfy?
+    def should_notify?
       [
         SettingsHelper.feature_on?("notifications.facility_product_notifications"),
         start_time&.future?,

--- a/app/services/product_notifications/slot_available_service.rb
+++ b/app/services/product_notifications/slot_available_service.rb
@@ -30,7 +30,7 @@ module ProductNotifications
           ProductNotificationMailer.slot_available(
             product, user,
             start_time, end_time,
-            subject: product_notification.email_subject,
+            subject: product_notification.email_subject.presence,
           ).deliver_later
         end
       end

--- a/app/services/product_notifications/slot_available_service.rb
+++ b/app/services/product_notifications/slot_available_service.rb
@@ -26,7 +26,13 @@ module ProductNotifications
       return unless should_notfy?
 
       product_notifications.find_each do |product_notification|
-        product_notification.users.where.not(id: exclude_user&.id).find_each do |user|
+        users =
+          product_notification
+          .users
+          .active
+          .where.not(id: exclude_user&.id)
+
+        users.find_each do |user|
           ProductNotificationMailer.slot_available(
             product, user,
             start_time, end_time,

--- a/app/services/product_notifications/slot_available_service.rb
+++ b/app/services/product_notifications/slot_available_service.rb
@@ -22,6 +22,10 @@ module ProductNotifications
       @exclude_user = exclude_user
     end
 
+    def notify_later
+      SlotAvailableJob.perform_later(product, start_time, end_time, exclude_user:)
+    end
+
     def notify!
       return unless should_notfy?
 

--- a/app/services/product_notifications/slot_available_service.rb
+++ b/app/services/product_notifications/slot_available_service.rb
@@ -24,6 +24,7 @@ module ProductNotifications
 
     def notify!
       return if SettingsHelper.feature_off?("notifications.facility_product_notifications")
+      return unless product_schedulable?
 
       product_notifications.find_each do |product_notification|
         product_notification.users.where.not(id: exclude_user&.id).find_each do |user|
@@ -37,6 +38,10 @@ module ProductNotifications
     end
 
     private
+
+    def product_schedulable?
+      product.schedule_rules.cover?(start_time, end_time)
+    end
 
     def product_notifications
       product

--- a/app/services/product_notifications/slot_available_service.rb
+++ b/app/services/product_notifications/slot_available_service.rb
@@ -23,8 +23,7 @@ module ProductNotifications
     end
 
     def notify!
-      return if SettingsHelper.feature_off?("notifications.facility_product_notifications")
-      return unless product_schedulable?
+      return unless should_notfy?
 
       product_notifications.find_each do |product_notification|
         product_notification.users.where.not(id: exclude_user&.id).find_each do |user|
@@ -38,6 +37,14 @@ module ProductNotifications
     end
 
     private
+
+    def should_notfy?
+      [
+        SettingsHelper.feature_on?("notifications.facility_product_notifications"),
+        start_time&.future?,
+        product_schedulable?,
+      ].all?
+    end
 
     def product_schedulable?
       product.schedule_rules.cover?(start_time, end_time)

--- a/app/services/product_notifications/slot_available_service.rb
+++ b/app/services/product_notifications/slot_available_service.rb
@@ -8,10 +8,10 @@ module ProductNotifications
 
     def self.from_reservation(reservation)
       new(
-        reservation.order_detail.product,
+        reservation.product,
         reservation.reserve_start_at,
         reservation.reserve_end_at,
-        exclude_user: reservation&.order_detail&.user,
+        exclude_user: reservation.order_detail&.user,
       )
     end
 

--- a/app/services/product_notifications/slot_available_service.rb
+++ b/app/services/product_notifications/slot_available_service.rb
@@ -11,7 +11,7 @@ module ProductNotifications
         reservation.order_detail.product,
         reservation.reserve_start_at,
         reservation.reserve_end_at,
-        exclude_user: reservation.order_detail.user,
+        exclude_user: reservation&.order_detail&.user,
       )
     end
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -2,6 +2,3 @@
 # the development environment. Changing it to true will allow you to log in
 # as any user without checking for a valid password.
 ignore_passwords: false
-
-feature:
-  facility_product_notification: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -2,3 +2,6 @@
 # the development environment. Changing it to true will allow you to log in
 # as any user without checking for a valid password.
 ignore_passwords: false
+
+feature:
+  facility_product_notification: true

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -280,6 +280,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:manage, ScheduleRule) }
     it { is_expected.to be_allowed_to(:manage, ProductAccessGroup) }
     it_is_not_allowed_to([:edit, :update]) { FactoryBot.create(:user) }
+    it { is_expected.to be_allowed_to(:manage, ProductNotification, facility_id: facility.id) }
 
     it_behaves_like "it can destroy admistrative reservations"
     it_behaves_like "it allows switch_to on active, but not deactivated users"
@@ -851,6 +852,7 @@ RSpec.describe Ability do
       it { is_expected.to be_allowed_to(:switch, Instrument) }
       it_is_allowed_to([:create, :edit_admin, :update_admin, :timeline, :index, :show], Reservation)
       it { is_expected.to be_allowed_to(:read, ProductAccessory) }
+      it { is_expected.to be_allowed_to(:manage, ProductNotification, facility_id: facility.id) }
 
       it_behaves_like "it can destroy admistrative reservations"
 

--- a/spec/requests/facility_reservations_spec.rb
+++ b/spec/requests/facility_reservations_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "FacilityReservationsController" do
+  describe "destroy" do
+    let(:facility) { create(:setup_facility) }
+    let(:instrument) { create(:setup_instrument, facility:) }
+    let(:director) { create(:user, :facility_director, facility:) }
+    let(:reservation) { create(:admin_reservation, product: instrument) }
+    let(:service_spy) { instance_spy(ProductNotifications::SlotAvailableService) }
+    let(:action) do
+      lambda do |reservation|
+        delete facility_instrument_reservation_path(facility, instrument, reservation)
+      end
+    end
+
+    before do
+      login_as director
+
+      allow(ProductNotifications::SlotAvailableService).to receive(:from_reservation).and_return(service_spy)
+    end
+
+    it "calls SlotAvailableService with the reservation" do
+      action.call(reservation)
+
+      expect(ProductNotifications::SlotAvailableService).to(
+        have_received(:from_reservation).with(reservation)
+      )
+    end
+
+    it "calls notify! on the service" do
+      action.call(reservation)
+
+      expect(service_spy).to have_received(:notify!)
+    end
+
+    it "sets a success notice" do
+      action.call(reservation)
+
+      expect(flash[:notice]).to eq("The reservation has been removed successfully")
+    end
+
+    it "redirects to the instrument schedule" do
+      action.call(reservation)
+
+      expect(response).to redirect_to(
+        facility_instrument_schedule_url(facility, instrument),
+      )
+    end
+
+    it "destroys the reservation" do
+      reservation
+
+      expect do
+        action.call(reservation)
+      end.to change(Reservation, :count).by(-1)
+    end
+
+    context "when reservation has an order" do
+      let(:reservation_with_order) do
+        create(:purchased_reservation, product: instrument)
+      end
+
+      it "returns forbidden when reservation has an order detail (not admin)" do
+        action.call(reservation_with_order)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(ProductNotifications::SlotAvailableService).not_to have_received(:from_reservation)
+      end
+    end
+  end
+end

--- a/spec/requests/facility_reservations_spec.rb
+++ b/spec/requests/facility_reservations_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe "FacilityReservationsController" do
       )
     end
 
-    it "calls notify! on the service" do
+    it "calls notify_later on the service" do
       action.call(reservation)
 
-      expect(service_spy).to have_received(:notify!)
+      expect(service_spy).to have_received(:notify_later)
     end
 
     it "sets a success notice" do

--- a/spec/services/order_detail_batch_updater_spec.rb
+++ b/spec/services/order_detail_batch_updater_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe OrderDetailBatchUpdater do
 
   let(:assigned_user_id) { "" }
   let(:facility) { order.facility }
-  let(:item) { FactoryBot.create(:setup_item) }
-  let(:order) { FactoryBot.create(:purchased_order, product: item) }
+  let(:item) { create(:setup_item) }
+  let(:order) { create(:purchased_order, product: item) }
   let(:order_detail) { order.order_details.first }
   let(:order_status_id) { "" }
   let(:params) do
     { assigned_user_id: assigned_user_id, order_status_id: order_status_id }
   end
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { create(:user) }
 
   describe "#update!" do
     shared_examples_for "batch updating" do
@@ -238,10 +238,54 @@ RSpec.describe OrderDetailBatchUpdater do
       let(:record_type) { "orders" }
 
       it_behaves_like "batch updating"
+
+      describe "slot available service call" do
+        let(:order_status_id) { OrderStatus.canceled.id }
+
+        it "does not call the service" do
+          expect(ProductNotifications::SlotAvailableService).not_to(
+            receive(:from_reservation)
+          )
+
+          updater.update!
+        end
+      end
     end
 
     context "when associated with Reservations" do
       let(:record_type) { "reservations" }
+      let(:instrument) { create(:setup_instrument) }
+      let(:reservation) { create(:setup_reservation, product: instrument) }
+      let(:order_detail) { reservation.order_detail }
+      let(:order) { order_detail.order }
+
+      describe "slot available service call" do
+        context "when new status is canceled" do
+          let(:order_status_id) { OrderStatus.canceled.id }
+
+          it "calls the service" do
+            skip "Only applies to orders with reservations" if order_detail.reservation.blank?
+
+            expect(ProductNotifications::SlotAvailableService).to(
+              receive_message_chain("from_reservation.notify!")
+            )
+
+            updater.update!
+          end
+        end
+
+        context "when new status is complete" do
+          let(:order_status_id) { OrderStatus.complete.id }
+
+          it "does not call the service" do
+            expect(ProductNotifications::SlotAvailableService).not_to(
+              receive(:from_reservation)
+            )
+
+            updater.update!
+          end
+        end
+      end
 
       it_behaves_like "batch updating"
     end
@@ -258,10 +302,10 @@ RSpec.describe OrderDetailBatchUpdater do
       end
 
       shared_examples_for "batch updating project_id" do
-        let(:other_project) { FactoryBot.create(:project, facility: facility) }
+        let(:other_project) { create(:project, facility: facility) }
 
         context "when project_id is already set" do
-          let(:existing_project) { FactoryBot.create(:project, facility: facility) }
+          let(:existing_project) { create(:project, facility: facility) }
 
           before { order_detail.update_attribute(:project_id, existing_project.id) }
 

--- a/spec/services/order_detail_batch_updater_spec.rb
+++ b/spec/services/order_detail_batch_updater_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe OrderDetailBatchUpdater do
             skip "Only applies to orders with reservations" if order_detail.reservation.blank?
 
             expect(ProductNotifications::SlotAvailableService).to(
-              receive_message_chain("from_reservation.notify!")
+              receive_message_chain("from_reservation.notify_later")
             )
 
             updater.update!

--- a/spec/services/product_notifications/slot_available_service_spec.rb
+++ b/spec/services/product_notifications/slot_available_service_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe(
     end
   end
 
-  describe "when product not available" do
+  describe "when product not schedulable" do
     let(:product) do
       create(
         :setup_instrument,
@@ -132,7 +132,21 @@ RSpec.describe(
       )
     end
 
-    it "does not call notify if product not schedulable" do
+    it "does not send emails" do
+      expect { subject.notify! }.not_to have_enqueued_mail
+    end
+  end
+
+  describe "when date in the past" do
+    let(:subject) do
+      described_class.new(
+        product,
+        2.days.ago,
+        1.day.ago,
+      )
+    end
+
+    it "does not send emails" do
       expect { subject.notify! }.not_to have_enqueued_mail
     end
   end

--- a/spec/services/product_notifications/slot_available_service_spec.rb
+++ b/spec/services/product_notifications/slot_available_service_spec.rb
@@ -103,6 +103,57 @@ RSpec.describe(
         )
       end
     end
+
+    describe "when date in the past" do
+      let(:subject) do
+        described_class.new(
+          product,
+          2.days.ago,
+          1.day.ago,
+        )
+      end
+
+      it "does not send emails" do
+        expect { subject.notify! }.not_to have_enqueued_mail
+      end
+    end
+
+    describe "when user is inactive" do
+      let(:start_time) { 1.day.from_now }
+      let(:end_time) { start_time + 1.hour }
+      let(:subject) do
+        described_class.new(
+          product,
+          start_time,
+          end_time,
+        )
+      end
+      let(:inactive_user) do
+        create(:user, suspended_at: Time.current)
+      end
+
+      before do
+        product_notification.users << inactive_user
+      end
+
+      it "enqueues some mails" do
+        expect { subject.notify! }.to(
+          have_enqueued_mail(
+            ProductNotificationMailer,
+            :slot_available,
+          ).exactly(2)
+        )
+      end
+
+      it "does not notify inactive users" do
+        expect { subject.notify! }.not_to(
+          have_enqueued_mail(
+            ProductNotificationMailer,
+            :slot_available,
+          ).with(product, inactive_user, start_time, end_time, subject: nil)
+        )
+      end
+    end
   end
 
   describe "when product not schedulable" do
@@ -129,20 +180,6 @@ RSpec.describe(
         :schedule_rule,
         :weekend,
         product:,
-      )
-    end
-
-    it "does not send emails" do
-      expect { subject.notify! }.not_to have_enqueued_mail
-    end
-  end
-
-  describe "when date in the past" do
-    let(:subject) do
-      described_class.new(
-        product,
-        2.days.ago,
-        1.day.ago,
       )
     end
 

--- a/spec/services/product_notifications/slot_available_service_spec.rb
+++ b/spec/services/product_notifications/slot_available_service_spec.rb
@@ -104,4 +104,36 @@ RSpec.describe(
       end
     end
   end
+
+  describe "when product not available" do
+    let(:product) do
+      create(
+        :setup_instrument,
+        skip_schedule_rules: true,
+      )
+    end
+    let(:start_time) do
+      Time.current.next_weekday.beginning_of_day
+    end
+    let(:end_time) { start_time + 1.hour }
+    let(:subject) do
+      described_class.new(
+        product,
+        start_time,
+        end_time
+      )
+    end
+
+    before do
+      create(
+        :schedule_rule,
+        :weekend,
+        product:,
+      )
+    end
+
+    it "does not call notify if product not schedulable" do
+      expect { subject.notify! }.not_to have_enqueued_mail
+    end
+  end
 end

--- a/spec/services/product_notifications/slot_available_service_spec.rb
+++ b/spec/services/product_notifications/slot_available_service_spec.rb
@@ -187,4 +187,13 @@ RSpec.describe(
       expect { subject.notify! }.not_to have_enqueued_mail
     end
   end
+
+  describe "notify_later" do
+    it "enqueues a SlotAvailableJob" do
+      expect { subject.notify_later }.to(
+        enqueue_job(SlotAvailableJob)
+        .with(product, start_time, end_time, exclude_user: nil)
+      )
+    end
+  end
 end


### PR DESCRIPTION
# Notes

- Call slot available notifier on: admin hold removal, batch order update
- Allow access to Facility Operators and facility users with product management
- Run slot available notification in a job

Part of [NU-444 | An automatic email that would notify user of canceled reservations](https://universe-of-universities.atlassian.net/browse/NU-444)