### PR TITLE
[NUOPEN-45] Remove dynamic form gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,8 +59,6 @@ gem "terser", "~> 1.2"
 gem "haml"
 gem "will_paginate"
 gem "turbo-rails", "~> 2.0"
-# TODO: Remove dynamic_form and use Rails to display errors
-gem "dynamic_form"
 gem "ckeditor", "~> 5.1.3"
 gem "jquery-rails"
 gem "jquery-ui-rails", "~> 6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,7 +295,6 @@ GEM
     diff-lcs (1.6.2)
     drb (2.2.3)
     dumb_delegator (1.1.0)
-    dynamic_form (1.2.0)
     erb (6.0.4)
     erubi (1.13.1)
     exception_notification (5.0.1)
@@ -766,7 +765,6 @@ DEPENDENCIES
   devise-encryptable
   devise-security
   drb
-  dynamic_form
   exception_notification
   eye-patch
   factory_bot_rails

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -235,12 +235,10 @@ li.nav-spacer {
   }
 }
 
-
-
 /*
   Errors
 */
-.errorExplanation {
+.error-explanation {
   @extend .alert;
   @extend .alert-danger;
   h2 {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,8 @@ class ApplicationController < ActionController::Base
   include DateHelper
 
   helper :all # include all helpers, all the time
+  helper Nucore::ModelErrorRender::HelperMethods
+
   protect_from_forgery # See ActionController::RequestForgeryProtection for details
 
   # Make the following methods available to all views

--- a/app/views/orders/choose_account.html.haml
+++ b/app/views/orders/choose_account.html.haml
@@ -1,7 +1,7 @@
 = content_for :h1 do
   = t(".select")
 
-= error_messages_for(object: @order, object_name: "order")
+= error_messages_for(@order)
 
 - if @accounts.empty?
   %p.notice= text("orders.choose_account.notice")

--- a/app/views/user_password/edit_current.html.haml
+++ b/app/views/user_password/edit_current.html.haml
@@ -1,6 +1,6 @@
 = content_for :h1 do
   = t("user_password.edit.head")
-= error_messages_for :user
+= error_messages_for @user
 = simple_form_for :user, :url => edit_current_password_path do |f|
   .form-inputs
     = f.input :current_password

--- a/config/initializers/form_errors.rb
+++ b/config/initializers/form_errors.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "nucore/model_error_render"
+
+ActionView::Helpers::FormBuilder.include(
+  Nucore::ModelErrorRender::FormBuilderMethods
+)

--- a/lib/nucore/model_error_render.rb
+++ b/lib/nucore/model_error_render.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Nucore
+  module ModelErrorRender
+    module HelperMethods
+      ##
+      # Helper method to render model errors
+      # Run in the context of a ActionView rendering
+      #
+      # This is a simplified implementation taken from
+      # dynamic_forms
+      def error_messages_for(object)
+        return if object.blank?
+        return if (count = object.errors.count).zero?
+
+        I18n.with_options(:scope => [:activerecord, :errors, :template]) do |locale|
+          header_message = locale.t(
+            :header, count:, model: object.model_name.human,
+          )
+          message = locale.t(:body)
+
+          error_messages =
+            object.errors.full_messages.map do |msg|
+              content_tag(:li, msg)
+            end.join.html_safe
+
+          contents = []
+          contents << content_tag(:h2, header_message) if header_message.present?
+          contents << content_tag(:p, message) if message.present?
+          contents << content_tag(:ul, error_messages)
+
+          content_tag(:div, contents.join.html_safe, class: "error-explanation")
+        end
+      end
+    end
+
+    module FormBuilderMethods
+      ##
+      # Render model errors in a form using the above helper method.
+      def error_messages(_options = {})
+        @template.error_messages_for(@object)
+      end
+    end
+  end
+end

--- a/lib/nucore/model_error_render.rb
+++ b/lib/nucore/model_error_render.rb
@@ -8,7 +8,7 @@ module Nucore
       # Run in the context of a ActionView rendering
       #
       # This is a simplified implementation taken from
-      # dynamic_forms
+      # dynamic_form gem
       def error_messages_for(object)
         return if object.blank?
         return if (count = object.errors.count).zero?

--- a/spec/system/admin/instrument_price_policies_controller_spec.rb
+++ b/spec/system/admin/instrument_price_policies_controller_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe InstrumentPricePoliciesController do
 
         click_button "Add Pricing Rules"
 
-        expect(page).to have_content("Duration rates base Rate must be lesser than or equal to Base rate")
+        expect(page).to have_content("Duration rates Rate must be lesser than or equal to Base rate")
       end
 
       it "fails to save when duration subsidy is higher than step rate", :js, feature_setting: { "pricing.facility_directors_can_manage_price_groups" => true } do


### PR DESCRIPTION
# Notes

Remove dynamic form gem and define helper method for the functionality used.

[NUOPEN-45 | Retire dynamic_form gem](https://universe-of-universities.atlassian.net/browse/NUOPEN-45)

