### PR TITLE
[NUOPEN-42] Redirect to account selection when adding a Billiable product to a Nonbilliable cart

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -186,7 +186,7 @@ class OrdersController < ApplicationController
     @product = if session[:add_to_cart].blank?
               @order.order_details[0].try(:product)
             else
-              Product.find(session[:add_to_cart].first[:product_id])
+              find_cart_product(session[:add_to_cart].first[:product_id])
             end
     # For nonbillable products, we don't ask the user to choose an account
     # POST requests are sent from the form on the choose_account page,
@@ -214,7 +214,7 @@ class OrdersController < ApplicationController
         if session[:add_to_cart] &&
            (ods = session[:add_to_cart].presence) &&
            (product_id = ods.first[:product_id])
-          error = account.validate_against_product(Product.find(product_id), acting_user)
+          error = account.validate_against_product(find_cart_product(product_id), acting_user)
           @errors[account.id] = error if error
         end
         next if @errors[account.id]
@@ -327,6 +327,10 @@ class OrdersController < ApplicationController
 
   private
 
+  def find_cart_product(product_id)
+    (@cart_products ||= {})[product_id.to_i] ||= Product.find(product_id)
+  end
+
   def payment_relevant_order_details
     @order.order_details.reject { |od| od.product.nonbillable_mode? }
   end
@@ -338,7 +342,7 @@ class OrdersController < ApplicationController
   def adding_billable_products_to_nonbillable_cart?(items)
     return false unless @order.account == NonbillableAccount.singleton_instance
 
-    items.any? { |item| !Product.find(item[:product_id]).nonbillable_mode? }
+    items.any? { |item| !find_cart_product(item[:product_id]).nonbillable_mode? }
   end
 
   def add_account_to_order(account)

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -109,8 +109,7 @@ class OrdersController < ApplicationController
       end
     end
 
-    ## make sure the order has an account
-    if @order.account.nil?
+    if needs_payment_source_selection?(items)
       ## add auto_assign back here if needed
 
       ## save the state to the session and redirect
@@ -210,7 +209,7 @@ class OrdersController < ApplicationController
       flash.now[:error] = I18n.t("controllers.orders.choose_account.missing_account") if account.blank? && request.post?
       @accounts = AvailableAccountsFinder.new(acting_user, @product.facility).accounts
       @errors   = {}
-      details   = @order.order_details
+      details   = payment_relevant_order_details
       @accounts.each do |account|
         if session[:add_to_cart] &&
            (ods = session[:add_to_cart].presence) &&
@@ -327,6 +326,20 @@ class OrdersController < ApplicationController
   end
 
   private
+
+  def payment_relevant_order_details
+    @order.order_details.reject { |od| od.product.nonbillable_mode? }
+  end
+
+  def needs_payment_source_selection?(items)
+    @order.account.nil? || adding_billable_products_to_nonbillable_cart?(items)
+  end
+
+  def adding_billable_products_to_nonbillable_cart?(items)
+    return false unless @order.account == NonbillableAccount.singleton_instance
+
+    items.any? { |item| !Product.find(item[:product_id]).nonbillable_mode? }
+  end
 
   def add_account_to_order(account)
     if account

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -82,7 +82,7 @@ class OrdersController < ApplicationController
     items = items.compact.map { |i| i.permit(:product_id, :quantity) }.select { |od| od[:quantity].to_i > 0 }
     return redirect_back_or_to(cart_path, notice: "Please add at least one quantity to order something") unless items.size > 0
 
-    first_product = Product.find(items.first[:product_id])
+    first_product = find_cart_product(items.first[:product_id])
     facility_ability = Ability.new(session_user, first_product.facility, self)
 
     # if acting_as, make sure the session user can place orders for the facility
@@ -120,7 +120,7 @@ class OrdersController < ApplicationController
     ## process each item
     @order.transaction do
       items.each do |item|
-        @product = Product.find(item[:product_id])
+        @product = find_cart_product(item[:product_id])
         begin
           @order.add(@product, item[:quantity])
           @order.invalidate! ## this is because we just added an order_detail
