### PR TITLE
[NUOPEN-327] Log reconciliation events for Statement regardless of feature flag

### DIFF
--- a/app/services/reconciliation_log_service.rb
+++ b/app/services/reconciliation_log_service.rb
@@ -7,8 +7,6 @@ class ReconciliationLogService
   end
 
   def log_events
-    return unless SettingsHelper.feature_on?("billing.billing_log_events")
-
     log_events_with_notes
   end
 

--- a/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
+++ b/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
@@ -177,25 +177,23 @@ RSpec.describe FacilityAccountsReconciliationController do
     describe "log event creation" do
       let(:reconciled_at) { Time.current }
 
-      context "when billing_log_events is enabled", feature_setting: { "billing.billing_log_events" => true } do
-        it "creates a log event for the statement" do
-          expect { perform }.to change {
-            LogEvent.where(loggable: statement, event_type: :closed).count
-          }.by(1)
-        end
+      it "creates a log event for the statement" do
+        expect { perform }.to change {
+          LogEvent.where(loggable: statement, event_type: :closed).count
+        }.by(1)
+      end
 
-        it "includes reconciled notes in metadata" do
-          perform
-          log_event = LogEvent.where(loggable: statement, event_type: :closed).last
-          expect(log_event.metadata["reconciled_notes"]).to eq(["A note"])
-        end
+      it "includes reconciled notes in metadata" do
+        perform
+        log_event = LogEvent.where(loggable: statement, event_type: :closed).last
+        expect(log_event.metadata["reconciled_notes"]).to eq(["A note"])
       end
 
       context "when billing_log_events is disabled", feature_setting: { "billing.billing_log_events" => false } do
-        it "does not create a log event" do
-          expect { perform }.not_to change {
+        it "still creates the statement closed log event" do
+          expect { perform }.to change {
             LogEvent.where(loggable: statement, event_type: :closed).count
-          }
+          }.by(1)
         end
       end
     end

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -196,12 +196,23 @@ RSpec.describe FacilityJournalsController do
         end
       end
 
-      describe "log event creation", feature_setting: { "billing.billing_log_events" => true } do
-        it "creates a log event when journal is closed" do
-          @params[:journal_status] = "succeeded"
-          expect { do_request }.to change {
-            LogEvent.where(loggable: @journal, event_type: :closed).count
-          }.by(1)
+      describe "log event creation" do
+        context "when billing_log_events is enabled", feature_setting: { "billing.billing_log_events" => true } do
+          it "creates a log event when journal is closed" do
+            @params[:journal_status] = "succeeded"
+            expect { do_request }.to change {
+              LogEvent.where(loggable: @journal, event_type: :closed).count
+            }.by(1)
+          end
+        end
+
+        context "when billing_log_events is disabled", feature_setting: { "billing.billing_log_events" => false } do
+          it "still creates a log event when journal is closed" do
+            @params[:journal_status] = "succeeded"
+            expect { do_request }.to change {
+              LogEvent.where(loggable: @journal, event_type: :closed).count
+            }.by(1)
+          end
         end
       end
     end

--- a/spec/services/reconciliation_log_service_spec.rb
+++ b/spec/services/reconciliation_log_service_spec.rb
@@ -22,31 +22,29 @@ RSpec.describe ReconciliationLogService do
   let(:service) { described_class.new(order_details, user) }
 
   describe "#log_events" do
-    context "when billing_log_events is enabled", feature_setting: { "billing.billing_log_events" => true } do
-      it "creates a log event with metadata" do
-        expect { service.log_events }.to change {
-          LogEvent.where(loggable: statement, event_type: :closed).count
-        }.by(1)
-      end
+    it "creates a log event with metadata" do
+      expect { service.log_events }.to change {
+        LogEvent.where(loggable: statement, event_type: :closed).count
+      }.by(1)
+    end
 
-      it "includes reconciled notes in metadata" do
-        service.log_events
-        log_event = LogEvent.where(loggable: statement, event_type: :closed).last
-        expect(log_event.metadata["reconciled_notes"]).to contain_exactly("Note 1", "Note 2")
-      end
+    it "includes reconciled notes in metadata" do
+      service.log_events
+      log_event = LogEvent.where(loggable: statement, event_type: :closed).last
+      expect(log_event.metadata["reconciled_notes"]).to contain_exactly("Note 1", "Note 2")
+    end
 
-      it "includes unrecoverable notes in metadata" do
-        service.log_events
-        log_event = LogEvent.where(loggable: statement, event_type: :closed).last
-        expect(log_event.metadata["unrecoverable_notes"]).to contain_exactly("Unrecoverable 1")
-      end
+    it "includes unrecoverable notes in metadata" do
+      service.log_events
+      log_event = LogEvent.where(loggable: statement, event_type: :closed).last
+      expect(log_event.metadata["unrecoverable_notes"]).to contain_exactly("Unrecoverable 1")
     end
 
     context "when billing_log_events is disabled", feature_setting: { "billing.billing_log_events" => false } do
-      it "does not create a log event" do
-        expect { service.log_events }.not_to change {
+      it "still creates the statement closed log event" do
+        expect { service.log_events }.to change {
           LogEvent.where(loggable: statement, event_type: :closed).count
-        }
+        }.by(1)
       end
     end
   end


### PR DESCRIPTION
# Notes
* Log reconciliation events for Statement regardless of feature flag

[NUOPEN-327 | Statements/Invoices closed at/by missing ](https://universe-of-universities.atlassian.net/browse/NUOPEN-327)

# Additional Context
Added a spec for journals, as it was already logging events regardless of the feature flag but it wasn't reflected in the specs.