### PR TITLE
[NUOPEN-295] Improve instrument availability loading

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -59,6 +59,8 @@ class FacilitiesController < ApplicationController
     @product_display_groups = current_facility.product_display_groups.sorted
     @product_display_groups = @product_display_groups.to_a + ProductDisplayGroup.fake_groups_by_type(current_facility.products.without_display_group)
 
+    @instrument_availability = Instruments::AvailabilityStatus.new(current_facility)
+
     render layout: "application"
   end
 

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -39,11 +39,11 @@ module ProductsHelper
     end
   end
 
-  def public_calendar_link(product)
+  def public_calendar_link(product, availability = nil)
     return unless product.respond_to? :reservations
 
     opts = if product.facility.show_instrument_availability?
-      public_calendar_availability_options(product)
+      public_calendar_availability_options(product, availability)
     else
       { class: ["fa fa-calendar fa-lg fa-fw"], title: t("instruments.public_schedule.icon") }
     end
@@ -57,11 +57,13 @@ module ProductsHelper
 
   private
 
-  def public_calendar_availability_options(product)
+  def public_calendar_availability_options(product, availability = nil)
+    availability ||= Instruments::AvailabilityStatus.new(product.facility)
+
     if product.offline?
       { class: ["fa fa-calendar fa-lg fa-fw", "in-use"],
         title: text("instruments.offline.note") }
-    elsif product.walkup_available?
+    elsif availability.available_now?(product)
       { class: ["fa fa-calendar fa-lg fa-fw", "available"],
         title: text("instruments.public_schedule.available") }
     else

--- a/app/services/instruments/availability_status.rb
+++ b/app/services/instruments/availability_status.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Instruments
+
+  # Request-scoped instrument availability for the public facility page: two
+  # facility-wide queries instead of running walkup_available? per instrument.
+  # Build once, reuse for every instrument on the page.
+  class AvailabilityStatus
+
+    def initialize(facility)
+      @facility = facility
+    end
+
+    # Open now per its schedule rules and its schedule not currently in use.
+    def available_now?(product)
+      return false if in_use_schedule_ids.include?(product.schedule_id)
+
+      schedule_rules_by_product.fetch(product.id, []).any? { |rule| rule.cover?(Time.current) }
+    end
+
+    private
+
+    # Keyed on schedule so shared-schedule instruments block each other, matching
+    # conflicting_*_reservation's `product.schedule.product_ids`.
+    def in_use_schedule_ids
+      @in_use_schedule_ids ||=
+        Reservation.current_in_use
+                   .joins(:product)
+                   .where(products: { facility_id: @facility.id })
+                   .distinct
+                   .pluck("products.schedule_id")
+                   .to_set
+    end
+
+    def schedule_rules_by_product
+      @schedule_rules_by_product ||=
+        ScheduleRule.joins(:product)
+                    .where(products: { facility_id: @facility.id })
+                    .group_by(&:product_id)
+    end
+
+  end
+
+end

--- a/app/services/instruments/availability_status.rb
+++ b/app/services/instruments/availability_status.rb
@@ -14,8 +14,8 @@ module Instruments
     # Open now per its schedule rules, its schedule not currently in use, and not
     # a holiday it restricts access on.
     def available_now?(product)
-      return false if in_use_schedule_ids.include?(product.schedule_id)
       return false if closed_for_holiday?(product)
+      return false if in_use_schedule_ids.include?(product.schedule_id)
 
       schedule_rules_by_product.fetch(product.id, []).any? { |rule| rule.cover?(Time.current) }
     end

--- a/app/services/instruments/availability_status.rb
+++ b/app/services/instruments/availability_status.rb
@@ -11,14 +11,28 @@ module Instruments
       @facility = facility
     end
 
-    # Open now per its schedule rules and its schedule not currently in use.
+    # Open now per its schedule rules, its schedule not currently in use, and not
+    # a holiday it restricts access on.
     def available_now?(product)
       return false if in_use_schedule_ids.include?(product.schedule_id)
