### PR TITLE
[Chore] Bootstrap upgrade style fixes

### DIFF
--- a/app/assets/stylesheets/app/header.scss
+++ b/app/assets/stylesheets/app/header.scss
@@ -52,10 +52,6 @@ header {
     @include gradient-vertical($headerBackgroundColorHighLight, $headerBackgroundColor);
   }
   
-  .dropdown-toggle {
-    @include gradient-vertical($headerBackgroundColorHighLight, $headerBackgroundColor);
-  }
-
   .container {
     position: relative;
     > .navbar-header,

--- a/app/assets/stylesheets/app/typography.scss
+++ b/app/assets/stylesheets/app/typography.scss
@@ -39,6 +39,7 @@ h1, h2, h3, h4, h5 {
 
 h1 {
   margin-top: 0.5em;
+  line-height: 40px;
   border-bottom: 1px solid #ddd;
 }
 

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -27,14 +27,13 @@ html {
 
 nav .navbar {
   margin-bottom: 0;
-  min-height: auto;
   border-radius: 0;
-  
+
   .navbar-nav > li {
     > a {
       padding: 12px 15px;
     }
-    
+
     &.active,
     &:hover {
       border-top: $navbarActiveBorderHeight solid $navbarActiveBorderColor;

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -169,11 +169,17 @@ ul, ol {
       line-height: 2em;
       margin-top: 0;
       color: $black;
+      text-transform: uppercase;
+      font-weight: bold;
     }
     &.divider {
       margin: 0.5em 1px;
+      height: 1px;
+      margin: 9px 0;
+      overflow: hidden;
+      background-color: #e5e5e5;
     }
-    
+
     > a {
       padding: 3px 15px;
     }

--- a/app/views/admin/shared/_sidenav_billing.html.haml
+++ b/app/views/admin/shared/_sidenav_billing.html.haml
@@ -12,13 +12,13 @@
     = tab text("orders_in_review"), facility_notifications_in_review_path, (sidenav_tab == 'in_review') if SettingsHelper::has_review_period?
 
   - if can?(:manage, Journal)
-    %li.divider
+    %li.divider{role: "separator"}
     %li.nav-header= text("internal_billing")
     = tab t_create_model(Journal), new_facility_journal_path, (sidenav_tab == 'new_journal') if current_facility.single_facility?
     = tab t_manage_models(Journal), facility_journals_path, (sidenav_tab == 'journals')
 
   - if can?(:manage, Statement) && Account.config.statements_enabled?
-    %li.divider
+    %li.divider{role: "separator"}
     %li.nav-header= text("external_billing")
     = tab t_create_models(Statement), new_facility_statement_path(current_facility), (sidenav_tab == 'statements')
     = tab text("statement_history"), facility_statements_path(current_facility), (sidenav_tab == "statement_history")
@@ -38,5 +38,5 @@
 
   - billing_log_events_ff = SettingsHelper.feature_on?("billing.billing_log_events")
   - if billing_log_events_ff && current_facility.cross_facility? && can?(:manage_billing, current_facility)
-    %li.divider
+    %li.divider{role: "separator"}
     = tab text("billing_log_event"), facility_billing_log_events_path(current_facility), (sidenav_tab == "billing_log")

--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -1,5 +1,5 @@
 -# .visible-with-nav is visible > 979px
-.navbar.navbar-default.hide-from-print.visible-with-nav
+.navbar.navbar-default.navbar-static-top.hide-from-print.visible-with-nav
   .container
     - if session_user
       = render "/shared/nav/nav_links"


### PR DESCRIPTION
# Notes

Bring back some styling lost during bootstrap upgrade:
- Billing sidebar menu headers and dividers (divider styles taken from bootstrap's dropdown divider)
- Navbar active menu styles and remove redundant css rules
- Remove notice menu background gradient which looks off
- H1 spacing between line below

## Screenshots

Before the upgrade

<img width="1036" height="897" alt="Captura desde 2026-07-02 15-22-07" src="https://github.com/user-attachments/assets/f2ed976b-7d22-4bb4-9721-b30482bd90eb" />

After (with this branch's changes)

<img width="1141" height="927" alt="Captura desde 2026-07-06 14-30-03" src="https://github.com/user-attachments/assets/802b254c-bde2-454a-b378-fe99810f7356" />

