### PR TITLE
[NUOPEN-280]  Migrate easy date inputs to native picker

### DIFF
--- a/app/controllers/facility_accounts_reconciliation_controller.rb
+++ b/app/controllers/facility_accounts_reconciliation_controller.rb
@@ -31,7 +31,12 @@ class FacilityAccountsReconciliationController < ApplicationController
   end
 
   def update
-    reconciled_at = params[:reconciled_at].presence&.to_date&.beginning_of_day
+    reconciled_at =
+      begin
+        params[:reconciled_at].presence&.to_date&.beginning_of_day
+      rescue ArgumentError
+        nil
+      end
     reconciler = OrderDetails::Reconciler.new(
       unreconciled_details,
       params[:order_detail],

--- a/app/controllers/facility_accounts_reconciliation_controller.rb
+++ b/app/controllers/facility_accounts_reconciliation_controller.rb
@@ -31,7 +31,7 @@ class FacilityAccountsReconciliationController < ApplicationController
   end
 
   def update
-    reconciled_at = parse_usa_date(params[:reconciled_at])
+    reconciled_at = params[:reconciled_at].presence&.to_date&.beginning_of_day
     reconciler = OrderDetails::Reconciler.new(
       unreconciled_details,
       params[:order_detail],

--- a/app/controllers/facility_accounts_reconciliation_controller.rb
+++ b/app/controllers/facility_accounts_reconciliation_controller.rb
@@ -31,12 +31,7 @@ class FacilityAccountsReconciliationController < ApplicationController
   end
 
   def update
-    reconciled_at =
-      begin
-        params[:reconciled_at].presence&.to_date&.beginning_of_day
-      rescue ArgumentError
-        nil
-      end
+    reconciled_at = parse_iso_date(params[:reconciled_at])&.beginning_of_day
     reconciler = OrderDetails::Reconciler.new(
       unreconciled_details,
       params[:order_detail],

--- a/app/controllers/facility_estimates_controller.rb
+++ b/app/controllers/facility_estimates_controller.rb
@@ -143,9 +143,6 @@ class FacilityEstimatesController < ApplicationController
         :duration_unit, :_destroy, :recalculate,
       ]
     )
-    if raw_params[:expires_at].present?
-      raw_params[:expires_at] = parse_usa_date(raw_params[:expires_at])
-    end
     if raw_params[:custom_name].present? && raw_params[:user_id].blank?
       raw_params[:user_id] = nil
     end

--- a/app/controllers/journal_creation_reminders_controller.rb
+++ b/app/controllers/journal_creation_reminders_controller.rb
@@ -13,7 +13,7 @@ class JournalCreationRemindersController < ApplicationController
 
   def new
     default_start_date = [JournalCreationReminder.maximum(:starts_at), Time.current].compact.max
-    @journal_creation_reminder.starts_at = l(default_start_date.to_date, format: :usa)
+    @journal_creation_reminder.starts_at = default_start_date.to_date
   end
 
   def create

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -361,7 +361,7 @@ class OrdersController < ApplicationController
 
   def build_order_date
     if params[:order_date].present?
-      parse_usa_date(params[:order_date])
+      params[:order_date].to_date.beginning_of_day
     end
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -360,9 +360,7 @@ class OrdersController < ApplicationController
   end
 
   def build_order_date
-    if params[:order_date].present?
-      params[:order_date].to_date.beginning_of_day
-    end
+    parse_iso_date(params[:order_date])&.beginning_of_day
   end
 
   def can_switch_instrument_on?

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -149,13 +149,6 @@ class PricePoliciesController < ApplicationController
     )
   end
 
-  # Returns nil for blank or unparseable (e.g. "5/0/2018") input.
-  def parse_iso_date(value)
-    value.presence&.to_date
-  rescue Date::Error
-    nil
-  end
-
   # TO DO: consider moving the methods below to InstrumentPricePolicyController
   ## Duration Rates methods start here
   ## These only apply to instruments with duration pricing mode

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -143,10 +143,17 @@ class PricePoliciesController < ApplicationController
     PricePolicyUpdater.update_all(
       @product,
       @price_policies,
-      params[:start_date].presence&.to_date&.beginning_of_day,
-      params[:expire_date].presence&.to_date&.end_of_day,
+      parse_iso_date(params[:start_date])&.beginning_of_day,
+      parse_iso_date(params[:expire_date])&.end_of_day,
       params.merge(created_by_id: current_user.id),
     )
+  end
+
+  # Returns nil for blank or unparseable (e.g. "5/0/2018") input.
+  def parse_iso_date(value)
+    value.presence&.to_date
+  rescue Date::Error
+    nil
   end
 
   # TO DO: consider moving the methods below to InstrumentPricePolicyController

--- a/app/controllers/price_policies_controller.rb
+++ b/app/controllers/price_policies_controller.rb
@@ -143,8 +143,8 @@ class PricePoliciesController < ApplicationController
     PricePolicyUpdater.update_all(
       @product,
       @price_policies,
-      parse_usa_date(params[:start_date])&.beginning_of_day,
-      parse_usa_date(params[:expire_date])&.end_of_day,
+      params[:start_date].presence&.to_date&.beginning_of_day,
+      params[:expire_date].presence&.to_date&.end_of_day,
       params.merge(created_by_id: current_user.id),
     )
   end

