### PR TITLE
[NUOPEN-282] Make Duration billing available for Global admin only

### DIFF
--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -111,20 +111,9 @@ class InstrumentsController < ProductsCommonController
       params += %i[min_reserve_days max_reserve_days start_time_disabled]
     end
 
-    params -= [:pricing_mode] if action_name == "update" && !allowed_to_set_pricing_mode?
+    params -= [:pricing_mode] if action_name == "update"
 
     params
-  end
-
-  def allowed_to_set_pricing_mode?
-    case params.dig(:instrument, :pricing_mode)
-    when Instrument::Pricing::SCHEDULE_DAILY
-      can?(:create_daily_booking, Instrument)
-    when Instrument::Pricing::DURATION
-      can?(:create_duration_billing, Instrument)
-    else
-      true
-    end
   end
 
   def start_time_disabled_changed_check

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -41,6 +41,10 @@ class InstrumentsController < ProductsCommonController
       flash.now[:error] = t("controllers.instruments.create.daily_booking_not_authorized")
 
       render :new
+    elsif resource_params[:pricing_mode] == Instrument::Pricing::DURATION && cannot?(:create_duration_billing, Instrument)
+      flash.now[:error] = t("controllers.instruments.create.duration_billing_not_authorized")
+
+      render :new
     else
       super
     end

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -111,7 +111,20 @@ class InstrumentsController < ProductsCommonController
       params += %i[min_reserve_days max_reserve_days start_time_disabled]
     end
 
+    params -= [:pricing_mode] if action_name == "update" && !allowed_to_set_pricing_mode?
+
     params
+  end
+
+  def allowed_to_set_pricing_mode?
+    case params.dig(:instrument, :pricing_mode)
+    when Instrument::Pricing::SCHEDULE_DAILY
+      can?(:create_daily_booking, Instrument)
+    when Instrument::Pricing::DURATION
+      can?(:create_duration_billing, Instrument)
+    else
+      true
+    end
   end
 
   def start_time_disabled_changed_check

--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -110,7 +110,11 @@ class ProductsCommonController < ApplicationController
 
   # Needs to be over-rideable from engines
   def permitted_params
-    default_permitted_params
+    params = default_permitted_params
+
+    params -= [:billing_mode] unless current_user&.administrator?
+
+    params
   end
 
   def default_permitted_params

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -32,10 +32,9 @@ module ProductsHelper
   end
 
   def instrument_pricing_modes
-    return Instrument::PRICING_MODES if can?(:create_daily_booking, Instrument)
-
     Instrument::PRICING_MODES.reject do |pricing_mode|
-      pricing_mode == Instrument::Pricing::SCHEDULE_DAILY
+      (pricing_mode == Instrument::Pricing::SCHEDULE_DAILY && cannot?(:create_daily_booking, Instrument)) ||
+        (pricing_mode == Instrument::Pricing::DURATION && cannot?(:create_duration_billing, Instrument))
     end
   end
 

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -421,6 +421,7 @@ class Ability
     ]
 
     cannot :create_daily_booking, Product
+    cannot :create_duration_billing, Product
     can :manage, User if controller.is_a?(FacilityUsersController)
 
     # ideally we don't use `cannot` as it adds a dependency on the order of assigning abilities for multiple roles

--- a/app/lib/facility_user_permission_ability.rb
+++ b/app/lib/facility_user_permission_ability.rb
@@ -104,6 +104,7 @@ class FacilityUserPermissionAbility
     ]
     can [:update, :destroy], Product
     cannot :create_daily_booking, Product
+    cannot :create_duration_billing, Product
     can [:show, :index], PriceGroup
     can [:show, :index], [PricePolicy, InstrumentPricePolicy, ItemPricePolicy, ServicePricePolicy]
     can [:read, :edit], PriceGroupProduct

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -104,6 +104,7 @@ en:
     instruments:
       create:
         daily_booking_not_authorized: "Not allowed to create daily booking instruments"
+        duration_billing_not_authorized: "Not allowed to create duration billing instruments"
         schedule_rules_updated: Start time disabled changed, Schedule Rules have been updated
         schedule_rules_need_update: Start time disabled changed, please update schedule rules
 

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -443,31 +443,18 @@ RSpec.describe InstrumentsController, type: :controller do
       assert_redirected_to manage_facility_instrument_url(facility, assigns(:product))
     end
 
-    describe "duration billing permissions" do
+    describe "pricing mode" do
+      let(:user) { create(:user, :administrator) }
+
       before do
         @params[:instrument] = { pricing_mode: Instrument::Pricing::DURATION }
       end
 
-      context "as a disallowed user" do
-        let(:user) { create(:user, :facility_director, facility:) }
+      it "does not change the instrument's pricing mode" do
+        sign_in(user)
 
-        it "does not switch the instrument to duration billing" do
-          sign_in(user)
-
-          expect { do_request }.not_to change { instrument.reload.pricing_mode }
-          expect(instrument.reload).not_to be_duration_pricing_mode
-        end
-      end
-
-      context "as an administrator" do
-        let(:user) { create(:user, :administrator) }
-
-        it "switches the instrument to duration billing" do
-          sign_in(user)
-
-          do_request
-          expect(instrument.reload).to be_duration_pricing_mode
-        end
+        expect { do_request }.not_to change { instrument.reload.pricing_mode }
+        expect(instrument.reload).not_to be_duration_pricing_mode
       end
     end
 

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -357,6 +357,49 @@ RSpec.describe InstrumentsController, type: :controller do
         end
       end
     end
