### PR TITLE
[NUOPEN-289] Refactor raw export

### DIFF
--- a/app/models/concerns/reports/csv_exporter.rb
+++ b/app/models/concerns/reports/csv_exporter.rb
@@ -62,7 +62,7 @@ module Reports
     private
 
     def csv_header
-      column_headers.join(",") + "\n"
+      CSV.generate_line(column_headers)
     end
 
     def csv_body
@@ -94,8 +94,10 @@ module Reports
       [error] + Array.new(report_hash.size - 1)
     end
 
+    # Memoized: format_row consults it for every row, and rebuilding it means
+    # re-running every registered transformer per row.
     def report_hash
-      transformers.reduce(default_report_hash) do |result, class_name|
+      @report_hash ||= transformers.reduce(default_report_hash) do |result, class_name|
         class_name.constantize.new.transform(result)
       end
     end

--- a/app/models/concerns/reports/csv_exporter.rb
+++ b/app/models/concerns/reports/csv_exporter.rb
@@ -89,7 +89,9 @@ module Reports
         end
       end
     rescue => e
-      ["*** ERROR WHEN REPORTING ON #{row.class} #{row.id}: #{e.message} ***"]
+      # Pad to full width so an errored row stays column-aligned in the CSV
+      error = "*** ERROR WHEN REPORTING ON #{row.class} #{row.id}: #{e.message} ***"
+      [error] + Array.new(report_hash.size - 1)
     end
 
     def report_hash

--- a/app/models/concerns/reports/csv_exporter.rb
+++ b/app/models/concerns/reports/csv_exporter.rb
@@ -94,8 +94,7 @@ module Reports
       [error] + Array.new(report_hash.size - 1)
     end
 
-    # Memoized: format_row consults it for every row, and rebuilding it means
-    # re-running every registered transformer per row.
+    # format_row reads this once per row - build it once.
     def report_hash
       @report_hash ||= transformers.reduce(default_report_hash) do |result, class_name|
         class_name.constantize.new.transform(result)

--- a/app/models/reports/export_raw.rb
+++ b/app/models/reports/export_raw.rb
@@ -173,9 +173,7 @@ module Reports
       ).perform
     end
 
-    # For rows without a price policy, ChargeMode falls back to
-    # Product#current_price_policies, which queries with a fresh timestamp on
-    # every call (uncacheable). Memoize per product for the report run.
+    # ChargeMode's no-policy fallback queries price policies per call; cache per product.
     def charge_mode_name(order_detail)
       return ChargeMode.for_order_detail(order_detail).to_s.titleize if order_detail.price_policy
 

--- a/app/models/reports/export_raw.rb
+++ b/app/models/reports/export_raw.rb
@@ -127,8 +127,14 @@ module Reports
         date_range_field: date_range_field,
         date_range_start: date_start,
         date_range_end: date_end,
-        includes: [:reservation, :statement, :reservation, order: [:user]],
-        preloads: [:created_by_user, :journal, order: [:facility], account: [:affiliate, :owner_user], price_policy: [:price_group]],
+        includes: [:reservation, :statement, order: [:user]],
+        preloads: [
+          :created_by_user, :journal, :bundle, :project,
+          :assigned_user, :price_changed_by_user, :canceled_by_user, :problem_resolved_by,
+          order: [:facility, :cross_core_project],
+          account: [:affiliate, :owner_user],
+          price_policy: [:price_group],
+        ],
         transformer_options: { time_data: true, reporting: true },
       ).perform
     end

--- a/app/models/reports/export_raw.rb
+++ b/app/models/reports/export_raw.rb
@@ -95,7 +95,7 @@ module Reports
     def cost_columns
       {
         price_group: ->(od) { od.price_policy.try(:price_group).try(:name) },
-        charge_for: ->(od) { ChargeMode.for_order_detail(od).to_s.titleize },
+        charge_for: ->(od) { charge_mode_name(od) },
         project: :project,
         estimated_cost: ->(od) { as_currency(od.estimated_cost) },
         estimated_subsidy: ->(od) { as_currency(od.estimated_subsidy) },
@@ -171,6 +171,16 @@ module Reports
         ],
         transformer_options: { time_data: true, reporting: true },
       ).perform
