### PR TITLE
[NUOPEN-273] Relay update fixes

### DIFF
--- a/app/controllers/instrument_relays_controller.rb
+++ b/app/controllers/instrument_relays_controller.rb
@@ -37,12 +37,9 @@ class InstrumentRelaysController < ApplicationController
   def handle_relay(action_string)
     old_id = params[:id]
 
-    @relay = @product.replace_relay(relay_params, params[:relay][:control_mechanism])
+    @relay = replace_relay(relay_params, params[:relay][:control_mechanism])
     if @relay.valid?
       @relay.try(:activate_secondary_outlet) if @relay.secondary_outlet.present?
-
-      # Need to update the loggable_id for the old relay, because the relay is being replaced.
-      LogEvent.where(loggable_type: "Relay", loggable_id: old_id).update_all(loggable_id: @relay.id) if old_id.present?
 
       LogEvent.log(@relay, :update, current_user, metadata: { instrument_name: @product.name }) if @relay.persisted?
 
@@ -84,5 +81,4 @@ class InstrumentRelaysController < ApplicationController
                   :circuit_number,
                   :ethernet_port_number)
   end
-
 end

--- a/app/controllers/instrument_relays_controller.rb
+++ b/app/controllers/instrument_relays_controller.rb
@@ -37,11 +37,16 @@ class InstrumentRelaysController < ApplicationController
   def handle_relay(action_string)
     old_id = params[:id]
 
-    @relay = replace_relay(relay_params, params[:relay][:control_mechanism])
+    control_mechanism = params[:relay][:control_mechanism]
+    @relay = @product.replace_relay(relay_params, control_mechanism)
+
+    if @relay&.valid? || (@relay.nil? && old_id.present?)
+      LogEvent.log(@product, :relay_update, current_user, metadata: { control_mechanism: })
+    end
+
+    @relay ||= Relay.new
     if @relay.valid?
       @relay.try(:activate_secondary_outlet) if @relay.secondary_outlet.present?
-
-      LogEvent.log(@relay, :update, current_user, metadata: { instrument_name: @product.name }) if @relay.persisted?
 
       flash[:notice] = "Relay was successfully updated."
       redirect_to facility_instrument_relays_path(current_facility, @product)

--- a/app/models/concerns/products/relay_support.rb
+++ b/app/models/concerns/products/relay_support.rb
@@ -24,18 +24,18 @@ module Products::RelaySupport
   # See https://andycroll.com/ruby/be-careful-assigning-to-has-one-relations/
   def replace_relay(attributes = nil, param_control_mechanism = nil)
     self.class.transaction do
+      id = relay&.id
       relay&.destroy!
       case param_control_mechanism
       when Relay::CONTROL_MECHANISMS[:relay]
-        create_relay!(attributes)
+        create_relay!(id:, **attributes)
       when Relay::CONTROL_MECHANISMS[:timer]
-        create_relay!(type: "RelayDummy")
+        create_relay!(id:, type: "RelayDummy")
       when "manual"
-        Relay.new # return a relay instance for the form to use
+        Relay.new
       end
     end
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotDestroyed
-    relay # returns invalid object for error handling
+    relay
   end
-
 end

--- a/app/models/concerns/products/relay_support.rb
+++ b/app/models/concerns/products/relay_support.rb
@@ -24,13 +24,12 @@ module Products::RelaySupport
   # See https://andycroll.com/ruby/be-careful-assigning-to-has-one-relations/
   def replace_relay(attributes = nil, param_control_mechanism = nil)
     self.class.transaction do
-      id = relay&.id
       relay&.destroy!
       case param_control_mechanism
       when Relay::CONTROL_MECHANISMS[:relay]
-        create_relay!(id:, **attributes)
+        create_relay!(**attributes)
       when Relay::CONTROL_MECHANISMS[:timer]
-        create_relay!(id:, type: "RelayDummy")
+        create_relay!(type: "RelayDummy")
       when "manual"
         nil
       end

--- a/app/models/concerns/products/relay_support.rb
+++ b/app/models/concerns/products/relay_support.rb
@@ -32,7 +32,7 @@ module Products::RelaySupport
       when Relay::CONTROL_MECHANISMS[:timer]
         create_relay!(id:, type: "RelayDummy")
       when "manual"
-        Relay.new
+        nil
       end
     end
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotDestroyed

--- a/app/models/reports/log_events_report.rb
+++ b/app/models/reports/log_events_report.rb
@@ -25,7 +25,7 @@ module Reports
       "facility.activate", "facility.deactivate",
       "price_group.create", "price_group.delete",
       "product.activate", "product.deactivate",
-      "product.create", "relay.update",
+      "product.create", "product.relay_update",
       "order_import.created",
     ].freeze
 

--- a/config/locales/en.log_event_types.yml
+++ b/config/locales/en.log_event_types.yml
@@ -47,6 +47,7 @@ en:
       create: Product created
       activate: Product activated
       deactivate: Product deactivated
+      relay_update: Relay updated
     relay:
       update: Relay updated
     user:

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe Instrument do
         end
 
         it "should succeed" do
-          expect(@updated.class).to be Relay
+          expect(@updated).to be nil
         end
 
         it "should have a control_mechanism of manual" do
@@ -241,7 +241,7 @@ RSpec.describe Instrument do
         end
 
         it "should succeed" do
-          expect(@updated.class).to be Relay
+          expect(@updated).to be nil
         end
 
         it "should have a control_mechanism of manual" do


### PR DESCRIPTION
# Notes

Relay log events have some issues related to the fact that relays records are replaced on every time there's a change on the instrument relay tab.

1. Log event references relay records: the workaround was to update all log events for the destroyed relay.
2. When relay type is "Reservation Only", there's actually no relay record which causes log events to object to be blank.

The workaround in this pr is to change log events to use the product with a new log event type.

**Existing log events**: there're not many log events for relay update since it's been one year since this was enabled. To update existing records we can use:
```ruby
LogEvent.where(loggable_type: "Relay", event_type: "update").find_each do |le| le.update(loggable: le.loggable.instrument, event_type: "relay_update") if le.loggable.present? end
```

[NUOPEN-273| Relays replaced on update](https://universe-of-universities.atlassian.net/browse/NUOPEN-273)