+
+    describe "duration billing permissions" do
+      before do
+        @params[:instrument] = attributes_for(
+          :instrument,
+          pricing_mode: Instrument::Pricing::DURATION,
+          facility_account_id: facility.facility_accounts.first.id,
+        )
+      end
+
+      shared_examples "duration billing creation disallowed" do
+        it "does not allow user to create duration billing instrument" do
+          sign_in(user)
+
+          expect { do_request }.to_not change { Instrument.count }
+          expect(@response.body).to(
+            include(I18n.t("controllers.instruments.create.duration_billing_not_authorized"))
+          )
+        end
+      end
+
+      context "as facility admin" do
+        let(:user) { create(:user, :facility_administrator, facility:) }
+
+        include_examples "duration billing creation disallowed"
+      end
+
+      context "as facility director" do
+        let(:user) { create(:user, :facility_director, facility:) }
+
+        include_examples "duration billing creation disallowed"
+      end
+
+      context "as administrator" do
+        let(:user) { create(:user, :administrator) }
+
+        it "allows to create a duration billing instrument" do
+          sign_in user
+
+          expect { do_request }.to change { Instrument.count }.by(1)
+        end
+      end
+    end
   end
 
   context "update" do

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -400,6 +400,34 @@ RSpec.describe InstrumentsController, type: :controller do
         end
       end
     end
+
+    describe "billing mode permissions" do
+      before do
+        @params[:instrument][:billing_mode] = "Nonbillable"
+      end
+
+      context "as a disallowed user" do
+        let(:user) { create(:user, :facility_director, facility:) }
+
+        it "does not set the billing mode" do
+          sign_in(user)
+
+          do_request
+          expect(assigns(:product).billing_mode).to eq("Default")
+        end
+      end
+
+      context "as an administrator" do
+        let(:user) { create(:user, :administrator) }
+
+        it "sets the billing mode" do
+          sign_in(user)
+
+          do_request
+          expect(assigns(:product).billing_mode).to eq("Nonbillable")
+        end
+      end
+    end
   end
 
   context "update" do
@@ -413,6 +441,61 @@ RSpec.describe InstrumentsController, type: :controller do
       yield
       is_expected.to set_flash
       assert_redirected_to manage_facility_instrument_url(facility, assigns(:product))
+    end
+
+    describe "duration billing permissions" do
+      before do
+        @params[:instrument] = { pricing_mode: Instrument::Pricing::DURATION }
+      end
+
+      context "as a disallowed user" do
+        let(:user) { create(:user, :facility_director, facility:) }
+
+        it "does not switch the instrument to duration billing" do
+          sign_in(user)
+
+          expect { do_request }.not_to change { instrument.reload.pricing_mode }
+          expect(instrument.reload).not_to be_duration_pricing_mode
+        end
+      end
+
+      context "as an administrator" do
+        let(:user) { create(:user, :administrator) }
+
+        it "switches the instrument to duration billing" do
+          sign_in(user)
+
+          do_request
+          expect(instrument.reload).to be_duration_pricing_mode
+        end
+      end
+    end
+
+    describe "billing mode permissions" do
+      before do
+        @params[:instrument] = { billing_mode: "Nonbillable" }
+      end
+
+      context "as a disallowed user" do
+        let(:user) { create(:user, :facility_director, facility:) }
+
+        it "does not change the billing mode" do
+          sign_in(user)
+
+          expect { do_request }.not_to change { instrument.reload.billing_mode }
+        end
+      end
+
+      context "as an administrator" do
+        let(:user) { create(:user, :administrator) }
+
+        it "changes the billing mode" do
+          sign_in(user)
+
+          do_request
+          expect(instrument.reload.billing_mode).to eq("Nonbillable")
+        end
+      end
     end
   end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -136,6 +136,7 @@ RSpec.describe Ability do
 
     it { is_expected.to be_allowed_to(:read, Notification) }
     it { is_expected.to be_allowed_to(:manage, Schedule) }
+    it { is_expected.to be_allowed_to(:create_duration_billing, Product) }
 
     describe StoredFile do
       describe "#download" do
@@ -279,6 +280,7 @@ RSpec.describe Ability do
     it { is_expected.to be_allowed_to(:manage, PriceGroupDiscount) }
     it { is_expected.to be_allowed_to(:manage, ScheduleRule) }
     it { is_expected.to be_allowed_to(:manage, ProductAccessGroup) }
+    it { is_expected.not_to be_allowed_to(:create_duration_billing, Product) }
     it_is_not_allowed_to([:edit, :update]) { FactoryBot.create(:user) }
     it { is_expected.to be_allowed_to(:manage, ProductNotification, facility_id: facility.id) }
 

--- a/spec/system/admin/creating_an_instrument_spec.rb
+++ b/spec/system/admin/creating_an_instrument_spec.rb
@@ -97,4 +97,30 @@ RSpec.describe "Creating an instrument", :js do
       end
     end
   end
+
+  describe "Duration Billing instrument" do
+    context "as disallowed user" do
+      let(:user) { create(:user, :facility_director, facility:) }
+
+      before { login_as user }
+
+      it "cannot select duration billing pricing mode" do
+        visit new_facility_instrument_path(facility)
+
+        expect(page).to_not have_field(Instrument::Pricing::DURATION)
+      end
+    end
+
+    context "as administrator" do
+      let(:user) { create(:user, :administrator) }
+
+      before { login_as user }
+
+      it "can select duration billing pricing mode" do
+        visit new_facility_instrument_path(facility)
+
+        expect(page).to have_field(Instrument::Pricing::DURATION)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Notes
* Make Duration billing available for Global admin only

[NUOPEN-282 | Duration Billing not global admin only? ](https://universe-of-universities.atlassian.net/browse/NUOPEN-282)

# Additional Context
Also made `permitted_params` remove the `pricing_mode` from `permitted_params`. While at it, I noticed we also had `billing_mode` hidden in the UI and present in the `permitted_params` and removed it in those cases.