--- a/app/forms/add_to_order_form.rb
+++ b/app/forms/add_to_order_form.rb
@@ -199,9 +199,9 @@ class AddToOrderForm
     @facility_id = original_order.facility_id
 
     if previously_added_to?
-      # This is a string so it displays on the form correctly.
+      # ISO-formatted string so the native date input pre-populates correctly.
       # It may be nil if the order is not complete
-      @fulfilled_at = format_usa_date(previously_added_order_detail.fulfilled_at)
+      @fulfilled_at = previously_added_order_detail.fulfilled_at&.to_date&.iso8601
       @order_status_id = previously_added_order_detail.order_status_id
     else
       @fulfilled_at = nil
@@ -284,9 +284,8 @@ class AddToOrderForm
   end
 
   def backdate(order_detail)
-    # `fulfilled_at` is a string and might get misinterpretted as DD/MM instead of MM/DD.
-    # `manual_fulfilled_at` already handles the proper string parsing so we can use
-    # it instead of duplicating the parsing effort.
+    # `fulfilled_at` is an ISO date string from the native date input.
+    # `manual_fulfilled_at` (ValidFulfilledAtDate) handles parsing and validation.
     order_detail.manual_fulfilled_at = fulfilled_at
     # If we are a merge order (i.e. requires more action like uploading an order form),
     # we do not want to set the ordered_at just yet. It will be set after the issues have

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -38,7 +38,9 @@ module DateHelper
   end
 
   def parse_iso_date(value)
-    value.presence&.to_date
+    return value.to_date if value.acts_like?(:date) || value.acts_like?(:time)
+
+    Date.iso8601(value.to_s)
   rescue Date::Error
     nil
   end

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -37,6 +37,12 @@ module DateHelper
     nil
   end
 
+  def parse_iso_date(value)
+    value.presence&.to_date
+  rescue Date::Error
+    nil
+  end
+
   def format_usa_date(datetime)
     format_usa_datetime(datetime.try(:to_date))
   end

--- a/app/inputs/date_field_input.rb
+++ b/app/inputs/date_field_input.rb
@@ -6,15 +6,22 @@
 # Usage:
 #   = f.input :starts_at, as: :date_field
 #   = f.input :expires_at, as: :date_field, min_date: Date.current
+#   = f.input :fulfilled_at, as: :date_field, min_date: x, max_date: y, input_html: { class: "js--hook" }
+#
+# An explicit input_html[:value] is respected as-is (must already be ISO); otherwise
+# the value is read from the object and normalized to ISO.
 class DateFieldInput < SimpleForm::Inputs::Base
   def input(_wrapper_options)
-    date = object.public_send(attribute_name)&.to_date
+    html_options = input_html_options.dup
 
-    html_options = input_html_options.merge(
-      value: date&.iso8601, class: "form-control",
-    )
-    html_options[:min] = options[:min_date].to_date.iso8601 if options[:min_date]
-    html_options[:max] = options[:max_date].to_date.iso8601 if options[:max_date]
+    unless html_options.key?(:value)
+      date = object.public_send(attribute_name)&.to_date
+      html_options[:value] = date&.iso8601
+    end
+
+    html_options[:class] = [*html_options[:class], "form-control"].uniq.join(" ")
+    html_options[:min] ||= options[:min_date]&.to_date&.iso8601
+    html_options[:max] ||= options[:max_date]&.to_date&.iso8601
 
     @builder.date_field attribute_name, html_options
   end

--- a/app/models/journal_creation_reminder.rb
+++ b/app/models/journal_creation_reminder.rb
@@ -11,8 +11,6 @@
 #   start Sep 1, 2021 and end on the August 2021 cutoff date:
 #   Sep 1, 2021 - Sep 8, 2021.
 class JournalCreationReminder < ApplicationRecord
-  include DateHelper
-
   validates :message, presence: true
   validates :starts_at, presence: true
   validates :ends_at, presence: true
@@ -25,14 +23,25 @@ class JournalCreationReminder < ApplicationRecord
   end
 
   def starts_at=(date_string)
-    super(parse_usa_date(date_string))
+    super(coerce_date(date_string)&.beginning_of_day)
   end
 
   def ends_at=(date_string)
-    super(parse_usa_date(date_string)&.end_of_day)
+    super(coerce_date(date_string)&.end_of_day)
   end
 
   private
+
+  # Accepts an ISO date string (from the form) or a Date/Time (set in code).
+  # Returns nil for blank or unparseable values.
+  def coerce_date(value)
+    return if value.blank?
+    return value.to_date if value.acts_like?(:date) || value.acts_like?(:time)
+
+    Date.iso8601(value.to_s)
+  rescue ArgumentError
+    nil
+  end
 
   def starts_before_ends
     if starts_at && ends_at

--- a/app/models/journal_creation_reminder.rb
+++ b/app/models/journal_creation_reminder.rb
@@ -11,6 +11,8 @@
 #   start Sep 1, 2021 and end on the August 2021 cutoff date:
 #   Sep 1, 2021 - Sep 8, 2021.
 class JournalCreationReminder < ApplicationRecord
+  include DateHelper
+
   validates :message, presence: true
   validates :starts_at, presence: true
   validates :ends_at, presence: true
