### PR TITLE
[NUOPEN-280] Migrate date range inputs

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -136,7 +136,7 @@ class FacilitiesController < ApplicationController
     @search_form = TransactionSearch::SearchForm.new(
       params[:search],
       defaults: {
-        date_range_start: format_usa_date(1.month.ago.beginning_of_month),
+        date_range_start: 1.month.ago.beginning_of_month.to_date,
       },
     )
 

--- a/app/controllers/facility_statements_controller.rb
+++ b/app/controllers/facility_statements_controller.rb
@@ -52,7 +52,7 @@ class FacilityStatementsController < ApplicationController
     order_details = OrderDetail.need_statement(@facility)
     @order_detail_action = :create
 
-    defaults = SettingsHelper.feature_on?("billing.set_statement_search_start_date") ? { date_range_start: format_usa_date(1.month.ago.beginning_of_month) } : {}
+    defaults = SettingsHelper.feature_on?("billing.set_statement_search_start_date") ? { date_range_start: 1.month.ago.beginning_of_month.to_date } : {}
     @search_form = TransactionSearch::SearchForm.new(params[:search], defaults:)
     @search =
       TransactionSearch::Searcher

--- a/app/controllers/reports/reports_controller.rb
+++ b/app/controllers/reports/reports_controller.rb
@@ -55,14 +55,14 @@ module Reports
     end
 
     def init_report_params
-      @date_start = parse_usa_date(params[:date_start])
+      @date_start = parse_iso_date(params[:date_start])
       @date_start = if @date_start.blank?
                       (Time.zone.now - 1.month).beginning_of_month
                     else
                       @date_start.beginning_of_day
                     end
 
-      @date_end = parse_usa_date(params[:date_end])
+      @date_end = parse_iso_date(params[:date_end])
       @date_end = if @date_end.blank?
                     @date_start.end_of_month
                   else

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -24,7 +24,7 @@ class TransactionsController < ApplicationController
     @search_form = TransactionSearch::SearchForm.new(
       params[:search],
       defaults: {
-        date_range_start: format_usa_date(1.month.ago.beginning_of_month),
+        date_range_start: 1.month.ago.beginning_of_month.to_date,
       },
     )
 

--- a/app/forms/statement_search_form.rb
+++ b/app/forms/statement_search_form.rb
@@ -33,7 +33,7 @@ class StatementSearchForm
               .for_facilities(facilities) # ANDs with the current facility so
               .for_accounts(accounts)
               .for_account_admins(account_admins)
-              .created_between(parse_usa_date(date_range_start)&.beginning_of_day, parse_usa_date(date_range_end)&.end_of_day)
+              .created_between(parse_iso_date(date_range_start)&.beginning_of_day, parse_iso_date(date_range_end)&.end_of_day)
     add_reconciled_status_filter(results)
   end
 

--- a/app/inputs/date_field_input.rb
+++ b/app/inputs/date_field_input.rb
@@ -8,20 +8,15 @@
 #   = f.input :expires_at, as: :date_field, min_date: Date.current
 #   = f.input :fulfilled_at, as: :date_field, min_date: x, max_date: y, input_html: { class: "js--hook" }
 #
-# An explicit input_html[:value] is respected as-is (must already be ISO); otherwise
-# the value is read from the object and normalized to ISO.
+# `date_field` renders any Date/Time/date-string value as ISO, so pass date
+# objects and let Rails format them — for value, min and max alike.
 class DateFieldInput < SimpleForm::Inputs::Base
   def input(_wrapper_options)
     html_options = input_html_options.dup
 
-    unless html_options.key?(:value)
-      date = object.public_send(attribute_name)&.to_date
-      html_options[:value] = date&.iso8601
-    end
-
     html_options[:class] = [*html_options[:class], "form-control"].uniq.join(" ")
-    html_options[:min] ||= options[:min_date]&.to_date&.iso8601
-    html_options[:max] ||= options[:max_date]&.to_date&.iso8601
+    html_options[:min] ||= options[:min_date]
+    html_options[:max] ||= options[:max_date]
 
     @builder.date_field attribute_name, html_options
   end

--- a/app/services/transaction_search/date_range_searcher.rb
+++ b/app/services/transaction_search/date_range_searcher.rb
@@ -32,17 +32,13 @@ module TransactionSearch
 
     def search(params)
       params ||= {}
