### PR TITLE
[Fix] OrderDetail show when order not purchased

### DIFF
--- a/app/views/order_details/show.html.haml
+++ b/app/views/order_details/show.html.haml
@@ -11,7 +11,8 @@
 - order_detail_presenter = OrderDetailPresenter.new(@order_detail)
 .row
   .col-md-6
-    %p= link_to t(".link.receipt"), receipt_order_path(@order)
+    - if @order.purchased?
+      %p= link_to t(".link.receipt"), receipt_order_path(@order)
 
     = readonly_form_for :order do |f|
       = f.input :facility, label: Facility.model_name.human
@@ -22,7 +23,7 @@
           = link_to t(".link.change_account"), [:edit, @order, @order_detail], class: "normal-weight" if order_editable?
         .controls= order_detail_presenter.account_description
 
-      = f.input :ordered_at, input_html: { value: @order_detail.ordered_at }
+      = f.input :ordered_at, input_html: { value: @order_detail.ordered_at || "-" }
       = f.input :user
       = f.input :created_by_user
 

--- a/spec/requests/order_details_spec.rb
+++ b/spec/requests/order_details_spec.rb
@@ -3,6 +3,74 @@
 require "rails_helper"
 
 RSpec.describe "order_details" do
+  describe "show" do
+    let(:user) { create(:user) }
+    let(:account) do
+      create(:setup_account).tap do |account|
+        create(:account_user, :purchaser, user:, account:)
+      end
+    end
+    let(:product) { create(:setup_item) }
+    let(:facility) { product.facility }
+    let(:action) do
+      lambda do
+        get order_order_detail_path(order, order_detail)
+      end
+    end
+
+    before { login_as user }
+
+    shared_examples "renders successfully" do
+      it "includes order detail" do
+        action.call
+
+        expect(page).to have_text(order_detail.order_number)
+      end
+
+      it "renders correctly" do
+        action.call
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when order is purchased" do
+      let(:order) do
+        create(:purchased_order, product:, user:, account:)
+      end
+      let(:order_detail) { order.order_details.first }
+
+      it_behaves_like "renders successfully"
+
+      it "does not show receipt link" do
+        action.call
+
+        expect(page).to have_link(
+          "Receipt",
+          href: receipt_order_path(order),
+        )
+      end
+    end
+
+    context "when ordered at is nil" do
+      let(:order) do
+        create(:setup_order, product:, ordered_at: nil, user:, account:)
+      end
+      let(:order_detail) { order.order_details.first }
+
+      it_behaves_like "renders successfully"
+
+      it "shows receipt link" do
+        action.call
+
+        expect(page).not_to have_link(
+          "Receipt",
+          href: receipt_order_path(order),
+        )
+      end
+    end
+  end
+
   describe "cancel" do
     let(:product) { create(:setup_instrument) }
     let(:facility) { product.facility }

--- a/spec/requests/order_details_spec.rb
+++ b/spec/requests/order_details_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe "order_details" do
       end
     end
     let(:product) { create(:setup_item) }
-    let(:facility) { product.facility }
     let(:action) do
       lambda do
         get order_order_detail_path(order, order_detail)
@@ -73,7 +72,6 @@ RSpec.describe "order_details" do
 
   describe "cancel" do
     let(:product) { create(:setup_instrument) }
-    let(:facility) { product.facility }
     let(:user) { create(:user) }
     let(:reservation) do
       create(:purchased_reservation, product:, user:)

--- a/spec/requests/order_details_spec.rb
+++ b/spec/requests/order_details_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "order_details" do
 
       it_behaves_like "renders successfully"
 
-      it "does not show receipt link" do
+      it "shows the receipt link" do
         action.call
 
         expect(page).to have_link(
@@ -59,7 +59,7 @@ RSpec.describe "order_details" do
 
       it_behaves_like "renders successfully"
 
-      it "shows receipt link" do
+      it "does not show receipt link" do
         action.call
 
         expect(page).not_to have_link(


### PR DESCRIPTION
# Notes

Fix order detail show page when order is not purchased, thus `ordered_at` attribute is nil causing the readonly form to attempt to fetch the value from the form object which is the order.

The order page can be access from the sanger sequencing submission page, before it's purchased.