### PR TITLE
[NUOPEN-280] Migrate single date filters

### DIFF
--- a/app/assets/stylesheets/app/transaction_search.scss
+++ b/app/assets/stylesheets/app/transaction_search.scss
@@ -32,6 +32,10 @@
     .form-group.fields {
       width: 60%;
       margin: auto;
+
+      .date-field {
+        max-width: 12em;
+      }
     }
   }
 

--- a/app/controllers/concerns/list_billing_log_events.rb
+++ b/app/controllers/concerns/list_billing_log_events.rb
@@ -4,8 +4,8 @@ module ListBillingLogEvents
   def index
     @billing_log_events = LogEventSearcher.new(
       relation: LogEvent.with_billing_type,
-      start_date: parse_usa_date(index_params[:start_date]),
-      end_date: parse_usa_date(index_params[:end_date]),
+      start_date: parse_iso_date(index_params[:start_date]),
+      end_date: parse_iso_date(index_params[:end_date]),
       events: index_params[:events],
       invoice_number: index_params[:invoice_number],
       payment_source: index_params[:payment_source],

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -50,7 +50,7 @@ class FacilityJournalsController < ApplicationController
 
     unless current_facility.has_pending_journals?
       @order_detail_action = :create
-      @action_date_field = { journal_date: @earliest_journal_date }
+      @action_date_field = { journal_date: Time.zone.now.to_date }
     end
 
     @valid_order_details, @invalid_order_details = AccountValidator::ValidatorFactory.partition_valid_order_details(@order_details.unexpired_account)

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -186,13 +186,13 @@ class FacilityJournalsController < ApplicationController
   def new_journal_from_params
     @journal = Journal.new(
       created_by: session_user.id,
-      journal_date: parse_usa_date(params[:journal_date]),
+      journal_date: parse_iso_date(params[:journal_date]),
       order_details_for_creation:
     )
   end
 
   def verify_journal_date_format
-    if params[:journal_date].present? && !usa_formatted_date?(params[:journal_date])
+    if params[:journal_date].present? && parse_iso_date(params[:journal_date]).nil?
       @journal.errors.add(:journal_date, :blank)
     end
   end

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -2,7 +2,6 @@
 
 class FacilityJournalsController < ApplicationController
 
-  include DateHelper
   include CSVHelper
   include OrderDetailsCsvExport
   include SortableBillingTable
@@ -97,7 +96,6 @@ class FacilityJournalsController < ApplicationController
     raise ActiveRecord::RecordNotFound if current_facility.cross_facility?
 
     new_journal_from_params
-    verify_journal_date_format
 
     # The referer can have a crazy long query string depending on how many checkboxes
     # are selected. We've seen Apache not like stuff like that and give a "malformed
@@ -186,15 +184,9 @@ class FacilityJournalsController < ApplicationController
   def new_journal_from_params
     @journal = Journal.new(
       created_by: session_user.id,
-      journal_date: parse_iso_date(params[:journal_date]),
+      journal_date: params[:journal_date],
       order_details_for_creation:
     )
-  end
-
-  def verify_journal_date_format
-    if params[:journal_date].present? && parse_iso_date(params[:journal_date]).nil?
-      @journal.errors.add(:journal_date, :blank)
-    end
   end
 
   def order_details_for_creation

--- a/app/controllers/facility_statements_controller.rb
+++ b/app/controllers/facility_statements_controller.rb
@@ -77,7 +77,7 @@ class FacilityStatementsController < ApplicationController
     }
 
     if can_set_invoice_date? && params[:invoice_date].present?
-      creator_params[:invoice_date] = parse_usa_date(params[:invoice_date])
+      creator_params[:invoice_date] = parse_iso_date(params[:invoice_date])
     end
 
     @statement_creator = StatementCreator.new(creator_params)

--- a/app/controllers/facility_statements_controller.rb
+++ b/app/controllers/facility_statements_controller.rb
@@ -77,7 +77,7 @@ class FacilityStatementsController < ApplicationController
     }
 
     if can_set_invoice_date? && params[:invoice_date].present?