-      start_date = to_date(params[:start])
-      end_date = to_date(params[:end])
+      start_date = parse_iso_date(params[:start])
+      end_date = parse_iso_date(params[:end])
       @date_range_field = extract_date_range_field(params)
 
       order_details
         .action_in_date_range(@date_range_field, start_date, end_date)
         .ordered_by_action_date(@date_range_field)
-    end
-
-    def to_date(param_value)
-      parse_usa_date(param_value.to_s.tr("-", "/"))
     end
 
     def extract_date_range_field(params)

--- a/app/views/facility_statements/index.html.haml
+++ b/app/views/facility_statements/index.html.haml
@@ -21,8 +21,8 @@
         hint: text(".account_admins_hint")
     %fieldset.col-md-4
       = f.input :status, collection: @search_form.available_statuses
-      = f.input :date_range_start, input_html: { class: "datepicker__data" }
-      = f.input :date_range_end, input_html: { class: "datepicker__data" }
+      = f.input :date_range_start, as: :date_field
+      = f.input :date_range_end, as: :date_field
 
     .submit_button.col-md-12
       = hidden_field_tag :email, current_user.email, disabled: true

--- a/app/views/reports/_date_range_fields.html.haml
+++ b/app/views/reports/_date_range_fields.html.haml
@@ -5,7 +5,7 @@
 %li= form.input :date_start,
   as: :date_field,
   label: t("reports.fields.date_start"),
-  input_html: { value: @date_start&.to_date&.iso8601 }
+  input_html: { value: @date_start }
 
 %li
   .field-clarifier= t("support.array.two_words_connector")
@@ -13,4 +13,4 @@
 %li= form.input :date_end,
   as: :date_field,
   label: t("reports.fields.#{controller_name}.date_end", default: t("reports.fields.date_end")),
-  input_html: { value: @date_end&.to_date&.iso8601 }
+  input_html: { value: @date_end }

--- a/app/views/reports/_date_range_fields.html.haml
+++ b/app/views/reports/_date_range_fields.html.haml
@@ -3,12 +3,14 @@
     = t("reports.fields.#{controller_name}.between", default: t("reports.fields.between"))
 
 %li= form.input :date_start,
+  as: :date_field,
   label: t("reports.fields.date_start"),
-  input_html: { value: format_usa_date(@date_start), class: "datepicker" }
+  input_html: { value: @date_start&.to_date&.iso8601 }
 
 %li
   .field-clarifier= t("support.array.two_words_connector")
 
 %li= form.input :date_end,
+  as: :date_field,
   label: t("reports.fields.#{controller_name}.date_end", default: t("reports.fields.date_end")),
-  input_html: { value: format_usa_date(@date_end), class: "datepicker" }
+  input_html: { value: @date_end&.to_date&.iso8601 }

--- a/app/views/reports/instrument_unavailable_reports/report_table.html.haml
+++ b/app/views/reports/instrument_unavailable_reports/report_table.html.haml
@@ -1,8 +1,8 @@
 -# TODO: this is very similar to reports/report_table
 
 .updated_values{ style: "display: none" }
-  .date_start= format_usa_date(@date_start)
-  .date_end= format_usa_date(@date_end)
+  .date_start= @date_start&.to_date&.iso8601
+  .date_end= @date_end&.to_date&.iso8601
 
 .export_raw{ data: { visible: export_raw_visible?.to_s } }
 

--- a/app/views/reports/instrument_unavailable_reports/report_table.html.haml
+++ b/app/views/reports/instrument_unavailable_reports/report_table.html.haml
@@ -1,8 +1,8 @@
 -# TODO: this is very similar to reports/report_table
 
 .updated_values{ style: "display: none" }
-  .date_start= @date_start&.to_date&.iso8601
-  .date_end= @date_end&.to_date&.iso8601
+  .date_start= @date_start&.to_date
+  .date_end= @date_end&.to_date
 
 .export_raw{ data: { visible: export_raw_visible?.to_s } }
 

--- a/app/views/reports/report_table.html.haml
+++ b/app/views/reports/report_table.html.haml
@@ -1,8 +1,8 @@
 -# TODO: this is very similar to instrument_unavailable_reports/report_table
 
 .updated_values{ style: "display: none" }
-  .date_start= @date_start&.to_date&.iso8601
-  .date_end= @date_end&.to_date&.iso8601
+  .date_start= @date_start&.to_date
+  .date_end= @date_end&.to_date
 
 .export_raw{ data: { visible: export_raw_visible?.to_s } }
 

