### PR TITLE
[Fix] Notices dropdown not visible

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -1,4 +1,4 @@
-.navbar.navbar-default.navbar-static-top{ style: staging_header_styles }
+.navbar.navbar-default{ style: staging_header_styles }
   .container
     .navbar-header
       - if responsive? && !session_user.nil?

--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -1,5 +1,5 @@
 -# .visible-with-nav is visible > 979px
-.navbar.navbar-default.navbar-static-top.hide-from-print.visible-with-nav
+.navbar.navbar-default.hide-from-print.visible-with-nav
   .container
     - if session_user
       = render "/shared/nav/nav_links"


### PR DESCRIPTION
# Notes

Fix notices dropdown not showing because of second navbar element z-index. The z-index is added by `.navbar-static-top` element which I end up removing.

## Screenshots

Bug

<img width="1116" height="293" alt="Captura desde 2026-07-09 10-05-03" src="https://github.com/user-attachments/assets/0aea6467-1a31-4751-8301-2187ef484ce3" />

Resolution
<img width="1116" height="293" alt="Captura desde 2026-07-09 10-04-45" src="https://github.com/user-attachments/assets/4b01b457-415e-48d4-8331-95526c0a6e36" />