@@ -23,25 +25,14 @@ class JournalCreationReminder < ApplicationRecord
   end
 
   def starts_at=(date_string)
-    super(coerce_date(date_string)&.beginning_of_day)
+    super(parse_iso_date(date_string)&.beginning_of_day)
   end
 
   def ends_at=(date_string)
-    super(coerce_date(date_string)&.end_of_day)
+    super(parse_iso_date(date_string)&.end_of_day)
   end
 
   private
-
-  # Accepts an ISO date string (from the form) or a Date/Time (set in code).
-  # Returns nil for blank or unparseable values.
-  def coerce_date(value)
-    return if value.blank?
-    return value.to_date if value.acts_like?(:date) || value.acts_like?(:time)
-
-    Date.iso8601(value.to_s)
-  rescue ArgumentError
-    nil
-  end
 
   def starts_before_ends
     if starts_at && ends_at

--- a/app/models/valid_fulfilled_at_date.rb
+++ b/app/models/valid_fulfilled_at_date.rb
@@ -32,8 +32,12 @@ class ValidFulfilledAtDate
 
   # Returns nil if the date is invalid
   def to_time
-    time = parse_usa_date(@string).try(:to_date)
-    time.beginning_of_day + 12.hours if time.present?
+    return if @string.blank?
+
+    date = Date.iso8601(@string.to_s)
+    date.beginning_of_day + 12.hours
+  rescue ArgumentError
+    nil
   end
   alias presence to_time
   # `in_time_zone` allows us to set something like

--- a/app/models/valid_fulfilled_at_date.rb
+++ b/app/models/valid_fulfilled_at_date.rb
@@ -3,6 +3,7 @@
 class ValidFulfilledAtDate
 
   include ActiveModel::Validations
+  include DateHelper
 
   validate :valid_format
   validate :not_in_future, if: :to_time
@@ -31,12 +32,8 @@ class ValidFulfilledAtDate
 
   # Returns nil if the date is invalid
   def to_time
-    return if @string.blank?
-
-    date = Date.iso8601(@string.to_s)
-    date.beginning_of_day + 12.hours
-  rescue ArgumentError
-    nil
+    date = parse_iso_date(@string)
+    date.beginning_of_day + 12.hours if date
   end
   alias presence to_time
   # `in_time_zone` allows us to set something like

--- a/app/models/valid_fulfilled_at_date.rb
+++ b/app/models/valid_fulfilled_at_date.rb
@@ -3,7 +3,6 @@
 class ValidFulfilledAtDate
 
   include ActiveModel::Validations
-  include DateHelper
 
   validate :valid_format
   validate :not_in_future, if: :to_time
@@ -41,7 +40,7 @@ class ValidFulfilledAtDate
   end
   alias presence to_time
   # `in_time_zone` allows us to set something like
-  # `record.fulfilled_at = ValidFulfilledAtDate.new("XX/XX/XXXX")`
+  # `record.fulfilled_at = ValidFulfilledAtDate.new("YYYY-MM-DD")`
   # and ActiveRecord will treat it like a normal date/time.
   alias in_time_zone to_time
 

--- a/app/views/facility_accounts_reconciliation/_action_row.html.haml
+++ b/app/views/facility_accounts_reconciliation/_action_row.html.haml
@@ -17,10 +17,11 @@
         .form-group
           = label_tag :reconciled_at, OrderDetail.human_attribute_name(:reconciled_at), class: "control-label col-md-2"
           .col-md-4
-            = text_field_tag :reconciled_at,
-              format_usa_date(Time.current),
-              class: "datepicker__data form-control",
-              data: { min_date: unreconciled_order_details.map(&:journal_or_statement_date).min&.iso8601, max_date: Time.current.iso8601 }
+            = date_field_tag :reconciled_at,
+              Time.current.to_date.iso8601,
+              class: "form-control",
+              min: unreconciled_order_details.map(&:journal_or_statement_date).min&.to_date&.iso8601,
+              max: Time.current.to_date.iso8601
     .row.table-actions.form-horizontal
       .form-group
         = label_tag :bulk_note_checkbox, t("facility_accounts_reconciliation.index.bulk_note_checkbox"), class: "control-label col-md-2"

--- a/app/views/facility_accounts_reconciliation/_action_row.html.haml
+++ b/app/views/facility_accounts_reconciliation/_action_row.html.haml
@@ -18,10 +18,10 @@
           = label_tag :reconciled_at, OrderDetail.human_attribute_name(:reconciled_at), class: "control-label col-md-2"
           .col-md-4
             = date_field_tag :reconciled_at,
-              Time.current.to_date.iso8601,
+              Date.current,
               class: "form-control",
-              min: unreconciled_order_details.map(&:journal_or_statement_date).min&.to_date&.iso8601,
-              max: Time.current.to_date.iso8601
+              min: unreconciled_order_details.map(&:journal_or_statement_date).min&.to_date,
+              max: Date.current
     .row.table-actions.form-horizontal
       .form-group
         = label_tag :bulk_note_checkbox, t("facility_accounts_reconciliation.index.bulk_note_checkbox"), class: "control-label col-md-2"

--- a/app/views/facility_estimates/_form.html.haml
+++ b/app/views/facility_estimates/_form.html.haml
@@ -19,7 +19,7 @@
       = f.hidden_field :user_id
 
     .col-md-3