--- a/app/views/reports/report_table.html.haml
+++ b/app/views/reports/report_table.html.haml
@@ -1,8 +1,8 @@
 -# TODO: this is very similar to instrument_unavailable_reports/report_table
 
 .updated_values{ style: "display: none" }
-  .date_start= format_usa_date(@date_start)
-  .date_end= format_usa_date(@date_end)
+  .date_start= @date_start&.to_date&.iso8601
+  .date_end= @date_end&.to_date&.iso8601
 
 .export_raw{ data: { visible: export_raw_visible?.to_s } }
 

--- a/app/views/shared/transactions/_search.html.haml
+++ b/app/views/shared/transactions/_search.html.haml
@@ -16,8 +16,8 @@
       - if @search.options.map(&:key).include?("date_ranges")
         %br
         = f.input :date_range_field, collection: TransactionSearch::DateRangeSearcher.options(only: @search_form.allowed_date_fields), label: false, include_blank: false
-        = f.input :date_range_start, input_html: {class: ["datepicker", "in_past"] }, label: t("reports.fields.date_start")
-        = f.input :date_range_end, input_html: { class: ["datepicker", "in_past"] }, label: t("reports.fields.date_end")
+        = f.input :date_range_start, as: :date_field, max_date: Date.current, label: t("reports.fields.date_start")
+        = f.input :date_range_end, as: :date_field, max_date: Date.current, label: t("reports.fields.date_end")
 
   %div
     = hidden_field_tag :email, current_user.email, disabled: true

--- a/spec/controllers/reports/general_reports_controller_project_spec.rb
+++ b/spec/controllers/reports/general_reports_controller_project_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Reports::GeneralReportsController do
     before do
       order.order_details.first.update!(project_id: project.id)
       sign_in administrator
-      get :index, params: { report_by: :project, date_start: 2.months.ago, date_end: Time.current,
+      get :index, params: { report_by: :project, date_start: 2.months.ago.to_date.iso8601, date_end: Time.current.to_date.iso8601,
                             status_filter: [OrderStatus.new_status], facility_id: facility.url_name,
                             date_range_field: "ordered_at" }, xhr: true
     end

--- a/spec/controllers/reports/general_reports_controller_spec.rb
+++ b/spec/controllers/reports/general_reports_controller_spec.rb
@@ -39,12 +39,12 @@ RSpec.describe Reports::GeneralReportsController do
 
     context "with date parameters" do
       it "assigns the start date to the beginning of the day" do
-        expect { get :index, params: { facility_id: facility.url_name, report_by: :product, date_start: "01/01/2014", date_end: "01/31/2014" } }.to raise_error(CanCan::AccessDenied)
+        expect { get :index, params: { facility_id: facility.url_name, report_by: :product, date_start: "2014-01-01", date_end: "2014-01-31" } }.to raise_error(CanCan::AccessDenied)
         expect(assigns(:date_start)).to eq(Time.zone.local(2014, 1, 1))
       end
 
       it "assigns the end date to the end of the day" do
-        expect { get :index, params: { facility_id: facility.url_name, report_by: :product, date_start: "01/01/2014", date_end: "01/31/2014" } }.to raise_error(CanCan::AccessDenied)
+        expect { get :index, params: { facility_id: facility.url_name, report_by: :product, date_start: "2014-01-01", date_end: "2014-01-31" } }.to raise_error(CanCan::AccessDenied)
         expect(assigns(:date_end).to_i).to eq(Time.zone.local(2014, 1, 31, 23, 59, 59).to_i)
       end
     end
@@ -91,8 +91,8 @@ RSpec.describe Reports::GeneralReportsController do
       @params = {
         report_by: :product,
         facility_id: @authable.url_name,
-        date_start: Time.zone.now.strftime("%m/%d/%Y"),
-        date_end: 1.day.from_now.strftime("%m/%d/%Y"),
+        date_start: Time.zone.now.to_date.iso8601,
+        date_end: 1.day.from_now.to_date.iso8601,
       }
 
       sign_in @admin
@@ -128,7 +128,7 @@ RSpec.describe Reports::GeneralReportsController do
 
       it "should find reconciled that started yesterday" do
         @params[:status_filter] = [OrderStatus.reconciled.id]
-        @params[:date_start] = 1.day.ago.strftime("%m/%d/%Y")
+        @params[:date_start] = 1.day.ago.to_date.iso8601
         do_request
         expect(assigns[:report_data].to_a).to contain_all [@order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_yesterday, @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today]
       end
@@ -159,7 +159,7 @@ RSpec.describe Reports::GeneralReportsController do
 
       it "should find reconciled that started yesterday" do
         @params[:status_filter] = [OrderStatus.reconciled.id]
-        @params[:date_start] = 1.day.ago.strftime("%m/%d/%Y")
+        @params[:date_start] = 1.day.ago.to_date.iso8601
         do_request
         expect(assigns[:report_data].to_a).to contain_all [@order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_yesterday, @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today]
       end
@@ -191,7 +191,7 @@ RSpec.describe Reports::GeneralReportsController do
 
       it "should find reconciled that started yesterday" do
         @params[:status_filter] = [OrderStatus.reconciled.id]
-        @params[:date_start] = 1.day.ago.strftime("%m/%d/%Y")
+        @params[:date_start] = 1.day.ago.to_date.iso8601
         do_request
         expect(assigns[:report_data].to_a).to contain_all [@order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_today, @order_detail_ordered_yesterday_fulfilled_yesterday_reconciled_yesterday]
       end

--- a/spec/controllers/reports/instrument_day_reports_controller_spec.rb
+++ b/spec/controllers/reports/instrument_day_reports_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Reports::InstrumentDayReportsController do
   private
 
   def setup_extra_test_data(_user)
-    start_at = parse_usa_date(@params[:date_start], "10:00 AM") + 10.days
+    start_at = Time.zone.parse("#{@params[:date_start]} 10:00 AM") + 10.days
     place_reservation(@authable, @order_detail, start_at)
     @reservation.actual_start_at = start_at
     @reservation.actual_end_at = start_at + 1.hour

--- a/spec/controllers/reports/instrument_reports_controller_project_spec.rb
+++ b/spec/controllers/reports/instrument_reports_controller_project_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Reports::InstrumentReportsController do
       order_detail.update(project: project)
       sign_in user
       get :index, params: { report_by: :project, facility_id: facility.url_name,
-                            date_start: 1.month.ago, date_end: Time.current }, xhr: true
+                            date_start: 1.month.ago.to_date.iso8601, date_end: Time.current.to_date.iso8601 }, xhr: true
     end
 
     describe "the project row" do

