### PR TITLE
[NUOPEN-292] Reservation button style

### DIFF
--- a/app/views/orders/_instrument_desc.html.haml
+++ b/app/views/orders/_instrument_desc.html.haml
@@ -4,4 +4,4 @@
   - if order_detail.reservation
     = link_to order_detail.reservation, edit_order_order_detail_reservation_path(order_detail.order, order_detail, order_detail.reservation)
   - else
-    = link_to 'Make a Reservation', new_order_order_detail_reservation_path(order_detail.order, order_detail), :class => 'btn'
+    = link_to 'Make a Reservation', new_order_order_detail_reservation_path(order_detail.order, order_detail), :class => 'btn btn-default'


### PR DESCRIPTION
  # Notes

  Fixes the "Make a Reservation" link on instrument orders so it looks like a clickable button instead of plain text.

  [NUOPEN-292 | Ordering on behalf for an Instrument](https://universe-of-universities.atlassian.net/browse/NUOPEN-292)

# Screenshot

<img width="806" height="579" alt="Screenshot 2026-07-15 at 5 28 18 PM" src="https://github.com/user-attachments/assets/08832af1-efc6-4c2e-9e46-6e2fa8c73703" />

