### PR TITLE
[NUOPEN-280] Migrate timeline and reservation edit dates

### DIFF
--- a/app/assets/stylesheets/app/order_management.scss
+++ b/app/assets/stylesheets/app/order_management.scss
@@ -49,8 +49,8 @@
     width: 5em;
   }
 
-  .datepicker {
-    width: 7em;
+  input[type="date"] {
+    width: 10em;
   }
 
   .note {

--- a/app/assets/stylesheets/app/timeline.scss
+++ b/app/assets/stylesheets/app/timeline.scss
@@ -219,11 +219,8 @@ body .unit {
   }
 }
 
-.ui-datepicker-trigger {
+.timeline-datepicker-button {
   cursor: pointer;
-}
-
-button.ui-datepicker-trigger {
   background-color: white;
   border: none;
 }

--- a/app/controllers/facility_reservations_controller.rb
+++ b/app/controllers/facility_reservations_controller.rb
@@ -160,7 +160,7 @@ class FacilityReservationsController < ApplicationController
   end
 
   def timeline
-    @display_datetime = parse_usa_date(params[:date]) || Time.current.beginning_of_day
+    @display_datetime = parse_iso_date(params[:date])&.beginning_of_day || Time.current.beginning_of_day
 
     @schedules = current_facility.schedules_for_timeline(:facility_instruments)
     instrument_ids = @schedules.flat_map { |schedule| schedule.facility_instruments.map(&:id) }

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -25,7 +25,7 @@ class ReservationsController < ApplicationController
   end
 
   def public_timeline
-    @display_datetime = parse_usa_date(params[:date]) || Time.current.beginning_of_day
+    @display_datetime = parse_iso_date(params[:date])&.beginning_of_day || Time.current.beginning_of_day
 
     @schedules = current_facility.schedules_for_timeline(:public_instruments)
     instrument_ids = @schedules.flat_map { |schedule| schedule.public_instruments.map(&:id) }

--- a/app/javascript/reservations.js
+++ b/app/javascript/reservations.js
@@ -24,6 +24,13 @@ $(document).ready(function() {
           $('#calendar').fullCalendar('gotoDate', d);
         });
     });
+
+    $('input[type="date"]').change(function() {
+      var parts = $(this).val().split('-');
+      if (parts.length !== 3) return;
+      var d = new Date(parts[0], parts[1] - 1, parts[2]);
+      $('#calendar').fullCalendar('gotoDate', d);
+    });
   }
 
   /* Copy in actual times from reservation time */

--- a/app/javascript/timeline.js
+++ b/app/javascript/timeline.js
@@ -16,14 +16,20 @@ $(function() {
   });
 
   // Date select calendar
