### PR TITLE
[NU-444] Update product notification labels and email

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -150,6 +150,7 @@ class ReservationsController < ApplicationController
     raise ActiveRecord::RecordNotFound unless @reservation.nil?
 
     @reservation = NextAvailableReservationFinder.new(@instrument).next_available_for(current_user, acting_user)
+
     @reservation.order_detail = @order_detail
 
     authorize! :new, @reservation

--- a/app/controllers/single_reservations_controller.rb
+++ b/app/controllers/single_reservations_controller.rb
@@ -10,7 +10,7 @@ class SingleReservationsController < ApplicationController
 
   def new
     @reservation = NextAvailableReservationFinder
-                   .new(@instrument)
+                   .new(@instrument, start_at: start_at_param)
                    .next_available_for(current_user, acting_user)
 
     @reservation.order_detail = @order_detail
@@ -64,4 +64,11 @@ class SingleReservationsController < ApplicationController
     @reservation_window = ReservationWindow.new(@reservation, current_user)
   end
 
+  def start_at_param
+    return if (start_at = params[:start_at]).blank?
+
+    Time.zone.parse(start_at)
+  rescue ArgumentError
+    nil
+  end
 end

--- a/app/services/next_available_reservation_finder.rb
+++ b/app/services/next_available_reservation_finder.rb
@@ -3,14 +3,17 @@
 # Used by the reservations controllers to find the default
 # reservation times to display
 class NextAvailableReservationFinder
-  def initialize(product)
+  attr_reader :product, :start_at
+
+  def initialize(product, start_at: nil)
     @product = product
+    @start_at = start_at || 1.minute.from_now
   end
 
   def next_available_for(current_user, acting_user)
     options = current_user.can_override_restrictions?(@product) ? {} : { user: acting_user }
     next_available = @product.next_available_reservation(
-      after: 1.minute.from_now,
+      after: start_at,
       duration: default_duration,
       options:
     )
@@ -22,8 +25,8 @@ class NextAvailableReservationFinder
 
   def default_reservation
     Reservation.new(product: @product,
-                    reserve_start_at: Time.current,
-                    reserve_end_at: default_duration.from_now)
+                    reserve_start_at: start_at,
+                    reserve_end_at: start_at + default_duration)
   end
 
   def default_duration

--- a/app/services/next_available_reservation_finder.rb
+++ b/app/services/next_available_reservation_finder.rb
@@ -11,8 +11,8 @@ class NextAvailableReservationFinder
   end
 
   def next_available_for(current_user, acting_user)