-      = f.input :expires_at, as: :date_picker, min_date: Time.current.iso8601
+      = f.input :expires_at, as: :date_field, min_date: Time.current.iso8601
 
   .row
     .col-md-3

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -39,12 +39,11 @@
           hint: @order.account.active? ? "" : t(".original_account_inactive", account: @order.account),
           input_html: input_html
 
-      = f.input_field :fulfilled_at,
-        placeholder: OrderDetail.human_attribute_name(:fulfilled_at),
-        data: { min_date: ValidFulfilledAtDate.min.iso8601,
-           max_date: ValidFulfilledAtDate.max.iso8601,
-           complete_target: "#add_to_order_form_order_status_id" },
-        class: "datepicker__data string optional js--showOnCompleteStatus"
+      = f.date_field :fulfilled_at,
+        min: ValidFulfilledAtDate.min.to_date.iso8601,
+        max: ValidFulfilledAtDate.max.to_date.iso8601,
+        data: { complete_target: "#add_to_order_form_order_status_id" },
+        class: "string optional js--showOnCompleteStatus form-control"
 
       .row
         .col-md-8

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -39,11 +39,12 @@
           hint: @order.account.active? ? "" : t(".original_account_inactive", account: @order.account),
           input_html: input_html
 
-      = f.date_field :fulfilled_at,
-        min: ValidFulfilledAtDate.min.to_date.iso8601,
-        max: ValidFulfilledAtDate.max.to_date.iso8601,
-        data: { complete_target: "#add_to_order_form_order_status_id" },
-        class: "string optional js--showOnCompleteStatus form-control"
+        = f.input :fulfilled_at,
+          as: :date_field,
+          label: OrderDetail.human_attribute_name(:fulfilled_at),
+          min_date: ValidFulfilledAtDate.min,
+          max_date: ValidFulfilledAtDate.max,
+          wrapper_html: { class: "js--showOnCompleteStatus", data: { complete_target: "#add_to_order_form_order_status_id" } }
 
       .row
         .col-md-8

--- a/app/views/journal_creation_reminders/_form.html.haml
+++ b/app/views/journal_creation_reminders/_form.html.haml
@@ -1,7 +1,7 @@
 = simple_form_for(@journal_creation_reminder) do |f|
 
-  = f.input :starts_at, as: :date_picker
-  = f.input :ends_at, as: :date_picker
+  = f.input :starts_at, as: :date_field
+  = f.input :ends_at, as: :date_field
 
   = f.input :message, input_html: { rows: 7, class: "form-control" }
 

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -22,14 +22,12 @@
             = f.association :order_status, collection: @order_statuses, label_method: :name_with_level, include_blank: false
             - if can_edit_fulfilled_at?(f.object, current_user)
               = f.input :fulfilled_at,
-                as: :string,
-                placeholder: OrderDetail.human_attribute_name(:fulfilled_at),
-                input_html: { class: "datepicker__data js--showOnCompleteStatus",
-                  value: format_usa_date(f.object.fulfilled_at),
+                as: :date_field,
+                min_date: ValidFulfilledAtDate.min,
+                max_date: ValidFulfilledAtDate.max,
+                input_html: { class: "js--showOnCompleteStatus",
                   autocomplete: "off",
-                  data: { min_date: ValidFulfilledAtDate.min.iso8601,
-                    max_date: ValidFulfilledAtDate.max.iso8601,
-                    complete_target: "#order_detail_order_status_id"}}
+                  data: { complete_target: "#order_detail_order_status_id"}}
 
           - else
             = f.label :order_status

--- a/app/views/orders/_edit_date.html.haml
+++ b/app/views/orders/_edit_date.html.haml
@@ -4,9 +4,9 @@
 
   = simple_fields_for :backdate, builder: ModelLessFormBuilder, defaults: { required: false } do |f|
     = f.input :order_date,
-      input_html: { value: params[:order_date] || format_usa_date(default_time),
-          class: "datepicker__data",
-          data: { max_date: Time.current.iso8601 } }
+      as: :date_field,
+      input_html: { value: params[:order_date].presence || default_time.to_date.iso8601,
+          max: Time.current.to_date.iso8601 }
 
     = f.input :order_status_id,
       collection: @order_statuses,
@@ -16,8 +16,9 @@
       label: OrderDetail.human_attribute_name(:order_status)
 
     = f.input :fulfilled_at,
-      input_html: { value: params[:fulfilled_at], class: "datepicker__data js--fulfilled_at",
-          data: { max_date: ValidFulfilledAtDate.max.iso8601, min_date: ValidFulfilledAtDate.min.iso8601 } }
+      as: :date_field,
+      input_html: { value: params[:fulfilled_at].presence, class: "js--fulfilled_at",
+          min: ValidFulfilledAtDate.min.to_date.iso8601, max: ValidFulfilledAtDate.max.to_date.iso8601 }
 
     = f.input :send_notification,
       as: :boolean,

