### PR TITLE
[OSU-229] Fix stepped billing external subsidies

### DIFF
--- a/app/javascript/price_policy.js
+++ b/app/javascript/price_policy.js
@@ -111,20 +111,25 @@ $(document).ready(function() {
     }
   });
 
+  // Duration rates
+
   $(".js--baseRate").each(function (_index, element) {
-    setRateForSubsidyPrieGroups(element);
+    setRateForSubsidyPriceGroups(element);
   });
 
   $(".js--baseRate").on("change", function (event) {
-    setRateForSubsidyPrieGroups(event.target)
+    setRateForSubsidyPriceGroups(event.target)
   });
 
-  function setRateForSubsidyPrieGroups(params) {
+  function setRateForSubsidyPriceGroups(params) {
     const columnIndex = params.dataset.index;
+    const priceGroupId = params.dataset.priceGroupId;
     const stepBaseRate = params.value;
-    $(
-      `input[name*='duration_rates_attributes][${columnIndex}][rate]'].js--hiddenRate`
-    ).val(stepBaseRate);
+
+    $('.js--hiddenRate')
+      .filter(`input[name*='duration_rates_attributes][${columnIndex}][rate]']`)
+      .filter(`[data-parent-price-group-id='${priceGroupId}']`)
+      .val(stepBaseRate);
   }
 
   $(".js--minDuration").on("change", function (event) {

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -42,6 +42,10 @@ class PriceGroup < ApplicationRecord
     base
   end
 
+  def self.master_internal
+    globals.find_by(is_internal: true, display_order: 1)
+  end
+
   # Create a global price group, if it does not exist, and setup all the
   # schedule rules with price group discounts for the price group.
   def self.setup_global(name:, is_internal: false, admin_editable: true, discount_percent: 0, display_order: nil)

--- a/app/views/time_based_price_policies/_price_policy_fields.html.haml
+++ b/app/views/time_based_price_policies/_price_policy_fields.html.haml
@@ -71,7 +71,7 @@
           - duration_rates = pp.object.duration_rates.sort_by { |d| d.min_duration_hours || 1_000 }
           = pp.fields_for :duration_rates, duration_rates do |dr|
             - if !price_group.subsidy_only?
-              - rate_input_class = price_group.master_internal? ? "js--baseRate usage_rate" : "usage_rate"
+              - rate_input_class = price_group.master_internal? || price_group.external? ? "js--baseRate usage_rate" : "usage_rate"
               %td
                 = dr.label :rate, t(".rate_per_hr"), class: "normal-weight"
                 = dr.text_field :rate,
@@ -86,4 +86,5 @@
                 %span.negative-number
                   = dr.text_field :subsidy, value: number_to_currency(dr.object.hourly_subsidy, unit: "", delimiter: ""), size: 8, class: "usage_adjustment"
                 = dr.hidden_field :min_duration_hours
-                = dr.hidden_field :rate, class: "js--hiddenRate"
+                = dr.hidden_field :rate, class: "js--hiddenRate",
+                  data: { parent_price_group_id: price_group.is_internal? ? PriceGroup.master_internal.id : price_group.parent_price_group_id }

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -416,17 +416,7 @@ RSpec.describe InstrumentPricePoliciesController do
   end
 
   context "External subsidy price groups", :js, feature_setting: { "pricing.external_price_group_subsidies" => true, "pricing.facility_directors_can_manage_price_groups" => true, "billing.charge_full_price_on_cancellation" => true } do
-    let!(:external_subsidy_group) do
-      create(
-        :price_group,
-        facility: nil,
-        is_internal: false,
-        global: true,
-        admin_editable: false,
-        name: "External Subsidy",
-        parent_price_group: external_price_group,
-      )
-    end
+    let!(:external_subsidy_group) { create(:price_group, facility: nil, is_internal: false, global: true, admin_editable: false, name: "External Subsidy", parent_price_group: external_price_group) }
 
     it "syncs fields from external parent (not base internal) and handles full cancellation correctly" do
       visit new_facility_instrument_price_policy_path(facility, instrument)

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -416,7 +416,17 @@ RSpec.describe InstrumentPricePoliciesController do
   end
 
   context "External subsidy price groups", :js, feature_setting: { "pricing.external_price_group_subsidies" => true, "pricing.facility_directors_can_manage_price_groups" => true, "billing.charge_full_price_on_cancellation" => true } do
-    let!(:external_subsidy_group) { create(:price_group, facility: nil, is_internal: false, global: true, admin_editable: false, name: "External Subsidy", parent_price_group: external_price_group) }
+    let!(:external_subsidy_group) do
+      create(
+        :price_group,
+        facility: nil,
+        is_internal: false,
+        global: true,
+        admin_editable: false,
+        name: "External Subsidy",
+        parent_price_group: external_price_group,
+      )
+    end
 
     it "syncs fields from external parent (not base internal) and handles full cancellation correctly" do
       visit new_facility_instrument_price_policy_path(facility, instrument)
@@ -465,6 +475,61 @@ RSpec.describe InstrumentPricePoliciesController do
         subsidy_policy = instrument.price_policies.find_by(price_group: external_subsidy_group)
         expect(subsidy_policy.usage_rate_daily).to eq(2000)
         expect(subsidy_policy.usage_subsidy_daily).to eq(1500)
+      end
+    end
+
+    context "with duration billing" do
+      let(:pricing_mode) { Instrument::Pricing::DURATION }
+
+      it "syncs fields from external parent (not base internal) and handles full cancellation correctly" do
+        visit new_facility_instrument_price_policy_path(facility, instrument)
+
+        fill_in "price_policy_#{base_price_group.id}[usage_rate]", with: "60"
+        fill_in "price_policy_#{external_price_group.id}[usage_rate]", with: "120"
+        fill_in(
+          "price_policy_#{external_price_group.id}[duration_rates_attributes][0][rate]",
+          with: "100",
+        )
+        # This is filled to focuse out previous input
+        fill_in(
+          "price_policy_#{external_price_group.id}[duration_rates_attributes][1][rate]",
+          with: "80",
+        )
+
+        expect(page).to have_field(
+          "price_policy_#{cancer_center.id}[usage_rate]",
+          type: :hidden,
+          with: "60",
+        )
+        # Verify external subsidy gets external rate (not base)
+        expect(page).to have_field(
+          "price_policy_#{external_subsidy_group.id}[usage_rate]",
+          with: "120",
+          type: :hidden,
+        )
+
+        # Verify external subsidy step 1 gets external base rate
+        expect(page).to have_field(
+          "price_policy_#{external_subsidy_group.id}[duration_rates_attributes][0][rate]",
+          with: "100",
+          type: :hidden,
+        )
+
+        # Check full cancellation on base - should not affect external subsidy
+        check "price_policy_#{base_price_group.id}[full_price_cancellation]"
+        expect(page).to have_field(
+          "price_policy_#{external_subsidy_group.id}[cancellation_cost]",
+          disabled: false,
+          type: :hidden,
+        )
+
+        # Check full cancellation on external parent - should affect external subsidy
+        check "price_policy_#{external_price_group.id}[full_price_cancellation]"
+        expect(page).to have_field(
+          "price_policy_#{external_subsidy_group.id}[cancellation_cost]",
+          disabled: true,
+          type: :hidden,
+        )
       end
     end
   end

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -480,7 +480,7 @@ RSpec.describe InstrumentPricePoliciesController do
           "price_policy_#{external_price_group.id}[duration_rates_attributes][0][rate]",
           with: "100",
         )
-        # This is filled to focuse out previous input
+        # This is filled to focus out previous input
         fill_in(
           "price_policy_#{external_price_group.id}[duration_rates_attributes][1][rate]",
           with: "80",


### PR DESCRIPTION
# Notes

Fix stepped billing with external subsidies using base internal rate for base external prices.
The issue was that stepped billing add up to three new rates for each price group to have in total four steps. The first rate is stored on the price group and the rest in the DurationRate model. The js that copied base rates to subsidies rates was working for the first step (rate stored in price group) but not for the others, it was taking the base rate to be the master internal. See screenshot for reference.

The rates per minute shown below the inputs fields are still incorrect. This is will be address later.

[OSU-229 | Stepped billing with external subsidies error](https://universe-of-universities.atlassian.net/browse/OSU-229)

## Screenshot

External subsidy for step 1 should be 16 - 10, but it ends up being 10 - 10.

<img width="919" height="741" alt="Captura desde 2026-06-24 10-17-35" src="https://github.com/user-attachments/assets/5085c729-368b-4bd0-be2a-614a533cb651" />

<img width="919" height="741" alt="Captura desde 2026-06-24 10-10-43" src="https://github.com/user-attachments/assets/dfbeb2d4-90b7-4343-9adf-c640bd5c4347" />