--- a/spec/controllers/reports/instrument_reports_controller_spec.rb
+++ b/spec/controllers/reports/instrument_reports_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Reports::InstrumentReportsController do
   private
 
   def setup_extra_test_data(_user)
-    start_at = parse_usa_date(@params[:date_start], "10:00 AM") + 10.days
+    start_at = Time.zone.parse("#{@params[:date_start]} 10:00 AM") + 10.days
     place_reservation(@authable, @order_detail, start_at)
     @reservation.actual_start_at = start_at
     @reservation.actual_end_at = start_at + 1.hour

--- a/spec/controllers/reports/instrument_unavailable_reports_controller_spec.rb
+++ b/spec/controllers/reports/instrument_unavailable_reports_controller_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Reports::InstrumentUnavailableReportsController do
   let(:params) do
     {
       facility_id: facility.url_name,
-      date_start: date_start.strftime("%m/%d/%Y"),
-      date_end: date_end.strftime("%m/%d/%Y"),
+      date_start: date_start.to_date.iso8601,
+      date_end: date_end.to_date.iso8601,
       report_by: :instrument_unavailable,
     }
   end

--- a/spec/report_spec_helper.rb
+++ b/spec/report_spec_helper.rb
@@ -17,8 +17,8 @@ module ReportSpecHelper
       @action = :index
       @params = {
         facility_id: @authable.url_name,
-        date_start: Time.zone.now.strftime("%m/%d/%Y"),
-        date_end: (Time.zone.now + 1.year).strftime("%m/%d/%Y"),
+        date_start: Time.zone.now.to_date.iso8601,
+        date_end: (Time.zone.now + 1.year).to_date.iso8601,
         report_by: @report_by,
       }
 
@@ -36,7 +36,7 @@ module ReportSpecHelper
             [:owner, :staff, :purchaser].each do |user|
               acct = create_nufs_account_with_owner user
               place_and_complete_item_order(instance_variable_get("@#{user}"), @authable, acct)