--- a/app/views/price_policies/_common_fields.html.haml
+++ b/app/views/price_policies/_common_fields.html.haml
@@ -1,5 +1,5 @@
-= f.input :start_date, input_html: { value: format_usa_date(price_policy.start_date), class: "datepicker__data" }, label: "Effective"
-= f.input :expire_date, input_html: { value: format_usa_date(price_policy.expire_date), class: "datepicker__data" }, label: "Expires"
+= f.input :start_date, as: :date_field, input_html: { value: price_policy.start_date&.to_date&.iso8601 }, label: "Effective"
+= f.input :expire_date, as: :date_field, input_html: { value: price_policy.expire_date&.to_date&.iso8601 }, label: "Expires"
 - if Settings.price_policy_note_options.present?
   = f.input :note_option, as: :select, collection: Settings.price_policy_note_options + ["Other"], selected: price_policy.note_option, include_blank: false, label: "Note", input_html: { class: "js--price-policy-note-select", name: nil, id: nil }
   = f.input :note, as: :text, label: false, input_html: { value: price_policy.note, class: "js--price-policy-note", hidden: price_policy.note_option != "Other" }, required: SettingsHelper.feature_on?("pricing.price_policy_requires_note")

--- a/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
+++ b/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe FacilityAccountsReconciliationController do
 
   describe "update" do
     before { sign_in admin }