+    end
+
+    # For rows without a price policy, ChargeMode falls back to
+    # Product#current_price_policies, which queries with a fresh timestamp on
+    # every call (uncacheable). Memoize per product for the report run.
+    def charge_mode_name(order_detail)
+      return ChargeMode.for_order_detail(order_detail).to_s.titleize if order_detail.price_policy
+
+      @charge_mode_by_product ||= {}
+      @charge_mode_by_product[order_detail.product_id] ||= ChargeMode.for_order_detail(order_detail).to_s.titleize
     end
 
     def as_currency_difference(minuend, subtrahend)

--- a/app/models/reports/export_raw.rb
+++ b/app/models/reports/export_raw.rb
@@ -1,24 +1,25 @@
 # frozen_string_literal: true
 
-require "csv"
-
 module Reports
 
   class ExportRaw
 
     include CsvExporter
 
+    REQUIRED_ARGS = [:date_start, :date_end, :facility_url_name, :order_status_ids].freeze
+
     attr_reader :order_status_ids, :facility_url_name, :date_range_field
 
-    def initialize(arguments)
-      [:date_end, :date_start, :facility_url_name, :order_status_ids].each do |property|
-        if arguments[property].present?
-          instance_variable_set("@#{property}".to_sym, arguments[property])
-        else
-          raise ArgumentError, "Required argument '#{property}' is missing"
-        end
+    def initialize(date_start:, date_end:, facility_url_name:, order_status_ids:, date_range_field: nil)
+      @date_start = date_start
+      @date_end = date_end
+      @facility_url_name = facility_url_name
+      @order_status_ids = order_status_ids
+      @date_range_field = date_range_field.presence || "journal_or_statement_date"
+
+      REQUIRED_ARGS.each do |arg|
+        raise ArgumentError, "Required argument '#{arg}' is missing" if public_send(arg).blank?
       end
-      @date_range_field = arguments[:date_range_field] || "journal_or_statement_date"
     end
 
     def facility
@@ -35,14 +36,32 @@ module Reports
 
     private
 