+      return false if closed_for_holiday?(product)
 
       schedule_rules_by_product.fetch(product.id, []).any? { |rule| rule.cover?(Time.current) }
     end
 
     private
+
+    # No user on the public page, so a holiday only closes instruments that
+    # restrict access (nobody to override it).
+    def closed_for_holiday?(product)
+      product.restrict_holiday_access? && holiday_today?
+    end
+
+    def holiday_today?
+      return @holiday_today unless @holiday_today.nil?
+
+      @holiday_today = Holiday.on(Time.current.to_date).exists?
+    end
 
     # Keyed on schedule so shared-schedule instruments block each other, matching
     # conflicting_*_reservation's `product.schedule.product_ids`.

--- a/app/views/facilities/_product.html.haml
+++ b/app/views/facilities/_product.html.haml
@@ -8,7 +8,7 @@
         = builder.text_field :quantity, value: 0, class: "product_quantity", index: nil, aria: { label: text("quantity", product: product) }, id: "order_order_details_#{product.id}_quantity"
         = builder.hidden_field :product_id, value: product.id, index: nil, id: "order_order_details_#{product.id}_product_id"
     = tooltip_icon "fa fa-question-circle-o text__alert", text("line_items") if !product.is_a?(Instrument) && Orders::ItemAdder.multiline?(product)
-  = public_calendar_link(product)
+  = public_calendar_link(product, @instrument_availability)
   = link_to ProductPresenter.new(product), facility_product_path(product.facility, product)
   - if acting_user.present? && !product.can_be_used_by?(acting_user)
     %i.fa.fa-lock

--- a/spec/helpers/products_helper_spec.rb
+++ b/spec/helpers/products_helper_spec.rb
@@ -24,4 +24,68 @@ RSpec.describe ProductsHelper do
       expect(subject.to_h).to_not include(RelaySynaccessRevA)
     end
   end
+
+  describe "#public_calendar_availability_options" do
+    subject(:classes) { helper.send(:public_calendar_availability_options, instrument)[:class] }
+
+    let(:instrument) { create(:setup_instrument) }
+
+    it "is available when open now with no current reservation" do
+      expect(classes).to include("available")
+    end
+
+    context "with a current reservation" do
+      before do
+        create(:purchased_reservation,
+                          reserve_start_at: 30.minutes.ago,
+                          reserve_end_at: 30.minutes.from_now,
+                          product: instrument)
+      end
+
+      it "is in use, not available" do
+        expect(classes).to include("in-use")
+        expect(classes).not_to include("available")
+      end
+    end
+
+    context "with a current reservation on a schedule-sharing sibling" do
+      before do
+        sibling = create(:setup_instrument,
+                                    facility: instrument.facility,
+                                    schedule: instrument.schedule)
+        create(:admin_reservation,
+                          reserve_start_at: 30.minutes.ago,
+                          reserve_end_at: 30.minutes.from_now,
+                          product: sibling)
+      end
+
+      it "marks this instrument in use too" do
+        expect(classes).to include("in-use")
+        expect(classes).not_to include("available")
+      end
+    end
+
+    context "when closed now (no schedule rule covers the current time)" do
+      before { instrument.schedule_rules.destroy_all }
+
+      it "is not available" do
+        expect(classes).to include("in-use")
+        expect(classes).not_to include("available")
+      end
+    end
+
+    context "when offline" do
+      before do
+        create(:offline_reservation,
+                          product: instrument,
+                          reserve_start_at: 1.hour.ago,
+                          reserve_end_at: nil)
+      end
+
+      it "shows the offline note" do
+        options = helper.send(:public_calendar_availability_options, instrument)
+        expect(options[:title]).to eq(I18n.t("instruments.offline.note"))
+      end
+    end
+  end
 end