-    options = current_user.can_override_restrictions?(@product) ? {} : { user: acting_user }
-    next_available = @product.next_available_reservation(
+    options = current_user.can_override_restrictions?(product) ? {} : { user: acting_user }
+    next_available = product.next_available_reservation(
       after: start_at,
       duration: default_duration,
       options:
@@ -24,16 +24,16 @@ class NextAvailableReservationFinder
   private
 
   def default_reservation
-    Reservation.new(product: @product,
+    Reservation.new(product:,
                     reserve_start_at: start_at,
                     reserve_end_at: start_at + default_duration)
   end
 
   def default_duration
-    if @product.daily_booking?
-      (@product.min_reserve_days || 1).days
+    if product.daily_booking?
+      (product.min_reserve_days || 1).days
     else
-      (@product.min_reserve_mins.to_i > 0 ? @product.min_reserve_mins : 30).minutes
+      (product.min_reserve_mins.to_i > 0 ? product.min_reserve_mins : 30).minutes
     end
   end
 end

--- a/app/views/product_notification_mailer/slot_available.html.haml
+++ b/app/views/product_notification_mailer/slot_available.html.haml
@@ -1,6 +1,6 @@
 = html("body",
   user_name: @user.full_name,
-  new_reservation_url: new_facility_instrument_single_reservation_url(@product.facility, @product),
+  new_reservation_url: new_facility_instrument_single_reservation_url(@product.facility, @product, start_at: @time_range.start_at&.iso8601),
   time_range: @time_range,
   product: @product,
   facility: @product.facility,

--- a/app/views/product_notification_mailer/slot_available.txt.erb
+++ b/app/views/product_notification_mailer/slot_available.txt.erb
@@ -1,6 +1,6 @@
 <%= text("body",
   user_name: @user.full_name,
-  new_reservation_url: new_facility_instrument_single_reservation_url(@product.facility, @product),
+  new_reservation_url: new_facility_instrument_single_reservation_url(@product.facility, @product, start_at: @time_range.start_at&.iso8601),
   time_range: @time_range,
   product: @product,
   facility: @product.facility)

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -224,7 +224,7 @@ en:
       product_display_group:
         one: Product Group
         other: Product Groups
-      product_notification: Product Notification
+      product_notification: User Notification
       research_safety_certificate:
         one: Certificate
         other: Certificates

--- a/config/locales/views/en.facility_product_notifications.yml
+++ b/config/locales/views/en.facility_product_notifications.yml
@@ -24,10 +24,10 @@ en:
       no_results: No users found
       selected_users: Selected Users
       select_products_hint: Select instruments
-      select_users_hint: Search and select users one by one
+      select_users_hint: Search and select users to receive notifications
       hints:
         email_subject: Override default email subject
-        reservation_days: Reservations canceled within this amount of days will trigger the notification
+        reservation_days: Reservations canceled within this number of days from today will trigger the notification.
         slot_available: Notify users when a Reservation or Admin Hold is canceled for any of the selected instruments
     user_search_results:
       add_user: Add

--- a/config/locales/views/en.product_notification_mailer.yml
+++ b/config/locales/views/en.product_notification_mailer.yml
@@ -6,6 +6,10 @@ en:
         body: |
           Hello %{user_name},
 
-          Time slot %{time_range} became available for %{product} at %{facility}.
+          There has been a cancellation on %{product}.
+
+          The following time slot is now available:
+
+          %{time_range}
 
           [Make a reservation](%{new_reservation_url})

--- a/spec/requests/facility_product_notifications_spec.rb
+++ b/spec/requests/facility_product_notifications_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "FacilityProductNotifications" do
 
         expect(page).to have_content("No Product Notifications have been created")
         expect(page).to have_link(
-          "Add Product Notification",
+          "Add User Notification",
           href: new_facility_product_notification_path(facility),
         )
       end

--- a/spec/requests/single_reservations_spec.rb
+++ b/spec/requests/single_reservations_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "SingleReservationsController" do
+  describe "new" do
+    let(:user) { create(:user) }
+    let(:instrument) { create(:setup_instrument) }
+    let(:facility) { instrument.facility }
+
+    let(:action) do
+      lambda do |params = {}|
+        get new_facility_instrument_single_reservation_path(facility, instrument, **params)
+      end
+    end
+
+    before do
+      login_as user
+    end
+
+    context "when start_at param is provided" do
+      let(:start_at) { 1.day.from_now }
+
+      it "finds next available with that value" do
+        expect(NextAvailableReservationFinder).to(
+          receive(:new)
+          .with(instrument, start_at:)
+        ).and_call_original
+
+        action.call(start_at:)
+      end
+
+      context "when start at is invalid" do
+        let(:start_at) { "Some invalid date" }
+
+        it "finds next available with start_at nil" do
+          expect(NextAvailableReservationFinder).to(
+            receive(:new)
+            .with(instrument, start_at: nil)
+          ).and_call_original
+
+          action.call(start_at:)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/next_available_reservation_finder_spec.rb
+++ b/spec/services/next_available_reservation_finder_spec.rb
@@ -4,7 +4,9 @@ require "rails_helper"
 
 RSpec.describe NextAvailableReservationFinder do
   let(:user) { build(:user) }
-  subject(:reservation) { described_class.new(instrument).next_available_for(user, user) }
+  subject(:reservation) do
+    described_class.new(instrument).next_available_for(user, user)
+  end
 
   describe "time scheduled instrument" do
     let(:instrument) { build(:instrument, min_reserve_mins: 0) }
@@ -64,6 +66,31 @@ RSpec.describe NextAvailableReservationFinder do
       it "sets reserve_end_at correctly" do
         expect(reservation.reserve_end_at).to eq(reservation.reserve_start_at + 1.day)
       end
+    end
+  end
+
+  describe "start time specified" do
+    let(:start_at) { 10.days.from_now }
+    let(:instrument) { build(:instrument, min_reserve_mins: 0) }
+    let(:finder) do
+      described_class
+        .new(instrument, start_at:)
+    end
+    let(:reservation) do
+      finder.next_available_for(user, user)
+    end
+
+    it "returns a reservation starting on start_at" do
+      expect(reservation.reserve_start_at).to eq(start_at)
+    end
+
+    it "calls next available reservation after start_at" do
+      expect(instrument).to(
+        receive(:next_available_reservation)
+        .with(a_hash_including(after: start_at))
+      )
+
+      finder.next_available_for(user, user)
     end
   end
 end


### PR DESCRIPTION
# Notes

- Update some labels and email
- Allow single reservation controller new action to receive a `start_at` parameter where to find the next available reservation to be used in the next available reservation email

Part of [NU-444 | An automatic email that would notify user of canceled reservations](https://universe-of-universities.atlassian.net/browse/NU-444)