-  $(".datepicker").datepicker({
-    showOn: "button",
-    buttonText: "<i class='fa fa-calendar icon-large'>",
-  }).change(function() {
+  $(".js--timelineDatePicker").change(function() {
     var form = $(this).parents('form');
     var formUrl = form.attr('action');
     form.attr('action', formUrl + '#' + lastHiddenInstrumentId());
     form.submit();
+  });
+
+  $(".js--timelineDatePickerButton").on("click", function() {
+    var input = $(".js--timelineDatePicker")[0];
+    if (input.showPicker) {
+      input.showPicker();
+    } else {
+      input.focus();
+    }
   });
 
   //Get the Current Hour, create a class and add it the time div

--- a/app/views/facility_reservations/edit.html.haml
+++ b/app/views/facility_reservations/edit.html.haml
@@ -1,8 +1,6 @@
 = content_for :head_content do
   :javascript
     var events_path     = "#{calendar_events_path(current_facility, @instrument)}";
-    var maxDaysFromNow  = #{@max_window};
-    var minDaysFromNow  = #{@max_days_ago};
     var minTime         = #{@instrument.first_available_hour};
     var maxTime         = #{@instrument.last_available_hour+1};
     var currentReservationId = #{@reservation.id};
@@ -22,7 +20,9 @@
 
   - if @reservation.admin_editable?
     .datetime-block
-      = f.input :reserve_start_date, input_html: { class: "datepicker" }
+      = f.input :reserve_start_date, as: :date_field,
+        min_date: @max_days_ago.days.from_now, max_date: @max_window.days.from_now,
+        input_html: { value: @reservation.reserve_start_at }
       .form-group
         .controls
           .string.optional.control-label &nbsp;
@@ -35,7 +35,9 @@
 
   - if @reservation.can_edit_actuals?
     .datetime-block
-      = f.input :actual_start_date, input_html: { class: "datepicker" }
+      = f.input :actual_start_date, as: :date_field,
+        min_date: @max_days_ago.days.from_now, max_date: Date.current,
+        input_html: { value: @reservation.actual_start_at }
       .form-group
         .controls
           .string.optional.control-label &nbsp;

--- a/app/views/facility_reservations/timeline.html.haml
+++ b/app/views/facility_reservations/timeline.html.haml
@@ -14,12 +14,14 @@
   = modelless_form_for url: timeline_facility_reservations_path(current_facility), method: :get, id: "timeline_date_search" do |f|
     #reservation_date_container
       = link_to "&laquo;".html_safe,
-        timeline_facility_reservations_path(current_facility, date: format_usa_date(@display_datetime - 1.day)), id: "reservation_left"
+        timeline_facility_reservations_path(current_facility, date: (@display_datetime - 1.day).to_date), id: "reservation_left"
       #reservation_date
         = l(@display_datetime.to_date, format: :timeline_navigation)
-        = hidden_field_tag "date", format_usa_date(@display_datetime), class: "datepicker"
+        = date_field_tag "date", @display_datetime.to_date, class: "sr-only js--timelineDatePicker"
+        %button.timeline-datepicker-button.js--timelineDatePickerButton{ type: "button" }
+          %i.fa.fa-calendar.icon-large
       = link_to "&raquo;".html_safe,
-        timeline_facility_reservations_path(current_facility, date: format_usa_date(@display_datetime + 1.day)), id: "reservation_right"
+        timeline_facility_reservations_path(current_facility, date: (@display_datetime + 1.day).to_date), id: "reservation_right"
     .timeline_options
       = f.input :show_canceled,
         as: :boolean,

--- a/app/views/order_management/order_details/_reservation.html.haml
+++ b/app/views/order_management/order_details/_reservation.html.haml
@@ -2,7 +2,8 @@
 = f.simple_fields_for reservation do |r|
   .datetime-block.js--pricingUpdate
     - if reservation.admin_editable?
-      = r.input :reserve_start_date, input_html: { class: "form-control datepicker" }
+      = r.input :reserve_start_date, as: :date_field,
+        input_html: { value: reservation.reserve_start_at }
       .form-group
         .controls
           %label &nbsp;
@@ -18,7 +19,8 @@
   .datetime-block.js--pricingUpdate
     - if reservation.can_edit_actuals? && !reservation.canceled?
       = f.input :editing_time_data, as: :hidden, input_html: { value: true }
-      = r.input :actual_start_date, input_html: { class: "form-control datepicker" }
+      = r.input :actual_start_date, as: :date_field, max_date: Date.current,
+        input_html: { value: reservation.actual_start_at }
       .form-group
         .controls
           %label &nbsp;

--- a/app/views/reservations/_datetime_edit.html.haml
+++ b/app/views/reservations/_datetime_edit.html.haml
@@ -1,9 +1,0 @@
-= f.fields_for field, f.object.send(field) do |d|
-  %li.left
-    = d.label :date, date_label
-    = d.text_field :date, :class => 'datepicker'
-  %li.left
-    = d.label :hour, time_label
-    = d.select :hour, (1..12).to_a
-    = d.select :min, (0..59).step(5).map{|d| [sprintf('%02d', d),d]}
-    = d.select :meridian, ['AM', 'PM']

--- a/app/views/reservations/public_timeline.html.haml
+++ b/app/views/reservations/public_timeline.html.haml
@@ -9,12 +9,14 @@
   = modelless_form_for url: facility_public_timeline_path(current_facility), method: :get, id: "timeline_date_search" do |f|
     #reservation_date_container
       = link_to "&laquo;".html_safe,
-        facility_public_timeline_path(current_facility, date: format_usa_date(@display_datetime - 1.day)), id: "reservation_left"
+        facility_public_timeline_path(current_facility, date: (@display_datetime - 1.day).to_date), id: "reservation_left"
       #reservation_date
         = l(@display_datetime.to_date, format: :timeline_navigation)
-        = hidden_field_tag "date", format_usa_date(@display_datetime), class: "datepicker"
+        = date_field_tag "date", @display_datetime.to_date, class: "sr-only js--timelineDatePicker"
+        %button.timeline-datepicker-button.js--timelineDatePickerButton{ type: "button" }
+          %i.fa.fa-calendar.icon-large
       = link_to "&raquo;".html_safe,
-        facility_public_timeline_path(current_facility, date: format_usa_date(@display_datetime + 1.day)), id: "reservation_right"
+        facility_public_timeline_path(current_facility, date: (@display_datetime + 1.day).to_date), id: "reservation_right"
 
 .row
   .col-md-12.timeline-wrapper

--- a/spec/controllers/facility_reservations_controller_spec.rb
+++ b/spec/controllers/facility_reservations_controller_spec.rb
@@ -250,6 +250,17 @@ RSpec.describe FacilityReservationsController do
         expect(assigns[:display_datetime]).to eq(Time.zone.parse("2015-06-14T00:00"))
       end
 
+      it "parses an ISO date" do
+        @params[:date] = "2015-06-14"
+        do_request
+        expect(assigns[:display_datetime]).to eq(Time.zone.parse("2015-06-14T00:00"))
+      end
+
+      it "renders a native date input for the date jump" do
+        do_request
+        expect(response.body).to include('type="date"')
+      end
+
       it "shows relay status toggles when the date is today" do
         allow_any_instance_of(Instrument).to receive(:has_real_relay?).and_return(true)
         do_request
@@ -327,7 +338,7 @@ RSpec.describe FacilityReservationsController do
     let(:reserve_start_at) { FactoryBot.attributes_for(:reservation)[:reserve_start_at] }
     let(:reservation_params) do
       {
-        reserve_start_date: reserve_start_at.strftime("%m/%d/%Y"),
+        reserve_start_date: reserve_start_at.to_date.iso8601,
         reserve_start_hour: reserve_start_at.hour.to_s,
         reserve_start_min: reserve_start_at.strftime("%M"),
         reserve_start_meridian: reserve_start_at.strftime("%p"),

--- a/spec/controllers/facility_reservations_controller_spec.rb
+++ b/spec/controllers/facility_reservations_controller_spec.rb
@@ -244,16 +244,16 @@ RSpec.describe FacilityReservationsController do
         expect(assigns[:display_datetime]).to eq(Time.current.beginning_of_day)
       end
 
-      it "parses the date" do
-        @params[:date] = "6/14/2015"
-        do_request
-        expect(assigns[:display_datetime]).to eq(Time.zone.parse("2015-06-14T00:00"))
-      end
-
       it "parses an ISO date" do
         @params[:date] = "2015-06-14"
         do_request
         expect(assigns[:display_datetime]).to eq(Time.zone.parse("2015-06-14T00:00"))
+      end
+
+      it "falls back to today when the date is not ISO formatted" do
+        @params[:date] = "6/14/2015"
+        do_request
+        expect(assigns[:display_datetime]).to eq(Time.current.beginning_of_day)
       end
 
       it "renders a native date input for the date jump" do
@@ -268,7 +268,7 @@ RSpec.describe FacilityReservationsController do
       end
 
       it "does not show relay status toggles when the date is not today" do
-        @params[:date] = "6/14/2015"
+        @params[:date] = "2015-06-14"
         allow_any_instance_of(Instrument).to receive(:has_real_relay?).and_return(true)
         do_request
         expect(response.body).not_to include("relay_checkbox")

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -6,14 +6,14 @@ require "controller_spec_helper"
 RSpec.describe OrderManagement::OrderDetailsController do
   def reservation_params(reserve_start_at, actual_start_at = nil)
     params = {
-      reserve_start_date: I18n.l(reserve_start_at.to_date, format: :usa),
+      reserve_start_date: reserve_start_at.to_date.iso8601,
       reserve_start_hour: reserve_start_at.strftime("%l"),
       reserve_start_min: reserve_start_at.strftime("%M"),
       reserve_start_meridian: reserve_start_at.strftime("%p"),
     }
 
     params.merge!(
-      actual_start_date: I18n.l(actual_start_at.to_date, format: :usa),
+      actual_start_date: actual_start_at.to_date.iso8601,
       actual_start_hour: actual_start_at.strftime("%l"),
       actual_start_min: actual_start_at.strftime("%M"),
       actual_start_meridian: actual_start_at.strftime("%p"),


### PR DESCRIPTION
# Notes

Replaces the jQuery datepicker with the browser's built-in date picker on the reservations timeline pages, the admin reservation edit form, and the Manage Order Detail form. Dates are now submitted in ISO format, removing the need for US-format date parsing on these screens.

[NUOPEN-280 | Standarize forms date input submission](https://universe-of-universities.atlassian.net/browse/NUOPEN-280)

# Screenshot

<img width="1242" height="608" alt="Screenshot 2026-07-13 at 12 30 55 PM" src="https://github.com/user-attachments/assets/2f93252e-f9c6-44db-a7d7-4d5d72b6209e" />
<img width="1190" height="961" alt="Screenshot 2026-07-13 at 12 56 32 PM" src="https://github.com/user-attachments/assets/43d031db-61fa-4b87-b453-4f59b429ecb4" />