-              @order_detail.ordered_at = parse_usa_date(@params[:date_start]) + 15.days
+              @order_detail.ordered_at = @params[:date_start].to_date + 15.days
               assert @order.save
               setup_extra_test_data(user)
             end
@@ -98,14 +98,14 @@ module ReportSpecHelper
     if @params[:date_start].blank?
       expect(assigns(:date_start)).to eq(date_start)
     else
-      expect(assigns(:date_start)).to eq(parse_usa_date(@params[:date_start]).beginning_of_day)
+      expect(assigns(:date_start)).to eq(@params[:date_start].to_date.beginning_of_day)
     end
 
     if @params[:date_end].blank?
       date_end = date_start + 42.days
       expect(assigns(:date_end)).to eq(Date.new(date_end.year, date_end.month) - 1.day)
     else
-      expect(assigns(:date_end)).to eq(parse_usa_date(@params[:date_end]).end_of_day)
+      expect(assigns(:date_end)).to eq(@params[:date_end].to_date.end_of_day)
     end
   end
 

--- a/spec/services/transaction_search/date_range_searcher_spec.rb
+++ b/spec/services/transaction_search/date_range_searcher_spec.rb
@@ -15,22 +15,22 @@ RSpec.describe TransactionSearch::DateRangeSearcher do
     end
 
     it "finds only the right ones when starting a day ago" do
-      results = searcher.search(field: :ordered_at, start: SpecDateHelper.format_usa_date(1.day.ago))
+      results = searcher.search(field: :ordered_at, start: 1.day.ago.to_date.iso8601)
       expect(results).to eq([order_details.last])
     end
 
     it "finds only the right one when ending a day ago" do
-      results = searcher.search(field: :ordered_at, end: SpecDateHelper.format_usa_date(2.days.ago))
+      results = searcher.search(field: :ordered_at, end: 2.days.ago.to_date.iso8601)
       expect(results).to eq([order_details.first])
     end
 
     it "finds nothing with an outside range" do
-      results = searcher.search(field: :ordered_at, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(3.days.ago))
+      results = searcher.search(field: :ordered_at, start: 5.days.ago.to_date.iso8601, end: 3.days.ago.to_date.iso8601)
       expect(results).to be_empty
     end
 
     it "finds all with a wide range in the ordered_at reverse chronological order" do
-      results = searcher.search(field: :ordered_at, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(1.day.from_now))
+      results = searcher.search(field: :ordered_at, start: 5.days.ago.to_date.iso8601, end: 1.day.from_now.to_date.iso8601)
       expect(results).to eq(order_details.reverse)
     end
   end
@@ -42,22 +42,22 @@ RSpec.describe TransactionSearch::DateRangeSearcher do
     end
 
     it "finds only the right ones when starting a day ago" do
-      results = searcher.search(field: :fulfilled_at, start: SpecDateHelper.format_usa_date(1.day.ago))
+      results = searcher.search(field: :fulfilled_at, start: 1.day.ago.to_date.iso8601)
       expect(results).to eq([order_details.last])
     end
 
     it "finds only the right one when ending a day ago" do
-      results = searcher.search(field: :fulfilled_at, end: SpecDateHelper.format_usa_date(2.days.ago))
+      results = searcher.search(field: :fulfilled_at, end: 2.days.ago.to_date.iso8601)
       expect(results).to eq([order_details.first])
     end
 
     it "finds nothing with an outside range" do
-      results = searcher.search(field: :fulfilled_at, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(3.days.ago))
+      results = searcher.search(field: :fulfilled_at, start: 5.days.ago.to_date.iso8601, end: 3.days.ago.to_date.iso8601)
       expect(results).to be_empty
     end
 
     it "finds all with a wide range in the fulfilled_at reverse chronological order" do
-      results = searcher.search(field: :fulfilled_at, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(1.day.from_now))
+      results = searcher.search(field: :fulfilled_at, start: 5.days.ago.to_date.iso8601, end: 1.day.from_now.to_date.iso8601)
       expect(results).to eq(order_details.reverse)
     end
   end
@@ -70,22 +70,22 @@ RSpec.describe TransactionSearch::DateRangeSearcher do
       end
 
       it "finds only the right ones when starting a day ago" do
-        results = searcher.search(field: :journal_or_statement_date, start: SpecDateHelper.format_usa_date(1.day.ago))
+        results = searcher.search(field: :journal_or_statement_date, start: 1.day.ago.to_date.iso8601)
         expect(results).to eq([order_details.last])
       end
 
       it "finds only the right one when ending a day ago" do