@@ -340,7 +340,7 @@ class OrdersController < ApplicationController
   end
 
   def adding_billable_products_to_nonbillable_cart?(items)
-    return false unless @order.account == NonbillableAccount.singleton_instance
+    return false unless @order.account.is_a?(NonbillableAccount)
 
     items.any? { |item| !find_cart_product(item[:product_id]).nonbillable_mode? }
   end

--- a/spec/models/order_import_csv_spec.rb
+++ b/spec/models/order_import_csv_spec.rb
@@ -89,5 +89,38 @@ RSpec.describe OrderImport, feature_setting: { "pricing.user_based_price_groups"
       end
 
     end
+
+    describe "when a row would mix billing modes on a nonbillable order" do
+      # There's no specific error handling for NUCore::MixedBillingMode the importer,
+      # so the mismatched row falls through to the generic rescue and error message.
+      let!(:nonbillable_order) do
+        create(:purchased_order,
+               product: nonbillable_item,
+               account: nonbillable_account,
+               user: user,
+               created_by: user.id)
+      end
+
+      let(:body) do
+        <<~CSV
+          #{I18n.t('order_row_importer.headers.user')},#{I18n.t('Chart_string')},Product Name,Quantity,Order Date,Fulfillment Date,Note,Order,Reference ID
+          sst123@example.com,#{account.account_number},Example Item,1,#{yesterday},#{yesterday},Mismatched add,#{nonbillable_order.id},123456789
+        CSV
+      end
+
+      it "does not add the billing-mode-mismatched product to the order" do
+        expect { order_import.process_upload! }
+          .not_to change { nonbillable_order.reload.order_details.count }
+      end
+
+      it "completes the import without raising" do
+        expect { order_import.process_upload! }.not_to raise_error
+      end
+
+      it "reports the row as a failure" do
+        order_import.process_upload!
+        expect(order_import.result.failures).to eq(1)
+      end
+    end
   end
 end

--- a/spec/system/cart_billing_mode_spec.rb
+++ b/spec/system/cart_billing_mode_spec.rb
@@ -72,16 +72,32 @@ RSpec.describe "Adding products with different billing modes to cart" do
         expect(page).to have_content(nonbillable_item.name).twice
       end
 
-      it "cannot add Skip Review item to cart" do
+      it "redirects to the payment selection page when adding a Skip Review item" do
         visit facility_item_path(facility, skip_review_item)
         click_on "Add to cart"
-        expect(page).to have_content("#{skip_review_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
+
+        expect(page).to have_content("Select Payment Source")
+        expect(page).not_to have_content("cannot be added to your cart because it's billing mode does not match")
+
+        choose account_used.to_s
+        click_button "Continue"
+
+        expect(page).to have_content(nonbillable_item.name)
+        expect(page).to have_content(skip_review_item.name)
       end
 
-      it "cannot add a Default billing mode product" do
+      it "redirects to the payment selection page when adding a Default item" do
         visit facility_item_path(facility, default_item)
         click_on "Add to cart"
-        expect(page).to have_content("#{default_item.name} cannot be added to your cart because it's billing mode does not match the current products in the cart; please clear your cart or place a separate order.")
+
+        expect(page).to have_content("Select Payment Source")
+        expect(page).not_to have_content("cannot be added to your cart because it's billing mode does not match")
+
+        choose account_used.to_s
+        click_button "Continue"
+
+        expect(page).to have_content(nonbillable_item.name)
+        expect(page).to have_content(default_item.name)
       end
     end
 


### PR DESCRIPTION
# Notes
* Redirect to account selection when adding a Billiable product to a Nonbilliable cart

[NUOPEN-42 | Redirect to payment selection when adding billable products to a nonbillable cart ](https://universe-of-universities.atlassian.net/browse/NUOPEN-42)

# Screen recording 


https://github.com/user-attachments/assets/3447d160-38f0-4a77-a709-fd1273bccf84