--- a/spec/helpers/products_helper_spec.rb
+++ b/spec/helpers/products_helper_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe ProductsHelper do
     context "with a current reservation" do
       before do
         create(:purchased_reservation,
-                          reserve_start_at: 30.minutes.ago,
-                          reserve_end_at: 30.minutes.from_now,
-                          product: instrument)
+               reserve_start_at: 30.minutes.ago,
+               reserve_end_at: 30.minutes.from_now,
+               product: instrument)
       end
 
       it "is in use, not available" do
@@ -51,12 +51,12 @@ RSpec.describe ProductsHelper do
     context "with a current reservation on a schedule-sharing sibling" do
       before do
         sibling = create(:setup_instrument,
-                                    facility: instrument.facility,
-                                    schedule: instrument.schedule)
+                         facility: instrument.facility,
+                         schedule: instrument.schedule)
         create(:admin_reservation,
-                          reserve_start_at: 30.minutes.ago,
-                          reserve_end_at: 30.minutes.from_now,
-                          product: sibling)
+               reserve_start_at: 30.minutes.ago,
+               reserve_end_at: 30.minutes.from_now,
+               product: sibling)
       end
 
       it "marks this instrument in use too" do
@@ -77,9 +77,9 @@ RSpec.describe ProductsHelper do
     context "when offline" do
       before do
         create(:offline_reservation,
-                          product: instrument,
-                          reserve_start_at: 1.hour.ago,
-                          reserve_end_at: nil)
+               product: instrument,
+               reserve_start_at: 1.hour.ago,
+               reserve_end_at: nil)
       end
 
       it "shows the offline note" do

--- a/spec/helpers/products_helper_spec.rb
+++ b/spec/helpers/products_helper_spec.rb
@@ -26,15 +26,15 @@ RSpec.describe ProductsHelper do
   end
 
   describe "#public_calendar_availability_options" do
-    subject(:classes) { helper.send(:public_calendar_availability_options, instrument)[:class] }
+    subject(:options) { helper.send(:public_calendar_availability_options, instrument) }
 
     let(:instrument) { create(:setup_instrument) }
 
-    it "is available when open now with no current reservation" do
-      expect(classes).to include("available")
+    it "marks an available instrument available" do
+      expect(options[:class]).to include("available")
     end
 
-    context "with a current reservation" do
+    context "when not available now" do
       before do
         create(:purchased_reservation,
                reserve_start_at: 30.minutes.ago,
@@ -42,50 +42,9 @@ RSpec.describe ProductsHelper do
                product: instrument)
       end
 
-      it "is in use, not available" do
-        expect(classes).to include("in-use")
-        expect(classes).not_to include("available")
-      end
-    end
-
-    context "with a current reservation on a schedule-sharing sibling" do
-      before do
-        sibling = create(:setup_instrument,
-                         facility: instrument.facility,
-                         schedule: instrument.schedule)
-        create(:admin_reservation,
-               reserve_start_at: 30.minutes.ago,
-               reserve_end_at: 30.minutes.from_now,
-               product: sibling)
-      end
-
-      it "marks this instrument in use too" do
-        expect(classes).to include("in-use")
-        expect(classes).not_to include("available")
-      end
-    end
-
-    context "when closed now (no schedule rule covers the current time)" do
-      before { instrument.schedule_rules.destroy_all }
-
-      it "is not available" do
-        expect(classes).to include("in-use")
-        expect(classes).not_to include("available")
-      end
-    end
-
-    context "on a holiday" do
-      before { Holiday.create!(date: Time.current.to_date) }
-
-      it "is not available when the instrument restricts holiday access" do
-        instrument.update!(restrict_holiday_access: true)
-        expect(classes).to include("in-use")
-        expect(classes).not_to include("available")
-      end
-
-      it "stays available when the instrument does not restrict holiday access" do
-        instrument.update!(restrict_holiday_access: false)
-        expect(classes).to include("available")
+      it "marks it in use" do
+        expect(options[:class]).to include("in-use")
+        expect(options[:class]).not_to include("available")
       end
     end
 
