### PR TITLE
[NUOPEN-348] Prevent possible cause of flaky spec

### DIFF
--- a/spec/system/admin/all_transactions_search_spec.rb
+++ b/spec/system/admin/all_transactions_search_spec.rb
@@ -59,6 +59,11 @@ RSpec.describe "All Transactions Search", :js do
         .for_accounts(some_account)
         .pluck(:order_id)
 
+      # appear_in_order matcher doesn't auto-wait
+      order_ids.each do |odid|
+        expect(page).to have_content("test_prefix_#{odid}")
+      end
+
       expect(order_ids.map { |odid| "test_prefix_#{odid}" }).to appear_in_order
     end
   end


### PR DESCRIPTION
# Notes
* Prevent possible cause of flaky spec

[NUOPEN-348 | Fix some flaky tests ](https://universe-of-universities.atlassian.net/browse/NUOPEN-348)

# Additional Context
I wasn't able to reproduce it locally but it makes sense to actually wait for the page to load before checking that the order is right.