### PR TITLE
[NUOPEN-280] Migrate problem reservation date inputs

### DIFF
--- a/app/javascript/app/reservation_time_field_adjustor.js
+++ b/app/javascript/app/reservation_time_field_adjustor.js
@@ -23,7 +23,8 @@ window.DateTimeSelectionWidgetGroup = class DateTimeSelectionWidgetGroup {
   setDateTime(dateTime) {
     const formatter = new TimeFormatter(dateTime);
 
-    this.$dateField.val(formatter.dateString());
+    const isNative = this.$dateField.attr("type") === "date";
+    this.$dateField.val(isNative ? formatter.isoDateString() : formatter.dateString());
     this.$hourField.val(formatter.hour12());
     this.$meridianField.val(formatter.meridian());
 

--- a/app/javascript/app/time_formatter.js
+++ b/app/javascript/app/time_formatter.js
@@ -43,6 +43,10 @@ window.TimeFormatter = class TimeFormatter {
     return this.dateTime.toString("M/d/yyyy");
   }
 
+  isoDateString() {
+    return this.dateTime.toString("yyyy-MM-dd");
+  }
+
   toString() {
     return this.dateTime.toString();
   }
@@ -57,14 +61,14 @@ window.TimeFormatter = class TimeFormatter {
 
     const parsedMinute = parseInt(minute, 10);
 
-    const split = date.split("/");
+    // Native date inputs submit ISO (yyyy-mm-dd); legacy datepickers submit US (m/d/yyyy)
+    const iso = date.includes("-");
+    const split = date.split(iso ? "-" : "/").map((n) => parseInt(n, 10));
+    const [parsedYear, parsedMonth, parsedDay] =
+      iso ? split : [split[2], split[0], split[1]];
 
     // Date uses 0-11 for months
-    const parsedMonth = parseInt(split[0], 10) - 1;
-    const parsedDay = parseInt(split[1], 10);
-    const parsedYear = parseInt(split[2], 10);
-
-    date = new Date(parsedYear, parsedMonth, parsedDay, parsedHour, parsedMinute);
+    date = new Date(parsedYear, parsedMonth - 1, parsedDay, parsedHour, parsedMinute);
     return new TimeFormatter(date);
   }
 };

--- a/app/views/problem_reservations/edit.html.haml
+++ b/app/views/problem_reservations/edit.html.haml
@@ -19,13 +19,13 @@
           = f.label :actual_start_date
           .row
             .col-md-3
-              = f.input :actual_start_date, label: false, disabled: true
+              = f.input :actual_start_date, as: :date_field, label: false, input_html: { value: f.object.actual_start_at&.to_date&.iso8601, disabled: true }
             .col-md-4
               = time_select f, :actual_start, { minute_step: 1 }, disabled: true
           = f.label :actual_end_date
           .row
             .col-md-3
-              = f.input :actual_end_date, input_html: { class: "datepicker__data", data: { min_date: f.object.actual_start_at&.beginning_of_day&.iso8601 } }, label: false
+              = f.input :actual_end_date, as: :date_field, label: false, min_date: f.object.actual_start_at, input_html: { value: f.object.actual_end_at&.to_date&.iso8601 }
             .col-md-4
               = time_select f, :actual_end, { minute_step: 1 }
 

--- a/app/views/problem_reservations/edit.html.haml
+++ b/app/views/problem_reservations/edit.html.haml
@@ -25,7 +25,7 @@
           = f.label :actual_end_date
           .row
             .col-md-3
-              = f.input :actual_end_date, as: :date_field, label: false, min_date: f.object.actual_start_at, input_html: { value: f.object.actual_end_at&.to_date&.iso8601 }
+              = f.input :actual_end_date, as: :date_field, label: false, min_date: f.object.actual_start_at, max_date: Date.current, input_html: { value: f.object.actual_end_at&.to_date&.iso8601 }
             .col-md-4
               = time_select f, :actual_end, { minute_step: 1 }
 

--- a/spec/system/fixing_a_problem_reservation_spec.rb
+++ b/spec/system/fixing_a_problem_reservation_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe "Fixing a problem reservation" do
     end
     before { MoveToProblemQueue.move!(reservation.order_detail, cause: :reservation_started) }
 
+    it "renders the actual end date as a native date input" do
+      visit edit_problem_reservation_path(reservation)
+      expect(page).to have_css("input[type='date'][name='reservation[actual_end_date]']")
+    end
+
     it "can edit the reservation" do
       visit reservations_path(status: :all)
       click_link "Fix Usage"
@@ -30,6 +35,7 @@ RSpec.describe "Fixing a problem reservation" do
       click_button "Save"
 
       expect(page).not_to have_content("Fix Usage")
+      expect(reservation.reload.actual_end_at).to be_within(1.minute).of(reservation.actual_start_at + 45.minutes)
       expect(reservation.order_detail.reload.problem_description_key_was).to eq("missing_actuals")
       expect(reservation.order_detail.problem_resolved_at).to be_present
       expect(reservation.order_detail.problem_resolved_by).to eq(reservation.user)


### PR DESCRIPTION
# Notes

TECH TASK: Replaces the jQuery datepicker on the problem-reservation ("Fix Usage") form with the browser's native date input, which submits dates in ISO format. No change to reservation times or charges — only the date-picker widget. Also bounds the picker to today so future end dates can't be picked (previously the picker allowed them and relied on server validation).

[NUOPEN-280 | Standarize forms date input submission](https://universe-of-universities.atlassian.net/browse/NUOPEN-280)

# Screenshot

<img width="1284" height="951" alt="Screenshot 2026-07-13 at 12 07 24 PM" src="https://github.com/user-attachments/assets/8d27c84c-fc73-4bd0-a8a8-b7eeb1d97673" />