-    let(:formatted_reconciled_at) { SpecDateHelper.format_usa_date(reconciled_at) }
+    let(:formatted_reconciled_at) { reconciled_at.presence&.to_date&.iso8601 }
 
     def perform
       post :update, params: { facility_id: facility.url_name, account_type: "ReconciliationTestAccount",

--- a/spec/controllers/facility_orders_controller_spec.rb
+++ b/spec/controllers/facility_orders_controller_spec.rb
@@ -314,7 +314,7 @@ RSpec.describe FacilityOrdersController do
           before { @params[:add_to_order_form][:order_status_id] = complete_status.id.to_s }
 
           context "and setting fulfilled_at" do
-            before { @params[:add_to_order_form][:fulfilled_at] = fulfilled_at.strftime("%m/%d/%Y") }
+            before { @params[:add_to_order_form][:fulfilled_at] = fulfilled_at.strftime("%Y-%m-%d") }
 
             context "to today" do
               let(:fulfilled_at) { Date.today }
@@ -358,7 +358,7 @@ RSpec.describe FacilityOrdersController do
 
         context "when not setting an order status" do
           context "and setting fulfilled_at" do
-            before { @params[:add_to_order_form][:fulfilled_at] = fulfilled_at.strftime("%m/%d/%Y") }
+            before { @params[:add_to_order_form][:fulfilled_at] = fulfilled_at.strftime("%Y-%m-%d") }
             let(:fulfilled_at) { Date.today }
 
             it_should_allow :director, "to add an item to existing order with status and fulfilled_at set to defaults" do

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -1050,7 +1050,7 @@ RSpec.describe OrderManagement::OrderDetailsController do
             before do
               @params[:order_detail] = {
                 order_status_id: OrderStatus.complete.id.to_s,
-                fulfilled_at: I18n.l(fulfilled_at.to_date, format: :usa),
+                fulfilled_at: fulfilled_at.to_date.iso8601,
               }
               do_request
             end

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -574,14 +574,14 @@ RSpec.describe OrdersController do
       it "sets ordered_at to a time in the past" do
         maybe_grant_always_sign_in :director
         switch_to @staff
-        @params[:order_date] = SpecDateHelper.format_usa_date(1.day.ago)
+        @params[:order_date] = 1.day.ago.to_date.iso8601
         do_request
         expect(assigns[:order].order_details.map(&:ordered_at)).to all(match_date yesterday)
       end
 
       it "sets ordered_at to now if not acting_as" do
         maybe_grant_always_sign_in :director
-        @params[:order_date] = SpecDateHelper.format_usa_date(1.day.ago)
+        @params[:order_date] = 1.day.ago.to_date.iso8601
         do_request
         expect(assigns[:order].order_details.map(&:ordered_at)).to all(match_date Time.current)
       end
@@ -593,7 +593,7 @@ RSpec.describe OrdersController do
 
         @params.merge!(
           "quantity#{@order_detail.id}" => 5,
-          "order_date" => "09/30/2016",
+          "order_date" => "2016-09-30",
           "order_time" => { "hour" => "4", "minute" => "0", "ampm" => "PM" },
         )
         do_request
@@ -651,7 +651,7 @@ RSpec.describe OrdersController do
 
           it "sets the order_detail fulfilled dates to the order time" do
             @item_pp = @item.item_price_policies.create!(FactoryBot.attributes_for(:item_price_policy, price_group_id: @price_group.id, start_date: 1.day.ago, expire_date: 1.day.from_now))
-            @params[:order_date] = SpecDateHelper.format_usa_date(1.day.ago)
+            @params[:order_date] = 1.day.ago.to_date.iso8601
             do_request
             assigns[:order].reload.order_details.all? { |od| expect(od.fulfilled_at).to match_date yesterday }
           end
@@ -664,20 +664,20 @@ RSpec.describe OrdersController do
             end
 
             it "uses the current price policy if the order date falls in the policy's date range" do
-              @params[:order_date] = SpecDateHelper.format_usa_date(yesterday)
+              @params[:order_date] = yesterday.to_date.iso8601
               do_request
               assigns[:order].reload.order_details.all? { |od| expect(od.price_policy).to eq(@item_pp) }
             end
 
             it "uses an old price policy if the order date falls in the old policy's date range" do
-              @params[:order_date] = SpecDateHelper.format_usa_date(5.days.ago)
+              @params[:order_date] = 5.days.ago.to_date.iso8601
               do_request
               assigns[:order].reload.order_details.all? { |od| expect(od.price_policy).to eq(@item_past_pp) }
             end
 
             # when backdating was initially set up, this would cause an error, but behavior changed as of ticket #51239
             it "does not error if there is no policy set for the date in the past" do
-              @params[:order_date] = SpecDateHelper.format_usa_date(9.days.ago)
+              @params[:order_date] = 9.days.ago.to_date.iso8601
               do_request
               assigns[:order].reload.order_details.all? do |od|
                 expect(od.price_policy).to be_nil
@@ -703,7 +703,7 @@ RSpec.describe OrdersController do
           @params[:id] = reservation.order_detail.order.id
           maybe_grant_always_sign_in :director
           switch_to @staff
-          @params[:order_date] = SpecDateHelper.format_usa_date(2.days.ago)
+          @params[:order_date] = 2.days.ago.to_date.iso8601
           @params[:order_time] = { hour: "2", minute: "27", ampm: "PM" }
         end
 

--- a/spec/forms/add_to_order_form_spec.rb
+++ b/spec/forms/add_to_order_form_spec.rb
@@ -101,8 +101,8 @@ RSpec.describe AddToOrderForm do
           expect(form.order_status_id).to eq(OrderStatus.complete.id)
         end
 
-        it "has the second order's fulfilled_at to the matching date" do
-          expect(SpecDateHelper.parse_usa_date(form.fulfilled_at)).to eq(second_order_detail.fulfilled_at.beginning_of_day)
+        it "pre-populates fulfilled_at as an ISO date string" do
+          expect(form.fulfilled_at).to eq(second_order_detail.fulfilled_at.to_date.iso8601)
         end
       end
     end

--- a/spec/models/journal_creation_reminder_spec.rb
+++ b/spec/models/journal_creation_reminder_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe JournalCreationReminder do
 
   describe "ends_at=" do
     context "with a valid string" do
-      let(:ends_at) { "02/01/2022" }
+      let(:ends_at) { "2022-02-01" }
 
       it "set the time to the end of the day" do
         expect(reminder.ends_at).to be_within(1.second).of(Time.zone.parse("2022-02-01 23:59:59"))
@@ -74,7 +74,7 @@ RSpec.describe JournalCreationReminder do
 
   describe "starts_at=" do
     context "with a valid string" do
-      let(:starts_at) { "02/01/2022" }
+      let(:starts_at) { "2022-02-01" }
 
       it "set the time to the start of the day" do
         expect(reminder.starts_at).to be_within(1.second).of(Time.zone.parse("2022-02-01 00:00:00"))

--- a/spec/models/journal_creation_reminder_spec.rb
+++ b/spec/models/journal_creation_reminder_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe JournalCreationReminder do
     end
 
     context "with an invalid string" do
-      let(:ends_at) { "02/01/222" }
+      let(:ends_at) { "2022-13-45" }
 
       it "doesn't error" do
         expect(reminder.ends_at).to eq nil
@@ -82,7 +82,7 @@ RSpec.describe JournalCreationReminder do
     end
 
     context "with an invalid string" do
-      let(:starts_at) { "02/01/222" }
+      let(:starts_at) { "2022-13-45" }
 
       it "doesn't error" do
         expect(reminder.starts_at).to eq nil

--- a/spec/models/valid_fulfilled_at_date_spec.rb
+++ b/spec/models/valid_fulfilled_at_date_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe ValidFulfilledAtDate do
   subject(:fulfilled_at) { described_class.new(string) }
-  let(:string) { I18n.l(date, format: :usa) }
+  let(:string) { date.iso8601 }
 
   describe "with a date in the future" do
     let(:date) { 1.day.from_now.to_date }

--- a/spec/price_policies_controller_shared_examples.rb
+++ b/spec/price_policies_controller_shared_examples.rb
@@ -232,8 +232,8 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
         @action = :create
         @start_date = 1.year.from_now
         @expire_date = PricePolicy.generate_expire_date(@start_date)
-        @params[:start_date] = @start_date.to_s
-        @params[:expire_date] = @expire_date.to_s
+        @params[:start_date] = @start_date.to_date.iso8601
+        @params[:expire_date] = @expire_date.to_date.iso8601
         @params[:note] = "This is a note"
 
         @params_modifier.before_create @params if @params_modifier.try :respond_to?, :before_create
@@ -271,7 +271,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
           end
 
           it "rejects everything if expire date is before start date" do
-            @params[:expire_date] = (@start_date - 2.days).to_s
+            @params[:expire_date] = (@start_date - 2.days).to_date.iso8601
             do_request
             expect(flash[:error]).not_to be_nil
             expect(response).to render_template "price_policies/new"
@@ -285,14 +285,14 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
             @order    = @director.orders.create(FactoryBot.attributes_for(:order, created_by: @director.id))
             @order_detail = @order.order_details.create(FactoryBot.attributes_for(:order_detail).update(product_id: @product.id, account_id: @account.id, price_policy: @price_policy))
 
-            @params[:start_date] = @price_policy.start_date
+            @params[:start_date] = @price_policy.start_date.to_date.iso8601
             do_request
             expect(assigns[:price_policies]).to be_empty
             expect(response).to redirect_to [@authable, @product, PricePolicy]
           end
 
           it "rejects everything if the expiration date spans into the next fiscal year" do
-            @params[:expire_date] = (PricePolicy.generate_expire_date(@start_date) + 1.day).to_s
+            @params[:expire_date] = (PricePolicy.generate_expire_date(@start_date) + 1.day).to_date.iso8601
             do_request
             expect(response).to be
             expect(flash[:error]).not_to be_nil
@@ -339,8 +339,8 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
         set_policy_date
         @params.merge!(
           id: price_policy.start_date.to_s,
-          start_date: price_policy.start_date.to_s,
-          expire_date: price_policy.expire_date.to_s,
+          start_date: price_policy.start_date.to_date.iso8601,
+          expire_date: price_policy.expire_date.to_date.iso8601,
           note: "This is a note",
         )
 
@@ -367,7 +367,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
             end
 
             before(:each) do
-              @params[:expire_date] = new_expire_date.to_s
+              @params[:expire_date] = new_expire_date.to_date.iso8601
               do_request
             end
 
@@ -383,7 +383,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
             let(:new_start_date) { price_policy.start_date + 1.day }
 
             before(:each) do
-              @params[:start_date] = new_start_date.to_s
+              @params[:start_date] = new_start_date.to_date.iso8601
               do_request
             end
 
@@ -440,7 +440,7 @@ RSpec.shared_examples_for PricePoliciesController do |product_type, params_modif
             end
 
             before(:each) do
-              @params[:expire_date] = expire_date.to_s
+              @params[:expire_date] = expire_date.to_date.iso8601
               do_request
             end
 

--- a/spec/system/admin/adding_to_a_cross_core_order_spec.rb
+++ b/spec/system/admin/adding_to_a_cross_core_order_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Adding to an existing order for cross core", :js do
       select_from_chosen facility2_account.to_s, from: "Payment Source", scroll_to: :center
       fill_in "add_to_order_form[quantity]", with: "1"
       select_from_chosen "Complete", from: "Order Status"
-      fill_in "add_to_order_form[fulfilled_at]", with: fulfilled_at_string
+      fill_in "add_to_order_form[fulfilled_at]", with: 1.day.ago.to_date
       click_button "Add to Cross-Core Order"
     end
 

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Adding to an existing order" do
 
       before do
         select "Complete", from: "Order Status"
-        fill_in "add_to_order_form[fulfilled_at]", with: fulfilled_at_string
+        fill_in "add_to_order_form[fulfilled_at]", with: 1.day.ago.to_date
         click_button "Add To Order"
       end
 
@@ -128,7 +128,7 @@ RSpec.describe "Adding to an existing order" do
       fill_in "add_to_order_form[quantity]", with: "1"
       select product.name, from: "add_to_order_form[product_id]"
       select "Complete", from: "Order Status"
-      fill_in "add_to_order_form[fulfilled_at]", with: fulfilled_at_string
+      fill_in "add_to_order_form[fulfilled_at]", with: 1.day.ago.to_date
       click_button "Add To Order"
     end
 

--- a/spec/system/admin/creating_an_estimate_spec.rb
+++ b/spec/system/admin/creating_an_estimate_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe(
     expect(page).to have_content "Create an Estimate"
 
     fill_in "Description", with: "Test Estimate"
-    fill_in "Expires at", with: 1.month.from_now.strftime("%m/%d/%Y")
+    fill_in "Expires at", with: 1.month.from_now.to_date
     select_from_chosen price_group.name, from: "Price group"
 
     fill_in "Note", with: "This is a test estimate"

--- a/spec/system/admin/duplicating_an_estimate_spec.rb
+++ b/spec/system/admin/duplicating_an_estimate_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Estimate Duplication", :js do
       expect(page).to have_css("form.new_estimate")
 
       expect(page).to have_field("Description", with: "Copy of #{estimate.description}")
-      expect(page).to have_field("Expires at", with: I18n.l(estimate.expires_at.to_date, format: :usa))
+      expect(page).to have_field("Expires at", with: estimate.expires_at.to_date.iso8601)
       expect(page).to have_field("Notes", with: estimate.note)
 
       within("#estimate_products_table") do

--- a/spec/system/admin/editing_an_estimate_spec.rb
+++ b/spec/system/admin/editing_an_estimate_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Editing an estimate", :js do
 
     fill_in "Description", with: "Updated Estimate Title"
     fill_in "Note", with: "Updated note text"
-    fill_in "Expires at", with: 2.months.from_now.strftime("%m/%d/%Y")
+    fill_in "Expires at", with: 2.months.from_now.to_date
 
     expect(page).to have_content "Add Products to Estimate"
 

--- a/spec/system/admin/manage_order_detail_spec.rb
+++ b/spec/system/admin/manage_order_detail_spec.rb
@@ -400,7 +400,7 @@ RSpec.describe "Managing an order detail" do
 
       before do
         expect(page).to have_selector("input[name='order_detail[fulfilled_at]']")
-        fill_in "order_detail[fulfilled_at]", with: SpecDateHelper.format_usa_date(1.day.ago)
+        fill_in "order_detail[fulfilled_at]", with: 1.day.ago.to_date
         click_button "Save"
         expect(page).to have_content("The order was successfully updated.")
         click_link order_detail.to_s
@@ -409,7 +409,7 @@ RSpec.describe "Managing an order detail" do
       it "can update the fulfilled at date", :js do
         expect(page).to have_content(SpecDateHelper.format_usa_date(1.day.ago))
         expect(page).not_to have_content("invalid date format")
-        expect(page).to have_field("order_detail[fulfilled_at]", with: SpecDateHelper.format_usa_date(1.day.ago))
+        expect(page).to have_field("order_detail[fulfilled_at]", with: 1.day.ago.to_date.iso8601)
       end
 
       it "logs fulfilled at date updates" do

--- a/spec/system/admin/managing_journal_creation_reminders_spec.rb
+++ b/spec/system/admin/managing_journal_creation_reminders_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Managing JournalCreationReminder" do
     it "allows creating a new reminder" do
       visit journal_creation_reminders_path
       click_link "Add New Reminder"
-      fill_in "Ending Date", with: 2.days.from_now
+      fill_in "Ending Date", with: 2.days.from_now.to_date
 
       # Leave the message field blank to test error handling
       click_button "Submit"
@@ -39,12 +39,12 @@ RSpec.describe "Managing JournalCreationReminder" do
       click_link "Edit"
 
       # Submit an invalid date to test error handling
-      fill_in "Ending Date", with: 2.weeks.ago
+      fill_in "Ending Date", with: 2.weeks.ago.to_date
       click_button "Submit"
       expect(page).to have_content("must be after Ending Date")
 
       # Happy path
-      fill_in "Ending Date", with: 1.year.from_now
+      fill_in "Ending Date", with: 1.year.from_now.to_date
       click_button "Submit"
       expect(page).to have_content("Reminder successfully updated")
       expect(page).to have_content("FY#{1.year.from_now.to_s[2,2]}")

--- a/spec/system/placing_an_order_on_behalf_of_spec.rb
+++ b/spec/system/placing_an_order_on_behalf_of_spec.rb
@@ -87,10 +87,10 @@ RSpec.describe "Placing an order on behalf of" do
       choose account.to_s
       click_button "Continue"
 
-      fill_in "Order date", with: two_days_ago
+      fill_in "Order date", with: 2.days.ago.to_date
       select "Complete", from: "Order Status"
 
-      fill_in "Fulfilled at", with: three_days_ago
+      fill_in "Fulfilled at", with: 3.days.ago.to_date
 
       click_button "Purchase"
 

--- a/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
+++ b/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Account Reconciliation", :js do
 
       check "order_detail_#{order_detail.id}_selected"
 
-      fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
+      fill_in "Reconciliation Date", with: 1.day.ago.to_date
       fill_in "order_detail_#{order_detail.id}_reconciled_note", with: "this is a note!"
 
       click_button "Update Orders", match: :first
@@ -96,7 +96,7 @@ RSpec.describe "Account Reconciliation", :js do
         expect(page).to have_button("Update Orders", disabled: false)
 
         check "order_detail_#{orders.last.order_details.first.id}_selected"
-        fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
+        fill_in "Reconciliation Date", with: 1.day.ago.to_date
         click_button "Update Orders", match: :first
 
         expect(page).to have_content("2 payments successfully updated")
@@ -114,7 +114,7 @@ RSpec.describe "Account Reconciliation", :js do
         uncheck "Use Bulk Note"
         check "order_detail_#{order_detail.id}_selected"
         check "order_detail_#{orders.last.order_details.first.id}_selected"
-        fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
+        fill_in "Reconciliation Date", with: 1.day.ago.to_date
         click_button "Update Orders", match: :first
 
         expect(page).to have_content("2 payments successfully updated")
@@ -150,7 +150,7 @@ RSpec.describe "Account Reconciliation", :js do
       expect(page).not_to have_content(other_order_number)
 
       check "order_detail_#{order_detail.id}_selected"
-      fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
+      fill_in "Reconciliation Date", with: 1.day.ago.to_date
       fill_in "order_detail_#{order_detail.id}_reconciled_note", with: "this is a note!"
       click_button "Update Orders", match: :first
 
@@ -175,7 +175,7 @@ RSpec.describe "Account Reconciliation", :js do
       fill_in "Bulk Note", with: "this is the bulk note"
       check "order_detail_#{order_detail.id}_selected"
       check "order_detail_#{orders.last.order_details.first.id}_selected"
-      fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
+      fill_in "Reconciliation Date", with: 1.day.ago.to_date
       click_button "Update Orders", match: :first
 
       expect(page).to have_content("2 payments successfully updated")


### PR DESCRIPTION
# Notes

Switches the standalone (single-date) form fields across several admin screens from the jQuery datepicker to the browser's native date picker, so dates are submitted in a consistent (ISO) format.

[NUOPEN-280 | Standarize forms date input submission](https://universe-of-universities.atlassian.net/browse/NUOPEN-280)

# Screenshots


Before:
<img width="1206" height="816" alt="Screenshot 2026-07-06 at 6 08 19 PM" src="https://github.com/user-attachments/assets/e6f7f436-4bb6-44da-9a58-8919c0dd1cf2" />


After:
<img width="1223" height="819" alt="Screenshot 2026-07-06 at 6 07 41 PM" src="https://github.com/user-attachments/assets/d7e9bbe6-b84e-421c-ab44-bd2b5361f323" />