-        results = searcher.search(field: :journal_or_statement_date, end: SpecDateHelper.format_usa_date(2.days.ago))
+        results = searcher.search(field: :journal_or_statement_date, end: 2.days.ago.to_date.iso8601)
         expect(results).to eq([order_details.first])
       end
 
       it "finds nothing with an outside range" do
-        results = searcher.search(field: :journal_or_statement_date, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(3.days.ago))
+        results = searcher.search(field: :journal_or_statement_date, start: 5.days.ago.to_date.iso8601, end: 3.days.ago.to_date.iso8601)
         expect(results).to be_empty
       end
 
       it "finds all with a wide range in the reverse chronological order" do
-        results = searcher.search(field: :journal_or_statement_date, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(1.day.from_now))
+        results = searcher.search(field: :journal_or_statement_date, start: 5.days.ago.to_date.iso8601, end: 1.day.from_now.to_date.iso8601)
         expect(results).to eq(order_details.reverse)
       end
     end
@@ -97,22 +97,22 @@ RSpec.describe TransactionSearch::DateRangeSearcher do
       end
 
       it "finds only the right ones when starting a day ago" do
-        results = searcher.search(field: :journal_or_statement_date, start: SpecDateHelper.format_usa_date(1.day.ago))
+        results = searcher.search(field: :journal_or_statement_date, start: 1.day.ago.to_date.iso8601)
         expect(results).to eq([order_details.last])
       end
 
       it "finds only the right one when ending a day ago" do
-        results = searcher.search(field: :journal_or_statement_date, end: SpecDateHelper.format_usa_date(2.days.ago))
+        results = searcher.search(field: :journal_or_statement_date, end: 2.days.ago.to_date.iso8601)
         expect(results).to eq([order_details.first])
       end
 
       it "finds nothing with an outside range" do
-        results = searcher.search(field: :journal_or_statement_date, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(3.days.ago))
+        results = searcher.search(field: :journal_or_statement_date, start: 5.days.ago.to_date.iso8601, end: 3.days.ago.to_date.iso8601)
         expect(results).to be_empty
       end
 
       it "finds all with a wide range in the reverse chronological order" do
-        results = searcher.search(field: :journal_or_statement_date, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(1.day.from_now))
+        results = searcher.search(field: :journal_or_statement_date, start: 5.days.ago.to_date.iso8601, end: 1.day.from_now.to_date.iso8601)
         expect(results).to eq(order_details.reverse)
       end
     end
@@ -125,22 +125,22 @@ RSpec.describe TransactionSearch::DateRangeSearcher do
     end
 
     it "finds only the right ones when starting a day ago" do
-      results = searcher.search(field: :reconciled_at, start: SpecDateHelper.format_usa_date(1.day.ago))
+      results = searcher.search(field: :reconciled_at, start: 1.day.ago.to_date.iso8601)
       expect(results).to eq([order_details.last])
     end
 
     it "finds only the right one when ending a day ago" do
-      results = searcher.search(field: :reconciled_at, end: SpecDateHelper.format_usa_date(2.days.ago))
+      results = searcher.search(field: :reconciled_at, end: 2.days.ago.to_date.iso8601)
       expect(results).to eq([order_details.first])
     end
 
     it "finds nothing with an outside range" do
-      results = searcher.search(field: :reconciled_at, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(3.days.ago))
+      results = searcher.search(field: :reconciled_at, start: 5.days.ago.to_date.iso8601, end: 3.days.ago.to_date.iso8601)
       expect(results).to be_empty
     end
 
     it "finds all with a wide range in the reconciled_at reverse chronological order" do
-      results = searcher.search(field: :reconciled_at, start: SpecDateHelper.format_usa_date(5.days.ago), end: SpecDateHelper.format_usa_date(1.day.from_now))
+      results = searcher.search(field: :reconciled_at, start: 5.days.ago.to_date.iso8601, end: 1.day.from_now.to_date.iso8601)
       expect(results).to eq(order_details.reverse)
     end
   end

--- a/spec/services/transaction_search/searcher_spec.rb
+++ b/spec/services/transaction_search/searcher_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe TransactionSearch::Searcher, type: :service do
       it "can find the order when it has a start date before" do
         params = {
           field: "ordered_at",
-          start: I18n.l(5.days.ago, format: :usa),
+          start: 5.days.ago.to_date.iso8601,
         }
         result = searcher.search(scope, date_ranges: params)
         expect(result.order_details).to include(order_detail)