-    def default_report_hash # rubocop:disable Metrics/AbcSize
-      hash = {
+    def default_report_hash
+      hash = order_columns
+             .merge(user_columns)
+             .merge(product_and_account_columns)
+             .merge(cost_columns)
+             .merge(reservation_columns)
+             .merge(resolution_columns)
+
+      return hash if SettingsHelper.has_review_period?
+
+      hash.except(:reviewed_at, :disputed_at, :dispute_reason, :dispute_resolved_at, :dispute_resolved_reason)
+    end
+
+    def order_columns
+      {
         facility: :facility,
         order: :to_s,
         ordered_at: :ordered_at,
         fulfilled_at: :fulfilled_at,
         order_status: ->(od) { od.order_status.name },
         order_state: :state,
+      }
+    end
+
+    def user_columns
+      {
         ordered_by: ->(od) { od.created_by_user.username },
         first_name: ->(od) { od.created_by_user.first_name },
         last_name: ->(od) { od.created_by_user.last_name },
@@ -51,6 +70,11 @@ module Reports
         purchaser_first_name: ->(od) { od.user.first_name },
         purchaser_last_name: ->(od) { od.user.last_name },
         purchaser_email: ->(od) { od.user.email },
+      }
+    end
+
+    def product_and_account_columns
+      {
         product_id: ->(od) { od.product.url_name },
         product_type: ->(od) { od.product.class.model_name.human },
         product: ->(od) { od.product.name },
@@ -65,6 +89,11 @@ module Reports
         owner_first_name: ->(od) { od.account.owner_user.first_name },
         owner_last_name: ->(od) { od.account.owner_user.last_name },
         owner_email: ->(od) { od.account.owner_user.email },
+      }
+    end
+
+    def cost_columns
+      {
         price_group: ->(od) { od.price_policy.try(:price_group).try(:name) },
         charge_for: ->(od) { ChargeMode.for_order_detail(od).to_s.titleize },
         project: :project,
@@ -80,12 +109,22 @@ module Reports
         difference_cost: ->(od) { as_currency_difference(od.actual_cost, od.calculated_cost) },
         difference_subsidy: ->(od) { as_currency_difference(od.actual_subsidy, od.calculated_subsidy) },
         difference_total: ->(od) { as_currency_difference(od.actual_total, od.calculated_total) },
+      }
+    end
+
+    def reservation_columns
+      {
         reservation_start_time: ->(od) { od.reservation.reserve_start_at if od.reservation },
         reservation_end_time: ->(od) { od.reservation.reserve_end_at if od.reservation },
         reservation_minutes: ->(od) { od.time_data.try(:duration_mins) },
         actual_start_time: ->(od) { od.time_data.try(:actual_start_at) },
         actual_end_time: ->(od) { od.time_data.try(:actual_end_at) },
         actual_minutes: ->(od) { od.time_data.try(:actual_duration_mins) },
+      }
+    end
+
+    def resolution_columns
+      {
         canceled_at: :canceled_at,
         canceled_by: ->(od) { canceled_by_name(od) },
         note: :note,
@@ -113,11 +152,6 @@ module Reports
         cross_core_project_active: ->(od) { od.order.cross_core_project&.active? },
         deposit_number: :deposit_number,
       }
-      if SettingsHelper.has_review_period?
-        hash
-      else
-        hash.except(:reviewed_at, :disputed_at, :dispute_reason, :dispute_resolved_at, :dispute_resolved_reason)
-      end
     end
 
     def report_data_query

--- a/app/models/reports/instrument_unavailable_export_raw.rb
+++ b/app/models/reports/instrument_unavailable_export_raw.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "csv"
-
 module Reports
 
   class InstrumentUnavailableExportRaw

--- a/spec/models/reports/export_raw_spec.rb
+++ b/spec/models/reports/export_raw_spec.rb
@@ -20,6 +20,26 @@ RSpec.describe Reports::ExportRaw do
     }
   end
 
+  describe "initialization" do
+    let(:args) do
+      {
+        facility_url_name: "some-facility",
+        order_status_ids: [1],
+        date_start: 1.day.ago,
+        date_end: 1.day.from_now,
+      }
+    end
+
+    it "defaults date_range_field to journal_or_statement_date" do
+      expect(described_class.new(**args).date_range_field).to eq("journal_or_statement_date")
+    end
+
+    it "raises when a required argument is blank" do
+      expect { described_class.new(**args, order_status_ids: []) }
+        .to raise_error(ArgumentError, /order_status_ids/)
+    end
+  end
+
   describe "for an item" do
     let(:item) { FactoryBot.create(:setup_item, facility: facility) }
     let(:order_detail) do

