### PR TITLE
[NUOPEN-369] Alphabetize permissions list

### DIFF
--- a/app/helpers/facility_user_permissions_helper.rb
+++ b/app/helpers/facility_user_permissions_helper.rb
@@ -3,10 +3,16 @@
 module FacilityUserPermissionsHelper
 
   def permission_summary(permission)
-    active = FacilityUserPermission.all_permissions.select { |perm| permission.public_send(perm) }
+    active = sorted_permissions.select { |perm| permission.public_send(perm) }
     active.map do |perm|
       FacilityUserPermission.human_attribute_name(perm)
     end.join(", ")
+  end
+
+  def sorted_permissions
+    FacilityUserPermission.all_permissions.sort_by do |perm|
+      [perm == :read_access ? 0 : 1, FacilityUserPermission.human_attribute_name(perm)]
+    end
   end
 
   def permission_checkbox_classes(perm)

--- a/app/helpers/facility_user_permissions_helper.rb
+++ b/app/helpers/facility_user_permissions_helper.rb
@@ -3,16 +3,15 @@
 module FacilityUserPermissionsHelper
 
   def permission_summary(permission)
-    active = sorted_permissions.select { |perm| permission.public_send(perm) }
-    active.map do |perm|
-      FacilityUserPermission.human_attribute_name(perm)
+    sorted_permissions_with_labels.filter_map do |perm, label|
+      label if permission.public_send(perm)
     end.join(", ")
   end
 
-  def sorted_permissions
-    FacilityUserPermission.all_permissions.sort_by do |perm|
-      [perm == :read_access ? 0 : 1, FacilityUserPermission.human_attribute_name(perm)]
-    end
+  def sorted_permissions_with_labels
+    FacilityUserPermission.all_permissions
+                          .map { |perm| [perm, FacilityUserPermission.human_attribute_name(perm)] }
+                          .sort_by { |perm, label| [perm == :read_access ? 0 : 1, label] }
   end
 
   def permission_checkbox_classes(perm)

--- a/app/views/facility_user_permissions/edit.html.haml
+++ b/app/views/facility_user_permissions/edit.html.haml
@@ -23,13 +23,13 @@
 
     %fieldset.js--permissionsFieldset
       %legend= text(".permissions")
-      - sorted_permissions.each do |perm|
+      - sorted_permissions_with_labels.each do |perm, label|
         - next if FacilityUserPermission::ADMIN_ONLY_PERMISSIONS.include?(perm) && !current_user.administrator?
         - next if perm == :quoting && SettingsHelper.feature_off?(:show_estimates_option)
         .checkbox
           %label
             = f.check_box perm, class: permission_checkbox_classes(perm)
-            = FacilityUserPermission.human_attribute_name(perm)
+            = label
 
   %ul.list-inline
     %li= f.submit text("shared.save"), class: "btn btn-primary"

--- a/app/views/facility_user_permissions/edit.html.haml
+++ b/app/views/facility_user_permissions/edit.html.haml
@@ -23,7 +23,7 @@
 
     %fieldset.js--permissionsFieldset
       %legend= text(".permissions")
-      - FacilityUserPermission.all_permissions.each do |perm|
+      - sorted_permissions.each do |perm|
         - next if FacilityUserPermission::ADMIN_ONLY_PERMISSIONS.include?(perm) && !current_user.administrator?
         - next if perm == :quoting && SettingsHelper.feature_off?(:show_estimates_option)
         .checkbox

--- a/spec/helpers/facility_user_permissions_helper_spec.rb
+++ b/spec/helpers/facility_user_permissions_helper_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FacilityUserPermissionsHelper do
+
+  describe "sorted_permissions" do
+    it "puts read_access first and the rest alphabetized by display name" do
+      expect(helper.sorted_permissions.first).to eq(:read_access)
+
+      labels = helper.sorted_permissions.drop(1).map { |perm| FacilityUserPermission.human_attribute_name(perm) }
+      expect(labels).to eq(labels.sort)
+    end
+  end
+
+  describe "permission_summary" do
+    let(:permission) do
+      build(:facility_user_permission, account_management: true, billing_journals: true)
+    end
+
+    it "lists Read Access first and the rest alphabetically" do
+      expect(helper.permission_summary(permission)).to eq("Read Access, Billing Journals, Payment Source Management")
+    end
+  end
+
+end

--- a/spec/helpers/facility_user_permissions_helper_spec.rb
+++ b/spec/helpers/facility_user_permissions_helper_spec.rb
@@ -4,11 +4,11 @@ require "rails_helper"
 
 RSpec.describe FacilityUserPermissionsHelper do
 
-  describe "sorted_permissions" do
+  describe "sorted_permissions_with_labels" do
     it "puts read_access first and the rest alphabetized by display name" do
-      expect(helper.sorted_permissions.first).to eq(:read_access)
+      expect(helper.sorted_permissions_with_labels.first).to eq([:read_access, "Read Access"])
 
-      labels = helper.sorted_permissions.drop(1).map { |perm| FacilityUserPermission.human_attribute_name(perm) }
+      labels = helper.sorted_permissions_with_labels.drop(1).map { |_perm, label| label }
       expect(labels).to eq(labels.sort)
     end
   end


### PR DESCRIPTION
# Notes

Permission names on the Manage Permissions form and in the Facility Users permissions column are now listed alphabetically, with Read Access shown first since it is required for all other permissions.

[NUOPEN-369 | Alphabetize the list of permissions](https://universe-of-universities.atlassian.net/browse/NUOPEN-369)

# Screenshot

<img width="479" height="555" alt="Screenshot 2026-07-15 at 10 26 16 AM" src="https://github.com/user-attachments/assets/0326de7e-6e51-4725-9757-0c48569bd863" />