@@ -79,7 +79,7 @@ RSpec.describe TransactionSearch::Searcher, type: :service do
       it "does not find it when the start date is after" do
         params = {
           field: "ordered_at",
-          start: I18n.l(1.day.ago.to_date, format: :usa),
+          start: 1.day.ago.to_date.iso8601,
         }
         result = searcher.search(scope, date_ranges: params)
         expect(result.order_details).to be_empty
@@ -88,8 +88,8 @@ RSpec.describe TransactionSearch::Searcher, type: :service do
       it "does not find it when the start and end dates are before" do
         params = {
           field: "ordered_at",
-          start: I18n.l(5.days.ago.to_date, format: :usa),
-          end: I18n.l(4.days.ago.to_date, format: :usa),
+          start: 5.days.ago.to_date.iso8601,
+          end: 4.days.ago.to_date.iso8601,
         }
         result = searcher.search(scope, date_ranges: params)
         expect(result.order_details).to be_empty

--- a/spec/system/admin/all_transactions_search_spec.rb
+++ b/spec/system/admin/all_transactions_search_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe "All Transactions Search", :js do
     login_as director
     visit facility_transactions_path(facility)
     expected_default_date = 1.month.ago.beginning_of_month
-    expect(page).to have_field("Start Date", with: expected_default_date.to_date.iso8601)
+    expect(page).to have_field("Start Date", with: expected_default_date.to_date)
 
     select_from_chosen accounts.second.account_list_item, from: "Payment Sources"
     click_button "Filter"

--- a/spec/system/admin/all_transactions_search_spec.rb
+++ b/spec/system/admin/all_transactions_search_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe "All Transactions Search", :js do
     login_as director
     visit facility_transactions_path(facility)
     expected_default_date = 1.month.ago.beginning_of_month
-    expect(page).to have_field("Start Date", with: I18n.l(expected_default_date.to_date, format: :usa))
+    expect(page).to have_field("Start Date", with: expected_default_date.to_date.iso8601)
 
     select_from_chosen accounts.second.account_list_item, from: "Payment Sources"
     click_button "Filter"

--- a/spec/system/admin/facility_statements_spec.rb
+++ b/spec/system/admin/facility_statements_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe "Facility Statement Admin" do
     end
 
     it "can filter by dates" do
-      fill_in "Start Date", with: I18n.l(4.days.ago.to_date, format: :usa)
+      fill_in "Start Date", with: 4.days.ago.to_date
       click_button "Filter"
 
       expect(page).not_to have_content(statement1.invoice_number)
@@ -171,7 +171,7 @@ RSpec.describe "Facility Statement Admin" do
       expect(page).to have_content(statement3.invoice_number)
 
       fill_in "Start Date", with: ""
-      fill_in "End Date", with: I18n.l(4.days.ago.to_date, format: :usa)
+      fill_in "End Date", with: 4.days.ago.to_date
 
       click_button "Filter"
       expect(page).to have_content(statement1.invoice_number)

--- a/vendor/engines/split_accounts/spec/controllers/instrument_day_reports_controller_spec.rb
+++ b/vendor/engines/split_accounts/spec/controllers/instrument_day_reports_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Reports::InstrumentDayReportsController, :enable_split_accounts d
   before { sign_in admin }
 
   def do_request(action)
-    get :index, params: { report_by: action, facility_id: facility.url_name, date_start: "03/01/2016", date_end: "03/31/2016" }, xhr: true
+    get :index, params: { report_by: action, facility_id: facility.url_name, date_start: "2016-03-01", date_end: "2016-03-31" }, xhr: true
   end
 
   describe "reserved_quantity" do


### PR DESCRIPTION
# Notes

Date-range filters on Reports, Transaction Search, and Statement search now use the browser's built-in date picker instead of the old calendar widget. Behavior is unchanged for users; dates are just entered through the native picker.

[NUOPEN-280 | Standardize forms date input submission](https://universe-of-universities.atlassian.net/browse/NUOPEN-280)


# Screenshots

<img width="1269" height="719" alt="Screenshot 2026-07-09 at 2 08 33 PM" src="https://github.com/user-attachments/assets/10bc6754-c977-4df8-bec4-dab51b4bd766" />