--- a/spec/models/reports/export_raw_spec.rb
+++ b/spec/models/reports/export_raw_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Reports::ExportRaw do
 
   let(:report_args) do
     {
-      action_name: "general",
       facility_url_name: facility.url_name,
       order_status_ids: [order_detail.order_status_id],
       date_end: 1.day.from_now,
@@ -83,7 +82,6 @@ RSpec.describe Reports::ExportRaw do
     context "in a cross facility context" do
       let(:report_args) do
         {
-          action_name: "general",
           facility_url_name: Facility.cross_facility.url_name,
           order_status_ids: [order_detail.order_status_id],
           date_end: 1.day.from_now,
@@ -211,7 +209,6 @@ RSpec.describe Reports::ExportRaw do
     context "in a cross facility context" do
       let(:report_args) do
         {
-          action_name: "general",
           facility_url_name: Facility.cross_facility.url_name,
           order_status_ids: [order_detail.order_status_id],
           date_end: 1.day.from_now,
@@ -257,6 +254,19 @@ RSpec.describe Reports::ExportRaw do
         "Product" => items.map(&:name),
         "Bundle" => [bundle.name, bundle.name],
       )
+    end
+  end
+
+  describe "when building a row raises an error" do
+    let(:item) { create(:setup_item, facility: facility) }
+    let!(:order_detail) { place_product_order(user, facility, item, account).tap(&:complete!) }
+
+    it "keeps the row column-aligned with the error in the first cell" do
+      allow_any_instance_of(OrderDetail).to receive(:to_s).and_raise("boom")
+      parsed = CSV.parse(report.to_csv)
+
+      expect(parsed.last.size).to eq(parsed.first.size)
+      expect(parsed.last.first).to include("ERROR WHEN REPORTING")
     end
   end
 

--- a/vendor/engines/secure_rooms/spec/models/reports/export_raw_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/reports/export_raw_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Reports::ExportRaw, :time_travel do
   let(:report) { described_class.new(**report_args) }
   let(:report_args) do
     {
-      action_name: "general",
       facility_url_name: facility.url_name,
       order_status_ids: [order_detail.order_status_id],
       date_end: 1.day.from_now,

--- a/vendor/engines/split_accounts/spec/models/reports/export_raw_spec.rb
+++ b/vendor/engines/split_accounts/spec/models/reports/export_raw_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe Reports::ExportRaw, :enable_split_accounts do
   subject(:report) { described_class.new(**report_args) }
   let(:report_args) do
     {
-      action_name: "general",
       facility_url_name: facility.url_name,
       order_status_ids: [order_detail.order_status_id],
       date_end: 1.day.from_now,


### PR DESCRIPTION
# Notes

TECH TASK: Refactor the Export Raw report so large exports generate with a fraction of the database queries (e.g. ~600 → ~74 on a 1,400-row export). The CSV content does not change.

[NUOPEN-289 | Refactor RawExport](https://universe-of-universities.atlassian.net/browse/NUOPEN-289)

# Additional Context

## Performance

Two N+1s fixed in `Reports::ExportRaw` (measured on a 1,407-row export against the demo dataset; query counts include cached queries, i.e. real round-trips with varied production data):

| Scenario | Before | After |
|---|---:|---:|
| Standard export | 617 queries | **74 queries** (−88%) |
| Rows without a price policy (canceled/unpriced) | 1,408 queries / 3.3s | **71 queries** / 1.1s |

- **Bundle N+1** (546 queries): the report read `od.bundle` per row — fixed by preloading `:bundle` plus other accessed associations (`assigned_user`, `canceled_by_user`, `price_changed_by_user`, `problem_resolved_by`, `project`, `order.cross_core_project`).
- **Charge mode N+1**: rows without a price policy fell back to `Product#current_price_policies(Time.zone.now)` per row — the fresh timestamp in the SQL makes it uncacheable. Now memoized per product for the report run.
- `report_hash` was rebuilt (running every registered engine transformer) once per row — now memoized per report instance.

## Refactorings

- `initialize` uses explicit keyword args instead of the `instance_variable_set` loop; specs dropped a silently-ignored dead argument (`action_name`).
- `default_report_hash` (75 columns, `rubocop:disable Metrics/AbcSize`) split into six named sections (`order_columns`, `user_columns`, …) — the disable is gone.
- `CsvExporter#format_row`: a row that raises now pads to the full column count, so the error lands in column 1 and the row keeps the CSV width for programmatic consumers (before: a 1-cell row).
- Header line built with `CSV.generate_line` (body already used `CSV`), so a translated header containing a comma/quote can't corrupt the file.
- Dropped redundant `require "csv"` (bundled via Gemfile).

# Screenshot
Before:
<img width="850" height="244" alt="Screenshot 2026-07-21 at 3 26 50 PM" src="https://github.com/user-attachments/assets/f1f269d8-d5f5-4bfe-891a-80159aafd40a" />

After:
<img width="887" height="322" alt="Screenshot 2026-07-21 at 3 26 59 PM" src="https://github.com/user-attachments/assets/86625949-59e4-4a8d-b4da-5c2288b7e75d" />

MiniProfiler for the same 567-row export request (job forced inline in dev):

| Before | After |
|---|---|
| 1,137 ms — 272 sql (229 cached) | 653 ms — 64 sql (20 cached) |