### PR TITLE
[Chore] Add secret key base for CI

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -95,6 +95,7 @@ jobs:
       MYSQL_USER: root
       MYSQL_PASSWORD: root
       PARALLEL_TEST_PROCESSORS: 4
+      SECRET_KEY_BASE: value_needed_for_ci
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-deps


### PR DESCRIPTION
# Notes

TECH TASK: Sets a static `SECRET_KEY_BASE` in the CI test job so the parallel test setup stops intermittently failing.