### PR TITLE
[FIX] Pass Instrument.name to of_type in product notifications

### DIFF
--- a/app/controllers/facility_product_notifications_controller.rb
+++ b/app/controllers/facility_product_notifications_controller.rb
@@ -78,7 +78,7 @@ class FacilityProductNotificationsController < ApplicationController
       .products
       .active
       .not_archived
-      .of_type(Instrument)
+      .of_type(Instrument.name)
       .alphabetized
   end
 


### PR DESCRIPTION
## Notes

Fix the code to be compatible with Oracle Databases