-      creator_params[:invoice_date] = parse_iso_date(params[:invoice_date])
+      creator_params[:invoice_date] = params[:invoice_date]
     end
 
     @statement_creator = StatementCreator.new(creator_params)

--- a/app/controllers/log_events_controller.rb
+++ b/app/controllers/log_events_controller.rb
@@ -27,8 +27,8 @@ class LogEventsController < GlobalSettingsController
 
   def report_args
     {
-      start_date: parse_usa_date(params[:start_date]),
-      end_date: parse_usa_date(params[:end_date]),
+      start_date: parse_iso_date(params[:start_date]),
+      end_date: parse_iso_date(params[:end_date]),
       events: params[:events],
       query: params[:query],
     }

--- a/app/views/facility_journals/new.html.haml
+++ b/app/views/facility_journals/new.html.haml
@@ -3,12 +3,14 @@
     = javascript_include_tag "facility_journal"
     :javascript
       $(function(){
-        var today = "#{l(Time.zone.now.to_date, format: :usa)}";
+        var today = "#{Time.zone.now.to_date.iso8601}";
+        var journalDate = document.getElementById("journal_date");
 
-        $("#journal_date").val(today).datepicker({
-          "minDate": "#{l(@earliest_journal_date, format: :usa)}",
-          "maxDate": today
-        });
+        if (journalDate) {
+          journalDate.value = today;
+          journalDate.min = "#{@earliest_journal_date.to_date.iso8601}";
+          journalDate.max = today;
+        }
       });
 
       $(function(){

--- a/app/views/facility_journals/new.html.haml
+++ b/app/views/facility_journals/new.html.haml
@@ -3,17 +3,6 @@
     = javascript_include_tag "facility_journal"
     :javascript
       $(function(){
-        var today = "#{Time.zone.now.to_date.iso8601}";
-        var journalDate = document.getElementById("journal_date");
-
-        if (journalDate) {
-          journalDate.value = today;
-          journalDate.min = "#{@earliest_journal_date.to_date.iso8601}";
-          journalDate.max = today;
-        }
-      });
-
-      $(function(){
         $("#journals_create_form").submit(function(e) {
           $(e.target).find(":submit").attr("disabled", "true");
         });

--- a/app/views/log_events/_filter_form.html.haml
+++ b/app/views/log_events/_filter_form.html.haml
@@ -2,10 +2,10 @@
   .row
     .col-md-3
       = label_tag(:start_date, text(:start_date))
-      = text_field_tag(:start_date, params[:start_date], class: :datepicker__data, autocomplete: "off")
+      = date_field_tag(:start_date, params[:start_date], class: "form-control")
     .col-md-3
       = label_tag(:end_date, text(:end_date))
-      = text_field_tag(:end_date, params[:end_date], class: :datepicker__data, autocomplete: "off")
+      = date_field_tag(:end_date, params[:end_date], class: "form-control")
   .row
     .col-md-3
       = label_tag(:events, text(:event_filter))

--- a/app/views/shared/transactions/_table.html.haml
+++ b/app/views/shared/transactions/_table.html.haml
@@ -17,7 +17,7 @@
               - is_invoice_date = field_name == :invoice_date
               %label.control-label{ for: field_name }= is_invoice_date ? Statement.human_attribute_name(:invoice_date) : field_name.to_s.titleize
               .controls
-                - field_options = { class: "form-control", style: "max-width: 12em" }
+                - field_options = { class: "form-control date-field" }
                 - field_options[:max] = Time.current.to_date.iso8601 if is_invoice_date
                 = date_field_tag field_name, date_value&.to_date&.iso8601, field_options
           - else

--- a/app/views/shared/transactions/_table.html.haml
+++ b/app/views/shared/transactions/_table.html.haml
@@ -18,7 +18,8 @@
               %label.control-label{ for: field_name }= is_invoice_date ? Statement.human_attribute_name(:invoice_date) : field_name.to_s.titleize
               .controls
                 - field_options = { class: "form-control date-field" }
-                - field_options[:max] = Time.current.to_date if is_invoice_date
+                - field_options[:max] = Time.current.to_date
+                - field_options[:min] = @earliest_journal_date&.to_date unless is_invoice_date
                 = date_field_tag field_name, date_value&.to_date, field_options
           - else
             &nbsp;

--- a/app/views/shared/transactions/_table.html.haml
+++ b/app/views/shared/transactions/_table.html.haml
@@ -17,7 +17,7 @@
               - is_invoice_date = field_name == :invoice_date
               %label.control-label{ for: field_name }= is_invoice_date ? Statement.human_attribute_name(:invoice_date) : field_name.to_s.titleize
               .controls
-                - field_options = { class: "form-control" }
+                - field_options = { class: "form-control", style: "max-width: 12em" }
                 - field_options[:max] = Time.current.to_date.iso8601 if is_invoice_date
                 = date_field_tag field_name, date_value&.to_date&.iso8601, field_options
           - else

--- a/app/views/shared/transactions/_table.html.haml
+++ b/app/views/shared/transactions/_table.html.haml
@@ -17,9 +17,9 @@
               - is_invoice_date = field_name == :invoice_date
               %label.control-label{ for: field_name }= is_invoice_date ? Statement.human_attribute_name(:invoice_date) : field_name.to_s.titleize
               .controls
-                - field_options = { class: is_invoice_date ? "datepicker__data" : :datepicker }
-                - field_options[:data] = { max_date: Time.current.iso8601 } if is_invoice_date
-                = text_field_tag field_name, date_value.present? ? date_value.strftime("%m/%d/%Y") : "", field_options
+                - field_options = { class: "form-control" }
+                - field_options[:max] = Time.current.to_date.iso8601 if is_invoice_date
+                = date_field_tag field_name, date_value&.to_date&.iso8601, field_options
           - else
             &nbsp;
         .col-md-2

--- a/app/views/shared/transactions/_table.html.haml
+++ b/app/views/shared/transactions/_table.html.haml
@@ -18,8 +18,8 @@
               %label.control-label{ for: field_name }= is_invoice_date ? Statement.human_attribute_name(:invoice_date) : field_name.to_s.titleize
               .controls
                 - field_options = { class: "form-control date-field" }
-                - field_options[:max] = Time.current.to_date.iso8601 if is_invoice_date
-                = date_field_tag field_name, date_value&.to_date&.iso8601, field_options
+                - field_options[:max] = Time.current.to_date if is_invoice_date
+                = date_field_tag field_name, date_value&.to_date, field_options
           - else
             &nbsp;
         .col-md-2

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe FacilityJournalsController do
   end
 
   describe "#create" do
-    let(:journal_date) { I18n.l(Time.zone.today, format: :usa) }
+    let(:journal_date) { Time.zone.today.iso8601 }
 
     before :each do
       @method = :post
@@ -311,7 +311,7 @@ RSpec.describe FacilityJournalsController do
 
       context "trying to journal in the future" do
         before :each do
-          @params[:journal_date] = SpecDateHelper.format_usa_date(1.day.from_now)
+          @params[:journal_date] = 1.day.from_now.to_date.iso8601
         end
 
         it_behaves_like "journal error", "Journal Date may not be in the future"
@@ -321,13 +321,13 @@ RSpec.describe FacilityJournalsController do
         before :each do
           @order_detail1.update(fulfilled_at: 5.days.ago)
           @order_detail3.update(fulfilled_at: 3.days.ago)
-          @params[:journal_date] = SpecDateHelper.format_usa_date(4.days.ago)
+          @params[:journal_date] = 4.days.ago.to_date.iso8601
         end
 
         it_behaves_like "journal error", "Journal Date may not be before the latest fulfillment date."
 
         it "does allow to be the same day" do
-          @params[:journal_date] = SpecDateHelper.format_usa_date(3.days.ago)
+          @params[:journal_date] = 3.days.ago.to_date.iso8601
           do_request
           expect(assigns(:journal)).to be_persisted
         end
@@ -767,13 +767,13 @@ RSpec.describe FacilityJournalsController do
 
       it "allows a user with billing_journals permission" do
         sign_in permitted_user
-        post :create, params: { facility_id: facility.url_name, journal_date: I18n.l(Time.zone.today, format: :usa), order_detail_ids: [@order_detail1.id, @order_detail3.id] }
+        post :create, params: { facility_id: facility.url_name, journal_date: Time.zone.today.iso8601, order_detail_ids: [@order_detail1.id, @order_detail3.id] }
         expect(response).to redirect_to(facility_journals_path(facility))
       end
 
       it "denies a user without billing_journals permission" do
         sign_in unpermitted_user
-        expect { post :create, params: { facility_id: facility.url_name, journal_date: I18n.l(Time.zone.today, format: :usa) } }.to raise_error(CanCan::AccessDenied)
+        expect { post :create, params: { facility_id: facility.url_name, journal_date: Time.zone.today.iso8601 } }.to raise_error(CanCan::AccessDenied)
       end
     end
   end

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -268,10 +268,10 @@ RSpec.describe FacilityJournalsController do
         it_behaves_like "journal error", "may not be blank"
       end
 
-      context "when the journal_date is in MM/YY/DD format" do
-        let(:journal_date) { "1/1/11" }
+      context "when the journal_date is an invalid date" do
+        let(:journal_date) { "not-a-date" }
 
-        it_behaves_like "journal error", "must be in MM/DD/YYYY format"
+        it_behaves_like "journal error", "may not be blank"
       end
 
       it "throttles the error message size" do

--- a/spec/controllers/facility_statements_controller_spec.rb
+++ b/spec/controllers/facility_statements_controller_spec.rb
@@ -239,7 +239,7 @@ if Account.config.statements_enabled?
         let(:billing_admin) { create(:user, :global_billing_administrator) }
         let(:regular_user) { create(:user) }
         let(:invoice_date_value) { 3.days.ago.to_date }
-        let(:invoice_date) { invoice_date_value.strftime("%m/%d/%Y") }
+        let(:invoice_date) { invoice_date_value.iso8601 }
 
         before do
           UserRole.grant(regular_user, UserRole::FACILITY_DIRECTOR, @authable)
@@ -294,7 +294,7 @@ if Account.config.statements_enabled?
         end
 
         context "when invoice_date is before fulfillment" do
-          let(:bad_invoice_date) { 10.days.ago.to_date.strftime("%m/%d/%Y") }
+          let(:bad_invoice_date) { 10.days.ago.to_date.iso8601 }
 
           before do
             sign_in billing_admin

--- a/spec/system/admin/billing_log_events_spec.rb
+++ b/spec/system/admin/billing_log_events_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "email log_events page" do
       it "filter events by date" do
         visit billing_log_events_path
 
-        fill_in("End Date", with: I18n.l(1.day.ago.to_date, format: :usa))
+        fill_in("End Date", with: 1.day.ago.to_date)
 
         click_button("Filter")
 


### PR DESCRIPTION
# Notes

The date fields on the Log Events filter, Create Journal, and Create Statement pages now use the browser's built-in date picker instead of the old calendar widget. Behavior is unchanged for users.

[NUOPEN-280 | Standardize forms date input submission](https://universe-of-universities.atlassian.net/browse/NUOPEN-280)

# Screenshots

Before:
<img width="679" height="351" alt="Screenshot 2026-07-10 at 2 49 49 PM" src="https://github.com/user-attachments/assets/8a55f762-0dbd-4f0a-91e3-6edbf2295d9a" />

After:
<img width="670" height="412" alt="Screenshot 2026-07-10 at 2 50 01 PM" src="https://github.com/user-attachments/assets/3635555e-4b4f-4033-8570-9376b5c98d54" />


