### PR TITLE
[DART-165] Allow to exclude suspended accounts on create Journal

### DIFF
--- a/app/assets/stylesheets/app/transaction_search.scss
+++ b/app/assets/stylesheets/app/transaction_search.scss
@@ -3,7 +3,8 @@
 */
 .search_form {
   fieldset#search, .full-width {
-    input, select {
+    input:not([type="checkbox"]),
+    select {
       width: 100%;
     }
 
@@ -14,14 +15,7 @@
 }
 
 .search_form input[type=submit] {
-  clear: both;
-  float: right;
   margin-bottom: 0.5em;
-
-  &.float-left {
-    float: left;
-    margin-bottom: 2em;
-  }
 }
 
 

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -83,15 +83,9 @@ legend {
   .row {
     margin-bottom: 15px;
   }
-  
-  input[type="text"]:not(.chosen-search-input),
-  select {
-    @extend .form-control;
-  }
-  
+
   label {
     display: block;
-    margin-bottom: 5px;
   }
 }
 

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -38,7 +38,7 @@ class FacilityJournalsController < ApplicationController
     @search_form = TransactionSearch::SearchForm.new(params[:search])
     @search =
       TransactionSearch::Searcher
-      .new(facilities: current_facility.cross_facility?)
+      .new(facilities: current_facility.cross_facility?, suspended_accounts: true)
       .search(order_details, @search_form)
 
     @date_range_field = @search_form.date_params[:field]

--- a/app/forms/transaction_search/search_form.rb
+++ b/app/forms/transaction_search/search_form.rb
@@ -10,9 +10,8 @@ module TransactionSearch
     attr_accessor :facilities, :accounts, :products, :account_owners,
                   :order_statuses, :statements, :date_ranges, :ordered_fors,
                   :account_types, :cross_cores, :cross_core_facilties,
-                  :current_facility_id,
-                  :projects,
-                  :price_groups
+                  :current_facility_id, :suspended_accounts,
+                  :projects, :price_groups
 
     def self.model_name
       ActiveModel::Name.new(self, nil, "Search")

--- a/app/helpers/transaction_searcher_helper.rb
+++ b/app/helpers/transaction_searcher_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module TransactionSearcherHelper
+  def searcher_input(form, searcher)
+    case searcher.input_type
+    when :transaction_chosen, :select then select_input(form, searcher)
+    when :boolean then boolean_input(form, searcher)
+    else
+      raise ArgumentError, "Unsupported transaction searcher input type: #{searcher.input_type}"
+    end
+  end
+
+  private
+
+  def select_input(form, searcher)
+    form.input(
+      searcher.key,
+      as: searcher.input_type,
+      collection: searcher.options,
+      label: searcher.label,
+      label_method: searcher.label_method,
+      data_attrs: searcher.method(:data_attrs),
+      input_html: { id: searcher.key, class: "quarter-width" },
+      include_blank: false
+    )
+  end
+
+  def boolean_input(form, searcher)
+    form.input(
+      searcher.key,
+      as: :boolean,
+      label: false,
+      inline_label: searcher.label,
+      data_attrs: searcher.method(:data_attrs),
+      input_html: { id: searcher.key },
+    )
+  end
+end

--- a/app/javascript/transaction_history.js
+++ b/app/javascript/transaction_history.js
@@ -1,36 +1,6 @@
 $(function() {
 	$("select[multiple]").chosen({ width: "100%" });
-
-  $(".datepicker").each(function() {
-    var datepickerParams = {};
-    if ($(this).hasClass('in_past')) datepickerParams.maxDate = new Date();
-    $(this).datepicker(datepickerParams);
-  });
-	// call trigger("change") to make sure that it updates on page load
-	$(".datepicker[name=start_date]").change(DatePickerRange.updateEndMaxDate).trigger("change");
-	$(".datepicker[name=end_date]").change(DatePickerRange.updateStartMinDate).trigger("change");
-
-
-
 });
-
-var DatePickerRange = {
-	updateEndMaxDate: function() {
-		$val = $(this).val();
-		if ($val) {
-			var start = Date.parse($val);
-			$(".datepicker[name=end_date]").datepicker("option", {minDate: start });
-		}
-	},
-	updateStartMinDate: function() {
-		$val = $(this).val();
-		if ($val) {
-			var end = Date.parse($val);
-			$(".datepicker[name=start_date]").datepicker("option", {maxDate: end});
-		}
-	}
-
-}
 
 $(function() {
 	$("#facilities").change(function() {

--- a/app/services/transaction_search/searcher.rb
+++ b/app/services/transaction_search/searcher.rb
@@ -12,6 +12,7 @@ module TransactionSearch
         TransactionSearch::FacilitySearcher,
         TransactionSearch::AccountSearcher,
         TransactionSearch::AccountTypeSearcher,
+        TransactionSearch::SuspendedAccountSearcher,
         TransactionSearch::ProductSearcher,
         TransactionSearch::AccountOwnerSearcher,
         TransactionSearch::PriceGroupSearcher,
@@ -36,6 +37,7 @@ module TransactionSearch
     cattr_accessor(:default_config) do
       {
         facilities: false,
+        suspended_accounts: false,
         price_groups: SettingsHelper.feature_on?("billing.billing_table_price_groups"),
       }
     end

--- a/app/services/transaction_search/suspended_account_searcher.rb
+++ b/app/services/transaction_search/suspended_account_searcher.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module TransactionSearch
+  class SuspendedAccountSearcher < BaseSearcher
+    def search(params)
+      if params.present? && to_bool(params.first)
+        order_details.where(account: Account.not_suspended)
+      else
+        order_details
+      end
+    end
+
+    def input_type
+      :boolean
+    end
+
+    def label
+      I18n.t("admin.transaction_search.suspended_accounts")
+    end
+
+    def to_bool(value)
+      ActiveModel::Type::Boolean.new.cast(value)
+    end
+  end
+end

--- a/app/views/shared/transactions/_search.html.haml
+++ b/app/views/shared/transactions/_search.html.haml
@@ -2,15 +2,7 @@
   .row
     %fieldset.col-md-8#search
       - @search.options.reject(&:multipart?).each do |searcher|
-        - html_class = searcher.input_type == :select ? "quarter-width" : ""
-        = f.input searcher.key,
-          as: searcher.input_type,
-          collection: searcher.options,
-          label: searcher.label,
-          label_method: searcher.label_method,
-          data_attrs: searcher.method(:data_attrs),
-          input_html: { id: searcher.key, class: html_class },
-          include_blank: false
+        = searcher_input(f, searcher)
 
     %fieldset.col-xs-6.col-md-4#calendar_filter
       - if @search.options.map(&:key).include?("date_ranges")
@@ -22,4 +14,4 @@
   %div
     = hidden_field_tag :email, current_user.email, disabled: true
     = hidden_field_tag :format, params[:format], disabled: true
-    = f.submit t("shared.filter"), class: "btn float-left"
+    = f.submit t("shared.filter"), class: "btn"

--- a/config/locales/views/admin/en.transaction_search.yml
+++ b/config/locales/views/admin/en.transaction_search.yml
@@ -1,6 +1,7 @@
 en:
   admin:
     transaction_search:
+      suspended_accounts: Exclude suspended Payment Sources
       date_range_fields:
         ordered_at: Ordered
         fulfilled_at: Fulfilled

--- a/spec/requests/facility_journals_spec.rb
+++ b/spec/requests/facility_journals_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "facilities journals" do
+  describe "search" do
+    let(:facility) { create(:setup_facility) }
+
+    before { login_as create(:user, :administrator) }
+
+    it "includes checkbox to filter suspended accounts" do
+      get new_facility_journal_path(facility)
+
+      expect(page).to have_field("search[suspended_accounts]", type: :checkbox)
+    end
+  end
+end

--- a/spec/services/transaction_search/suspended_account_searcher_spec.rb
+++ b/spec/services/transaction_search/suspended_account_searcher_spec.rb
@@ -47,6 +47,10 @@ RSpec.describe TransactionSearch::Searcher, :use_test_account do
     context "when true" do
       let(:suspended_accounts_param) { "1" }
 
+      it "returns non empty set" do
+        expect(searched_order_details).not_to be_empty
+      end
+
       it "filters out orders with suspended accounts" do
         expect(searched_order_details).not_to include(
           *suspended_account.order_details.to_a
@@ -59,6 +63,10 @@ RSpec.describe TransactionSearch::Searcher, :use_test_account do
 
     context "when false" do
       let(:suspended_accounts_param) { "0" }
+
+      it "returns non empty set" do
+        expect(searched_order_details).not_to be_empty
+      end
 
       it "does not filter orders" do
         expect(searched_order_details).to include(

--- a/spec/services/transaction_search/suspended_account_spec.rb
+++ b/spec/services/transaction_search/suspended_account_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TransactionSearch::Searcher, :use_test_account do
+
+  describe "suspended accounts filter" do
+    let(:facility) { create(:setup_facility) }
+    let(:user) { create(:user) }
+    let(:account) do
+      create(:test_account, :with_account_owner, created_by: user.id)
+    end
+    let(:suspended_account) do
+      create(
+        :test_account,
+        :with_account_owner,
+        created_by: user.id,
+        suspended_at: Time.current,
+      )
+    end
+    let(:searcher) do
+      described_class.new(suspended_accounts: true)
+    end
+    let(:searched_order_details) do
+      searcher.search(
+        facility.order_details,
+        suspended_accounts: suspended_accounts_param,
+      ).order_details
+    end
+
+    before do
+      create(
+        :complete_order,
+        product: create(:setup_item, facility:),
+        account:,
+      )
+      create(
+        :complete_order,
+        product: create(:setup_item, facility:),
+        account: suspended_account,
+      )
+      facility.orders.each do |order|
+        order.order_details.update_all(reviewed_at: Time.current)
+      end
+    end
+
+    context "when true" do
+      let(:suspended_accounts_param) { "1" }
+
+      it "filters out orders with suspended accounts" do
+        expect(searched_order_details).not_to include(
+          *suspended_account.order_details.to_a
+        )
+        expect(searched_order_details).to include(
+          *account.order_details.to_a
+        )
+      end
+    end
+
+    context "when false" do
+      let(:suspended_accounts_param) { "0" }
+
+      it "does not filter orders" do
+        expect(searched_order_details).to include(
+          *facility.order_details.to_a
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Notes

Add filter to be able to exclude suspended accounts on the create Journal page.

Also:
- Remove css breaking checkbox inputs applied to search_form
- Remove js which handled jquery datepickers which are no longer used

[DART-165 | Ability to Filter Orders to identify and/or exclude "Suspended" payment sources from the journal](https://universe-of-universities.atlassian.net/browse/DART-165)

# Screenshot

<img width="1069" height="921" alt="Captura desde 2026-07-29 16-46-10" src="https://github.com/user-attachments/assets/d1876949-44f6-4659-b1f6-8342e80a2247" />