@@ -98,7 +57,6 @@ RSpec.describe ProductsHelper do
       end
 
       it "shows the offline note" do
-        options = helper.send(:public_calendar_availability_options, instrument)
         expect(options[:title]).to eq(I18n.t("instruments.offline.note"))
       end
     end

--- a/spec/helpers/products_helper_spec.rb
+++ b/spec/helpers/products_helper_spec.rb
@@ -74,6 +74,21 @@ RSpec.describe ProductsHelper do
       end
     end
 
+    context "on a holiday" do
+      before { Holiday.create!(date: Time.current.to_date) }
+
+      it "is not available when the instrument restricts holiday access" do
+        instrument.update!(restrict_holiday_access: true)
+        expect(classes).to include("in-use")
+        expect(classes).not_to include("available")
+      end
+
+      it "stays available when the instrument does not restrict holiday access" do
+        instrument.update!(restrict_holiday_access: false)
+        expect(classes).to include("available")
+      end
+    end
+
     context "when offline" do
       before do
         create(:offline_reservation,

--- a/spec/services/instruments/availability_status_spec.rb
+++ b/spec/services/instruments/availability_status_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Instruments::AvailabilityStatus do
+  subject(:status) { described_class.new(instrument.facility) }
+
+  let(:instrument) { create(:setup_instrument) }
+
+  describe "#available_now?" do
+    it "is true when open now with no current reservation" do
+      expect(status.available_now?(instrument)).to be true
+    end
+
+    context "with a current reservation" do
+      before do
+        create(:purchased_reservation,
+               reserve_start_at: 30.minutes.ago,
+               reserve_end_at: 30.minutes.from_now,
+               product: instrument)
+      end
+
+      it "is false" do
+        expect(status.available_now?(instrument)).to be false
+      end
+    end
+
+    context "with a current reservation on a schedule-sharing sibling" do
+      before do
+        sibling = create(:setup_instrument,
+                         facility: instrument.facility,
+                         schedule: instrument.schedule)
+        create(:admin_reservation,
+               reserve_start_at: 30.minutes.ago,
+               reserve_end_at: 30.minutes.from_now,
+               product: sibling)
+      end
+
+      it "is false because the shared schedule is in use" do
+        expect(status.available_now?(instrument)).to be false
+      end
+    end
+
+    context "when closed now (no schedule rule covers the current time)" do
+      before { instrument.schedule_rules.destroy_all }
+
+      it "is false" do
+        expect(status.available_now?(instrument)).to be false
+      end
+    end
+
+    context "on a holiday" do
+      before { Holiday.create!(date: Time.current.to_date) }
+
+      it "is false when the instrument restricts holiday access" do
+        instrument.update!(restrict_holiday_access: true)
+        expect(status.available_now?(instrument)).to be false
+      end
+
+      it "is true when the instrument does not restrict holiday access" do
+        instrument.update!(restrict_holiday_access: false)
+        expect(status.available_now?(instrument)).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Notes

The public facility page shows a colored icon for each instrument's current availability. With that feature enabled the page had become noticeably slower — roughly doubling its load time on facilities with many instruments. This makes it load quickly regardless of how many instruments a facility has, with no change to what users see.

[NUOPEN-295 | [Investigate] Facility show page: improve Instrument availability loading](https://universe-of-universities.atlassian.net/browse/NUOPEN-295)


# Screenshot

Before:
<img width="763" height="409" alt="Screenshot 2026-07-20 at 4 09 56 PM" src="https://github.com/user-attachments/assets/a3cd9395-7d6a-4513-8fda-793db1c8b20b" />

After:
<img width="761" height="416" alt="Screenshot 2026-07-20 at 4 10 06 PM" src="https://github.com/user-attachments/assets/adb013ce-8387-456b-96f1-7b39c34b6b85" />
