### PR TITLE
[NUOPEN-368] Lock Payment Source Management permission to global admins

### DIFF
--- a/app/controllers/facility_user_permissions_controller.rb
+++ b/app/controllers/facility_user_permissions_controller.rb
@@ -55,7 +55,7 @@ class FacilityUserPermissionsController < ApplicationController
 
   def permission_params
     allowed = FacilityUserPermission.all_permissions
-    allowed -= [:assign_permissions] unless current_user.administrator?
+    allowed -= [:assign_permissions, :account_management] unless current_user.administrator?
     allowed -= [:quoting] if SettingsHelper.feature_off?(:show_estimates_option)
 
     permitted = params.require(:facility_user_permission).permit(*allowed)

--- a/app/controllers/facility_user_permissions_controller.rb
+++ b/app/controllers/facility_user_permissions_controller.rb
@@ -55,7 +55,7 @@ class FacilityUserPermissionsController < ApplicationController
 
   def permission_params
     allowed = FacilityUserPermission.all_permissions
-    allowed -= [:assign_permissions, :account_management] unless current_user.administrator?
+    allowed -= FacilityUserPermission::ADMIN_ONLY_PERMISSIONS unless current_user.administrator?
     allowed -= [:quoting] if SettingsHelper.feature_off?(:show_estimates_option)
 
     permitted = params.require(:facility_user_permission).permit(*allowed)

--- a/app/models/facility_user_permission.rb
+++ b/app/models/facility_user_permission.rb
@@ -24,6 +24,11 @@ class FacilityUserPermission < ApplicationRecord
     quoting
   ].freeze
 
+  ADMIN_ONLY_PERMISSIONS = %i[
+    assign_permissions
+    account_management
+  ].freeze
+
   validates :user_id, uniqueness: { scope: :facility_id }
   validate :read_access_required_with_other_permissions
 

--- a/app/views/facility_user_permissions/edit.html.haml
+++ b/app/views/facility_user_permissions/edit.html.haml
@@ -24,7 +24,7 @@
     %fieldset.js--permissionsFieldset
       %legend= text(".permissions")
       - FacilityUserPermission.all_permissions.each do |perm|
-        - next if perm == :assign_permissions && !current_user.administrator?
+        - next if [:assign_permissions, :account_management].include?(perm) && !current_user.administrator?
         - next if perm == :quoting && SettingsHelper.feature_off?(:show_estimates_option)
         .checkbox
           %label

--- a/app/views/facility_user_permissions/edit.html.haml
+++ b/app/views/facility_user_permissions/edit.html.haml
@@ -24,7 +24,7 @@
     %fieldset.js--permissionsFieldset
       %legend= text(".permissions")
       - FacilityUserPermission.all_permissions.each do |perm|
-        - next if [:assign_permissions, :account_management].include?(perm) && !current_user.administrator?
+        - next if FacilityUserPermission::ADMIN_ONLY_PERMISSIONS.include?(perm) && !current_user.administrator?
         - next if perm == :quoting && SettingsHelper.feature_off?(:show_estimates_option)
         .checkbox
           %label

--- a/spec/controllers/facility_user_permissions_controller_spec.rb
+++ b/spec/controllers/facility_user_permissions_controller_spec.rb
@@ -46,6 +46,11 @@ RSpec.describe FacilityUserPermissionsController, feature_setting: { granular_pe
         get :edit, params: @params
         expect(response.body).not_to include("assign_permissions")
       end
+
+      it "does not show the account_management checkbox" do
+        get :edit, params: @params
+        expect(response.body).not_to include("account_management")
+      end
     end
 
     context "as a user without assign_permissions" do
@@ -114,6 +119,13 @@ RSpec.describe FacilityUserPermissionsController, feature_setting: { granular_pe
         expect(permission.assign_permissions).to be true
       end
 
+      it "can assign the account_management permission" do
+        @params[:facility_user_permission] = { account_management: true }
+        patch :update, params: @params
+        permission = FacilityUserPermission.find_by(user: target_user, facility:)
+        expect(permission.account_management).to be true
+      end
+
       it "destroys the record when all permissions are unchecked" do
         create(:facility_user_permission, user: target_user, facility:, product_edition: true)
         @params[:facility_user_permission] = FacilityUserPermission.all_permissions.index_with { false }
@@ -156,6 +168,14 @@ RSpec.describe FacilityUserPermissionsController, feature_setting: { granular_pe
         patch :update, params: @params
         permission = FacilityUserPermission.find_by(user: target_user, facility:)
         expect(permission.assign_permissions).to be false
+        expect(permission.product_edition).to be true
+      end
+
+      it "cannot assign the account_management permission" do
+        @params[:facility_user_permission] = { account_management: true, product_edition: true }
+        patch :update, params: @params
+        permission = FacilityUserPermission.find_by(user: target_user, facility:)
+        expect(permission.account_management).to be false
         expect(permission.product_edition).to be true
       end
     end


### PR DESCRIPTION
# Notes

  The "Payment Source Management" permission in the granular permissions list can now only be granted by a Global Admin. For everyone else the option is hidden, matching how "Assign Permissions" already behaves.
  
  [NUOPEN-368](https://universe-of-universities.atlassian.net/browse/NUOPEN-368)
