### PR TITLE
[NUOPEN-280] Standarize date input submission

### DIFF
--- a/app/controllers/holidays_controller.rb
+++ b/app/controllers/holidays_controller.rb
@@ -15,8 +15,6 @@ class HolidaysController < ApplicationController
   end
 
   def create
-    @holiday.date = parse_usa_date(holiday_params[:date])
-
     if @holiday.save
       redirect_to holidays_path, notice: t("holidays.create.success")
     else
@@ -28,7 +26,7 @@ class HolidaysController < ApplicationController
   end
 
   def update
-    if @holiday.update(date: parse_usa_date(holiday_params[:date]))
+    if @holiday.update(holiday_params)
       redirect_to holidays_path, notice: t("holidays.update.success")
     else
       render :edit

--- a/app/inputs/date_field_input.rb
+++ b/app/inputs/date_field_input.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Native HTML5 date input (browser's built-in picker). Submits values in ISO
+# format (yyyy-mm-dd), so no server-side parsing is needed.
+#
+# Usage:
+#   = f.input :starts_at, as: :date_field
+#   = f.input :expires_at, as: :date_field, min_date: Date.current
+class DateFieldInput < SimpleForm::Inputs::Base
+  def input(_wrapper_options)
+    date = object.public_send(attribute_name)&.to_date
+
+    html_options = input_html_options.merge(
+      value: date&.iso8601, class: "form-control",
+    )
+    html_options[:min] = options[:min_date].to_date.iso8601 if options[:min_date]
+    html_options[:max] = options[:max_date].to_date.iso8601 if options[:max_date]
+
+    @builder.date_field attribute_name, html_options
+  end
+end

--- a/app/views/holidays/_form.html.haml
+++ b/app/views/holidays/_form.html.haml
@@ -1,4 +1,4 @@
 = simple_form_for(@holiday) do |f|
-  = f.input :date, as: :date_picker
+  = f.input :date, as: :date_field
   = f.button :submit, t(".submit"), class: ["btn", "btn-primary"]
   = link_to t(".cancel"), holidays_path

--- a/spec/requests/holidays_spec.rb
+++ b/spec/requests/holidays_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Holidays" do
+  before { login_as create(:user, :administrator) }
+
+  describe "new" do
+    it "renders a native date input" do
+      get new_holiday_path
+
+      expect(response.body).to include('type="date"')
+      expect(response.body).to include('name="holiday[date]"')
+    end
+  end
+
+  describe "create" do
+    it "saves the ISO-formatted date with no server-side parsing" do
+      expect do
+        post holidays_path, params: { holiday: { date: "2026-12-25" } }
+      end.to change(Holiday, :count).by(1)
+
+      expect(Holiday.last.date.to_date).to eq(Date.new(2026, 12, 25))
+      expect(response).to redirect_to(holidays_path)
+    end
+  end
+
+  describe "edit" do
+    let(:holiday) { Holiday.create!(date: Date.new(2026, 12, 25)) }
+
+    it "renders the stored date in ISO format" do
+      get edit_holiday_path(holiday)
+
+      expect(response.body).to include('value="2026-12-25"')
+    end
+  end
+
+  describe "update" do
+    let(:holiday) { Holiday.create!(date: Date.new(2026, 12, 25)) }
+
+    it "updates from the ISO-formatted date" do
+      patch holiday_path(holiday), params: { holiday: { date: "2027-01-01" } }
+
+      expect(holiday.reload.date.to_date).to eq(Date.new(2027, 1, 1))
+      expect(response).to redirect_to(holidays_path)
+    end
+  end
+end


### PR DESCRIPTION
# Notes

Introduces a standard date field that uses the browser's built-in date picker, so dates are always submitted in a consistent (ISO) format and the server no longer has to interpret different formats. Applied it to the Holidays admin form as the first usage.

[NUOPEN-280 | Standarize forms date input submission](https://universe-of-universities.atlassian.net/browse/NUOPEN-280)

# Screenshots
Before:
<img width="1215" height="598" alt="Screenshot 2026-07-02 at 10 43 01 AM" src="https://github.com/user-attachments/assets/92565ea1-e741-4fc8-acd8-b3170d46e395" />

After:
<img width="1232" height="623" alt="Screenshot 2026-07-02 at 10 42 40 AM" src="https://github.com/user-attachments/assets/174e81e3-4f07-4478-a204-b8e454028909" />
